### PR TITLE
WS4.3: Add Watch append-before-apply boundary

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2601,7 +2601,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 5"
+                |> should contain "schema_version is 6"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2661,7 +2661,11 @@ module DoctorCliTests =
 
                 do
                     use connection = openRawConnection dbPath
-                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (1, 1);"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES (1, 1, 'Change', 'File', 'doctor-one.txt');"
+
                     executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
 
                 let beforeRoot = snapshotFiles root
@@ -2747,8 +2751,10 @@ module DoctorCliTests =
                     use connection = openRawConnection dbPath
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
+
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
+
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '1');"
 
                 let beforeRoot = snapshotFiles root
@@ -2792,7 +2798,8 @@ module DoctorCliTests =
                     use connection = openRawConnection dbPath
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
+
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
                 let beforeRoot = snapshotFiles root
@@ -2885,8 +2892,15 @@ module DoctorCliTests =
 
                 do
                     use connection = openRawConnection dbPath
-                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (1, 1);"
-                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (2, 2);"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES (1, 1, 'Change', 'File', 'doctor-one.txt');"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES (2, 2, 'Delete', 'File', 'doctor-two.txt');"
+
                     executeNonQuery connection "UPDATE sqlite_sequence SET seq = 1 WHERE name = 'watch_journal';"
 
                 let beforeRoot = snapshotFiles root
@@ -3047,7 +3061,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 5"
+                        |> should contain "schema_version is 6"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -175,7 +175,13 @@ module LocalStateDbTests =
     let private insertWatchJournalRows (connection: SqliteConnection) throughSequence =
         [| 1L .. throughSequence |]
         |> Array.iter (fun sequence ->
-            executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});")
+            executeNonQuery
+                connection
+                $"INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES ({sequence}, {sequence}, 'Change', 'File', 'file-{sequence}.txt');")
+
+    /// Builds a replayable Watch journal observation for local-state ordering tests.
+    let private watchJournalObservation differenceType entryType (relativePath: string) : LocalStateDb.WatchJournalObservation =
+        { DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
 
     /// Gets corrupt backups needed by the test scenario.
     let private getCorruptBackups (dbPath: string) =
@@ -252,9 +258,9 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL);"
 
-        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '5');"
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '6');"
         executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
         executeNonQuery
@@ -349,7 +355,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -733,6 +739,44 @@ module LocalStateDbTests =
                 readThrough |> should equal 4L
             })
 
+    /// Verifies that applied boundary advancement cannot skip lower pending journal rows.
+    [<Test>]
+    let ``watch journal contiguous advance does not skip pending lower sequence`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let firstObservation = watchJournalObservation DifferenceType.Delete FileSystemEntryType.File "first.txt"
+                let secondObservation = watchJournalObservation DifferenceType.Change FileSystemEntryType.File "second.txt"
+
+                let! firstSequences = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile [ firstObservation ]
+                let! secondSequences = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile [ secondObservation ]
+
+                firstSequences |> should equal [| 1L |]
+                secondSequences |> should equal [| 2L |]
+
+                let! skippedAdvance = LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences configuration.GraceStatusFile secondSequences
+                skippedAdvance |> should equal 0L
+
+                let! afterSkippedAdvance = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                afterSkippedAdvance |> should equal 0L
+
+                let! firstAdvance = LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences configuration.GraceStatusFile firstSequences
+                firstAdvance |> should equal 1L
+
+                let! secondAdvance = LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences configuration.GraceStatusFile secondSequences
+                secondAdvance |> should equal 2L
+
+                let! snapshot = LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "applied" None 10
+
+                snapshot.Rows
+                |> Array.map (fun row -> row.Sequence, row.DifferenceType, row.EntryType, row.RelativePath)
+                |> should
+                    equal
+                    [|
+                        2L, "Change", "File", Some "second.txt"
+                        1L, "Delete", "File", Some "first.txt"
+                    |]
+            })
+
     /// Verifies that round trips status snapshot.
     [<Test>]
     let ``round trips status snapshot`` () =
@@ -999,7 +1043,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1008,9 +1052,9 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
-    /// Verifies that ensure db initialized recreates db when schema v5 has a malformed Watch journal table.
+    /// Verifies that ensure db initialized recreates db when schema v6 has a malformed Watch journal table.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 watch journal shape is malformed`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 watch journal shape is malformed`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1035,7 +1079,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
                 sequencePk |> should equal 1
@@ -1060,9 +1104,9 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
-    /// Verifies that ensure db initialized recreates db when schema v5 reuses rowids for Watch journal sequences.
+    /// Verifies that ensure db initialized recreates db when schema v6 reuses rowids for Watch journal sequences.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 watch journal lacks autoincrement`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 watch journal lacks autoincrement`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1087,7 +1131,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -1103,7 +1147,7 @@ module LocalStateDbTests =
 
     /// Verifies that AUTOINCREMENT acceptance belongs to the sequence column declaration, not nearby SQL text.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 autoincrement text is outside sequence declaration`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 autoincrement text is outside sequence declaration`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1127,7 +1171,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -1144,7 +1188,7 @@ module LocalStateDbTests =
     /// Verifies that ensure db initialized recreates db when Watch recovery metadata is malformed.
     [<TestCase("not-a-number")>]
     [<TestCase("-1")>]
-    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata is invalid`` (appliedThroughValue: string) =
+    let ``ensureDbInitialized recreates DB when schema v6 applied through metadata is invalid`` (appliedThroughValue: string) =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1167,7 +1211,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
@@ -1180,9 +1224,9 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
-    /// Verifies that schema acceptance rejects duplicated Watch recovery metadata in malformed schema v5 tables.
+    /// Verifies that schema acceptance rejects duplicated Watch recovery metadata in malformed schema v6 tables.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata is duplicated`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 applied through metadata is duplicated`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1194,7 +1238,7 @@ module LocalStateDbTests =
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '1');"
 
@@ -1209,7 +1253,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let duplicateRows = executeScalarInt connection "SELECT COUNT(*) FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 duplicateRows |> should equal 1
 
@@ -1222,7 +1266,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects meta tables that cannot preserve one row per key.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 meta key is not unique`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 meta key is not unique`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1234,7 +1278,7 @@ module LocalStateDbTests =
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
                 let corruptBefore =
@@ -1254,7 +1298,7 @@ module LocalStateDbTests =
                     with
                     | :? SqliteException -> false
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 duplicateInsertSucceeded |> should equal false
 
@@ -1268,7 +1312,7 @@ module LocalStateDbTests =
     /// Verifies that schema acceptance rejects malformed SQLite journal allocation metadata.
     [<TestCase("not-a-number")>]
     [<TestCase("-1")>]
-    let ``ensureDbInitialized recreates DB when schema v5 allocated journal sequence is invalid`` (allocatedSequence: string) =
+    let ``ensureDbInitialized recreates DB when schema v6 allocated journal sequence is invalid`` (allocatedSequence: string) =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1293,7 +1337,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1304,10 +1348,10 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
-    /// Verifies that empty schema v5 databases still reject malformed SQLite journal allocation metadata.
+    /// Verifies that empty schema v6 databases still reject malformed SQLite journal allocation metadata.
     [<TestCase("not-a-number")>]
     [<TestCase("-1")>]
-    let ``ensureDbInitialized recreates DB when schema v5 empty journal has invalid allocation row`` (allocatedSequence: string) =
+    let ``ensureDbInitialized recreates DB when schema v6 empty journal has invalid allocation row`` (allocatedSequence: string) =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1332,7 +1376,7 @@ module LocalStateDbTests =
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
                 let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
                 allocationRows |> should equal 0
@@ -1346,7 +1390,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects missing SQLite journal allocation metadata when rows exist.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 journal rows have no allocation row`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 journal rows have no allocation row`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1370,7 +1414,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1383,7 +1427,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects stale SQLite journal allocation below the highest persisted row.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 allocated journal sequence is below journal max`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 allocated journal sequence is below journal max`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1407,7 +1451,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1420,7 +1464,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects Watch recovery metadata beyond SQLite's allocated journal sequence.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata exceeds allocated sequence`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 applied through metadata exceeds allocated sequence`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1444,7 +1488,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1457,7 +1501,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects NULL Watch recovery metadata without throwing.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 applied through metadata is null`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 applied through metadata is null`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1469,7 +1513,7 @@ module LocalStateDbTests =
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', NULL);"
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
@@ -1490,7 +1534,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1503,7 +1547,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance skips expression indexes when proving metadata key uniqueness.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 meta uniqueness is expression index only`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 meta uniqueness is expression index only`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1516,7 +1560,7 @@ module LocalStateDbTests =
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
                     executeNonQuery connection "CREATE UNIQUE INDEX ux_meta_lower_key ON meta(lower(key));"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
@@ -1537,7 +1581,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1550,7 +1594,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects composite primary keys before trusting metadata key uniqueness.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 meta key is part of composite primary key`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 meta key is part of composite primary key`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1562,7 +1606,7 @@ module LocalStateDbTests =
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL, PRIMARY KEY (key, value));"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
@@ -1583,7 +1627,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1596,7 +1640,7 @@ module LocalStateDbTests =
 
     /// Verifies that schema acceptance rejects journal rows whose SQLite sequence was not positively allocated.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 journal rows have non-positive sequence`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 journal rows have non-positive sequence`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1606,7 +1650,11 @@ module LocalStateDbTests =
 
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
-                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (0, 1);"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES (0, 1, 'Change', 'File', 'zero.txt');"
+
                     executeNonQuery connection "UPDATE sqlite_sequence SET seq = 0 WHERE name = 'watch_journal';"
 
                 let inspection = LocalStateDb.inspectReadOnly configuration.GraceStatusFile
@@ -1627,7 +1675,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1638,9 +1686,9 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
-    /// Verifies that schema v5 databases with journal rows must carry trustworthy Watch recovery metadata.
+    /// Verifies that schema v6 databases with journal rows must carry trustworthy Watch recovery metadata.
     [<Test>]
-    let ``ensureDbInitialized recreates DB when schema v5 has journal rows without applied through metadata`` () =
+    let ``ensureDbInitialized recreates DB when schema v6 has journal rows without applied through metadata`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -1650,7 +1698,11 @@ module LocalStateDbTests =
 
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
-                    executeNonQuery connection "INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES (1, 1);"
+
+                    executeNonQuery
+                        connection
+                        "INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES (1, 1, 'Change', 'File', 'one.txt');"
+
                     executeNonQuery connection "DELETE FROM meta WHERE key = 'AppliedThroughSequence';"
 
                 let corruptBefore =
@@ -1664,7 +1716,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1694,7 +1746,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1749,7 +1801,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "5")
+                |> should equal (Some "6")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -1794,7 +1846,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "5")
+                |> should equal (Some "6")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -2072,7 +2124,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -2109,7 +2161,7 @@ module LocalStateDbTests =
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
                 let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
                 readRootBlake3Hash |> should equal rootBlake3Hash
@@ -2138,9 +2190,9 @@ module LocalStateDbTests =
                 corruptAfter |> should equal corruptBefore
             })
 
