### PR TITLE
WS5.5: Refresh Watch SignalR subscriptions after branch transition

### DIFF
--- a/docs/adr/0009-refresh-watch-signalr-subscriptions-at-branch-transition.md
+++ b/docs/adr/0009-refresh-watch-signalr-subscriptions-at-branch-transition.md
@@ -43,8 +43,14 @@ When Watch completes a trusted branch transition:
 - it clears the locally trusted SignalR branch/parent identity before recalculating the new parent;
 - it re-registers the live SignalR connection with `RegisterParentBranch(currentBranchId, currentParentBranchId)`;
 - it replaces the local auto-rebase predicate only after the new parent registration path succeeds;
+- it ignores any in-flight parent refresh completion whose observed branch or refresh generation is no longer current;
 - it rejects promotion events for the old parent after the branch identity has moved to the new branch;
 - it allows promotion events for the new parent to reach the existing auto-rebase path after transition completion.
+
+Parent registration is a local trust enhancer, not a prerequisite for scan-derived Watch recovery. If a transition
+clears parent trust and the refresh cannot complete, Watch keeps the parent predicate empty for the current process so
+parent-triggered auto-rebase remains disabled until a later successful registration. That failure must not move an
+unrelated local resync that has already proven `GraceStatus` coherence back into `Resynchronizing`.
 
 Repository-wide SignalR registration remains outside the refresh work because the current server contract registers that
 group by `RepositoryId` only. A branch switch does not change repository identity, so `RegisterRepository(repositoryId)`

--- a/docs/adr/0009-refresh-watch-signalr-subscriptions-at-branch-transition.md
+++ b/docs/adr/0009-refresh-watch-signalr-subscriptions-at-branch-transition.md
@@ -1,0 +1,88 @@
+---
+status: accepted
+date: 2026-07-04
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Refresh Watch SignalR subscriptions at branch transition
+
+Grace Watch will refresh branch-scoped SignalR subscription state at the same-process branch transition boundary. When
+Watch observes that another Grace command has completed a Grace-owned branch switch, Watch reloads the current
+repository configuration, retargets branch-scoped local coordination, recalculates the current branch's parent branch,
+and re-registers the live SignalR connection for that parent before trusting parent-promotion events again.
+
+## Context
+
+`grace watch` keeps a foreground SignalR connection open so Grace Server can notify it about repository events and
+parent-branch promotions. Parent promotions are the trigger for Watch auto-rebase: if the promotion event targets the
+parent branch Watch currently trusts, Watch reads local status and runs the rebase path for the current branch.
+
+Same-process branch switches are different from a fresh `grace watch` start. The process, timers, SignalR connection,
+and event handlers continue running while the persisted repository configuration changes from branch A to branch B.
+Without an explicit refresh, the connection and local parent predicate can still reflect branch A's parent after Watch
+has adopted branch B. That creates two incorrect outcomes:
+
+- a promotion of branch B's parent may not trigger the intended Watch auto-rebase path;
+- a promotion of branch A's old parent can still satisfy a stale predicate and run auto-rebase under branch B's current
+  configuration.
+
+The transition boundary is already the point where Watch retires the previous branch IPC, reloads `Current()`, retargets
+the update-marker watcher, reloads `GraceStatus`, and decides whether healthy incremental work can resume. That makes
+it the nearest serialized boundary that knows the old branch identity has been abandoned and the new branch identity is
+authoritative.
+
+## Decision
+
+The same-process branch transition boundary owns SignalR branch subscription refresh.
+
+When Watch completes a trusted branch transition:
+
+- it clears the locally trusted SignalR branch/parent identity before recalculating the new parent;
+- it re-registers the live SignalR connection with `RegisterParentBranch(currentBranchId, currentParentBranchId)`;
+- it replaces the local auto-rebase predicate only after the new parent registration path succeeds;
+- it rejects promotion events for the old parent after the branch identity has moved to the new branch;
+- it allows promotion events for the new parent to reach the existing auto-rebase path after transition completion.
+
+Repository-wide SignalR registration remains outside the refresh work because the current server contract registers that
+group by `RepositoryId` only. A branch switch does not change repository identity, so `RegisterRepository(repositoryId)`
+is branch-independent for WS5.5. If a future server contract adds branch-sensitive repository subscriptions, that change
+must extend this transition-boundary refresh rather than relying on startup-only registration.
+
+## Consequences
+
+This keeps Watch's parent-promotion trust aligned with the same branch identity used by local config, IPC, marker
+watching, and `GraceStatus`. The fix is intentionally local to the transition boundary and SignalR predicate; it does
+not introduce a broad branch-transition domain construct.
+
+The server's current parent-branch registration API is additive and does not expose an unregister operation. The client
+therefore refreshes by registering the new parent and replacing its local predicate so any stale old-parent delivery is
+ignored. A future server-side unsubscribe or connection restart can tighten group membership, but it is not required for
+the WS5.5 invariant because stale old-parent events no longer satisfy Watch's auto-rebase predicate.
+
+## Outside WS5.5
+
+This ADR does not define remote sync materialization, durable journal authority, new `--force` or `--wait` behavior,
+or a `grace watch flush` command. Those surfaces belong to other workstreams. It also does not change SDK, OpenAPI, or
+public CLI output contracts.
+
+## Rejected alternatives
+
+### Refresh only on Watch startup
+
+Startup registration is insufficient for a same-process branch switch. The SignalR connection and handler closures can
+outlive the original branch identity, so startup-only registration leaves stale parent state in a running process.
+
+### Run auto-rebase based only on the event target
+
+Trusting any promotion event that reaches the client would make server group membership the only authority. Watch must
+also enforce the current branch's parent identity locally so additive or delayed SignalR delivery cannot trigger a
+stale rebase.
+
+### Move refresh into the rebase handler
+
+The rebase handler runs after an event has already passed the parent predicate. Refreshing there is too late to prevent
+old-parent events from satisfying the stale predicate. The transition boundary must refresh before Watch resumes
+trusting parent-promotion events.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -905,6 +905,58 @@ module WatchTests =
                 Watch.resetUpdateMarkerWatcherRebindForWatchTests ()
                 Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
