### PR TITLE
WS4.2: Add Watch journal maintenance commands

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -133,8 +133,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `206`
-- JSON-ready routed commands: `185`
+- Total leaf commands: `208`
+- JSON-ready routed commands: `187`
 - Conditionally JSON-ready routed commands: `1`
 - Intentionally human-only commands: `0`
 - Deferred routed commands with explicit V2 scope: `11`

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -238,16 +238,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 206
+        |> should equal 208
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 197
+        |> should equal 199
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 185
+        |> should equal 187
 
         countBy ImmediateJsonErrorOnly |> should equal 0
 
@@ -298,7 +298,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 185
+        jsonReady |> should equal 187
         intentionallyHumanOnly |> should equal 0
         conditionalStatus |> should equal 1
         deferredV2 |> should equal 11
@@ -480,7 +480,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 185
+        commonEntries.Length |> should equal 187
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -498,7 +498,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 185
+        commonEntries.Length |> should equal 187
 
         let parserInvalidEntries =
             commonEntries
@@ -862,8 +862,10 @@ module CommandOutputContractRegistryTests =
         let cases =
             [
                 CommandOutputContract.commandIdentity [ "maintenance" ] "check-ignore-entries", "MaintenanceIgnoreEntriesDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "clear-journal", "MaintenanceClearJournalDto"
                 CommandOutputContract.commandIdentity [ "maintenance" ] "list-contents", "MaintenanceListContentsDto"
                 CommandOutputContract.commandIdentity [ "maintenance" ] "scan", "MaintenanceScanDto"
+                CommandOutputContract.commandIdentity [ "maintenance" ] "show-journal", "MaintenanceShowJournalDto"
                 CommandOutputContract.commandIdentity [ "maintenance" ] "stats", "MaintenanceStatsDto"
                 CommandOutputContract.commandIdentity [ "maintenance" ] "update-index", "MaintenanceStatsDto"
             ]

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -261,6 +261,12 @@ module LocalStateDbTests =
             connection
             $"INSERT OR REPLACE INTO status_meta (id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, last_successful_file_upload_unix_ticks, last_successful_directory_version_upload_unix_ticks) VALUES (1, '{rootId}', '{rootSha256Hash}', '{rootBlake3Hash}', {ticks}, {ticks});"
 
+    /// Seeds an unrelated object-cache row so journal-only resets prove they do not recreate local state.
+    let private seedObjectCacheDirectory (connection: SqliteConnection) directoryVersionId relativePath sha256Hash blake3Hash =
+        executeNonQuery
+            connection
+            $"INSERT OR REPLACE INTO object_cache_directories (directory_version_id, relative_path, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ('{directoryVersionId}', '{relativePath}', '{sha256Hash}', '{blake3Hash}', 10, 11, 12);"
+
     /// Builds seed partial v4 without root blake3 column test data used to exercise CLI local State Db behavior.
     let private seedPartialV4WithoutRootBlake3Column (dbPath: string) (rootId: Guid) rootSha256Hash ticks =
         Directory.CreateDirectory(Path.GetDirectoryName(dbPath))
@@ -537,6 +543,64 @@ module LocalStateDbTests =
 
                 statusAfter.RootDirectorySha256Hash
                 |> should equal rootHash
+            })
+
+    /// Verifies that journal-only clear repairs untrusted Watch metadata without recreating unrelated local state.
+    [<TestCase("missing")>]
+    [<TestCase("malformed")>]
+    let ``clear watch journal repairs journal metadata without recreating status or object cache`` metadataCase =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let objectCacheId = Guid.NewGuid()
+                let rootHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                let rootBlake3Hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                let objectHash = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                let objectBlake3Hash = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash rootBlake3Hash 123L
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 2L
+                    seedObjectCacheDirectory connection objectCacheId "cache" objectHash objectBlake3Hash
+
+                    match metadataCase with
+                    | "missing" -> executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
+                    | "malformed" -> executeNonQuery connection "UPDATE meta SET value = 'not-a-sequence' WHERE key = 'AppliedThroughSequence';"
+                    | value -> failwith $"Unsupported metadata case: {value}"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let! result = LocalStateDb.clearWatchJournal configuration.GraceStatusFile
+
+                result.RowsDeleted |> should equal 2L
+
+                result.AppliedThroughSequenceAfter
+                |> should equal 0L
+
+                result.AllocatedSequenceAfter |> should equal 0L
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+                let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let statusRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
+                let objectCacheRows = executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directories;"
+
+                journalRows |> should equal 0
+                allocationRows |> should equal 0
+                appliedThrough |> should equal "0"
+                statusRootId |> should equal (string rootId)
+                objectCacheRows |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal corruptBefore
             })
 
     /// Verifies that concurrent Watch recovery watermark advances cannot let a lower stale write win.

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -491,6 +491,54 @@ module LocalStateDbTests =
                 readThrough |> should equal 0L
             })
 
+    /// Verifies that the explicit maintenance reset clears only Watch journal state.
+    [<Test>]
+    let ``clear watch journal resets only journal rows allocation and watermark`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let rootId = Guid.NewGuid()
+                let rootHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                let status = createTestStatus rootId rootHash 123L
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile status
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 3L
+                    executeNonQuery connection "UPDATE meta SET value = '2' WHERE key = 'AppliedThroughSequence';"
+
+                let! result = LocalStateDb.clearWatchJournal configuration.GraceStatusFile
+
+                result.RowsDeleted |> should equal 3L
+
+                result.AppliedThroughSequenceBefore
+                |> should equal 2L
+
+                result.AppliedThroughSequenceAfter
+                |> should equal 0L
+
+                result.AllocatedSequenceBefore |> should equal 3L
+                result.AllocatedSequenceAfter |> should equal 0L
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+                let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let statusMetaRows = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
+
+                journalRows |> should equal 0
+                allocationRows |> should equal 0
+                appliedThrough |> should equal "0"
+                statusMetaRows |> should equal 1
+
+                let! statusAfter = LocalStateDb.readStatusSnapshot configuration.GraceStatusFile
+                statusAfter.RootDirectoryId |> should equal rootId
+
+                statusAfter.RootDirectorySha256Hash
+                |> should equal rootHash
+            })
+
     /// Verifies that concurrent Watch recovery watermark advances cannot let a lower stale write win.
     [<Test>]
     let ``watch journal applied through sequence is atomic under interleaved advances`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -545,6 +545,86 @@ module LocalStateDbTests =
                 |> should equal rootHash
             })
 