-    /// Verifies that ensure db initialized rejects schema v5 databases without watch journal.
+    /// Verifies that ensure db initialized rejects schema v6 databases without watch journal.
     [<Test>]
-    let ``ensureDbInitialized recreates schema v5 database missing watch journal`` () =
+    let ``ensureDbInitialized recreates schema v6 database missing watch journal`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -2164,7 +2216,7 @@ module LocalStateDbTests =
                 let watchJournalCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 watchJournalCount |> should equal 1
                 appliedThrough |> should equal "0"
 
@@ -2200,7 +2252,7 @@ module LocalStateDbTests =
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 rootBlake3Columns |> should equal 1
                 statusMetaCount |> should equal 1
 
@@ -2241,7 +2293,7 @@ module LocalStateDbTests =
                 let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
                 statusDirectoryCount |> should equal 0
                 statusMetaCount |> should equal 1
 
@@ -2434,7 +2486,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -2461,7 +2513,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "5"
+                schemaVersion |> should equal "6"
             })
 
     /// Verifies that replace status snapshot fully clears old snapshot rows.
@@ -2775,7 +2827,7 @@ module LocalStateDbTests =
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '5');"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '6');"
 
                     executeNonQuery
                         connection
@@ -3685,7 +3737,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "5"
+                    schemaVersion |> should equal "6"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -2227,6 +2227,59 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Verifies that ensure db initialized recreates current schema databases with append-incompatible journal columns.
+    [<Test>]
+    let ``ensureDbInitialized recreates schema v6 database with hidden required watch journal column`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let rootHash = "required-journal-column-root-hash"
+                let ticks = 1234567890L
+
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash "root-blake3" ticks
+
+                do
+                    use seedConnection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery seedConnection "ALTER TABLE watch_journal RENAME TO watch_journal_valid;"
+
+                    executeNonQuery
+                        seedConnection
+                        "CREATE TABLE watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, hidden_required TEXT NOT NULL);"
+
+                    executeNonQuery
+                        seedConnection
+                        "INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path, hidden_required) SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path, 'seeded' FROM watch_journal_valid;"
+
+                    executeNonQuery seedConnection "DROP TABLE watch_journal_valid;"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+
+                let hiddenRequiredColumns =
+                    executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('watch_journal') WHERE name = 'hidden_required';"
+
+                let journalColumns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('watch_journal');"
+
+                let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
+
+                schemaVersion |> should equal "6"
+                hiddenRequiredColumns |> should equal 0
+                journalColumns |> should equal 5
+                appliedThrough |> should equal "0"
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that ensure db initialized recreates partial schema v4 database missing root blake3 column.
     [<Test>]
     let ``ensureDbInitialized recreates partial schema v4 database missing root blake3 column`` () =

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -582,6 +582,13 @@ module MaintenanceCliTests =
         withTempRepo (fun root ->
             seedWatchJournalRows root 4L 2L
 
+            let dbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+            use setupConnection = new SqliteConnection($"Data Source={dbPath}")
+            setupConnection.Open()
+
+            executeNonQuery setupConnection "UPDATE watch_journal SET relative_path = 'src/file-2.txt' WHERE sequence = 2;"
+
             /// Verifies that the CLI maintenance scenario exits with the expected process status.
             let exitCode, standardOut, standardError =
                 runJsonMaintenance [| "show-journal"
@@ -661,7 +668,7 @@ module MaintenanceCliTests =
             let pathExitCode, pathStandardOut, pathStandardError =
                 runJsonMaintenance [| "show-journal"
                                       "--path"
-                                      "file-2"
+                                      "src\\file-2"
                                       "--limit"
                                       "1" |]
 
@@ -684,7 +691,7 @@ module MaintenanceCliTests =
             |> should equal 2L
 
             pathRow.GetProperty("RelativePath").GetString()
-            |> should equal "file-2.txt")
+            |> should equal "src/file-2.txt")
 
     /// Verifies that maintenance show journal reports unhealthy local state without repairing or rotating the DB.
     [<Test>]

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -655,7 +655,36 @@ module MaintenanceCliTests =
                     .GetProperty("Rows")[0]
 
             appliedRow.GetProperty("Sequence").GetInt64()
-            |> should equal 2L)
+            |> should equal 2L
+
+            /// Verifies that path filtering happens before limit selection.
+            let pathExitCode, pathStandardOut, pathStandardError =
+                runJsonMaintenance [| "show-journal"
+                                      "--path"
+                                      "file-2"
+                                      "--limit"
+                                      "1" |]
+
+            pathExitCode |> should equal 0
+            pathStandardError |> should equal String.Empty
+
+            use pathDocument = assertCleanJsonStdout pathStandardOut
+
+            let pathRows =
+                pathDocument
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Rows")
+
+            pathRows.GetArrayLength() |> should equal 1
+
+            let pathRow = pathRows[0]
+
+            pathRow.GetProperty("Sequence").GetInt64()
+            |> should equal 2L
+
+            pathRow.GetProperty("RelativePath").GetString()
+            |> should equal "file-2.txt")
 
     /// Verifies that maintenance show journal reports unhealthy local state without repairing or rotating the DB.
     [<Test>]

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -97,7 +97,9 @@ module MaintenanceCliTests =
         connection.Open()
 
         for sequence in [| 1L .. throughSequence |] do
-            executeNonQuery connection $"INSERT INTO watch_journal (sequence, created_at_unix_ticks) VALUES ({sequence}, {sequence});"
+            executeNonQuery
+                connection
+                $"INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES ({sequence}, {sequence}, 'Change', 'File', 'file-{sequence}.txt');"
 
         executeNonQuery connection $"UPDATE meta SET value = '{appliedThrough}' WHERE key = 'AppliedThroughSequence';"
 
@@ -623,6 +625,15 @@ module MaintenanceCliTests =
 
             row.GetProperty("State").GetString()
             |> should equal "pending"
+
+            row.GetProperty("DifferenceType").GetString()
+            |> should equal "Change"
+
+            row.GetProperty("FileSystemEntryType").GetString()
+            |> should equal "File"
+
+            row.GetProperty("RelativePath").GetString()
+            |> should equal "file-4.txt"
 
             /// Verifies that state filtering happens before limit selection.
             let appliedExitCode, appliedStandardOut, appliedStandardError =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -409,6 +409,10 @@ module WatchTests =
     /// Builds changed event test data used to exercise CLI watch behavior.
     let private changedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