+    /// Verifies that an event authorized before a branch reload cannot rebase the reloaded branch.
+    [<Test>]
+    let ``signalr parent event rechecks branch identity before auto rebase`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let parentBId = Guid.NewGuid()
+            let repositoryName = "transition-signalr-recheck-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
+
+                Watch.setSignalRBranchSubscriptionForWatchTests branchAId parentAId
+
+                let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+                let rebasedUnderReloadedConfig = ResizeArray<BranchId * DirectoryVersionId>()
+
+                let readStatus () =
+                    task {
+                        writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+                        resetConfiguration ()
+                        Current() |> ignore
+                        Watch.setSignalRBranchSubscriptionForWatchTests branchBId parentBId
+                        return statusB
+                    }
+
+                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedUnderReloadedConfig.Add(Current().BranchId, status.RootDirectoryId) }
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentAId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Current().BranchId |> should equal branchBId
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                subscription.BranchId |> should equal branchBId
+
+                subscription.ParentBranchId
+                |> should equal parentBId
+
+                rebasedUnderReloadedConfig.ToArray()
+                |> should equal Array.empty<BranchId * DirectoryVersionId>
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
     /// Verifies that a missed marker-created callback cannot leave Watch serving the previous branch indefinitely.
     [<Test>]
     let ``unobserved current marker completed sidecar reloads target branch resync ipc`` () =
@@ -1139,6 +1191,68 @@ module WatchTests =
 
                 inspection.EffectiveMode
                 |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+
+                /// Records upload calls for the scan-derived recovery pass.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the incremental status helper available without mutating status in this recovery scenario.
+                let updateGraceStatus status _ = Task.FromResult(Some status)
+                /// Produces a clean scan so recovery can republish the target branch IPC boundary.
+                let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+                /// Applies the scan-derived status boundary for the recovered target branch.
+                let updateGraceStatusFromDifferences status _ _ = Task.FromResult(Some status)
+                /// Keeps incremental application available without changing the recovery status.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Writes the target branch Watch IPC after resync recovery proves durable status.
+                let updateIpc status directoryIds = Services.updateGraceWatchInterprocessFile status directoryIds
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal false
+
+                refreshCalls |> should equal 1
+
+                let recoveredSubscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                recoveredSubscription.BranchId
+                |> should equal branchBId
+
+                recoveredSubscription.ParentBranchId
+                |> should equal parentBId
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentAId
+                |> should equal false
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentBId
+                |> should equal true
+
+                Services.getGraceWatchStatus().Result
+                |> Option.map (fun status -> status.RootDirectoryId)
+                |> should equal (Some statusB.RootDirectoryId)
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentBId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentAId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                rebasedStatuses.ToArray()
+                |> should equal [| statusB.RootDirectoryId |]
 
                 writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
                 resetConfiguration ()

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -957,6 +957,198 @@ module WatchTests =
             finally
                 Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
+    /// Verifies that an in-flight parent refresh cannot restore stale trust after a branch transition advances.
+    [<Test>]
+    let ``stale signalr parent refresh completion cannot restore old branch trust`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let parentBId = Guid.NewGuid()
+            let repositoryName = "transition-signalr-stale-refresh-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
+
+                let staleRefreshAuthority = Watch.beginSignalRBranchSubscriptionRefreshForWatchTests ()
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+                resetConfiguration ()
+                Current() |> ignore
+
+                Watch.clearSignalRBranchSubscriptionForTransitionForWatchTests ()
+                Watch.setSignalRBranchSubscriptionForWatchTests branchBId parentBId
+
+                Watch.trySetSignalRBranchSubscriptionForWatchTests staleRefreshAuthority parentAId
+                |> should equal false
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                subscription.BranchId |> should equal branchBId
+
+                subscription.ParentBranchId
+                |> should equal parentBId
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentAId
+                |> should equal false
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentBId
+                |> should equal true
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
+    /// Verifies that ordinary scan-derived resync recovery does not depend on transition SignalR refresh success.
+    [<Test>]
+    let ``unrelated resync recovery does not invoke signalr transition refresh`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let parentId = Guid.NewGuid()
+            let repositoryName = "ordinary-resync-signalr-failure-repo"
+            let branchName = "branch-a"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchId branchName
+                resetConfiguration ()
+                Current() |> ignore
+
+                let status = graceStatusTracking Array.empty<string> Array.empty<string>
+                Watch.setSignalRBranchSubscriptionForWatchTests branchId parentId
+                Watch.requestGraceWatchExplicitResyncForWatchTests "test-controlled ordinary confidence loss"
+
+                let mutable refreshCalls = 0
+
+                Watch.setSignalRSubscriptionRefreshForWatchTests (fun () ->
+                    refreshCalls <- refreshCalls + 1
+                    raise (InvalidOperationException("ordinary resync must not depend on SignalR refresh")))
+
+                /// Reads the durable status snapshot used by scan-derived recovery.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps file upload retry available without queuing new content.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the incremental status helper available without changing status.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+                /// Produces a clean scan for an ordinary local resync recovery.
+                let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+                /// Applies the scan-derived status boundary when differences exist.
+                let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+                /// Keeps incremental application available without changing status.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Writes Watch IPC after local coherence is proven.
+                let updateIpc currentStatus directoryIds = Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                refreshCalls |> should equal 0
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal false
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                subscription.BranchId |> should equal branchId
+
+                subscription.ParentBranchId
+                |> should equal parentId
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
+    /// Verifies that transition-stale parent trust remains empty when recovery cannot refresh SignalR.
+    [<Test>]
+    let ``transition resync recovery tolerates signalr refresh failure with empty trust`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let parentId = Guid.NewGuid()
+            let repositoryName = "transition-resync-signalr-failure-repo"
+            let branchName = "branch-b"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchId branchName
+                resetConfiguration ()
+                Current() |> ignore
+
+                let status = graceStatusTracking Array.empty<string> Array.empty<string>
+
+                Watch.setSignalRBranchSubscriptionForWatchTests branchId parentId
+                Watch.clearSignalRBranchSubscriptionForTransitionForWatchTests ()
+                Watch.requestGraceWatchExplicitResyncForWatchTests "test-controlled transition recovery"
+
+                let mutable refreshCalls = 0
+
+                Watch.setSignalRSubscriptionRefreshForWatchTests (fun () ->
+                    refreshCalls <- refreshCalls + 1
+                    raise (InvalidOperationException("test-controlled SignalR refresh failure")))
+
+                /// Reads the durable status snapshot used by transition recovery.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps file upload retry available without queuing new content.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the incremental status helper available without changing status.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+                /// Produces a clean scan after transition recovery reloads durable status.
+                let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+                /// Applies the scan-derived status boundary when differences exist.
+                let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+                /// Keeps incremental application available without changing status.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Writes Watch IPC after local coherence is proven.
+                let updateIpc currentStatus directoryIds = Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                refreshCalls |> should equal 1
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal false
+
+                Watch.signalRBranchSubscriptionRefreshNeededForTransitionForWatchTests ()
+                |> should equal false
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                subscription.BranchId
+                |> should equal BranchId.Empty
+
+                subscription.ParentBranchId
+                |> should equal BranchId.Empty
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentId
+                |> should equal false
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
     /// Verifies that a missed marker-created callback cannot leave Watch serving the previous branch indefinitely.
     [<Test>]
     let ``unobserved current marker completed sidecar reloads target branch resync ipc`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -784,12 +784,26 @@ module WatchTests =
                     .GetResult()
 
                 let refreshedSubscriptions = ResizeArray<BranchId * BranchId>()
+                let refreshObservedStatusRoots = ResizeArray<DirectoryVersionId option>()
+                let rebasedStatuses = ResizeArray<DirectoryVersionId>()
+
+                let readStatus () = Task.FromResult(statusB)
+
+                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedStatuses.Add(status.RootDirectoryId) }
 
                 Watch.setSignalRSubscriptionRefreshForWatchTests (fun () ->
                     let current = Current()
                     Watch.setSignalRBranchSubscriptionForWatchTests current.BranchId parentBId
                     let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
-                    refreshedSubscriptions.Add(subscription.BranchId, subscription.ParentBranchId))
+                    refreshedSubscriptions.Add(subscription.BranchId, subscription.ParentBranchId)
+
+                    Services.getGraceWatchStatus().Result
+                    |> Option.map (fun status -> status.RootDirectoryId)
+                    |> refreshObservedStatusRoots.Add
+
+                    (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentBId (Guid.NewGuid())))
+                        .GetAwaiter()
+                        .GetResult())
 
                 writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
                 Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
@@ -798,6 +812,9 @@ module WatchTests =
 
                 refreshedSubscriptions.ToArray()
                 |> should equal [| branchBId, parentBId |]
+
+                refreshObservedStatusRoots.ToArray()
+                |> should equal [| Some statusB.RootDirectoryId |]
 
                 let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
                 subscription.BranchId |> should equal branchBId
@@ -811,26 +828,81 @@ module WatchTests =
                 Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentBId
                 |> should equal true
 
-                let rebasedStatuses = ResizeArray<DirectoryVersionId>()
-
-                let readStatus () = Task.FromResult(statusB)
-
-                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedStatuses.Add(status.RootDirectoryId) }
-
                 (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentAId (Guid.NewGuid())))
                     .GetAwaiter()
                     .GetResult()
 
                 rebasedStatuses.ToArray()
-                |> should equal Array.empty<DirectoryVersionId>
+                |> should equal [| statusB.RootDirectoryId |]
 
                 (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentBId (Guid.NewGuid())))
                     .GetAwaiter()
                     .GetResult()
 
                 rebasedStatuses.ToArray()
-                |> should equal [| statusB.RootDirectoryId |]
+                |> should
+                    equal
+                    [|
+                        statusB.RootDirectoryId
+                        statusB.RootDirectoryId
+                    |]
             finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
+    /// Verifies that stale parent events cannot auto-rebase after target branch config reload begins.
+    [<Test>]
+    let ``update marker deletion clears stale signalr parent before target config reload`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let repositoryName = "transition-signalr-stale-parent-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+                Watch.setSignalRBranchSubscriptionForWatchTests branchAId parentAId
+
+                let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+                let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+
+                (Services.updateGraceWatchInterprocessFile statusA (Some(HashSet<DirectoryVersionId>(statusA.Index.Keys))))
+                    .GetAwaiter()
+                    .GetResult()
+
+                let rebasedUnderReloadedConfig = ResizeArray<BranchId * DirectoryVersionId>()
+
+                let readStatus () = Task.FromResult(statusB)
+
+                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedUnderReloadedConfig.Add(Current().BranchId, status.RootDirectoryId) }
+
+                Watch.setUpdateMarkerWatcherRebindForWatchTests (fun () ->
+                    Current().BranchId |> should equal branchBId
+
+                    Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentAId
+                    |> should equal false
+
+                    (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentAId (Guid.NewGuid())))
+                        .GetAwaiter()
+                        .GetResult())
+
+                Watch.setSignalRSubscriptionRefreshForWatchTests (fun () -> ())
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+                Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+                recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+                rebasedUnderReloadedConfig.ToArray()
+                |> should equal Array.empty<BranchId * DirectoryVersionId>
+            finally
+                Watch.resetUpdateMarkerWatcherRebindForWatchTests ()
                 Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
     /// Verifies that a missed marker-created callback cannot leave Watch serving the previous branch indefinitely.
