### PR TITLE
WS4.1: Add local watch journal schema scaffold

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2594,7 +2594,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 4"
+                |> should contain "schema_version is 5"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2731,7 +2731,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 4"
+                        |> should contain "schema_version is 5"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2779,6 +2779,50 @@ module DoctorCliTests =
 
                 snapshotFiles root |> should equal beforeRoot))
 
+    /// Verifies that doctor reports meta tables that cannot preserve one row per key without repairing local state.
+    [<Test>]
+    let ``doctor local-state reports malformed meta key uniqueness`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "malformed"
+
+                snapshotFiles root |> should equal beforeRoot))
+
     /// Verifies that doctor reports stale Watch journal allocation without repairing local state.
     [<Test>]
     let ``doctor local-state reports stale watch journal allocation with rows`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2823,6 +2823,57 @@ module DoctorCliTests =
 
                 snapshotFiles root |> should equal beforeRoot))
 
+    /// Verifies that doctor reports meta tables whose hidden constraints would ignore default Watch metadata writes.
+    [<Test>]
+    let ``doctor local-state reports constrained meta default insert shape`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "ALTER TABLE meta RENAME TO meta_valid;"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL, required_marker TEXT NOT NULL CHECK (required_marker = 'seeded'));"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO meta (key, value, required_marker) SELECT key, value, 'seeded' FROM meta_valid WHERE key <> 'AppliedThroughSequence';"
+
+                    executeNonQuery connection "DROP TABLE meta_valid;"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "malformed"
+
+                snapshotFiles root |> should equal beforeRoot))
+
     /// Verifies that doctor reports stale Watch journal allocation without repairing local state.
     [<Test>]
     let ``doctor local-state reports stale watch journal allocation with rows`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -435,6 +435,7 @@ module DoctorCliTests =
             "state.db.required-indexes"
             "state.db.integrity-check"
             "state.db.foreign-key-check"
+            "state.db.watch-journal"
             "object-cache.index-readable"
         |]
 
@@ -535,12 +536,12 @@ module DoctorCliTests =
             |> should equal "Ok"
 
             returnValue.GetProperty("Checks").GetArrayLength()
-            |> should equal 27
+            |> should equal 28
 
             returnValue
                 .GetProperty("Catalog")
                 .GetArrayLength()
-            |> should equal 27
+            |> should equal 28
 
             let catalogIds =
                 returnValue
@@ -581,6 +582,9 @@ module DoctorCliTests =
 
             catalogIds
             |> should contain "state.db.foreign-key-check"
+
+            catalogIds
+            |> should contain "state.db.watch-journal"
 
             catalogIds
             |> should contain "object-cache.index-readable"
@@ -642,7 +646,7 @@ module DoctorCliTests =
                         |> Seq.map (fun check -> check.GetProperty("Id").GetString())
                         |> Set.ofSeq
 
-                    catalogIds.Count |> should equal 27
+                    catalogIds.Count |> should equal 28
 
                     catalogIds |> should contain "config.file.parse"
 
@@ -663,6 +667,9 @@ module DoctorCliTests =
 
                     catalogIds
                     |> should contain "state.db.file-present"
+
+                    catalogIds
+                    |> should contain "state.db.watch-journal"
 
                     catalogIds
                     |> should contain "object-cache.index-readable"
@@ -2600,6 +2607,90 @@ module DoctorCliTests =
                     .GetProperty("Summary")
                     .GetString()
                 |> should contain "without mutation"))
+
+    /// Verifies that doctor reports malformed Watch journal table shape without repairing local state.
+    [<Test>]
+    let ``doctor local-state reports malformed watch journal shape`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "DROP TABLE watch_journal;"
+                    executeNonQuery connection "CREATE TABLE watch_journal (sequence INTEGER PRIMARY KEY, created_at_unix_ticks INTEGER NOT NULL);"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "Watch journal table shape is invalid"
+
+                snapshotFiles root |> should equal beforeRoot))
+
+    /// Verifies that doctor reports missing Watch recovery metadata when journal rows exist.
+    [<Test>]
+    let ``doctor local-state reports missing watch journal metadata with rows`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (1, 1);"
+                    executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "applied-through metadata is missing"
+
+                snapshotFiles root |> should equal beforeRoot))
 
     /// Verifies that doctor missing local state parent reports check result without creating files.
     [<Test>]

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2692,6 +2692,48 @@ module DoctorCliTests =
 
                 snapshotFiles root |> should equal beforeRoot))
 
+    /// Verifies that doctor reports malformed Watch journal allocation without repairing local state.
+    [<Test>]
+    let ``doctor local-state reports malformed watch journal allocation without rows`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
+                    executeNonQuery connection "INSERT INTO sqlite_sequence (name, seq) VALUES ('watch_journal', 'not-a-number');"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "malformed"
+
+                snapshotFiles root |> should equal beforeRoot))
+
     /// Verifies that doctor reports stale Watch journal allocation without repairing local state.
     [<Test>]
     let ``doctor local-state reports stale watch journal allocation with rows`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2692,6 +2692,49 @@ module DoctorCliTests =
 
                 snapshotFiles root |> should equal beforeRoot))
 
+    /// Verifies that doctor reports stale Watch journal allocation without repairing local state.
+    [<Test>]
+    let ``doctor local-state reports stale watch journal allocation with rows`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (1, 1);"
+                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (2, 2);"
+                    executeNonQuery connection "UPDATE sqlite_sequence SET seq = 1 WHERE name = 'watch_journal';"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "applied-through metadata is missing"
+
+                snapshotFiles root |> should equal beforeRoot))
+
     /// Verifies that doctor missing local state parent reports check result without creating files.
     [<Test>]
     let ``doctor missing local-state parent reports check result without creating files`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2734,6 +2734,51 @@ module DoctorCliTests =
 
                 snapshotFiles root |> should equal beforeRoot))
 
+    /// Verifies that doctor reports duplicate Watch recovery metadata without repairing local state.
+    [<Test>]
+    let ``doctor local-state reports duplicate watch journal metadata`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                ensureValidLocalStateDb root
+
+                let dbPath = localStateDbPath root
+
+                do
+                    use connection = openRawConnection dbPath
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '1');"
+
+                let beforeRoot = snapshotFiles root
+
+                /// Verifies that the CLI doctor scenario exits with the expected process status.
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "doctor"
+                                                      "--check"
+                                                      "state.db.watch-journal" |]
+
+                exitCode |> should equal 1
+
+                use document = assertCleanJsonOutput standardOut standardError
+
+                let check =
+                    document
+                        .RootElement
+                        .GetProperty("ReturnValue")
+                        .GetProperty("Checks")[0]
+
+                check.GetProperty("Status").GetString()
+                |> should equal "Failed"
+
+                check.GetProperty("Summary").GetString()
+                |> should contain "malformed"
+
+                snapshotFiles root |> should equal beforeRoot))
+
     /// Verifies that doctor reports stale Watch journal allocation without repairing local state.
     [<Test>]
     let ``doctor local-state reports stale watch journal allocation with rows`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -243,7 +243,13 @@ module LocalStateDbTests =
             "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
 
         executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
-        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '4');"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL);"
+
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '5');"
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
         executeNonQuery
             connection
@@ -331,11 +337,66 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
                 statusMetaCount |> should equal 1
+            })
+
+    /// Verifies that initializes watch journal schema and applied through metadata.
+    [<Test>]
+    let ``initializes watch journal schema and applied through metadata`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                let journalTableCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
+
+                journalTableCount |> should equal 1
+
+                let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
+
+                let sequenceType = executeScalarString connection "SELECT UPPER(type) FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
+
+                sequencePk |> should equal 1
+                sequenceType |> should equal "INTEGER"
+
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                appliedThrough |> should equal "0"
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 0L
+            })
+
+    /// Verifies that watch journal retention keeps unapplied rows and a bounded applied tail.
+    [<Test>]
+    let ``watch journal retention keeps unapplied rows and bounded applied tail`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                for sequence in 1L .. 1030L do
+                    executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});"
+
+                do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 1026L
+                do! LocalStateDb.pruneWatchJournalRetention configuration.GraceStatusFile
+
+                let minSequence = executeScalarInt64 connection "SELECT MIN(sequence) FROM watch_journal;"
+                let maxSequence = executeScalarInt64 connection "SELECT MAX(sequence) FROM watch_journal;"
+                let rowCount = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                minSequence |> should equal 3L
+                maxSequence |> should equal 1030L
+                rowCount |> should equal 1028
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 1026L
             })
 
     /// Verifies that round trips status snapshot.
@@ -604,7 +665,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -632,7 +693,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -687,7 +748,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "4")
+                |> should equal (Some "5")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -732,7 +793,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "4")
+                |> should equal (Some "5")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -910,6 +971,7 @@ module LocalStateDbTests =
                         "index:ix_object_cache_children_parent"
                         "table:object_cache_directory_files"
                         "index:ix_object_cache_files_path_hash"
+                        "table:watch_journal"
                     |]
 
                 expected
@@ -926,7 +988,9 @@ module LocalStateDbTests =
                 use connection1 = openRawConnection configuration.GraceStatusFile
                 let createdAt1 = executeScalarInt64 connection1 "SELECT CAST(value AS INTEGER) FROM meta WHERE key = 'created_at_unix_ticks';"
                 let statusMetaCount1 = executeScalarInt connection1 "SELECT COUNT(*) FROM status_meta;"
+                let appliedThrough1 = executeScalarString connection1 "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 statusMetaCount1 |> should equal 1
+                appliedThrough1 |> should equal "0"
 
                 do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
 
@@ -935,7 +999,9 @@ module LocalStateDbTests =
                 createdAt2 |> should equal createdAt1
 
                 let statusMetaCount2 = executeScalarInt connection2 "SELECT COUNT(*) FROM status_meta;"
+                let appliedThrough2 = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 statusMetaCount2 |> should equal 1
+                appliedThrough2 |> should equal "0"
             })
 
     /// Verifies that ensure db initialized recreates legacy schema v2 database without blake3 columns.
@@ -975,7 +1041,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -989,9 +1055,9 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
-    /// Verifies that ensure db initialized preserves existing schema v4 current schema status meta row.
+    /// Verifies that ensure db initialized preserves existing current schema status meta row.
     [<Test>]
-    let ``ensureDbInitialized preserves existing schema v4 current schema status_meta row`` () =
+    let ``ensureDbInitialized preserves existing current schema status_meta row`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1012,7 +1078,7 @@ module LocalStateDbTests =
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
                 let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
                 readRootBlake3Hash |> should equal rootBlake3Hash
@@ -1041,6 +1107,43 @@ module LocalStateDbTests =
                 corruptAfter |> should equal corruptBefore
             })
 
+    /// Verifies that ensure db initialized rejects schema v5 databases without watch journal.
+    [<Test>]
+    let ``ensureDbInitialized recreates schema v5 database missing watch journal`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let rootHash = "missing-journal-root-hash"
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash "root-blake3" ticks
+
+                use seedConnection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery seedConnection "DROP TABLE watch_journal;"
+                seedConnection.Dispose()
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let watchJournalCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                schemaVersion |> should equal "5"
+                watchJournalCount |> should equal 1
+                appliedThrough |> should equal "0"
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that ensure db initialized recreates partial schema v4 database missing root blake3 column.
     [<Test>]
     let ``ensureDbInitialized recreates partial schema v4 database missing root blake3 column`` () =
@@ -1066,7 +1169,7 @@ module LocalStateDbTests =
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
                 rootBlake3Columns |> should equal 1
                 statusMetaCount |> should equal 1
 
@@ -1107,7 +1210,7 @@ module LocalStateDbTests =
                 let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
                 statusDirectoryCount |> should equal 0
                 statusMetaCount |> should equal 1
 