+    /// Builds a replayable Watch journal observation for Watch command retention tests.
+    let private watchJournalObservation differenceType entryType (relativePath: string) : LocalStateDb.WatchJournalObservation =
+        { DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
+
     /// Builds local file version test data used to exercise CLI watch behavior.
     let private localFileVersion relativePath =
         LocalFileVersion.CreateWithHashes
@@ -3098,6 +3102,122 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
+    /// Verifies that successful trusted journal boundary advancement prunes applied rows.
+    [<Test>]
+    let ``watch prunes journal retention after trusted boundary advance`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-prune-after-advance-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let mutable appendCalls = 0
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+            let mutable pruneCalls = 0
+            let mutable recoveryCalls = 0
+
+            let seededObservations =
+                [ 1..1026 ]
+                |> Seq.map (fun index -> watchJournalObservation DifferenceType.Change FileSystemEntryType.File $"seed-{index}.txt")
+                |> Seq.toArray
+
+            let seededSequences =
+                (LocalStateDb.appendWatchJournalObservations dbPath seededObservations)
+                    .GetAwaiter()
+                    .GetResult()
+
+            seededSequences
+            |> Array.length
+            |> should equal 1026
+
+            (LocalStateDb.setWatchJournalAppliedThroughSequence dbPath 1026L)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun observations ->
+                        appendCalls <- appendCalls + 1
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
+                    (fun sequences ->
+                        advanceCalls <- advanceCalls + 1
+
+                        sequences
+                        |> Seq.toArray
+                        |> should equal [| 1027L |]
+
+                        LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences dbPath sequences)
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun _ _ ->
+                        recoveryCalls <- recoveryCalls + 1
+                        Task.FromResult(()))
+                    (fun () ->
+                        pruneCalls <- pruneCalls + 1
+                        LocalStateDb.pruneWatchJournalRetention dbPath)
+
+                /// Reads status needed by the trusted journal pruning scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Simulates successful status application after the corresponding journal append.
+                let updateGraceStatusFromDifferences currentStatus _ _ =
+                    applyCalls <- applyCalls + 1
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the journal pruning scenario.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                applyCalls |> should equal 1
+                advanceCalls |> should equal 1
+                pruneCalls |> should equal 1
+                recoveryCalls |> should equal 0
+
+                let journalSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 2048)
+                        .GetAwaiter()
+                        .GetResult()
+
+                journalSnapshot.AppliedThroughSequence
+                |> should equal 1027L
+
+                journalSnapshot.TotalRows |> should equal 1024
+
+                journalSnapshot.Rows
+                |> Array.map (fun row -> row.Sequence)
+                |> Array.min
+                |> should equal 4L
+
+                journalSnapshot.Rows
+                |> Array.map (fun row -> row.Sequence)
+                |> Array.max
+                |> should equal 1027L
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that a non-contiguous journal boundary result forces resync instead of healthy status draining.
     [<Test>]
     let ``watch quarantines status work when journal boundary cannot advance through appended sequence`` () =
@@ -3105,21 +3225,51 @@ module WatchTests =
             let relativePath = "journal-non-contiguous-retry-delete.txt"
             let filePath = Path.Combine(root, relativePath)
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
             let mutable appendCalls = 0
             let mutable applyCalls = 0
             let mutable advanceCalls = 0
+            let mutable recoveryCalls = 0
+            let mutable pruneCalls = 0
+            let mutable recoveredAdvancedThrough = -1L
+            let mutable recoveredRequiredThrough = -1L
+
+            let seededSequences =
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [
+                        watchJournalObservation DifferenceType.Change FileSystemEntryType.File "older-pending.txt"
+                    ])
+                    .GetAwaiter()
+                    .GetResult()
+
+            seededSequences |> should equal [| 1L |]
 
             Watch.OnDeleted(deletedEvent filePath)
 
             try
                 Watch.setWatchJournalClientsForWatchTests
-                    (fun _ ->
+                    (fun observations ->
                         appendCalls <- appendCalls + 1
-                        Task.FromResult([| 2L |]))
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
                     (fun sequences ->
                         advanceCalls <- advanceCalls + 1
                         sequences |> Seq.toArray |> should equal [| 2L |]
-                        Task.FromResult(0L))
+                        LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences dbPath sequences)
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun advancedThrough requiredThrough ->
+                        recoveryCalls <- recoveryCalls + 1
+                        recoveredAdvancedThrough <- advancedThrough
+                        recoveredRequiredThrough <- requiredThrough
+
+                        task {
+                            let! _ = LocalStateDb.clearWatchJournal dbPath
+                            return ()
+                        })
+                    (fun () ->
+                        pruneCalls <- pruneCalls + 1
+                        Task.FromResult(()))
 
                 /// Reads status needed by the non-contiguous journal retry scenario.
                 let readStatus () = Task.FromResult(status)
@@ -3153,6 +3303,21 @@ module WatchTests =
                 appendCalls |> should equal 1
                 applyCalls |> should equal 1
                 advanceCalls |> should equal 1
+                recoveryCalls |> should equal 1
+                recoveredAdvancedThrough |> should equal 0L
+                recoveredRequiredThrough |> should equal 2L
+                pruneCalls |> should equal 0
+
+                let repairedJournalSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                repairedJournalSnapshot.TotalRows
+                |> should equal 0
+
+                repairedJournalSnapshot.AppliedThroughSequence
+                |> should equal 0L
 
                 Watch.currentGraceWatchRuntimeModeForWatchTests ()
                 |> should equal Services.GraceWatchRuntimeMode.Resynchronizing

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3102,6 +3102,105 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
+    /// Verifies that a status exception after append repairs the journal before resync.
+    [<Test>]
+    let ``watch repairs journal before resync when status application throws after append`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-status-throw-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let mutable appendCalls = 0
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+            let mutable recoveryCalls = 0
+            let mutable pruneCalls = 0
+            let mutable recoveredAdvancedThrough = -1L
+            let mutable recoveredRequiredThrough = -1L
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun observations ->
+                        appendCalls <- appendCalls + 1
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
+                    (fun _ ->
+                        advanceCalls <- advanceCalls + 1
+                        Task.FromResult(1L))
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun advancedThrough requiredThrough ->
+                        recoveryCalls <- recoveryCalls + 1
+                        recoveredAdvancedThrough <- advancedThrough
+                        recoveredRequiredThrough <- requiredThrough
+
+                        task {
+                            let! _ = LocalStateDb.clearWatchJournal dbPath
+                            return ()
+                        })
+                    (fun () ->
+                        pruneCalls <- pruneCalls + 1
+                        Task.FromResult(()))
+
+                /// Reads status needed by the status-throw journal repair scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Simulates an exception after the journal append succeeds but before status can be trusted.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    applyCalls <- applyCalls + 1
+                    Task.FromException<GraceStatus option>(InvalidOperationException("test status application failure"))
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the status-throw journal repair scenario.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                applyCalls |> should equal 1
+                advanceCalls |> should equal 0
+                recoveryCalls |> should equal 1
+                recoveredAdvancedThrough |> should equal 0L
+                recoveredRequiredThrough |> should equal 1L
+                pruneCalls |> should equal 0
+
+                let repairedJournalSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                repairedJournalSnapshot.TotalRows
+                |> should equal 0
+
+                repairedJournalSnapshot.AppliedThroughSequence
+                |> should equal 0L
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that successful trusted journal boundary advancement prunes applied rows.
     [<Test>]
     let ``watch prunes journal retention after trusted boundary advance`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3046,26 +3046,45 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
-    /// Verifies that failed status application leaves appended observations pending.
+    /// Verifies that failed status application clears appended observations before retry.
     [<Test>]
-    let ``watch does not advance journal boundary when status application returns none`` () =
+    let ``watch clears journal for retry when status application returns none after append`` () =
         withTempRepo (fun root ->
             let relativePath = "journal-status-none-delete.txt"
             let filePath = Path.Combine(root, relativePath)
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
             let mutable appendCalls = 0
             let mutable advanceCalls = 0
+            let mutable recoveryCalls = 0
+            let mutable pruneCalls = 0
+            let mutable recoveredAdvancedThrough = -1L
+            let mutable recoveredRequiredThrough = -1L
 
             Watch.OnDeleted(deletedEvent filePath)
 
             try
                 Watch.setWatchJournalClientsForWatchTests
-                    (fun _ ->
+                    (fun observations ->
                         appendCalls <- appendCalls + 1
-                        Task.FromResult([| 1L |]))
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
                     (fun _ ->
                         advanceCalls <- advanceCalls + 1
                         Task.FromResult(1L))
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun advancedThrough requiredThrough ->
+                        recoveryCalls <- recoveryCalls + 1
+                        recoveredAdvancedThrough <- advancedThrough
+                        recoveredRequiredThrough <- requiredThrough
+
+                        task {
+                            let! _ = LocalStateDb.clearWatchJournal dbPath
+                            return ()
+                        })
+                    (fun () ->
+                        pruneCalls <- pruneCalls + 1
+                        Task.FromResult(()))
 
                 /// Reads status needed by the status-failure scenario.
                 let readStatus () = Task.FromResult(status)
@@ -3094,6 +3113,24 @@ module WatchTests =
 
                 appendCalls |> should equal 1
                 advanceCalls |> should equal 0
+                recoveryCalls |> should equal 1
+                recoveredAdvancedThrough |> should equal 0L
+                recoveredRequiredThrough |> should equal 1L
+                pruneCalls |> should equal 0
+
+                let repairedJournalSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                repairedJournalSnapshot.TotalRows
+                |> should equal 0
+
+                repairedJournalSnapshot.AppliedThroughSequence
+                |> should equal 0L
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
 
                 Watch
                     .pendingWatchWorkSnapshotForTests()
@@ -3134,6 +3171,12 @@ module WatchTests =
                         recoveryCalls <- recoveryCalls + 1
                         recoveredAdvancedThrough <- advancedThrough
                         recoveredRequiredThrough <- requiredThrough
+
+                        Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                        |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                        Watch.isGraceWatchResyncPendingForWatchTests ()
+                        |> should equal true
 
                         task {
                             let! _ = LocalStateDb.clearWatchJournal dbPath
@@ -3362,6 +3405,12 @@ module WatchTests =
                         recoveredAdvancedThrough <- advancedThrough
                         recoveredRequiredThrough <- requiredThrough
 
+                        Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                        |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                        Watch.isGraceWatchResyncPendingForWatchTests ()
+                        |> should equal true
+
                         task {
                             let! _ = LocalStateDb.clearWatchJournal dbPath
                             return ()
@@ -3465,6 +3514,12 @@ module WatchTests =
                         recoveredAdvancedThrough <- advancedThrough
                         recoveredRequiredThrough <- requiredThrough
 
+                        Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                        |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                        Watch.isGraceWatchResyncPendingForWatchTests ()
+                        |> should equal true
+
                         task {
                             let! _ = LocalStateDb.clearWatchJournal dbPath
                             return ()
@@ -3526,6 +3581,100 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
+    /// Verifies that resync is published before fallible repair after status side effects commit.
+    [<Test>]
+    let ``watch requests resync before failed journal repair after status write`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-repair-throw-after-status-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let mutable appendCalls = 0
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+            let mutable recoveryCalls = 0
+            let mutable recoveryObservedResync = false
+            let mutable updateIpcCalls = 0
+            let mutable updateIpcSawNonIncremental = false
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun observations ->
+                        appendCalls <- appendCalls + 1
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
+                    (fun sequences ->
+                        advanceCalls <- advanceCalls + 1
+                        sequences |> Seq.toArray |> should equal [| 1L |]
+                        Task.FromException<int64>(InvalidOperationException("test boundary failure before repair")))
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun _ _ ->
+                        recoveryCalls <- recoveryCalls + 1
+
+                        recoveryObservedResync <-
+                            Watch.currentGraceWatchRuntimeModeForWatchTests () = Services.GraceWatchRuntimeMode.Resynchronizing
+                            && Watch.isGraceWatchResyncPendingForWatchTests ()
+
+                        Task.FromException<unit>(InvalidOperationException("test repair failure after resync request")))
+                    (fun () -> Task.FromResult(()))
+
+                /// Reads status needed by the repair-failure publication scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Simulates successful status application before the boundary repair fails.
+                let updateGraceStatusFromDifferences currentStatus _ _ =
+                    applyCalls <- applyCalls + 1
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+
+                /// Tracks the final non-incremental IPC publication after repair failure.
+                let updateIpc (_: GraceStatus) (directoryIds: HashSet<DirectoryVersionId> option) =
+                    updateIpcCalls <- updateIpcCalls + 1
+
+                    if directoryIds
+                       |> Option.exists (fun ids -> ids.Count = 0) then
+                        updateIpcSawNonIncremental <- true
+
+                    Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                applyCalls |> should equal 1
+                advanceCalls |> should equal 1
+                recoveryCalls |> should equal 1
+                recoveryObservedResync |> should equal true
+                updateIpcCalls |> should equal 1
+                updateIpcSawNonIncremental |> should equal true
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that confidence loss after a status write still advances the applied journal boundary.
     [<Test>]
     let ``watch advances journal boundary when confidence is lost after status write`` () =
@@ -3536,6 +3685,8 @@ module WatchTests =
             let mutable appendCalls = 0
             let mutable applyCalls = 0
             let mutable advanceCalls = 0
+            let mutable recoveryCalls = 0
+            let mutable pruneCalls = 0
 
             Watch.OnDeleted(deletedEvent filePath)
 
@@ -3547,6 +3698,14 @@ module WatchTests =
                     (fun _ ->
                         advanceCalls <- advanceCalls + 1
                         Task.FromResult(1L))
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun _ _ ->
+                        recoveryCalls <- recoveryCalls + 1
+                        Task.FromResult(()))
+                    (fun () ->
+                        pruneCalls <- pruneCalls + 1
+                        Task.FromResult(()))
 
                 /// Reads status needed by the confidence-loss scenario.
                 let readStatus () = Task.FromResult(status)
@@ -3581,6 +3740,8 @@ module WatchTests =
                 appendCalls |> should equal 1
                 applyCalls |> should equal 1
                 advanceCalls |> should equal 1
+                recoveryCalls |> should equal 0
+                pruneCalls |> should equal 1
 
                 Watch.currentGraceWatchRuntimeModeForWatchTests ()
                 |> should equal Services.GraceWatchRuntimeMode.Resynchronizing

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3098,6 +3098,75 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
+    /// Verifies that a non-contiguous journal boundary result forces resync instead of healthy status draining.
+    [<Test>]
+    let ``watch quarantines status work when journal boundary cannot advance through appended sequence`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-non-contiguous-retry-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let mutable appendCalls = 0
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ ->
+                        appendCalls <- appendCalls + 1
+                        Task.FromResult([| 2L |]))
+                    (fun sequences ->
+                        advanceCalls <- advanceCalls + 1
+                        sequences |> Seq.toArray |> should equal [| 2L |]
+                        Task.FromResult(0L))
+
+                /// Reads status needed by the non-contiguous journal retry scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Simulates a successful status application after only a later journal sequence was appended.
+                let updateGraceStatusFromDifferences currentStatus _ _ =
+                    applyCalls <- applyCalls + 1
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the non-contiguous journal retry scenario.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                applyCalls |> should equal 1
+                advanceCalls |> should equal 1
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                Watch.quarantinedWatchObservationCountForWatchTests ()
+                |> should equal 2
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that confidence loss after append keeps the applied boundary unchanged.
     [<Test>]
     let ``watch does not advance journal boundary when confidence is lost after append`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -2892,6 +2892,273 @@ module WatchTests =
             afterSuccess.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