@@ -972,6 +1044,8 @@ module WatchTests =
             let repositoryId = Guid.NewGuid()
             let branchAId = Guid.NewGuid()
             let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let parentBId = Guid.NewGuid()
             let repositoryName = "transition-locked-old-ipc-repo"
             let branchAName = "branch-a"
             let branchBName = "branch-b"
@@ -981,6 +1055,7 @@ module WatchTests =
             Current() |> ignore
 
             Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            Watch.setSignalRBranchSubscriptionForWatchTests branchAId parentAId
 
             let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
             let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
@@ -999,8 +1074,13 @@ module WatchTests =
             Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
 
             let mutable oldIpcReader: FileStream option = Some(new FileStream(branchAIpc, FileMode.Open, FileAccess.Read, FileShare.Read))
+            let mutable refreshCalls = 0
 
             try
+                Watch.setSignalRSubscriptionRefreshForWatchTests (fun () ->
+                    refreshCalls <- refreshCalls + 1
+                    Watch.setSignalRBranchSubscriptionForWatchTests branchBId parentBId)
+
                 Watch.setRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests (fun _ ->
                     raise (IOException("test-controlled old branch IPC retirement failure")))
 
@@ -1021,6 +1101,33 @@ module WatchTests =
 
                 Watch.isGraceWatchResyncPendingForWatchTests ()
                 |> should equal true
+
+                refreshCalls |> should equal 0
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                subscription.BranchId
+                |> should equal BranchId.Empty
+
+                subscription.ParentBranchId
+                |> should equal BranchId.Empty
+
+                let rebasedStatuses = ResizeArray<DirectoryVersionId>()
+
+                let readStatus () = Task.FromResult(statusB)
+
+                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedStatuses.Add(status.RootDirectoryId) }
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentAId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentBId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                rebasedStatuses.ToArray()
+                |> should equal Array.empty<DirectoryVersionId>
 
                 readWatchStatusJsonStringProperty "BranchId"
                 |> should equal $"{branchBId}"
@@ -1052,7 +1159,8 @@ module WatchTests =
                 |> Option.iter (fun reader -> reader.Dispose())
 
                 Watch.resetRetirePreviousBranchWatchIpcForTransitionCompletionForWatchTests ()
-                Watch.resetPreviousBranchIpcDowngradeRetryProbeForWatchTests ())
+                Watch.resetPreviousBranchIpcDowngradeRetryProbeForWatchTests ()
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
     /// Verifies that transition reload clears process-wide ignore decisions after `.graceignore` changes.
     [<Test>]
@@ -1523,50 +1631,85 @@ module WatchTests =
             let repositoryId = Guid.NewGuid()
             let branchAId = Guid.NewGuid()
             let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let parentBId = Guid.NewGuid()
             let repositoryName = "transition-incoherent-repo"
             let branchAName = "branch-a"
             let branchBName = "branch-b"
 
-            writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
-            resetConfiguration ()
-            Current() |> ignore
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
 
-            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+                Watch.setSignalRBranchSubscriptionForWatchTests branchAId parentAId
 
-            let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
-            let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
+                let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+                let directoryIdsA = HashSet<DirectoryVersionId>(statusA.Index.Keys)
 
-            (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
-                .GetAwaiter()
-                .GetResult()
+                (Services.updateGraceWatchInterprocessFile statusA (Some directoryIdsA))
+                    .GetAwaiter()
+                    .GetResult()
 
-            writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
-            Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(GraceStatus.Default))
+                let mutable refreshCalls = 0
 
-            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+                Watch.setSignalRSubscriptionRefreshForWatchTests (fun () ->
+                    refreshCalls <- refreshCalls + 1
+                    Watch.setSignalRBranchSubscriptionForWatchTests branchBId parentBId)
 
-            let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
+                writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+                Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(GraceStatus.Default))
 
-            Services.IpcFileName() |> should equal branchBIpc
+                recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
 
-            branchBIpc |> File.Exists |> should equal true
+                let branchBIpc = Services.IpcFileNameForIdentity repositoryId repositoryName root branchBId branchBName
 
-            Services.getGraceWatchStatus().Result
-            |> should equal None
+                Services.IpcFileName() |> should equal branchBIpc
 
-            readWatchStatusJsonStringProperty "BranchId"
-            |> should equal $"{branchBId}"
+                branchBIpc |> File.Exists |> should equal true
 
-            readWatchStatusJsonStringProperty "BranchName"
-            |> should equal branchBName
+                Services.getGraceWatchStatus().Result
+                |> should equal None
 
-            let inspection = Services.inspectGraceWatchStatus().Result
+                refreshCalls |> should equal 0
 
-            inspection.EffectiveMode
-            |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
 
-            Watch.currentGraceWatchRuntimeModeForWatchTests ()
-            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing)
+                subscription.BranchId
+                |> should equal BranchId.Empty
+
+                subscription.ParentBranchId
+                |> should equal BranchId.Empty
+
+                let rebasedStatuses = ResizeArray<DirectoryVersionId>()
+
+                let readStatus () = Task.FromResult(GraceStatus.Default)
+
+                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedStatuses.Add(status.RootDirectoryId) }
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentBId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                rebasedStatuses.ToArray()
+                |> should equal Array.empty<DirectoryVersionId>
+
+                readWatchStatusJsonStringProperty "BranchId"
+                |> should equal $"{branchBId}"
+
+                readWatchStatusJsonStringProperty "BranchName"
+                |> should equal branchBName
+
+                let inspection = Services.inspectGraceWatchStatus().Result
+
+                inspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
     /// Verifies that startup marker completion cannot skip startup catch-up and publish healthy incremental status.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -7,6 +7,7 @@ open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Parameters.Storage
 open Grace.Shared.Utilities
+open Grace.Types.Automation
 open Grace.Types.Common
 open NodaTime
 open NUnit.Framework
@@ -506,6 +507,22 @@ module WatchTests =
         File.Delete(updateMarkerFile)
         Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
 
+    /// Builds a promotion-applied automation event targeting the supplied branch.
+    let private promotionAppliedEnvelope targetBranchId terminalReferenceId =
+        let current = Current()
+
+        let dataJson = JsonSerializer.Serialize({| targetBranchId = $"{targetBranchId}"; terminalPromotionReferenceId = $"{terminalReferenceId}" |})
+
+        AutomationEventEnvelope.Create
+            AutomationEventType.PromotionSetApplied
+            (getCurrentInstant ())
+            (generateCorrelationId ())
+            current.OwnerId
+            current.OrganizationId
+            current.RepositoryId
+            $"{targetBranchId}"
+            dataJson
+
     /// Builds renamed event test data used to exercise CLI watch behavior.
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
@@ -737,6 +754,84 @@ module WatchTests =
 
             Services.getGraceWatchStatus().Result
             |> should equal None)