@@ -1300,7 +1403,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -1327,7 +1430,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "4"
+                schemaVersion |> should equal "5"
             })
 
     /// Verifies that replace status snapshot fully clears old snapshot rows.
@@ -1641,7 +1744,7 @@ module LocalStateDbTests =
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '4');"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '5');"
 
                     executeNonQuery
                         connection
@@ -2551,7 +2654,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "4"
+                    schemaVersion |> should equal "5"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -988,6 +988,51 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that schema acceptance rejects meta tables that cannot preserve one row per key.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 meta key is not unique`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                let duplicateInsertSucceeded =
+                    try
+                        executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '1');"
+                        true
+                    with
+                    | :? SqliteException -> false
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                duplicateInsertSucceeded |> should equal false
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that schema acceptance rejects malformed SQLite journal allocation metadata.
     [<TestCase("not-a-number")>]
     [<TestCase("-1")>]

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -171,6 +171,12 @@ module LocalStateDbTests =
         cmd.CommandText <- sql
         cmd.ExecuteNonQuery() |> ignore
 
+    /// Allocates Watch journal sequences without adding replay semantics beyond the schema scaffold.
+    let private insertWatchJournalRows (connection: SqliteConnection) throughSequence =
+        [| 1L .. throughSequence |]
+        |> Array.iter (fun sequence ->
+            executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});")
+
     /// Gets corrupt backups needed by the test scenario.
     let private getCorruptBackups (dbPath: string) =
         let directoryPath = Path.GetDirectoryName(dbPath)
@@ -386,9 +392,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
 
-                [| 1L .. 1030L |]
-                |> Array.iter (fun sequence ->
-                    executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});")
+                insertWatchJournalRows connection 1030L
 
                 do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 1026L
                 do! LocalStateDb.pruneWatchJournalRetention configuration.GraceStatusFile
@@ -411,6 +415,11 @@ module LocalStateDbTests =
         withTempDir (fun _ configuration ->
             task {
                 do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 5L
+
                 do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 5L
 
                 let operation = Func<Task>(fun () -> LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 4L :> Task)
@@ -422,6 +431,74 @@ module LocalStateDbTests =
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
                 readThrough |> should equal 5L
+            })
+
+    /// Verifies that Watch recovery metadata cannot outrun SQLite's allocated journal sequence.
+    [<Test>]
+    let ``watch journal applied through sequence cannot exceed allocated sequence`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let operation = Func<Task>(fun () -> LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 1L :> Task)
+
+                let ex = Assert.ThrowsAsync<InvalidOperationException>(operation)
+
+                ex.Message
+                |> should contain "only allocated through 0"
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 0L
+            })
+
+    /// Verifies that concurrent Watch recovery watermark advances cannot let a lower stale write win.
+    [<Test>]
+    let ``watch journal applied through sequence is atomic under interleaved advances`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                do
+                    use seedConnection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows seedConnection 4L
+
+                use lockConnection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery lockConnection "BEGIN IMMEDIATE;"
+
+                let runAdvance sequence =
+                    task {
+                        try
+                            do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile sequence
+                            return Some sequence
+                        with
+                        | :? InvalidOperationException as ex when ex.Message.Contains("cannot move backward", StringComparison.OrdinalIgnoreCase) -> return None
+                    }
+
+                let startAdvance sequence =
+                    Task
+                        .Factory
+                        .StartNew(Func<Task<int64 option>>(fun () -> runAdvance sequence))
+                        .Unwrap()
+
+                let highTask = startAdvance 4L
+                do! Task.Delay(50)
+
+                let lowerTasks = [| 1L .. 3L |] |> Array.map startAdvance
+
+                do! Task.Delay(100)
+                executeNonQuery lockConnection "ROLLBACK;"
+
+                let! highResult = highTask
+                let! lowerResults = Task.WhenAll lowerTasks
+
+                highResult |> should equal (Some 4L)
+
+                lowerResults
+                |> Array.choose id
+                |> Array.iter (fun sequence -> sequence |> should be (lessThanOrEqualTo 4L))
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 4L
             })
 
     /// Verifies that round trips status snapshot.
@@ -792,6 +869,46 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that AUTOINCREMENT acceptance belongs to the sequence column declaration, not nearby SQL text.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 autoincrement text is outside sequence declaration`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE watch_journal;"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE watch_journal (sequence INTEGER PRIMARY KEY, created_at_unix_ticks INTEGER NOT NULL CHECK ('sequence INTEGER PRIMARY KEY AUTOINCREMENT' IS NOT NULL));"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                schemaVersion |> should equal "5"
+
+                let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
+
+                tableSql.IndexOf("sequence INTEGER PRIMARY KEY AUTOINCREMENT", StringComparison.OrdinalIgnoreCase)
+                |> should be (greaterThanOrEqualTo 0)
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that ensure db initialized recreates db when Watch recovery metadata is malformed.
     [<TestCase("not-a-number")>]
     [<TestCase("-1")>]
@@ -823,6 +940,43 @@ module LocalStateDbTests =
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
                 readThrough |> should equal 0L
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that schema acceptance rejects Watch recovery metadata beyond SQLite's allocated journal sequence.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata exceeds allocated sequence`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 2L
+                    executeNonQuery connection "UPDATE meta SET value = '3' WHERE key = 'AppliedThroughSequence';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -987,6 +987,80 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that schema acceptance rejects missing SQLite journal allocation metadata when rows exist.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 journal rows have no allocation row`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 2L
+                    executeNonQuery connection "DELETE FROM sqlite_sequence WHERE name = 'watch_journal';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that schema acceptance rejects stale SQLite journal allocation below the highest persisted row.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 allocated journal sequence is below journal max`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 2L
+                    executeNonQuery connection "UPDATE sqlite_sequence SET seq = 1 WHERE name = 'watch_journal';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that schema acceptance rejects Watch recovery metadata beyond SQLite's allocated journal sequence.
     [<Test>]
     let ``ensureDbInitialized recreates DB when schema v5 applied through metadata exceeds allocated sequence`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -948,6 +948,45 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that schema acceptance rejects malformed SQLite journal allocation metadata.
+    [<TestCase("not-a-number")>]
+    [<TestCase("-1")>]
+    let ``ensureDbInitialized recreates DB when schema v5 allocated journal sequence is invalid`` (allocatedSequence: string) =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 2L
+                    executeNonQuery connection "UPDATE meta SET value = '1' WHERE key = 'AppliedThroughSequence';"
+                    executeNonQuery connection $"UPDATE sqlite_sequence SET seq = '{allocatedSequence}' WHERE name = 'watch_journal';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that schema acceptance rejects Watch recovery metadata beyond SQLite's allocated journal sequence.
     [<Test>]
     let ``ensureDbInitialized recreates DB when schema v5 applied through metadata exceeds allocated sequence`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -674,6 +674,53 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that ensure db initialized recreates db when schema v5 has a malformed Watch journal table.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 watch journal shape is malformed`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+
+                let ticks =
+                    Instant
+                        .FromUtc(2026, 1, 2, 3, 4)
+                        .ToUnixTimeTicks()
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE watch_journal;"
+                    executeNonQuery connection "CREATE TABLE watch_journal (sequence TEXT PRIMARY KEY);"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                schemaVersion |> should equal "5"
+
+                let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
+                sequencePk |> should equal 1
+
+                let sequenceType = executeScalarString connection "SELECT UPPER(type) FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
+                sequenceType |> should equal "INTEGER"
+
+                let createdAtNotNull =
+                    executeScalarInt connection "SELECT [notnull] FROM pragma_table_info('watch_journal') WHERE name = 'created_at_unix_ticks';"
+
+                createdAtNotNull |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that ensure db initialized recovers from a corrupt non sqlite file.
     [<Test>]
     let ``ensureDbInitialized recovers from a corrupt non-sqlite file`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -383,6 +383,46 @@ module LocalStateDbTests =
                 readThrough |> should equal 0L
             })
 
+    /// Verifies that v5 initialization recreates meta tables that ignore the default Watch watermark insert.
+    [<Test>]
+    let ``initialization recreates constrained meta table when default watch watermark insert is ignored`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = getCurrentInstant().ToUnixTimeTicks()
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile (Guid.NewGuid()) "root-sha" "root-blake3" now
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "ALTER TABLE meta RENAME TO meta_valid;"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL, required_marker TEXT NOT NULL CHECK (required_marker = 'seeded'));"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO meta (key, value, required_marker) SELECT key, value, 'seeded' FROM meta_valid WHERE key <> 'AppliedThroughSequence';"
+
+                    executeNonQuery connection "DROP TABLE meta_valid;"
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 0L
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                appliedThrough |> should equal "0"
+
+                let requiredMarkerColumns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('meta') WHERE name = 'required_marker';"
+                requiredMarkerColumns |> should equal 0
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 0L
+
+                getCorruptBackups configuration.GraceStatusFile
+                |> should haveLength 1
+            })
+
     /// Verifies that watch journal retention keeps unapplied rows and a bounded applied tail.
     [<Test>]
     let ``watch journal retention keeps unapplied rows and bounded applied tail`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -1223,6 +1223,189 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that schema acceptance rejects NULL Watch recovery metadata without throwing.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata is null`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NULL);"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', NULL);"
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.WatchJournalAppliedThroughMetadataValid
+                |> should equal (Some false)
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that schema acceptance skips expression indexes when proving metadata key uniqueness.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 meta uniqueness is expression index only`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
+                    executeNonQuery connection "CREATE UNIQUE INDEX ux_meta_lower_key ON meta(lower(key));"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.WatchJournalAppliedThroughMetadataValid
+                |> should equal (Some false)
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that schema acceptance rejects composite primary keys before trusting metadata key uniqueness.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 meta key is part of composite primary key`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL, PRIMARY KEY (key, value));"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.WatchJournalAppliedThroughMetadataValid
+                |> should equal (Some false)
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that schema acceptance rejects journal rows whose SQLite sequence was not positively allocated.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 journal rows have non-positive sequence`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (0, 1);"
+                    executeNonQuery connection "UPDATE sqlite_sequence SET seq = 0 WHERE name = 'watch_journal';"
+
+                let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
+
+                inspection.OpenedReadOnly |> should equal true
+
+                inspection.WatchJournalAppliedThroughMetadataValid
+                |> should equal (Some false)
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that schema v5 databases with journal rows must carry trustworthy Watch recovery metadata.
     [<Test>]
     let ``ensureDbInitialized recreates DB when schema v5 has journal rows without applied through metadata`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -987,6 +987,46 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that empty schema v5 databases still reject malformed SQLite journal allocation metadata.
+    [<TestCase("not-a-number")>]
+    [<TestCase("-1")>]
+    let ``ensureDbInitialized recreates DB when schema v5 empty journal has invalid allocation row`` (allocatedSequence: string) =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
+                    executeNonQuery connection $"INSERT INTO sqlite_sequence (name, seq) VALUES ('watch_journal', '{allocatedSequence}');"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+                let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
+                allocationRows |> should equal 0
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that schema acceptance rejects missing SQLite journal allocation metadata when rows exist.
     [<Test>]
     let ``ensureDbInitialized recreates DB when schema v5 journal rows have no allocation row`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -364,6 +364,11 @@ module LocalStateDbTests =
                 sequencePk |> should equal 1
                 sequenceType |> should equal "INTEGER"
 
+                let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
+
+                tableSql.IndexOf("AUTOINCREMENT", StringComparison.OrdinalIgnoreCase)
+                |> should be (greaterThanOrEqualTo 0)
+
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
                 appliedThrough |> should equal "0"
@@ -381,8 +386,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
 