+    /// Verifies that normalized observations are durable before status application and applied after success.
+    [<Test>]
+    let ``watch appends journal before applying status and advances boundary after commit`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-order-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let ordering = ResizeArray<string>()
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun observations ->
+                        task {
+                            let observationArray = observations |> Seq.toArray
+
+                            observationArray
+                            |> Array.map (fun observation -> observation.DifferenceType, observation.EntryType, string observation.RelativePath)
+                            |> should
+                                equal
+                                [|
+                                    DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                                |]
+
+                            ordering.Add("append")
+                            return [| 1L |]
+                        })
+                    (fun sequences ->
+                        task {
+                            sequences |> Seq.toArray |> should equal [| 1L |]
+
+                            ordering.ToArray()
+                            |> should equal [| "append"; "apply" |]
+
+                            ordering.Add("advance")
+                            return 1L
+                        })
+
+                /// Reads status needed by the durable journal ordering scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Applies the normalized observation after journal append succeeds.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    ordering.ToArray() |> should equal [| "append" |]
+
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, string difference.RelativePath)
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                        |]
+
+                    ordering.Add("apply")
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the ordering test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                ordering.ToArray()
+                |> should equal [| "append"; "apply"; "advance" |]
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that journal append failure prevents unjournaled status application.
+    [<Test>]
+    let ``watch skips status application when journal append fails`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-append-failure-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("test journal append failure")))
+                    (fun _ ->
+                        advanceCalls <- advanceCalls + 1
+                        Task.FromResult(0L))
+
+                /// Reads status needed by the append-failure scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if unjournaled work reaches status application.
+                let updateGraceStatusFromDifferences currentStatus _ _ =
+                    applyCalls <- applyCalls + 1
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the append-failure test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                applyCalls |> should equal 0
+                advanceCalls |> should equal 0
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that failed status application leaves appended observations pending.
+    [<Test>]
+    let ``watch does not advance journal boundary when status application returns none`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-status-none-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let mutable appendCalls = 0
+            let mutable advanceCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ ->
+                        appendCalls <- appendCalls + 1
+                        Task.FromResult([| 1L |]))
+                    (fun _ ->
+                        advanceCalls <- advanceCalls + 1
+                        Task.FromResult(1L))
+
+                /// Reads status needed by the status-failure scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+                /// Simulates a failed durable status application after append succeeds.
+                let updateGraceStatusFromDifferences _ _ _ = Task.FromResult(None)
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the status-failure test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                advanceCalls |> should equal 0
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal [| relativePath |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that confidence loss after append keeps the applied boundary unchanged.
+    [<Test>]
+    let ``watch does not advance journal boundary when confidence is lost after append`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-confidence-loss-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let mutable appendCalls = 0
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ ->
+                        appendCalls <- appendCalls + 1
+                        Task.FromResult([| 1L |]))
+                    (fun _ ->
+                        advanceCalls <- advanceCalls + 1
+                        Task.FromResult(1L))
+
+                /// Reads status needed by the confidence-loss scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Simulates cancellation after append and before the commit boundary can advance.
+                let updateGraceStatusFromDifferences currentStatus _ _ =
+                    applyCalls <- applyCalls + 1
+                    Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.Resynchronizing
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the confidence-loss test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                applyCalls |> should equal 1
+                advanceCalls |> should equal 0
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that a stale status only delete requeues recreated content without a canceled upload marker.
     [<Test>]
     let ``stale status-only delete requeues recreated changed tracked file without canceled upload`` () =
@@ -3267,7 +3534,7 @@ module WatchTests =
             let afterFailure = Watch.pendingWatchWorkSnapshotForTests ()
 
             afterFailure.StatusUpdateTriggers
-            |> should equal [| "old-status-only-name.txt" |]
+            |> should equal Array.empty<string>
 
             afterFailure.FilesToProcess
             |> should equal Array.empty<string>)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3332,9 +3332,104 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
-    /// Verifies that confidence loss after append keeps the applied boundary unchanged.
+    /// Verifies that an applied status write repairs appended journal rows when boundary advancement throws.
     [<Test>]
-    let ``watch does not advance journal boundary when confidence is lost after append`` () =
+    let ``watch repairs journal before resync when boundary advancement throws after status write`` () =
+        withTempRepo (fun root ->
+            let relativePath = "journal-advance-throw-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let mutable appendCalls = 0
+            let mutable applyCalls = 0
+            let mutable advanceCalls = 0
+            let mutable recoveryCalls = 0
+            let mutable pruneCalls = 0
+            let mutable recoveredAdvancedThrough = -1L
+            let mutable recoveredRequiredThrough = -1L
+
+            Watch.OnDeleted(deletedEvent filePath)
+
+            try
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun observations ->
+                        appendCalls <- appendCalls + 1
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
+                    (fun sequences ->
+                        advanceCalls <- advanceCalls + 1
+                        sequences |> Seq.toArray |> should equal [| 1L |]
+                        Task.FromException<int64>(InvalidOperationException("test boundary failure")))
+
+                Watch.setWatchJournalMaintenanceClientsForWatchTests
+                    (fun advancedThrough requiredThrough ->
+                        recoveryCalls <- recoveryCalls + 1
+                        recoveredAdvancedThrough <- advancedThrough
+                        recoveredRequiredThrough <- requiredThrough
+
+                        task {
+                            let! _ = LocalStateDb.clearWatchJournal dbPath
+                            return ()
+                        })
+                    (fun () ->
+                        pruneCalls <- pruneCalls + 1
+                        Task.FromResult(()))
+
+                /// Reads status needed by the boundary-throw journal repair scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only observation scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Simulates successful status application before the boundary advancement failure.
+                let updateGraceStatusFromDifferences currentStatus _ _ =
+                    applyCalls <- applyCalls + 1
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only observation scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the boundary-throw journal repair scenario.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendCalls |> should equal 1
+                applyCalls |> should equal 1
+                advanceCalls |> should equal 1
+                recoveryCalls |> should equal 1
+                recoveredAdvancedThrough |> should equal 0L
+                recoveredRequiredThrough |> should equal 1L
+                pruneCalls |> should equal 0
+
+                let repairedJournalSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                repairedJournalSnapshot.TotalRows
+                |> should equal 0
+
+                repairedJournalSnapshot.AppliedThroughSequence
+                |> should equal 0L
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that confidence loss after a status write still advances the applied journal boundary.
+    [<Test>]
+    let ``watch advances journal boundary when confidence is lost after status write`` () =
         withTempRepo (fun root ->
             let relativePath = "journal-confidence-loss-delete.txt"
             let filePath = Path.Combine(root, relativePath)
@@ -3386,10 +3481,15 @@ module WatchTests =
 
                 appendCalls |> should equal 1
                 applyCalls |> should equal 1
-                advanceCalls |> should equal 0
+                advanceCalls |> should equal 1
 
                 Watch.currentGraceWatchRuntimeModeForWatchTests ()
                 |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal [| relativePath |]
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -152,7 +152,15 @@ module Common =
             }
 
         /// Models one durable Watch journal row emitted by maintenance show-journal.
-        type MaintenanceJournalRowDto = { Sequence: int64; CreatedAtUnixTicks: int64; State: string; RelativePath: string option }
+        type MaintenanceJournalRowDto =
+            {
+                Sequence: int64
+                CreatedAtUnixTicks: int64
+                State: string
+                DifferenceType: string
+                FileSystemEntryType: string
+                RelativePath: string option
+            }
 
         /// Models filtered durable Watch journal diagnostics for maintenance show-journal.
         type MaintenanceShowJournalDto =

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -105,7 +105,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "5"
+    let private ExpectedLocalStateSchemaVersion = "6"
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500
@@ -1094,7 +1094,7 @@ module Doctor =
                 | Some true, Some true -> ok "Watch journal table shape and applied-through metadata match the local-state schema contract."
                 | Some false, _ ->
                     failed
-                        "Watch journal table shape is invalid; expected sequence INTEGER PRIMARY KEY AUTOINCREMENT and created_at_unix_ticks INTEGER NOT NULL. Doctor did not repair or recreate local state."
+                        "Watch journal table shape is invalid; expected sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, and normalized observation payload columns. Doctor did not repair or recreate local state."
                 | Some true, Some false ->
                     failed
                         "Watch journal applied-through metadata is missing while journal rows exist, malformed, or negative. Doctor did not write default metadata."

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -274,7 +274,14 @@ module Maintenance =
 
     /// Converts one durable Watch journal row into the maintenance command output contract.
     let private toJournalRowDto (row: Grace.CLI.LocalStateDb.WatchJournalRow) : LocalOutputDto.MaintenanceJournalRowDto =
-        { Sequence = row.Sequence; CreatedAtUnixTicks = row.CreatedAtUnixTicks; State = $"{row.State}".ToLowerInvariant(); RelativePath = row.RelativePath }
+        {
+            Sequence = row.Sequence
+            CreatedAtUnixTicks = row.CreatedAtUnixTicks
+            State = $"{row.State}".ToLowerInvariant()
+            DifferenceType = row.DifferenceType
+            FileSystemEntryType = row.EntryType
+            RelativePath = row.RelativePath
+        }
 
     /// Converts a Watch journal diagnostic snapshot into the maintenance command output contract.
     let private toShowJournalDto (snapshot: Grace.CLI.LocalStateDb.WatchJournalSnapshot) : LocalOutputDto.MaintenanceShowJournalDto =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -64,6 +64,25 @@ module Watch =
     /// Checks whether the current runtime mode can record filesystem observations.
     let private canCaptureFilesystemObservation () = isGraceWatchObservationCaptureLegal (currentGraceWatchRuntimeMode ())
 
+    let mutable private appendWatchJournalObservationsForWatch =
+        fun observations -> Grace.CLI.LocalStateDb.appendWatchJournalObservations (Current().GraceStatusFile) observations
+
+    let mutable private advanceWatchJournalAppliedThroughSequencesForWatch =
+        fun sequences -> Grace.CLI.LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences (Current().GraceStatusFile) sequences
+
+    /// Installs durable journal clients used by append-before-apply ordering tests.
+    let internal setWatchJournalClientsForWatchTests appendObservations advanceAppliedSequences =
+        appendWatchJournalObservationsForWatch <- appendObservations
+        advanceWatchJournalAppliedThroughSequencesForWatch <- advanceAppliedSequences
+
+    /// Restores durable journal clients after tests replace append or boundary behavior.
+    let internal resetWatchJournalClientsForWatchTests () =
+        appendWatchJournalObservationsForWatch <-
+            fun observations -> Grace.CLI.LocalStateDb.appendWatchJournalObservations (Current().GraceStatusFile) observations
+
+        advanceWatchJournalAppliedThroughSequencesForWatch <-
+            fun sequences -> Grace.CLI.LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences (Current().GraceStatusFile) sequences
+
     /// Reports that a filesystem observation was ignored because the current runtime mode cannot capture it.
     let private logObservationSuppressed fullPath =
         logToAnsiConsole Colors.Verbose $"Grace Watch ignored filesystem observation for {fullPath} while runtime mode is {currentGraceWatchRuntimeMode ()}."
@@ -1319,6 +1338,10 @@ module Watch =
     /// Models the differences that can be applied and the queued work they resolve.
     type private StatusDifferencesForApply = { Applicable: List<FileSystemDifference>; Resolved: List<FileSystemDifference> }
 
+    /// Converts an already-normalized status difference into the replay payload owned by the local Watch journal.
+    let private journalObservationForDifference (difference: FileSystemDifference) : Grace.CLI.LocalStateDb.WatchJournalObservation =
+        { DifferenceType = difference.DifferenceType; EntryType = difference.FileSystemEntryType; RelativePath = difference.RelativePath }
+
     /// Checks whether a pending uploaded file difference must be dropped because final path state no longer has a file.
     let private isStaleUploadedFileDifference (difference: FileSystemDifference) =
         difference.FileSystemEntryType = FileSystemEntryType.File
@@ -2414,6 +2437,7 @@ module Watch =
         clearShouldIgnoreCache ()
         resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
         resetSignalRSubscriptionRefreshForWatchTests ()
+        resetWatchJournalClientsForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
         enumerateDirectoriesForDirectoryStatusAdd <- enumerateDirectoriesForDirectoryStatusAddWithPruning
         clearGraceUpdateMarkerDeletedUtcForReset ()
@@ -3719,6 +3743,7 @@ module Watch =
                                 isGraceWatchObservationApplicationLegal runtimeModeBeforeStatusApplication
 
                         let statusApplicationLegal = statusApplicationModeStillTrusted ()
+                        let mutable appendedWatchJournalSequences = Array.empty<int64>
 
                         let statusUpdateStillTrusted () =
                             filesToProcess.IsEmpty
@@ -3746,12 +3771,32 @@ module Watch =
 
                                 Task.FromResult(None)
                             elif statusDifferencesForApply.Applicable.Count > 0 then
-                                updateGraceStatusFromDifferencesWhenTrusted
-                                    statusUpdateStillTrusted
-                                    updateGraceStatusFromDifferencesClient
-                                    graceStatus
-                                    statusDifferencesForApply.Applicable
-                                    correlationId
+                                task {
+                                    try
+                                        let! sequences =
+                                            statusDifferencesForApply.Applicable
+                                            |> Seq.map journalObservationForDifference
+                                            |> appendWatchJournalObservationsForWatch
+
+                                        appendedWatchJournalSequences <- sequences
+
+                                        return!
+                                            updateGraceStatusFromDifferencesWhenTrusted
+                                                statusUpdateStillTrusted
+                                                updateGraceStatusFromDifferencesClient
+                                                graceStatus
+                                                statusDifferencesForApply.Applicable
+                                                correlationId
+                                    with
+                                    | ex ->
+                                        requestGraceWatchExplicitResync $"Watch journal append failed before status application: {ex.Message}"
+
+                                        logToAnsiConsole
+                                            Colors.Error
+                                            $"Grace Watch could not append normalized observations to the durable journal; unjournaled status application was skipped and resync is required: {Markup.Escape(ex.Message)}."
+
+                                        return None
+                                }
                             else
                                 Task.FromResult(Some graceStatus)
 
@@ -3766,6 +3811,19 @@ module Watch =
 
                             if statusUpdateCanCommit then
                                 graceStatus <- newGraceStatus
+
+                                if appendedWatchJournalSequences.Length > 0 then
+                                    try
+                                        let! _ = advanceWatchJournalAppliedThroughSequencesForWatch appendedWatchJournalSequences
+                                        ()
+                                    with
+                                    | ex ->
+                                        requestGraceWatchExplicitResync
+                                            $"Watch journal applied boundary advancement failed after status application: {ex.Message}"
+
+                                        logToAnsiConsole
+                                            Colors.Error
+                                            $"Grace Watch applied status but could not advance the durable journal boundary; resync is required before incremental shortcuts are trusted: {Markup.Escape(ex.Message)}."
 
                                 if startupPendingDifferences.Count = 0 then
                                     drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3810,14 +3810,26 @@ module Watch =
                                     || isGraceWatchObservationApplicationLegal commitRuntimeMode)
 
                             if statusUpdateCanCommit then
