### PR TITLE
WS4.4: Add Watch startup replay and quarantine

### DIFF
--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -1056,6 +1056,26 @@ module CommandOutputContractRegistryTests =
             |> should equal "correlation-id"
         | None -> Assert.Fail("authenticate.logout should have a registry entry.")
 
+    /// Verifies that maintenance show journal examples include every required journal row property.
+    [<Test>]
+    let ``maintenance show journal example includes quarantine reason`` () =
+        let identity = CommandOutputContract.commandIdentity [ "maintenance" ] "show-journal"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            let document = CommandOutputContract.introspectionDocument Examples entry
+            use success = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[0].Document)
+
+            let row =
+                success
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Rows")[0]
+
+            row.GetProperty("QuarantineReason").ValueKind
+            |> should equal JsonValueKind.Null
+        | None -> Assert.Fail("maintenance.show-journal should have a registry entry.")
+
     /// Verifies that all registry schema and example documents serialize as json.
     [<Test>]
     let ``all registry schema and example documents serialize as json`` () =

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2601,7 +2601,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 6"
+                |> should contain "schema_version is 7"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -2751,7 +2751,7 @@ module DoctorCliTests =
                     use connection = openRawConnection dbPath
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '7');"
 
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
@@ -2798,7 +2798,7 @@ module DoctorCliTests =
                     use connection = openRawConnection dbPath
                     executeNonQuery connection "DROP TABLE meta;"
                     executeNonQuery connection "CREATE TABLE meta (key TEXT NOT NULL, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '6');"
+                    executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('schema_version', '7');"
 
                     executeNonQuery connection "INSERT INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
@@ -3061,7 +3061,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 6"
+                        |> should contain "schema_version is 7"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -38,6 +38,7 @@ module LocalStateDbTests =
         configuration.OwnerId <- Guid.NewGuid()
         configuration.OrganizationId <- Guid.NewGuid()
         configuration.RepositoryId <- Guid.NewGuid()
+        configuration.BranchId <- Guid.NewGuid()
         configuration.RootDirectory <- root
         configuration.StandardizedRootDirectory <- normalizeFilePath root
         configuration.GraceDirectory <- Path.Combine(root, Constants.GraceConfigDirectory)
@@ -180,8 +181,24 @@ module LocalStateDbTests =
                 $"INSERT INTO watch_journal (sequence, created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES ({sequence}, {sequence}, 'Change', 'File', 'file-{sequence}.txt');")
 
     /// Builds a replayable Watch journal observation for local-state ordering tests.
+    let private watchJournalScope (configuration: GraceConfiguration) : LocalStateDb.WatchJournalScope =
+        {
+            RepositoryId = configuration.RepositoryId
+            BranchId = configuration.BranchId
+            WorkspaceRoot = configuration.RootDirectory
+            WatchRoot = configuration.RootDirectory
+            RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
+            RootDirectoryBlake3Hash = Blake3Hash "test-root-blake3"
+            WatchMode = "repository-root"
+        }
+
+    /// Builds a replayable Watch journal observation for local-state ordering tests.
     let private watchJournalObservation differenceType entryType (relativePath: string) : LocalStateDb.WatchJournalObservation =
-        { DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
+        { Scope = watchJournalScope (Current()); DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
+
+    /// Builds a scoped replayable Watch journal observation for startup recovery tests.
+    let private scopedWatchJournalObservation scope differenceType entryType (relativePath: string) : LocalStateDb.WatchJournalObservation =
+        { Scope = scope; DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
 
     /// Gets corrupt backups needed by the test scenario.
     let private getCorruptBackups (dbPath: string) =
@@ -258,9 +275,13 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
 
-        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '6');"
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
+
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '7');"
         executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
         executeNonQuery
@@ -355,7 +376,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -777,6 +798,127 @@ module LocalStateDbTests =
                     |]
             })
 
+    /// Verifies that startup recovery returns compatible pending rows without mutating them before Watch replays them.
+    [<Test>]
+    let ``watch journal startup recovery returns compatible pending rows`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+
+                let! sequences =
+                    LocalStateDb.appendWatchJournalObservations
+                        configuration.GraceStatusFile
+                        [
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "src/app.fs"
+                        ]
+
+                let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences |> should equal [| 1L |]
+                recovery.AppliedThroughSequence |> should equal 0L
+                recovery.QuarantinedRows |> should haveLength 0
+
+                recovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.DifferenceType, row.EntryType, row.RelativePath)
+                |> should
+                    equal
+                    [|
+                        1L, DifferenceType.Change, FileSystemEntryType.File, RelativePath "src/app.fs"
+                    |]
+
+                let! snapshot = LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "pending" None 10
+                snapshot.Rows |> should haveLength 1
+
+                snapshot.Rows[0].State
+                |> should equal LocalStateDb.WatchJournalRowState.Pending
+            })
+
+    /// Verifies that startup recovery quarantines rows from stale identity scopes and retires only contiguous failures.
+    [<Test>]
+    let ``watch journal startup recovery quarantines incompatible identity rows`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+
+                let wrongRepository = { scope with RepositoryId = Guid.NewGuid() }
+
+                let wrongBranch = { scope with BranchId = Guid.NewGuid() }
+
+                let wrongWorkspace = { scope with WorkspaceRoot = Path.Combine(configuration.RootDirectory, "other-workspace") }
+
+                let wrongRoot = { scope with WatchRoot = Path.Combine(configuration.RootDirectory, "other-root") }
+
+                let failedContinuity = { scope with RootDirectoryBlake3Hash = Blake3Hash "different-root-blake3" }
+
+                let observations =
+                    [|
+                        scopedWatchJournalObservation wrongRepository DifferenceType.Change FileSystemEntryType.File "wrong-repo.txt"
+                        scopedWatchJournalObservation wrongBranch DifferenceType.Change FileSystemEntryType.File "wrong-branch.txt"
+                        scopedWatchJournalObservation wrongWorkspace DifferenceType.Change FileSystemEntryType.File "wrong-workspace.txt"
+                        scopedWatchJournalObservation wrongRoot DifferenceType.Change FileSystemEntryType.File "wrong-root.txt"
+                        scopedWatchJournalObservation failedContinuity DifferenceType.Change FileSystemEntryType.File "failed-continuity.txt"
+                        scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "compatible.txt"
+                    |]
+
+                let! sequences = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile observations
+                let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences
+                |> should equal [| 1L; 2L; 3L; 4L; 5L; 6L |]
+
+                recovery.QuarantinedRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "wrong-repo.txt", Some "wrong repository"
+                        2L, Some "wrong-branch.txt", Some "wrong branch"
+                        3L, Some "wrong-workspace.txt", Some "wrong workspace root"
+                        4L, Some "wrong-root.txt", Some "wrong watch root"
+                        5L, Some "failed-continuity.txt", Some "failed root hash continuity"
+                    |]
+
+                recovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath)
+                |> should equal [| 6L, RelativePath "compatible.txt" |]
+
+                let! appliedThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                appliedThrough |> should equal 5L
+
+                let! quarantinedSnapshot = LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "quarantined" None 10
+                quarantinedSnapshot.Rows |> should haveLength 5
+
+                let! pendingSnapshot = LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "pending" None 10
+
+                pendingSnapshot.Rows
+                |> Array.map (fun row -> row.Sequence)
+                |> should equal [| 6L |]
+            })
+
+    /// Verifies that lifecycle diagnostics are durable and explicitly non-replayable.
+    [<Test>]
+    let ``watch lifecycle events are recorded as non replayable diagnostics`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+
+                do!
+                    LocalStateDb.recordWatchLifecycleEvent
+                        configuration.GraceStatusFile
+                        { Scope = scope; EventType = "startup-replay-complete"; Message = "Startup replay completed." }
+
+                use connection = new SqliteConnection($"Data Source={configuration.GraceStatusFile}")
+                connection.Open()
+                let eventCount = executeScalarInt connection "SELECT COUNT(*) FROM watch_lifecycle_events WHERE event_type = 'startup-replay-complete';"
+                let replayableTotal = executeScalarInt connection "SELECT SUM(replayable) FROM watch_lifecycle_events;"
+
+                eventCount |> should equal 1
+                replayableTotal |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
+                |> should equal 0
+            })
+
     /// Verifies that round trips status snapshot.
     [<Test>]
     let ``round trips status snapshot`` () =
@@ -1043,7 +1185,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1079,7 +1221,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
                 sequencePk |> should equal 1
@@ -1131,7 +1273,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -1171,7 +1313,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -1211,7 +1353,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
@@ -1253,7 +1395,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let duplicateRows = executeScalarInt connection "SELECT COUNT(*) FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 duplicateRows |> should equal 1
 
@@ -1298,7 +1440,7 @@ module LocalStateDbTests =
                     with
                     | :? SqliteException -> false
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 duplicateInsertSucceeded |> should equal false
 
@@ -1337,7 +1479,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1376,7 +1518,7 @@ module LocalStateDbTests =
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
                 let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
                 allocationRows |> should equal 0
@@ -1414,7 +1556,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1451,7 +1593,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1488,7 +1630,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1534,7 +1676,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1581,7 +1723,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1627,7 +1769,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1675,7 +1817,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1716,7 +1858,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1746,7 +1888,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1801,7 +1943,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "6")
+                |> should equal (Some "7")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -1846,7 +1988,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "6")
+                |> should equal (Some "7")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -2124,7 +2266,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -2161,7 +2303,7 @@ module LocalStateDbTests =
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
                 let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
                 readRootBlake3Hash |> should equal rootBlake3Hash
@@ -2216,7 +2358,7 @@ module LocalStateDbTests =
                 let watchJournalCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 watchJournalCount |> should equal 1
                 appliedThrough |> should equal "0"
 
@@ -2268,9 +2410,9 @@ module LocalStateDbTests =
 
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 hiddenRequiredColumns |> should equal 0
-                journalColumns |> should equal 5
+                journalColumns |> should equal 14
                 appliedThrough |> should equal "0"
 
                 let corruptAfter =
@@ -2305,7 +2447,7 @@ module LocalStateDbTests =
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 rootBlake3Columns |> should equal 1
                 statusMetaCount |> should equal 1
 
@@ -2346,7 +2488,7 @@ module LocalStateDbTests =
                 let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
                 statusDirectoryCount |> should equal 0
                 statusMetaCount |> should equal 1
 
@@ -2539,7 +2681,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -2566,7 +2708,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "6"
+                schemaVersion |> should equal "7"
             })
 
     /// Verifies that replace status snapshot fully clears old snapshot rows.
@@ -2880,7 +3022,7 @@ module LocalStateDbTests =
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '6');"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '7');"
 
                     executeNonQuery
                         connection
@@ -3790,7 +3932,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "6"
+                    schemaVersion |> should equal "7"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -833,6 +833,80 @@ module LocalStateDbTests =
                 |> should equal LocalStateDb.WatchJournalRowState.Pending
             })
 
+    /// Verifies that startup recovery quarantines persisted relative paths that would escape the watch root.
+    [<Test>]
+    let ``watch journal startup recovery quarantines relative paths that escape watch root`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+
+                let! sequences =
+                    LocalStateDb.appendWatchJournalObservations
+                        configuration.GraceStatusFile
+                        [
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "../outside.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "dir/../../outside.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "src/app.fs"
+                        ]
+
+                let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences |> should equal [| 1L; 2L; 3L |]
+
+                recovery.QuarantinedRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "../outside.txt", Some "relative path escapes watch root"
+                        2L, Some "dir/../../outside.txt", Some "relative path escapes watch root"
+                    |]
+
+                recovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath)
+                |> should equal [| 3L, RelativePath "src/app.fs" |]
+
+                let! appliedThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                appliedThrough |> should equal 2L
+            })
+
+    /// Verifies that startup recovery quarantines malformed durable roots instead of throwing during classification.
+    [<Test>]
+    let ``watch journal startup recovery quarantines malformed durable roots`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+                let malformedRoot = "malformed" + string (char 0)
+                let malformedWorkspace = { scope with WorkspaceRoot = malformedRoot }
+                let malformedWatchRoot = { scope with WatchRoot = malformedRoot }
+
+                let! sequences =
+                    LocalStateDb.appendWatchJournalObservations
+                        configuration.GraceStatusFile
+                        [
+                            scopedWatchJournalObservation malformedWorkspace DifferenceType.Change FileSystemEntryType.File "workspace.txt"
+                            scopedWatchJournalObservation malformedWatchRoot DifferenceType.Change FileSystemEntryType.File "watch-root.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "compatible.txt"
+                        ]
+
+                let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences |> should equal [| 1L; 2L; 3L |]
+
+                recovery.QuarantinedRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "workspace.txt", Some "invalid workspace root"
+                        2L, Some "watch-root.txt", Some "invalid watch root"
+                    |]
+
+                recovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath)
+                |> should equal [| 3L, RelativePath "compatible.txt" |]
+            })
+
     /// Verifies that startup recovery quarantines rows from stale identity scopes and retires only contiguous failures.
     [<Test>]
     let ``watch journal startup recovery quarantines incompatible identity rows`` () =
@@ -917,6 +991,49 @@ module LocalStateDbTests =
 
                 executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
                 |> should equal 0
+            })
+
+    /// Verifies that current-schema initialization recreates malformed lifecycle tables before inserts trust them.
+    [<Test>]
+    let ``ensureDbInitialized recreates current schema database with malformed watch lifecycle table`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE watch_lifecycle_events;"
+                    executeNonQuery connection "CREATE TABLE watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT);"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+
+                let lifecycleColumns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('watch_lifecycle_events');"
+
+                schemaVersion |> should equal "7"
+                lifecycleColumns |> should equal 12
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+
+                do!
+                    LocalStateDb.recordWatchLifecycleEvent
+                        configuration.GraceStatusFile
+                        { Scope = watchJournalScope configuration; EventType = "startup-replay-complete"; Message = "Lifecycle table was repaired." }
+
+                let lifecycleRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_lifecycle_events;"
+                lifecycleRows |> should equal 1
             })
 
     /// Verifies that round trips status snapshot.

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -187,6 +187,7 @@ module LocalStateDbTests =
             BranchId = configuration.BranchId
             WorkspaceRoot = configuration.RootDirectory
             WatchRoot = configuration.RootDirectory
+            PathComparison = StringComparison.Ordinal
             RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
             RootDirectoryBlake3Hash = Blake3Hash "test-root-blake3"
             WatchMode = "repository-root"
@@ -868,6 +869,81 @@ module LocalStateDbTests =
 
                 let! appliedThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
                 appliedThrough |> should equal 2L
+            })
+
+    /// Verifies that startup recovery uses the repository path comparison when matching durable replay roots.
+    [<Test>]
+    let ``watch journal startup recovery matches roots with repository path comparison`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = { watchJournalScope configuration with PathComparison = StringComparison.OrdinalIgnoreCase }
+
+                let differentlyCasedScope =
+                    { scope with WorkspaceRoot = configuration.RootDirectory.ToUpperInvariant(); WatchRoot = configuration.RootDirectory.ToUpperInvariant() }
+
+                let caseSensitiveScope = { watchJournalScope configuration with PathComparison = StringComparison.Ordinal }
+
+                let! sequences =
+                    LocalStateDb.appendWatchJournalObservations
+                        configuration.GraceStatusFile
+                        [
+                            scopedWatchJournalObservation differentlyCasedScope DifferenceType.Change FileSystemEntryType.File "compatible.txt"
+                        ]
+
+                let! insensitiveRecovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences |> should equal [| 1L |]
+
+                insensitiveRecovery.QuarantinedRows
+                |> should haveLength 0
+
+                insensitiveRecovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath)
+                |> should equal [| 1L, RelativePath "compatible.txt" |]
+
+                let! sensitiveRecovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile caseSensitiveScope
+
+                sensitiveRecovery.QuarantinedRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "compatible.txt", Some "wrong workspace root"
+                    |]
+            })
+
+    /// Verifies that startup recovery rejects non-canonical durable replay paths before they can become status keys.
+    [<Test>]
+    let ``watch journal startup recovery quarantines non canonical relative paths`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+
+                let! sequences =
+                    LocalStateDb.appendWatchJournalObservations
+                        configuration.GraceStatusFile
+                        [
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "./file.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "sub/../file.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "src/app.fs"
+                        ]
+
+                let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences |> should equal [| 1L; 2L; 3L |]
+
+                recovery.QuarantinedRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "./file.txt", Some "relative path is not canonical"
+                        2L, Some "sub/../file.txt", Some "relative path is not canonical"
+                    |]
+
+                recovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath)
+                |> should equal [| 3L, RelativePath "src/app.fs" |]
             })
 
     /// Verifies that durable replay shape classification rejects rows Watch cannot emit before status mutation.

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -870,6 +870,58 @@ module LocalStateDbTests =
                 appliedThrough |> should equal 2L
             })
 
+    /// Verifies that durable replay shape classification rejects rows Watch cannot emit before status mutation.
+    [<Test>]
+    let ``watch journal startup recovery classifies durable replay shapes before replay`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let scope = watchJournalScope configuration
+
+                let! sequences =
+                    LocalStateDb.appendWatchJournalObservations
+                        configuration.GraceStatusFile
+                        [
+                            scopedWatchJournalObservation scope DifferenceType.Delete FileSystemEntryType.File "."
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.Directory "changed-directory"
+                            scopedWatchJournalObservation scope DifferenceType.Delete FileSystemEntryType.File "deleted-directory/"
+                            scopedWatchJournalObservation scope DifferenceType.Add FileSystemEntryType.File "file-add.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "file-change.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Delete FileSystemEntryType.File "file-delete.txt"
+                            scopedWatchJournalObservation scope DifferenceType.Add FileSystemEntryType.Directory "directory-add"
+                            scopedWatchJournalObservation scope DifferenceType.Delete FileSystemEntryType.Directory "directory-delete"
+                        ]
+
+                let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
+
+                sequences
+                |> should equal [| 1L; 2L; 3L; 4L; 5L; 6L; 7L; 8L |]
+
+                recovery.QuarantinedRows
+                |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some ".", Some "watch root path cannot be replayed as a status difference"
+                        2L, Some "changed-directory", Some "directory change rows are not emitted by Watch startup scan"
+                        3L, Some "deleted-directory/", Some "file replay row targets a directory-shaped path"
+                    |]
+
+                recovery.CompatibleReplayRows
+                |> Array.map (fun row -> row.Sequence, row.DifferenceType, row.EntryType, row.RelativePath)
+                |> should
+                    equal
+                    [|
+                        4L, DifferenceType.Add, FileSystemEntryType.File, RelativePath "file-add.txt"
+                        5L, DifferenceType.Change, FileSystemEntryType.File, RelativePath "file-change.txt"
+                        6L, DifferenceType.Delete, FileSystemEntryType.File, RelativePath "file-delete.txt"
+                        7L, DifferenceType.Add, FileSystemEntryType.Directory, RelativePath "directory-add"
+                        8L, DifferenceType.Delete, FileSystemEntryType.Directory, RelativePath "directory-delete"
+                    |]
+
+                let! appliedThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
+                appliedThrough |> should equal 3L
+            })
+
     /// Verifies that startup recovery quarantines malformed durable roots instead of throwing during classification.
     [<Test>]
     let ``watch journal startup recovery quarantines malformed durable roots`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -1210,6 +1210,7 @@ module LocalStateDbTests =
 
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "UPDATE meta SET value = '6' WHERE key = 'schema_version';"
                     executeNonQuery connection "DROP TABLE watch_journal;"
                     executeNonQuery connection "CREATE TABLE watch_journal (sequence TEXT PRIMARY KEY);"
 
@@ -2344,6 +2345,7 @@ module LocalStateDbTests =
                 seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId rootHash "root-blake3" ticks
 
                 use seedConnection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery seedConnection "UPDATE meta SET value = '6' WHERE key = 'schema_version';"
                 executeNonQuery seedConnection "DROP TABLE watch_journal;"
                 seedConnection.Dispose()
 

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -882,6 +882,8 @@ module LocalStateDbTests =
                         configuration.GraceStatusFile
                         [
                             scopedWatchJournalObservation scope DifferenceType.Delete FileSystemEntryType.File "."
+                            scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "dir/.."
+                            scopedWatchJournalObservation scope DifferenceType.Add FileSystemEntryType.File "child/../."
                             scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.Directory "changed-directory"
                             scopedWatchJournalObservation scope DifferenceType.Delete FileSystemEntryType.File "deleted-directory/"
                             scopedWatchJournalObservation scope DifferenceType.Add FileSystemEntryType.File "file-add.txt"
@@ -894,7 +896,20 @@ module LocalStateDbTests =
                 let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
 
                 sequences
-                |> should equal [| 1L; 2L; 3L; 4L; 5L; 6L; 7L; 8L |]
+                |> should
+                    equal
+                    [|
+                        1L
+                        2L
+                        3L
+                        4L
+                        5L
+                        6L
+                        7L
+                        8L
+                        9L
+                        10L
+                    |]
 
                 recovery.QuarantinedRows
                 |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
@@ -902,8 +917,10 @@ module LocalStateDbTests =
                     equal
                     [|
                         1L, Some ".", Some "watch root path cannot be replayed as a status difference"
-                        2L, Some "changed-directory", Some "directory change rows are not emitted by Watch startup scan"
-                        3L, Some "deleted-directory/", Some "file replay row targets a directory-shaped path"
+                        2L, Some "dir/..", Some "watch root path cannot be replayed as a status difference"
+                        3L, Some "child/../.", Some "watch root path cannot be replayed as a status difference"
+                        4L, Some "changed-directory", Some "directory change rows are not emitted by Watch startup scan"
+                        5L, Some "deleted-directory/", Some "file replay row targets a directory-shaped path"
                     |]
 
                 recovery.CompatibleReplayRows
@@ -911,15 +928,15 @@ module LocalStateDbTests =
                 |> should
                     equal
                     [|
-                        4L, DifferenceType.Add, FileSystemEntryType.File, RelativePath "file-add.txt"
-                        5L, DifferenceType.Change, FileSystemEntryType.File, RelativePath "file-change.txt"
-                        6L, DifferenceType.Delete, FileSystemEntryType.File, RelativePath "file-delete.txt"
-                        7L, DifferenceType.Add, FileSystemEntryType.Directory, RelativePath "directory-add"
-                        8L, DifferenceType.Delete, FileSystemEntryType.Directory, RelativePath "directory-delete"
+                        6L, DifferenceType.Add, FileSystemEntryType.File, RelativePath "file-add.txt"
+                        7L, DifferenceType.Change, FileSystemEntryType.File, RelativePath "file-change.txt"
+                        8L, DifferenceType.Delete, FileSystemEntryType.File, RelativePath "file-delete.txt"
+                        9L, DifferenceType.Add, FileSystemEntryType.Directory, RelativePath "directory-add"
+                        10L, DifferenceType.Delete, FileSystemEntryType.Directory, RelativePath "directory-delete"
                     |]
 
                 let! appliedThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
-                appliedThrough |> should equal 3L
+                appliedThrough |> should equal 5L
             })
 
     /// Verifies that startup recovery quarantines malformed durable roots instead of throwing during classification.
@@ -1086,6 +1103,54 @@ module LocalStateDbTests =
 
                 let lifecycleRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_lifecycle_events;"
                 lifecycleRows |> should equal 1
+            })
+
+    /// Verifies that current-schema validation rejects lifecycle tables that allow replayable diagnostics.
+    [<Test>]
+    let ``ensureDbInitialized recreates current schema database with replayable lifecycle constraint`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let ticks = 1234567890L
+                seedCurrentSchemaWithStatusMeta configuration.GraceStatusFile rootId "root-sha" "root-blake3" ticks
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "DROP TABLE watch_lifecycle_events;"
+
+                    executeNonQuery
+                        connection
+                        "CREATE TABLE watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 1));"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                schemaVersion |> should equal "7"
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+
+                do!
+                    LocalStateDb.recordWatchLifecycleEvent
+                        configuration.GraceStatusFile
+                        { Scope = watchJournalScope configuration; EventType = "startup-replay-complete"; Message = "Lifecycle table was repaired." }
+
+                let lifecycleRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_lifecycle_events WHERE replayable = 0;"
+                lifecycleRows |> should equal 1
+
+                (fun () ->
+                    executeNonQuery
+                        connection
+                        "INSERT INTO watch_lifecycle_events (created_at_unix_ticks, event_type, message, replayable) VALUES (1, 'malformed', 'must fail', 1);")
+                |> should throw typeof<SqliteException>
             })
 
     /// Verifies that round trips status snapshot.

--- a/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Maintenance.CLI.Tests.fs
@@ -693,6 +693,50 @@ module MaintenanceCliTests =
             pathRow.GetProperty("RelativePath").GetString()
             |> should equal "src/file-2.txt")
 
+    /// Verifies that maintenance show journal exposes startup quarantine diagnostics in the JSON contract.
+    [<Test>]
+    let ``maintenance show journal json exposes quarantine reason`` () =
+        withTempRepo (fun root ->
+            seedWatchJournalRows root 2L 0L
+
+            let dbPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
+
+            use setupConnection = new SqliteConnection($"Data Source={dbPath}")
+            setupConnection.Open()
+
+            executeNonQuery setupConnection "UPDATE watch_journal SET quarantined_at_unix_ticks = 99, quarantine_reason = 'wrong branch' WHERE sequence = 1;"
+
+            /// Verifies that the CLI maintenance scenario exits with the expected process status.
+            let exitCode, standardOut, standardError =
+                runJsonMaintenance [| "show-journal"
+                                      "--state"
+                                      "quarantined"
+                                      "--limit"
+                                      "10" |]
+
+            exitCode |> should equal 0
+            standardError |> should equal String.Empty
+
+            use document = assertCleanJsonStdout standardOut
+
+            let rows =
+                document
+                    .RootElement
+                    .GetProperty("ReturnValue")
+                    .GetProperty("Rows")
+
+            rows.GetArrayLength() |> should equal 1
+            let row = rows[0]
+
+            row.GetProperty("Sequence").GetInt64()
+            |> should equal 1L
+
+            row.GetProperty("State").GetString()
+            |> should equal "quarantined"
+
+            row.GetProperty("QuarantineReason").GetString()
+            |> should equal "wrong branch")
+
     /// Verifies that maintenance show journal reports unhealthy local state without repairing or rotating the DB.
     [<Test>]
     let ``maintenance show journal json reports stale schema without mutating local db`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -410,8 +410,22 @@ module WatchTests =
     let private changedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
     /// Builds a replayable Watch journal observation for Watch command retention tests.