-                for sequence in 1L .. 1030L do
-                    executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});"
+                [| 1L .. 1030L |]
+                |> Array.iter (fun sequence ->
+                    executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});")
 
                 do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 1026L
                 do! LocalStateDb.pruneWatchJournalRetention configuration.GraceStatusFile
@@ -709,10 +715,95 @@ module LocalStateDbTests =
                 let sequenceType = executeScalarString connection "SELECT UPPER(type) FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
                 sequenceType |> should equal "INTEGER"
 
+                let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
+
+                tableSql.IndexOf("AUTOINCREMENT", StringComparison.OrdinalIgnoreCase)
+                |> should be (greaterThanOrEqualTo 0)
+
                 let createdAtNotNull =
                     executeScalarInt connection "SELECT [notnull] FROM pragma_table_info('watch_journal') WHERE name = 'created_at_unix_ticks';"
 
                 createdAtNotNull |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that ensure db initialized recreates db when schema v5 reuses rowids for Watch journal sequences.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 watch journal lacks autoincrement`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+
+                let ticks =
+                    Instant
+                        .FromUtc(2026, 1, 2, 3, 4)
+                        .ToUnixTimeTicks()
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE watch_journal;"
+                    executeNonQuery connection "CREATE TABLE watch_journal (sequence INTEGER PRIMARY KEY, created_at_unix_ticks INTEGER NOT NULL);"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                schemaVersion |> should equal "5"
+
+                let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
+
+                tableSql.IndexOf("AUTOINCREMENT", StringComparison.OrdinalIgnoreCase)
+                |> should be (greaterThanOrEqualTo 0)
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that ensure db initialized recreates db when Watch recovery metadata is malformed.
+    [<TestCase("not-a-number")>]
+    [<TestCase("-1")>]
+    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata is invalid`` (appliedThroughValue: string) =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+
+                    executeNonQuery connection $"UPDATE meta SET value = '{appliedThroughValue}' WHERE key = 'AppliedThroughSequence';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 0L
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -826,8 +917,8 @@ module LocalStateDbTests =
                 let walPath = configuration.GraceStatusFile + "-wal"
                 let shmPath = configuration.GraceStatusFile + "-shm"
 
-                for sidecar in [| walPath; shmPath |] do
-                    if File.Exists(sidecar) then File.Delete(sidecar)
+                [| walPath; shmPath |]
+                |> Array.iter (fun sidecar -> if File.Exists(sidecar) then File.Delete(sidecar))
 
                 File.Exists(walPath) |> should equal false
                 File.Exists(shmPath) |> should equal false
@@ -893,9 +984,10 @@ module LocalStateDbTests =
                     [| "-journal"; "-wal"; "-shm" |]
                     |> Array.map (fun suffix -> configuration.GraceStatusFile + suffix)
 
-                for sidecar in sidecars do
+                sidecars
+                |> Array.iter (fun sidecar ->
                     File.WriteAllText(sidecar, $"sentinel-{Path.GetFileName(sidecar)}")
-                    File.SetLastWriteTimeUtc(sidecar, oldTime)
+                    File.SetLastWriteTimeUtc(sidecar, oldTime))
 
                 let dbBefore = snapshotFile configuration.GraceStatusFile
                 let sidecarsBefore = sidecars |> Array.map snapshotFile

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -948,6 +948,46 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that schema acceptance rejects duplicated Watch recovery metadata in malformed schema v5 tables.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata is duplicated`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE meta;"
+                    executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '1');"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let duplicateRows = executeScalarInt connection "SELECT COUNT(*) FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                duplicateRows |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that schema acceptance rejects malformed SQLite journal allocation metadata.
     [<TestCase("not-a-number")>]
     [<TestCase("-1")>]

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -405,6 +405,25 @@ module LocalStateDbTests =
                 readThrough |> should equal 1026L
             })
 
+    /// Verifies that Watch recovery metadata cannot be moved behind the current applied sequence.
+    [<Test>]
+    let ``watch journal applied through sequence cannot rewind`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                do! LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 5L
+
+                let operation = Func<Task>(fun () -> LocalStateDb.setWatchJournalAppliedThroughSequence configuration.GraceStatusFile 4L :> Task)
+
+                let ex = Assert.ThrowsAsync<InvalidOperationException>(operation)
+
+                ex.Message
+                |> should contain "cannot move backward"
+
+                let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                readThrough |> should equal 5L
+            })
+
     /// Verifies that round trips status snapshot.
     [<Test>]
     let ``round trips status snapshot`` () =
@@ -804,6 +823,43 @@ module LocalStateDbTests =
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
                 readThrough |> should equal 0L
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
+    /// Verifies that schema v5 databases with journal rows must carry trustworthy Watch recovery metadata.
+    [<Test>]
+    let ``ensureDbInitialized recreates DB when schema v5 has journal rows without applied through metadata`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (1, 1);"
+                    executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+
+                schemaVersion |> should equal "5"
+                appliedThrough |> should equal "0"
+                journalRows |> should equal 0
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -102,7 +102,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "4"
+    let private ExpectedLocalStateSchemaVersion = "5"
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -87,6 +87,9 @@ module Doctor =
     let private StateDbForeignKeyCheckId = "state.db.foreign-key-check"
 
     [<Literal>]
+    let private StateDbWatchJournalCheckId = "state.db.watch-journal"
+
+    [<Literal>]
     let private ObjectCacheIndexReadableCheckId = "object-cache.index-readable"
 
     [<Literal>]
@@ -312,6 +315,14 @@ module Doctor =
                 Category = "Local state"
                 Title = "SQLite foreign-key check"
                 Description = "Runs SQLite foreign_key_check read-only and reports violations without mutation."
+                DefaultEnabled = true
+                SupportsOffline = true
+            }
+            {
+                Id = StateDbWatchJournalCheckId
+                Category = "Local state"
+                Title = "Watch journal persisted shape"
+                Description = "Verifies Watch journal table shape and applied-through metadata without mutating local state."
                 DefaultEnabled = true
                 SupportsOffline = true
             }
@@ -1073,6 +1084,21 @@ module Doctor =
             else
                 failed
                     $"SQLite foreign_key_check reported violations: {formatListOrNone inspection.ForeignKeyViolations}. Doctor did not repair object-cache rows."
+        | StateDbWatchJournalCheckId ->
+            let inspection = context.LocalStateInspection.Value
+
+            if not inspection.OpenedReadOnly then
+                skipped check (localStateUnavailableSummary StateDbWatchJournalCheckId inspection)
+            else
+                match inspection.WatchJournalShapeValid, inspection.WatchJournalAppliedThroughMetadataValid with
+                | Some true, Some true -> ok "Watch journal table shape and applied-through metadata match the local-state schema contract."
+                | Some false, _ ->
+                    failed
+                        "Watch journal table shape is invalid; expected sequence INTEGER PRIMARY KEY AUTOINCREMENT and created_at_unix_ticks INTEGER NOT NULL. Doctor did not repair or recreate local state."
+                | Some true, Some false ->
+                    failed
+                        "Watch journal applied-through metadata is missing while journal rows exist, malformed, or negative. Doctor did not write default metadata."
+                | _, _ -> skipped check "Watch journal persisted-shape inspection was not attempted."
         | ObjectCacheIndexReadableCheckId ->
             let inspection = context.LocalStateInspection.Value
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -18,7 +18,15 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "4"
+    let private SchemaVersion = "5"
+
+    /// Identifies the single local Watch journal metadata row that records applied-through progress.
+    [<Literal>]
+    let WatchJournalAppliedThroughSequenceMetaKey = "AppliedThroughSequence"
+
+    /// Keeps a bounded diagnostic tail of already-applied Watch journal rows.
+    [<Literal>]
+    let WatchJournalRetainedAppliedRows = 1024L
 
     [<Literal>]
     let private BusyTimeoutMs = 30000
@@ -177,6 +185,7 @@ module LocalStateDb =
             "CREATE INDEX IF NOT EXISTS ix_object_cache_children_parent ON object_cache_directory_children(parent_directory_version_id);"
             "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL);"
         |]
 
     let private requiredTableNames =
@@ -188,6 +197,7 @@ module LocalStateDb =
             "object_cache_directories"
             "object_cache_directory_children"
             "object_cache_directory_files"
+            "watch_journal"
         |]
 
     let private requiredIndexNames =
@@ -390,6 +400,17 @@ module LocalStateDb =
 
         found
 
+    /// Reports whether a LocalStateDb table exists before writable operations trust the schema version.
+    let private tableExists (connection: SqliteConnection) tableName =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = $table_name LIMIT 1;"
+
+        command.Parameters.AddWithValue("$table_name", tableName)
+        |> ignore
+
+        use reader = command.ExecuteReader()
+        reader.Read()
+
     /// Reads inspect object cache read only data from the local SQLite state database.
     let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
         try
@@ -504,6 +525,21 @@ module LocalStateDb =
             parameters.AddWithValue("$key", key) |> ignore
             parameters.AddWithValue("$value", value) |> ignore)
 
+    /// Persists the watch journal applied-through metadata default without advancing recovery state.
+    let private insertWatchJournalAppliedThroughIfMissing (connection: SqliteConnection) =
+        executeNonQueryWithParams connection "INSERT OR IGNORE INTO meta (key, value) VALUES ($key, '0');" (fun parameters ->
+            parameters.AddWithValue("$key", WatchJournalAppliedThroughSequenceMetaKey)
+            |> ignore)
+
+    /// Reads the applied-through journal sequence used by future Watch recovery work.
+    let private readWatchJournalAppliedThroughSequenceInternal (connection: SqliteConnection) =
+        match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
+        | Some value ->
+            match Int64.TryParse(value) with
+            | true, sequence when sequence >= 0L -> sequence
+            | _ -> 0L
+        | None -> 0L
+
     /// Persists insert status meta if missing changes in the local SQLite state database.
     let private insertStatusMetaIfMissing (connection: SqliteConnection) =
         let defaultStatus = GraceStatus.Default
@@ -534,6 +570,7 @@ module LocalStateDb =
         && columnExists connection "status_files" "blake3_hash"
         && columnExists connection "object_cache_directories" "blake3_hash"
         && columnExists connection "object_cache_directory_files" "blake3_hash"
+        && tableExists connection "watch_journal"
 
     /// Evaluates has empty writable status blake3 rows against parsed options and command state.
     let private hasEmptyWritableStatusBlake3Rows (connection: SqliteConnection) =
@@ -646,6 +683,7 @@ module LocalStateDb =
                                                 if not recreate then
                                                     logTrace "status_meta ensuring default row"
                                                     insertStatusMetaIfMissing connection
+                                                    insertWatchJournalAppliedThroughIfMissing connection
                                             with
                                             | :? SqliteException as ex when ex.SqliteErrorCode = 26 -> recreate <- true
                                         with
@@ -664,6 +702,7 @@ module LocalStateDb =
                                         ensureJournalMode connection
                                         setMetaValue connection "schema_version" SchemaVersion
                                         setMetaValue connection "created_at_unix_ticks" $"{getCurrentInstant().ToUnixTimeTicks()}"
+                                        insertWatchJournalAppliedThroughIfMissing connection
                                         logTrace "status_meta ensuring default row"
                                         insertStatusMetaIfMissing connection
                                 })
@@ -671,6 +710,54 @@ module LocalStateDb =
                         initializedDbs[normalizedPath] <- true
                 finally
                     semaphore.Release() |> ignore