-                                graceStatus <- newGraceStatus
+                                let mutable watchJournalBoundaryTrusted = true
 
                                 if appendedWatchJournalSequences.Length > 0 then
                                     try
-                                        let! _ = advanceWatchJournalAppliedThroughSequencesForWatch appendedWatchJournalSequences
-                                        ()
+                                        let! advancedThrough = advanceWatchJournalAppliedThroughSequencesForWatch appendedWatchJournalSequences
+                                        let requiredAppliedThrough = appendedWatchJournalSequences |> Array.max
+
+                                        if advancedThrough < requiredAppliedThrough then
+                                            watchJournalBoundaryTrusted <- false
+
+                                            requestGraceWatchExplicitResync
+                                                $"Watch journal applied boundary advanced only through {advancedThrough} after status application required {requiredAppliedThrough}."
+
+                                            logToAnsiConsole
+                                                Colors.Error
+                                                $"Grace Watch applied status but could not advance the durable journal boundary through the appended observations; resync is required before status work is drained."
                                     with
                                     | ex ->
+                                        watchJournalBoundaryTrusted <- false
+
                                         requestGraceWatchExplicitResync
                                             $"Watch journal applied boundary advancement failed after status application: {ex.Message}"
 
@@ -3825,25 +3837,28 @@ module Watch =
                                             Colors.Error
                                             $"Grace Watch applied status but could not advance the durable journal boundary; resync is required before incremental shortcuts are trusted: {Markup.Escape(ex.Message)}."
 
-                                if startupPendingDifferences.Count = 0 then
-                                    drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
-                                else
-                                    drainAppliedStatusWork directorySnapshot statusTriggerSnapshot statusDifferencesForApply.Resolved
+                                if watchJournalBoundaryTrusted then
+                                    graceStatus <- newGraceStatus
 
-                                let canceledFileUploadDeletePathsToClear =
                                     if startupPendingDifferences.Count = 0 then
-                                        statusTriggerSnapshot
-                                        |> Seq.map (fun statusTrigger -> RelativePath statusTrigger.RelativePath)
+                                        drainStatusOnlyTriggers directorySnapshot statusTriggerSnapshot
                                     else
-                                        statusDifferencesForApply.Resolved
-                                        |> Seq.filter (fun difference -> difference.FileSystemEntryType = FileSystemEntryType.File)
-                                        |> Seq.map (fun difference -> difference.RelativePath)
+                                        drainAppliedStatusWork directorySnapshot statusTriggerSnapshot statusDifferencesForApply.Resolved
 
-                                clearCanceledFileUploadDeleteRelativePaths canceledFileUploadDeletePathsToClear
+                                    let canceledFileUploadDeletePathsToClear =
+                                        if startupPendingDifferences.Count = 0 then
+                                            statusTriggerSnapshot
+                                            |> Seq.map (fun statusTrigger -> RelativePath statusTrigger.RelativePath)
+                                        else
+                                            statusDifferencesForApply.Resolved
+                                            |> Seq.filter (fun difference -> difference.FileSystemEntryType = FileSystemEntryType.File)
+                                            |> Seq.map (fun difference -> difference.RelativePath)
 
-                                clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
-                                clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
-                                removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
+                                    clearCanceledFileUploadDeleteRelativePaths canceledFileUploadDeletePathsToClear
+
+                                    clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
+                                    clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
+                                    removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
                             else
                                 clearPendingStatusDifferences pendingDifferencesToClear
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3566,6 +3566,52 @@ module Watch =
                 return None
         }
 
+    /// Prunes applied Watch journal rows immediately after a trusted applied-boundary advance.
+    let private pruneWatchJournalAfterTrustedBoundaryAdvance (appendedWatchJournalSequences: int64 array) =
+        task {
+            if appendedWatchJournalSequences.Length > 0 then
+                try
+                    do! pruneWatchJournalRetentionForWatch ()
+                with
+                | ex ->
+                    logToAnsiConsole
+                        Colors.Verbose
+                        $"Grace Watch could not prune applied journal rows after a trusted boundary advance; retention will retry after later status work: {Markup.Escape(ex.Message)}."
+        }
+
+    /// Requests resync before fallible journal repair so non-incremental IPC is published even when repair fails.
+    let private repairWatchJournalAfterStatusTrustLoss advancedThrough requiredAppliedThrough resyncReason repairFailureContext =
+        task {
+            requestGraceWatchExplicitResync resyncReason
+
+            try
+                do! recoverWatchJournalBoundaryGapForWatch advancedThrough requiredAppliedThrough
+            with
+            | ex -> logToAnsiConsole Colors.Error $"{repairFailureContext}; resync was already requested before repair failed: {Markup.Escape(ex.Message)}."
+        }
+
+    /// Clears appended journal rows after status returns no durable result so the pending retry can reappend them.
+    let private clearWatchJournalAfterNoDurableStatus appendedWatchJournalSequences =
+        task {
+            if Array.isEmpty appendedWatchJournalSequences then
+                return false
+            else
+                let requiredAppliedThrough = appendedWatchJournalSequences |> Array.max
+
+                try
+                    do! recoverWatchJournalBoundaryGapForWatch 0L requiredAppliedThrough
+                    return false
+                with
+                | ex ->
+                    requestGraceWatchExplicitResync $"Watch status application returned no durable status and journal repair failed: {ex.Message}"
+
+                    logToAnsiConsole
+                        Colors.Error
+                        $"Grace Watch appended normalized observations and status application returned no durable status, but journal repair failed; resync is required before incremental work can resume: {Markup.Escape(ex.Message)}."
+
+                    return true
+        }
+
     /// Converges appended journal rows after status side effects commit so recovery never resumes from stale pending rows.
     let private convergeWatchJournalAfterStatusApplication (appendedWatchJournalSequences: int64 array) =
         task {
@@ -3578,10 +3624,12 @@ module Watch =
                     let! advancedThrough = advanceWatchJournalAppliedThroughSequencesForWatch appendedWatchJournalSequences
 
                     if advancedThrough < requiredAppliedThrough then
-                        do! recoverWatchJournalBoundaryGapForWatch advancedThrough requiredAppliedThrough
-
-                        requestGraceWatchExplicitResync
-                            $"Watch journal applied boundary advanced only through {advancedThrough} after status application required {requiredAppliedThrough}."
+                        do!
+                            repairWatchJournalAfterStatusTrustLoss
+                                advancedThrough
+                                requiredAppliedThrough
+                                $"Watch journal applied boundary advanced only through {advancedThrough} after status application required {requiredAppliedThrough}."
+                                "Grace Watch applied status but could not repair the durable journal boundary through the appended observations"
 
                         logToAnsiConsole
                             Colors.Error
@@ -3589,16 +3637,20 @@ module Watch =
 
                         return false
                     else
+                        do! pruneWatchJournalAfterTrustedBoundaryAdvance appendedWatchJournalSequences
                         return true
                 with
                 | ex ->
-                    do! recoverWatchJournalBoundaryGapForWatch 0L requiredAppliedThrough
-
-                    requestGraceWatchExplicitResync $"Watch journal applied boundary advancement failed after status application: {ex.Message}"
+                    do!
+                        repairWatchJournalAfterStatusTrustLoss
+                            0L
+                            requiredAppliedThrough
+                            $"Watch journal applied boundary advancement failed after status application: {ex.Message}"
+                            "Grace Watch applied status but could not repair the durable journal boundary after advancement failed"
 
                     logToAnsiConsole
                         Colors.Error
-                        $"Grace Watch applied status but could not advance the durable journal boundary; the journal was repaired before resync so incremental shortcuts cannot replay already-applied work: {Markup.Escape(ex.Message)}."
+                        $"Grace Watch applied status but could not advance the durable journal boundary; resync was requested before journal repair so incremental shortcuts cannot replay already-applied work: {Markup.Escape(ex.Message)}."
 
                     return false
         }