+    let private watchJournalScope () : LocalStateDb.WatchJournalScope =
+        let current = Current()
+
+        {
+            RepositoryId = current.RepositoryId
+            BranchId = current.BranchId
+            WorkspaceRoot = current.RootDirectory
+            WatchRoot = current.RootDirectory
+            RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
+            RootDirectoryBlake3Hash = Blake3Hash "test-root-blake3"
+            WatchMode = "repository-root"
+        }
+
+    /// Builds a replayable Watch journal observation for Watch command retention tests.
     let private watchJournalObservation differenceType entryType (relativePath: string) : LocalStateDb.WatchJournalObservation =
-        { DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
+        { Scope = watchJournalScope (); DifferenceType = differenceType; EntryType = entryType; RelativePath = RelativePath relativePath }
 
     /// Builds local file version test data used to exercise CLI watch behavior.
     let private localFileVersion relativePath =
@@ -2984,6 +2998,137 @@ module WatchTests =
                 |> should equal Array.empty<string>
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that startup replay reuses compatible pending journal sequences after reconciliation.
+    [<Test>]
+    let ``watch startup replay reuses pending journal sequence after reconciliation`` () =
+        withTempRepo (fun _ ->
+            let relativePath = "startup-replay-delete.txt"
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let ordering = ResizeArray<string>()
+
+            try
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun scope ->
+                        task {
+                            scope.RepositoryId
+                            |> should equal (Current().RepositoryId)
+
+                            scope.BranchId
+                            |> should equal (Current().BranchId)
+
+                            scope.WatchRoot
+                            |> should equal (Path.GetFullPath(Current().RootDirectory))
+
+                            ordering.Add("recover")
+
+                            return
+                                {
+                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
+                                    AppliedThroughSequence = 0L
+                                    CompatibleReplayRows =
+                                        [|
+                                            {
+                                                LocalStateDb.WatchJournalPendingReplay.Sequence = 42L
+                                                DifferenceType = DifferenceType.Delete
+                                                EntryType = FileSystemEntryType.File
+                                                RelativePath = RelativePath relativePath
+                                            }
+                                        |]
+                                    QuarantinedRows = Array.empty
+                                }
+                        })
+                    (fun event ->
+                        task {
+                            let expectedLifecycleEvent =
+                                event.Message.Contains("replay", StringComparison.OrdinalIgnoreCase)
+                                || event.EventType = "startup-reconciliation-complete"
+
+                            expectedLifecycleEvent |> should equal true
+
+                            ordering.Add($"lifecycle:{event.EventType}")
+                        })
+
+                Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status
+                |> fun recoveryTask -> recoveryTask.GetAwaiter().GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
+                )
+                |> should equal (Some 42L)
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("startup replay must not append duplicate rows")))
+                    (fun sequences ->
+                        task {
+                            sequences |> Seq.toArray |> should equal [| 42L |]
+                            ordering.Add("advance")
+                            return 42L
+                        })
+
+                /// Reads status needed by the startup replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this replayed delete scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Applies only the replayed pending row after startup recovery has completed.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    ordering.ToArray()
+                    |> should
+                        equal
+                        [|
+                            "lifecycle:startup-reconciliation-complete"
+                            "recover"
+                            "lifecycle:startup-replay-complete"
+                        |]
+
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, string difference.RelativePath)
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                        |]
+
+                    ordering.Add("apply")
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this replay ordering scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the replay ordering test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                ordering.ToArray()
+                |> should
+                    equal
+                    [|
+                        "lifecycle:startup-reconciliation-complete"
+                        "recover"
+                        "lifecycle:startup-replay-complete"
+                        "apply"
+                        "advance"
+                    |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
 
     /// Verifies that journal append failure prevents unjournaled status application.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3002,10 +3002,16 @@ module WatchTests =
     /// Verifies that startup replay reuses compatible pending journal sequences after reconciliation.
     [<Test>]
     let ``watch startup replay reuses pending journal sequence after reconciliation`` () =
-        withTempRepo (fun _ ->
+        withTempRepo (fun root ->
             let relativePath = "startup-replay-delete.txt"
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
             let ordering = ResizeArray<string>()
+            let childDirectory = Path.Combine(root, "child")
+
+            Directory.CreateDirectory(childDirectory)
+            |> ignore
+
+            Environment.CurrentDirectory <- childDirectory
 
             try
                 Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
@@ -3018,6 +3024,9 @@ module WatchTests =
 
                             scope.BranchId
                             |> should equal (Current().BranchId)
+
+                            scope.WorkspaceRoot
+                            |> should equal (Path.GetFullPath(Current().RootDirectory))
 
                             scope.WatchRoot
                             |> should equal (Path.GetFullPath(Current().RootDirectory))
@@ -3126,6 +3135,284 @@ module WatchTests =
                         "apply"
                         "advance"
                     |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that delayed startup replay runs after pending startup backlog drains on a later timer pass.
+    [<Test>]
+    let ``startup recovery runs after delayed backlog drains`` () =
+        withTempRepo (fun _ ->
+            let relativePath = "delayed-startup-replay.txt"
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let ordering = ResizeArray<string>()
+
+            try
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun _ ->
+                        task {
+                            ordering.Add("recover")
+
+                            return
+                                {
+                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
+                                    AppliedThroughSequence = 0L
+                                    CompatibleReplayRows =
+                                        [|
+                                            {
+                                                LocalStateDb.WatchJournalPendingReplay.Sequence = 77L
+                                                DifferenceType = DifferenceType.Delete
+                                                EntryType = FileSystemEntryType.File
+                                                RelativePath = RelativePath relativePath
+                                            }
+                                        |]
+                                    QuarantinedRows = Array.empty
+                                }
+                        })
+                    (fun event -> task { ordering.Add($"lifecycle:{event.EventType}") })
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("startup replay must not append duplicate rows")))
+                    (fun sequences ->
+                        task {
+                            sequences |> Seq.toArray |> should equal [| 77L |]
+                            ordering.Add("advance")
+                            return 77L
+                        })
+
+                /// Reads status needed by the delayed startup completion scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this replayed delete scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Applies the replayed pending row that delayed startup recovery queued.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, string difference.RelativePath)
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                        |]
+
+                    ordering.Add("apply")
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this replay ordering scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+
+                /// Keeps IPC publication deterministic for the delayed startup recovery test.
+                let updateIpc _ _ =
+                    ordering.Add("ipc")
+                    Task.FromResult(())
+
+                let processStartupReplay () =
+                    task {
+                        ordering.Add("process")
+
+                        do!
+                            Watch.processChangedFilesWithClients
+                                readStatus
+                                readStatus
+                                upload
+                                updateGraceStatus
+                                scannerHostileDifferenceDiscovery
+                                updateGraceStatusFromDifferences
+                                applyIncremental
+                                updateIpc
+                    }
+
+                (Watch.completeStartupRecoveryIfPendingWorkDrainedForWatchTests readStatus updateIpc processStartupReplay)
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+
+                ordering.ToArray()
+                |> should
+                    equal
+                    [|
+                        "lifecycle:startup-reconciliation-complete"
+                        "recover"
+                        "lifecycle:startup-replay-complete"
+                        "process"
+                        "apply"
+                        "advance"
+                        "ipc"
+                        "ipc"
+                    |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that replayed rows resolved before apply are still retired durably.
+    [<Test>]
+    let ``watch retires resolved startup replay rows`` () =
+        withTempRepo (fun root ->
+            let relativePath = "resolved-replay-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            File.WriteAllText(filePath, "recreated")
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Delete
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath relativePath
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                /// Reads status needed by the resolved replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only replay scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if resolved replay work reaches status application.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("resolved replay rows should not apply status"))
+
+                /// Leaves incremental status writes outside this resolved replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the resolved replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let snapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "applied" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                snapshot.AppliedThroughSequence |> should equal 1L
+                snapshot.Rows |> should haveLength 1
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
+                )
+                |> should equal None
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that existing replay rows remain durable when status application defers before side effects.
+    [<Test>]
+    let ``watch keeps existing startup replay row when status apply defers`` () =
+        withTempRepo (fun root ->
+            let relativePath = "deferred-startup-replay.txt"
+            let liveRelativePath = "deferred-live-delete.txt"
+            let status = graceStatusTracking [| liveRelativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        { Scope = scope; DifferenceType = DifferenceType.Add; EntryType = FileSystemEntryType.File; RelativePath = RelativePath relativePath }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.OnDeleted(deletedEvent (Path.Combine(root, liveRelativePath)))
+
+                /// Reads status needed by the deferred replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only replay scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+                /// Simulates status application deferring before durable side effects.
+                let updateGraceStatusFromDifferences _ _ _ = Task.FromResult(None)
+                /// Leaves incremental status writes outside this deferred replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the deferred replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let snapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                snapshot.AppliedThroughSequence |> should equal 0L
+                snapshot.TotalRows |> should equal 2
+                snapshot.Rows |> should haveLength 2
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.File (RelativePath relativePath)
+                )
+                |> should equal (Some 1L)
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath liveRelativePath)
+                )
+                |> should equal (Some 2L)
             finally
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3139,6 +3139,110 @@ module WatchTests =
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
 
+    /// Verifies that coalesced duplicate startup replay rows all retire after one status application.
+    [<Test>]
+    let ``watch startup replay retires all duplicate sequences for coalesced difference`` () =
+        withTempRepo (fun _ ->
+            let relativePath = "startup-replay-duplicate.txt"
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let ordering = ResizeArray<string>()
+
+            try
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun _ ->
+                        task {
+                            ordering.Add("recover")
+
+                            let replayRow sequence : LocalStateDb.WatchJournalPendingReplay =
+                                {
+                                    Sequence = sequence
+                                    DifferenceType = DifferenceType.Delete
+                                    EntryType = FileSystemEntryType.File
+                                    RelativePath = RelativePath relativePath
+                                }
+
+                            return
+                                {
+                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
+                                    AppliedThroughSequence = 0L
+                                    CompatibleReplayRows = [| replayRow 41L; replayRow 42L |]
+                                    QuarantinedRows = Array.empty
+                                }
+                        })
+                    (fun _ -> Task.FromResult(()))
+
+                Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status
+                |> fun recoveryTask -> recoveryTask.GetAwaiter().GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
+                )
+                |> should equal (Some 41L)
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("startup replay must not append duplicate rows")))
+                    (fun sequences ->
+                        task {
+                            sequences
+                            |> Seq.toArray
+                            |> should equal [| 41L; 42L |]
+
+                            ordering.Add("advance")
+                            return 42L
+                        })
+
+                /// Reads status needed by the duplicate startup replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this replayed delete scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Applies one coalesced difference while preserving all represented replay sequences.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, string difference.RelativePath)
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                        |]
+
+                    ordering.Add("apply")
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this replay ordering scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the replay ordering test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                ordering.ToArray()
+                |> should equal [| "recover"; "apply"; "advance" |]
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
+                )
+                |> should equal None
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
     /// Verifies that delayed startup replay runs after pending startup backlog drains on a later timer pass.
     [<Test>]
     let ``startup recovery runs after delayed backlog drains`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3243,6 +3243,120 @@ module WatchTests =
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
 
+    /// Verifies that replayed file rows inconsistent with current GraceStatus retire before status mutation.
+    [<Test>]
+    let ``watch startup recovery quarantines replayed file rows inconsistent with GraceStatus`` () =
+        withTempRepo (fun root ->
+            let ghostChangePath = "ghost.txt"
+            let trackedAddPath = "tracked.txt"
+            let status = graceStatusTracking [| trackedAddPath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            File.WriteAllText(Path.Combine(root, ghostChangePath), "untracked content")
+            File.WriteAllText(Path.Combine(root, trackedAddPath), "tracked content")
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Change
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath ghostChangePath
+                        }
+                        { Scope = scope; DifferenceType = DifferenceType.Add; EntryType = FileSystemEntryType.File; RelativePath = RelativePath trackedAddPath }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File (RelativePath ghostChangePath)
+                )
+                |> should equal None
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.File (RelativePath trackedAddPath)
+                )
+                |> should equal None
+
+                /// Reads status needed by the inconsistent replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Fails the test if inconsistent replay rows try to upload content.
+                let upload _ _ = Task.FromException<unit>(InvalidOperationException("inconsistent replay rows should not upload"))
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if inconsistent replay rows reach status application after quarantine.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("inconsistent replay rows should not apply status"))
+
+                /// Leaves incremental status writes outside this inconsistent replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the inconsistent replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.AppliedThroughSequence
+                |> should equal 2L
+
+                quarantinedSnapshot.Rows
+                |> Array.sortBy (fun row -> row.Sequence)
+                |> Array.map (fun row -> row.Sequence, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "startup replay file change is not tracked"
+                        2L, Some "startup replay file add already tracked"
+                    |]
+
+                pendingSnapshot.Rows |> should haveLength 0
+
+                let pendingWork = Watch.pendingWatchWorkSnapshotForTests ()
+
+                pendingWork.FilesToProcess
+                |> should equal Array.empty<string>
+
+                pendingWork.StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
     /// Verifies that startup scan work cannot append a duplicate when replay already recovered the same difference.
     [<Test>]
     let ``watch startup replay before scan prevents duplicate journal append`` () =
@@ -3337,6 +3451,108 @@ module WatchTests =
                 snapshot.TotalRows |> should equal 1
                 ordering.ToArray() |> should contain "apply"
                 ordering.ToArray() |> should contain "advance"
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that replay and startup scan observations coalesce with repository path comparison before status application.
+    [<Test>]
+    let ``watch startup replay and scan coalesce case variants before status application`` () =
+        withTempRepo (fun _ ->
+            let replayPath = "CasePath.txt"
+            let scanPath = "casepath.txt"
+            let status = graceStatusTracking [| replayPath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+            let ordering = ResizeArray<string>()
+
+            try
+                Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        { Scope = scope; DifferenceType = DifferenceType.Delete; EntryType = FileSystemEntryType.File; RelativePath = RelativePath replayPath }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.queueStartupDifferenceForWatch (FileSystemDifference.Create Delete FileSystemEntryType.File (RelativePath scanPath))
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("case-variant startup scan must not append a duplicate replay row")))
+                    (fun sequences ->
+                        task {
+                            sequences |> Seq.toArray |> should equal [| 1L |]
+                            ordering.Add("advance")
+                            return! LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences dbPath sequences
+                        })
+
+                /// Reads status needed by the case-insensitive replay-before-scan scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this replayed delete scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Applies one replayed difference even though startup scan queued a case variant afterward.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, string difference.RelativePath)
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Delete, FileSystemEntryType.File, replayPath
+                        |]
+
+                    ordering.Add("apply")
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this replay ordering scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the case-insensitive replay-before-scan test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let snapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "applied" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                snapshot.AppliedThroughSequence |> should equal 1L
+                snapshot.TotalRows |> should equal 1
+
+                ordering.ToArray()
+                |> should equal [| "apply"; "advance" |]
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath replayPath)
+                )
+                |> should equal None
             finally
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -4318,30 +4318,27 @@ module WatchTests =
         withTempRepo (fun _ ->
             let relativePath = "quarantined-startup-replay-delete.txt"
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
 
             try
-                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+                let replaySequences =
+                    (LocalStateDb.appendWatchJournalObservations
+                        dbPath
+                        [|
+                            {
+                                Scope = scope
+                                DifferenceType = DifferenceType.Delete
+                                EntryType = FileSystemEntryType.File
+                                RelativePath = RelativePath relativePath
+                            }
+                        |])
+                        .GetAwaiter()
+                        .GetResult()
 
-                Watch.setWatchJournalStartupClientsForWatchTests
-                    (fun _ ->
-                        task {
-                            return
-                                {
-                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
-                                    AppliedThroughSequence = 0L
-                                    CompatibleReplayRows =
-                                        [|
-                                            {
-                                                LocalStateDb.WatchJournalPendingReplay.Sequence = 101L
-                                                DifferenceType = DifferenceType.Delete
-                                                EntryType = FileSystemEntryType.File
-                                                RelativePath = RelativePath relativePath
-                                            }
-                                        |]
-                                    QuarantinedRows = Array.empty
-                                }
-                        })
-                    (fun _ -> Task.FromResult(()))
+                replaySequences |> should equal [| 1L |]
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
 
                 (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
                     .GetAwaiter()
@@ -4351,12 +4348,35 @@ module WatchTests =
                 let difference = FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
 
                 Watch.tryPeekStartupReplaySequenceForWatchTests difference
-                |> should equal (Some 101L)
+                |> should equal (Some 1L)
 
                 Watch.requestGraceWatchExplicitResyncForWatchTests "test replay-key quarantine"
 
                 Watch.tryPeekStartupReplaySequenceForWatchTests difference
                 |> should equal None
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                pendingSnapshot.RowCount |> should equal 0
+
+                pendingSnapshot.AppliedThroughSequence
+                |> should equal 1L
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.Rows
+                |> Array.map (fun row -> row.Sequence, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "confidence loss discarded startup replay work: test replay-key quarantine"
+                    |]
             finally
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
@@ -4368,32 +4388,29 @@ module WatchTests =
             let relativePath = "same-path-after-quarantine-delete.txt"
             let filePath = Path.Combine(root, relativePath)
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
             let appendedDifferences = ResizeArray<FileSystemDifference>()
             let advancedSequences = ResizeArray<int64>()
 
             try
-                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+                let replaySequences =
+                    (LocalStateDb.appendWatchJournalObservations
+                        dbPath
+                        [|
+                            {
+                                Scope = scope
+                                DifferenceType = DifferenceType.Delete
+                                EntryType = FileSystemEntryType.File
+                                RelativePath = RelativePath relativePath
+                            }
+                        |])
+                        .GetAwaiter()
+                        .GetResult()
 
-                Watch.setWatchJournalStartupClientsForWatchTests
-                    (fun _ ->
-                        task {
-                            return
-                                {
-                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
-                                    AppliedThroughSequence = 0L
-                                    CompatibleReplayRows =
-                                        [|
-                                            {
-                                                LocalStateDb.WatchJournalPendingReplay.Sequence = 102L
-                                                DifferenceType = DifferenceType.Delete
-                                                EntryType = FileSystemEntryType.File
-                                                RelativePath = RelativePath relativePath
-                                            }
-                                        |]
-                                    QuarantinedRows = Array.empty
-                                }
-                        })
-                    (fun _ -> Task.FromResult(()))
+                replaySequences |> should equal [| 1L |]
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
 
                 (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
                     .GetAwaiter()
@@ -4403,9 +4420,27 @@ module WatchTests =
                 let staleDifference = FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
 
                 Watch.tryPeekStartupReplaySequenceForWatchTests staleDifference
-                |> should equal (Some 102L)
+                |> should equal (Some 1L)
 
                 Watch.requestGraceWatchExplicitResyncForWatchTests "test same-path replay quarantine"
+
+                let afterQuarantineSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                afterQuarantineSnapshot.AppliedThroughSequence
+                |> should equal 1L
+
+                afterQuarantineSnapshot.Rows
+                |> Array.map (fun row -> row.Sequence, row.State, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L,
+                        LocalStateDb.WatchJournalRowState.Quarantined,
+                        Some "confidence loss discarded startup replay work: test same-path replay quarantine"
+                    |]
 
                 /// Reads status needed while resync clears the confidence-loss boundary.
                 let readStatus () = Task.FromResult(status)
@@ -4455,12 +4490,12 @@ module WatchTests =
                         for observation in observationsArray do
                             appendedDifferences.Add(FileSystemDifference.Create observation.DifferenceType observation.EntryType observation.RelativePath)
 
-                        Task.FromResult([| 202L |]))
+                        LocalStateDb.appendWatchJournalObservations dbPath observations)
                     (fun sequences ->
                         for sequence in sequences do
                             advancedSequences.Add(sequence)
 
-                        Task.FromResult(202L))
+                        LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences dbPath sequences)
 
                 Watch.OnDeleted(deletedEvent filePath)
 
@@ -4480,7 +4515,27 @@ module WatchTests =
                 |> should equal [| staleDifference |]
 
                 advancedSequences.ToArray()
-                |> should equal [| 202L |]
+                |> should equal [| 2L |]
+
+                let finalSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "all" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                finalSnapshot.AppliedThroughSequence
+                |> should equal 2L
+
+                finalSnapshot.Rows
+                |> Array.sortBy (fun row -> row.Sequence)
+                |> Array.map (fun row -> row.Sequence, row.State, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L,
+                        LocalStateDb.WatchJournalRowState.Quarantined,
+                        Some "confidence loss discarded startup replay work: test same-path replay quarantine"
+                        2L, LocalStateDb.WatchJournalRowState.Applied, None
+                    |]
 
                 Watch.tryPeekStartupReplaySequenceForWatchTests staleDifference
                 |> should equal None

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -4311,6 +4311,182 @@ module WatchTests =
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
 
+    /// Verifies that confidence-loss quarantine retires replay keys for the pending differences it discards.
+    [<Test>]
+    let ``watch quarantine clears startup replay key for pending difference`` () =
+        withTempRepo (fun _ ->
+            let relativePath = "quarantined-startup-replay-delete.txt"
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+
+            try
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun _ ->
+                        task {
+                            return
+                                {
+                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
+                                    AppliedThroughSequence = 0L
+                                    CompatibleReplayRows =
+                                        [|
+                                            {
+                                                LocalStateDb.WatchJournalPendingReplay.Sequence = 101L
+                                                DifferenceType = DifferenceType.Delete
+                                                EntryType = FileSystemEntryType.File
+                                                RelativePath = RelativePath relativePath
+                                            }
+                                        |]
+                                    QuarantinedRows = Array.empty
+                                }
+                        })
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                let difference = FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests difference
+                |> should equal (Some 101L)
+
+                Watch.requestGraceWatchExplicitResyncForWatchTests "test replay-key quarantine"
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests difference
+                |> should equal None
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that a same-path observation after replay quarantine appends fresh durable journal evidence.
+    [<Test>]
+    let ``watch same path observation after replay quarantine appends fresh journal row`` () =
+        withTempRepo (fun root ->
+            let relativePath = "same-path-after-quarantine-delete.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let appendedDifferences = ResizeArray<FileSystemDifference>()
+            let advancedSequences = ResizeArray<int64>()
+
+            try
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun _ ->
+                        task {
+                            return
+                                {
+                                    LocalStateDb.WatchJournalStartupRecovery.DbPath = Current().GraceStatusFile
+                                    AppliedThroughSequence = 0L
+                                    CompatibleReplayRows =
+                                        [|
+                                            {
+                                                LocalStateDb.WatchJournalPendingReplay.Sequence = 102L
+                                                DifferenceType = DifferenceType.Delete
+                                                EntryType = FileSystemEntryType.File
+                                                RelativePath = RelativePath relativePath
+                                            }
+                                        |]
+                                    QuarantinedRows = Array.empty
+                                }
+                        })
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                let staleDifference = FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath relativePath)
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests staleDifference
+                |> should equal (Some 102L)
+
+                Watch.requestGraceWatchExplicitResyncForWatchTests "test same-path replay quarantine"
+
+                /// Reads status needed while resync clears the confidence-loss boundary.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only resync scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper available without changing status.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+                /// Produces a clean resync scan before same-path incremental capture resumes.
+                let cleanScan _ = Task.FromResult(List<FileSystemDifference>())
+
+                /// Applies same-path status differences after resync has completed.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    differences
+                    |> Seq.toArray
+                    |> should equal [| staleDifference |]
+
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this status-only replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the replay quarantine test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    cleanScan
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun observations ->
+                        let observationsArray = observations |> Seq.toArray
+
+                        observationsArray
+                        |> Array.map (fun observation -> FileSystemDifference.Create observation.DifferenceType observation.EntryType observation.RelativePath)
+                        |> should equal [| staleDifference |]
+
+                        for observation in observationsArray do
+                            appendedDifferences.Add(FileSystemDifference.Create observation.DifferenceType observation.EntryType observation.RelativePath)
+
+                        Task.FromResult([| 202L |]))
+                    (fun sequences ->
+                        for sequence in sequences do
+                            advancedSequences.Add(sequence)
+
+                        Task.FromResult(202L))
+
+                Watch.OnDeleted(deletedEvent filePath)
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                appendedDifferences.ToArray()
+                |> should equal [| staleDifference |]
+
+                advancedSequences.ToArray()
+                |> should equal [| 202L |]
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests staleDifference
+                |> should equal None
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
     /// Verifies that journal append failure prevents unjournaled status application.
     [<Test>]
     let ``watch skips status application when journal append fails`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3581,6 +3581,239 @@ module WatchTests =
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
 