+        }
+
+    /// Reads the local Watch journal recovery watermark from LocalStateDb metadata.
+    let readWatchJournalAppliedThroughSequence (dbPath: string) =
+        task {
+            do! ensureDbInitialized dbPath
+            use connection = openConnection dbPath
+            return readWatchJournalAppliedThroughSequenceInternal connection
+        }
+
+    /// Persists the local Watch journal recovery watermark without changing journal rows.
+    let setWatchJournalAppliedThroughSequence (dbPath: string) (sequence: int64) =
+        task {
+            if sequence < 0L then
+                invalidArg (nameof sequence) "Applied-through sequence must be greater than or equal to zero."
+
+            do! ensureDbInitialized dbPath
+
+            return!
+                executeWithRetry (fun () ->
+                    task {
+                        use connection = openConnection dbPath
+                        setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{sequence}"
+                    })
+        }
+
+    /// Prunes applied Watch journal rows while keeping a small diagnostic tail behind the watermark.
+    let pruneWatchJournalRetention (dbPath: string) =
+        task {
+            do! ensureDbInitialized dbPath
+
+            return!
+                executeWithRetry (fun () ->
+                    task {
+                        use connection = openConnection dbPath
+                        let appliedThroughSequence = readWatchJournalAppliedThroughSequenceInternal connection
+
+                        let pruneThroughSequence =
+                            max
+                                0L
+                                (appliedThroughSequence
+                                 - WatchJournalRetainedAppliedRows)
+
+                        if pruneThroughSequence > 0L then
+                            executeNonQueryWithParams connection "DELETE FROM watch_journal WHERE sequence <= $sequence;" (fun parameters ->
+                                parameters.AddWithValue("$sequence", pruneThroughSequence)
+                                |> ignore)
+                    })
         }
 
     /// Models status meta values passed between the parser and local state db handlers.

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -227,6 +227,8 @@ module LocalStateDb =
             MissingRequiredIndexes: string array
             IntegrityCheckRows: string array
             ForeignKeyViolations: string array
+            WatchJournalShapeValid: bool option
+            WatchJournalAppliedThroughMetadataValid: bool option
             ObjectCacheReadable: bool option
             ObjectCacheError: string option
         }
@@ -245,6 +247,8 @@ module LocalStateDb =
             MissingRequiredIndexes = requiredIndexNames
             IntegrityCheckRows = Array.empty
             ForeignKeyViolations = Array.empty
+            WatchJournalShapeValid = None
+            WatchJournalAppliedThroughMetadataValid = None
             ObjectCacheReadable = None
             ObjectCacheError = None
         }
@@ -477,6 +481,26 @@ module LocalStateDb =
         && hasCreatedAtColumn
         && watchJournalUsesAutoincrement connection
 
+    /// Reports whether the Watch journal contains rows that require trustworthy recovery metadata.
+    let private hasWatchJournalRows (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT EXISTS(SELECT 1 FROM watch_journal LIMIT 1);"
+        Convert.ToInt32(command.ExecuteScalar()) <> 0
+
+    /// Reads local-state metadata for read-only inspection checks without writing default rows.
+    let private tryGetMetaValueReadOnly (connection: SqliteConnection) (key: string) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "SELECT value FROM meta WHERE key = $key LIMIT 1;"
+        cmd.Parameters.AddWithValue("$key", key) |> ignore
+        use reader = cmd.ExecuteReader()
+        if reader.Read() then Some(reader.GetString(0)) else None
+
+    /// Parses read-only Watch recovery metadata using the same nonnegative sequence contract as writable acceptance.
+    let private tryParseWatchJournalAppliedThroughSequenceReadOnly (value: string) =
+        match Int64.TryParse(value) with
+        | true, sequence when sequence >= 0L -> Some sequence
+        | _ -> None
+
     /// Reads inspect object cache read only data from the local SQLite state database.
     let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
         try
@@ -493,6 +517,32 @@ module LocalStateDb =
             Some true, None
         with
         | ex -> Some false, Some ex.Message
+
+    /// Reads Watch journal schema and recovery metadata health without mutating local state.
+    let private inspectWatchJournalReadOnly (connection: SqliteConnection) =
+        if not (tableExists connection "watch_journal") then
+            Some false, None
+        else
+            let shapeValid =
+                try
+                    hasRequiredWatchJournalShape connection
+                with
+                | _ -> false
+
+            let metadataValid =
+                if shapeValid then
+                    try
+                        match tryGetMetaValueReadOnly connection WatchJournalAppliedThroughSequenceMetaKey with
+                        | Some value ->
+                            tryParseWatchJournalAppliedThroughSequenceReadOnly value
+                            |> Option.isSome
+                        | None -> not (hasWatchJournalRows connection)
+                    with
+                    | _ -> false
+                else
+                    false
+
+            Some shapeValid, Some metadataValid
 
     /// Reads inspect read only data from the local SQLite state database.
     let inspectReadOnly (dbPath: string) =
@@ -558,6 +608,7 @@ module LocalStateDb =
                         | ex -> [| ex.Message |]
 
                     let objectCacheReadable, objectCacheError = inspectObjectCacheReadOnly connection
+                    let watchJournalShapeValid, watchJournalAppliedThroughMetadataValid = inspectWatchJournalReadOnly connection
 
                     {
                         DbPath = normalizedPath
@@ -571,6 +622,8 @@ module LocalStateDb =
                         MissingRequiredIndexes = missingRequiredIndexes
                         IntegrityCheckRows = integrityRows
                         ForeignKeyViolations = foreignKeyViolations
+                        WatchJournalShapeValid = watchJournalShapeValid
+                        WatchJournalAppliedThroughMetadataValid = watchJournalAppliedThroughMetadataValid
                         ObjectCacheReadable = objectCacheReadable
                         ObjectCacheError = objectCacheError
                     }
@@ -609,7 +662,7 @@ module LocalStateDb =
         | Some value ->
             tryParseWatchJournalAppliedThroughSequence value
             |> Option.isSome
-        | None -> true
+        | None -> not (hasWatchJournalRows connection)
 
     /// Reads the applied-through journal sequence used by future Watch recovery work.
     let private readWatchJournalAppliedThroughSequenceInternal (connection: SqliteConnection) =
@@ -814,6 +867,11 @@ module LocalStateDb =
                 executeWithRetry (fun () ->
                     task {
                         use connection = openConnection dbPath
+                        let currentSequence = readWatchJournalAppliedThroughSequenceInternal connection
+
+                        if sequence < currentSequence then
+                            invalidOp $"Applied-through sequence cannot move backward from {currentSequence} to {sequence}."
+
                         setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{sequence}"
                     })
         }

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -411,6 +411,51 @@ module LocalStateDb =
         use reader = command.ExecuteReader()
         reader.Read()
 
+    /// Captures the SQLite column shape that writable schema checks must trust before using a table.
+    type private TableColumnShape = { Name: string; TypeName: string; NotNull: bool; PrimaryKeyOrdinal: int }
+
+    /// Reads SQLite table column metadata so schema-version checks can reject partially created local databases.
+    let private readTableColumnShapes (connection: SqliteConnection) tableName =
+        use command = connection.CreateCommand()
+        command.CommandText <- $"PRAGMA table_info({tableName});"
+        use reader = command.ExecuteReader()
+        let columns = ResizeArray<TableColumnShape>()
+
+        while reader.Read() do
+            columns.Add(
+                { Name = reader.GetString(1); TypeName = reader.GetString(2); NotNull = reader.GetInt32(3) <> 0; PrimaryKeyOrdinal = reader.GetInt32(5) }
+            )
+
+        columns |> Seq.toArray
+
+    /// Reports whether SQLite declared a column with INTEGER affinity for a trusted local-state sequence.
+    let private isIntegerColumnType (typeName: string) = StringComparer.OrdinalIgnoreCase.Equals(typeName.Trim(), "INTEGER")
+
+    /// Verifies that the Watch journal table can support ordered local recovery and retention operations.
+    let private hasRequiredWatchJournalShape (connection: SqliteConnection) =
+        let columns = readTableColumnShapes connection "watch_journal"
+
+        let tryFindColumn columnName =
+            columns
+            |> Array.tryFind (fun column -> StringComparer.OrdinalIgnoreCase.Equals(column.Name, columnName))
+
+        let hasSequenceColumn =
+            match tryFindColumn "sequence" with
+            | Some column ->
+                isIntegerColumnType column.TypeName
+                && column.PrimaryKeyOrdinal = 1
+            | None -> false
+
+        let hasCreatedAtColumn =
+            match tryFindColumn "created_at_unix_ticks" with
+            | Some column ->
+                isIntegerColumnType column.TypeName
+                && column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+            | None -> false
+
+        hasSequenceColumn && hasCreatedAtColumn
+
     /// Reads inspect object cache read only data from the local SQLite state database.
     let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
         try
@@ -571,6 +616,7 @@ module LocalStateDb =
         && columnExists connection "object_cache_directories" "blake3_hash"
         && columnExists connection "object_cache_directory_files" "blake3_hash"
         && tableExists connection "watch_journal"
+        && hasRequiredWatchJournalShape connection
 
     /// Evaluates has empty writable status blake3 rows against parsed options and command state.
     let private hasEmptyWritableStatusBlake3Rows (connection: SqliteConnection) =

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -692,6 +692,13 @@ module LocalStateDb =
         use reader = cmd.ExecuteReader()
         if reader.Read() then Some(reader.GetString(0)) else None
 
+    /// Counts persisted metadata rows for a key so schema trust rejects duplicate recovery watermarks.
+    let private countMetaValues (connection: SqliteConnection) (key: string) =
+        use cmd = connection.CreateCommand()
+        cmd.CommandText <- "SELECT COUNT(*) FROM meta WHERE key = $key;"
+        cmd.Parameters.AddWithValue("$key", key) |> ignore
+        cmd.ExecuteScalar() |> Convert.ToInt32
+
     /// Parses read-only Watch recovery metadata using the same nonnegative sequence contract as writable acceptance.
     let private tryParseWatchJournalAppliedThroughSequenceReadOnly (value: string) =
         match Int64.TryParse(value) with
@@ -730,13 +737,14 @@ module LocalStateDb =
                 if shapeValid then
                     try
                         match tryGetMetaValueReadOnly connection WatchJournalAppliedThroughSequenceMetaKey with
-                        | Some value ->
+                        | Some value when countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey = 1 ->
                             match tryParseWatchJournalAppliedThroughSequenceReadOnly value with
                             | Some sequence ->
                                 match tryReadConsistentAllocatedWatchJournalSequence connection with
                                 | Some allocatedSequence -> sequence <= allocatedSequence
                                 | None -> false
                             | None -> false
+                        | Some _ -> false
                         | None ->
                             not (hasWatchJournalRows connection)
                             && tryReadConsistentAllocatedWatchJournalSequence connection
@@ -863,13 +871,14 @@ module LocalStateDb =
     /// Verifies that existing Watch recovery metadata can be trusted before accepting schema version 5.
     let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
         match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
-        | Some value ->
+        | Some value when countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey = 1 ->
             match tryParseWatchJournalAppliedThroughSequence value with
             | Some sequence ->
                 match tryReadConsistentAllocatedWatchJournalSequence connection with
                 | Some allocatedSequence -> sequence <= allocatedSequence
                 | None -> false
             | None -> false
+        | Some _ -> false
         | None ->
             not (hasWatchJournalRows connection)
             && tryReadConsistentAllocatedWatchJournalSequence connection

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -737,7 +737,10 @@ module LocalStateDb =
                                 | Some allocatedSequence -> sequence <= allocatedSequence
                                 | None -> false
                             | None -> false
-                        | None -> not (hasWatchJournalRows connection)
+                        | None ->
+                            not (hasWatchJournalRows connection)
+                            && tryReadConsistentAllocatedWatchJournalSequence connection
+                               |> Option.isSome
                     with
                     | _ -> false
                 else
@@ -867,7 +870,10 @@ module LocalStateDb =
                 | Some allocatedSequence -> sequence <= allocatedSequence
                 | None -> false
             | None -> false