@@ -3804,6 +3856,7 @@ module Watch =
 
                         let statusApplicationLegal = statusApplicationModeStillTrusted ()
                         let mutable appendedWatchJournalSequences = Array.empty<int64>
+                        let mutable appendedWatchJournalConverged = false
 
                         let statusUpdateStillTrusted () =
                             filesToProcess.IsEmpty
@@ -3865,13 +3918,18 @@ module Watch =
                                                 else
                                                     appendedWatchJournalSequences |> Array.max
 
-                                            do! recoverWatchJournalBoundaryGapForWatch 0L requiredAppliedThrough
+                                            do!
+                                                repairWatchJournalAfterStatusTrustLoss
+                                                    0L
+                                                    requiredAppliedThrough
+                                                    $"Watch status application failed after journal append: {ex.Message}"
+                                                    "Grace Watch appended normalized observations but could not repair the journal after status application failed"
 
-                                            requestGraceWatchExplicitResync $"Watch status application failed after journal append: {ex.Message}"
+                                            appendedWatchJournalConverged <- true
 
                                             logToAnsiConsole
                                                 Colors.Error
-                                                $"Grace Watch appended normalized observations but status application failed; the journal was repaired before resync so pending rows cannot replay as still-unapplied work: {Markup.Escape(ex.Message)}."
+                                                $"Grace Watch appended normalized observations but status application failed; resync was requested before journal repair so pending rows cannot replay as still-unapplied work: {Markup.Escape(ex.Message)}."
 
                                             return None
                                     | Error ex ->
@@ -3896,6 +3954,7 @@ module Watch =
                                     || isGraceWatchObservationApplicationLegal commitRuntimeMode)
 
                             let! watchJournalBoundaryTrusted = convergeWatchJournalAfterStatusApplication appendedWatchJournalSequences
+                            appendedWatchJournalConverged <- true
 
                             if statusUpdateCanCommit then
                                 if watchJournalBoundaryTrusted then
@@ -3920,15 +3979,6 @@ module Watch =
                                     clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
                                     clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
                                     removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
-
-                                    if appendedWatchJournalSequences.Length > 0 then
-                                        try
-                                            do! pruneWatchJournalRetentionForWatch ()
-                                        with
-                                        | ex ->
-                                            logToAnsiConsole
-                                                Colors.Verbose
-                                                $"Grace Watch could not prune applied journal rows after a trusted boundary advance; retention will retry after later status work: {Markup.Escape(ex.Message)}."
                             else
                                 clearPendingStatusDifferences pendingDifferencesToClear
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
@@ -3938,6 +3988,20 @@ module Watch =
                                     Colors.Important
                                     $"Grace Status file update completed while newer file upload work was pending; status-only triggers will retry."
                         | None ->
+                            if appendedWatchJournalSequences.Length > 0
+                               && not appendedWatchJournalConverged then
+                                let! noDurableStatusRepairFailed = clearWatchJournalAfterNoDurableStatus appendedWatchJournalSequences
+                                appendedWatchJournalConverged <- true
+
+                                if noDurableStatusRepairFailed then
+                                    logToAnsiConsole
+                                        Colors.Error
+                                        $"Grace Watch appended normalized observations but status application returned no durable status; repair failed and resync is required before incremental work can resume."
+                                else
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch appended normalized observations but status application returned no durable status; appended journal rows were cleared so the pending status work can retry."
+
                             logToAnsiConsole Colors.Important $"Grace Status file was not updated."
                             () // Something went wrong, don't update the in-memory Grace Status.
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3832,23 +3832,49 @@ module Watch =
                                 Task.FromResult(None)
                             elif statusDifferencesForApply.Applicable.Count > 0 then
                                 task {
-                                    try
-                                        let! sequences =
-                                            statusDifferencesForApply.Applicable
-                                            |> Seq.map journalObservationForDifference
-                                            |> appendWatchJournalObservationsForWatch
+                                    let! appendResult =
+                                        task {
+                                            try
+                                                let! sequences =
+                                                    statusDifferencesForApply.Applicable
+                                                    |> Seq.map journalObservationForDifference
+                                                    |> appendWatchJournalObservationsForWatch
 
+                                                return Ok sequences
+                                            with
+                                            | ex -> return Error ex
+                                        }
+
+                                    match appendResult with
+                                    | Ok sequences ->
                                         appendedWatchJournalSequences <- sequences
 
-                                        return!
-                                            updateGraceStatusFromDifferencesWhenTrusted
-                                                statusUpdateStillTrusted
-                                                updateGraceStatusFromDifferencesClient
-                                                graceStatus
-                                                statusDifferencesForApply.Applicable
-                                                correlationId
-                                    with
-                                    | ex ->
+                                        try
+                                            return!
+                                                updateGraceStatusFromDifferencesWhenTrusted
+                                                    statusUpdateStillTrusted
+                                                    updateGraceStatusFromDifferencesClient
+                                                    graceStatus
+                                                    statusDifferencesForApply.Applicable
+                                                    correlationId
+                                        with
+                                        | ex ->
+                                            let requiredAppliedThrough =
+                                                if appendedWatchJournalSequences.Length = 0 then
+                                                    0L
+                                                else
+                                                    appendedWatchJournalSequences |> Array.max
+
+                                            do! recoverWatchJournalBoundaryGapForWatch 0L requiredAppliedThrough
+
+                                            requestGraceWatchExplicitResync $"Watch status application failed after journal append: {ex.Message}"
+
+                                            logToAnsiConsole
+                                                Colors.Error
+                                                $"Grace Watch appended normalized observations but status application failed; the journal was repaired before resync so pending rows cannot replay as still-unapplied work: {Markup.Escape(ex.Message)}."
+
+                                            return None
+                                    | Error ex ->
                                         requestGraceWatchExplicitResync $"Watch journal append failed before status application: {ex.Message}"
 
                                         logToAnsiConsole

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -70,10 +70,24 @@ module Watch =
     let mutable private advanceWatchJournalAppliedThroughSequencesForWatch =
         fun sequences -> Grace.CLI.LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences (Current().GraceStatusFile) sequences
 
+    let mutable private recoverWatchJournalBoundaryGapForWatch =
+        fun _ _ ->
+            task {
+                let! _ = Grace.CLI.LocalStateDb.clearWatchJournal (Current().GraceStatusFile)
+                return ()
+            }
+
+    let mutable private pruneWatchJournalRetentionForWatch = fun () -> Grace.CLI.LocalStateDb.pruneWatchJournalRetention (Current().GraceStatusFile)
+
     /// Installs durable journal clients used by append-before-apply ordering tests.
     let internal setWatchJournalClientsForWatchTests appendObservations advanceAppliedSequences =
         appendWatchJournalObservationsForWatch <- appendObservations
         advanceWatchJournalAppliedThroughSequencesForWatch <- advanceAppliedSequences
+
+    /// Installs durable journal maintenance clients used by boundary repair and retention tests.
+    let internal setWatchJournalMaintenanceClientsForWatchTests recoverBoundaryGap pruneRetention =
+        recoverWatchJournalBoundaryGapForWatch <- recoverBoundaryGap
+        pruneWatchJournalRetentionForWatch <- pruneRetention
 
     /// Restores durable journal clients after tests replace append or boundary behavior.
     let internal resetWatchJournalClientsForWatchTests () =
@@ -82,6 +96,15 @@ module Watch =
 
         advanceWatchJournalAppliedThroughSequencesForWatch <-
             fun sequences -> Grace.CLI.LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences (Current().GraceStatusFile) sequences
+
+        recoverWatchJournalBoundaryGapForWatch <-
+            fun _ _ ->
+                task {
+                    let! _ = Grace.CLI.LocalStateDb.clearWatchJournal (Current().GraceStatusFile)
+                    return ()
+                }
+
+        pruneWatchJournalRetentionForWatch <- fun () -> Grace.CLI.LocalStateDb.pruneWatchJournalRetention (Current().GraceStatusFile)
 
     /// Reports that a filesystem observation was ignored because the current runtime mode cannot capture it.
     let private logObservationSuppressed fullPath =
@@ -3819,6 +3842,7 @@ module Watch =
 
                                         if advancedThrough < requiredAppliedThrough then
                                             watchJournalBoundaryTrusted <- false
+                                            do! recoverWatchJournalBoundaryGapForWatch advancedThrough requiredAppliedThrough
 
                                             requestGraceWatchExplicitResync
                                                 $"Watch journal applied boundary advanced only through {advancedThrough} after status application required {requiredAppliedThrough}."
@@ -3859,6 +3883,15 @@ module Watch =
                                     clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
                                     clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
                                     removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
+
+                                    if appendedWatchJournalSequences.Length > 0 then
+                                        try
+                                            do! pruneWatchJournalRetentionForWatch ()
+                                        with
+                                        | ex ->
+                                            logToAnsiConsole
+                                                Colors.Verbose
+                                                $"Grace Watch could not prune applied journal rows after a trusted boundary advance; retention will retry after later status work: {Markup.Escape(ex.Message)}."
                             else
                                 clearPendingStatusDifferences pendingDifferencesToClear
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3566,6 +3566,43 @@ module Watch =
                 return None
         }
 
+    /// Converges appended journal rows after status side effects commit so recovery never resumes from stale pending rows.
+    let private convergeWatchJournalAfterStatusApplication (appendedWatchJournalSequences: int64 array) =
+        task {
+            if appendedWatchJournalSequences.Length = 0 then
+                return true
+            else
+                let requiredAppliedThrough = appendedWatchJournalSequences |> Array.max
+
+                try
+                    let! advancedThrough = advanceWatchJournalAppliedThroughSequencesForWatch appendedWatchJournalSequences
+
+                    if advancedThrough < requiredAppliedThrough then
+                        do! recoverWatchJournalBoundaryGapForWatch advancedThrough requiredAppliedThrough
+
+                        requestGraceWatchExplicitResync
+                            $"Watch journal applied boundary advanced only through {advancedThrough} after status application required {requiredAppliedThrough}."
+
+                        logToAnsiConsole
+                            Colors.Error
+                            $"Grace Watch applied status but could not advance the durable journal boundary through the appended observations; resync is required before status work is drained."
+
+                        return false
+                    else
+                        return true
+                with
+                | ex ->
+                    do! recoverWatchJournalBoundaryGapForWatch 0L requiredAppliedThrough
+
+                    requestGraceWatchExplicitResync $"Watch journal applied boundary advancement failed after status application: {ex.Message}"
+
+                    logToAnsiConsole
+                        Colors.Error
+                        $"Grace Watch applied status but could not advance the durable journal boundary; the journal was repaired before resync so incremental shortcuts cannot replay already-applied work: {Markup.Escape(ex.Message)}."
+
+                    return false
+        }
+
     /// Processes any changed files since the last timer tick.
     let internal processChangedFilesWithClients
         readGraceStatusMetaClient