+
+    /// Verifies that branch transition completion refreshes SignalR parent identity before auto-rebase events resume.
+    [<Test>]
+    let ``update marker deletion refreshes signalr parent subscription for new branch`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let parentBId = Guid.NewGuid()
+            let repositoryName = "transition-signalr-repo"
+            let branchAName = "branch-a"
+            let branchBName = "branch-b"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId branchAName
+                resetConfiguration ()
+                Current() |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+                Watch.setSignalRBranchSubscriptionForWatchTests branchAId parentAId
+
+                let statusA = graceStatusTracking Array.empty<string> Array.empty<string>
+                let statusB = graceStatusTracking Array.empty<string> Array.empty<string>
+
+                (Services.updateGraceWatchInterprocessFile statusA (Some(HashSet<DirectoryVersionId>(statusA.Index.Keys))))
+                    .GetAwaiter()
+                    .GetResult()
+
+                let refreshedSubscriptions = ResizeArray<BranchId * BranchId>()
+
+                Watch.setSignalRSubscriptionRefreshForWatchTests (fun () ->
+                    let current = Current()
+                    Watch.setSignalRBranchSubscriptionForWatchTests current.BranchId parentBId
+                    let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+                    refreshedSubscriptions.Add(subscription.BranchId, subscription.ParentBranchId))
+
+                writeRepositoryConfiguration root repositoryId repositoryName branchBId branchBName
+                Watch.setReadGraceStatusFileForTransitionCompletionForWatchTests (fun () -> Task.FromResult(statusB))
+
+                recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) DateTime.UtcNow
+
+                refreshedSubscriptions.ToArray()
+                |> should equal [| branchBId, parentBId |]
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+                subscription.BranchId |> should equal branchBId
+
+                subscription.ParentBranchId
+                |> should equal parentBId
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentAId
+                |> should equal false
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentBId
+                |> should equal true
+
+                let rebasedStatuses = ResizeArray<DirectoryVersionId>()
+
+                let readStatus () = Task.FromResult(statusB)
+
+                let rebaseCurrentBranch (status: GraceStatus) = task { rebasedStatuses.Add(status.RootDirectoryId) }
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentAId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                rebasedStatuses.ToArray()
+                |> should equal Array.empty<DirectoryVersionId>
+
+                (Watch.handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch (promotionAppliedEnvelope parentBId (Guid.NewGuid())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                rebasedStatuses.ToArray()
+                |> should equal [| statusB.RootDirectoryId |]
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
     /// Verifies that a missed marker-created callback cannot leave Watch serving the previous branch indefinitely.
     [<Test>]

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -560,27 +560,91 @@ module Watch =
     let mutable private readGraceStatusFileForTransitionCompletion = readGraceStatusFile
 
     /// Records the branch-scoped SignalR identity that Watch currently trusts for auto-rebase events.
-    type internal SignalRBranchSubscriptionState = { BranchId: BranchId; ParentBranchId: BranchId }
+    type internal SignalRBranchSubscriptionState = { BranchId: BranchId; ParentBranchId: BranchId; Generation: int64 }
 
-    let private emptySignalRBranchSubscription = { BranchId = BranchId.Empty; ParentBranchId = BranchId.Empty }
+    /// Names the branch and generation that an in-flight SignalR parent refresh is allowed to update.
+    type internal SignalRBranchSubscriptionRefreshAuthority = { BranchId: BranchId; Generation: int64 }
+
+    let private emptySignalRBranchSubscription generation = { BranchId = BranchId.Empty; ParentBranchId = BranchId.Empty; Generation = generation }
 
     let private signalRBranchSubscriptionLock = obj ()
-    let mutable private signalRBranchSubscription = emptySignalRBranchSubscription
+    let mutable private signalRBranchSubscription = emptySignalRBranchSubscription 0L
+    let mutable private signalRBranchSubscriptionRefreshNeededAfterTransition = false
     let private signalRSubscriptionRefreshLock = obj ()
     let mutable private refreshSignalRBranchSubscriptionsForTransitionCompletion = ignore
 
-    /// Replaces the watched SignalR branch identity after registration reaches the current parent branch.
-    let private setSignalRBranchSubscription branchId parentBranchId =
-        lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription <- { BranchId = branchId; ParentBranchId = parentBranchId })
+    /// Clears branch-scoped SignalR trust while preserving whether transition recovery still owes a refresh attempt.
+    let private clearSignalRBranchSubscriptionWithRefreshFlag refreshNeededAfterTransition =
+        lock signalRBranchSubscriptionLock (fun () ->
+            let generation = signalRBranchSubscription.Generation + 1L
+            signalRBranchSubscription <- emptySignalRBranchSubscription generation
+            signalRBranchSubscriptionRefreshNeededAfterTransition <- refreshNeededAfterTransition
+            generation)
+
+    /// Captures the exact branch and generation that may commit an in-flight parent refresh.
+    let private beginSignalRBranchSubscriptionRefresh () =
+        lock signalRBranchSubscriptionLock (fun () ->
+            let generation = signalRBranchSubscription.Generation + 1L
+            let currentBranchId = Current().BranchId
+            signalRBranchSubscription <- emptySignalRBranchSubscription generation
+
+            { BranchId = currentBranchId; Generation = generation })
+
+    /// Replaces the watched SignalR branch identity only if the refresh still belongs to the current branch.
+    let private trySetSignalRBranchSubscription refreshAuthority parentBranchId =
+        lock signalRBranchSubscriptionLock (fun () ->
+            let currentBranchId = Current().BranchId
+
+            if currentBranchId = refreshAuthority.BranchId
+               && signalRBranchSubscription.Generation = refreshAuthority.Generation then
+                signalRBranchSubscription <- { BranchId = refreshAuthority.BranchId; ParentBranchId = parentBranchId; Generation = refreshAuthority.Generation }
+
+                signalRBranchSubscriptionRefreshNeededAfterTransition <- false
+                true
+            else
+                false)
 
     /// Clears branch-scoped SignalR trust while Watch recalculates the current parent branch.
-    let private clearSignalRBranchSubscription () = lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription <- emptySignalRBranchSubscription)
+    let private clearSignalRBranchSubscription () =
+        clearSignalRBranchSubscriptionWithRefreshFlag false
+        |> ignore
+
+    /// Clears branch-scoped SignalR trust because transition completion invalidated the old parent.
+    let private clearSignalRBranchSubscriptionForTransition () =
+        clearSignalRBranchSubscriptionWithRefreshFlag true
+        |> ignore
+
+    /// Records that a transition parent refresh was attempted and left local parent trust empty.
+    let private completeSignalRBranchSubscriptionRefreshWithoutTrust () =
+        lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscriptionRefreshNeededAfterTransition <- false)
+
+    /// Reports whether transition recovery still owes a SignalR parent refresh attempt.
+    let private signalRBranchSubscriptionRefreshNeededForTransition () =
+        lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscriptionRefreshNeededAfterTransition)
 
     /// Reads the watched SignalR branch identity without exposing the mutable cell.
     let internal signalRBranchSubscriptionForWatchTests () = lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription)
 
     /// Replaces the watched SignalR branch identity in Watch tests without opening a HubConnection.
-    let internal setSignalRBranchSubscriptionForWatchTests branchId parentBranchId = setSignalRBranchSubscription branchId parentBranchId
+    let internal setSignalRBranchSubscriptionForWatchTests branchId parentBranchId =
+        lock signalRBranchSubscriptionLock (fun () ->
+            let generation = signalRBranchSubscription.Generation + 1L
+
+            signalRBranchSubscription <- { BranchId = branchId; ParentBranchId = parentBranchId; Generation = generation }
+
+            signalRBranchSubscriptionRefreshNeededAfterTransition <- false)
+
+    /// Begins a test-controlled SignalR parent refresh for the current branch.
+    let internal beginSignalRBranchSubscriptionRefreshForWatchTests () = beginSignalRBranchSubscriptionRefresh ()
+
+    /// Attempts to commit a test-controlled SignalR parent refresh.
+    let internal trySetSignalRBranchSubscriptionForWatchTests refreshAuthority parentBranchId = trySetSignalRBranchSubscription refreshAuthority parentBranchId
+
+    /// Clears SignalR parent trust through the same transition path used by branch switch recovery.
+    let internal clearSignalRBranchSubscriptionForTransitionForWatchTests () = clearSignalRBranchSubscriptionForTransition ()
+
+    /// Reports whether transition recovery still owes a SignalR parent refresh attempt.
+    let internal signalRBranchSubscriptionRefreshNeededForTransitionForWatchTests () = signalRBranchSubscriptionRefreshNeededForTransition ()
 
     /// Reports whether a SignalR automation event targets the parent branch Watch currently trusts.
     let internal signalRAutomationEventTargetsWatchedParentBranchForWatchTests targetBranchId =
@@ -2142,7 +2206,7 @@ module Watch =
 
     /// Publishes a target-branch non-incremental snapshot when old IPC retirement is temporarily blocked.
     let private publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc failure =
-        clearSignalRBranchSubscription ()
+        clearSignalRBranchSubscriptionForTransition ()
         let previousIpcFileName = IpcFileName()
 
         logToAnsiConsole
@@ -2164,7 +2228,7 @@ module Watch =
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
         lock watchStatusPublishLock (fun () ->
             recordGraceUpdateMarkerCompletedUtc completedUtc
-            clearSignalRBranchSubscription ()
+            clearSignalRBranchSubscriptionForTransition ()
             let previousIpcFileName = IpcFileName()
 
             let previousIpcRetired =
@@ -2230,10 +2294,11 @@ module Watch =
                                             $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
                                     with
                                     | ex ->
-                                        clearSignalRBranchSubscription ()
+                                        completeSignalRBranchSubscriptionRefreshWithoutTrust ()
 
-                                        requestGraceWatchExplicitResync
-                                            $"branch transition completion could not refresh SignalR parent subscription: {ex.Message}"
+                                        logToAnsiConsole
+                                            Colors.Error
+                                            $"Grace Watch completed branch transition but could not refresh SignalR parent subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}."
                                 else
                                     requestGraceWatchExplicitResync "branch transition completion could not verify new branch IPC publication"
                             else
@@ -2705,7 +2770,7 @@ module Watch =
     /// Registers the current repository branch with its parent-branch SignalR group and refreshes local event trust.
     let private registerCurrentSignalRParentBranch (signalRConnection: HubConnection) cancellationToken =
         task {
-            clearSignalRBranchSubscription ()
+            let refreshAuthority = beginSignalRBranchSubscriptionRefresh ()
 
             let current = Current()
 
@@ -2721,16 +2786,22 @@ module Watch =
             | Ok returnValue ->
                 let parentBranchDto = returnValue.ReturnValue
 
-                do! signalRConnection.InvokeAsync("RegisterParentBranch", current.BranchId, parentBranchDto.BranchId, cancellationToken)
-                setSignalRBranchSubscription current.BranchId parentBranchDto.BranchId
+                do! signalRConnection.InvokeAsync("RegisterParentBranch", refreshAuthority.BranchId, parentBranchDto.BranchId, cancellationToken)
 
-                logToAnsiConsole
-                    Colors.Highlighted
-                    $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {signalRConnection.ConnectionId}."
+                if trySetSignalRBranchSubscription refreshAuthority parentBranchDto.BranchId then
+                    logToAnsiConsole
+                        Colors.Highlighted
+                        $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {signalRConnection.ConnectionId}."
 
-                return Ok parentBranchDto
+                    return Ok parentBranchDto
+                else
+                    logToAnsiConsole
+                        Colors.Important
+                        $"Grace Watch ignored stale SignalR parent subscription refresh for branch {refreshAuthority.BranchId}; current branch identity changed before registration completed."
+
+                    return Ok parentBranchDto
             | Error error ->
-                clearSignalRBranchSubscription ()
+                completeSignalRBranchSubscriptionRefreshWithoutTrust ()
                 return Error error
         }
 
@@ -3541,25 +3612,20 @@ module Watch =
                                 publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
                                     updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 
-                                try
-                                    refreshSignalRSubscriptionsAfterTransitionCompletion ()
-                                with
-                                | ex ->
-                                    clearSignalRBranchSubscription ()
+                                if signalRBranchSubscriptionRefreshNeededForTransition () then
+                                    try
+                                        refreshSignalRSubscriptionsAfterTransitionCompletion ()
+                                    with
+                                    | ex ->
+                                        completeSignalRBranchSubscriptionRefreshWithoutTrust ()
 
-                                    requestGraceWatchExplicitResync $"resync recovery could not refresh SignalR parent subscription: {ex.Message}"
+                                        logToAnsiConsole
+                                            Colors.Error
+                                            $"Grace Watch resync recovered local status but could not refresh SignalR parent subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}."
 
-                                if
-                                    currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
-                                    && not (isGraceWatchResyncPending ())
-                                then
-                                    logToAnsiConsole
-                                        Colors.Important
-                                        $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
-                                else
-                                    logToAnsiConsole
-                                        Colors.Important
-                                        $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences, but parent subscription refresh kept resync pending."
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
                             else
                                 setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
 
@@ -3958,12 +4024,15 @@ module Watch =
                                     with
                                 | Ok _ -> ()
                                 | Error error ->
-                                    requestGraceWatchExplicitResync "branch transition completion could not refresh SignalR parent subscription"
+                                    completeSignalRBranchSubscriptionRefreshWithoutTrust ()
                                     logToAnsiConsole Colors.Error $"Failed to refresh SignalR parent branch subscription: {Markup.Escape(error.ToString())}"
                             with
                             | ex ->
-                                clearSignalRBranchSubscription ()
-                                requestGraceWatchExplicitResync $"branch transition completion could not refresh SignalR parent subscription: {ex.Message}")
+                                completeSignalRBranchSubscriptionRefreshWithoutTrust ()
+
+                                logToAnsiConsole
+                                    Colors.Error
+                                    $"Failed to refresh SignalR parent branch subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}.")
 
                     use notifyRepository =
                         signalRConnection.On<RepositoryId, ReferenceId>(

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -589,6 +589,22 @@ module Watch =
             && signalRBranchSubscription.ParentBranchId
                <> BranchId.Empty)
 
+    /// Returns the current branch-scoped SignalR trust snapshot when the event targets the watched parent.
+    let private signalRBranchSubscriptionForWatchedParentBranch targetBranchId =
+        lock signalRBranchSubscriptionLock (fun () ->
+            if signalRBranchSubscription.ParentBranchId = targetBranchId
+               && signalRBranchSubscription.BranchId
+                  <> BranchId.Empty
+               && signalRBranchSubscription.ParentBranchId
+                  <> BranchId.Empty then
+                Some signalRBranchSubscription
+            else
+                Option.None)
+
+    /// Reports whether the SignalR trust snapshot still belongs to the branch about to mutate its working tree.
+    let private signalRBranchSubscriptionStillTrusted trustedSubscription =
+        lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription = trustedSubscription)
+
     /// Installs the active SignalR parent-branch refresh operation used after branch identity changes.
     let private registerSignalRSubscriptionRefresh refresh =
         lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- refresh)
@@ -2637,36 +2653,47 @@ module Watch =
         with
         | _ -> Option.None
 
-    /// Reports whether an automation envelope is a parent-branch promotion for the current Watch subscription.
-    let private automationEventTargetsWatchedParentBranch (envelope: AutomationEventEnvelope) =
+    /// Returns a trusted SignalR branch snapshot only for promotion events targeting the watched parent.
+    let private trustedSignalRBranchSubscriptionForAutomationEvent (envelope: AutomationEventEnvelope) =
         if envelope.EventType = AutomationEventType.PromotionSetApplied then
             let targetBranchId =
                 tryParseAutomationEventGuidProperty "targetBranchId" envelope.DataJson
                 |> Option.defaultValue BranchId.Empty
 
-            signalRAutomationEventTargetsWatchedParentBranchForWatchTests targetBranchId
+            signalRBranchSubscriptionForWatchedParentBranch targetBranchId
         else
-            false
+            Option.None
 
     /// Handles SignalR automation events that can drive Watch auto-rebase.
     let private handleSignalRAutomationEvent readStatus rebaseCurrentBranch (envelope: AutomationEventEnvelope) =
         task {
             try
-                if automationEventTargetsWatchedParentBranch envelope then
+                match trustedSignalRBranchSubscriptionForAutomationEvent envelope with
+                | Some trustedSubscription ->
                     let terminalReferenceId =
                         tryParseAutomationEventGuidProperty "terminalPromotionReferenceId" envelope.DataJson
                         |> Option.defaultValue ReferenceId.Empty
 
-                    let watchedParentBranchId =
-                        (signalRBranchSubscriptionForWatchTests ())
-                            .ParentBranchId
-
                     logToAnsiConsole
                         Colors.Highlighted
-                        $"Parent branch {watchedParentBranchId} received terminal promotion {terminalReferenceId}; starting auto-rebase."
+                        $"Parent branch {trustedSubscription.ParentBranchId} received terminal promotion {terminalReferenceId}; evaluating auto-rebase."
 
                     let! currentStatus = readStatus ()
-                    do! rebaseCurrentBranch currentStatus
+
+                    let currentBranchId = Current().BranchId
+
+                    if currentBranchId = trustedSubscription.BranchId
+                       && signalRBranchSubscriptionStillTrusted trustedSubscription then
+                        logToAnsiConsole
+                            Colors.Highlighted
+                            $"Parent branch {trustedSubscription.ParentBranchId} still matches branch {trustedSubscription.BranchId}; starting auto-rebase."
+
+                        do! rebaseCurrentBranch currentStatus
+                    else
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Skipped auto-rebase for parent branch {trustedSubscription.ParentBranchId} because Watch branch identity changed before rebase."
+                | None -> ()
             with
             | ex -> logToAnsiConsole Colors.Error $"Failed to process automation event payload for {envelope.EventType}: {Markup.Escape(ex.Message)}."
         }
@@ -3514,9 +3541,25 @@ module Watch =
                                 publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
                                     updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 
-                                logToAnsiConsole
-                                    Colors.Important
-                                    $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                                try
+                                    refreshSignalRSubscriptionsAfterTransitionCompletion ()
+                                with
+                                | ex ->
+                                    clearSignalRBranchSubscription ()
+
+                                    requestGraceWatchExplicitResync $"resync recovery could not refresh SignalR parent subscription: {ex.Message}"
+
+                                if
+                                    currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+                                    && not (isGraceWatchResyncPending ())
+                                then
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                                else
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences, but parent subscription refresh kept resync pending."
                             else
                                 setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2126,6 +2126,7 @@ module Watch =
 
     /// Publishes a target-branch non-incremental snapshot when old IPC retirement is temporarily blocked.
     let private publishNonIncrementalTransitionCompletionAfterRetireFailure completedUtc failure =
+        clearSignalRBranchSubscription ()
         let previousIpcFileName = IpcFileName()
 
         logToAnsiConsole
@@ -2147,6 +2148,7 @@ module Watch =
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
         lock watchStatusPublishLock (fun () ->
             recordGraceUpdateMarkerCompletedUtc completedUtc
+            clearSignalRBranchSubscription ()
             let previousIpcFileName = IpcFileName()
 
             let previousIpcRetired =
@@ -2169,7 +2171,6 @@ module Watch =
                     try
                         reloadConfigurationForTransitionCompletion ()
                         rebindUpdateMarkerWatcherAfterTransitionCompletion ()
-                        refreshSignalRSubscriptionsAfterTransitionCompletion ()
                         true
                     with
                     | ex ->
@@ -2205,9 +2206,18 @@ module Watch =
                                         updateGraceWatchInterprocessFile graceStatus (Some graceStatusDirectoryIds))
 
                                 if transitionPublicationVerified then
-                                    logToAnsiConsole
-                                        Colors.Important
-                                        $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                                    try
+                                        refreshSignalRSubscriptionsAfterTransitionCompletion ()
+
+                                        logToAnsiConsole
+                                            Colors.Important
+                                            $"Grace Watch completed branch transition from marker deletion at {completedUtc:O}; incremental observations may resume for {Current().BranchName}."
+                                    with
+                                    | ex ->
+                                        clearSignalRBranchSubscription ()
+
+                                        requestGraceWatchExplicitResync
+                                            $"branch transition completion could not refresh SignalR parent subscription: {ex.Message}"
                                 else
                                     requestGraceWatchExplicitResync "branch transition completion could not verify new branch IPC publication"
                             else

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -559,6 +559,58 @@ module Watch =
     let mutable private readGraceStatusFileForPendingWorkTransition = readGraceStatusFile
     let mutable private readGraceStatusFileForTransitionCompletion = readGraceStatusFile
 
+    /// Records the branch-scoped SignalR identity that Watch currently trusts for auto-rebase events.
+    type internal SignalRBranchSubscriptionState = { BranchId: BranchId; ParentBranchId: BranchId }
+
+    let private emptySignalRBranchSubscription = { BranchId = BranchId.Empty; ParentBranchId = BranchId.Empty }
+
+    let private signalRBranchSubscriptionLock = obj ()
+    let mutable private signalRBranchSubscription = emptySignalRBranchSubscription
+    let private signalRSubscriptionRefreshLock = obj ()
+    let mutable private refreshSignalRBranchSubscriptionsForTransitionCompletion = ignore
+
+    /// Replaces the watched SignalR branch identity after registration reaches the current parent branch.
+    let private setSignalRBranchSubscription branchId parentBranchId =
+        lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription <- { BranchId = branchId; ParentBranchId = parentBranchId })
+
+    /// Clears branch-scoped SignalR trust while Watch recalculates the current parent branch.
+    let private clearSignalRBranchSubscription () = lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription <- emptySignalRBranchSubscription)
+
+    /// Reads the watched SignalR branch identity without exposing the mutable cell.
+    let internal signalRBranchSubscriptionForWatchTests () = lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription)
+
+    /// Replaces the watched SignalR branch identity in Watch tests without opening a HubConnection.
+    let internal setSignalRBranchSubscriptionForWatchTests branchId parentBranchId = setSignalRBranchSubscription branchId parentBranchId
+
+    /// Reports whether a SignalR automation event targets the parent branch Watch currently trusts.
+    let internal signalRAutomationEventTargetsWatchedParentBranchForWatchTests targetBranchId =
+        lock signalRBranchSubscriptionLock (fun () ->
+            signalRBranchSubscription.ParentBranchId = targetBranchId
+            && signalRBranchSubscription.ParentBranchId
+               <> BranchId.Empty)
+
+    /// Installs the active SignalR parent-branch refresh operation used after branch identity changes.
+    let private registerSignalRSubscriptionRefresh refresh =
+        lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- refresh)
+
+        { new IDisposable with
+            member _.Dispose() = lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- ignore)
+        }
+
+    /// Runs the current SignalR subscription refresh after transition identity reloads.
+    let private refreshSignalRSubscriptionsAfterTransitionCompletion () =
+        let refresh = lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion)
+        refresh ()
+
+    /// Installs the SignalR parent-branch refresh operation used by transition-completion tests.
+    let internal setSignalRSubscriptionRefreshForWatchTests refresh =
+        lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- refresh)
+
+    /// Restores SignalR subscription refresh state after transition-completion tests.
+    let internal resetSignalRSubscriptionRefreshForWatchTests () =
+        lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- ignore)
+        clearSignalRBranchSubscription ()
+
     let private updateMarkerWatcherRebindLock = obj ()
     let mutable private rebindUpdateMarkerWatcherForTransitionCompletion = ignore
     let private branchTransitionCompletionProbeLock = obj ()
@@ -2117,6 +2169,7 @@ module Watch =
                     try
                         reloadConfigurationForTransitionCompletion ()
                         rebindUpdateMarkerWatcherAfterTransitionCompletion ()
+                        refreshSignalRSubscriptionsAfterTransitionCompletion ()
                         true
                     with
                     | ex ->
@@ -2269,6 +2322,7 @@ module Watch =
         readGraceStatusFileForTransitionCompletion <- readGraceStatusFile
         clearShouldIgnoreCache ()
         resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
+        resetSignalRSubscriptionRefreshForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
         clearGraceUpdateMarkerDeletedUtcForReset ()
@@ -2549,6 +2603,99 @@ module Watch =
                             })
             )
             .Build()
+
+    /// Reads a GUID-valued property from a SignalR automation event payload without throwing on unsupported input.
+    let private tryParseAutomationEventGuidProperty (propertyName: string) (dataJson: string) =
+        try
+            use document = JsonDocument.Parse(dataJson)
+            let root = document.RootElement
+            let mutable propertyValue = Unchecked.defaultof<JsonElement>
+
+            if root.TryGetProperty(propertyName, &propertyValue) then
+                let propertyText = propertyValue.GetString()
+                let mutable parsedGuid = Guid.Empty
+
+                if
+                    String.IsNullOrWhiteSpace propertyText |> not
+                    && Guid.TryParse(propertyText, &parsedGuid)
+                then
+                    Some parsedGuid
+                else
+                    Option.None
+            else
+                Option.None
+        with
+        | _ -> Option.None
+
+    /// Reports whether an automation envelope is a parent-branch promotion for the current Watch subscription.
+    let private automationEventTargetsWatchedParentBranch (envelope: AutomationEventEnvelope) =
+        if envelope.EventType = AutomationEventType.PromotionSetApplied then
+            let targetBranchId =
+                tryParseAutomationEventGuidProperty "targetBranchId" envelope.DataJson
+                |> Option.defaultValue BranchId.Empty
+
+            signalRAutomationEventTargetsWatchedParentBranchForWatchTests targetBranchId
+        else
+            false
+
+    /// Handles SignalR automation events that can drive Watch auto-rebase.
+    let private handleSignalRAutomationEvent readStatus rebaseCurrentBranch (envelope: AutomationEventEnvelope) =
+        task {
+            try
+                if automationEventTargetsWatchedParentBranch envelope then
+                    let terminalReferenceId =
+                        tryParseAutomationEventGuidProperty "terminalPromotionReferenceId" envelope.DataJson
+                        |> Option.defaultValue ReferenceId.Empty
+
+                    let watchedParentBranchId =
+                        (signalRBranchSubscriptionForWatchTests ())
+                            .ParentBranchId
+
+                    logToAnsiConsole
+                        Colors.Highlighted
+                        $"Parent branch {watchedParentBranchId} received terminal promotion {terminalReferenceId}; starting auto-rebase."
+
+                    let! currentStatus = readStatus ()
+                    do! rebaseCurrentBranch currentStatus
+            with
+            | ex -> logToAnsiConsole Colors.Error $"Failed to process automation event payload for {envelope.EventType}: {Markup.Escape(ex.Message)}."
+        }
+
+    /// Exposes the SignalR automation-event path to Watch tests without opening a HubConnection.
+    let internal handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch envelope =
+        handleSignalRAutomationEvent readStatus rebaseCurrentBranch envelope
+
+    /// Registers the current repository branch with its parent-branch SignalR group and refreshes local event trust.
+    let private registerCurrentSignalRParentBranch (signalRConnection: HubConnection) cancellationToken =
+        task {
+            clearSignalRBranchSubscription ()
+
+            let current = Current()
+
+            let branchGetParameters =
+                GetBranchParameters(
+                    OwnerId = $"{current.OwnerId}",
+                    OrganizationId = $"{current.OrganizationId}",
+                    RepositoryId = $"{current.RepositoryId}",
+                    BranchId = $"{current.BranchId}"
+                )
+
+            match! Branch.GetParentBranch branchGetParameters with
+            | Ok returnValue ->
+                let parentBranchDto = returnValue.ReturnValue
+
+                do! signalRConnection.InvokeAsync("RegisterParentBranch", current.BranchId, parentBranchDto.BranchId, cancellationToken)
+                setSignalRBranchSubscription current.BranchId parentBranchDto.BranchId
+
+                logToAnsiConsole
+                    Colors.Highlighted
+                    $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {signalRConnection.ConnectionId}."
+
+                return Ok parentBranchDto
+            | Error error ->
+                clearSignalRBranchSubscription ()
+                return Error error
+        }
 
     /// Evaluates is grace status artifact against parsed options and command state.
     let private isGraceStatusArtifact (fullPath: string) =
@@ -3749,7 +3896,21 @@ module Watch =
 
                     use signalRConnection = createSignalRConnection signalRUrl
 
-                    let mutable watchedParentBranchId = BranchId.Empty
+                    use refreshSignalRSubscriptions =
+                        registerSignalRSubscriptionRefresh (fun () ->
+                            try
+                                match (registerCurrentSignalRParentBranch signalRConnection cancellationToken)
+                                    .GetAwaiter()
+                                    .GetResult()
+                                    with
+                                | Ok _ -> ()
+                                | Error error ->
+                                    requestGraceWatchExplicitResync "branch transition completion could not refresh SignalR parent subscription"
+                                    logToAnsiConsole Colors.Error $"Failed to refresh SignalR parent branch subscription: {Markup.Escape(error.ToString())}"
+                            with
+                            | ex ->
+                                clearSignalRBranchSubscription ()
+                                requestGraceWatchExplicitResync $"branch transition completion could not refresh SignalR parent subscription: {ex.Message}")
 
                     use notifyRepository =
                         signalRConnection.On<RepositoryId, ReferenceId>(
@@ -3768,53 +3929,14 @@ module Watch =
                         signalRConnection.On<AutomationEventEnvelope>(
                             "NotifyAutomationEvent",
                             fun envelope ->
-                                (task {
-                                    if envelope.EventType = AutomationEventType.PromotionSetApplied then
-                                        try
-                                            use document = JsonDocument.Parse(envelope.DataJson)
-                                            let root = document.RootElement
-
-                                            /// Tries to map parse guid property and returns a GraceError instead of throwing on unsupported input.
-                                            let tryParseGuidProperty (propertyName: string) : Guid option =
-                                                let mutable propertyValue = Unchecked.defaultof<JsonElement>
-
-                                                if root.TryGetProperty(propertyName, &propertyValue) then
-                                                    let propertyText = propertyValue.GetString()
-                                                    let mutable parsedGuid = Guid.Empty
-
-                                                    if
-                                                        String.IsNullOrWhiteSpace propertyText |> not
-                                                        && Guid.TryParse(propertyText, &parsedGuid)
-                                                    then
-                                                        Some parsedGuid
-                                                    else
-                                                        Option.None
-                                                else
-                                                    Option.None
-
-                                            let targetBranchId =
-                                                tryParseGuidProperty "targetBranchId"
-                                                |> Option.defaultValue BranchId.Empty
-
-                                            let terminalReferenceId =
-                                                tryParseGuidProperty "terminalPromotionReferenceId"
-                                                |> Option.defaultValue ReferenceId.Empty
-
-                                            if watchedParentBranchId = targetBranchId
-                                               && watchedParentBranchId <> BranchId.Empty then
-                                                logToAnsiConsole
-                                                    Colors.Highlighted
-                                                    $"Parent branch {watchedParentBranchId} received terminal promotion {terminalReferenceId}; starting auto-rebase."
-
-                                                let! currentStatus = readGraceStatusFile ()
-                                                let! _ = Branch.rebaseHandler (parseResult |> getNormalizedIdsAndNames) currentStatus
-                                                ()
-                                        with
-                                        | ex ->
-                                            logToAnsiConsole
-                                                Colors.Error
-                                                $"Failed to process automation event payload for {envelope.EventType}: {Markup.Escape(ex.Message)}."
-                                })
+                                (handleSignalRAutomationEvent
+                                    readGraceStatusFile
+                                    (fun currentStatus ->
+                                        task {
+                                            let! _ = Branch.rebaseHandler (parseResult |> getNormalizedIdsAndNames) currentStatus
+                                            ()
+                                        })
+                                    envelope)
                                 :> Task
                         )
 
@@ -3862,31 +3984,15 @@ module Watch =
                         task { logToAnsiConsole Colors.Important $"SignalR connection reconnected: {connectionId}." })
 
                     do! signalRConnection.StartAsync(cancellationToken)
+                    // Repository-wide notifications are keyed only by RepositoryId, so same-process branch switches do not change this group.
                     do! signalRConnection.InvokeAsync("RegisterRepository", Current().RepositoryId, cancellationToken)
 
                     logToAnsiConsole
                         Colors.Highlighted
                         $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in repository {Current().RepositoryName} ({Current().RepositoryId}); connectionId: {signalRConnection.ConnectionId}."
 
-                    // Get the parent BranchId so we can tell SignalR what to notify us about.
-                    let branchGetParameters =
-                        GetBranchParameters(
-                            OwnerId = $"{Current().OwnerId}",
-                            OrganizationId = $"{Current().OrganizationId}",
-                            RepositoryId = $"{Current().RepositoryId}",
-                            BranchId = $"{Current().BranchId}"
-                        )
-
-                    match! Branch.GetParentBranch branchGetParameters with
-                    | Ok returnValue ->
-                        let parentBranchDto = returnValue.ReturnValue
-                        watchedParentBranchId <- parentBranchDto.BranchId
-
-                        do! signalRConnection.InvokeAsync("RegisterParentBranch", Current().BranchId, parentBranchDto.BranchId, cancellationToken)
-
-                        logToAnsiConsole
-                            Colors.Highlighted
-                            $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {signalRConnection.ConnectionId}."
+                    match! registerCurrentSignalRParentBranch signalRConnection cancellationToken with
+                    | Ok _ -> ()
                     | Error error ->
                         logToAnsiConsole Colors.Error $"Failed to retrieve branch metadata. Cannot connect to SignalR Hub."
 


### PR DESCRIPTION
## Summary

- Refresh Watch's branch-scoped SignalR parent subscription after same-process branch transition completion.
- Clear stale parent-branch trust, recalculate the new branch parent, and re-register `RegisterParentBranch` before
  allowing parent-promotion events to trigger auto-rebase.
- Document the transition-boundary decision in ADR 0009.

## Related Issue

Related to #496. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This completes WS5's transition-boundary safety model for `grace watch`. After Watch adopts a new branch identity, it
must not keep making auto-rebase decisions from the old branch's parent subscription. Refreshing this state at the same
boundary that reloads Watch identity keeps branch-switch follow-up behavior aligned with the branch Grace now owns.

## Validation

- `dotnet tool run fantomas src\Grace.CLI\Command\Watch.CLI.fs src\Grace.CLI.Tests\Watch.Tests.fs`: passed after the
  final code edit.
- `npx --yes markdownlint-cli2 "docs/adr/0009-refresh-watch-signalr-subscriptions-at-branch-transition.md"`: passed.
- `dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~WatchTests"`:
  passed, 210 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- Worker bot-prevention self-review completed over the final diff.