-        | None -> not (hasWatchJournalRows connection)
+        | None ->
+            not (hasWatchJournalRows connection)
+            && tryReadConsistentAllocatedWatchJournalSequence connection
+               |> Option.isSome
 
     /// Reads the applied-through journal sequence used by future Watch recovery work.
     let private readWatchJournalAppliedThroughSequenceInternal (connection: SqliteConnection) =

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -436,13 +436,164 @@ module LocalStateDb =
     /// Reports whether SQLite declared a column with INTEGER affinity for a trusted local-state sequence.
     let private isIntegerColumnType (typeName: string) = StringComparer.OrdinalIgnoreCase.Equals(typeName.Trim(), "INTEGER")
 
-    /// Matches the Watch journal sequence declaration that prevents SQLite rowid reuse after retention pruning.
-    let private watchJournalSequenceAutoincrementPattern =
+    /// Locates the top-level column list inside SQLite's stored CREATE TABLE statement.
+    let private tryGetCreateTableColumnList (sql: string) =
+        let mutable startIndex = -1
+        let mutable endIndex = -1
+        let mutable depth = 0
+        let mutable quote = '\000'
+        let mutable index = 0
+
+        while index < sql.Length && endIndex < 0 do
+            let ch = sql[index]
+
+            if quote <> '\000' then
+                if quote = ']' then
+                    if ch = ']' then quote <- '\000'
+                elif ch = quote then
+                    if index + 1 < sql.Length && sql[index + 1] = quote then
+                        index <- index + 1
+                    else
+                        quote <- '\000'
+            else
+                match ch with
+                | '\''
+                | '"'
+                | '`' -> quote <- ch
+                | '[' -> quote <- ']'
+                | '(' ->
+                    if depth = 0 then startIndex <- index + 1
+                    depth <- depth + 1
+                | ')' ->
+                    if depth > 0 then
+                        depth <- depth - 1
+
+                        if depth = 0 then endIndex <- index
+                | _ -> ()
+
+            index <- index + 1
+
+        if startIndex >= 0 && endIndex > startIndex then
+            Some(sql.Substring(startIndex, endIndex - startIndex))
+        else
+            None
+
+    /// Splits SQLite column and constraint declarations without trusting text inside defaults or CHECK expressions.
+    let private splitTopLevelSqlDeclarations (declarations: string) =
+        let parts = ResizeArray<string>()
+        let mutable startIndex = 0
+        let mutable depth = 0
+        let mutable quote = '\000'
+        let mutable index = 0
+
+        while index < declarations.Length do
+            let ch = declarations[index]
+
+            if quote <> '\000' then
+                if quote = ']' then
+                    if ch = ']' then quote <- '\000'
+                elif ch = quote then
+                    if index + 1 < declarations.Length
+                       && declarations[index + 1] = quote then
+                        index <- index + 1
+                    else
+                        quote <- '\000'
+            else
+                match ch with
+                | '\''
+                | '"'
+                | '`' -> quote <- ch
+                | '[' -> quote <- ']'
+                | '(' -> depth <- depth + 1
+                | ')' when depth > 0 -> depth <- depth - 1
+                | ',' when depth = 0 ->
+                    parts.Add(
+                        declarations
+                            .Substring(startIndex, index - startIndex)
+                            .Trim()
+                    )
+
+                    startIndex <- index + 1
+                | _ -> ()
+
+            index <- index + 1
+
+        let last = declarations.Substring(startIndex).Trim()
+
+        if not (String.IsNullOrWhiteSpace(last)) then parts.Add(last)
+
+        parts |> Seq.toArray
+
+    /// Parses the leading SQLite identifier from a column declaration.
+    let private tryReadLeadingSqlIdentifier (declaration: string) =
+        let mutable index = 0
+
+        while index < declaration.Length
+              && Char.IsWhiteSpace(declaration[index]) do
+            index <- index + 1
+
+        if index >= declaration.Length then
+            None
+        else
+            let ch = declaration[index]
+
+            if ch = '"' || ch = '`' || ch = '[' then
+                let terminator = if ch = '[' then ']' else ch
+                let startIndex = index + 1
+                index <- startIndex
+                let mutable identifier = StringBuilder()
+                let mutable closed = false
+
+                while index < declaration.Length && not closed do
+                    if declaration[index] = terminator then
+                        if terminator <> ']'
+                           && index + 1 < declaration.Length
+                           && declaration[index + 1] = terminator then
+                            identifier.Append(terminator) |> ignore
+                            index <- index + 2
+                        else
+                            closed <- true
+                            index <- index + 1
+                    else
+                        identifier.Append(declaration[index]) |> ignore
+                        index <- index + 1
+
+                if closed then
+                    Some(identifier.ToString(), declaration.Substring(index))
+                else
+                    None
+            else
+                let startIndex = index
+
+                while index < declaration.Length
+                      && not (Char.IsWhiteSpace(declaration[index]))
+                      && declaration[index] <> ',' do
+                    index <- index + 1
+
+                if index > startIndex then
+                    Some(declaration.Substring(startIndex, index - startIndex), declaration.Substring(index))
+                else
+                    None
+
+    /// Matches the actual Watch journal sequence column declaration that prevents rowid reuse after pruning.
+    let private watchJournalSequenceAutoincrementDeclarationPattern =
         Regex(
-            @"(?:""sequence""|\[sequence\]|`sequence`|sequence)\s+INTEGER\s+PRIMARY\s+KEY\s+AUTOINCREMENT\b",
+            @"^\s+INTEGER\s+PRIMARY\s+KEY\s+AUTOINCREMENT\b",
             RegexOptions.IgnoreCase
             ||| RegexOptions.CultureInvariant
         )
+
+    /// Reports whether SQLite's stored CREATE TABLE statement gives the sequence column AUTOINCREMENT semantics.
+    let private createSqlDeclaresSequenceAutoincrement (sql: string) =
+        match tryGetCreateTableColumnList sql with
+        | Some columnList ->
+            splitTopLevelSqlDeclarations columnList
+            |> Array.exists (fun declaration ->
+                match tryReadLeadingSqlIdentifier declaration with
+                | Some (identifier, remainder) when StringComparer.OrdinalIgnoreCase.Equals(identifier, "sequence") ->
+                    watchJournalSequenceAutoincrementDeclarationPattern.IsMatch(remainder)
+                | _ -> false)
+        | None -> false
 
     /// Reports whether SQLite stored the Watch journal table as an AUTOINCREMENT sequence table.
     let private watchJournalUsesAutoincrement (connection: SqliteConnection) =
@@ -451,7 +602,7 @@ module LocalStateDb =
         let value = command.ExecuteScalar()
 
         match value with
-        | :? string as sql -> watchJournalSequenceAutoincrementPattern.IsMatch(sql)
+        | :? string as sql -> createSqlDeclaresSequenceAutoincrement sql
         | _ -> false
 
     /// Verifies that the Watch journal table can support ordered local recovery and retention operations.
@@ -486,6 +637,17 @@ module LocalStateDb =
         use command = connection.CreateCommand()
         command.CommandText <- "SELECT EXISTS(SELECT 1 FROM watch_journal LIMIT 1);"
         Convert.ToInt32(command.ExecuteScalar()) <> 0
+
+    /// Reads SQLite's allocated Watch journal sequence so recovery metadata cannot outrun future row ids.
+    let private readAllocatedWatchJournalSequence (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT seq FROM sqlite_sequence WHERE name = 'watch_journal' LIMIT 1;"
+        let value = command.ExecuteScalar()
+
+        match value with
+        | null
+        | :? DBNull -> 0L
+        | _ -> Convert.ToInt64(value)
 
     /// Reads local-state metadata for read-only inspection checks without writing default rows.
     let private tryGetMetaValueReadOnly (connection: SqliteConnection) (key: string) =
@@ -534,8 +696,11 @@ module LocalStateDb =
                     try
                         match tryGetMetaValueReadOnly connection WatchJournalAppliedThroughSequenceMetaKey with
                         | Some value ->
-                            tryParseWatchJournalAppliedThroughSequenceReadOnly value
-                            |> Option.isSome
+                            match tryParseWatchJournalAppliedThroughSequenceReadOnly value with
+                            | Some sequence ->
+                                sequence
+                                <= readAllocatedWatchJournalSequence connection
+                            | None -> false
                         | None -> not (hasWatchJournalRows connection)
                     with
                     | _ -> false
@@ -660,8 +825,11 @@ module LocalStateDb =
     let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
         match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
         | Some value ->
-            tryParseWatchJournalAppliedThroughSequence value
-            |> Option.isSome
+            match tryParseWatchJournalAppliedThroughSequence value with
+            | Some sequence ->
+                sequence
+                <= readAllocatedWatchJournalSequence connection
+            | None -> false
         | None -> not (hasWatchJournalRows connection)
 
     /// Reads the applied-through journal sequence used by future Watch recovery work.
@@ -867,12 +1035,30 @@ module LocalStateDb =
                 executeWithRetry (fun () ->
                     task {
                         use connection = openConnection dbPath
-                        let currentSequence = readWatchJournalAppliedThroughSequenceInternal connection
+                        executeNonQuery connection "BEGIN IMMEDIATE;"
+                        let mutable committed = false
 
-                        if sequence < currentSequence then
-                            invalidOp $"Applied-through sequence cannot move backward from {currentSequence} to {sequence}."
+                        try
+                            let currentSequence = readWatchJournalAppliedThroughSequenceInternal connection
 
-                        setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{sequence}"
+                            if sequence < currentSequence then
+                                invalidOp $"Applied-through sequence cannot move backward from {currentSequence} to {sequence}."
+
+                            let allocatedSequence = readAllocatedWatchJournalSequence connection
+
+                            if sequence > allocatedSequence then
+                                invalidOp
+                                    $"Applied-through sequence cannot advance to {sequence} because the Watch journal has only allocated through {allocatedSequence}."
+
+                            setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{sequence}"
+                            executeNonQuery connection "COMMIT;"
+                            committed <- true
+                        finally
+                            if not committed then
+                                try
+                                    executeNonQuery connection "ROLLBACK;"
+                                with
+                                | _ -> ()
                     })
         }
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -436,6 +436,9 @@ module LocalStateDb =
     /// Reports whether SQLite declared a column with INTEGER affinity for a trusted local-state sequence.
     let private isIntegerColumnType (typeName: string) = StringComparer.OrdinalIgnoreCase.Equals(typeName.Trim(), "INTEGER")
 
+    /// Reports whether SQLite declared a column with TEXT affinity for trusted local metadata.
+    let private isTextColumnType (typeName: string) = StringComparer.OrdinalIgnoreCase.Equals(typeName.Trim(), "TEXT")
+
     /// Quotes SQLite identifiers used by schema PRAGMA calls against Grace-owned table and index names.
     let private quoteSqlIdentifier (identifier: string) = "\"" + identifier.Replace("\"", "\"\"") + "\""
 
@@ -494,6 +497,27 @@ module LocalStateDb =
                 match readIndexColumnNames connection indexName with
                 | Some [| columnName |] -> StringComparer.OrdinalIgnoreCase.Equals(columnName, "key")
                 | _ -> false)
+
+    /// Verifies that Grace-owned metadata can accept key/value writes without hidden required columns.
+    let private hasRequiredMetaKeyValueShape (connection: SqliteConnection) =
+        let columns = readTableColumnShapes connection "meta"
+
+        let hasOnlyKeyAndValueColumns =
+            columns.Length = 2
+            && columns
+               |> Array.exists (fun column ->
+                   StringComparer.OrdinalIgnoreCase.Equals(column.Name, "key")
+                   && isTextColumnType column.TypeName
+                   && column.PrimaryKeyOrdinal = 1)
+            && columns
+               |> Array.exists (fun column ->
+                   StringComparer.OrdinalIgnoreCase.Equals(column.Name, "value")
+                   && isTextColumnType column.TypeName
+                   && column.NotNull
+                   && column.PrimaryKeyOrdinal = 0)
+
+        hasOnlyKeyAndValueColumns
+        && hasUniqueMetaKeyConstraint connection
 
     /// Locates the top-level column list inside SQLite's stored CREATE TABLE statement.
     let private tryGetCreateTableColumnList (sql: string) =