@@ -3832,35 +3869,9 @@ module Watch =
                                 && (startupPendingDifferences.Count > 0
                                     || isGraceWatchObservationApplicationLegal commitRuntimeMode)
 
+                            let! watchJournalBoundaryTrusted = convergeWatchJournalAfterStatusApplication appendedWatchJournalSequences
+
                             if statusUpdateCanCommit then
-                                let mutable watchJournalBoundaryTrusted = true
-
-                                if appendedWatchJournalSequences.Length > 0 then
-                                    try
-                                        let! advancedThrough = advanceWatchJournalAppliedThroughSequencesForWatch appendedWatchJournalSequences
-                                        let requiredAppliedThrough = appendedWatchJournalSequences |> Array.max
-
-                                        if advancedThrough < requiredAppliedThrough then
-                                            watchJournalBoundaryTrusted <- false
-                                            do! recoverWatchJournalBoundaryGapForWatch advancedThrough requiredAppliedThrough
-
-                                            requestGraceWatchExplicitResync
-                                                $"Watch journal applied boundary advanced only through {advancedThrough} after status application required {requiredAppliedThrough}."
-
-                                            logToAnsiConsole
-                                                Colors.Error
-                                                $"Grace Watch applied status but could not advance the durable journal boundary through the appended observations; resync is required before status work is drained."
-                                    with
-                                    | ex ->
-                                        watchJournalBoundaryTrusted <- false
-
-                                        requestGraceWatchExplicitResync
-                                            $"Watch journal applied boundary advancement failed after status application: {ex.Message}"
-
-                                        logToAnsiConsole
-                                            Colors.Error
-                                            $"Grace Watch applied status but could not advance the durable journal boundary; resync is required before incremental shortcuts are trusted: {Markup.Escape(ex.Message)}."
-
                                 if watchJournalBoundaryTrusted then
                                     graceStatus <- newGraceStatus
 

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -431,12 +431,16 @@ module CommandOutputContract =
                 "Sequence", scalarSchema "integer"
                 "CreatedAtUnixTicks", scalarSchema "integer"
                 "State", scalarSchema "string"
-                "RelativePath", nullableStringSchema "Repository-relative path when the durable journal row stores path metadata."
+                "DifferenceType", scalarSchema "string"
+                "FileSystemEntryType", scalarSchema "string"
+                "RelativePath", nullableStringSchema "Repository-relative path for the normalized replay observation."
             ]
             [|
                 "Sequence"
                 "CreatedAtUnixTicks"
                 "State"
+                "DifferenceType"
+                "FileSystemEntryType"
                 "RelativePath"
             |]
 
@@ -479,7 +483,14 @@ module CommandOutputContract =
                 Limit = 1
                 Rows =
                     [|
-                        {| Sequence = 4L; CreatedAtUnixTicks = 4L; State = "pending"; RelativePath = null |}
+                        {|
+                            Sequence = 4L
+                            CreatedAtUnixTicks = 4L
+                            State = "pending"
+                            DifferenceType = "Change"
+                            FileSystemEntryType = "File"
+                            RelativePath = "src/Program.fs"
+                        |}
                     |]
             |}
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -417,7 +417,7 @@ module LocalStateDb =
         reader.Read()
 
     /// Captures the SQLite column shape that writable schema checks must trust before using a table.
-    type private TableColumnShape = { Name: string; TypeName: string; NotNull: bool; PrimaryKeyOrdinal: int }
+    type private TableColumnShape = { Name: string; TypeName: string; NotNull: bool; DefaultValueSql: string option; PrimaryKeyOrdinal: int }
 
     /// Reads SQLite table column metadata so schema-version checks can reject partially created local databases.
     let private readTableColumnShapes (connection: SqliteConnection) tableName =
@@ -428,7 +428,13 @@ module LocalStateDb =
 
         while reader.Read() do
             columns.Add(
-                { Name = reader.GetString(1); TypeName = reader.GetString(2); NotNull = reader.GetInt32(3) <> 0; PrimaryKeyOrdinal = reader.GetInt32(5) }
+                {
+                    Name = reader.GetString(1)
+                    TypeName = reader.GetString(2)
+                    NotNull = reader.GetInt32(3) <> 0
+                    DefaultValueSql = if reader.IsDBNull(4) then None else Some(reader.GetString(4))
+                    PrimaryKeyOrdinal = reader.GetInt32(5)
+                }
             )
 
         columns |> Seq.toArray
@@ -692,15 +698,30 @@ module LocalStateDb =
     let private hasRequiredWatchJournalShape (connection: SqliteConnection) =
         let columns = readTableColumnShapes connection "watch_journal"
 
+        let expectedColumnNames =
+            [|
+                "sequence"
+                "created_at_unix_ticks"
+                "difference_type"
+                "entry_type"
+                "relative_path"
+            |]
+
         let tryFindColumn columnName =
             columns
             |> Array.tryFind (fun column -> StringComparer.OrdinalIgnoreCase.Equals(column.Name, columnName))
+
+        let hasExpectedColumnSet =
+            columns.Length = expectedColumnNames.Length
+            && expectedColumnNames
+               |> Array.forall (fun columnName -> tryFindColumn columnName |> Option.isSome)
 
         let hasSequenceColumn =
             match tryFindColumn "sequence" with
             | Some column ->
                 isIntegerColumnType column.TypeName
                 && column.PrimaryKeyOrdinal = 1
+                && column.DefaultValueSql.IsNone
             | None -> false
 
         let hasCreatedAtColumn =
@@ -709,6 +730,7 @@ module LocalStateDb =
                 isIntegerColumnType column.TypeName
                 && column.NotNull
                 && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
             | None -> false
 
         let hasRequiredTextColumn columnName =
@@ -717,9 +739,11 @@ module LocalStateDb =
                 isTextColumnType column.TypeName
                 && column.NotNull
                 && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
             | None -> false
 
-        hasSequenceColumn
+        hasExpectedColumnSet
+        && hasSequenceColumn
         && hasCreatedAtColumn
         && hasRequiredTextColumn "difference_type"
         && hasRequiredTextColumn "entry_type"

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -19,7 +19,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "5"
+    let private SchemaVersion = "6"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -186,7 +186,7 @@ module LocalStateDb =
             "CREATE INDEX IF NOT EXISTS ix_object_cache_children_parent ON object_cache_directory_children(parent_directory_version_id);"
             "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL);"
         |]
 
     let private requiredTableNames =
@@ -711,8 +711,19 @@ module LocalStateDb =
                 && column.PrimaryKeyOrdinal = 0
             | None -> false
 
+        let hasRequiredTextColumn columnName =
+            match tryFindColumn columnName with
+            | Some column ->
+                isTextColumnType column.TypeName
+                && column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+            | None -> false
+
         hasSequenceColumn
         && hasCreatedAtColumn
+        && hasRequiredTextColumn "difference_type"
+        && hasRequiredTextColumn "entry_type"
+        && hasRequiredTextColumn "relative_path"
         && watchJournalUsesAutoincrement connection
 
     /// Reports whether the Watch journal contains rows that require trustworthy recovery metadata.
@@ -1005,7 +1016,7 @@ module LocalStateDb =
             | None -> false
         | _ -> false
 
-    /// Verifies that existing Watch recovery metadata can be trusted before accepting schema version 5.
+    /// Verifies that existing Watch recovery metadata can be trusted before accepting the current schema.
     let private hasValidWatchJournalAppliedThroughSequenceMeta (connection: SqliteConnection) =
         match countMetaValues connection WatchJournalAppliedThroughSequenceMetaKey with
         | 1 -> hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection
@@ -1043,7 +1054,7 @@ module LocalStateDb =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL);"
 
     /// Replaces malformed or missing Watch recovery metadata with the clear-journal reset watermark.
     let private resetWatchJournalAppliedThroughSequenceForClear (connection: SqliteConnection) =
@@ -1059,7 +1070,18 @@ module LocalStateDb =
         | Pending
 
     /// Models one durable Watch journal sequence row for diagnostics.
-    type WatchJournalRow = { Sequence: int64; CreatedAtUnixTicks: int64; State: WatchJournalRowState; RelativePath: string option }
+    type WatchJournalRow =
+        {
+            Sequence: int64
+            CreatedAtUnixTicks: int64
+            State: WatchJournalRowState
+            DifferenceType: string
+            EntryType: string
+            RelativePath: string option
+        }
+
+    /// Models the replayable normalized Watch observation persisted before status application.
+    type WatchJournalObservation = { DifferenceType: DifferenceType; EntryType: FileSystemEntryType; RelativePath: RelativePath }
 
     /// Models a filtered Watch journal diagnostic snapshot.
     type WatchJournalSnapshot =
@@ -1350,10 +1372,11 @@ module LocalStateDb =
             command.CommandText <-
                 match normalizedStateFilter with
                 | "applied" ->
-                    "SELECT sequence, created_at_unix_ticks FROM watch_journal WHERE sequence <= $applied_through ORDER BY sequence DESC LIMIT $limit;"
+                    "SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal WHERE sequence <= $applied_through ORDER BY sequence DESC LIMIT $limit;"
                 | "pending" ->
-                    "SELECT sequence, created_at_unix_ticks FROM watch_journal WHERE sequence > $applied_through ORDER BY sequence DESC LIMIT $limit;"
-                | _ -> "SELECT sequence, created_at_unix_ticks FROM watch_journal ORDER BY sequence DESC LIMIT $limit;"
+                    "SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal WHERE sequence > $applied_through ORDER BY sequence DESC LIMIT $limit;"
+                | _ ->
+                    "SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal ORDER BY sequence DESC LIMIT $limit;"
 
             command.Parameters.AddWithValue("$limit", limit)
             |> ignore
@@ -1371,7 +1394,15 @@ module LocalStateDb =
 
                 let state = if sequence <= appliedThroughSequence then Applied else Pending
 
-                let row = { Sequence = sequence; CreatedAtUnixTicks = reader.GetInt64(1); State = state; RelativePath = None }
+                let row =
+                    {
+                        Sequence = sequence
+                        CreatedAtUnixTicks = reader.GetInt64(1)
+                        State = state
+                        DifferenceType = reader.GetString(2)
+                        EntryType = reader.GetString(3)
+                        RelativePath = Some(reader.GetString(4))
+                    }
 
                 if watchJournalRowMatches normalizedStateFilter normalizedPathFilter row then
                     rows.Add(row)
@@ -1456,6 +1487,118 @@ module LocalStateDb =
                 match result with
                 | Some result -> return result
                 | None -> return failwith "Watch journal clear did not produce a result."