+    /// Verifies that clear-journal treats malformed SQLite allocation metadata as resettable journal-only state.
+    [<Test>]
+    let ``clear watch journal clears malformed allocation metadata without recreating local state`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let objectCacheId = Guid.NewGuid()
+                let rootHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                let rootBlake3Hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                let objectHash = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                let objectBlake3Hash = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash rootBlake3Hash 123L
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    insertWatchJournalRows connection 2L
+                    seedObjectCacheDirectory connection objectCacheId "cache" objectHash objectBlake3Hash
+                    executeNonQuery connection "UPDATE meta SET value = '1' WHERE key = 'AppliedThroughSequence';"
+                    executeNonQuery connection "UPDATE sqlite_sequence SET seq = 'not-a-number' WHERE name = 'watch_journal';"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let! result = LocalStateDb.clearWatchJournal configuration.GraceStatusFile
+
+                result.RowsDeleted |> should equal 2L
+
+                result.AppliedThroughSequenceBefore
+                |> should equal 1L
+
+                result.AllocatedSequenceBefore |> should equal 0L
+                result.AllocatedSequenceAfter |> should equal 0L
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+                let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+                let statusRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
+                let objectCacheRows = executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directories;"
+
+                journalRows |> should equal 0
+                allocationRows |> should equal 0
+                appliedThrough |> should equal "0"
+                statusRootId |> should equal (string rootId)
+                objectCacheRows |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal corruptBefore
+            })
+
+    /// Verifies that empty clear-journal does not create a partial local-state database.
+    [<Test>]
+    let ``clear watch journal no-ops without creating a missing local state database`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                File.Exists(configuration.GraceStatusFile)
+                |> should equal false
+
+                let! result = LocalStateDb.clearWatchJournal configuration.GraceStatusFile
+
+                result.RowsDeleted |> should equal 0L
+
+                result.AppliedThroughSequenceBefore
+                |> should equal 0L
+
+                result.AppliedThroughSequenceAfter
+                |> should equal 0L
+
+                result.AllocatedSequenceBefore |> should equal 0L
+                result.AllocatedSequenceAfter |> should equal 0L
+
+                File.Exists(configuration.GraceStatusFile)
+                |> should equal false
+            })
+
     /// Verifies that journal-only clear repairs untrusted Watch metadata without recreating unrelated local state.
     [<TestCase("missing")>]
     [<TestCase("malformed")>]
@@ -1822,6 +1902,35 @@ module LocalStateDbTests =
 
                 inspection.MissingRequiredIndexes
                 |> should contain "ix_object_cache_files_path_hash"