@@ -813,7 +837,7 @@ module LocalStateDb =
 
             let metadataValid =
                 if shapeValid
-                   && hasUniqueMetaKeyConstraint connection then
+                   && hasRequiredMetaKeyValueShape connection then
                     try
                         match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
                         | 1 ->
@@ -954,8 +978,8 @@ module LocalStateDb =
         | true, sequence when sequence >= 0L -> Some sequence
         | _ -> None
 
-    /// Verifies that existing Watch recovery metadata can be trusted before accepting schema version 5.
-    let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
+    /// Verifies that the persisted Watch recovery metadata row can be trusted.
+    let private hasPersistedValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
         match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
         | 1 ->
             match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
@@ -967,6 +991,12 @@ module LocalStateDb =
                     | None -> false
                 | None -> false
             | None -> false
+        | _ -> false
+
+    /// Verifies that existing Watch recovery metadata can be trusted before accepting schema version 5.
+    let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
+        match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
+        | 1 -> hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection
         | count when count > 1 -> false
         | _ ->
             not (hasWatchJournalRows connection)
@@ -1008,7 +1038,7 @@ module LocalStateDb =
     /// Evaluates has required writable schema against parsed options and command state.
     let private hasRequiredWritableSchema (connection: SqliteConnection) =
         columnExists connection "status_meta" "root_directory_blake3_hash"
-        && hasUniqueMetaKeyConstraint connection
+        && hasRequiredMetaKeyValueShape connection
         && columnExists connection "status_directories" "blake3_hash"
         && columnExists connection "status_files" "blake3_hash"
         && columnExists connection "object_cache_directories" "blake3_hash"
@@ -1129,6 +1159,9 @@ module LocalStateDb =
                                                     logTrace "status_meta ensuring default row"
                                                     insertStatusMetaIfMissing connection
                                                     insertWatchJournalAppliedThroughIfMissing connection
+
+                                                    if not (hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection) then
+                                                        recreate <- true
                                             with
                                             | :? SqliteException as ex when ex.SqliteErrorCode = 26 -> recreate <- true
                                         with
@@ -1148,6 +1181,10 @@ module LocalStateDb =
                                         setMetaValue connection "schema_version" SchemaVersion
                                         setMetaValue connection "created_at_unix_ticks" $"{getCurrentInstant().ToUnixTimeTicks()}"
                                         insertWatchJournalAppliedThroughIfMissing connection
+
+                                        if not (hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection) then
+                                            raise (InvalidDataException($"{WatchJournalAppliedThroughSequenceMetaKey} default could not be stored."))
+
                                         logTrace "status_meta ensuring default row"
                                         insertStatusMetaIfMissing connection
                                 })

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -655,6 +655,29 @@ module LocalStateDb =
             | _ -> None
         | _ -> None
 