+    /// Verifies that replayed directory Add rows ignored by current startup rules retire before status application.
+    [<Test>]
+    let ``watch startup recovery quarantines currently ignored replayed directory add rows`` () =
+        withTempRepo (fun root ->
+            let ignoredDirectory = Path.Combine(root, "ignored-dir")
+            let ignoredDirectoryRelativePath = "ignored-dir"
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+            let lifecycleEvents = ResizeArray<string>()
+
+            Directory.CreateDirectory(ignoredDirectory)
+            |> ignore
+
+            writeGraceIgnore root [| "ignored-dir/" |]
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Add
+                            EntryType = FileSystemEntryType.Directory
+                            RelativePath = RelativePath ignoredDirectoryRelativePath
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun event -> task { lifecycleEvents.Add(event.EventType) })
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath ignoredDirectoryRelativePath)
+                )
+                |> should equal None
+
+                /// Reads status needed by the ignored directory replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Fails the test if ignored directory replay rows try to upload content.
+                let upload _ _ = Task.FromException<unit>(InvalidOperationException("ignored directory replay rows should not upload"))
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if ignored directory replay rows reach status application after quarantine.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("ignored directory replay rows should not apply status"))
+
+                /// Leaves incremental status writes outside this ignored replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the ignored replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.AppliedThroughSequence
+                |> should equal 1L
+
+                quarantinedSnapshot.Rows
+                |> Array.map (fun row -> row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        Some "current startup replay directory ignored before status application"
+                    |]
+
+                pendingSnapshot.Rows |> should haveLength 0
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .DirectoriesToProcess
+                |> should equal Array.empty<string>
+
+                lifecycleEvents.ToArray()
+                |> should contain "startup-ignored-directory-replay-retired"
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that replayed delete rows retire when current final path kind contradicts the durable entry kind.
+    [<Test>]
+    let ``watch startup recovery quarantines delete replay rows whose current path kind changed`` () =
+        withTempRepo (fun root ->
+            let fileDeleteNowDirectory = "file-delete-now-directory"
+            let directoryDeleteNowFile = "directory-delete-now-file"
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            Directory.CreateDirectory(Path.Combine(root, fileDeleteNowDirectory))
+            |> ignore
+
+            File.WriteAllText(Path.Combine(root, directoryDeleteNowFile), "live file payload")
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Delete
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath fileDeleteNowDirectory
+                        }
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Delete
+                            EntryType = FileSystemEntryType.Directory
+                            RelativePath = RelativePath directoryDeleteNowFile
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.File (RelativePath fileDeleteNowDirectory)
+                )
+                |> should equal None
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Delete FileSystemEntryType.Directory (RelativePath directoryDeleteNowFile)
+                )
+                |> should equal None
+
+                /// Reads status needed by the changed-kind replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Fails the test if changed-kind replay rows try to upload content.
+                let upload _ _ = Task.FromException<unit>(InvalidOperationException("changed-kind replay rows should not upload"))
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if changed-kind replay rows reach status application after quarantine.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("changed-kind replay rows should not apply status"))
+
+                /// Leaves incremental status writes outside this changed-kind replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the changed-kind replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.AppliedThroughSequence
+                |> should equal 2L
+
+                quarantinedSnapshot.Rows
+                |> Array.sortBy (fun row -> row.Sequence)
+                |> Array.map (fun row -> row.Sequence, row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        1L, Some "startup replay file delete now targets a directory"
+                        2L, Some "startup replay directory delete now targets a file"
+                    |]
+
+                pendingSnapshot.Rows |> should haveLength 0
+
+                let pendingWork = Watch.pendingWatchWorkSnapshotForTests ()
+
+                pendingWork.FilesToProcess
+                |> should equal Array.empty<string>
+
+                pendingWork.DirectoriesToProcess
+                |> should equal Array.empty<string>
+
+                pendingWork.StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
     /// Verifies that delayed startup replay runs after pending startup backlog drains on a later timer pass.
     [<Test>]
     let ``startup recovery runs after delayed backlog drains`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3442,6 +3442,145 @@ module WatchTests =
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
 
+    /// Verifies that replayed file Add/Change rows ignored by current startup rules retire before status application.
+    [<Test>]
+    let ``watch startup recovery quarantines currently ignored replayed file add and change rows`` () =
+        withTempRepo (fun root ->
+            let ignoredFilePath = Path.Combine(root, "ignored-file.tmp")
+            let ignoredDirectory = Path.Combine(root, "ignored-dir")
+            let ignoredDirectoryFilePath = Path.Combine(ignoredDirectory, "live.txt")
+            let ignoredFileRelativePath = "ignored-file.tmp"
+            let ignoredDirectoryFileRelativePath = "ignored-dir/live.txt"
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+            let lifecycleEvents = ResizeArray<string>()
+
+            Directory.CreateDirectory(ignoredDirectory)
+            |> ignore
+
+            File.WriteAllText(ignoredFilePath, "ignored file payload")
+            File.WriteAllText(ignoredDirectoryFilePath, "ignored directory payload")
+
+            writeGraceIgnore
+                root
+                [|
+                    ignoredFileRelativePath
+                    "ignored-dir/"
+                |]
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Add
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath ignoredFileRelativePath
+                        }
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Change
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath ignoredDirectoryFileRelativePath
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun event -> task { lifecycleEvents.Add(event.EventType) })
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.File (RelativePath ignoredFileRelativePath)
+                )
+                |> should equal None
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File (RelativePath ignoredDirectoryFileRelativePath)
+                )
+                |> should equal None
+
+                /// Reads status needed by the ignored replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Fails the test if ignored replay rows try to upload live but excluded content.
+                let upload _ _ = Task.FromException<unit>(InvalidOperationException("ignored replay rows should not upload"))
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if ignored replay rows reach status application after quarantine.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("ignored file replay rows should not apply status"))
+
+                /// Leaves incremental status writes outside this ignored replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the ignored replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.AppliedThroughSequence
+                |> should equal 2L
+
+                quarantinedSnapshot.Rows |> should haveLength 2
+
+                quarantinedSnapshot.Rows
+                |> Array.map (fun row -> row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        Some "current startup replay file content ignored before status application"
+                        Some "current startup replay file content ignored before status application"
+                    |]
+
+                pendingSnapshot.Rows |> should haveLength 0
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .FilesToProcess
+                |> should equal Array.empty<string>
+
+                Watch
+                    .pendingWatchWorkSnapshotForTests()
+                    .StatusUpdateTriggers
+                |> should equal Array.empty<string>
+
+                lifecycleEvents.ToArray()
+                |> should contain "startup-ignored-file-replay-retired"
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
     /// Verifies that delayed startup replay runs after pending startup backlog drains on a later timer pass.
     [<Test>]
     let ``startup recovery runs after delayed backlog drains`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -3243,6 +3243,205 @@ module WatchTests =
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())
 
+    /// Verifies that startup scan work cannot append a duplicate when replay already recovered the same difference.
+    [<Test>]
+    let ``watch startup replay before scan prevents duplicate journal append`` () =
+        withTempRepo (fun _ ->
+            let relativePath = "startup-replay-scan-duplicate.txt"
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+            let ordering = ResizeArray<string>()
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Delete
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath relativePath
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun event -> task { ordering.Add($"lifecycle:{event.EventType}") })
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.queueStartupDifferenceForWatch (FileSystemDifference.Create Delete FileSystemEntryType.File (RelativePath relativePath))
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("startup scan must not append a duplicate replay row")))
+                    (fun sequences ->
+                        task {
+                            sequences |> Seq.toArray |> should equal [| 1L |]
+                            ordering.Add("advance")
+                            return! LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences dbPath sequences
+                        })
+
+                /// Reads status needed by the replay-before-scan scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this replayed delete scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Applies one replayed difference even though startup scan queued the same path afterward.
+                let updateGraceStatusFromDifferences currentStatus differences _ =
+                    differences
+                    |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, string difference.RelativePath)
+                    |> Seq.toArray
+                    |> should
+                        equal
+                        [|
+                            DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                        |]
+
+                    ordering.Add("apply")
+                    Task.FromResult(Some currentStatus)
+
+                /// Leaves incremental status writes outside this replay ordering scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the replay-before-scan test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let snapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "applied" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                snapshot.AppliedThroughSequence |> should equal 1L
+                snapshot.TotalRows |> should equal 1
+                ordering.ToArray() |> should contain "apply"
+                ordering.ToArray() |> should contain "advance"
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that missing replayed file Add/Change rows retire durably instead of reaching upload status application.
+    [<Test>]
+    let ``watch startup recovery quarantines missing replayed file add and change rows`` () =
+        withTempRepo (fun _ ->
+            let addPath = "missing-replayed-add.txt"
+            let changePath = "missing-replayed-change.txt"
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+            let lifecycleEvents = ResizeArray<string>()
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        { Scope = scope; DifferenceType = DifferenceType.Add; EntryType = FileSystemEntryType.File; RelativePath = RelativePath addPath }
+                        { Scope = scope; DifferenceType = DifferenceType.Change; EntryType = FileSystemEntryType.File; RelativePath = RelativePath changePath }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun event -> task { lifecycleEvents.Add(event.EventType) })
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.File (RelativePath addPath))
+                |> should equal None
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File (RelativePath changePath)
+                )
+                |> should equal None
+
+                /// Reads status needed by the stale replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this status-only replay scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if stale replay rows reach status application after quarantine.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("stale file replay rows should not apply status"))
+
+                /// Leaves incremental status writes outside this stale replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the stale replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.AppliedThroughSequence
+                |> should equal 2L
+
+                quarantinedSnapshot.Rows |> should haveLength 2
+
+                quarantinedSnapshot.Rows
+                |> Array.map (fun row -> row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        Some "stale startup replay file content missing before status application"
+                        Some "stale startup replay file content missing before status application"
+                    |]
+
+                pendingSnapshot.Rows |> should haveLength 0
+
+                lifecycleEvents.ToArray()
+                |> should contain "startup-stale-file-replay-retired"
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
     /// Verifies that delayed startup replay runs after pending startup backlog drains on a later timer pass.
     [<Test>]
     let ``startup recovery runs after delayed backlog drains`` () =