+
+                snapshotFile configuration.GraceStatusFile
+                |> should equal dbBefore
+
+                let backupsAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                backupsAfter |> should equal backupsBefore
+            })
+
+    /// Verifies that Watch journal diagnostics report stale schema without repairing or rotating the DB.
+    [<Test>]
+    let ``watch journal snapshot reports stale schema without mutating local state`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                seedSchemaVersionOnly configuration.GraceStatusFile "0"
+                let dbBefore = snapshotFile configuration.GraceStatusFile
+
+                let backupsBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                let operation = Func<Task>(fun () -> LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "all" None 10 :> Task)
+
+                let ex = Assert.ThrowsAsync<InvalidDataException>(operation)
+
+                ex.Message
+                |> should contain "healthy local state database"
 
                 snapshotFile configuration.GraceStatusFile
                 |> should equal dbBefore

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -108,6 +108,32 @@ module MaintenanceCliTests =
         connection.Open()
         executeScalarInt connection $"SELECT COUNT(*) FROM {tableName};"
 
+    /// Gets corrupt backups needed by the maintenance command mutation assertions.
+    let private getCorruptBackups root =
+        let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)
+
+        if Directory.Exists(graceDir) then
+            Directory.GetFiles(graceDir, "grace-local.corrupt.*.db")
+        else
+            Array.empty
+
+    /// Captures database bytes so read-only diagnostic commands can prove they did not repair local state.
+    let private snapshotFile path =
+        if File.Exists(path) then
+            use stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ||| FileShare.Delete)
+            use reader = new BinaryReader(stream)
+            Some(reader.ReadBytes(int stream.Length), File.GetLastWriteTimeUtc(path))
+        else
+            None
+
+    /// Seeds only stale schema metadata so show-journal can prove read-only diagnostic behavior.
+    let private seedSchemaVersionOnly root schemaVersion =
+        let dbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+        use connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+        executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+        executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{schemaVersion}');"
+
     /// Writes a fresh Watch IPC snapshot so clear-journal can prove the v1 single-writer refusal.
     let private writeLiveWatchIpc () =
         let current = Current()
@@ -620,6 +646,37 @@ module MaintenanceCliTests =
             appliedRow.GetProperty("Sequence").GetInt64()
             |> should equal 2L)
 
+    /// Verifies that maintenance show journal reports unhealthy local state without repairing or rotating the DB.
+    [<Test>]
+    let ``maintenance show journal json reports stale schema without mutating local db`` () =
+        withTempRepo (fun root ->
+            seedSchemaVersionOnly root "0"
+
+            let localStateDbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+            let dbBefore = snapshotFile localStateDbPath
+            let corruptBefore = getCorruptBackups root |> Array.length
+
+            /// Verifies that the CLI maintenance scenario exits with the expected process status.
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "show-journal" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+
+            document
+                .RootElement
+                .GetProperty("Error")
+                .GetString()
+            |> should contain "healthy local state database"
+
+            snapshotFile localStateDbPath
+            |> should equal dbBefore
+
+            getCorruptBackups root
+            |> Array.length
+            |> should equal corruptBefore)
+
     /// Verifies that maintenance clear journal resets journal state without removing status data.
     [<Test>]
     let ``maintenance clear journal json clears only journal rows and metadata`` () =
@@ -655,6 +712,35 @@ module MaintenanceCliTests =
 
             countRows root "status_meta"
             |> should equal statusRowsBefore)
+
+    /// Verifies that maintenance clear journal does not create a partial local-state database when nothing exists.
+    [<Test>]
+    let ``maintenance clear journal json no-ops without creating local db`` () =
+        withTempRepo (fun root ->
+            let localStateDbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+            File.Exists(localStateDbPath)
+            |> should equal false
+
+            /// Verifies that the CLI maintenance scenario exits with the expected process status.
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "clear-journal" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue.GetProperty("RowsDeleted").GetInt64()
+            |> should equal 0L
+
+            returnValue
+                .GetProperty("AppliedThroughSequenceBefore")
+                .GetInt64()
+            |> should equal 0L
+
+            File.Exists(localStateDbPath)
+            |> should equal false)
 
     /// Verifies that maintenance clear journal refuses while a fresh Watch process owns IPC.
     [<Test>]

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -2,12 +2,16 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client.Configuration
 open Grace.Types.Common
+open Microsoft.Data.Sqlite
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Generic
 open System.IO
 open System.Text.Json
 
@@ -68,6 +72,71 @@ module MaintenanceCliTests =
         |> should equal true
 
         JsonDocument.Parse(output)
+
+    /// Executes a scalar integer query against the local state database.
+    let private executeScalarInt (connection: SqliteConnection) (sql: string) =
+        use command = connection.CreateCommand()
+        command.CommandText <- sql
+        command.ExecuteScalar() |> Convert.ToInt32
+
+    /// Writes a SQL statement against the local state database for maintenance command setup.
+    let private executeNonQuery (connection: SqliteConnection) (sql: string) =
+        use command = connection.CreateCommand()
+        command.CommandText <- sql
+        command.ExecuteNonQuery() |> ignore
+
+    /// Seeds durable Watch journal rows without persisting raw watcher event payloads.
+    let private seedWatchJournalRows root throughSequence appliedThrough =
+        let dbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+        LocalStateDb.ensureDbInitialized dbPath
+        |> Async.AwaitTask
+        |> Async.RunSynchronously
+
+        use connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+
+        for sequence in [| 1L .. throughSequence |] do
+            executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});"
+
+        executeNonQuery connection $"UPDATE meta SET value = '{appliedThrough}' WHERE key = 'AppliedThroughSequence';"
+
+    /// Counts local state rows so maintenance reset tests can prove destructive scope.
+    let private countRows root tableName =
+        let dbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+        use connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+        executeScalarInt connection $"SELECT COUNT(*) FROM {tableName};"
+
+    /// Writes a fresh Watch IPC snapshot so clear-journal can prove the v1 single-writer refusal.
+    let private writeLiveWatchIpc () =
+        let current = Current()
+
+        let status: Services.GraceWatchStatus =
+            {
+                UpdatedAt = Grace.Shared.Utilities.getCurrentInstant ()
+                IsStartupClaim = false
+                RepositoryId = current.RepositoryId
+                RepositoryName = RepositoryName current.RepositoryName
+                BranchId = current.BranchId
+                BranchName = BranchName current.BranchName
+                RootDirectory = current.RootDirectory
+                HasPendingWatchWork = false
+                IsWorkingTreeClean = true
+                RootDirectoryId = Guid.NewGuid()
+                RootDirectorySha256Hash = Sha256Hash "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                RootDirectoryBlake3Hash = Blake3Hash "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                LastFileUploadInstant = Instant.MinValue
+                LastDirectoryVersionInstant = Instant.MinValue
+                DirectoryIds = HashSet<DirectoryVersionId>()
+            }
+
+        let ipcFileName = Services.IpcFileName()
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+        |> ignore
+
+        File.WriteAllText(ipcFileName, Grace.Shared.Utilities.serialize status)
 
     /// Asserts that clean json stdout matches the expected contract.
     let private assertCleanJsonStdout (standardOut: string) =
@@ -469,3 +538,140 @@ module MaintenanceCliTests =
                 .GetProperty("Directories")
                 .GetArrayLength()
             |> should equal 0)
+
+    /// Verifies that maintenance show journal emits filtered Watch journal rows in the JSON contract.
+    [<Test>]
+    let ``maintenance show journal json filters by pending state and limit`` () =
+        withTempRepo (fun root ->
+            seedWatchJournalRows root 4L 2L
+
+            /// Verifies that the CLI maintenance scenario exits with the expected process status.
+            let exitCode, standardOut, standardError =
+                runJsonMaintenance [| "show-journal"
+                                      "--state"
+                                      "pending"
+                                      "--limit"
+                                      "1" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue
+                .GetProperty("AppliedThroughSequence")
+                .GetInt64()
+            |> should equal 2L
+
+            returnValue
+                .GetProperty("AllocatedSequence")
+                .GetInt64()
+            |> should equal 4L
+
+            returnValue.GetProperty("TotalRows").GetInt64()
+            |> should equal 4L
+
+            returnValue.GetProperty("StateFilter").GetString()
+            |> should equal "pending"
+
+            returnValue.GetProperty("Limit").GetInt32()
+            |> should equal 1
+
+            let rows = returnValue.GetProperty("Rows")
+            rows.GetArrayLength() |> should equal 1
+
+            let row = rows[0]
+
+            row.GetProperty("Sequence").GetInt64()
+            |> should equal 4L
+
+            row.GetProperty("State").GetString()
+            |> should equal "pending"
+
+            /// Verifies that state filtering happens before limit selection.
+            let appliedExitCode, appliedStandardOut, appliedStandardError =
+                runJsonMaintenance [| "show-journal"
+                                      "--state"
+                                      "applied"
+                                      "--limit"
+                                      "1" |]
+
+            appliedExitCode |> should equal 0
+            appliedStandardError |> should equal String.Empty
+
+            use appliedDocument = assertCleanJsonStdout appliedStandardOut
+
+            let appliedRow =
+                appliedDocument
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Rows")[0]
+
+            appliedRow.GetProperty("Sequence").GetInt64()
+            |> should equal 2L)
+
+    /// Verifies that maintenance clear journal resets journal state without removing status data.
+    [<Test>]
+    let ``maintenance clear journal json clears only journal rows and metadata`` () =
+        withTempRepo (fun root ->
+            createIndex ()
+            seedWatchJournalRows root 3L 2L
+
+            let statusRowsBefore = countRows root "status_meta"
+
+            /// Verifies that the CLI maintenance scenario exits with the expected process status.
+            let exitCode, standardOut, standardError = runJsonMaintenance [| "clear-journal" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+            let returnValue = document.RootElement.GetProperty("ReturnValue")
+
+            returnValue.GetProperty("RowsDeleted").GetInt64()
+            |> should equal 3L
+
+            returnValue
+                .GetProperty("AppliedThroughSequenceBefore")
+                .GetInt64()
+            |> should equal 2L
+
+            returnValue
+                .GetProperty("AppliedThroughSequenceAfter")
+                .GetInt64()
+            |> should equal 0L
+
+            countRows root "watch_journal" |> should equal 0
+
+            countRows root "status_meta"
+            |> should equal statusRowsBefore)
+
+    /// Verifies that maintenance clear journal refuses while a fresh Watch process owns IPC.
+    [<Test>]
+    let ``maintenance clear journal refuses while watch is running`` () =
+        withTempRepo (fun root ->
+            seedWatchJournalRows root 2L 1L
+
+            try
+                writeLiveWatchIpc ()
+
+                /// Verifies that the CLI maintenance scenario exits with the expected process status.
+                let exitCode, standardOut, standardError = runJsonMaintenance [| "clear-journal" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = assertCleanJsonStdout standardOut
+
+                document
+                    .RootElement
+                    .GetProperty("Error")
+                    .GetString()
+                |> should contain "Grace Watch is running"
+
+                countRows root "watch_journal" |> should equal 2
+            finally
+                let ipcFileName = Services.IpcFileName()
+
+                if File.Exists(ipcFileName) then File.Delete(ipcFileName))

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -138,6 +138,15 @@ module MaintenanceCliTests =
 
         File.WriteAllText(ipcFileName, Grace.Shared.Utilities.serialize status)
 
+    /// Writes an unreadable Watch IPC payload for conservative clear-journal refusal coverage.
+    let private writeUnreadableWatchIpc () =
+        let ipcFileName = Services.IpcFileName()
+
+        Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+        |> ignore
+
+        File.WriteAllText(ipcFileName, "{")
+
     /// Asserts that clean json stdout matches the expected contract.
     let private assertCleanJsonStdout (standardOut: string) =
         standardOut |> should not' (contain "Elapsed:")
@@ -669,6 +678,35 @@ module MaintenanceCliTests =
                     .GetProperty("Error")
                     .GetString()
                 |> should contain "Grace Watch is running"
+
+                countRows root "watch_journal" |> should equal 2
+            finally
+                let ipcFileName = Services.IpcFileName()
+
+                if File.Exists(ipcFileName) then File.Delete(ipcFileName))
+
+    /// Verifies that maintenance clear journal treats unreadable Watch IPC as live to avoid racing a heartbeat write.
+    [<Test>]
+    let ``maintenance clear journal refuses when watch status exists but cannot be read`` () =
+        withTempRepo (fun root ->
+            seedWatchJournalRows root 2L 1L
+
+            try
+                writeUnreadableWatchIpc ()
+
+                /// Verifies that the CLI maintenance scenario exits with the expected process status.
+                let exitCode, standardOut, standardError = runJsonMaintenance [| "clear-journal" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = assertCleanJsonStdout standardOut
+
+                document
+                    .RootElement
+                    .GetProperty("Error")
+                    .GetString()
+                |> should contain "could not be read"
 
                 countRows root "watch_journal" |> should equal 2
             finally

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -151,6 +151,34 @@ module Common =
                 NewDirectoryVersions: MaintenanceScanDirectoryVersionDto array
             }
 
+        /// Models one durable Watch journal row emitted by maintenance show-journal.
+        type MaintenanceJournalRowDto = { Sequence: int64; CreatedAtUnixTicks: int64; State: string; RelativePath: string option }
+
+        /// Models filtered durable Watch journal diagnostics for maintenance show-journal.
+        type MaintenanceShowJournalDto =
+            {
+                DbPath: string
+                AppliedThroughSequence: int64
+                AllocatedSequence: int64
+                TotalRows: int64
+                RowCount: int
+                StateFilter: string
+                PathFilter: string option
+                Limit: int
+                Rows: MaintenanceJournalRowDto array
+            }
+
+        /// Models the scoped durable Watch journal reset result for maintenance clear-journal.
+        type MaintenanceClearJournalDto =
+            {
+                DbPath: string
+                RowsDeleted: int64
+                AppliedThroughSequenceBefore: int64
+                AppliedThroughSequenceAfter: int64
+                AllocatedSequenceBefore: int64
+                AllocatedSequenceAfter: int64
+            }
+
         /// Defines structured data exchanged by CLI helpers.
         type DoctorCheckDto = { Id: string; Category: string; Title: string; Description: string; DefaultEnabled: bool; SupportsOffline: bool }
 

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -975,6 +975,11 @@ module Maintenance =
 
                     if inspection.IsLiveProcess then
                         return renderMaintenanceError parseResult "Grace Watch is running; stop grace watch before clearing the durable Watch journal."
+                    elif inspection.Exists && inspection.ReadError.IsSome then
+                        return
+                            renderMaintenanceError
+                                parseResult
+                                "Grace Watch status exists but could not be read; stop grace watch or remove stale Watch IPC before clearing the durable Watch journal."
                     else
                         let! result = Grace.CLI.LocalStateDb.clearWatchJournal (Current().GraceStatusFile)
                         let dto = toClearJournalDto result

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -112,6 +112,32 @@ module Maintenance =
                 DefaultValueFactory = (fun _ -> "*.*")
             )
 
+        let journalState =
+            new Option<string>(
+                "--state",
+                Required = false,
+                Description = "Filter Watch journal rows by derived state: all, applied, or pending. [default: all]",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> "all")
+            )
+
+        let journalPath =
+            new Option<string>(
+                "--path",
+                Required = false,
+                Description = "Filter Watch journal rows by repository-relative path when row path metadata is available.",
+                Arity = ArgumentArity.ZeroOrOne
+            )
+
+        let journalLimit =
+            new Option<int>(
+                "--limit",
+                Required = false,
+                Description = "Maximum number of Watch journal rows to inspect. [default: 100]",
+                Arity = ArgumentArity.ZeroOrOne,
+                DefaultValueFactory = (fun _ -> 100)
+            )
+
     /// Tries to map get root sha256 hash and returns a GraceError instead of throwing on unsupported input.
     let private tryGetRootSha256Hash (graceStatus: GraceStatus) =
         let rootHashFromIndex =
@@ -246,10 +272,49 @@ module Maintenance =
                 |> Seq.toArray
         }
 
+    /// Converts one durable Watch journal row into the maintenance command output contract.
+    let private toJournalRowDto (row: Grace.CLI.LocalStateDb.WatchJournalRow) : LocalOutputDto.MaintenanceJournalRowDto =
+        { Sequence = row.Sequence; CreatedAtUnixTicks = row.CreatedAtUnixTicks; State = $"{row.State}".ToLowerInvariant(); RelativePath = row.RelativePath }
+
+    /// Converts a Watch journal diagnostic snapshot into the maintenance command output contract.
+    let private toShowJournalDto (snapshot: Grace.CLI.LocalStateDb.WatchJournalSnapshot) : LocalOutputDto.MaintenanceShowJournalDto =
+        {
+            DbPath = snapshot.DbPath
+            AppliedThroughSequence = snapshot.AppliedThroughSequence
+            AllocatedSequence = snapshot.AllocatedSequence
+            TotalRows = snapshot.TotalRows
+            RowCount = snapshot.RowCount
+            StateFilter = snapshot.StateFilter
+            PathFilter = snapshot.PathFilter
+            Limit = snapshot.Limit
+            Rows = snapshot.Rows |> Array.map toJournalRowDto
+        }
+
+    /// Converts a scoped Watch journal reset result into the maintenance command output contract.
+    let private toClearJournalDto (result: Grace.CLI.LocalStateDb.ClearWatchJournalResult) : LocalOutputDto.MaintenanceClearJournalDto =
+        {
+            DbPath = result.DbPath
+            RowsDeleted = result.RowsDeleted
+            AppliedThroughSequenceBefore = result.AppliedThroughSequenceBefore
+            AppliedThroughSequenceAfter = result.AppliedThroughSequenceAfter
+            AllocatedSequenceBefore = result.AllocatedSequenceBefore
+            AllocatedSequenceAfter = result.AllocatedSequenceAfter
+        }
+
     /// Renders local json results only when the selected output mode includes human-readable console text.
     let private renderLocalJson parseResult dto =
         Ok(GraceReturnValue.Create dto (getCorrelationId parseResult))
         |> renderOutput parseResult
+
+    /// Emits a maintenance command failure through the selected output mode.
+    let private renderMaintenanceError parseResult message =
+        if parseResult |> json then
+            GraceError.Create message (getCorrelationId parseResult)
+            |> writeJsonErrorStdout
+        else
+            logToAnsiConsole Colors.Error message
+
+        -1
 
     /// Routes the update index command from parsed options through validation, the SDK call, and result rendering.
     let private updateIndexHandler (parseResult: ParseResult) =
@@ -855,6 +920,80 @@ module Maintenance =
                     return 0
             }
 
+    /// Executes the show journal command by reading durable Watch journal diagnostics from local state.
+    type ShowJournal() =
+        inherit AsynchronousCommandLineAction()
+
+        /// Runs the asynchronous show journal action when System.CommandLine dispatches the parsed command.
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let stateFilter = parseResult.GetValue(Options.journalState)
+                    let pathFilter = parseResult.GetValue(Options.journalPath)
+                    let limit = parseResult.GetValue(Options.journalLimit)
+
+                    let! snapshot =
+                        Grace.CLI.LocalStateDb.readWatchJournalSnapshot
+                            (Current().GraceStatusFile)
+                            stateFilter
+                            (if String.IsNullOrWhiteSpace(pathFilter) then None else Some pathFilter)
+                            limit
+
+                    let dto = toShowJournalDto snapshot
+
+                    if parseResult |> json then
+                        return renderLocalJson parseResult dto
+                    else
+                        AnsiConsole.MarkupLine($"[{Colors.Important}]Watch journal database: {Markup.Escape(dto.DbPath)}[/]")
+                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Rows shown: {dto.RowCount}; total rows: {dto.TotalRows}; limit: {dto.Limit}.[/]")
+
+                        AnsiConsole.MarkupLine(
+                            $"[{Colors.Highlighted}]Applied through sequence: {dto.AppliedThroughSequence}; allocated sequence: {dto.AllocatedSequence}.[/]"
+                        )
+
+                        for row in dto.Rows do
+                            AnsiConsole.MarkupLine($"[{Colors.Verbose}]#{row.Sequence} {row.State} created_at_unix_ticks={row.CreatedAtUnixTicks}[/]")
+
+                        return 0
+                with
+                | ex -> return renderMaintenanceError parseResult $"Exception in ShowJournal: {ExceptionResponse.Create ex}"
+            }
+
+    /// Executes the clear journal command while refusing to race a live Watch process.
+    type ClearJournal() =
+        inherit AsynchronousCommandLineAction()
+
+        /// Runs the asynchronous clear journal action when System.CommandLine dispatches the parsed command.
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
+            task {
+                try
+                    if parseResult |> verbose then printParseResult parseResult
+
+                    let! inspection = inspectGraceWatchStatus ()
+
+                    if inspection.IsLiveProcess then
+                        return renderMaintenanceError parseResult "Grace Watch is running; stop grace watch before clearing the durable Watch journal."
+                    else
+                        let! result = Grace.CLI.LocalStateDb.clearWatchJournal (Current().GraceStatusFile)
+                        let dto = toClearJournalDto result
+
+                        if parseResult |> json then
+                            return renderLocalJson parseResult dto
+                        else
+                            AnsiConsole.MarkupLine($"[{Colors.Important}]Cleared durable Watch journal rows from local state.[/]")
+                            AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Rows deleted: {dto.RowsDeleted}.[/]")
+
+                            AnsiConsole.MarkupLine(
+                                $"[{Colors.Highlighted}]Applied-through sequence reset from {dto.AppliedThroughSequenceBefore} to {dto.AppliedThroughSequenceAfter}; allocation reset from {dto.AllocatedSequenceBefore} to {dto.AllocatedSequenceAfter}.[/]"
+                            )
+
+                            return 0
+                with
+                | ex -> return renderMaintenanceError parseResult $"Exception in ClearJournal: {ExceptionResponse.Create ex}"
+            }
+
     /// Executes the check ignore entries command by binding ParseResult values to the SDK request and CLI output contract.
     type CheckIgnoreEntries() =
         inherit AsynchronousCommandLineAction()
@@ -933,6 +1072,20 @@ module Maintenance =
 
         listContentsCommand.Action <- new ListContents()
         maintenanceCommand.Subcommands.Add(listContentsCommand)
+
+        let showJournalCommand =
+            new Command("show-journal", Description = "Show durable local Watch journal diagnostics.")
+            |> addOption Options.journalState
+            |> addOption Options.journalPath
+            |> addOption Options.journalLimit
+
+        showJournalCommand.Action <- new ShowJournal()
+        maintenanceCommand.Subcommands.Add(showJournalCommand)
+
+        let clearJournalCommand = new Command("clear-journal", Description = "Clear only durable local Watch journal rows and metadata.")
+
+        clearJournalCommand.Action <- new ClearJournal()
+        maintenanceCommand.Subcommands.Add(clearJournalCommand)
 
         let checkIgnoreEntriesCommand =
             new Command("check-ignore-entries", Description = "Check the .graceignore entries for validity.")

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -424,6 +424,96 @@ module CommandOutputContract =
                     |]
             |}
 
+    let private maintenanceJournalRowSchema =
+        schemaObject
+            "MaintenanceJournalRowDto"
+            [
+                "Sequence", scalarSchema "integer"
+                "CreatedAtUnixTicks", scalarSchema "integer"
+                "State", scalarSchema "string"
+                "RelativePath", nullableStringSchema "Repository-relative path when the durable journal row stores path metadata."
+            ]
+            [|
+                "Sequence"
+                "CreatedAtUnixTicks"
+                "State"
+                "RelativePath"
+            |]
+
+    let private maintenanceShowJournalSchema =
+        schemaObject
+            "MaintenanceShowJournalDto"
+            [
+                "DbPath", scalarSchema "string"
+                "AppliedThroughSequence", scalarSchema "integer"
+                "AllocatedSequence", scalarSchema "integer"
+                "TotalRows", scalarSchema "integer"
+                "RowCount", scalarSchema "integer"
+                "StateFilter", scalarSchema "string"
+                "PathFilter", nullableStringSchema "Path filter echoed from the command invocation."
+                "Limit", scalarSchema "integer"
+                "Rows", arraySchema maintenanceJournalRowSchema "Filtered durable Watch journal rows."
+            ]
+            [|
+                "DbPath"
+                "AppliedThroughSequence"
+                "AllocatedSequence"
+                "TotalRows"
+                "RowCount"
+                "StateFilter"
+                "PathFilter"
+                "Limit"
+                "Rows"
+            |]
+
+    let private maintenanceShowJournalExample =
+        box
+            {|
+                DbPath = "C:\\repo\\.grace\\grace-local.db"
+                AppliedThroughSequence = 2L
+                AllocatedSequence = 4L
+                TotalRows = 4L
+                RowCount = 1
+                StateFilter = "pending"
+                PathFilter = null
+                Limit = 1
+                Rows =
+                    [|
+                        {| Sequence = 4L; CreatedAtUnixTicks = 4L; State = "pending"; RelativePath = null |}
+                    |]
+            |}
+
+    let private maintenanceClearJournalSchema =
+        schemaObject
+            "MaintenanceClearJournalDto"
+            [
+                "DbPath", scalarSchema "string"
+                "RowsDeleted", scalarSchema "integer"
+                "AppliedThroughSequenceBefore", scalarSchema "integer"
+                "AppliedThroughSequenceAfter", scalarSchema "integer"
+                "AllocatedSequenceBefore", scalarSchema "integer"
+                "AllocatedSequenceAfter", scalarSchema "integer"
+            ]
+            [|
+                "DbPath"
+                "RowsDeleted"
+                "AppliedThroughSequenceBefore"
+                "AppliedThroughSequenceAfter"
+                "AllocatedSequenceBefore"
+                "AllocatedSequenceAfter"
+            |]
+
+    let private maintenanceClearJournalExample =
+        box
+            {|
+                DbPath = "C:\\repo\\.grace\\grace-local.db"
+                RowsDeleted = 3L
+                AppliedThroughSequenceBefore = 2L
+                AppliedThroughSequenceAfter = 0L
+                AllocatedSequenceBefore = 3L
+                AllocatedSequenceAfter = 0L
+            |}
+
     let private watchStatusSchema =
         schemaObject
             "WatchStatusDto"
@@ -686,6 +776,26 @@ module CommandOutputContract =
                 maintenanceScanExample
                 [
                     "Command-specific CLI DTO emitted by maintenance scan in the common Grace result envelope."
+                ]
+        | "maintenance.show-journal", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceShowJournalDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceShowJournalSchema
+                maintenanceShowJournalExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance show-journal in the common Grace result envelope."
+                    "Rows expose durable sequence diagnostics and derived applied/pending state without storing raw watcher events as replay data."
+                ]
+        | "maintenance.clear-journal", ExistingGraceResultEnvelope RequiresCliDto ->
+            supportedReturnValueContract
+                "MaintenanceClearJournalDto"
+                "Grace.CLI.Command.Common.LocalOutputDto"
+                maintenanceClearJournalSchema
+                maintenanceClearJournalExample
+                [
+                    "Command-specific CLI DTO emitted by maintenance clear-journal in the common Grace result envelope."
+                    "The command clears only Watch journal rows, SQLite allocation metadata, and the AppliedThroughSequence watermark."
                 ]
         | "maintenance.stats", ExistingGraceResultEnvelope RequiresCliDto ->
             supportedReturnValueContract
@@ -1159,8 +1269,10 @@ module CommandOutputContract =
             row [ "history" ] "show" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [] "doctor" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "check-ignore-entries" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
+            row [ "maintenance" ] "clear-journal" true true common_renderOutput_envelope mutating local_client RequiresCliDto
             row [ "maintenance" ] "list-contents" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "scan" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
+            row [ "maintenance" ] "show-journal" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "stats" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "maintenance" ] "update-index" true true common_renderOutput_envelope progress_local_workflow local_client RequiresCliDto
             row [ "organization" ] "create" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -782,6 +782,12 @@ module LocalStateDb =
         | Some sequence -> sequence
         | None -> raise (InvalidDataException("sqlite_sequence.seq for watch_journal must be a non-negative 64-bit integer."))
 
+    /// Counts durable Watch journal rows without reading any replay payload.
+    let private countWatchJournalRows (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT COUNT(*) FROM watch_journal;"
+        command.ExecuteScalar() |> Convert.ToInt64
+
     /// Reads local-state metadata for read-only inspection checks without writing default rows.
     let private tryGetMetaValueReadOnly (connection: SqliteConnection) (key: string) =
         use cmd = connection.CreateCommand()
@@ -1012,6 +1018,69 @@ module LocalStateDb =
             | None -> raise (InvalidDataException($"{WatchJournalAppliedThroughSequenceMetaKey} must be a non-negative 64-bit integer."))
         | None -> 0L
 
+    /// Defines the derived state used when showing journal rows without storing raw watcher events.
+    type WatchJournalRowState =
+        | Applied
+        | Pending
+
+    /// Models one durable Watch journal sequence row for diagnostics.
+    type WatchJournalRow = { Sequence: int64; CreatedAtUnixTicks: int64; State: WatchJournalRowState; RelativePath: string option }
+
+    /// Models a filtered Watch journal diagnostic snapshot.
+    type WatchJournalSnapshot =
+        {
+            DbPath: string
+            AppliedThroughSequence: int64
+            AllocatedSequence: int64
+            TotalRows: int64
+            RowCount: int
+            StateFilter: string
+            PathFilter: string option
+            Limit: int
+            Rows: WatchJournalRow array
+        }
+
+    /// Models the result of explicitly resetting only durable Watch journal state.
+    type ClearWatchJournalResult =
+        {
+            DbPath: string
+            RowsDeleted: int64
+            AppliedThroughSequenceBefore: int64
+            AppliedThroughSequenceAfter: int64
+            AllocatedSequenceBefore: int64
+            AllocatedSequenceAfter: int64
+        }
+
+    /// Normalizes the journal row state filter used by diagnostic show commands.
+    let private normalizeWatchJournalStateFilter (stateFilter: string) =
+        if String.IsNullOrWhiteSpace(stateFilter) then
+            "all"
+        else
+            let normalized = stateFilter.Trim().ToLowerInvariant()
+
+            match normalized with
+            | "all"
+            | "applied"
+            | "pending" -> normalized
+            | _ -> invalidArg (nameof stateFilter) "Watch journal state must be one of: all, applied, pending."
+
+    /// Determines whether a diagnostic journal row should be returned for the requested filters.
+    let private watchJournalRowMatches stateFilter pathFilter (row: WatchJournalRow) =
+        let stateMatches =
+            match stateFilter, row.State with
+            | "all", _ -> true
+            | "applied", Applied -> true
+            | "pending", Pending -> true
+            | _ -> false
+
+        let pathMatches =
+            match pathFilter, row.RelativePath with
+            | None, _ -> true
+            | Some filter, Some relativePath -> relativePath.Contains((filter: string), StringComparison.OrdinalIgnoreCase)
+            | Some _, None -> false
+
+        stateMatches && pathMatches
+
     /// Persists insert status meta if missing changes in the local SQLite state database.
     let private insertStatusMetaIfMissing (connection: SqliteConnection) =
         let defaultStatus = GraceStatus.Default
@@ -1200,6 +1269,120 @@ module LocalStateDb =
             do! ensureDbInitialized dbPath
             use connection = openConnection dbPath
             return readWatchJournalAppliedThroughSequenceInternal connection
+        }
+
+    /// Reads a bounded diagnostic snapshot of the durable Watch journal.
+    let readWatchJournalSnapshot (dbPath: string) (stateFilter: string) (pathFilter: string option) (limit: int) =
+        task {
+            if limit < 1 then
+                invalidArg (nameof limit) "Watch journal limit must be greater than zero."
+
+            do! ensureDbInitialized dbPath
+            use connection = openConnection dbPath
+            let appliedThroughSequence = readWatchJournalAppliedThroughSequenceInternal connection
+            let allocatedSequence = readAllocatedWatchJournalSequence connection
+            let totalRows = countWatchJournalRows connection
+            let normalizedStateFilter = normalizeWatchJournalStateFilter stateFilter
+
+            let normalizedPathFilter =
+                pathFilter
+                |> Option.bind (fun value -> if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim()))
+
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                match normalizedStateFilter with
+                | "applied" ->
+                    "SELECT sequence, created_at_unix_ticks FROM watch_journal WHERE sequence <= $applied_through ORDER BY sequence DESC LIMIT $limit;"
+                | "pending" ->
+                    "SELECT sequence, created_at_unix_ticks FROM watch_journal WHERE sequence > $applied_through ORDER BY sequence DESC LIMIT $limit;"
+                | _ -> "SELECT sequence, created_at_unix_ticks FROM watch_journal ORDER BY sequence DESC LIMIT $limit;"
+
+            command.Parameters.AddWithValue("$limit", limit)
+            |> ignore
+
+            if normalizedStateFilter = "applied"
+               || normalizedStateFilter = "pending" then
+                command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
+                |> ignore
+
+            use reader = command.ExecuteReader()
+            let rows = ResizeArray<WatchJournalRow>()
+
+            while reader.Read() do
+                let sequence = reader.GetInt64(0)
+
+                let state = if sequence <= appliedThroughSequence then Applied else Pending
+
+                let row = { Sequence = sequence; CreatedAtUnixTicks = reader.GetInt64(1); State = state; RelativePath = None }
+
+                if watchJournalRowMatches normalizedStateFilter normalizedPathFilter row then
+                    rows.Add(row)
+
+            return
+                {
+                    DbPath = Path.GetFullPath(dbPath)
+                    AppliedThroughSequence = appliedThroughSequence
+                    AllocatedSequence = allocatedSequence
+                    TotalRows = totalRows
+                    RowCount = rows.Count
+                    StateFilter = normalizedStateFilter
+                    PathFilter = normalizedPathFilter
+                    Limit = limit
+                    Rows = rows |> Seq.toArray
+                }
+        }
+
+    /// Clears only the durable Watch journal rows, allocation metadata, and recovery watermark.
+    let clearWatchJournal (dbPath: string) =
+        task {
+            do! ensureDbInitialized dbPath
+            let mutable result = None
+
+            do!
+                executeWithRetry (fun () ->
+                    task {
+                        use connection = openConnection dbPath
+                        executeNonQuery connection "BEGIN IMMEDIATE;"
+                        let mutable committed = false
+
+                        try
+                            let rowsBefore = countWatchJournalRows connection
+                            let appliedBefore = readWatchJournalAppliedThroughSequenceInternal connection
+                            let allocatedBefore = readAllocatedWatchJournalSequence connection
+
+                            executeNonQuery connection "DELETE FROM watch_journal;"
+                            executeNonQuery connection "DELETE FROM sqlite_sequence WHERE name = 'watch_journal';"
+                            setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey "0"
+
+                            let rowsAfter = countWatchJournalRows connection
+                            let appliedAfter = readWatchJournalAppliedThroughSequenceInternal connection
+                            let allocatedAfter = readAllocatedWatchJournalSequence connection
+
+                            executeNonQuery connection "COMMIT;"
+                            committed <- true
+
+                            result <-
+                                Some
+                                    {
+                                        DbPath = Path.GetFullPath(dbPath)
+                                        RowsDeleted = rowsBefore - rowsAfter
+                                        AppliedThroughSequenceBefore = appliedBefore
+                                        AppliedThroughSequenceAfter = appliedAfter
+                                        AllocatedSequenceBefore = allocatedBefore
+                                        AllocatedSequenceAfter = allocatedAfter
+                                    }
+                        finally
+                            if not committed then
+                                try
+                                    executeNonQuery connection "ROLLBACK;"
+                                with
+                                | _ -> ()
+                    })
+
+            match result with
+            | Some result -> return result
+            | None -> return failwith "Watch journal clear did not produce a result."
         }
 
     /// Persists the local Watch journal recovery watermark without changing journal rows.

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1018,6 +1018,35 @@ module LocalStateDb =
             | None -> raise (InvalidDataException($"{WatchJournalAppliedThroughSequenceMetaKey} must be a non-negative 64-bit integer."))
         | None -> 0L
 
+    /// Reads the clear-journal starting watermark without trusting malformed journal-only metadata.
+    let private readWatchJournalAppliedThroughSequenceForClear (connection: SqliteConnection) =
+        match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
+        | 1 ->
+            match tryGetMetaValue connection WatchJournalAppliedThroughSequenceMetaKey with
+            | Some value ->
+                match tryParseWatchJournalAppliedThroughSequence value with
+                | Some sequence -> sequence
+                | None -> 0L
+            | None -> 0L
+        | _ -> 0L
+
+    /// Ensures clear-journal has the minimal journal tables it mutates without recreating unrelated local state.
+    let private ensureWatchJournalClearSchema (connection: SqliteConnection) =
+        ensureJournalMode connection
+        executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL);"
+
+    /// Replaces malformed or missing Watch recovery metadata with the clear-journal reset watermark.
+    let private resetWatchJournalAppliedThroughSequenceForClear (connection: SqliteConnection) =
+        executeNonQueryWithParams connection "DELETE FROM meta WHERE key = $key;" (fun parameters ->
+            parameters.AddWithValue("$key", WatchJournalAppliedThroughSequenceMetaKey)
+            |> ignore)
+
+        setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey "0"
+
     /// Defines the derived state used when showing journal rows without storing raw watcher events.
     type WatchJournalRowState =
         | Applied
@@ -1336,24 +1365,24 @@ module LocalStateDb =
     /// Clears only the durable Watch journal rows, allocation metadata, and recovery watermark.
     let clearWatchJournal (dbPath: string) =
         task {
-            do! ensureDbInitialized dbPath
             let mutable result = None
 
             do!
                 executeWithRetry (fun () ->
                     task {
                         use connection = openConnection dbPath
+                        ensureWatchJournalClearSchema connection
                         executeNonQuery connection "BEGIN IMMEDIATE;"
                         let mutable committed = false
 
                         try
                             let rowsBefore = countWatchJournalRows connection
-                            let appliedBefore = readWatchJournalAppliedThroughSequenceInternal connection
+                            let appliedBefore = readWatchJournalAppliedThroughSequenceForClear connection
                             let allocatedBefore = readAllocatedWatchJournalSequence connection
 
                             executeNonQuery connection "DELETE FROM watch_journal;"
                             executeNonQuery connection "DELETE FROM sqlite_sequence WHERE name = 'watch_journal';"
-                            setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey "0"
+                            resetWatchJournalAppliedThroughSequenceForClear connection
 
                             let rowsAfter = countWatchJournalRows connection
                             let appliedAfter = readWatchJournalAppliedThroughSequenceInternal connection

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -782,6 +782,12 @@ module LocalStateDb =
         | Some sequence -> sequence
         | None -> raise (InvalidDataException("sqlite_sequence.seq for watch_journal must be a non-negative 64-bit integer."))
 
+    /// Reads the clear-journal allocation watermark without trusting malformed journal-only metadata.
+    let private readAllocatedWatchJournalSequenceForClear (connection: SqliteConnection) =
+        match tryReadAllocatedWatchJournalSequence connection with
+        | Some sequence -> sequence
+        | None -> 0L
+
     /// Counts durable Watch journal rows without reading any replay payload.
     let private countWatchJournalRows (connection: SqliteConnection) =
         use command = connection.CreateCommand()
@@ -1306,8 +1312,30 @@ module LocalStateDb =
             if limit < 1 then
                 invalidArg (nameof limit) "Watch journal limit must be greater than zero."
 
-            do! ensureDbInitialized dbPath
-            use connection = openConnection dbPath
+            let normalizedPath = Path.GetFullPath(dbPath)
+            let inspection = inspectReadOnly normalizedPath
+
+            if not inspection.OpenedReadOnly then
+                let detail =
+                    inspection.OpenError
+                    |> Option.defaultValue "local state database does not exist or could not be opened read-only."
+
+                raise (InvalidDataException($"Watch journal diagnostics require a readable local state database: {detail}"))
+
+            if inspection.SchemaVersion <> Some SchemaVersion
+               || inspection.MissingRequiredTables.Length > 0
+               || inspection.MissingRequiredIndexes.Length > 0
+               || inspection.WatchJournalShapeValid <> Some true
+               || inspection.WatchJournalAppliedThroughMetadataValid
+                  <> Some true then
+                raise (
+                    InvalidDataException(
+                        "Watch journal diagnostics require a healthy local state database; run grace doctor or a writable command to repair local state."
+                    )
+                )
+
+            let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
+            use connection = openReadOnlyConnection normalizedPath immutableSnapshot
             let appliedThroughSequence = readWatchJournalAppliedThroughSequenceInternal connection
             let allocatedSequence = readAllocatedWatchJournalSequence connection
             let totalRows = countWatchJournalRows connection
@@ -1350,7 +1378,7 @@ module LocalStateDb =
 
             return
                 {
-                    DbPath = Path.GetFullPath(dbPath)
+                    DbPath = normalizedPath
                     AppliedThroughSequence = appliedThroughSequence
                     AllocatedSequence = allocatedSequence
                     TotalRows = totalRows
@@ -1365,53 +1393,69 @@ module LocalStateDb =
     /// Clears only the durable Watch journal rows, allocation metadata, and recovery watermark.
     let clearWatchJournal (dbPath: string) =
         task {
-            let mutable result = None
+            let normalizedPath = Path.GetFullPath(dbPath)
 
-            do!
-                executeWithRetry (fun () ->
-                    task {
-                        use connection = openConnection dbPath
-                        ensureWatchJournalClearSchema connection
-                        executeNonQuery connection "BEGIN IMMEDIATE;"
-                        let mutable committed = false
+            if
+                not (File.Exists(normalizedPath))
+                && not (Directory.Exists(normalizedPath))
+            then
+                return
+                    {
+                        DbPath = normalizedPath
+                        RowsDeleted = 0L
+                        AppliedThroughSequenceBefore = 0L
+                        AppliedThroughSequenceAfter = 0L
+                        AllocatedSequenceBefore = 0L
+                        AllocatedSequenceAfter = 0L
+                    }
+            else
+                let mutable result = None
 
-                        try
-                            let rowsBefore = countWatchJournalRows connection
-                            let appliedBefore = readWatchJournalAppliedThroughSequenceForClear connection
-                            let allocatedBefore = readAllocatedWatchJournalSequence connection
+                do!
+                    executeWithRetry (fun () ->
+                        task {
+                            use connection = openConnection normalizedPath
+                            ensureWatchJournalClearSchema connection
+                            executeNonQuery connection "BEGIN IMMEDIATE;"
+                            let mutable committed = false
 
-                            executeNonQuery connection "DELETE FROM watch_journal;"
-                            executeNonQuery connection "DELETE FROM sqlite_sequence WHERE name = 'watch_journal';"
-                            resetWatchJournalAppliedThroughSequenceForClear connection
+                            try
+                                let rowsBefore = countWatchJournalRows connection
+                                let appliedBefore = readWatchJournalAppliedThroughSequenceForClear connection
+                                let allocatedBefore = readAllocatedWatchJournalSequenceForClear connection
 
-                            let rowsAfter = countWatchJournalRows connection
-                            let appliedAfter = readWatchJournalAppliedThroughSequenceInternal connection
-                            let allocatedAfter = readAllocatedWatchJournalSequence connection
+                                executeNonQuery connection "DELETE FROM watch_journal;"
+                                executeNonQuery connection "DELETE FROM sqlite_sequence WHERE name = 'watch_journal';"
+                                resetWatchJournalAppliedThroughSequenceForClear connection
 
-                            executeNonQuery connection "COMMIT;"
-                            committed <- true
+                                let rowsAfter = countWatchJournalRows connection
+                                let appliedAfter = readWatchJournalAppliedThroughSequenceInternal connection
+                                let allocatedAfter = readAllocatedWatchJournalSequenceForClear connection
 
-                            result <-
-                                Some
-                                    {
-                                        DbPath = Path.GetFullPath(dbPath)
-                                        RowsDeleted = rowsBefore - rowsAfter
-                                        AppliedThroughSequenceBefore = appliedBefore
-                                        AppliedThroughSequenceAfter = appliedAfter
-                                        AllocatedSequenceBefore = allocatedBefore
-                                        AllocatedSequenceAfter = allocatedAfter
-                                    }
-                        finally
-                            if not committed then
-                                try
-                                    executeNonQuery connection "ROLLBACK;"
-                                with
-                                | _ -> ()
-                    })
+                                executeNonQuery connection "COMMIT;"
+                                committed <- true
 
-            match result with
-            | Some result -> return result
-            | None -> return failwith "Watch journal clear did not produce a result."
+                                result <-
+                                    Some
+                                        {
+                                            DbPath = normalizedPath
+                                            RowsDeleted = rowsBefore - rowsAfter
+                                            AppliedThroughSequenceBefore = appliedBefore
+                                            AppliedThroughSequenceAfter = appliedAfter
+                                            AllocatedSequenceBefore = allocatedBefore
+                                            AllocatedSequenceAfter = allocatedAfter
+                                        }
+                            finally
+                                if not committed then
+                                    try
+                                        executeNonQuery connection "ROLLBACK;"
+                                    with
+                                    | _ -> ()
+                        })
+
+                match result with
+                | Some result -> return result
+                | None -> return failwith "Watch journal clear did not produce a result."
         }
 
     /// Persists the local Watch journal recovery watermark without changing journal rows.


### PR DESCRIPTION
## Summary

Adds the WS4.2 maintenance commands for the local Watch journal:

- `grace maintenance show-journal` with JSON output, `--state`, `--limit`, and path echo support.
- `grace maintenance clear-journal`, which clears only journal rows, journal allocation metadata, and the applied
  journal watermark.
- Command-output registry and generated CLI output documentation updates for the two new commands.

Related to #498.
Part of #473.

## Why This Matters

Grace Watch needs operator-visible journal state before later append/apply and replay slices depend on it. These
maintenance commands make the new local SQLite journal inspectable and safely resettable without touching Grace status,
object cache, references, repository files, or repository content.

## Validation

- RED evidence: focused CLI test failed before implementation on missing `LocalStateDb.clearWatchJournal`.
- `dotnet tool run fantomas ...` on touched F# files: passed.
- `npx --yes markdownlint-cli2 "docs/Machine-readable CLI output.md"`: passed, 0 errors.
- Focused post-fix CLI tests passed, 110/110:

  ```powershell
  dotnet test --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~MaintenanceCliTests|FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~CommandOutputContractRegistryTests"
  ```

- `git diff --check`: passed.
- Final gate passed, 910/910:

  ```powershell
  pwsh ./scripts/validate.ps1 -Fast
  ```

## Acceptance Mapping

- JSON output and filters: `Maintenance.CLI.fs` handlers plus `MaintenanceShowJournalDto`, proven by maintenance CLI
  tests including the applied-before-limit regression.
- Clear only journal rows and metadata: `LocalStateDb.clearWatchJournal`, proven by local-state tests that verify only
  journal rows, allocation, and the watermark change.
- Refuse while Watch is running: `ClearJournal.InvokeAsync` checks `inspectGraceWatchStatus().IsLiveProcess`, proven by
  maintenance CLI tests.
- Preserve existing Watch/current-state/local-state/branch/SignalR surfaces: final `validate -Fast` passed.
- Forbidden shapes: no `WatchSessionId`, `ObservationId`, `BatchId`, `ApplyAttemptId`, startup reconciliation
  replacement, cross-machine sync log, or raw watcher event replay payloads introduced.

## Docs Impact

Updated `docs/Machine-readable CLI output.md` because the command-output registry now has 208 total leaf commands and
187 JSON-ready routed commands.

## Scope Notes

The implementation narrowly expanded into `src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs` and
`docs/Machine-readable CLI output.md` because adding two command-output registry entries changed accepted registry
totals and generated docs evidence.

Residual risk: `--path` is accepted and echoed, but v1 journal rows do not persist path metadata because raw watcher
events are intentionally not replayable correctness data. A path filter therefore returns rows only if future journal
rows carry path metadata; current rows have `RelativePath = null`.

## Review Status

- Final head: `8ff852c5f97289f7227c966152c85497351fd6d2`.
- CI: `full` passed on `8ff852c5f97289f7227c966152c85497351fd6d2`.
- Codex Code Review Bot: 👍 no-issues signal on `8ff852c5f97289f7227c966152c85497351fd6d2`.
- Codex review session 1 completed on `43514d2a6838f020e694006d2b8ea9d47b9f2261` with 2 fresh P2 findings;
  both were fixed in `c138e1c0ee4590936acafd5099e49012d421e2f1`, replied to, and resolved.
- Codex review session 2 completed on `c138e1c0ee4590936acafd5099e49012d421e2f1` with 3 fresh P2 findings;
  all were fixed in `8ff852c5f97289f7227c966152c85497351fd6d2`, replied to, and resolved.
- Finding 3524054762: fixed malformed `sqlite_sequence.seq` handling before allocation metadata is deleted; reply posted
  as discussion `r3524070580`.
- Finding 3524054764: fixed `show-journal` to use read-only inspection and report unhealthy or stale DB state instead
  of repairing or recreating while inspecting; reply posted as discussion `r3524070650`.
- Finding 3524054767: fixed empty `clear-journal` to no-op when the DB file is absent without creating a partial DB;
  reply posted as discussion `r3524070693`.
- Validation for `8ff852c5f97289f7227c966152c85497351fd6d2`: targeted Fantomas passed; focused
  `LocalStateDbTests` and `MaintenanceCliTests` passed 96/96; `git diff --check` passed;
  `pwsh ./scripts/validate.ps1 -Fast` passed, including `Grace.CLI.Tests`: 918/918.
- Prevention: acceptance-criteria / negative-proof gap; #498 now proves malformed allocation reset, read-only diagnostics
  on unhealthy/stale DB state, and empty clear non-mutation.
- Review sessions: 2 completed on this PR; substantive cycle count is 1.
- Final gate: all bot conversations are resolved, CI is green, and Codex reports no issues on the final head.