+    /// Reads the highest persisted Watch journal row sequence so schema acceptance can reject stale allocation state.
+    let private tryReadMaxWatchJournalSequence (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT MAX(sequence) FROM watch_journal;"
+        let value = command.ExecuteScalar()
+
+        match value with
+        | null
+        | :? DBNull -> Some 0L
+        | :? int64 as sequence when sequence >= 0L -> Some sequence
+        | :? int as sequence when sequence >= 0 -> Some(int64 sequence)
+        | :? string as value ->
+            match Int64.TryParse(value) with
+            | true, sequence when sequence >= 0L -> Some sequence
+            | _ -> None
+        | _ -> None
+
+    /// Accepts SQLite's Watch journal allocation only when it covers every currently persisted journal row.
+    let private tryReadConsistentAllocatedWatchJournalSequence (connection: SqliteConnection) =
+        match tryReadAllocatedWatchJournalSequence connection, tryReadMaxWatchJournalSequence connection with
+        | Some allocatedSequence, Some maxJournalSequence when allocatedSequence >= maxJournalSequence -> Some allocatedSequence
+        | _ -> None
+
     /// Reads SQLite's allocated Watch journal sequence so recovery metadata cannot outrun future row ids.
     let private readAllocatedWatchJournalSequence (connection: SqliteConnection) =
         match tryReadAllocatedWatchJournalSequence connection with
@@ -710,7 +733,7 @@ module LocalStateDb =
                         | Some value ->
                             match tryParseWatchJournalAppliedThroughSequenceReadOnly value with
                             | Some sequence ->
-                                match tryReadAllocatedWatchJournalSequence connection with
+                                match tryReadConsistentAllocatedWatchJournalSequence connection with
                                 | Some allocatedSequence -> sequence <= allocatedSequence
                                 | None -> false
                             | None -> false
@@ -840,7 +863,7 @@ module LocalStateDb =
         | Some value ->
             match tryParseWatchJournalAppliedThroughSequence value with
             | Some sequence ->
-                match tryReadAllocatedWatchJournalSequence connection with
+                match tryReadConsistentAllocatedWatchJournalSequence connection with
                 | Some allocatedSequence -> sequence <= allocatedSequence
                 | None -> false
             | None -> false

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -6,6 +6,7 @@ open System.Collections.Generic
 open System.Diagnostics
 open System.IO
 open System.Text
+open System.Text.RegularExpressions
 open System.Threading
 open System.Threading.Tasks
 open Grace.Shared.Client.Configuration
@@ -431,6 +432,24 @@ module LocalStateDb =
     /// Reports whether SQLite declared a column with INTEGER affinity for a trusted local-state sequence.
     let private isIntegerColumnType (typeName: string) = StringComparer.OrdinalIgnoreCase.Equals(typeName.Trim(), "INTEGER")
 
+    /// Matches the Watch journal sequence declaration that prevents SQLite rowid reuse after retention pruning.
+    let private watchJournalSequenceAutoincrementPattern =
+        Regex(
+            @"(?:""sequence""|\[sequence\]|`sequence`|sequence)\s+INTEGER\s+PRIMARY\s+KEY\s+AUTOINCREMENT\b",
+            RegexOptions.IgnoreCase
+            ||| RegexOptions.CultureInvariant
+        )
+
+    /// Reports whether SQLite stored the Watch journal table as an AUTOINCREMENT sequence table.
+    let private watchJournalUsesAutoincrement (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal' LIMIT 1;"
+        let value = command.ExecuteScalar()
+
+        match value with
+        | :? string as sql -> watchJournalSequenceAutoincrementPattern.IsMatch(sql)
+        | _ -> false
+
     /// Verifies that the Watch journal table can support ordered local recovery and retention operations.
     let private hasRequiredWatchJournalShape (connection: SqliteConnection) =
         let columns = readTableColumnShapes connection "watch_journal"
@@ -454,7 +473,9 @@ module LocalStateDb =
                 && column.PrimaryKeyOrdinal = 0
             | None -> false
 
-        hasSequenceColumn && hasCreatedAtColumn
+        hasSequenceColumn
+        && hasCreatedAtColumn
+        && watchJournalUsesAutoincrement connection
 
     /// Reads inspect object cache read only data from the local SQLite state database.
     let private inspectObjectCacheReadOnly (connection: SqliteConnection) =
@@ -576,13 +597,27 @@ module LocalStateDb =
             parameters.AddWithValue("$key", WatchJournalAppliedThroughSequenceMetaKey)
             |> ignore)
 
+    /// Parses Watch journal recovery metadata only when it preserves the nonnegative sequence invariant.
+    let private tryParseWatchJournalAppliedThroughSequence (value: string) =
+        match Int64.TryParse(value) with
+        | true, sequence when sequence >= 0L -> Some sequence
+        | _ -> None
+
+    /// Verifies that existing Watch recovery metadata can be trusted before accepting schema version 5.
+    let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
+        match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
+        | Some value ->
+            tryParseWatchJournalAppliedThroughSequence value
+            |> Option.isSome
+        | None -> true
+
     /// Reads the applied-through journal sequence used by future Watch recovery work.
     let private readWatchJournalAppliedThroughSequenceInternal (connection: SqliteConnection) =
         match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
         | Some value ->
-            match Int64.TryParse(value) with
-            | true, sequence when sequence >= 0L -> sequence
-            | _ -> 0L
+            match tryParseWatchJournalAppliedThroughSequence value with
+            | Some sequence -> sequence
+            | None -> raise (InvalidDataException($"{WatchJournalAppliedThroughSequenceMetaKey} must be a non-negative 64-bit integer."))
         | None -> 0L
 
     /// Persists insert status meta if missing changes in the local SQLite state database.
@@ -617,6 +652,7 @@ module LocalStateDb =
         && columnExists connection "object_cache_directory_files" "blake3_hash"
         && tableExists connection "watch_journal"
         && hasRequiredWatchJournalShape connection
+        && hasValidWatchJournalAppliedThroughSequenceMeta connection
 
     /// Evaluates has empty writable status blake3 rows against parsed options and command state.
     let private hasEmptyWritableStatusBlake3Rows (connection: SqliteConnection) =

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -436,6 +436,54 @@ module LocalStateDb =
     /// Reports whether SQLite declared a column with INTEGER affinity for a trusted local-state sequence.
     let private isIntegerColumnType (typeName: string) = StringComparer.OrdinalIgnoreCase.Equals(typeName.Trim(), "INTEGER")
 
+    /// Quotes SQLite identifiers used by schema PRAGMA calls against Grace-owned table and index names.
+    let private quoteSqlIdentifier (identifier: string) = "\"" + identifier.Replace("\"", "\"\"") + "\""
+
+    /// Reads the ordered table columns that make up an SQLite index.
+    let private readIndexColumnNames (connection: SqliteConnection) indexName =
+        use command = connection.CreateCommand()
+        command.CommandText <- $"PRAGMA index_info({quoteSqlIdentifier indexName});"
+        use reader = command.ExecuteReader()
+        let columns = ResizeArray<int * string>()
+
+        while reader.Read() do
+            columns.Add(reader.GetInt32(0), reader.GetString(2))
+
+        columns
+        |> Seq.sortBy fst
+        |> Seq.map snd
+        |> Seq.toArray
+
+    /// Verifies that SQLite enforces one metadata row for each key before INSERT OR IGNORE can be trusted.
+    let private hasUniqueMetaKeyConstraint (connection: SqliteConnection) =
+        let columns = readTableColumnShapes connection "meta"
+
+        let keyIsPrimaryKey =
+            columns
+            |> Array.exists (fun column ->
+                StringComparer.OrdinalIgnoreCase.Equals(column.Name, "key")
+                && column.PrimaryKeyOrdinal = 1)
+
+        if keyIsPrimaryKey then
+            true
+        else
+            use command = connection.CreateCommand()
+            command.CommandText <- "PRAGMA index_list(meta);"
+            use reader = command.ExecuteReader()
+            let uniqueIndexNames = ResizeArray<string>()
+
+            while reader.Read() do
+                let isUnique = reader.GetInt32(2) <> 0
+                let isPartial = reader.FieldCount > 4 && reader.GetInt32(4) <> 0
+
+                if isUnique && not isPartial then uniqueIndexNames.Add(reader.GetString(1))
+
+            uniqueIndexNames
+            |> Seq.exists (fun indexName ->
+                match readIndexColumnNames connection indexName with
+                | [| columnName |] -> StringComparer.OrdinalIgnoreCase.Equals(columnName, "key")
+                | _ -> false)
+
     /// Locates the top-level column list inside SQLite's stored CREATE TABLE statement.
     let private tryGetCreateTableColumnList (sql: string) =
         let mutable startIndex = -1
@@ -734,7 +782,8 @@ module LocalStateDb =
                 | _ -> false
 
             let metadataValid =
-                if shapeValid then
+                if shapeValid
+                   && hasUniqueMetaKeyConstraint connection then
                     try
                         match tryGetMetaValueReadOnly connection WatchJournalAppliedThroughSequenceMetaKey with
                         | Some value when countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey = 1 ->
@@ -919,6 +968,7 @@ module LocalStateDb =
     /// Evaluates has required writable schema against parsed options and command state.
     let private hasRequiredWritableSchema (connection: SqliteConnection) =
         columnExists connection "status_meta" "root_directory_blake3_hash"
+        && hasUniqueMetaKeyConstraint connection
         && columnExists connection "status_directories" "blake3_hash"
         && columnExists connection "status_files" "blake3_hash"
         && columnExists connection "object_cache_directories" "blake3_hash"

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -638,16 +638,28 @@ module LocalStateDb =
         command.CommandText <- "SELECT EXISTS(SELECT 1 FROM watch_journal LIMIT 1);"
         Convert.ToInt32(command.ExecuteScalar()) <> 0
 
-    /// Reads SQLite's allocated Watch journal sequence so recovery metadata cannot outrun future row ids.
-    let private readAllocatedWatchJournalSequence (connection: SqliteConnection) =
+    /// Tries to read SQLite's allocated Watch journal sequence without trusting malformed persisted values.
+    let private tryReadAllocatedWatchJournalSequence (connection: SqliteConnection) =
         use command = connection.CreateCommand()
         command.CommandText <- "SELECT seq FROM sqlite_sequence WHERE name = 'watch_journal' LIMIT 1;"
         let value = command.ExecuteScalar()
 
         match value with
         | null
-        | :? DBNull -> 0L
-        | _ -> Convert.ToInt64(value)
+        | :? DBNull -> Some 0L
+        | :? int64 as sequence when sequence >= 0L -> Some sequence
+        | :? int as sequence when sequence >= 0 -> Some(int64 sequence)
+        | :? string as value ->
+            match Int64.TryParse(value) with
+            | true, sequence when sequence >= 0L -> Some sequence
+            | _ -> None
+        | _ -> None
+
+    /// Reads SQLite's allocated Watch journal sequence so recovery metadata cannot outrun future row ids.
+    let private readAllocatedWatchJournalSequence (connection: SqliteConnection) =
+        match tryReadAllocatedWatchJournalSequence connection with
+        | Some sequence -> sequence
+        | None -> raise (InvalidDataException("sqlite_sequence.seq for watch_journal must be a non-negative 64-bit integer."))
 
     /// Reads local-state metadata for read-only inspection checks without writing default rows.
     let private tryGetMetaValueReadOnly (connection: SqliteConnection) (key: string) =
@@ -698,8 +710,9 @@ module LocalStateDb =
                         | Some value ->
                             match tryParseWatchJournalAppliedThroughSequenceReadOnly value with
                             | Some sequence ->
-                                sequence
-                                <= readAllocatedWatchJournalSequence connection
+                                match tryReadAllocatedWatchJournalSequence connection with
+                                | Some allocatedSequence -> sequence <= allocatedSequence
+                                | None -> false
                             | None -> false
                         | None -> not (hasWatchJournalRows connection)
                     with
@@ -827,8 +840,9 @@ module LocalStateDb =
         | Some value ->
             match tryParseWatchJournalAppliedThroughSequence value with
             | Some sequence ->
-                sequence
-                <= readAllocatedWatchJournalSequence connection
+                match tryReadAllocatedWatchJournalSequence connection with
+                | Some allocatedSequence -> sequence <= allocatedSequence
+                | None -> false
             | None -> false
         | None -> not (hasWatchJournalRows connection)
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -439,20 +439,28 @@ module LocalStateDb =
     /// Quotes SQLite identifiers used by schema PRAGMA calls against Grace-owned table and index names.
     let private quoteSqlIdentifier (identifier: string) = "\"" + identifier.Replace("\"", "\"\"") + "\""
 
-    /// Reads the ordered table columns that make up an SQLite index.
+    /// Reads the ordered table columns that make up an SQLite index, rejecting expression index entries.
     let private readIndexColumnNames (connection: SqliteConnection) indexName =
         use command = connection.CreateCommand()
         command.CommandText <- $"PRAGMA index_info({quoteSqlIdentifier indexName});"
         use reader = command.ExecuteReader()
         let columns = ResizeArray<int * string>()
+        let mutable containsExpression = false
 
         while reader.Read() do
-            columns.Add(reader.GetInt32(0), reader.GetString(2))
+            if reader.IsDBNull(2) then
+                containsExpression <- true
+            else
+                columns.Add(reader.GetInt32(0), reader.GetString(2))
 
-        columns
-        |> Seq.sortBy fst
-        |> Seq.map snd
-        |> Seq.toArray
+        if containsExpression then
+            None
+        else
+            columns
+            |> Seq.sortBy fst
+            |> Seq.map snd
+            |> Seq.toArray
+            |> Some
 
     /// Verifies that SQLite enforces one metadata row for each key before INSERT OR IGNORE can be trusted.
     let private hasUniqueMetaKeyConstraint (connection: SqliteConnection) =
@@ -460,9 +468,12 @@ module LocalStateDb =
 
         let keyIsPrimaryKey =
             columns
-            |> Array.exists (fun column ->
-                StringComparer.OrdinalIgnoreCase.Equals(column.Name, "key")
-                && column.PrimaryKeyOrdinal = 1)
+            |> Array.filter (fun column -> column.PrimaryKeyOrdinal > 0)
+            |> function
+                | [| column |] ->
+                    StringComparer.OrdinalIgnoreCase.Equals(column.Name, "key")
+                    && column.PrimaryKeyOrdinal = 1
+                | _ -> false
 
         if keyIsPrimaryKey then
             true
@@ -481,7 +492,7 @@ module LocalStateDb =
             uniqueIndexNames
             |> Seq.exists (fun indexName ->
                 match readIndexColumnNames connection indexName with
-                | [| columnName |] -> StringComparer.OrdinalIgnoreCase.Equals(columnName, "key")
+                | Some [| columnName |] -> StringComparer.OrdinalIgnoreCase.Equals(columnName, "key")
                 | _ -> false)
 
     /// Locates the top-level column list inside SQLite's stored CREATE TABLE statement.
@@ -703,27 +714,42 @@ module LocalStateDb =
             | _ -> None
         | _ -> None
 
-    /// Reads the highest persisted Watch journal row sequence so schema acceptance can reject stale allocation state.
-    let private tryReadMaxWatchJournalSequence (connection: SqliteConnection) =
+    /// Reads trusted Watch journal sequence bounds so malformed rows cannot be accepted by allocation checks.
+    let private tryReadWatchJournalSequenceBounds (connection: SqliteConnection) =
         use command = connection.CreateCommand()
-        command.CommandText <- "SELECT MAX(sequence) FROM watch_journal;"
-        let value = command.ExecuteScalar()
+        command.CommandText <- "SELECT COUNT(*), MIN(sequence), MAX(sequence) FROM watch_journal;"
 
-        match value with
-        | null
-        | :? DBNull -> Some 0L
-        | :? int64 as sequence when sequence >= 0L -> Some sequence
-        | :? int as sequence when sequence >= 0 -> Some(int64 sequence)
-        | :? string as value ->
-            match Int64.TryParse(value) with
-            | true, sequence when sequence >= 0L -> Some sequence
-            | _ -> None
-        | _ -> None
+        use reader = command.ExecuteReader()
+
+        if reader.Read() then
+            let rowCount = reader.GetInt64(0)
+
+            if rowCount = 0L then
+                Some(0L, 0L)
+            else
+                let tryReadSequence ordinal =
+                    if reader.IsDBNull(ordinal) then
+                        None
+                    else
+                        match reader.GetValue(ordinal) with
+                        | :? int64 as sequence -> Some sequence
+                        | :? int as sequence -> Some(int64 sequence)
+                        | :? string as value ->
+                            match Int64.TryParse(value) with
+                            | true, sequence -> Some sequence
+                            | _ -> None
+                        | _ -> None
+
+                match tryReadSequence 1, tryReadSequence 2 with
+                | Some minSequence, Some maxSequence when minSequence > 0L && maxSequence >= minSequence -> Some(minSequence, maxSequence)
+                | _ -> None
+        else
+            None
 
     /// Accepts SQLite's Watch journal allocation only when it covers every currently persisted journal row.
     let private tryReadConsistentAllocatedWatchJournalSequence (connection: SqliteConnection) =
-        match tryReadAllocatedWatchJournalSequence connection, tryReadMaxWatchJournalSequence connection with
-        | Some allocatedSequence, Some maxJournalSequence when allocatedSequence >= maxJournalSequence -> Some allocatedSequence
+        match tryReadAllocatedWatchJournalSequence connection, tryReadWatchJournalSequenceBounds connection with
+        | Some allocatedSequence, Some (_, maxJournalSequence) when allocatedSequence >= maxJournalSequence -> Some allocatedSequence
         | _ -> None
 
     /// Reads SQLite's allocated Watch journal sequence so recovery metadata cannot outrun future row ids.
@@ -738,7 +764,11 @@ module LocalStateDb =
         cmd.CommandText <- "SELECT value FROM meta WHERE key = $key LIMIT 1;"
         cmd.Parameters.AddWithValue("$key", key) |> ignore
         use reader = cmd.ExecuteReader()
-        if reader.Read() then Some(reader.GetString(0)) else None
+
+        if reader.Read() && not (reader.IsDBNull(0)) then
+            Some(reader.GetString(0))
+        else
+            None
 
     /// Counts persisted metadata rows for a key so schema trust rejects duplicate recovery watermarks.
     let private countMetaValues (connection: SqliteConnection) (key: string) =
@@ -785,16 +815,19 @@ module LocalStateDb =
                 if shapeValid
                    && hasUniqueMetaKeyConstraint connection then
                     try
-                        match tryGetMetaValueReadOnly connection WatchJournalAppliedThroughSequenceMetaKey with
-                        | Some value when countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey = 1 ->
-                            match tryParseWatchJournalAppliedThroughSequenceReadOnly value with
-                            | Some sequence ->
-                                match tryReadConsistentAllocatedWatchJournalSequence connection with
-                                | Some allocatedSequence -> sequence <= allocatedSequence
+                        match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
+                        | 1 ->
+                            match tryGetMetaValueReadOnly connection WatchJournalAppliedThroughSequenceMetaKey with
+                            | Some value ->
+                                match tryParseWatchJournalAppliedThroughSequenceReadOnly value with
+                                | Some sequence ->
+                                    match tryReadConsistentAllocatedWatchJournalSequence connection with
+                                    | Some allocatedSequence -> sequence <= allocatedSequence
+                                    | None -> false
                                 | None -> false
                             | None -> false
-                        | Some _ -> false
-                        | None ->
+                        | count when count > 1 -> false
+                        | _ ->
                             not (hasWatchJournalRows connection)
                             && tryReadConsistentAllocatedWatchJournalSequence connection
                                |> Option.isSome
@@ -897,7 +930,11 @@ module LocalStateDb =
         cmd.CommandText <- "SELECT value FROM meta WHERE key = $key LIMIT 1;"
         cmd.Parameters.AddWithValue("$key", key) |> ignore
         use reader = cmd.ExecuteReader()
-        if reader.Read() then Some(reader.GetString(0)) else None
+
+        if reader.Read() && not (reader.IsDBNull(0)) then
+            Some(reader.GetString(0))
+        else
+            None
 
     /// Coordinates local SQLite state for set meta value, including Grace status, object cache, or watch metadata.
     let private setMetaValue (connection: SqliteConnection) (key: string) (value: string) =
@@ -919,16 +956,19 @@ module LocalStateDb =
 
     /// Verifies that existing Watch recovery metadata can be trusted before accepting schema version 5.
     let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
-        match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
-        | Some value when countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey = 1 ->
-            match tryParseWatchJournalAppliedThroughSequence value with
-            | Some sequence ->
-                match tryReadConsistentAllocatedWatchJournalSequence connection with
-                | Some allocatedSequence -> sequence <= allocatedSequence
+        match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
+        | 1 ->
+            match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
+            | Some value ->
+                match tryParseWatchJournalAppliedThroughSequence value with
+                | Some sequence ->
+                    match tryReadConsistentAllocatedWatchJournalSequence connection with
+                    | Some allocatedSequence -> sequence <= allocatedSequence
+                    | None -> false
                 | None -> false
             | None -> false
-        | Some _ -> false
-        | None ->
+        | count when count > 1 -> false
+        | _ ->
             not (hasWatchJournalRows connection)
             && tryReadConsistentAllocatedWatchJournalSequence connection
                |> Option.isSome


### PR DESCRIPTION
## Summary

- Add LocalStateDb schema v5 with a bounded `watch_journal` scaffold.
- Add the `AppliedThroughSequence` metadata key and a retention helper for applied journal rows.
- Update Doctor diagnostics so healthy schema v5 local state is not reported as stale.
- Tighten schema v5 acceptance so malformed `watch_journal` tables are recreated instead of trusted.
- Require actual AUTOINCREMENT declaration, allocated sequence bounds, atomic watermark updates, and Doctor diagnostics.

## Related Issue

Related to #497. This PR targets the epic integration branch, so it intentionally does not use a closing keyword.

## Why This Matters

This advances the WS4 durable local journal foundation for Grace Watch without turning Watch into a raw replay log or
cross-machine ledger. Grace gets a local, bounded observation scaffold that later WS4 leaves can build on for replay,
quarantine, and diagnostics while preserving the existing Watch runtime behavior in this slice.

## Status Map

- Durable `watch_journal` table without replay semantics: implemented and proven.
- SQLite-owned integer primary key journal sequence with actual AUTOINCREMENT declaration: implemented and proven.
- Exactly one valid applied boundary metadata key, `AppliedThroughSequence`: implemented and proven.
- Missing applied-through metadata with existing journal rows is rejected: implemented and proven.
- Applied-through updates are atomic, monotonic, and bounded by SQLite's allocated journal sequence: implemented and
  proven.
- Doctor local-state diagnostics report malformed journal shape or missing metadata: implemented and proven.
- Retention scaffold only, not replay behavior: implemented and proven.
- Existing Watch and LocalStateDb behavior outside the scaffold: preserved.
- WS4.2 maintenance commands, WS4.3 append/apply, WS4.4 replay/quarantine, and WS4.5 cleanup: intentionally out of scope.

## Path Expansion

The implementation touched `Doctor.CLI.fs` and `Doctor.CLI.Tests.fs` because Doctor owns the existing read-only
LocalStateDb schema diagnostic. Since #497 moves the LocalStateDb schema from v4 to v5, Doctor must expect v5 and must
not report green local-state health for journal shapes the writable path rejects. The Doctor changes are limited to
schema v5 and Watch journal diagnostic assertions.

## Validation

Initial implementation:

- Fantomas over the four touched F# files: passed.
- Focused LocalStateDb and Doctor CLI tests: passed, 132 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

Review fix `e8333cf2802e0686e99f4d012a3bcb12735ab7a0`:

- Fantomas over `LocalStateDb.CLI.fs` and `LocalStateDb.Tests.fs`: passed.
- Focused LocalStateDb tests: passed, 54 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- Bot-prevention self-review over the final diff: passed.

Review fix `10e9308810783eab4498633f1652d77a05dcc588`:

- Fantomas over `LocalStateDb.CLI.fs` and `LocalStateDb.Tests.fs`: passed.
- Release build for `Grace.CLI.Tests.fsproj`: passed with 0 warnings and 0 errors.
- Focused LocalStateDb tests: passed, 57 tests.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; `Grace.CLI.Tests` passed 880 tests.
- Bot-prevention self-review over the final diff: passed.

Stabilization fix `27fcb1fa22020cd2eeeeb56f8f1cbd7edb0141d7`:

- Fantomas over `LocalStateDb.CLI.fs`, `Doctor.CLI.fs`, `LocalStateDb.Tests.fs`, and `Doctor.CLI.Tests.fs`: passed.
- Focused LocalStateDb and Doctor CLI tests: passed, 140 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; fast profile included CLI 884 tests.
- `git diff --check`: passed.
- Stabilization self-review over the final diff: passed.

Addendum fix `690f434102d716781a51422a8cd9cf0f5e2cc821`:

- Fantomas over `LocalStateDb.CLI.fs` and `LocalStateDb.Tests.fs`: passed.
- Focused addendum regression filter: passed, 5 tests.
- `git diff --check`: passed before and after final validation.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; fast profile included CLI 888 tests.
- Addendum stabilization self-review over the final diff: passed.

Addendum 2 fix `0d0acd91eca0b3292d950a95e31a96761db4b39b`:

- Fantomas over `LocalStateDb.CLI.fs` and `LocalStateDb.Tests.fs`: passed; files unchanged.
- Release build for `Grace.CLI.Tests.fsproj`: passed with 0 warnings and 0 errors.
- Focused allocated-sequence regression filter: passed, 4 tests.
- Nearby Watch journal test filter: passed, 81 tests.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: intentionally not rerun for this narrow review fix; the affected project built
  in Release, the new regression plus nearby Watch tests passed, and the previous head already passed `validate -Fast`
  and GitHub `full`.
- Addendum 2 self-review over defensive schema validation, no exception escape, and safe allocation comparison: passed.

Addendum 3 fix `44cecaefeade342b2b8c57d2750be282175ae0d2`:

- Fantomas over `LocalStateDb.CLI.fs`, `LocalStateDb.Tests.fs`, and `Doctor.CLI.Tests.fs`: passed; files unchanged.
- Focused `LocalStateDbTests` and `DoctorCliTests`: passed, 149 tests.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: intentionally not rerun for this narrow review fix; the fix is isolated to CLI
  SQLite schema trust and Doctor read-only diagnostics, and focused validation covered the changed and nearby surfaces.
- Addendum 3 self-review over defensive schema validation, no exception escape, allocation coverage of actual rows, and
  safe watermark comparison: passed.

Addendum 4 structural fix `17015953fd522545f2b2b3f8557686b5b8121a74` and
`1239d510bfda7e39797fe666f5c854bc26d1521b`:

- Fantomas over `LocalStateDb.CLI.fs`, `LocalStateDb.Tests.fs`, and `Doctor.CLI.Tests.fs`: passed; files unchanged.
- Focused `LocalStateDbTests` and `DoctorCliTests`: passed, 154 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; fast profile included CLI 898 tests, Types 133 tests, Authorization 53
  tests, and Server.Unit 723 tests.
- `git diff --check`: passed.
- Truth-table self-review over row presence, applied-through metadata state, allocation state, and writable/read-only
  inspection: passed.

Addendum 5 structural fix `25389296ef4d254d3687a24933543f8e3c4f59fe`:

- Fantomas over `LocalStateDb.CLI.fs`, `LocalStateDb.Tests.fs`, and `Doctor.CLI.Tests.fs`: passed.
- Focused `LocalStateDbTests` and `DoctorCliTests`: passed, 156 tests.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; fast profile included CLI 900 tests, Types 133 tests, Authorization 53
  tests, and Server.Unit 723 tests.
- Meta-key uniqueness self-review over schema predicate, `INSERT OR IGNORE` semantics, metadata ambiguity, writable
  acceptance, and read-only Doctor consistency: passed.

Addendum 6 structural fix `49c9dbe2ab1162f7643a141d0e3f42f7fc5d1d01`:

- Fantomas over `LocalStateDb.CLI.fs` and `LocalStateDb.Tests.fs`: passed.
- Focused `LocalStateDbTests`: passed, 75 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; fast profile included CLI 904 tests, Types 133 tests, Authorization 53
  tests, and Server.Unit 723 tests.
- `git diff --check`: passed.
- Adversarial SQLite trust self-review over NULL metadata, expression indexes, composite primary keys, non-positive
  journal sequences, and no throw-before-recreate paths: passed.

Addendum 7 structural fix `7199f310fd3e3d518cb4bf2067f48507de99bca7`:

- Fantomas over `LocalStateDb.CLI.fs`, `LocalStateDb.Tests.fs`, and `Doctor.CLI.Tests.fs`: passed.
- Focused `LocalStateDbTests` and `DoctorCliTests`: passed, 162 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed; fast profile included CLI 906 tests.
- `git diff --check`: passed.
- Default-watermark insertion self-review over post-insert row existence, missing-watermark branch safety, and initialized
  cache behavior: passed.

## Stabilization Status Map

- Existing v5 DB acceptance rejects missing applied-through metadata when journal rows exist.
  - Status: implemented and proven.
  - Code seam: LocalStateDb schema acceptance.
  - Proof seam: LocalStateDb regression.
  - Residual risk: none.
- Applied-through updates are atomic, monotonic, and bounded by SQLite's allocated journal sequence.
  - Status: implemented and proven.
  - Code seam: LocalStateDb watermark writer.
  - Proof seam: LocalStateDb interleaving and allocated-sequence regressions.
  - Residual risk: none.
- AUTOINCREMENT validation proves the actual `sequence` column declaration.
  - Status: implemented and proven.
  - Code seam: LocalStateDb schema acceptance and read-only inspection.
  - Proof seam: misleading-SQL regression.
  - Residual risk: none.
- Doctor reports malformed journal shape or missing journal metadata instead of green local-state health.
  - Status: implemented and proven.
  - Code seam: Doctor local-state inspection and LocalStateDb read-only journal inspection.
  - Proof seam: Doctor regressions.
  - Residual risk: none.
- Journal remains a bounded scaffold only, with no raw watcher replay or maintenance command behavior.
  - Status: implemented and proven.
  - Code seam: LocalStateDb helpers only.
  - Proof seam: existing bounded-retention regression plus metadata, monotonic, allocation, and declaration regressions.
  - Residual risk: none.

## Docs Impact

No ADR or user-facing docs changed. This is an internal schema scaffold plus Doctor diagnostic alignment.

## Review Status

Current head: `7199f310fd3e3d518cb4bf2067f48507de99bca7`.

- Checks: GitHub `full` passed on the current head.
- Codex Code Review Bot: completed on the current head with no unresolved findings; bot left a thumbs-up reaction on
  the PR.
- Manual trigger: not attempted on `7199f310`.
- Stabilization: ledger through addendum 7 is implemented, proven, mapped to code/proof by worker handoffs, and reviewed
  cleanly by Codex on the latest head.

Prevention line: #497 keeps the journal as a bounded LocalStateDb scaffold with a SQLite-owned AUTOINCREMENT sequence,
exactly one valid applied-through metadata key, schema-required table, column-shape, AUTOINCREMENT, allocated-sequence,
and metadata checks, defensive malformed-sequence parsing, allocation coverage of actual journal rows, allocation
consistency across all v5 acceptance branches, `meta.key` uniqueness before metadata trust or `INSERT OR IGNORE`,
defensive NULL metadata and expression-index handling, positive journal row sequence validation, verified default
watermark insertion before initialization caching, atomic and monotonic watermark writes, Doctor diagnostics for malformed
v5 journal state, and no raw watcher replay, maintenance-command, or startup replay behavior.