@@ -3447,11 +3646,14 @@ module WatchTests =
         withTempRepo (fun root ->
             let relativePath = "deferred-startup-replay.txt"
             let liveRelativePath = "deferred-live-delete.txt"
+            let replayFilePath = Path.Combine(root, relativePath)
             let status = graceStatusTracking [| liveRelativePath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
             let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
 
             try
+                File.WriteAllText(replayFilePath, "startup replay content still exists")
+
                 (LocalStateDb.appendWatchJournalObservations
                     dbPath
                     [|

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -12,6 +12,7 @@ open Grace.Types.Automation
 open Grace.Types.Common
 open Grace.Types.Reference
 open Microsoft.AspNetCore.SignalR
+open Microsoft.Data.Sqlite
 open NodaTime
 open NUnit.Framework
 open Spectre.Console
@@ -3474,6 +3475,305 @@ module WatchTests =
 
                 pendingWork.StatusUpdateTriggers
                 |> should equal Array.empty<string>
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that same-content replayed changes advance their durable journal sequence when upload cleanup drains them.
+    [<Test>]
+    let ``watch startup replay retires same-content uploaded change sequence durably`` () =
+        withTempRepo (fun root ->
+            let relativePath = "startup-replay-same-content.txt"
+            let filePath = Path.Combine(root, relativePath)
+            let dbPath = Current().GraceStatusFile
+            let mutable uploadCalls = 0
+            let mutable applyFromDifferencesCalls = 0
+
+            File.WriteAllText(filePath, "same content")
+
+            let trackedFile =
+                (Services.createLocalFileVersion (FileInfo(filePath)))
+                    .GetAwaiter()
+                    .GetResult()
+                    .Value
+
+            let status = graceStatusTrackingFileVersions [| trackedFile |]
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Change
+                            EntryType = FileSystemEntryType.File
+                            RelativePath = RelativePath relativePath
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.queueStartupDifferenceForWatch (FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File (RelativePath relativePath))
+
+                Watch.setWatchJournalClientsForWatchTests
+                    (fun _ -> Task.FromException<int64 array>(InvalidOperationException("same-content replay must not append duplicate rows")))
+                    (fun sequences ->
+                        task {
+                            sequences |> Seq.toArray |> should equal [| 1L |]
+
+                            return! LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences dbPath sequences
+                        })
+
+                /// Reads status needed by the same-content replay scenario.
+                let readStatus () = Task.FromResult(status)
+
+                /// Records the replayed upload while leaving content equivalent to GraceStatus.
+                let upload _ pendingFilePath =
+                    uploadCalls <- uploadCalls + 1
+                    recordUploadedFileVersion $"{pendingFilePath}"
+                    Task.FromResult(())
+
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails if same-content replay reaches status mutation instead of retiring through cleanup.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                    Task.FromException<GraceStatus option>(InvalidOperationException("same-content replay should not apply a status difference"))
+
+                /// Leaves incremental status writes outside this same-content replay scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the same-content replay test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let appliedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "applied" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                let pendingSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "pending" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                uploadCalls |> should equal 1
+                applyFromDifferencesCalls |> should equal 0
+
+                appliedSnapshot.AppliedThroughSequence
+                |> should equal 1L
+
+                pendingSnapshot.Rows |> should haveLength 0
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Change FileSystemEntryType.File (RelativePath relativePath)
+                )
+                |> should equal None
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.clearPendingWatchWorkForTests ())
+
+    /// Verifies that malformed SQLite payload types quarantine instead of aborting startup replay recovery.
+    [<Test>]
+    let ``watch startup recovery quarantines non-text replay payload fields`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            (LocalStateDb.recoverWatchJournalForStartup dbPath scope)
+                .GetAwaiter()
+                .GetResult()
+            |> ignore
+
+            use connection = new SqliteConnection($"Data Source={dbPath}")
+            connection.Open()
+
+            /// Inserts one malformed replay row while preserving all scope fields needed to reach payload classification.
+            let insertMalformed differenceType entryType relativePath =
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    "INSERT INTO watch_journal (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $difference_type, $entry_type, $relative_path);"
+
+                command.Parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
+                |> ignore
+
+                command.Parameters.AddWithValue("$repository_id", scope.RepositoryId.ToString())
+                |> ignore
+
+                command.Parameters.AddWithValue("$branch_id", scope.BranchId.ToString())
+                |> ignore
+
+                command.Parameters.AddWithValue("$workspace_root", scope.WorkspaceRoot)
+                |> ignore
+
+                command.Parameters.AddWithValue("$watch_root", scope.WatchRoot)
+                |> ignore
+
+                command.Parameters.AddWithValue("$root_directory_version_id", scope.RootDirectoryId.ToString())
+                |> ignore
+
+                command.Parameters.AddWithValue("$root_directory_blake3_hash", string scope.RootDirectoryBlake3Hash)
+                |> ignore
+
+                command.Parameters.AddWithValue("$watch_mode", scope.WatchMode)
+                |> ignore
+
+                command.Parameters.AddWithValue("$difference_type", differenceType)
+                |> ignore
+
+                command.Parameters.AddWithValue("$entry_type", entryType)
+                |> ignore
+
+                command.Parameters.AddWithValue("$relative_path", relativePath)
+                |> ignore
+
+                command.ExecuteNonQuery() |> ignore
+
+            insertMalformed [| 1uy |] "File" "non-text-difference.txt"
+            insertMalformed "Change" [| 2uy |] "non-text-entry.txt"
+            insertMalformed "Change" "File" [| 3uy |]
+
+            let recovery =
+                (LocalStateDb.recoverWatchJournalForStartup dbPath scope)
+                    .GetAwaiter()
+                    .GetResult()
+
+            recovery.CompatibleReplayRows
+            |> should haveLength 0
+
+            recovery.QuarantinedRows |> should haveLength 3
+
+            let quarantinedSnapshot =
+                (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                    .GetAwaiter()
+                    .GetResult()
+
+            quarantinedSnapshot.AppliedThroughSequence
+            |> should equal 3L
+
+            quarantinedSnapshot.Rows
+            |> Array.sortBy (fun row -> row.Sequence)
+            |> Array.map (fun row -> row.Sequence, row.QuarantineReason)
+            |> should
+                equal
+                [|
+                    1L, Some "non-text difference_type"
+                    2L, Some "non-text entry_type"
+                    3L, Some "non-text relative_path"
+                |])
+
+    /// Verifies that replayed nested directory adds quarantine when their parent is neither tracked nor replayed.
+    [<Test>]
+    let ``watch startup recovery quarantines orphan replayed directory add`` () =
+        withTempRepo (fun root ->
+            let relativePath = "new/child"
+            let directoryPath = Path.Combine(root, "new", "child")
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let dbPath = Current().GraceStatusFile
+            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            try
+                (LocalStateDb.appendWatchJournalObservations
+                    dbPath
+                    [|
+                        {
+                            Scope = scope
+                            DifferenceType = DifferenceType.Add
+                            EntryType = FileSystemEntryType.Directory
+                            RelativePath = RelativePath relativePath
+                        }
+                    |])
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+                Watch.setWatchJournalStartupClientsForWatchTests
+                    (fun recoveryScope -> LocalStateDb.recoverWatchJournalForStartup dbPath recoveryScope)
+                    (fun _ -> Task.FromResult(()))
+
+                (Watch.recoverStartupWatchJournalAfterReconciliationForWatchTests status)
+                    .GetAwaiter()
+                    .GetResult()
+                |> ignore
+
+                Watch.tryPeekStartupReplaySequenceForWatchTests (
+                    FileSystemDifference.Create DifferenceType.Add FileSystemEntryType.Directory (RelativePath relativePath)
+                )
+                |> should equal None
+
+                /// Reads status needed by the orphan directory replay scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Keeps uploads out of this directory replay scenario.
+                let upload _ _ = Task.FromResult(())
+                /// Keeps the legacy status helper unused by the current Watch path.
+                let updateGraceStatus currentStatus _ = Task.FromResult(Some currentStatus)
+
+                /// Fails the test if an orphan directory add reaches status construction.
+                let updateGraceStatusFromDifferences _ _ _ =
+                    Task.FromException<GraceStatus option>(InvalidOperationException("orphan directory add should not apply status"))
+
+                /// Leaves incremental status writes outside this orphan directory scenario.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Keeps IPC publication deterministic for the orphan directory test.
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scannerHostileDifferenceDiscovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                let quarantinedSnapshot =
+                    (LocalStateDb.readWatchJournalSnapshot dbPath "quarantined" None 10)
+                        .GetAwaiter()
+                        .GetResult()
+
+                quarantinedSnapshot.AppliedThroughSequence
+                |> should equal 1L
+
+                quarantinedSnapshot.Rows
+                |> Array.map (fun row -> row.QuarantineReason)
+                |> should
+                    equal
+                    [|
+                        Some "startup replay directory add parent is not tracked or replayed"
+                    |]
             finally
                 Watch.resetWatchJournalClientsForWatchTests ()
                 Watch.clearPendingWatchWorkForTests ())

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -418,6 +418,7 @@ module WatchTests =
             BranchId = current.BranchId
             WorkspaceRoot = current.RootDirectory
             WatchRoot = current.RootDirectory
+            PathComparison = StringComparison.Ordinal
             RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
             RootDirectoryBlake3Hash = Blake3Hash "test-root-blake3"
             WatchMode = "repository-root"

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -160,6 +160,7 @@ module Common =
                 DifferenceType: string
                 FileSystemEntryType: string
                 RelativePath: string option
+                QuarantineReason: string option
             }
 
         /// Models filtered durable Watch journal diagnostics for maintenance show-journal.

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -105,7 +105,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "6"
+    let private ExpectedLocalStateSchemaVersion = "7"
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500

--- a/src/Grace.CLI/Command/Maintenance.CLI.fs
+++ b/src/Grace.CLI/Command/Maintenance.CLI.fs
@@ -281,6 +281,7 @@ module Maintenance =
             DifferenceType = row.DifferenceType
             FileSystemEntryType = row.EntryType
             RelativePath = row.RelativePath
+            QuarantineReason = row.QuarantineReason
         }
 
     /// Converts a Watch journal diagnostic snapshot into the maintenance command output contract.
@@ -962,6 +963,10 @@ module Maintenance =
 
                         for row in dto.Rows do
                             AnsiConsole.MarkupLine($"[{Colors.Verbose}]#{row.Sequence} {row.State} created_at_unix_ticks={row.CreatedAtUnixTicks}[/]")
+
+                            match row.QuarantineReason with
+                            | Some reason -> AnsiConsole.MarkupLine($"[{Colors.Verbose}]  quarantine_reason={Markup.Escape(reason)}[/]")
+                            | None -> ()
 
                         return 0
                 with

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -4278,23 +4278,38 @@ module Watch =
             enqueueFileUpload difference.RelativePath
             |> ignore
 
-    /// Classifies replayed startup file content that current Watch startup rules would not scan or upload.
-    let private tryStartupFileReplayRetirementReason (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
-        if row.EntryType = FileSystemEntryType.File
-           && (row.DifferenceType = DifferenceType.Add
-               || row.DifferenceType = DifferenceType.Change) then
-            match finalPathKind row.RelativePath with
-            | FinalPathFile ->
-                let fullPath = Path.Combine(Current().RootDirectory, $"{row.RelativePath}")
+    /// Classifies compatible durable replay rows against current startup scan applicability before status mutation.
+    let private tryStartupReplayRetirementReason (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
+        let fullPath = Path.Combine(Current().RootDirectory, $"{row.RelativePath}")
 
-                if shouldIgnoreFile fullPath then
-                    Some "current startup replay file content ignored before status application"
-                else
-                    None
-            | FinalPathMissing
-            | FinalPathDirectory -> Some "stale startup replay file content missing before status application"
-        else
-            None
+        match row.EntryType, row.DifferenceType, finalPathKind row.RelativePath with
+        | FileSystemEntryType.File,
+          (DifferenceType.Add
+          | DifferenceType.Change),
+          FinalPathFile ->
+            if shouldIgnoreFile fullPath then
+                Some "current startup replay file content ignored before status application"
+            else
+                None
+        | FileSystemEntryType.File,
+          (DifferenceType.Add
+          | DifferenceType.Change),
+          (FinalPathMissing
+          | FinalPathDirectory) -> Some "stale startup replay file content missing before status application"
+        | FileSystemEntryType.File, DifferenceType.Delete, FinalPathDirectory -> Some "startup replay file delete now targets a directory"
+        | FileSystemEntryType.File, DifferenceType.Delete, _ -> None
+        | FileSystemEntryType.Directory, DifferenceType.Add, FinalPathDirectory ->
+            if shouldIgnoreDirectory fullPath then
+                Some "current startup replay directory ignored before status application"
+            else
+                None
+        | FileSystemEntryType.Directory,
+          DifferenceType.Add,
+          (FinalPathMissing
+          | FinalPathFile) -> Some "stale startup replay directory missing before status application"
+        | FileSystemEntryType.Directory, DifferenceType.Change, _ -> Some "directory change rows are not emitted by Watch startup scan"
+        | FileSystemEntryType.Directory, DifferenceType.Delete, FinalPathFile -> Some "startup replay directory delete now targets a file"
+        | FileSystemEntryType.Directory, DifferenceType.Delete, _ -> None
 
     /// Records a startup lifecycle event as diagnostics that cannot be replayed as Watch correctness data.
     let private recordStartupLifecycleEvent status eventType message =
@@ -4316,9 +4331,9 @@ module Watch =
 
             let startupReplayClassifications =
                 recovery.CompatibleReplayRows
-                |> Array.map (fun row -> row, tryStartupFileReplayRetirementReason row)
+                |> Array.map (fun row -> row, tryStartupReplayRetirementReason row)
 
-            let retiredFileReplayRows =
+            let retiredReplayRows =
                 startupReplayClassifications
                 |> Array.choose (fun (row, reason) ->
                     reason
@@ -4331,9 +4346,9 @@ module Watch =
                     | Some _ -> None
                     | None -> Some row)
 
-            if retiredFileReplayRows.Length > 0 then
+            if retiredReplayRows.Length > 0 then
                 for row, reason in
-                    retiredFileReplayRows
+                    retiredReplayRows
                     |> Array.sortBy (fun (row, _) -> row.Sequence) do
                     let! _ = quarantineWatchJournalSequencesForWatch [| row.Sequence |] reason
 
@@ -4345,16 +4360,26 @@ module Watch =
                         | "current startup replay file content ignored before status application" ->
                             "startup-ignored-file-replay-retired",
                             $"Startup replay retired file add/change row {row.Sequence} because current startup ignore rules skip its final file content."
-                        | _ ->
-                            "startup-file-replay-retired",
-                            $"Startup replay retired file add/change row {row.Sequence} because current startup rules would not apply it."
+                        | "current startup replay directory ignored before status application" ->
+                            "startup-ignored-directory-replay-retired",
+                            $"Startup replay retired directory add row {row.Sequence} because current startup ignore rules skip that directory."
+                        | "stale startup replay directory missing before status application" ->
+                            "startup-stale-directory-replay-retired",
+                            $"Startup replay retired directory add row {row.Sequence} because its final directory was missing."
+                        | "startup replay file delete now targets a directory" ->
+                            "startup-file-delete-replay-retired",
+                            $"Startup replay retired file delete row {row.Sequence} because the current path is a directory."
+                        | "startup replay directory delete now targets a file" ->
+                            "startup-directory-delete-replay-retired",
+                            $"Startup replay retired directory delete row {row.Sequence} because the current path is a file."
+                        | _ -> "startup-replay-retired", $"Startup replay retired row {row.Sequence} because current startup rules would not apply it."
 
                     do! recordStartupLifecycleEvent status lifecycleEventType lifecycleMessage
 
-                Interlocked.Add(&quarantinedWatchObservationCount, retiredFileReplayRows.Length)
+                Interlocked.Add(&quarantinedWatchObservationCount, retiredReplayRows.Length)
                 |> ignore
 
-                logToAnsiConsole Colors.Important $"Grace Watch retired {retiredFileReplayRows.Length} startup file replay rows before status application."
+                logToAnsiConsole Colors.Important $"Grace Watch retired {retiredReplayRows.Length} startup replay rows before status application."
 
             for row in replayRows do
                 let difference = FileSystemDifference.Create row.DifferenceType row.EntryType row.RelativePath
@@ -4367,7 +4392,7 @@ module Watch =
                 recordStartupLifecycleEvent
                     status
                     "startup-replay-complete"
-                    $"Startup replay queued {replayRows.Length} compatible rows, retired {retiredFileReplayRows.Length} file rows, and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
+                    $"Startup replay queued {replayRows.Length} compatible rows, retired {retiredReplayRows.Length} replay rows, and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
 
             return recovery
         }

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1407,6 +1407,7 @@ module Watch =
             BranchId = Current().BranchId
             WorkspaceRoot = Path.GetFullPath(Current().RootDirectory)
             WatchRoot = Path.GetFullPath(Current().RootDirectory)
+            PathComparison = watchPathComparison
             RootDirectoryId = status.RootDirectoryId
             RootDirectoryBlake3Hash = rootDirectoryBlake3HashForWatchJournal status
             WatchMode = "repository-root"

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1851,14 +1851,23 @@ module Watch =
     /// Reports the replay sequence queued for a difference in startup recovery tests.
     let internal tryPeekStartupReplaySequenceForWatchTests difference = tryPeekStartupReplaySequence difference
 
-    /// Removes replay metadata for one pending difference after it has reached a terminal local outcome.
-    let private clearStartupReplaySequenceForDifference (difference: FileSystemDifference) =
+    /// Removes replay metadata for one pending difference and returns the durable rows it represented.
+    let private takeStartupReplaySequencesForDifference (difference: FileSystemDifference) =
         let key = pendingStatusDifferenceReplayKey difference
         let mutable queue = Unchecked.defaultof<Queue<int64>>
 
         if pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue) then
             pendingStatusDifferenceReplaySequences.Remove(key)
             |> ignore
+
+            queue.ToArray()
+        else
+            Array.empty<int64>
+
+    /// Removes replay metadata for one pending difference after it has reached a terminal local outcome.
+    let private clearStartupReplaySequenceForDifference (difference: FileSystemDifference) =
+        takeStartupReplaySequencesForDifference difference
+        |> ignore
 
     /// Consumes replay sequence metadata only after the corresponding pending status difference is cleared.
     let private clearStartupReplaySequences (differences: seq<FileSystemDifference>) =
@@ -1942,20 +1951,44 @@ module Watch =
                 quarantineWatchObservation reason "status-trigger" pendingTrigger.Key
                 quarantinedCount <- quarantinedCount + 1
 
-        let pendingDifferences =
+        let pendingDifferences, startupReplaySequencesToQuarantine =
             lock pendingStatusDifferencesLock (fun () ->
                 ensureStartupReplaySequenceComparer ()
                 let snapshot = pendingStatusDifferences.ToArray()
+                let replaySequences = ResizeArray<int64>()
 
                 for pendingDifference in snapshot do
-                    clearStartupReplaySequenceForDifference pendingDifference
+                    replaySequences.AddRange(takeStartupReplaySequencesForDifference pendingDifference)
 
                 pendingStatusDifferences.Clear()
-                snapshot)
+                snapshot, replaySequences.ToArray())
 
         for pendingDifference in pendingDifferences do
             quarantineWatchObservation reason "status-difference" $"{pendingDifference.RelativePath}"
             quarantinedCount <- quarantinedCount + 1
+
+        let startupReplayRowsDurablyTerminal =
+            if startupReplaySequencesToQuarantine.Length > 0 then
+                try
+                    let advancedThrough =
+                        (quarantineWatchJournalSequencesForWatch startupReplaySequencesToQuarantine $"confidence loss discarded startup replay work: {reason}")
+                            .GetAwaiter()
+                            .GetResult()
+
+                    logToAnsiConsole
+                        Colors.Verbose
+                        $"Grace Watch durably quarantined {startupReplaySequencesToQuarantine.Length} startup replay journal rows through applied boundary {advancedThrough} after confidence loss."
+
+                    true
+                with
+                | ex ->
+                    logToAnsiConsole
+                        Colors.Error
+                        $"Grace Watch could not durably quarantine startup replay journal rows after confidence loss; Watch will remain suspended so the old startup replay sequence cannot block later applied-boundary advancement silently: {Markup.Escape(ex.Message)}."
+
+                    false
+            else
+                true
 
         uploadedFileVersions.Clear()
         lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
@@ -1963,6 +1996,8 @@ module Watch =
 
         if quarantinedCount > 0 then
             logToAnsiConsole Colors.Important $"Grace Watch quarantined {quarantinedCount} pending observations after confidence loss: {reason}."
+
+        startupReplayRowsDurablyTerminal
 
     /// Reads the active explicit-resync attempt token used to reject stale recovery side effects.
     let private currentGraceWatchResyncAttempt () = Volatile.Read(&graceWatchResyncGeneration)
@@ -2271,7 +2306,8 @@ module Watch =
     /// Suspends only the resync attempt that observed the failure, preserving newer overflow requests.
     let private suspendGraceWatchAttemptAfterFailedRecovery attempt reason =
         if isGraceWatchResyncAttemptActive attempt then
-            quarantinePendingWatchWork reason
+            quarantinePendingWatchWork reason |> ignore
+
             setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
 
             if tryClearGraceWatchResyncAttempt attempt then
@@ -2286,14 +2322,24 @@ module Watch =
 
     /// Requests a scan-derived resync and quarantines observations captured under the previous root confidence.
     let private requestGraceWatchExplicitResync reason =
-        quarantinePendingWatchWork reason
+        let startupReplayRowsDurablyTerminal = quarantinePendingWatchWork reason
 
         Interlocked.Increment(&graceWatchResyncGeneration)
         |> ignore
 
-        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+        if startupReplayRowsDurablyTerminal then
+            setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+        else
+            setGraceWatchRuntimeMode GraceWatchRuntimeMode.Suspended
+
         publishGraceWatchResyncRequired ()
-        logToAnsiConsole Colors.Important $"Grace Watch requires an explicit resync before incremental observations can resume: {reason}."
+
+        if startupReplayRowsDurablyTerminal then
+            logToAnsiConsole Colors.Important $"Grace Watch requires an explicit resync before incremental observations can resume: {reason}."
+        else
+            logToAnsiConsole
+                Colors.Error
+                $"Grace Watch suspended incremental processing because startup replay journal rows could not be made terminal after confidence loss: {reason}."
 
     /// Requests explicit resync for tests that exercise confidence-loss and deferred-observation behavior.
     let internal requestGraceWatchExplicitResyncForWatchTests reason = requestGraceWatchExplicitResync reason

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1812,8 +1812,8 @@ module Watch =
     /// Remembers a row appended during deferred replay so the next retry does not append it again.
     let private rememberDeferredStartupReplaySequence sequence (difference: FileSystemDifference) = recordStartupReplaySequence false sequence difference
 
-    /// Reads the existing startup replay sequence for a difference that should not be appended again.
-    let private tryPeekStartupReplaySequence (difference: FileSystemDifference) =
+    /// Reads the existing startup replay sequences for a difference that should not be appended again.
+    let private startupReplaySequencesForDifference (difference: FileSystemDifference) =
         lock pendingStatusDifferencesLock (fun () ->
             ensureStartupReplaySequenceComparer ()
             let key = pendingStatusDifferenceReplayKey difference
@@ -1823,9 +1823,15 @@ module Watch =
                 pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue)
                 && queue.Count > 0
             then
-                Some(queue.Peek())
+                queue.ToArray()
             else
-                None)
+                Array.empty<int64>)
+
+    /// Reads the first existing startup replay sequence for tests that assert duplicate append prevention.
+    let private tryPeekStartupReplaySequence (difference: FileSystemDifference) =
+        match startupReplaySequencesForDifference difference with
+        | [||] -> None
+        | sequences -> Some sequences[0]
 
     /// Reports the replay sequence queued for a difference in startup recovery tests.
     let internal tryPeekStartupReplaySequenceForWatchTests difference = tryPeekStartupReplaySequence difference
@@ -1839,15 +1845,9 @@ module Watch =
                 let key = pendingStatusDifferenceReplayKey difference
                 let mutable queue = Unchecked.defaultof<Queue<int64>>
 
-                if
-                    pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue)
-                    && queue.Count > 0
-                then
-                    queue.Dequeue() |> ignore
-
-                    if queue.Count = 0 then
-                        pendingStatusDifferenceReplaySequences.Remove(key)
-                        |> ignore)
+                if pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue) then
+                    pendingStatusDifferenceReplaySequences.Remove(key)
+                    |> ignore)
 
     /// Reads the best available GraceStatus snapshot for classifying directory-create observations.
     let private readGraceStatusForDirectoryAddClassification () =
@@ -4030,7 +4030,7 @@ module Watch =
                                             try
                                                 let startupReplaySequences =
                                                     statusDifferencesForApply.Applicable
-                                                    |> Seq.choose tryPeekStartupReplaySequence
+                                                    |> Seq.collect startupReplaySequencesForDifference
                                                     |> Seq.toArray
 
                                                 let differencesNeedingJournalAppend =
@@ -4108,7 +4108,7 @@ module Watch =
 
                             let resolvedStartupReplaySequences =
                                 statusDifferencesForApply.Resolved
-                                |> Seq.choose tryPeekStartupReplaySequence
+                                |> Seq.collect startupReplaySequencesForDifference
                                 |> Seq.toArray
 
                             appendedWatchJournalSequences <- combineWatchJournalSequences appendedWatchJournalSequences resolvedStartupReplaySequences

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -82,6 +82,9 @@ module Watch =
     let mutable private recoverWatchJournalForStartupForWatch =
         fun scope -> Grace.CLI.LocalStateDb.recoverWatchJournalForStartup (Current().GraceStatusFile) scope
 
+    let mutable private quarantineWatchJournalSequencesForWatch =
+        fun sequences reason -> Grace.CLI.LocalStateDb.quarantineWatchJournalSequences (Current().GraceStatusFile) sequences reason
+
     let mutable private recordWatchLifecycleEventForWatch = fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
 
     /// Installs durable journal clients used by append-before-apply ordering tests.
@@ -117,6 +120,9 @@ module Watch =
         pruneWatchJournalRetentionForWatch <- fun () -> Grace.CLI.LocalStateDb.pruneWatchJournalRetention (Current().GraceStatusFile)
 
         recoverWatchJournalForStartupForWatch <- fun scope -> Grace.CLI.LocalStateDb.recoverWatchJournalForStartup (Current().GraceStatusFile) scope
+
+        quarantineWatchJournalSequencesForWatch <-
+            fun sequences reason -> Grace.CLI.LocalStateDb.quarantineWatchJournalSequences (Current().GraceStatusFile) sequences reason
 
         recordWatchLifecycleEventForWatch <- fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
 
@@ -4272,6 +4278,13 @@ module Watch =
             enqueueFileUpload difference.RelativePath
             |> ignore
 
+    /// Checks whether replayed startup file content can no longer produce an upload side effect.
+    let private isStaleStartupFileReplayRow (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
+        row.EntryType = FileSystemEntryType.File
+        && (row.DifferenceType = DifferenceType.Add
+            || row.DifferenceType = DifferenceType.Change)
+        && finalPathKind row.RelativePath <> FinalPathFile
+
     /// Records a startup lifecycle event as diagnostics that cannot be replayed as Watch correctness data.
     let private recordStartupLifecycleEvent status eventType message =
         recordWatchLifecycleEventForWatch (
@@ -4290,20 +4303,40 @@ module Watch =
 
                 logToAnsiConsole Colors.Important $"Grace Watch quarantined {recovery.QuarantinedRows.Length} incompatible startup journal rows before replay."
 
-            for row in recovery.CompatibleReplayRows do
+            let staleFileReplayRows, replayRows =
+                recovery.CompatibleReplayRows
+                |> Array.partition isStaleStartupFileReplayRow
+
+            if staleFileReplayRows.Length > 0 then
+                let staleReplaySequences =
+                    staleFileReplayRows
+                    |> Array.map (fun row -> row.Sequence)
+
+                let! _ = quarantineWatchJournalSequencesForWatch staleReplaySequences "stale startup replay file content missing before status application"
+
+                Interlocked.Add(&quarantinedWatchObservationCount, staleFileReplayRows.Length)
+                |> ignore
+
+                logToAnsiConsole Colors.Important $"Grace Watch retired {staleFileReplayRows.Length} stale startup file replay rows before status application."
+
+                do!
+                    recordStartupLifecycleEvent
+                        status
+                        "startup-stale-file-replay-retired"
+                        $"Startup replay retired {staleFileReplayRows.Length} stale file add/change rows because their final file content was missing."
+
+            for row in replayRows do
                 let difference = FileSystemDifference.Create row.DifferenceType row.EntryType row.RelativePath
                 addStartupReplayedStatusDifference row.Sequence difference
 
-            if recovery.CompatibleReplayRows.Length > 0 then
-                logToAnsiConsole
-                    Colors.Important
-                    $"Grace Watch replayed {recovery.CompatibleReplayRows.Length} compatible pending journal rows after startup reconciliation."
+            if replayRows.Length > 0 then
+                logToAnsiConsole Colors.Important $"Grace Watch replayed {replayRows.Length} compatible pending journal rows after startup reconciliation."
 
             do!
                 recordStartupLifecycleEvent
                     status
                     "startup-replay-complete"
-                    $"Startup replay queued {recovery.CompatibleReplayRows.Length} compatible rows and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
+                    $"Startup replay queued {replayRows.Length} compatible rows, retired {staleFileReplayRows.Length} stale file rows, and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
 
             return recovery
         }
@@ -4590,6 +4623,11 @@ module Watch =
                         logToAnsiConsole Colors.Error $"Failed to retrieve branch metadata. Cannot connect to SignalR Hub."
 
                         logToAnsiConsole Colors.Error $"{Markup.Escape(error.ToString())}"
+
+                    let! startupRecovery = recoverStartupWatchJournalAfterReconciliation graceStatus
+
+                    if startupRecovery.CompatibleReplayRows.Length > 0 then
+                        logToAnsiConsole Colors.Verbose $"Grace Watch recovered startup journal rows before scanning for offline differences."
 
                     // Check for changes that occurred while not running.
                     logToAnsiConsole Colors.Verbose $"Scanning for differences."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1394,7 +1394,7 @@ module Watch =
         {
             RepositoryId = Current().RepositoryId
             BranchId = Current().BranchId
-            WorkspaceRoot = Path.GetFullPath(Directory.GetCurrentDirectory())
+            WorkspaceRoot = Path.GetFullPath(Current().RootDirectory)
             WatchRoot = Path.GetFullPath(Current().RootDirectory)
             RootDirectoryId = status.RootDirectoryId
             RootDirectoryBlake3Hash = rootDirectoryBlake3HashForWatchJournal status
@@ -1790,11 +1790,13 @@ module Watch =
 
             pendingStatusDifferenceReplaySequences <- replacement
 
-    /// Queues one startup-replayed difference without creating a duplicate durable journal row.
-    let private addStartupReplayedStatusDifference sequence (difference: FileSystemDifference) =
+    /// Records one replay sequence and optionally queues its difference for startup status application.
+    let private recordStartupReplaySequence queueDifference sequence (difference: FileSystemDifference) =
         lock pendingStatusDifferencesLock (fun () ->
             ensureStartupReplaySequenceComparer ()
-            addPendingStatusDifference difference
+
+            if queueDifference then addPendingStatusDifference difference
+
             let key = pendingStatusDifferenceReplayKey difference
             let mutable queue = Unchecked.defaultof<Queue<int64>>
 
@@ -1803,6 +1805,12 @@ module Watch =
                 pendingStatusDifferenceReplaySequences.Add(key, queue)
 
             queue.Enqueue(sequence))
+
+    /// Queues one startup-replayed difference without creating a duplicate durable journal row.
+    let private addStartupReplayedStatusDifference sequence (difference: FileSystemDifference) = recordStartupReplaySequence true sequence difference
+
+    /// Remembers a row appended during deferred replay so the next retry does not append it again.
+    let private rememberDeferredStartupReplaySequence sequence (difference: FileSystemDifference) = recordStartupReplaySequence false sequence difference
 
     /// Reads the existing startup replay sequence for a difference that should not be appended again.
     let private tryPeekStartupReplaySequence (difference: FileSystemDifference) =
@@ -3731,6 +3739,16 @@ module Watch =
                     return true
         }
 
+    /// Combines durable journal sequences without reordering the first observation for each sequence.
+    let private combineWatchJournalSequences (first: int64 array) (second: int64 array) =
+        seq {
+            yield! first
+            yield! second
+        }
+        |> Seq.filter (fun sequence -> sequence > 0L)
+        |> Seq.distinct
+        |> Seq.toArray
+
     /// Converges appended journal rows after status side effects commit so recovery never resumes from stale pending rows.
     let private convergeWatchJournalAfterStatusApplication (appendedWatchJournalSequences: int64 array) =
         task {
@@ -3975,6 +3993,9 @@ module Watch =
 
                         let statusApplicationLegal = statusApplicationModeStillTrusted ()
                         let mutable appendedWatchJournalSequences = Array.empty<int64>
+                        let mutable newlyAppendedWatchJournalSequences = Array.empty<int64>
+                        let mutable newlyAppendedWatchJournalReplayRows = Array.empty<int64 * FileSystemDifference>
+                        let mutable startupReplayRowsParticipated = false
                         let mutable appendedWatchJournalConverged = false
 
                         let statusUpdateStillTrusted () =
@@ -4027,14 +4048,17 @@ module Watch =
                                                         |> Seq.map journalObservationForDifference
                                                         |> appendWatchJournalObservationsForWatch
 
-                                                return Ok(Array.append startupReplaySequences sequences)
+                                                return Ok(startupReplaySequences, sequences, differencesNeedingJournalAppend)
                                             with
                                             | ex -> return Error ex
                                         }
 
                                     match appendResult with
-                                    | Ok sequences ->
-                                        appendedWatchJournalSequences <- sequences
+                                    | Ok (startupReplaySequences, sequences, newlyAppendedDifferences) ->
+                                        startupReplayRowsParticipated <- startupReplaySequences.Length > 0
+                                        newlyAppendedWatchJournalSequences <- sequences
+                                        newlyAppendedWatchJournalReplayRows <- Array.zip sequences newlyAppendedDifferences
+                                        appendedWatchJournalSequences <- combineWatchJournalSequences startupReplaySequences sequences
 
                                         try
                                             return!
@@ -4082,6 +4106,13 @@ module Watch =
                         | Some newGraceStatus ->
                             let commitRuntimeMode = currentGraceWatchRuntimeMode ()
 
+                            let resolvedStartupReplaySequences =
+                                statusDifferencesForApply.Resolved
+                                |> Seq.choose tryPeekStartupReplaySequence
+                                |> Seq.toArray
+
+                            appendedWatchJournalSequences <- combineWatchJournalSequences appendedWatchJournalSequences resolvedStartupReplaySequences
+
                             let statusUpdateCanCommit =
                                 statusUpdateStillTrusted ()
                                 && (startupPendingDifferences.Count > 0
@@ -4124,9 +4155,19 @@ module Watch =
                                     Colors.Important
                                     $"Grace Status file update completed while newer file upload work was pending; status-only triggers will retry."
                         | None ->
-                            if appendedWatchJournalSequences.Length > 0
-                               && not appendedWatchJournalConverged then
-                                let! noDurableStatusRepairFailed = clearWatchJournalAfterNoDurableStatus appendedWatchJournalSequences
+                            if startupReplayRowsParticipated then
+                                for sequence, difference in newlyAppendedWatchJournalReplayRows do
+                                    rememberDeferredStartupReplaySequence sequence difference
+
+                                appendedWatchJournalConverged <- true
+
+                                if newlyAppendedWatchJournalReplayRows.Length > 0 then
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch kept existing startup replay rows durable after status application deferred; newly appended rows will retry without duplicate journal append."
+                            elif newlyAppendedWatchJournalSequences.Length > 0
+                                 && not appendedWatchJournalConverged then
+                                let! noDurableStatusRepairFailed = clearWatchJournalAfterNoDurableStatus newlyAppendedWatchJournalSequences
                                 appendedWatchJournalConverged <- true
 
                                 if noDurableStatusRepairFailed then
@@ -4269,6 +4310,54 @@ module Watch =
 
     /// Exposes startup journal recovery to tests without starting the foreground watcher loop.
     let internal recoverStartupWatchJournalAfterReconciliationForWatchTests status = recoverStartupWatchJournalAfterReconciliation status
+
+    /// Re-enters startup replay and promotion after delayed startup work drains on a later timer pass.
+    let private completeStartupRecoveryIfPendingWorkDrained readGraceStatusFileClient updateGraceWatchInterprocessFileClient processChangedFilesClient =
+        task {
+            let mutable attemptedStartupCompletion = false
+
+            if
+                not (hasPendingWatchWork ())
+                && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.StartingUp
+            then
+                attemptedStartupCompletion <- true
+                let! reconciledStartupStatus = readGraceStatusFileClient ()
+                graceStatus <- reconciledStartupStatus
+                updateGraceStatusDirectoryIds reconciledStartupStatus
+                let! startupRecovery = recoverStartupWatchJournalAfterReconciliation reconciledStartupStatus
+
+                if startupRecovery.CompatibleReplayRows.Length > 0 then
+                    graceStatus <- GraceStatus.Default
+                    do! processChangedFilesClient ()
+
+            if
+                attemptedStartupCompletion
+                && not (hasPendingWatchWork ())
+            then
+                promoteStartupModeIfRecoverySucceeded ()
+
+            if
+                attemptedStartupCompletion
+                && not (hasPendingWatchWork ())
+            then
+                let! startupCatchUpStatus = readGraceStatusFileClient ()
+                updateGraceStatusDirectoryIds startupCatchUpStatus
+
+                do!
+                    publishGraceWatchInterprocessFileForCurrentConfidence
+                        startupCatchUpStatus
+                        graceStatusDirectoryIds
+                        updateGraceWatchInterprocessFileClient
+                        "startup catch-up"
+        }
+
+    /// Exposes delayed startup replay completion to tests without starting the foreground watcher loop.
+    let internal completeStartupRecoveryIfPendingWorkDrainedForWatchTests
+        readGraceStatusFileClient
+        updateGraceWatchInterprocessFileClient
+        processChangedFilesClient
+        =
+        completeStartupRecoveryIfPendingWorkDrained readGraceStatusFileClient updateGraceWatchInterprocessFileClient processChangedFilesClient
 
     /// Executes the watch command by binding ParseResult values to the SDK request and CLI output contract.
     type Watch() =
@@ -4524,32 +4613,7 @@ module Watch =
                     // Process any changes that occurred while not running.
                     graceStatus <- GraceStatus.Default
                     do! processChangedFiles ()
-
-                    if
-                        not (hasPendingWatchWork ())
-                        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.StartingUp
-                    then
-                        let! reconciledStartupStatus = readGraceStatusFile ()
-                        graceStatus <- reconciledStartupStatus
-                        updateGraceStatusDirectoryIds reconciledStartupStatus
-                        let! startupRecovery = recoverStartupWatchJournalAfterReconciliation reconciledStartupStatus
-
-                        if startupRecovery.CompatibleReplayRows.Length > 0 then
-                            graceStatus <- GraceStatus.Default
-                            do! processChangedFiles ()
-
-                    if not (hasPendingWatchWork ()) then promoteStartupModeIfRecoverySucceeded ()
-
-                    if not (hasPendingWatchWork ()) then
-                        let! startupCatchUpStatus = readGraceStatusFile ()
-                        updateGraceStatusDirectoryIds startupCatchUpStatus
-
-                        do!
-                            publishGraceWatchInterprocessFileForCurrentConfidence
-                                startupCatchUpStatus
-                                graceStatusDirectoryIds
-                                updateGraceWatchInterprocessFile
-                                "startup catch-up"
+                    do! completeStartupRecoveryIfPendingWorkDrained readGraceStatusFile updateGraceWatchInterprocessFile processChangedFiles
 
                     // Create a timer to process the file changes detected by the FileSystemWatcher.
                     // This timer is the reason that there's a delay in stopping `grace watch`.
@@ -4568,6 +4632,7 @@ module Watch =
                             do! publishGraceStatusRefreshSnapshot refreshGeneration updatedGraceStatus updateGraceWatchInterprocessFile
 
                         do! processChangedFiles ()
+                        do! completeStartupRecoveryIfPendingWorkDrained readGraceStatusFile updateGraceWatchInterprocessFile processChangedFiles
                         let! tick = periodicTimer.WaitForNextTickAsync()
                         ticked <- tick
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -4278,12 +4278,23 @@ module Watch =
             enqueueFileUpload difference.RelativePath
             |> ignore
 
-    /// Checks whether replayed startup file content can no longer produce an upload side effect.
-    let private isStaleStartupFileReplayRow (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
-        row.EntryType = FileSystemEntryType.File
-        && (row.DifferenceType = DifferenceType.Add
-            || row.DifferenceType = DifferenceType.Change)
-        && finalPathKind row.RelativePath <> FinalPathFile
+    /// Classifies replayed startup file content that current Watch startup rules would not scan or upload.
+    let private tryStartupFileReplayRetirementReason (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
+        if row.EntryType = FileSystemEntryType.File
+           && (row.DifferenceType = DifferenceType.Add
+               || row.DifferenceType = DifferenceType.Change) then
+            match finalPathKind row.RelativePath with
+            | FinalPathFile ->
+                let fullPath = Path.Combine(Current().RootDirectory, $"{row.RelativePath}")
+
+                if shouldIgnoreFile fullPath then
+                    Some "current startup replay file content ignored before status application"
+                else
+                    None
+            | FinalPathMissing
+            | FinalPathDirectory -> Some "stale startup replay file content missing before status application"
+        else
+            None
 
     /// Records a startup lifecycle event as diagnostics that cannot be replayed as Watch correctness data.
     let private recordStartupLifecycleEvent status eventType message =
@@ -4303,27 +4314,47 @@ module Watch =
 
                 logToAnsiConsole Colors.Important $"Grace Watch quarantined {recovery.QuarantinedRows.Length} incompatible startup journal rows before replay."
 
-            let staleFileReplayRows, replayRows =
+            let startupReplayClassifications =
                 recovery.CompatibleReplayRows
-                |> Array.partition isStaleStartupFileReplayRow
+                |> Array.map (fun row -> row, tryStartupFileReplayRetirementReason row)
 
-            if staleFileReplayRows.Length > 0 then
-                let staleReplaySequences =
-                    staleFileReplayRows
-                    |> Array.map (fun row -> row.Sequence)
+            let retiredFileReplayRows =
+                startupReplayClassifications
+                |> Array.choose (fun (row, reason) ->
+                    reason
+                    |> Option.map (fun retirementReason -> row, retirementReason))
 
-                let! _ = quarantineWatchJournalSequencesForWatch staleReplaySequences "stale startup replay file content missing before status application"
+            let replayRows =
+                startupReplayClassifications
+                |> Array.choose (fun (row, reason) ->
+                    match reason with
+                    | Some _ -> None
+                    | None -> Some row)
 
-                Interlocked.Add(&quarantinedWatchObservationCount, staleFileReplayRows.Length)
+            if retiredFileReplayRows.Length > 0 then
+                for row, reason in
+                    retiredFileReplayRows
+                    |> Array.sortBy (fun (row, _) -> row.Sequence) do
+                    let! _ = quarantineWatchJournalSequencesForWatch [| row.Sequence |] reason
+
+                    let lifecycleEventType, lifecycleMessage =
+                        match reason with
+                        | "stale startup replay file content missing before status application" ->
+                            "startup-stale-file-replay-retired",
+                            $"Startup replay retired stale file add/change row {row.Sequence} because its final file content was missing."
+                        | "current startup replay file content ignored before status application" ->
+                            "startup-ignored-file-replay-retired",
+                            $"Startup replay retired file add/change row {row.Sequence} because current startup ignore rules skip its final file content."
+                        | _ ->
+                            "startup-file-replay-retired",
+                            $"Startup replay retired file add/change row {row.Sequence} because current startup rules would not apply it."
+
+                    do! recordStartupLifecycleEvent status lifecycleEventType lifecycleMessage
+
+                Interlocked.Add(&quarantinedWatchObservationCount, retiredFileReplayRows.Length)
                 |> ignore
 
-                logToAnsiConsole Colors.Important $"Grace Watch retired {staleFileReplayRows.Length} stale startup file replay rows before status application."
-
-                do!
-                    recordStartupLifecycleEvent
-                        status
-                        "startup-stale-file-replay-retired"
-                        $"Startup replay retired {staleFileReplayRows.Length} stale file add/change rows because their final file content was missing."
+                logToAnsiConsole Colors.Important $"Grace Watch retired {retiredFileReplayRows.Length} startup file replay rows before status application."
 
             for row in replayRows do
                 let difference = FileSystemDifference.Create row.DifferenceType row.EntryType row.RelativePath
@@ -4336,7 +4367,7 @@ module Watch =
                 recordStartupLifecycleEvent
                     status
                     "startup-replay-complete"
-                    $"Startup replay queued {replayRows.Length} compatible rows, retired {staleFileReplayRows.Length} stale file rows, and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
+                    $"Startup replay queued {replayRows.Length} compatible rows, retired {retiredFileReplayRows.Length} file rows, and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
 
             return recovery
         }

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1877,6 +1877,12 @@ module Watch =
     /// Reports the replay sequence queued for a difference in startup recovery tests.
     let internal tryPeekStartupReplaySequenceForWatchTests difference = tryPeekStartupReplaySequence difference
 
+    /// Reads the replay sequences represented by differences that reached a durable terminal outcome.
+    let private startupReplaySequencesForTerminalDifferences (differences: seq<FileSystemDifference>) =
+        differences
+        |> Seq.collect startupReplaySequencesForDifference
+        |> Seq.toArray
+
     /// Removes replay metadata for one pending difference and returns the durable rows it represented.
     let private takeStartupReplaySequencesForDifference (difference: FileSystemDifference) =
         let key = pendingStatusDifferenceReplayKey difference
@@ -4264,9 +4270,9 @@ module Watch =
                             let commitRuntimeMode = currentGraceWatchRuntimeMode ()
 
                             let resolvedStartupReplaySequences =
-                                statusDifferencesForApply.Resolved
-                                |> Seq.collect startupReplaySequencesForDifference
-                                |> Seq.toArray
+                                startupReplaySequencesForTerminalDifferences (
+                                    mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved
+                                )
 
                             appendedWatchJournalSequences <- combineWatchJournalSequences appendedWatchJournalSequences resolvedStartupReplaySequences
 
@@ -4429,8 +4435,45 @@ module Watch =
             enqueueFileUpload difference.RelativePath
             |> ignore
 
+    /// Finds the parent directory path that must exist before a replayed directory add can be materialized.
+    let private tryParentRelativePathForDirectoryReplayAdd (relativePath: RelativePath) =
+        let segments =
+            (normalizeRelativePath relativePath)
+                .Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+        if segments.Length <= 1 then
+            None
+        else
+            Some(RelativePath(String.Join("/", segments[0 .. segments.Length - 2])))
+
+    /// Checks whether startup replay can provide an untracked directory add's missing parent in the same batch.
+    let private replayRowsContainDirectoryAdd (rows: Grace.CLI.LocalStateDb.WatchJournalPendingReplay array) (relativePath: RelativePath) =
+        let normalizedRelativePath = normalizeRelativePath relativePath
+
+        rows
+        |> Array.exists (fun row ->
+            row.EntryType = FileSystemEntryType.Directory
+            && row.DifferenceType = DifferenceType.Add
+            && String.Equals(normalizeRelativePath row.RelativePath, normalizedRelativePath, watchPathComparison))
+
+    /// Checks whether a replayed directory add can link to a tracked parent or one replayed by the same startup batch.
+    let private replayDirectoryAddHasParentContinuity
+        (status: GraceStatus)
+        (replayRows: Grace.CLI.LocalStateDb.WatchJournalPendingReplay array)
+        (relativePath: RelativePath)
+        =
+        match tryParentRelativePathForDirectoryReplayAdd relativePath with
+        | None -> true
+        | Some parentRelativePath ->
+            isTrackedDirectory status parentRelativePath
+            || replayRowsContainDirectoryAdd replayRows parentRelativePath
+
     /// Classifies compatible durable replay rows against current startup scan applicability before status mutation.
-    let private tryStartupReplayRetirementReason (status: GraceStatus) (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
+    let private tryStartupReplayRetirementReason
+        (status: GraceStatus)
+        (compatibleReplayRows: Grace.CLI.LocalStateDb.WatchJournalPendingReplay array)
+        (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay)
+        =
         let fullPath = Path.Combine(Current().RootDirectory, $"{row.RelativePath}")
 
         match row.EntryType, row.DifferenceType, finalPathKind row.RelativePath with
@@ -4466,6 +4509,8 @@ module Watch =
                 Some "current startup replay directory ignored before status application"
             elif isTrackedDirectory status row.RelativePath then
                 Some "startup replay directory add already tracked"
+            elif not (replayDirectoryAddHasParentContinuity status compatibleReplayRows row.RelativePath) then
+                Some "startup replay directory add parent is not tracked or replayed"
             else
                 None
         | FileSystemEntryType.Directory,
@@ -4500,7 +4545,7 @@ module Watch =
 
             let startupReplayClassifications =
                 recovery.CompatibleReplayRows
-                |> Array.map (fun row -> row, tryStartupReplayRetirementReason status row)
+                |> Array.map (fun row -> row, tryStartupReplayRetirementReason status recovery.CompatibleReplayRows row)
 
             let retiredReplayRows =
                 startupReplayClassifications
@@ -4553,6 +4598,9 @@ module Watch =
                         | "startup replay directory add already tracked" ->
                             "startup-tracked-directory-add-replay-retired",
                             $"Startup replay retired directory add row {row.Sequence} because GraceStatus already tracks that directory."
+                        | "startup replay directory add parent is not tracked or replayed" ->
+                            "startup-orphan-directory-add-replay-retired",
+                            $"Startup replay retired directory add row {row.Sequence} because its parent directory was not tracked or replayed."
                         | "startup replay directory delete is not tracked" ->
                             "startup-untracked-directory-delete-replay-retired",
                             $"Startup replay retired directory delete row {row.Sequence} because GraceStatus does not track that directory."

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1850,18 +1850,22 @@ module Watch =
     /// Reports the replay sequence queued for a difference in startup recovery tests.
     let internal tryPeekStartupReplaySequenceForWatchTests difference = tryPeekStartupReplaySequence difference
 
+    /// Removes replay metadata for one pending difference after it has reached a terminal local outcome.
+    let private clearStartupReplaySequenceForDifference (difference: FileSystemDifference) =
+        let key = pendingStatusDifferenceReplayKey difference
+        let mutable queue = Unchecked.defaultof<Queue<int64>>
+
+        if pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue) then
+            pendingStatusDifferenceReplaySequences.Remove(key)
+            |> ignore
+
     /// Consumes replay sequence metadata only after the corresponding pending status difference is cleared.
     let private clearStartupReplaySequences (differences: seq<FileSystemDifference>) =
         lock pendingStatusDifferencesLock (fun () ->
             ensureStartupReplaySequenceComparer ()
 
             for difference in differences do
-                let key = pendingStatusDifferenceReplayKey difference
-                let mutable queue = Unchecked.defaultof<Queue<int64>>
-
-                if pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue) then
-                    pendingStatusDifferenceReplaySequences.Remove(key)
-                    |> ignore)
+                clearStartupReplaySequenceForDifference difference)
 
     /// Reads the best available GraceStatus snapshot for classifying directory-create observations.
     let private readGraceStatusForDirectoryAddClassification () =
@@ -1939,7 +1943,12 @@ module Watch =
 
         let pendingDifferences =
             lock pendingStatusDifferencesLock (fun () ->
+                ensureStartupReplaySequenceComparer ()
                 let snapshot = pendingStatusDifferences.ToArray()
+
+                for pendingDifference in snapshot do
+                    clearStartupReplaySequenceForDifference pendingDifference
+
                 pendingStatusDifferences.Clear()
                 snapshot)
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -1071,6 +1071,11 @@ module Watch =
     /// Finds the tracked file entry that owns a repository-relative path in GraceStatus.
     let private tryFindTrackedFile (status: GraceStatus) (relativePath: RelativePath) = tryFindTrackedFileWithComparison watchPathComparison status relativePath
 
+    /// Checks whether GraceStatus already tracks a repository-relative file path.
+    let private isTrackedFile (status: GraceStatus) (relativePath: RelativePath) =
+        tryFindTrackedFile status relativePath
+        |> Option.isSome
+
     /// Checks whether GraceStatus already tracks a repository-relative directory path.
     let private isTrackedDirectory (status: GraceStatus) (relativePath: RelativePath) =
         let normalizedRelativePath = normalizeRelativePath relativePath
@@ -1764,14 +1769,17 @@ module Watch =
 
         canceledFileUpload
 
+    /// Checks whether two status differences represent the same repository path observation.
+    let private statusDifferenceMatches (left: FileSystemDifference) (right: FileSystemDifference) =
+        left.DifferenceType = right.DifferenceType
+        && left.FileSystemEntryType = right.FileSystemEntryType
+        && String.Equals(normalizeRelativePath left.RelativePath, normalizeRelativePath right.RelativePath, watchPathComparison)
+
     /// Records an already-derived filesystem difference so status application can retry without duplicating work.
     let private addPendingStatusDifference (difference: FileSystemDifference) =
         lock pendingStatusDifferencesLock (fun () ->
             if not
-               <| pendingStatusDifferences.Exists (fun (existing: FileSystemDifference) ->
-                   existing.RelativePath = difference.RelativePath
-                   && existing.DifferenceType = difference.DifferenceType
-                   && existing.FileSystemEntryType = difference.FileSystemEntryType) then
+               <| pendingStatusDifferences.Exists(fun existing -> statusDifferenceMatches existing difference) then
                 pendingStatusDifferences.Add(difference))
 
     /// Builds the stable key used to pair a startup-replayed difference with its existing journal sequence.
@@ -2493,10 +2501,7 @@ module Watch =
 
         let addIfMissing (difference: FileSystemDifference) =
             if not
-               <| merged.Exists (fun existing ->
-                   existing.RelativePath = difference.RelativePath
-                   && existing.DifferenceType = difference.DifferenceType
-                   && existing.FileSystemEntryType = difference.FileSystemEntryType) then
+               <| merged.Exists(fun existing -> statusDifferenceMatches existing difference) then
                 merged.Add(difference)
 
         for difference in first do
@@ -2506,12 +2511,6 @@ module Watch =
             addIfMissing difference
 
         merged
-
-    /// Checks whether two status differences represent the same repository path observation.
-    let private statusDifferenceMatches (left: FileSystemDifference) (right: FileSystemDifference) =
-        left.DifferenceType = right.DifferenceType
-        && left.FileSystemEntryType = right.FileSystemEntryType
-        && String.Equals(normalizeRelativePath left.RelativePath, normalizeRelativePath right.RelativePath, watchPathComparison)
 
     /// Checks whether a difference came from uploaded file work that newer event-derived upload state can supersede.
     let private isUploadedFileAddOrChangeDifference (difference: FileSystemDifference) =
@@ -4279,7 +4278,7 @@ module Watch =
             |> ignore
 
     /// Classifies compatible durable replay rows against current startup scan applicability before status mutation.
-    let private tryStartupReplayRetirementReason (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
+    let private tryStartupReplayRetirementReason (status: GraceStatus) (row: Grace.CLI.LocalStateDb.WatchJournalPendingReplay) =
         let fullPath = Path.Combine(Current().RootDirectory, $"{row.RelativePath}")
 
         match row.EntryType, row.DifferenceType, finalPathKind row.RelativePath with
@@ -4289,6 +4288,14 @@ module Watch =
           FinalPathFile ->
             if shouldIgnoreFile fullPath then
                 Some "current startup replay file content ignored before status application"
+            elif row.DifferenceType = DifferenceType.Add
+                 && isTrackedFile status row.RelativePath then
+                Some "startup replay file add already tracked"
+            elif
+                row.DifferenceType = DifferenceType.Change
+                && not (isTrackedFile status row.RelativePath)
+            then
+                Some "startup replay file change is not tracked"
             else
                 None
         | FileSystemEntryType.File,
@@ -4297,10 +4304,16 @@ module Watch =
           (FinalPathMissing
           | FinalPathDirectory) -> Some "stale startup replay file content missing before status application"
         | FileSystemEntryType.File, DifferenceType.Delete, FinalPathDirectory -> Some "startup replay file delete now targets a directory"
-        | FileSystemEntryType.File, DifferenceType.Delete, _ -> None
+        | FileSystemEntryType.File, DifferenceType.Delete, _ ->
+            if isTrackedFile status row.RelativePath then
+                None
+            else
+                Some "startup replay file delete is not tracked"
         | FileSystemEntryType.Directory, DifferenceType.Add, FinalPathDirectory ->
             if shouldIgnoreDirectory fullPath then
                 Some "current startup replay directory ignored before status application"
+            elif isTrackedDirectory status row.RelativePath then
+                Some "startup replay directory add already tracked"
             else
                 None
         | FileSystemEntryType.Directory,
@@ -4309,7 +4322,11 @@ module Watch =
           | FinalPathFile) -> Some "stale startup replay directory missing before status application"
         | FileSystemEntryType.Directory, DifferenceType.Change, _ -> Some "directory change rows are not emitted by Watch startup scan"
         | FileSystemEntryType.Directory, DifferenceType.Delete, FinalPathFile -> Some "startup replay directory delete now targets a file"
-        | FileSystemEntryType.Directory, DifferenceType.Delete, _ -> None
+        | FileSystemEntryType.Directory, DifferenceType.Delete, _ ->
+            if isTrackedDirectory status row.RelativePath then
+                None
+            else
+                Some "startup replay directory delete is not tracked"
 
     /// Records a startup lifecycle event as diagnostics that cannot be replayed as Watch correctness data.
     let private recordStartupLifecycleEvent status eventType message =
@@ -4331,7 +4348,7 @@ module Watch =
 
             let startupReplayClassifications =
                 recovery.CompatibleReplayRows
-                |> Array.map (fun row -> row, tryStartupReplayRetirementReason row)
+                |> Array.map (fun row -> row, tryStartupReplayRetirementReason status row)
 
             let retiredReplayRows =
                 startupReplayClassifications
@@ -4372,6 +4389,21 @@ module Watch =
                         | "startup replay directory delete now targets a file" ->
                             "startup-directory-delete-replay-retired",
                             $"Startup replay retired directory delete row {row.Sequence} because the current path is a file."
+                        | "startup replay file add already tracked" ->
+                            "startup-tracked-file-add-replay-retired",
+                            $"Startup replay retired file add row {row.Sequence} because GraceStatus already tracks that file."
+                        | "startup replay file change is not tracked" ->
+                            "startup-untracked-file-change-replay-retired",
+                            $"Startup replay retired file change row {row.Sequence} because GraceStatus does not track that file."
+                        | "startup replay file delete is not tracked" ->
+                            "startup-untracked-file-delete-replay-retired",
+                            $"Startup replay retired file delete row {row.Sequence} because GraceStatus does not track that file."
+                        | "startup replay directory add already tracked" ->
+                            "startup-tracked-directory-add-replay-retired",
+                            $"Startup replay retired directory add row {row.Sequence} because GraceStatus already tracks that directory."
+                        | "startup replay directory delete is not tracked" ->
+                            "startup-untracked-directory-delete-replay-retired",
+                            $"Startup replay retired directory delete row {row.Sequence} because GraceStatus does not track that directory."
                         | _ -> "startup-replay-retired", $"Startup replay retired row {row.Sequence} because current startup rules would not apply it."
 
                     do! recordStartupLifecycleEvent status lifecycleEventType lifecycleMessage

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -79,6 +79,11 @@ module Watch =
 
     let mutable private pruneWatchJournalRetentionForWatch = fun () -> Grace.CLI.LocalStateDb.pruneWatchJournalRetention (Current().GraceStatusFile)
 
+    let mutable private recoverWatchJournalForStartupForWatch =
+        fun scope -> Grace.CLI.LocalStateDb.recoverWatchJournalForStartup (Current().GraceStatusFile) scope
+
+    let mutable private recordWatchLifecycleEventForWatch = fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
+
     /// Installs durable journal clients used by append-before-apply ordering tests.
     let internal setWatchJournalClientsForWatchTests appendObservations advanceAppliedSequences =
         appendWatchJournalObservationsForWatch <- appendObservations
@@ -88,6 +93,11 @@ module Watch =
     let internal setWatchJournalMaintenanceClientsForWatchTests recoverBoundaryGap pruneRetention =
         recoverWatchJournalBoundaryGapForWatch <- recoverBoundaryGap
         pruneWatchJournalRetentionForWatch <- pruneRetention
+
+    /// Installs startup recovery clients used by replay and quarantine ordering tests.
+    let internal setWatchJournalStartupClientsForWatchTests recoverStartup recordLifecycle =
+        recoverWatchJournalForStartupForWatch <- recoverStartup
+        recordWatchLifecycleEventForWatch <- recordLifecycle
 
     /// Restores durable journal clients after tests replace append or boundary behavior.
     let internal resetWatchJournalClientsForWatchTests () =
@@ -105,6 +115,10 @@ module Watch =
                 }
 
         pruneWatchJournalRetentionForWatch <- fun () -> Grace.CLI.LocalStateDb.pruneWatchJournalRetention (Current().GraceStatusFile)
+
+        recoverWatchJournalForStartupForWatch <- fun scope -> Grace.CLI.LocalStateDb.recoverWatchJournalForStartup (Current().GraceStatusFile) scope
+
+        recordWatchLifecycleEventForWatch <- fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
 
     /// Reports that a filesystem observation was ignored because the current runtime mode cannot capture it.
     let private logObservationSuppressed fullPath =
@@ -262,6 +276,9 @@ module Watch =
     let private pendingStatusDifferencesLock = obj ()
 
     let private pendingStatusDifferences = List<FileSystemDifference>()
+
+    /// Tracks startup-replayed journal sequences by normalized difference so status application does not append duplicates.
+    let mutable private pendingStatusDifferenceReplaySequences = Dictionary<string, Queue<int64>>(StringComparer.Ordinal)
 
     let mutable private quarantinedWatchObservationCount = 0
 
@@ -1361,9 +1378,37 @@ module Watch =
     /// Models the differences that can be applied and the queued work they resolve.
     type private StatusDifferencesForApply = { Applicable: List<FileSystemDifference>; Resolved: List<FileSystemDifference> }
 
+    /// Returns the root BLAKE3 hash that durable Watch journal identity expects for replay.
+    let private rootDirectoryBlake3HashForWatchJournal (status: GraceStatus) =
+        let mutable rootDirectoryVersion = LocalDirectoryVersion.Default
+
+        if status.Index.TryGetValue(status.RootDirectoryId, &rootDirectoryVersion) then
+            rootDirectoryVersion.Blake3Hash
+        elif not (String.IsNullOrWhiteSpace(string status.RootDirectoryBlake3Hash)) then
+            status.RootDirectoryBlake3Hash
+        else
+            Blake3Hash String.Empty
+
+    /// Captures the current repository identity that makes normalized Watch journal rows replayable.
+    let private currentWatchJournalScope (status: GraceStatus) : Grace.CLI.LocalStateDb.WatchJournalScope =
+        {
+            RepositoryId = Current().RepositoryId
+            BranchId = Current().BranchId
+            WorkspaceRoot = Path.GetFullPath(Directory.GetCurrentDirectory())
+            WatchRoot = Path.GetFullPath(Current().RootDirectory)
+            RootDirectoryId = status.RootDirectoryId
+            RootDirectoryBlake3Hash = rootDirectoryBlake3HashForWatchJournal status
+            WatchMode = "repository-root"
+        }
+
     /// Converts an already-normalized status difference into the replay payload owned by the local Watch journal.
     let private journalObservationForDifference (difference: FileSystemDifference) : Grace.CLI.LocalStateDb.WatchJournalObservation =
-        { DifferenceType = difference.DifferenceType; EntryType = difference.FileSystemEntryType; RelativePath = difference.RelativePath }
+        {
+            Scope = currentWatchJournalScope graceStatus
+            DifferenceType = difference.DifferenceType
+            EntryType = difference.FileSystemEntryType
+            RelativePath = difference.RelativePath
+        }
 
     /// Checks whether a pending uploaded file difference must be dropped because final path state no longer has a file.
     let private isStaleUploadedFileDifference (difference: FileSystemDifference) =
@@ -1722,6 +1767,79 @@ module Watch =
                    && existing.DifferenceType = difference.DifferenceType
                    && existing.FileSystemEntryType = difference.FileSystemEntryType) then
                 pendingStatusDifferences.Add(difference))
+
+    /// Builds the stable key used to pair a startup-replayed difference with its existing journal sequence.
+    let private pendingStatusDifferenceReplayKey (difference: FileSystemDifference) =
+        $"{getDiscriminatedUnionCaseName difference.DifferenceType}|{getDiscriminatedUnionCaseName difference.FileSystemEntryType}|{normalizeRelativePath difference.RelativePath}"
+
+    /// Rebuilds the replay sequence dictionary when repository path comparison changes.
+    let private ensureStartupReplaySequenceComparer () =
+        let desiredComparer =
+            if watchPathComparison = StringComparison.OrdinalIgnoreCase
+               || watchPathComparison = StringComparison.InvariantCultureIgnoreCase
+               || watchPathComparison = StringComparison.CurrentCultureIgnoreCase then
+                StringComparer.OrdinalIgnoreCase
+            else
+                StringComparer.Ordinal
+
+        if not (obj.ReferenceEquals(pendingStatusDifferenceReplaySequences.Comparer, desiredComparer)) then
+            let replacement = Dictionary<string, Queue<int64>>(desiredComparer)
+
+            for pair in pendingStatusDifferenceReplaySequences do
+                replacement[pair.Key] <- Queue<int64>(pair.Value)
+
+            pendingStatusDifferenceReplaySequences <- replacement
+
+    /// Queues one startup-replayed difference without creating a duplicate durable journal row.
+    let private addStartupReplayedStatusDifference sequence (difference: FileSystemDifference) =
+        lock pendingStatusDifferencesLock (fun () ->
+            ensureStartupReplaySequenceComparer ()
+            addPendingStatusDifference difference
+            let key = pendingStatusDifferenceReplayKey difference
+            let mutable queue = Unchecked.defaultof<Queue<int64>>
+
+            if not (pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue)) then
+                queue <- Queue<int64>()
+                pendingStatusDifferenceReplaySequences.Add(key, queue)
+
+            queue.Enqueue(sequence))
+
+    /// Reads the existing startup replay sequence for a difference that should not be appended again.
+    let private tryPeekStartupReplaySequence (difference: FileSystemDifference) =
+        lock pendingStatusDifferencesLock (fun () ->
+            ensureStartupReplaySequenceComparer ()
+            let key = pendingStatusDifferenceReplayKey difference
+            let mutable queue = Unchecked.defaultof<Queue<int64>>
+
+            if
+                pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue)
+                && queue.Count > 0
+            then
+                Some(queue.Peek())
+            else
+                None)
+
+    /// Reports the replay sequence queued for a difference in startup recovery tests.
+    let internal tryPeekStartupReplaySequenceForWatchTests difference = tryPeekStartupReplaySequence difference
+
+    /// Consumes replay sequence metadata only after the corresponding pending status difference is cleared.
+    let private clearStartupReplaySequences (differences: seq<FileSystemDifference>) =
+        lock pendingStatusDifferencesLock (fun () ->
+            ensureStartupReplaySequenceComparer ()
+
+            for difference in differences do
+                let key = pendingStatusDifferenceReplayKey difference
+                let mutable queue = Unchecked.defaultof<Queue<int64>>
+
+                if
+                    pendingStatusDifferenceReplaySequences.TryGetValue(key, &queue)
+                    && queue.Count > 0
+                then
+                    queue.Dequeue() |> ignore
+
+                    if queue.Count = 0 then
+                        pendingStatusDifferenceReplaySequences.Remove(key)
+                        |> ignore)
 
     /// Reads the best available GraceStatus snapshot for classifying directory-create observations.
     let private readGraceStatusForDirectoryAddClassification () =
@@ -2433,6 +2551,7 @@ module Watch =
         lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
         lock canceledFileUploadDeleteRelativePathsLock (fun () -> canceledFileUploadDeleteRelativePaths.Clear())
         clearPendingStatusDifferencesForTests ()
+        lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferenceReplaySequences.Clear())
         clearGraceWatchResyncPending ()
 
         Interlocked.Exchange(&quarantinedWatchObservationCount, 0)
@@ -3888,12 +4007,27 @@ module Watch =
                                     let! appendResult =
                                         task {
                                             try
-                                                let! sequences =
+                                                let startupReplaySequences =
                                                     statusDifferencesForApply.Applicable
-                                                    |> Seq.map journalObservationForDifference
-                                                    |> appendWatchJournalObservationsForWatch
+                                                    |> Seq.choose tryPeekStartupReplaySequence
+                                                    |> Seq.toArray
 
-                                                return Ok sequences
+                                                let differencesNeedingJournalAppend =
+                                                    statusDifferencesForApply.Applicable
+                                                    |> Seq.filter (fun difference ->
+                                                        tryPeekStartupReplaySequence difference
+                                                        |> Option.isNone)
+                                                    |> Seq.toArray
+
+                                                let! sequences =
+                                                    if Array.isEmpty differencesNeedingJournalAppend then
+                                                        Task.FromResult(Array.empty<int64>)
+                                                    else
+                                                        differencesNeedingJournalAppend
+                                                        |> Seq.map journalObservationForDifference
+                                                        |> appendWatchJournalObservationsForWatch
+
+                                                return Ok(Array.append startupReplaySequences sequences)
                                             with
                                             | ex -> return Error ex
                                         }
@@ -3977,10 +4111,12 @@ module Watch =
                                     clearCanceledFileUploadDeleteRelativePaths canceledFileUploadDeletePathsToClear
 
                                     clearPendingStatusDifferences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
+                                    clearStartupReplaySequences (mergeStatusDifferences pendingDifferencesToClear statusDifferencesForApply.Resolved)
                                     clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
                                     removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
                             else
                                 clearPendingStatusDifferences pendingDifferencesToClear
+                                clearStartupReplaySequences pendingDifferencesToClear
                                 clearProcessedFileRelativePathsPendingStatus processedFileRelativePathsForStatus
                                 removeUploadedFileVersionsForPaths processedFileRelativePathsForStatus
 
@@ -4094,6 +4230,45 @@ module Watch =
         | File, _ ->
             enqueueFileUpload difference.RelativePath
             |> ignore
+
+    /// Records a startup lifecycle event as diagnostics that cannot be replayed as Watch correctness data.
+    let private recordStartupLifecycleEvent status eventType message =
+        recordWatchLifecycleEventForWatch (
+            { Scope = currentWatchJournalScope status; EventType = eventType; Message = message }: Grace.CLI.LocalStateDb.WatchLifecycleEvent
+        )
+
+    /// Replays compatible pending journal rows after startup reconciliation and quarantines rows from stale scopes.
+    let private recoverStartupWatchJournalAfterReconciliation status =
+        task {
+            do! recordStartupLifecycleEvent status "startup-reconciliation-complete" "Startup scan reconciliation completed before journal replay."
+            let! recovery = recoverWatchJournalForStartupForWatch (currentWatchJournalScope status)
+
+            if recovery.QuarantinedRows.Length > 0 then
+                Interlocked.Add(&quarantinedWatchObservationCount, recovery.QuarantinedRows.Length)
+                |> ignore
+
+                logToAnsiConsole Colors.Important $"Grace Watch quarantined {recovery.QuarantinedRows.Length} incompatible startup journal rows before replay."
+
+            for row in recovery.CompatibleReplayRows do
+                let difference = FileSystemDifference.Create row.DifferenceType row.EntryType row.RelativePath
+                addStartupReplayedStatusDifference row.Sequence difference
+
+            if recovery.CompatibleReplayRows.Length > 0 then
+                logToAnsiConsole
+                    Colors.Important
+                    $"Grace Watch replayed {recovery.CompatibleReplayRows.Length} compatible pending journal rows after startup reconciliation."
+
+            do!
+                recordStartupLifecycleEvent
+                    status
+                    "startup-replay-complete"
+                    $"Startup replay queued {recovery.CompatibleReplayRows.Length} compatible rows and quarantined {recovery.QuarantinedRows.Length} incompatible rows."
+
+            return recovery
+        }
+
+    /// Exposes startup journal recovery to tests without starting the foreground watcher loop.
+    let internal recoverStartupWatchJournalAfterReconciliationForWatchTests status = recoverStartupWatchJournalAfterReconciliation status
 
     /// Executes the watch command by binding ParseResult values to the SDK request and CLI output contract.
     type Watch() =
@@ -4349,7 +4524,21 @@ module Watch =
                     // Process any changes that occurred while not running.
                     graceStatus <- GraceStatus.Default
                     do! processChangedFiles ()
-                    promoteStartupModeIfRecoverySucceeded ()
+
+                    if
+                        not (hasPendingWatchWork ())
+                        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.StartingUp
+                    then
+                        let! reconciledStartupStatus = readGraceStatusFile ()
+                        graceStatus <- reconciledStartupStatus
+                        updateGraceStatusDirectoryIds reconciledStartupStatus
+                        let! startupRecovery = recoverStartupWatchJournalAfterReconciliation reconciledStartupStatus
+
+                        if startupRecovery.CompatibleReplayRows.Length > 0 then
+                            graceStatus <- GraceStatus.Default
+                            do! processChangedFiles ()
+
+                    if not (hasPendingWatchWork ()) then promoteStartupModeIfRecoverySucceeded ()
 
                     if not (hasPendingWatchWork ()) then
                         let! startupCatchUpStatus = readGraceStatusFile ()

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -434,6 +434,7 @@ module CommandOutputContract =
                 "DifferenceType", scalarSchema "string"
                 "FileSystemEntryType", scalarSchema "string"
                 "RelativePath", nullableStringSchema "Repository-relative path for the normalized replay observation."
+                "QuarantineReason", nullableStringSchema "Reason a startup recovery pass retired this row instead of replaying it."
             ]
             [|
                 "Sequence"
@@ -442,6 +443,7 @@ module CommandOutputContract =
                 "DifferenceType"
                 "FileSystemEntryType"
                 "RelativePath"
+                "QuarantineReason"
             |]
 
     let private maintenanceShowJournalSchema =

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -492,6 +492,7 @@ module CommandOutputContract =
                             DifferenceType = "Change"
                             FileSystemEntryType = "File"
                             RelativePath = "src/Program.fs"
+                            QuarantineReason = null
                         |}
                     |]
             |}

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1395,10 +1395,14 @@ module LocalStateDb =
                                                 match tryGetMetaValue connection "schema_version" with
                                                 | Some version when version = SchemaVersion -> ()
                                                 | Some "6" ->
-                                                    if hasRequiredMetaKeyValueShape connection then
-                                                        logTrace "migrating local state DB schema from v6 to v7"
-                                                        migrateWatchJournalV6ToV7 connection
-                                                        setMetaValue connection "schema_version" SchemaVersion
+                                                    if hasRequiredMetaKeyValueShape connection
+                                                       && tableExists connection "watch_journal" then
+                                                        try
+                                                            logTrace "migrating local state DB schema from v6 to v7"
+                                                            migrateWatchJournalV6ToV7 connection
+                                                            setMetaValue connection "schema_version" SchemaVersion
+                                                        with
+                                                        | :? SqliteException -> recreate <- true
                                                     else
                                                         recreate <- true
                                                 | Some _ -> recreate <- true

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1677,6 +1677,24 @@ module LocalStateDb =
             use reader = command.ExecuteReader()
             let rows = ResizeArray<WatchJournalRow>()
 
+            /// Reads journal payload text for diagnostics without trusting SQLite dynamic typing.
+            let readDiagnosticText ordinal fieldName =
+                if reader.IsDBNull(ordinal) then
+                    $"<missing {fieldName}>"
+                else
+                    match reader.GetValue(ordinal) with
+                    | :? string as value -> value
+                    | _ -> $"<non-text {fieldName}>"
+
+            /// Reads optional journal payload text for diagnostics without throwing on malformed local rows.
+            let readOptionalDiagnosticText ordinal fieldName =
+                if reader.IsDBNull(ordinal) then
+                    None
+                else
+                    match reader.GetValue(ordinal) with
+                    | :? string as value -> Some value
+                    | _ -> Some $"<non-text {fieldName}>"
+
             while reader.Read() do
                 let sequence = reader.GetInt64(0)
 
@@ -1690,10 +1708,10 @@ module LocalStateDb =
                         Sequence = sequence
                         CreatedAtUnixTicks = reader.GetInt64(1)
                         State = state
-                        DifferenceType = reader.GetString(2)
-                        EntryType = reader.GetString(3)
-                        RelativePath = Some(reader.GetString(4))
-                        QuarantineReason = if reader.IsDBNull(6) then None else Some(reader.GetString(6))
+                        DifferenceType = readDiagnosticText 2 "difference_type"
+                        EntryType = readDiagnosticText 3 "entry_type"
+                        RelativePath = readOptionalDiagnosticText 4 "relative_path"
+                        QuarantineReason = readOptionalDiagnosticText 6 "quarantine_reason"
                     }
 
                 if watchJournalRowMatches normalizedStateFilter normalizedPathFilter row then
@@ -1981,6 +1999,36 @@ module LocalStateDb =
     /// Reads a nullable text column from a journal query without converting database null into a trusted value.
     let private readNullableText (reader: SqliteDataReader) ordinal = if reader.IsDBNull(ordinal) then None else Some(reader.GetString(ordinal))
 
+    /// Reads a nullable journal text field without trusting SQLite's dynamic type coercion.
+    let private tryReadNullableJournalText (reader: SqliteDataReader) ordinal fieldName =
+        if reader.IsDBNull(ordinal) then
+            Ok None
+        else
+            match reader.GetValue(ordinal) with
+            | :? string as value -> Ok(Some value)
+            | _ -> Error $"non-text {fieldName}"
+
+    /// Reads a required replay payload text field before parsing the row's Watch semantics.
+    let private tryReadRequiredJournalText (reader: SqliteDataReader) ordinal fieldName =
+        if reader.IsDBNull(ordinal) then
+            Error $"missing {fieldName}"
+        else
+            match reader.GetValue(ordinal) with
+            | :? string as value -> Ok value
+            | _ -> Error $"non-text {fieldName}"
+
+    /// Provides diagnostic text for rows already quarantined because their payload cannot be trusted.
+    let private readJournalDiagnosticText (reader: SqliteDataReader) ordinal fieldName =
+        match tryReadRequiredJournalText reader ordinal fieldName with
+        | Ok value -> value
+        | Error reason -> $"<{reason}>"
+
+    /// Provides optional diagnostic text for rows already quarantined because their payload cannot be trusted.
+    let private readOptionalJournalDiagnosticText (reader: SqliteDataReader) ordinal fieldName =
+        match tryReadNullableJournalText reader ordinal fieldName with
+        | Ok value -> value
+        | Error reason -> Some $"<{reason}>"
+
     /// Builds a diagnostic row for a startup quarantine decision.
     let private quarantinedJournalRowFromReader appliedThroughSequence (reader: SqliteDataReader) =
         let sequence = reader.GetInt64(0)
@@ -1989,11 +2037,46 @@ module LocalStateDb =
             Sequence = sequence
             CreatedAtUnixTicks = reader.GetInt64(1)
             State = Quarantined
-            DifferenceType = reader.GetString(9)
-            EntryType = reader.GetString(10)
-            RelativePath = Some(reader.GetString(11))
-            QuarantineReason = readNullableText reader 13
+            DifferenceType = readJournalDiagnosticText reader 9 "difference_type"
+            EntryType = readJournalDiagnosticText reader 10 "entry_type"
+            RelativePath = readOptionalJournalDiagnosticText reader 11 "relative_path"
+            QuarantineReason = readOptionalJournalDiagnosticText reader 13 "quarantine_reason"
         }
+
+    /// Reads the identity and payload fields needed to classify one startup replay row.
+    let private tryReadWatchJournalReplayFields (reader: SqliteDataReader) =
+        match tryReadNullableJournalText reader 2 "repository_id",
+              tryReadNullableJournalText reader 3 "branch_id",
+              tryReadNullableJournalText reader 4 "workspace_root",
+              tryReadNullableJournalText reader 5 "watch_root",
+              tryReadNullableJournalText reader 6 "root_directory_version_id",
+              tryReadNullableJournalText reader 7 "root_directory_blake3_hash",
+              tryReadNullableJournalText reader 8 "watch_mode",
+              tryReadRequiredJournalText reader 9 "difference_type",
+              tryReadRequiredJournalText reader 10 "entry_type",
+              tryReadRequiredJournalText reader 11 "relative_path"
+            with
+        | Ok repositoryId,
+          Ok branchId,
+          Ok workspaceRoot,
+          Ok watchRoot,
+          Ok rootDirectoryId,
+          Ok rootDirectoryBlake3Hash,
+          Ok watchMode,
+          Ok differenceType,
+          Ok entryType,
+          Ok relativePath ->
+            Ok(repositoryId, branchId, workspaceRoot, watchRoot, rootDirectoryId, rootDirectoryBlake3Hash, watchMode, differenceType, entryType, relativePath)
+        | Error reason, _, _, _, _, _, _, _, _, _
+        | _, Error reason, _, _, _, _, _, _, _, _
+        | _, _, Error reason, _, _, _, _, _, _, _
+        | _, _, _, Error reason, _, _, _, _, _, _
+        | _, _, _, _, Error reason, _, _, _, _, _
+        | _, _, _, _, _, Error reason, _, _, _, _
+        | _, _, _, _, _, _, Error reason, _, _, _
+        | _, _, _, _, _, _, _, Error reason, _, _
+        | _, _, _, _, _, _, _, _, Error reason, _
+        | _, _, _, _, _, _, _, _, _, Error reason -> Error reason
 
     /// Explains why an unapplied row cannot be trusted for startup replay in the current repository scope.
     let private tryFindWatchJournalReplayIncompatibility (scope: WatchJournalScope) row =
@@ -2138,40 +2221,31 @@ module LocalStateDb =
                             let rowsToQuarantine = ResizeArray<int64 * string>()
 
                             while reader.Read() do
-                                let differenceTypeValue = reader.GetString(9)
-                                let entryTypeValue = reader.GetString(10)
-                                let relativePath = reader.GetString(11)
+                                let sequence = reader.GetInt64(0)
 
-                                let rowIdentity =
-                                    (readNullableText reader 2,
-                                     readNullableText reader 3,
-                                     readNullableText reader 4,
-                                     readNullableText reader 5,
-                                     readNullableText reader 6,
-                                     readNullableText reader 7,
-                                     readNullableText reader 8,
-                                     differenceTypeValue,
-                                     entryTypeValue,
-                                     relativePath)
+                                match tryReadWatchJournalReplayFields reader with
+                                | Error reason -> rowsToQuarantine.Add(sequence, reason)
+                                | Ok rowIdentity ->
+                                    try
+                                        match tryFindWatchJournalReplayIncompatibility scope rowIdentity with
+                                        | Some reason -> rowsToQuarantine.Add(sequence, reason)
+                                        | None ->
+                                            let (_, _, _, _, _, _, _, differenceTypeValue, entryTypeValue, relativePath) = rowIdentity
 
-                                try
-                                    match tryFindWatchJournalReplayIncompatibility scope rowIdentity with
-                                    | Some reason -> rowsToQuarantine.Add(reader.GetInt64(0), reason)
-                                    | None ->
-                                        compatibleRows.Add(
-                                            {
-                                                Sequence = reader.GetInt64(0)
-                                                DifferenceType =
-                                                    tryParseWatchJournalDifferenceType differenceTypeValue
-                                                    |> Option.get
-                                                EntryType =
-                                                    tryParseWatchJournalEntryType entryTypeValue
-                                                    |> Option.get
-                                                RelativePath = RelativePath relativePath
-                                            }
-                                        )
-                                with
-                                | :? InvalidOperationException as ex -> rowsToQuarantine.Add(reader.GetInt64(0), ex.Message)
+                                            compatibleRows.Add(
+                                                {
+                                                    Sequence = sequence
+                                                    DifferenceType =
+                                                        tryParseWatchJournalDifferenceType differenceTypeValue
+                                                        |> Option.get
+                                                    EntryType =
+                                                        tryParseWatchJournalEntryType entryTypeValue
+                                                        |> Option.get
+                                                    RelativePath = RelativePath relativePath
+                                                }
+                                            )
+                                    with
+                                    | :? InvalidOperationException as ex -> rowsToQuarantine.Add(sequence, ex.Message)
 
                             reader.Close()
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -703,6 +703,32 @@ module LocalStateDb =
     /// Reports whether SQLite stored the Watch journal table as an AUTOINCREMENT sequence table.
     let private watchJournalUsesAutoincrement (connection: SqliteConnection) = tableUsesAutoincrementSequence connection "watch_journal"
 
+    /// Matches the lifecycle diagnostics invariant that no row can become replayable Watch work.
+    let private lifecycleReplayableCheckPattern =
+        Regex(
+            @"\bCHECK\s*\(\s*replayable\s*=\s*0\s*\)",
+            RegexOptions.IgnoreCase
+            ||| RegexOptions.CultureInvariant
+        )
+
+    /// Reports whether SQLite stored the lifecycle replayability constraint that keeps diagnostics terminal.
+    let private watchLifecycleReplayableColumnRejectsReplayableRows (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_lifecycle_events' LIMIT 1;"
+
+        match command.ExecuteScalar() with
+        | :? string as sql ->
+            match tryGetCreateTableColumnList sql with
+            | Some columnList ->
+                splitTopLevelSqlDeclarations columnList
+                |> Array.exists (fun declaration ->
+                    match tryReadLeadingSqlIdentifier declaration with
+                    | Some (identifier, _) when StringComparer.OrdinalIgnoreCase.Equals(identifier, "replayable") ->
+                        lifecycleReplayableCheckPattern.IsMatch(declaration)
+                    | _ -> false)
+            | None -> false
+        | _ -> false
+
     /// Adds one nullable Watch journal column when migrating v6 databases without deleting pending rows.
     let private addWatchJournalColumnIfMissing (connection: SqliteConnection) columnName columnDeclaration =
         if not (columnExists connection "watch_journal" columnName) then
@@ -906,6 +932,7 @@ module LocalStateDb =
         && hasRequiredTextColumn "message"
         && hasReplayableColumn
         && tableUsesAutoincrementSequence connection "watch_lifecycle_events"
+        && watchLifecycleReplayableColumnRejectsReplayableRows connection
 
     /// Reports whether the Watch journal contains rows that require trustworthy recovery metadata.
     let private hasWatchJournalRows (connection: SqliteConnection) =
@@ -1908,10 +1935,9 @@ module LocalStateDb =
                         normalizedWatchRoot
                         + string Path.DirectorySeparatorChar
 
-                    if
-                        String.Equals(candidatePath, normalizedWatchRoot, comparison)
-                        || candidatePath.StartsWith(rootWithSeparator, comparison)
-                    then
+                    if String.Equals(candidatePath, normalizedWatchRoot, comparison) then
+                        Some "watch root path cannot be replayed as a status difference"
+                    elif candidatePath.StartsWith(rootWithSeparator, comparison) then
                         None
                     else
                         Some "relative path escapes watch root"

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -19,7 +19,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "6"
+    let private SchemaVersion = "7"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -186,7 +186,8 @@ module LocalStateDb =
             "CREATE INDEX IF NOT EXISTS ix_object_cache_children_parent ON object_cache_directory_children(parent_directory_version_id);"
             "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
+            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
         |]
 
     let private requiredTableNames =
@@ -199,6 +200,7 @@ module LocalStateDb =
             "object_cache_directory_children"
             "object_cache_directory_files"
             "watch_journal"
+            "watch_lifecycle_events"
         |]
 
     let private requiredIndexNames =
@@ -694,6 +696,30 @@ module LocalStateDb =
         | :? string as sql -> createSqlDeclaresSequenceAutoincrement sql
         | _ -> false
 
+    /// Adds one nullable Watch journal column when migrating v6 databases without deleting pending rows.
+    let private addWatchJournalColumnIfMissing (connection: SqliteConnection) columnName columnDeclaration =
+        if not (columnExists connection "watch_journal" columnName) then
+            executeNonQuery connection $"ALTER TABLE watch_journal ADD COLUMN {columnDeclaration};"
+
+    /// Adds the lifecycle diagnostics table that records Watch recovery decisions without replay payloads.
+    let private ensureWatchLifecycleEventTable (connection: SqliteConnection) =
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
+
+    /// Migrates the v6 Watch journal shape by preserving rows and adding identity plus quarantine metadata.
+    let private migrateWatchJournalV6ToV7 (connection: SqliteConnection) =
+        addWatchJournalColumnIfMissing connection "repository_id" "repository_id TEXT"
+        addWatchJournalColumnIfMissing connection "branch_id" "branch_id TEXT"
+        addWatchJournalColumnIfMissing connection "workspace_root" "workspace_root TEXT"
+        addWatchJournalColumnIfMissing connection "watch_root" "watch_root TEXT"
+        addWatchJournalColumnIfMissing connection "root_directory_version_id" "root_directory_version_id TEXT"
+        addWatchJournalColumnIfMissing connection "root_directory_blake3_hash" "root_directory_blake3_hash TEXT"
+        addWatchJournalColumnIfMissing connection "watch_mode" "watch_mode TEXT"
+        addWatchJournalColumnIfMissing connection "quarantined_at_unix_ticks" "quarantined_at_unix_ticks INTEGER"
+        addWatchJournalColumnIfMissing connection "quarantine_reason" "quarantine_reason TEXT"
+        ensureWatchLifecycleEventTable connection
+
     /// Verifies that the Watch journal table can support ordered local recovery and retention operations.
     let private hasRequiredWatchJournalShape (connection: SqliteConnection) =
         let columns = readTableColumnShapes connection "watch_journal"
@@ -702,9 +728,18 @@ module LocalStateDb =
             [|
                 "sequence"
                 "created_at_unix_ticks"
+                "repository_id"
+                "branch_id"
+                "workspace_root"
+                "watch_root"
+                "root_directory_version_id"
+                "root_directory_blake3_hash"
+                "watch_mode"
                 "difference_type"
                 "entry_type"
                 "relative_path"
+                "quarantined_at_unix_ticks"
+                "quarantine_reason"
             |]
 
         let tryFindColumn columnName =
@@ -742,12 +777,39 @@ module LocalStateDb =
                 && column.DefaultValueSql.IsNone
             | None -> false
 
+        let hasOptionalTextColumn columnName =
+            match tryFindColumn columnName with
+            | Some column ->
+                isTextColumnType column.TypeName
+                && not column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
+        let hasOptionalIntegerColumn columnName =
+            match tryFindColumn columnName with
+            | Some column ->
+                isIntegerColumnType column.TypeName
+                && not column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
         hasExpectedColumnSet
         && hasSequenceColumn
         && hasCreatedAtColumn
+        && hasOptionalTextColumn "repository_id"
+        && hasOptionalTextColumn "branch_id"
+        && hasOptionalTextColumn "workspace_root"
+        && hasOptionalTextColumn "watch_root"
+        && hasOptionalTextColumn "root_directory_version_id"
+        && hasOptionalTextColumn "root_directory_blake3_hash"
+        && hasOptionalTextColumn "watch_mode"
         && hasRequiredTextColumn "difference_type"
         && hasRequiredTextColumn "entry_type"
         && hasRequiredTextColumn "relative_path"
+        && hasOptionalIntegerColumn "quarantined_at_unix_ticks"
+        && hasOptionalTextColumn "quarantine_reason"
         && watchJournalUsesAutoincrement connection
 
     /// Reports whether the Watch journal contains rows that require trustworthy recovery metadata.
@@ -828,6 +890,16 @@ module LocalStateDb =
         use command = connection.CreateCommand()
         command.CommandText <- "SELECT COUNT(*) FROM watch_journal;"
         command.ExecuteScalar() |> Convert.ToInt64
+
+    /// Reports whether a journal sequence was retired by quarantine and can be skipped by the replay watermark.
+    let private isWatchJournalSequenceQuarantined (connection: SqliteConnection) sequence =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT EXISTS(SELECT 1 FROM watch_journal WHERE sequence = $sequence AND quarantined_at_unix_ticks IS NOT NULL);"
+
+        command.Parameters.AddWithValue("$sequence", sequence)
+        |> ignore
+
+        Convert.ToInt32(command.ExecuteScalar()) <> 0
 
     /// Reads local-state metadata for read-only inspection checks without writing default rows.
     let private tryGetMetaValueReadOnly (connection: SqliteConnection) (key: string) =
@@ -1078,7 +1150,9 @@ module LocalStateDb =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
+
+        ensureWatchLifecycleEventTable connection
 
     /// Replaces malformed or missing Watch recovery metadata with the clear-journal reset watermark.
     let private resetWatchJournalAppliedThroughSequenceForClear (connection: SqliteConnection) =
@@ -1092,6 +1166,19 @@ module LocalStateDb =
     type WatchJournalRowState =
         | Applied
         | Pending
+        | Quarantined
+
+    /// Identifies the repository, branch, workspace, root, and mode that make a Watch journal row replay-compatible.
+    type WatchJournalScope =
+        {
+            RepositoryId: RepositoryId
+            BranchId: BranchId
+            WorkspaceRoot: string
+            WatchRoot: string
+            RootDirectoryId: DirectoryVersionId
+            RootDirectoryBlake3Hash: Blake3Hash
+            WatchMode: string
+        }
 
     /// Models one durable Watch journal sequence row for diagnostics.
     type WatchJournalRow =
@@ -1102,10 +1189,26 @@ module LocalStateDb =
             DifferenceType: string
             EntryType: string
             RelativePath: string option
+            QuarantineReason: string option
         }
 
     /// Models the replayable normalized Watch observation persisted before status application.
-    type WatchJournalObservation = { DifferenceType: DifferenceType; EntryType: FileSystemEntryType; RelativePath: RelativePath }
+    type WatchJournalObservation = { Scope: WatchJournalScope; DifferenceType: DifferenceType; EntryType: FileSystemEntryType; RelativePath: RelativePath }
+
+    /// Models one compatible unapplied Watch journal row that startup recovery can replay after reconciliation.
+    type WatchJournalPendingReplay = { Sequence: int64; DifferenceType: DifferenceType; EntryType: FileSystemEntryType; RelativePath: RelativePath }
+
+    /// Models startup recovery's durable quarantine and replay classification result.
+    type WatchJournalStartupRecovery =
+        {
+            DbPath: string
+            AppliedThroughSequence: int64
+            CompatibleReplayRows: WatchJournalPendingReplay array
+            QuarantinedRows: WatchJournalRow array
+        }
+
+    /// Models a non-replayable Watch lifecycle diagnostic event.
+    type WatchLifecycleEvent = { Scope: WatchJournalScope; EventType: string; Message: string }
 
     /// Models a filtered Watch journal diagnostic snapshot.
     type WatchJournalSnapshot =
@@ -1142,8 +1245,9 @@ module LocalStateDb =
             match normalized with
             | "all"
             | "applied"
-            | "pending" -> normalized
-            | _ -> invalidArg (nameof stateFilter) "Watch journal state must be one of: all, applied, pending."
+            | "pending"
+            | "quarantined" -> normalized
+            | _ -> invalidArg (nameof stateFilter) "Watch journal state must be one of: all, applied, pending, quarantined."
 
     /// Determines whether a diagnostic journal row should be returned for the requested filters.
     let private watchJournalRowMatches stateFilter pathFilter (row: WatchJournalRow) =
@@ -1152,6 +1256,7 @@ module LocalStateDb =
             | "all", _ -> true
             | "applied", Applied -> true
             | "pending", Pending -> true
+            | "quarantined", Quarantined -> true
             | _ -> false
 
         let pathMatches =
@@ -1194,6 +1299,7 @@ module LocalStateDb =
         && columnExists connection "object_cache_directories" "blake3_hash"
         && columnExists connection "object_cache_directory_files" "blake3_hash"
         && tableExists connection "watch_journal"
+        && tableExists connection "watch_lifecycle_events"
         && hasRequiredWatchJournalShape connection
         && hasValidWatchJournalAppliedThroughSequenceMeta connection
 
@@ -1288,6 +1394,13 @@ module LocalStateDb =
 
                                                 match tryGetMetaValue connection "schema_version" with
                                                 | Some version when version = SchemaVersion -> ()
+                                                | Some "6" ->
+                                                    if hasRequiredMetaKeyValueShape connection then
+                                                        logTrace "migrating local state DB schema from v6 to v7"
+                                                        migrateWatchJournalV6ToV7 connection
+                                                        setMetaValue connection "schema_version" SchemaVersion
+                                                    else
+                                                        recreate <- true
                                                 | Some _ -> recreate <- true
                                                 | None ->
                                                     logTrace "meta schema_version missing; writing defaults"
@@ -1399,14 +1512,17 @@ module LocalStateDb =
             match normalizedStateFilter with
             | "applied" ->
                 whereClauses.Add("sequence <= $applied_through")
+                whereClauses.Add("quarantined_at_unix_ticks IS NULL")
 
                 command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
                 |> ignore
             | "pending" ->
                 whereClauses.Add("sequence > $applied_through")
+                whereClauses.Add("quarantined_at_unix_ticks IS NULL")
 
                 command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
                 |> ignore
+            | "quarantined" -> whereClauses.Add("quarantined_at_unix_ticks IS NOT NULL")
             | _ -> ()
 
             match normalizedPathFilter with
@@ -1425,7 +1541,7 @@ module LocalStateDb =
                     $" WHERE {joinedWhereClauses}"
 
             command.CommandText <-
-                $"SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path FROM watch_journal{whereSql} ORDER BY sequence DESC LIMIT $limit;"
+                $"SELECT sequence, created_at_unix_ticks, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal{whereSql} ORDER BY sequence DESC LIMIT $limit;"
 
             command.Parameters.AddWithValue("$limit", limit)
             |> ignore
@@ -1436,7 +1552,10 @@ module LocalStateDb =
             while reader.Read() do
                 let sequence = reader.GetInt64(0)
 
-                let state = if sequence <= appliedThroughSequence then Applied else Pending
+                let state =
+                    if not (reader.IsDBNull(5)) then Quarantined
+                    elif sequence <= appliedThroughSequence then Applied
+                    else Pending
 
                 let row =
                     {
@@ -1446,6 +1565,7 @@ module LocalStateDb =
                         DifferenceType = reader.GetString(2)
                         EntryType = reader.GetString(3)
                         RelativePath = Some(reader.GetString(4))
+                        QuarantineReason = if reader.IsDBNull(6) then None else Some(reader.GetString(6))
                     }
 
                 if watchJournalRowMatches normalizedStateFilter normalizedPathFilter row then
@@ -1555,9 +1675,30 @@ module LocalStateDb =
                                 use command = connection.CreateCommand()
 
                                 command.CommandText <-
-                                    "INSERT INTO watch_journal (created_at_unix_ticks, difference_type, entry_type, relative_path) VALUES ($created_at, $difference_type, $entry_type, $relative_path) RETURNING sequence;"
+                                    "INSERT INTO watch_journal (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $difference_type, $entry_type, $relative_path) RETURNING sequence;"
 
                                 command.Parameters.Add("$created_at", SqliteType.Integer)
+                                |> ignore
+
+                                command.Parameters.Add("$repository_id", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$branch_id", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$workspace_root", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$watch_root", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$root_directory_version_id", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$root_directory_blake3_hash", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$watch_mode", SqliteType.Text)
                                 |> ignore
 
                                 command.Parameters.Add("$difference_type", SqliteType.Text)
@@ -1573,6 +1714,13 @@ module LocalStateDb =
 
                                 for observation in observationArray do
                                     command.Parameters["$created_at"].Value <- getCurrentInstant().ToUnixTimeTicks()
+                                    command.Parameters["$repository_id"].Value <- observation.Scope.RepositoryId.ToString()
+                                    command.Parameters["$branch_id"].Value <- observation.Scope.BranchId.ToString()
+                                    command.Parameters["$workspace_root"].Value <- observation.Scope.WorkspaceRoot
+                                    command.Parameters["$watch_root"].Value <- observation.Scope.WatchRoot
+                                    command.Parameters["$root_directory_version_id"].Value <- observation.Scope.RootDirectoryId.ToString()
+                                    command.Parameters["$root_directory_blake3_hash"].Value <- string observation.Scope.RootDirectoryBlake3Hash
+                                    command.Parameters["$watch_mode"].Value <- observation.Scope.WatchMode
                                     command.Parameters["$difference_type"].Value <- getDiscriminatedUnionCaseName observation.DifferenceType
                                     command.Parameters["$entry_type"].Value <- getDiscriminatedUnionCaseName observation.EntryType
                                     command.Parameters["$relative_path"].Value <- string observation.RelativePath
@@ -1590,6 +1738,342 @@ module LocalStateDb =
                         })
 
                 return sequences
+        }
+
+    /// Parses a durable journal difference type only when it matches the normalized Watch payload contract.
+    let private tryParseWatchJournalDifferenceType value =
+        match value with
+        | "Add" -> Some DifferenceType.Add
+        | "Change" -> Some DifferenceType.Change
+        | "Delete" -> Some DifferenceType.Delete
+        | _ -> None
+
+    /// Parses a durable journal entry type only when it matches the normalized Watch payload contract.
+    let private tryParseWatchJournalEntryType value =
+        match value with
+        | "Directory" -> Some FileSystemEntryType.Directory
+        | "File" -> Some FileSystemEntryType.File
+        | _ -> None
+
+    /// Normalizes filesystem roots stored in journal identity fields before comparing startup compatibility.
+    let private normalizeWatchJournalRoot value =
+        if String.IsNullOrWhiteSpace(value) then
+            String.Empty
+        else
+            Path
+                .GetFullPath(value)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+    /// Uses platform path rules when comparing workspace and watch roots from durable journal rows.
+    let private watchJournalRootEquals expected actual =
+        let comparison =
+            if OperatingSystem.IsWindows() then
+                StringComparison.OrdinalIgnoreCase
+            else
+                StringComparison.Ordinal
+
+        String.Equals(normalizeWatchJournalRoot expected, normalizeWatchJournalRoot actual, comparison)
+
+    /// Reads a nullable text column from a journal query without converting database null into a trusted value.
+    let private readNullableText (reader: SqliteDataReader) ordinal = if reader.IsDBNull(ordinal) then None else Some(reader.GetString(ordinal))
+
+    /// Builds a diagnostic row for a startup quarantine decision.
+    let private quarantinedJournalRowFromReader appliedThroughSequence (reader: SqliteDataReader) =
+        let sequence = reader.GetInt64(0)
+
+        {
+            Sequence = sequence
+            CreatedAtUnixTicks = reader.GetInt64(1)
+            State = Quarantined
+            DifferenceType = reader.GetString(9)
+            EntryType = reader.GetString(10)
+            RelativePath = Some(reader.GetString(11))
+            QuarantineReason = readNullableText reader 13
+        }
+
+    /// Explains why an unapplied row cannot be trusted for startup replay in the current repository scope.
+    let private tryFindWatchJournalReplayIncompatibility (scope: WatchJournalScope) row =
+        let (repositoryId, branchId, workspaceRoot, watchRoot, rootDirectoryId, rootDirectoryBlake3Hash, watchMode, differenceType, entryType, relativePath) =
+            row
+
+        let checks =
+            [|
+                match repositoryId with
+                | Some value when String.Equals(value, scope.RepositoryId.ToString(), StringComparison.OrdinalIgnoreCase) -> None
+                | Some _ -> Some "wrong repository"
+                | None -> Some "missing repository identity"
+
+                match branchId with
+                | Some value when String.Equals(value, scope.BranchId.ToString(), StringComparison.OrdinalIgnoreCase) -> None
+                | Some _ -> Some "wrong branch"
+                | None -> Some "missing branch identity"
+
+                match workspaceRoot with
+                | Some value when watchJournalRootEquals scope.WorkspaceRoot value -> None
+                | Some _ -> Some "wrong workspace root"
+                | None -> Some "missing workspace root"
+
+                match watchRoot with
+                | Some value when watchJournalRootEquals scope.WatchRoot value -> None
+                | Some _ -> Some "wrong watch root"
+                | None -> Some "missing watch root"
+
+                match rootDirectoryId with
+                | Some value when String.Equals(value, scope.RootDirectoryId.ToString(), StringComparison.OrdinalIgnoreCase) -> None
+                | Some _ -> Some "failed root continuity"
+                | None -> Some "missing root continuity"
+
+                match rootDirectoryBlake3Hash with
+                | Some value when String.Equals(value, string scope.RootDirectoryBlake3Hash, StringComparison.OrdinalIgnoreCase) -> None
+                | Some _ -> Some "failed root hash continuity"
+                | None -> Some "missing root hash continuity"
+
+                match watchMode with
+                | Some value when String.Equals(value, scope.WatchMode, StringComparison.Ordinal) -> None
+                | Some _ -> Some "wrong watch mode"
+                | None -> Some "missing watch mode"
+
+                if tryParseWatchJournalDifferenceType differenceType
+                   |> Option.isSome then
+                    None
+                else
+                    Some "invalid difference type"
+
+                if tryParseWatchJournalEntryType entryType
+                   |> Option.isSome then
+                    None
+                else
+                    Some "invalid entry type"
+
+                if
+                    String.IsNullOrWhiteSpace(relativePath)
+                    || Path.IsPathRooted(relativePath)
+                then
+                    Some "invalid relative path"
+                else
+                    None
+            |]
+
+        checks |> Array.tryPick id
+
+    /// Records one Watch lifecycle event as non-replayable diagnostics.
+    let recordWatchLifecycleEvent (dbPath: string) (event: WatchLifecycleEvent) =
+        task {
+            do! ensureDbInitialized dbPath
+
+            do!
+                executeWithRetry (fun () ->
+                    task {
+                        use connection = openConnection dbPath
+
+                        executeNonQueryWithParams
+                            connection
+                            "INSERT INTO watch_lifecycle_events (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, event_type, message, replayable) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $event_type, $message, 0);"
+                            (fun parameters ->
+                                parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
+                                |> ignore
+
+                                parameters.AddWithValue("$repository_id", event.Scope.RepositoryId.ToString())
+                                |> ignore
+
+                                parameters.AddWithValue("$branch_id", event.Scope.BranchId.ToString())
+                                |> ignore
+
+                                parameters.AddWithValue("$workspace_root", event.Scope.WorkspaceRoot)
+                                |> ignore
+
+                                parameters.AddWithValue("$watch_root", event.Scope.WatchRoot)
+                                |> ignore
+
+                                parameters.AddWithValue("$root_directory_version_id", event.Scope.RootDirectoryId.ToString())
+                                |> ignore
+
+                                parameters.AddWithValue("$root_directory_blake3_hash", string event.Scope.RootDirectoryBlake3Hash)
+                                |> ignore
+
+                                parameters.AddWithValue("$watch_mode", event.Scope.WatchMode)
+                                |> ignore
+
+                                parameters.AddWithValue("$event_type", event.EventType)
+                                |> ignore
+
+                                parameters.AddWithValue("$message", event.Message)
+                                |> ignore)
+                    })
+        }
+
+    /// Classifies unapplied startup journal rows after reconciliation and quarantines rows that cannot be replayed safely.
+    let recoverWatchJournalForStartup (dbPath: string) (scope: WatchJournalScope) =
+        task {
+            do! ensureDbInitialized dbPath
+            let normalizedPath = Path.GetFullPath(dbPath)
+            let mutable result = None
+
+            do!
+                executeWithRetry (fun () ->
+                    task {
+                        use connection = openConnection normalizedPath
+                        executeNonQuery connection "BEGIN IMMEDIATE;"
+                        let mutable committed = false
+
+                        try
+                            let appliedThroughSequence = readWatchJournalAppliedThroughSequenceInternal connection
+
+                            use command = connection.CreateCommand()
+
+                            command.CommandText <-
+                                "SELECT sequence, created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NULL ORDER BY sequence ASC;"
+
+                            command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
+                            |> ignore
+
+                            use reader = command.ExecuteReader()
+                            let compatibleRows = ResizeArray<WatchJournalPendingReplay>()
+                            let rowsToQuarantine = ResizeArray<int64 * string>()
+
+                            while reader.Read() do
+                                let differenceTypeValue = reader.GetString(9)
+                                let entryTypeValue = reader.GetString(10)
+                                let relativePath = reader.GetString(11)
+
+                                let rowIdentity =
+                                    (readNullableText reader 2,
+                                     readNullableText reader 3,
+                                     readNullableText reader 4,
+                                     readNullableText reader 5,
+                                     readNullableText reader 6,
+                                     readNullableText reader 7,
+                                     readNullableText reader 8,
+                                     differenceTypeValue,
+                                     entryTypeValue,
+                                     relativePath)
+
+                                try
+                                    match tryFindWatchJournalReplayIncompatibility scope rowIdentity with
+                                    | Some reason -> rowsToQuarantine.Add(reader.GetInt64(0), reason)
+                                    | None ->
+                                        compatibleRows.Add(
+                                            {
+                                                Sequence = reader.GetInt64(0)
+                                                DifferenceType =
+                                                    tryParseWatchJournalDifferenceType differenceTypeValue
+                                                    |> Option.get
+                                                EntryType =
+                                                    tryParseWatchJournalEntryType entryTypeValue
+                                                    |> Option.get
+                                                RelativePath = RelativePath relativePath
+                                            }
+                                        )
+                                with
+                                | :? InvalidOperationException as ex -> rowsToQuarantine.Add(reader.GetInt64(0), ex.Message)
+
+                            reader.Close()
+
+                            if rowsToQuarantine.Count > 0 then
+                                use quarantineCommand = connection.CreateCommand()
+
+                                quarantineCommand.CommandText <-
+                                    "UPDATE watch_journal SET quarantined_at_unix_ticks = $quarantined_at, quarantine_reason = $reason WHERE sequence = $sequence AND quarantined_at_unix_ticks IS NULL;"
+
+                                quarantineCommand.Parameters.Add("$quarantined_at", SqliteType.Integer)
+                                |> ignore
+
+                                quarantineCommand.Parameters.Add("$reason", SqliteType.Text)
+                                |> ignore
+
+                                quarantineCommand.Parameters.Add("$sequence", SqliteType.Integer)
+                                |> ignore
+
+                                for sequence, reason in rowsToQuarantine do
+                                    quarantineCommand.Parameters["$quarantined_at"].Value <- getCurrentInstant().ToUnixTimeTicks()
+                                    quarantineCommand.Parameters["$reason"].Value <- reason
+                                    quarantineCommand.Parameters["$sequence"].Value <- sequence
+                                    quarantineCommand.ExecuteNonQuery() |> ignore
+
+                                let mutable candidate = appliedThroughSequence + 1L
+                                let mutable targetSequence = appliedThroughSequence
+
+                                while isWatchJournalSequenceQuarantined connection candidate do
+                                    targetSequence <- candidate
+                                    candidate <- candidate + 1L
+
+                                if targetSequence > appliedThroughSequence then
+                                    setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{targetSequence}"
+
+                                executeNonQueryWithParams
+                                    connection
+                                    "INSERT INTO watch_lifecycle_events (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, event_type, message, replayable) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $event_type, $message, 0);"
+                                    (fun parameters ->
+                                        parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$repository_id", scope.RepositoryId.ToString())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$branch_id", scope.BranchId.ToString())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$workspace_root", scope.WorkspaceRoot)
+                                        |> ignore
+
+                                        parameters.AddWithValue("$watch_root", scope.WatchRoot)
+                                        |> ignore
+
+                                        parameters.AddWithValue("$root_directory_version_id", scope.RootDirectoryId.ToString())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$root_directory_blake3_hash", string scope.RootDirectoryBlake3Hash)
+                                        |> ignore
+
+                                        parameters.AddWithValue("$watch_mode", scope.WatchMode)
+                                        |> ignore
+
+                                        parameters.AddWithValue("$event_type", "startup-quarantine")
+                                        |> ignore
+
+                                        parameters.AddWithValue(
+                                            "$message",
+                                            $"Quarantined {rowsToQuarantine.Count} incompatible Watch journal rows before replay."
+                                        )
+                                        |> ignore)
+
+                            use quarantinedCommand = connection.CreateCommand()
+
+                            quarantinedCommand.CommandText <-
+                                "SELECT sequence, created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NOT NULL ORDER BY sequence ASC;"
+
+                            quarantinedCommand.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
+                            |> ignore
+
+                            use quarantinedReader = quarantinedCommand.ExecuteReader()
+                            let quarantinedRows = ResizeArray<WatchJournalRow>()
+
+                            while quarantinedReader.Read() do
+                                quarantinedRows.Add(quarantinedJournalRowFromReader appliedThroughSequence quarantinedReader)
+
+                            executeNonQuery connection "COMMIT;"
+                            committed <- true
+
+                            result <-
+                                Some
+                                    {
+                                        DbPath = normalizedPath
+                                        AppliedThroughSequence = appliedThroughSequence
+                                        CompatibleReplayRows = compatibleRows.ToArray()
+                                        QuarantinedRows = quarantinedRows.ToArray()
+                                    }
+                        finally
+                            if not committed then
+                                try
+                                    executeNonQuery connection "ROLLBACK;"
+                                with
+                                | _ -> ()
+                    })
+
+            return
+                match result with
+                | Some value -> value
+                | None -> failwith "Watch journal startup recovery did not produce a result."
         }
 
     /// Advances the Watch journal watermark only across applied sequences that are contiguous from the current boundary.
@@ -1618,7 +2102,8 @@ module LocalStateDb =
                                 let mutable candidate = currentSequence + 1L
                                 let mutable targetSequence = currentSequence
 
-                                while appliedSequenceSet.Contains(candidate) do
+                                while appliedSequenceSet.Contains(candidate)
+                                      || isWatchJournalSequenceQuarantined connection candidate do
                                     targetSequence <- candidate
                                     candidate <- candidate + 1L
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -686,15 +686,22 @@ module LocalStateDb =
                 | _ -> false)
         | None -> false
 
-    /// Reports whether SQLite stored the Watch journal table as an AUTOINCREMENT sequence table.
-    let private watchJournalUsesAutoincrement (connection: SqliteConnection) =
+    /// Reports whether SQLite stored a local-state table as an AUTOINCREMENT sequence table.
+    let private tableUsesAutoincrementSequence (connection: SqliteConnection) tableName =
         use command = connection.CreateCommand()
-        command.CommandText <- "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal' LIMIT 1;"
+        command.CommandText <- "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = $table_name LIMIT 1;"
+
+        command.Parameters.AddWithValue("$table_name", tableName)
+        |> ignore
+
         let value = command.ExecuteScalar()
 
         match value with
         | :? string as sql -> createSqlDeclaresSequenceAutoincrement sql
         | _ -> false
+
+    /// Reports whether SQLite stored the Watch journal table as an AUTOINCREMENT sequence table.
+    let private watchJournalUsesAutoincrement (connection: SqliteConnection) = tableUsesAutoincrementSequence connection "watch_journal"
 
     /// Adds one nullable Watch journal column when migrating v6 databases without deleting pending rows.
     let private addWatchJournalColumnIfMissing (connection: SqliteConnection) columnName columnDeclaration =
@@ -811,6 +818,94 @@ module LocalStateDb =
         && hasOptionalIntegerColumn "quarantined_at_unix_ticks"
         && hasOptionalTextColumn "quarantine_reason"
         && watchJournalUsesAutoincrement connection
+
+    /// Verifies that lifecycle diagnostics can be inserted without trusting a malformed existing table.
+    let private hasRequiredWatchLifecycleEventShape (connection: SqliteConnection) =
+        let columns = readTableColumnShapes connection "watch_lifecycle_events"
+
+        let expectedColumnNames =
+            [|
+                "sequence"
+                "created_at_unix_ticks"
+                "repository_id"
+                "branch_id"
+                "workspace_root"
+                "watch_root"
+                "root_directory_version_id"
+                "root_directory_blake3_hash"
+                "watch_mode"
+                "event_type"
+                "message"
+                "replayable"
+            |]
+
+        let tryFindColumn columnName =
+            columns
+            |> Array.tryFind (fun column -> StringComparer.OrdinalIgnoreCase.Equals(column.Name, columnName))
+
+        let hasExpectedColumnSet =
+            columns.Length = expectedColumnNames.Length
+            && expectedColumnNames
+               |> Array.forall (fun columnName -> tryFindColumn columnName |> Option.isSome)
+
+        let hasSequenceColumn =
+            match tryFindColumn "sequence" with
+            | Some column ->
+                isIntegerColumnType column.TypeName
+                && column.PrimaryKeyOrdinal = 1
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
+        let hasCreatedAtColumn =
+            match tryFindColumn "created_at_unix_ticks" with
+            | Some column ->
+                isIntegerColumnType column.TypeName
+                && column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
+        let hasOptionalTextColumn columnName =
+            match tryFindColumn columnName with
+            | Some column ->
+                isTextColumnType column.TypeName
+                && not column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
+        let hasRequiredTextColumn columnName =
+            match tryFindColumn columnName with
+            | Some column ->
+                isTextColumnType column.TypeName
+                && column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
+        let hasReplayableColumn =
+            match tryFindColumn "replayable" with
+            | Some column ->
+                isIntegerColumnType column.TypeName
+                && column.NotNull
+                && column.PrimaryKeyOrdinal = 0
+                && column.DefaultValueSql.IsNone
+            | None -> false
+
+        hasExpectedColumnSet
+        && hasSequenceColumn
+        && hasCreatedAtColumn
+        && hasOptionalTextColumn "repository_id"
+        && hasOptionalTextColumn "branch_id"
+        && hasOptionalTextColumn "workspace_root"
+        && hasOptionalTextColumn "watch_root"
+        && hasOptionalTextColumn "root_directory_version_id"
+        && hasOptionalTextColumn "root_directory_blake3_hash"
+        && hasOptionalTextColumn "watch_mode"
+        && hasRequiredTextColumn "event_type"
+        && hasRequiredTextColumn "message"
+        && hasReplayableColumn
+        && tableUsesAutoincrementSequence connection "watch_lifecycle_events"
 
     /// Reports whether the Watch journal contains rows that require trustworthy recovery metadata.
     let private hasWatchJournalRows (connection: SqliteConnection) =
@@ -1301,6 +1396,7 @@ module LocalStateDb =
         && tableExists connection "watch_journal"
         && tableExists connection "watch_lifecycle_events"
         && hasRequiredWatchJournalShape connection
+        && hasRequiredWatchLifecycleEventShape connection
         && hasValidWatchJournalAppliedThroughSequenceMeta connection
 
     /// Evaluates has empty writable status blake3 rows against parsed options and command state.
@@ -1760,23 +1856,67 @@ module LocalStateDb =
         | _ -> None
 
     /// Normalizes filesystem roots stored in journal identity fields before comparing startup compatibility.
-    let private normalizeWatchJournalRoot value =
-        if String.IsNullOrWhiteSpace(value) then
-            String.Empty
-        else
-            Path
-                .GetFullPath(value)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+    let private tryNormalizeWatchJournalRoot value =
+        try
+            if String.IsNullOrWhiteSpace(value) then
+                Ok String.Empty
+            else
+                Ok(
+                    Path
+                        .GetFullPath(value)
+                        .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                )
+        with
+        | ex -> Error ex.Message
 
     /// Uses platform path rules when comparing workspace and watch roots from durable journal rows.
-    let private watchJournalRootEquals expected actual =
+    let private tryWatchJournalRootEquals expected actual =
         let comparison =
             if OperatingSystem.IsWindows() then
                 StringComparison.OrdinalIgnoreCase
             else
                 StringComparison.Ordinal
 
-        String.Equals(normalizeWatchJournalRoot expected, normalizeWatchJournalRoot actual, comparison)
+        match tryNormalizeWatchJournalRoot expected, tryNormalizeWatchJournalRoot actual with
+        | Ok normalizedExpected, Ok normalizedActual -> Ok(String.Equals(normalizedExpected, normalizedActual, comparison))
+        | Error reason, _
+        | _, Error reason -> Error reason
+
+    /// Rejects persisted relative paths that would escape the current watch root during replay.
+    let private tryFindWatchJournalRelativePathIncompatibility watchRoot relativePath =
+        try
+            if String.IsNullOrWhiteSpace(relativePath) then
+                Some "invalid relative path"
+            elif Path.IsPathRooted(relativePath) then
+                Some "invalid relative path"
+            else
+                match tryNormalizeWatchJournalRoot watchRoot with
+                | Error _ -> Some "invalid watch root"
+                | Ok normalizedWatchRoot ->
+                    let candidatePath =
+                        Path
+                            .GetFullPath(Path.Combine(normalizedWatchRoot, relativePath))
+                            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+                    let comparison =
+                        if OperatingSystem.IsWindows() then
+                            StringComparison.OrdinalIgnoreCase
+                        else
+                            StringComparison.Ordinal
+
+                    let rootWithSeparator =
+                        normalizedWatchRoot
+                        + string Path.DirectorySeparatorChar
+
+                    if
+                        String.Equals(candidatePath, normalizedWatchRoot, comparison)
+                        || candidatePath.StartsWith(rootWithSeparator, comparison)
+                    then
+                        None
+                    else
+                        Some "relative path escapes watch root"
+        with
+        | _ -> Some "invalid relative path"
 
     /// Reads a nullable text column from a journal query without converting database null into a trusted value.
     let private readNullableText (reader: SqliteDataReader) ordinal = if reader.IsDBNull(ordinal) then None else Some(reader.GetString(ordinal))
@@ -1813,13 +1953,19 @@ module LocalStateDb =
                 | None -> Some "missing branch identity"
 
                 match workspaceRoot with
-                | Some value when watchJournalRootEquals scope.WorkspaceRoot value -> None
-                | Some _ -> Some "wrong workspace root"
+                | Some value ->
+                    match tryWatchJournalRootEquals scope.WorkspaceRoot value with
+                    | Ok true -> None
+                    | Ok false -> Some "wrong workspace root"
+                    | Error _ -> Some "invalid workspace root"
                 | None -> Some "missing workspace root"
 
                 match watchRoot with
-                | Some value when watchJournalRootEquals scope.WatchRoot value -> None
-                | Some _ -> Some "wrong watch root"
+                | Some value ->
+                    match tryWatchJournalRootEquals scope.WatchRoot value with
+                    | Ok true -> None
+                    | Ok false -> Some "wrong watch root"
+                    | Error _ -> Some "invalid watch root"
                 | None -> Some "missing watch root"
 
                 match rootDirectoryId with
@@ -1849,13 +1995,7 @@ module LocalStateDb =
                 else
                     Some "invalid entry type"
 
-                if
-                    String.IsNullOrWhiteSpace(relativePath)
-                    || Path.IsPathRooted(relativePath)
-                then
-                    Some "invalid relative path"
-                else
-                    None
+                tryFindWatchJournalRelativePathIncompatibility scope.WatchRoot relativePath
             |]
 
         checks |> Array.tryPick id

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1297,6 +1297,7 @@ module LocalStateDb =
             BranchId: BranchId
             WorkspaceRoot: string
             WatchRoot: string
+            PathComparison: StringComparison
             RootDirectoryId: DirectoryVersionId
             RootDirectoryBlake3Hash: Blake3Hash
             WatchMode: string
@@ -1896,21 +1897,15 @@ module LocalStateDb =
         with
         | ex -> Error ex.Message
 
-    /// Uses platform path rules when comparing workspace and watch roots from durable journal rows.
-    let private tryWatchJournalRootEquals expected actual =
-        let comparison =
-            if OperatingSystem.IsWindows() then
-                StringComparison.OrdinalIgnoreCase
-            else
-                StringComparison.Ordinal
-
+    /// Uses repository path rules when comparing workspace and watch roots from durable journal rows.
+    let private tryWatchJournalRootEquals comparison expected actual =
         match tryNormalizeWatchJournalRoot expected, tryNormalizeWatchJournalRoot actual with
         | Ok normalizedExpected, Ok normalizedActual -> Ok(String.Equals(normalizedExpected, normalizedActual, comparison))
         | Error reason, _
         | _, Error reason -> Error reason
 
-    /// Rejects persisted relative paths that would escape the current watch root during replay.
-    let private tryFindWatchJournalRelativePathIncompatibility watchRoot relativePath =
+    /// Rejects persisted relative paths that would escape the current watch root or use non-canonical replay spelling.
+    let private tryFindWatchJournalRelativePathIncompatibility watchRoot comparison relativePath =
         try
             if String.IsNullOrWhiteSpace(relativePath) then
                 Some "invalid relative path"
@@ -1925,12 +1920,6 @@ module LocalStateDb =
                             .GetFullPath(Path.Combine(normalizedWatchRoot, relativePath))
                             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
 
-                    let comparison =
-                        if OperatingSystem.IsWindows() then
-                            StringComparison.OrdinalIgnoreCase
-                        else
-                            StringComparison.Ordinal
-
                     let rootWithSeparator =
                         normalizedWatchRoot
                         + string Path.DirectorySeparatorChar
@@ -1938,7 +1927,21 @@ module LocalStateDb =
                     if String.Equals(candidatePath, normalizedWatchRoot, comparison) then
                         Some "watch root path cannot be replayed as a status difference"
                     elif candidatePath.StartsWith(rootWithSeparator, comparison) then
-                        None
+                        let canonicalRelativePath =
+                            Path
+                                .GetRelativePath(normalizedWatchRoot, candidatePath)
+                                .Replace(Path.DirectorySeparatorChar, '/')
+                                .Replace(Path.AltDirectorySeparatorChar, '/')
+
+                        let normalizedRelativePath =
+                            relativePath
+                                .Replace(Path.DirectorySeparatorChar, '/')
+                                .Replace(Path.AltDirectorySeparatorChar, '/')
+
+                        if String.Equals(normalizedRelativePath, canonicalRelativePath, StringComparison.Ordinal) then
+                            None
+                        else
+                            Some "relative path is not canonical"
                     else
                         Some "relative path escapes watch root"
         with
@@ -2011,7 +2014,7 @@ module LocalStateDb =
 
                 match workspaceRoot with
                 | Some value ->
-                    match tryWatchJournalRootEquals scope.WorkspaceRoot value with
+                    match tryWatchJournalRootEquals scope.PathComparison scope.WorkspaceRoot value with
                     | Ok true -> None
                     | Ok false -> Some "wrong workspace root"
                     | Error _ -> Some "invalid workspace root"
@@ -2019,7 +2022,7 @@ module LocalStateDb =
 
                 match watchRoot with
                 | Some value ->
-                    match tryWatchJournalRootEquals scope.WatchRoot value with
+                    match tryWatchJournalRootEquals scope.PathComparison scope.WatchRoot value with
                     | Ok true -> None
                     | Ok false -> Some "wrong watch root"
                     | Error _ -> Some "invalid watch root"
@@ -2052,9 +2055,9 @@ module LocalStateDb =
                 else
                     Some "invalid entry type"
 
-                tryFindWatchJournalRelativePathIncompatibility scope.WatchRoot relativePath
-
                 tryFindWatchJournalReplayShapeIncompatibility differenceType entryType relativePath
+
+                tryFindWatchJournalRelativePathIncompatibility scope.WatchRoot scope.PathComparison relativePath
             |]
 
         checks |> Array.tryPick id

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1918,6 +1918,37 @@ module LocalStateDb =
         with
         | _ -> Some "invalid relative path"
 
+    /// Checks whether a durable Watch replay path names the repository root instead of a child path.
+    let private isWatchJournalRootRelativePath (relativePath: string) =
+        let trimmedPath = relativePath.Trim()
+
+        String.Equals(trimmedPath, ".", StringComparison.Ordinal)
+
+    /// Checks whether a durable Watch replay path uses directory-target spelling that file rows cannot consume.
+    let private isWatchJournalDirectoryShapedRelativePath (relativePath: string) =
+        relativePath.EndsWith(string Path.DirectorySeparatorChar, StringComparison.Ordinal)
+        || relativePath.EndsWith(string Path.AltDirectorySeparatorChar, StringComparison.Ordinal)
+
+    /// Applies the Watch startup replay shape table that is independent of current filesystem state.
+    let private tryFindWatchJournalReplayShapeIncompatibility differenceType entryType (relativePath: string) =
+        match tryParseWatchJournalDifferenceType differenceType, tryParseWatchJournalEntryType entryType with
+        | Some differenceType, Some entryType ->
+            if isWatchJournalRootRelativePath relativePath then
+                Some "watch root path cannot be replayed as a status difference"
+            else
+                match entryType, differenceType with
+                | FileSystemEntryType.Directory, DifferenceType.Change -> Some "directory change rows are not emitted by Watch startup scan"
+                | FileSystemEntryType.File, _ when isWatchJournalDirectoryShapedRelativePath relativePath ->
+                    Some "file replay row targets a directory-shaped path"
+                | FileSystemEntryType.File,
+                  (DifferenceType.Add
+                  | DifferenceType.Change
+                  | DifferenceType.Delete)
+                | FileSystemEntryType.Directory,
+                  (DifferenceType.Add
+                  | DifferenceType.Delete) -> None
+        | _ -> None
+
     /// Reads a nullable text column from a journal query without converting database null into a trusted value.
     let private readNullableText (reader: SqliteDataReader) ordinal = if reader.IsDBNull(ordinal) then None else Some(reader.GetString(ordinal))
 
@@ -1996,6 +2027,8 @@ module LocalStateDb =
                     Some "invalid entry type"
 
                 tryFindWatchJournalRelativePathIncompatibility scope.WatchRoot relativePath
+
+                tryFindWatchJournalReplayShapeIncompatibility differenceType entryType relativePath
             |]
 
         checks |> Array.tryPick id

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -2220,6 +2220,80 @@ module LocalStateDb =
                 | None -> failwith "Watch journal startup recovery did not produce a result."
         }
 
+    /// Quarantines known-stale Watch journal rows and advances the startup replay boundary through contiguous terminal rows.
+    let quarantineWatchJournalSequences (dbPath: string) (sequences: IEnumerable<int64>) reason =
+        task {
+            let sequenceSet =
+                sequences
+                |> Seq.filter (fun sequence -> sequence > 0L)
+                |> HashSet<int64>
+
+            if sequenceSet.Count = 0 then
+                return 0L
+            else
+                do! ensureDbInitialized dbPath
+                let normalizedPath = Path.GetFullPath(dbPath)
+                let mutable advancedThrough = 0L
+
+                do!
+                    executeWithRetry (fun () ->
+                        task {
+                            use connection = openConnection normalizedPath
+                            executeNonQuery connection "BEGIN IMMEDIATE;"
+                            let mutable committed = false
+
+                            try
+                                let currentSequence = readWatchJournalAppliedThroughSequenceInternal connection
+                                let quarantineAt = getCurrentInstant().ToUnixTimeTicks()
+
+                                use quarantineCommand = connection.CreateCommand()
+
+                                quarantineCommand.CommandText <-
+                                    "UPDATE watch_journal SET quarantined_at_unix_ticks = $quarantined_at, quarantine_reason = $reason WHERE sequence = $sequence AND sequence > $applied_through AND quarantined_at_unix_ticks IS NULL;"
+
+                                quarantineCommand.Parameters.Add("$quarantined_at", SqliteType.Integer)
+                                |> ignore
+
+                                quarantineCommand.Parameters.Add("$reason", SqliteType.Text)
+                                |> ignore
+
+                                quarantineCommand.Parameters.Add("$sequence", SqliteType.Integer)
+                                |> ignore
+
+                                quarantineCommand.Parameters.Add("$applied_through", SqliteType.Integer)
+                                |> ignore
+
+                                for sequence in sequenceSet do
+                                    quarantineCommand.Parameters["$quarantined_at"].Value <- quarantineAt
+                                    quarantineCommand.Parameters["$reason"].Value <- reason
+                                    quarantineCommand.Parameters["$sequence"].Value <- sequence
+                                    quarantineCommand.Parameters["$applied_through"].Value <- currentSequence
+                                    quarantineCommand.ExecuteNonQuery() |> ignore
+
+                                let mutable candidate = currentSequence + 1L
+                                let mutable targetSequence = currentSequence
+
+                                while isWatchJournalSequenceQuarantined connection candidate do
+                                    targetSequence <- candidate
+                                    candidate <- candidate + 1L
+
+                                if targetSequence > currentSequence then
+                                    setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{targetSequence}"
+
+                                executeNonQuery connection "COMMIT;"
+                                committed <- true
+                                advancedThrough <- targetSequence
+                            finally
+                                if not committed then
+                                    try
+                                        executeNonQuery connection "ROLLBACK;"
+                                    with
+                                    | _ -> ()
+                        })
+
+                return advancedThrough
+        }
+
     /// Advances the Watch journal watermark only across applied sequences that are contiguous from the current boundary.
     let advanceWatchJournalAppliedThroughContiguousSequences (dbPath: string) (appliedSequences: IEnumerable<int64>) =
         task {


### PR DESCRIPTION
## Summary

Implements WS4.4 startup replay, quarantine, and lifecycle diagnostics for the durable Watch journal:

- Adds local-state schema v7 with scoped Watch journal identity, quarantine metadata, and non-replayable lifecycle
  diagnostics.
- Reconciles on Watch startup before recovering pending journal rows.
- Replays compatible pending rows after reconciliation using their original journal sequence.
- Quarantines incompatible pending rows before healthy incremental mode.
- Exposes quarantine reason additively through maintenance journal output and command-output contract metadata.
- Updates Doctor schema health expectations for local-state schema v7.

Related to #500.
Part of #473.

## Why This Matters

Grace Watch needs startup recovery that can trust durable local observations without replaying stale or cross-scope data.
This slice makes pending journal recovery explicit: compatible rows can resume safely after reconciliation, incompatible
rows are quarantined with diagnostics, and lifecycle events stay diagnostic instead of becoming replayable correctness
records.

## Validation

- Targeted Fantomas on touched F# files: passed.
- Focused Release build passed:

  ```powershell
  dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj
  ```

- Focused Doctor tests passed, 86/86.
- Focused Watch/LocalStateDb/Maintenance tests passed, 327/327:

  ```powershell
  dotnet test --no-build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~LocalStateDbTests|FullyQualifiedName~WatchTests|FullyQualifiedName~Maintenance"
  ```

- `git diff --check`: passed.
- Final gate passed:

  ```powershell
  pwsh ./scripts/validate.ps1 -Fast
  ```

  Fast-profile evidence included `Grace.Authorization.Tests` 53/53, `Grace.Types.Tests` 133/133,
  `Grace.Server.Unit.Tests` 723/723, and `Grace.CLI.Tests` 934/934.

## Acceptance Mapping

- Startup reconciliation before replay: Watch startup runs reconciliation before pending journal recovery.
- Compatible pending rows replay after reconciliation: startup recovery queues compatible rows with their original
  journal sequences.
- Incompatible rows quarantine: LocalStateDb classifies wrong repository, branch, workspace root, watch root, root
  continuity, root hash continuity, watch mode, parseable event shape, and rooted or blank relative paths.
- Lifecycle diagnostics are non-replayable: `watch_lifecycle_events` records diagnostics with `replayable = 0` and does
  not add replayable `watch_journal` rows.
- #499 convergence contract preserved: replay consumes existing pending rows rather than compensating for stale pending
  rows, schema-shape gaps, or append/apply failures.
- Maintenance output compatibility: `QuarantineReason` is additive in maintenance output and command-output metadata.
- Doctor compatibility: Doctor now expects and validates current local-state schema v7.

## Path Expansion

- `src/Grace.CLI/Command/Common.CLI.fs`: DTO-host expansion for additive `QuarantineReason`.
- `src/Grace.CLI/Command/Doctor.CLI.fs`: Doctor owns the expected local-state schema-version contract and needed v7.
- `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`: test expansion for schema v7 and Doctor validation coverage.

## Docs Impact

No ADR or narrative docs were added. Waiver: this is internal startup recovery behavior exposed through existing
maintenance surfaces; the user-visible command-output contract registry was updated and covered by tests.

## Residual Risks

Startup replay has deterministic CLI/local-state unit coverage rather than an end-to-end live filesystem watcher session.
The final fast gate is clean.

## Review Status

- Current head: `53dcedc367ab5a06dd3913d4b309a63f03b2354e`.
- Codex review sessions 1 through 8 completed on earlier heads; all findings from those sessions were fixed, replied
  to, and resolved.
- Codex review session 9 completed on `4c80d0f26f79a851e50f519fdaada4edcaa5ff48` with 1 fresh finding; it was fixed in
  `42d84af11b2c91380625c867b55cae3519d77fbf`, replied to, and resolved.
- Session 9 finding `3524622494`: confidence-loss quarantine now gives replayed durable journal sequences a terminal
  durable outcome, not only clearing in-memory replay keys and pending differences. Reply `3524641411`.
- Codex review session 10 completed on `42d84af11b2c91380625c867b55cae3519d77fbf` with 3 fresh findings; all three were
  fixed in `53dcedc367ab5a06dd3913d4b309a63f03b2354e`, replied to, and resolved.
- Session 10 finding `3524657732`: same-content upload cleanup now gives superseded replay rows a durable terminal
  outcome so the original `watch_journal` row cannot replay again or block applied-through advancement. Reply
  `3524681712`.
- Session 10 finding `3524657734`: non-text replay payload fields now quarantine the row instead of aborting startup
  recovery before the per-row quarantine path can run. Reply `3524681743`.
- Session 10 finding `3524657735`: orphan replayed nested directory adds now quarantine before status construction
  assumes the parent directory exists. Reply `3524681775`.
- Session-10 stabilization addendum posted to
  [PR #546](https://github.com/ScottArbeit/Grace/pull/546#issuecomment-4885610220) and
  [issue #500](https://github.com/ScottArbeit/Grace/issues/500#issuecomment-4885610263).
- Previous stabilization ledger/addenda are posted to PR #546 and issue #500 for sessions 3 through 9.
- Validation for `53dcedc367ab5a06dd3913d4b309a63f03b2354e`: targeted Fantomas passed; focused `Grace.CLI.Tests`
  WatchTests passed 245/245; `pwsh ./scripts/validate.ps1 -Fast` passed, including `Grace.CLI.Tests` 962/962;
  `git diff --check` passed; `git diff --cached --check` passed.
- Base update: this branch merged current `origin/epic/473-grace-watch-incremental-sync` at
  `3da88d086016089493b6358977d48c043c412f47` before final validation and push, preserving the merged #502 / PR #547
  WS7.1 changes.
- GitHub `full` passed for `53dcedc367ab5a06dd3913d4b309a63f03b2354e`.
- Codex Code Review Bot reported no issues for `53dcedc367ab5a06dd3913d4b309a63f03b2354e` with a 👍 reaction, and no
  unresolved bot review threads remain.
- Prevention: durable replay terminal outcomes, row-scoped malformed payload quarantine, and replay parent-continuity
  validation are now explicit stabilization invariants with focused proof coverage.
- Review sessions: 11 completed on this PR including the final no-issues latest-head pass; substantive cycle count is 9.
- Current gate: satisfied for merge into `epic/473-grace-watch-incremental-sync`.