+        }
+
+    /// Appends replayable normalized Watch observations before the corresponding status application begins.
+    let appendWatchJournalObservations (dbPath: string) (observations: IEnumerable<WatchJournalObservation>) =
+        task {
+            let observationArray = observations |> Seq.toArray
+
+            if observationArray.Length = 0 then
+                return Array.empty<int64>
+            else
+                do! ensureDbInitialized dbPath
+                let mutable sequences = Array.empty<int64>
+
+                do!
+                    executeWithRetry (fun () ->
+                        task {
+                            use connection = openConnection dbPath
+                            executeNonQuery connection "BEGIN IMMEDIATE;"
+                            let mutable committed = false
+
+                            try
+                                use command = connection.CreateCommand()
+
+                                command.CommandText <-
+                                    "INSERT INTO watch_journal (created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES ($created_at, $difference_type, $entry_type, $relative_path) RETURNING sequence;"
+
+                                command.Parameters.Add("$created_at", SqliteType.Integer)
+                                |> ignore
+
+                                command.Parameters.Add("$difference_type", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$entry_type", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$relative_path", SqliteType.Text)
+                                |> ignore
+
+                                let appendedSequences = ResizeArray<int64>()
+
+                                for observation in observationArray do
+                                    command.Parameters["$created_at"].Value <- getCurrentInstant().ToUnixTimeTicks()
+                                    command.Parameters["$difference_type"].Value <- getDiscriminatedUnionCaseName observation.DifferenceType
+                                    command.Parameters["$entry_type"].Value <- getDiscriminatedUnionCaseName observation.EntryType
+                                    command.Parameters["$relative_path"].Value <- string observation.RelativePath
+                                    appendedSequences.Add(Convert.ToInt64(command.ExecuteScalar()))
+
+                                executeNonQuery connection "COMMIT;"
+                                committed <- true
+                                sequences <- appendedSequences.ToArray()
+                            finally
+                                if not committed then
+                                    try
+                                        executeNonQuery connection "ROLLBACK;"
+                                    with
+                                    | _ -> ()
+                        })
+
+                return sequences
+        }
+
+    /// Advances the Watch journal watermark only across applied sequences that are contiguous from the current boundary.
+    let advanceWatchJournalAppliedThroughContiguousSequences (dbPath: string) (appliedSequences: IEnumerable<int64>) =
+        task {
+            let appliedSequenceSet =
+                appliedSequences
+                |> Seq.filter (fun sequence -> sequence > 0L)
+                |> HashSet<int64>
+
+            if appliedSequenceSet.Count = 0 then
+                return 0L
+            else
+                do! ensureDbInitialized dbPath
+                let mutable advancedThrough = 0L
+
+                do!
+                    executeWithRetry (fun () ->
+                        task {
+                            use connection = openConnection dbPath
+                            executeNonQuery connection "BEGIN IMMEDIATE;"
+                            let mutable committed = false
+
+                            try
+                                let currentSequence = readWatchJournalAppliedThroughSequenceInternal connection
+                                let mutable candidate = currentSequence + 1L
+                                let mutable targetSequence = currentSequence
+
+                                while appliedSequenceSet.Contains(candidate) do
+                                    targetSequence <- candidate
+                                    candidate <- candidate + 1L
+
+                                if targetSequence > currentSequence then
+                                    let allocatedSequence = readAllocatedWatchJournalSequence connection
+
+                                    if targetSequence > allocatedSequence then
+                                        invalidOp
+                                            $"Applied-through sequence cannot advance to {targetSequence} because the Watch journal has only allocated through {allocatedSequence}."
+
+                                    setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{targetSequence}"
+
+                                executeNonQuery connection "COMMIT;"
+                                committed <- true
+                                advancedThrough <- targetSequence
+                            finally
+                                if not committed then
+                                    try
+                                        executeNonQuery connection "ROLLBACK;"
+                                    with
+                                    | _ -> ()
+                        })
+
+                return advancedThrough
         }
 
     /// Persists the local Watch journal recovery watermark without changing journal rows.

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1366,6 +1366,7 @@ module LocalStateDb =
             let normalizedPathFilter =
                 pathFilter
                 |> Option.bind (fun value -> if String.IsNullOrWhiteSpace(value) then None else Some(value.Trim()))
+                |> Option.map normalizeFilePath
 
             use command = connection.CreateCommand()
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1369,22 +1369,41 @@ module LocalStateDb =
 
             use command = connection.CreateCommand()
 
+            let whereClauses = List<string>()
+
+            match normalizedStateFilter with
+            | "applied" ->
+                whereClauses.Add("sequence <= $applied_through")
+
+                command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
+                |> ignore
+            | "pending" ->
+                whereClauses.Add("sequence > $applied_through")
+
+                command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
+                |> ignore
+            | _ -> ()
+
+            match normalizedPathFilter with
+            | Some filter ->
+                whereClauses.Add("instr(lower(relative_path), lower($path_filter)) > 0")
+
+                command.Parameters.AddWithValue("$path_filter", filter)
+                |> ignore
+            | None -> ()
+
+            let whereSql =
+                if whereClauses.Count = 0 then
+                    String.Empty
+                else
+                    let joinedWhereClauses = String.Join(" AND ", whereClauses)
+                    $" WHERE {joinedWhereClauses}"
+
             command.CommandText <-
-                match normalizedStateFilter with
-                | "applied" ->
-                    "SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal WHERE sequence <= $applied_through ORDER BY sequence DESC LIMIT $limit;"
-                | "pending" ->
-                    "SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal WHERE sequence > $applied_through ORDER BY sequence DESC LIMIT $limit;"
-                | _ ->
-                    "SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal ORDER BY sequence DESC LIMIT $limit;"
+                $"SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal{whereSql} ORDER BY sequence DESC LIMIT $limit;"
 
             command.Parameters.AddWithValue("$limit", limit)
             |> ignore
-
-            if normalizedStateFilter = "applied"
-               || normalizedStateFilter = "pending" then
-                command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
-                |> ignore
 
             use reader = command.ExecuteReader()
             let rows = ResizeArray<WatchJournalRow>()


### PR DESCRIPTION
## Summary

Implements the WS4.3 append/apply boundary for durable Watch observations:

- Appends normalized `FileSystemDifference` observations to the local journal before status application.
- Advances `AppliedThroughSequence` only after the corresponding status application succeeds.
- Keeps failed, canceled, or confidence-loss observations pending instead of marking them applied.
- Preserves #498 maintenance visibility for pending/applied journal state.
- Updates Doctor local-state diagnostics for the schema 6 journal payload shape.

Related to #499.
Part of #473.

## Why This Matters

Grace Watch needs durable incremental state that can distinguish work that was observed, work that was applied, and work
that still needs recovery. This slice makes the local journal a real append-before-apply boundary without turning it
into raw watcher-event storage or a cross-machine sync log.

## Validation

- Targeted Fantomas on touched F# files: passed.
- Focused CLI build passed:

  ```powershell
  dotnet build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release
  ```

- Focused CLI test project passed, 923/923:

  ```powershell
  dotnet test src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --configuration Release --no-build
  ```

- `git diff --check`: passed.
- Final gate passed:

  ```powershell
  pwsh ./scripts/validate.ps1 -Fast
  ```

  Fast-profile evidence included `Grace.CLI.Tests` 923/923, `Grace.Types.Tests` 133/133,
  `Grace.Authorization.Tests` 53/53, and `Grace.Server.Unit.Tests` 723/723.

## Acceptance Mapping

- Durable normalized observation append before status apply: `Watch.CLI.fs` converts `FileSystemDifference` into
  `WatchJournalObservation` and appends it before status application.
- Boundary only advances after apply succeeds: `Watch.CLI.fs` advances the journal watermark only after the status
  commit path accepts the new Grace status.
- Append failure does not apply unjournaled work: append exceptions trigger explicit resync/confidence loss and skip
  status application.
- Apply failure or cancellation leaves pending rows and boundary unchanged: tests cover status returning `None` and
  confidence loss after append, with no boundary advance.
- Monotonic/no-skip boundary: `advanceWatchJournalAppliedThroughContiguousSequences` only advances through contiguous
  supplied sequences from the current `AppliedThroughSequence`.
- #498 maintenance behavior is preserved: `show-journal --state pending|applied --limit` reflects the final durable
  boundary state and now includes replay payload fields.
- Forbidden shapes avoided: no `WatchSessionId`, `ObservationId`, `BatchId`, `ApplyAttemptId`, raw watcher-event
  persistence, startup replay/quarantine, cross-machine sync log, or startup reconciliation replacement.

## Path Expansion

`src/Grace.CLI/Command/Doctor.CLI.fs` and `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs` were included because #499 changes
the current local-state schema from 5 to 6 by adding replayable Watch journal payload columns. Doctor owns the CLI
local-state schema health invariant, so it must treat schema 6 plus the new `watch_journal` shape as healthy. The Doctor
tests prove that invariant and preserve failure behavior for malformed metadata/journal state without mutation.

## Docs Impact

No docs or ADR updates were added. Waiver: this is internal local-state/watch durability wiring, and the user-visible
command-output contract was updated in `CommandOutputContract.CLI.fs`. WS4.4 startup replay/quarantine documentation
remains out of scope for #499.

## Residual Risks

- Schema version is now 6. Doctor and tests recognize it; old local-state DB compatibility/migration was not added
  because Grace is pre-production and the issue did not require compatibility behavior.
- If boundary advancement fails after status application, the implementation requests resync because status already
  committed. That preserves correctness but may force a reconciliation pass.

## Review Status

- Current head: `7bc645c3a07a51b1b62dedf3119f7b921faf71dd`.
- GitHub `full` check passed on this head after rerun: run `28728792118`, job `85191210984`.
- Codex Code Review Bot reported no issues for this head with 👍.
- All Codex review threads are resolved.
- Stabilization ledgers posted to PR #545 and #499:
  [original PR ledger](https://github.com/ScottArbeit/Grace/pull/545#issuecomment-4884586167),
  [session 4 PR addendum](https://github.com/ScottArbeit/Grace/pull/545#issuecomment-4884658550),
  [session 5 PR addendum](https://github.com/ScottArbeit/Grace/pull/545#issuecomment-4884714253).
- Codex review sessions 1-2: earlier findings were fixed in `ea97b8b3725552800b8928b072ca03c89ec05f35` and
  `25fe98ce90a8184ed9cca3acecbe59a45227d07e`, replied to, and resolved.
- Codex review session 3 on `25fe98ce90a8184ed9cca3acecbe59a45227d07e`: 3 fresh findings, addressed structurally in
  `dc7baea88f8e56ef72b2e265f9410bc7c37dc858`; replies posted and inline threads resolved.
- Codex review session 4 on `dc7baea88f8e56ef72b2e265f9410bc7c37dc858`: 2 fresh findings, addressed in
  `565e79bed6455ae4c2aee4cb4b6a63ade83c50dc`; replies posted and inline threads resolved.
- Codex review session 5 on `565e79bed6455ae4c2aee4cb4b6a63ade83c50dc`: 3 fresh findings, addressed in
  `7bc645c3a07a51b1b62dedf3119f7b921faf71dd`; replies posted and inline threads resolved.
- Validation for `7bc645c3a07a51b1b62dedf3119f7b921faf71dd`: targeted Fantomas passed; focused `WatchTests` passed
  224/224; `git diff --check` passed; `pwsh ./scripts/validate.ps1 -Fast` passed after a final self-review fix.
- Prevention: acceptance-criteria / negative-proof gap; #499 stabilization now covers all post-append terminal outcomes,
  resync-before-fallible-repair, retention-after-boundary-advance, strict schema-shape validation, and maintenance path
  filter parity.
- Final gate: ready to merge into `epic/473-grace-watch-incremental-sync`.