## Docs Impact

Added ADR 0009 at `docs/adr/0009-refresh-watch-signalr-subscriptions-at-branch-transition.md` documenting:

- why transition completion owns the SignalR refresh;
- why repository-wide SignalR registration is branch-independent under the current server contract;
- why additive server group membership is acceptable for WS5.5;
- which remote materialization and durable-journal concerns remain outside WS5.

## Review Status

- Current head: `685c45a0059f58a714d1558064674c322faeaf19`.
- GitHub checks: `full:COMPLETED:SUCCESS` for `685c45a0`, completed 2026-07-04T18:58:16Z.
- Codex Code Review Bot current-head gate: thumbs-up no-issues reaction on `685c45a0`; no current-head review threads
  or unresolved conversations.
- Stabilization ledger:
  - PR ledger: [#4883429667](https://github.com/ScottArbeit/Grace/pull/541#issuecomment-4883429667)
  - Issue ledger: [#4883429714](https://github.com/ScottArbeit/Grace/issues/496#issuecomment-4883429714)
- Latest completed Codex Code Review Bot review with findings: review `4630096558`, submitted
  2026-07-04T18:38:51Z on prior head `02ab6a93dd32753413b6fc4fd756fc24054da22e`.
- Fresh findings from `4630096558` fixed by `685c45a0059f58a714d1558064674c322faeaf19`:
  - `r3523681891`: stale async SignalR refresh completions now cannot restore old branch parent trust after a newer
    transition wins. Reply/resolution:
    [discussion_r3523702406](https://github.com/ScottArbeit/Grace/pull/541#discussion_r3523702406).
  - `r3523681895`: unrelated resync recovery no longer depends on SignalR refresh success. Reply/resolution:
    [discussion_r3523702446](https://github.com/ScottArbeit/Grace/pull/541#discussion_r3523702446).
- Worker Godel validation for `685c45a0`: targeted Fantomas passed; focused Watch tests passed 215/215; ADR
  MarkdownLint passed; `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed; bot-prevention
  self-review passed.
- Manual trigger: not attempted. Codex acknowledged and completed review automatically.
- Review cycle note: the high-risk repeated-review threshold triggered a stabilization ledger. The current head maps the
  ledger's versioned SignalR parent-trust model to code, tests, ADR, and validation evidence.
- Prevention line: #496 now models SignalR parent trust as versioned authority tied to current branch identity,
  transition-only refresh debt, async refresh completion, nonfatal refresh failure, and event-time recheck. Stale refresh
  completions cannot commit, unrelated resync is not blocked by SignalR availability, and auto-rebase still requires
  current branch/parent trust immediately before rebasing.

### Ledger Status Map

- Versioned commit authority: implemented and proven.
  Code seam: `SignalRBranchSubscriptionState.Generation`, `beginSignalRBranchSubscriptionRefresh`, and
  `trySetSignalRBranchSubscription`.
  Proof seam: `stale signalr parent refresh completion cannot restore old branch trust`; GitHub `full`; Codex thumbs-up.
  Residual risk: none identified.
- Trust lifecycle: implemented and proven.
  Code seam: `signalRBranchSubscriptionRefreshNeededAfterTransition`, `clearSignalRBranchSubscriptionForTransition`,
  and ordinary `clearSignalRBranchSubscription`.
  Proof seam: `unrelated resync recovery does not invoke signalr transition refresh` and
  `transition resync recovery tolerates signalr refresh failure with empty trust`; GitHub `full`; Codex thumbs-up.
  Residual risk: none identified.
- Recovery-to-healthy behavior: implemented and proven.
  Code seam: `processChangedFilesWithClients` attempts transition refresh only when transition-cleared trust owes it and
  leaves local recovery healthy on refresh failure.
  Proof seam: existing transition success tests plus new transition refresh failure test; GitHub `full`; Codex thumbs-up.
  Residual risk: parent-triggered auto-rebase remains intentionally disabled when refresh fails.
- Auto-rebase authority: implemented and proven.
  Code seam: `trustedSignalRBranchSubscriptionForAutomationEvent`, `signalRBranchSubscriptionStillTrusted`, and
  `Current().BranchId` recheck before `rebaseCurrentBranch`.
  Proof seam: existing branch-identity recheck test plus stale refresh trust test; GitHub `full`; Codex thumbs-up.
  Residual risk: none identified.
- Nonfatal SignalR failure policy: implemented and proven.
  Code seam: `completeSignalRBranchSubscriptionRefreshWithoutTrust`, transition completion catch paths, and registered
  refresh callback failure paths.
  Proof seam: transition refresh failure and unrelated resync recovery tests; GitHub `full`; Codex thumbs-up.
  Residual risk: none identified.
- Proof/docs alignment: implemented and proven.
  Code seam: ADR 0009 documents versioned refresh, transition-only refresh debt, empty trust on refresh failure, and
  ordinary resync independence.
  Proof seam: ADR MarkdownLint, focused Watch tests, `validate -Fast`, GitHub `full`, and Codex thumbs-up.
  Residual risk: none identified.
- Remote sync materialization, durable journal authority, and new force/wait/flush behavior remain outside WS5.5:
  not applicable, with reason.
  Code seam: no edits to those surfaces.
  Proof seam: diff scoped to Watch CLI/tests and ADR.
  Residual risk: none identified.

## Residual Risks

- If a future server contract makes repository-wide SignalR registration branch-sensitive, ADR 0009 says that contract
  must add a refresh obligation at the same transition boundary.
- Remote sync materialization and durable journal authority remain outside WS5.5.
