### PR TITLE
WS7.1: Add current-branch SignalR reference contract

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -9,6 +9,7 @@ open Grace.Shared.Parameters.Storage
 open Grace.Shared.Utilities
 open Grace.Types.Automation
 open Grace.Types.Common
+open Grace.Types.Reference
 open NodaTime
 open NUnit.Framework
 open Spectre.Console
@@ -11215,6 +11216,30 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> Option.isSome
             |> should equal true)
+
+    /// Verifies that current-branch SignalR payloads must match the current repository and branch identity.
+    [<Test>]
+    let WatchCurrentBranchSignalRPayloadRejectsStaleRepositoryOrBranchIdentity () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    BranchName = BranchName "current-branch"
+                    ReferenceId = Guid.NewGuid()
+                    ReferenceType = ReferenceType.Save
+                }
+
+            Watch.currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests payload
+            |> should equal true
+
+            Watch.currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests { payload with RepositoryId = Guid.NewGuid() }
+            |> should equal false
+
+            Watch.currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests { payload with BranchId = Guid.NewGuid() }
+            |> should equal false)
 
     /// Verifies that stale non-empty ids cannot be rescued by matching display names.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -10,6 +10,7 @@ open Grace.Shared.Utilities
 open Grace.Types.Automation
 open Grace.Types.Common
 open Grace.Types.Reference
+open Microsoft.AspNetCore.SignalR
 open NodaTime
 open NUnit.Framework
 open Spectre.Console
@@ -1006,6 +1007,46 @@ module WatchTests =
                 |> should equal true
             finally
                 Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
+    /// Verifies that reconnect refresh invokes registration and clears local trust when registration fails.
+    [<Test>]
+    let ``signalr reconnect refresh reruns current branch registration and fails closed`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let parentId = Guid.NewGuid()
+
+            writeRepositoryConfiguration root repositoryId "reconnect-refresh-repo" branchId "feature/reconnect"
+            resetConfiguration ()
+            Current() |> ignore
+
+            Watch.setSignalRBranchSubscriptionForWatchTests branchId parentId
+
+            let mutable refreshCalls = 0
+
+            let refreshed =
+                Watch.refreshSignalRSubscriptionsForActiveConnectionForWatchTests (fun () ->
+                    task {
+                        refreshCalls <- refreshCalls + 1
+                        let _ = Watch.beginSignalRBranchSubscriptionRefreshForWatchTests ()
+                        return Error(GraceError.Create "test registration failed" "signalr-reconnect-test")
+                    })
+
+            refreshed |> should equal false
+            refreshCalls |> should equal 1
+
+            Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentId
+            |> should equal false)
+
+    /// Verifies that Watch uses Grace JSON options for typed SignalR payloads.
+    [<Test>]
+    let ``signalr json protocol uses grace serializer options`` () =
+        let options = JsonHubProtocolOptions()
+
+        Watch.configureGraceSignalRJsonProtocolForWatchTests options
+
+        obj.ReferenceEquals(options.PayloadSerializerOptions, Constants.JsonSerializerOptions)
+        |> should equal true
 
     /// Verifies that ordinary scan-derived resync recovery does not depend on transition SignalR refresh success.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
 open Grace.Shared.Client.Configuration
+open Grace.Shared.Parameters.Branch
 open Grace.Shared.Parameters.Storage
 open Grace.Shared.Utilities
 open Grace.Types.Automation
@@ -992,6 +993,83 @@ module WatchTests =
 
                 Watch.trySetSignalRBranchSubscriptionForWatchTests staleRefreshAuthority parentAId
                 |> should equal false
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+                subscription.BranchId |> should equal branchBId
+
+                subscription.ParentBranchId
+                |> should equal parentBId
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentAId
+                |> should equal false
+
+                Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentBId
+                |> should equal true
+            finally
+                Watch.resetSignalRSubscriptionRefreshForWatchTests ())
+
+    /// Verifies that stale reconnect refreshes cannot replace the hub's active current-branch group.
+    [<Test>]
+    let ``stale signalr refresh does not invoke current branch hub registration`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchAId = Guid.NewGuid()
+            let branchBId = Guid.NewGuid()
+            let parentAId = Guid.NewGuid()
+            let parentBId = Guid.NewGuid()
+            let repositoryName = "transition-signalr-hub-authority-repo"
+
+            try
+                writeRepositoryConfiguration root repositoryId repositoryName branchAId "branch-a"
+                resetConfiguration ()
+                Current() |> ignore
+
+                let parentBranchDto =
+                    { Grace.Types.Branch.BranchDto.Default with RepositoryId = repositoryId; BranchId = parentAId; BranchName = BranchName "parent-a" }
+
+                /// Advances local branch identity while an old-branch SignalR refresh is awaiting parent metadata.
+                let getParentBranch (_: GetBranchParameters) =
+                    writeRepositoryConfiguration root repositoryId repositoryName branchBId "branch-b"
+                    resetConfiguration ()
+                    Current() |> ignore
+
+                    Watch.clearSignalRBranchSubscriptionForTransitionForWatchTests ()
+                    Watch.setSignalRBranchSubscriptionForWatchTests branchBId parentBId
+
+                    Task.FromResult(Ok(GraceReturnValue.Create parentBranchDto "stale-refresh-test"))
+
+                let currentRegistrations = ResizeArray<RepositoryId * BranchId>()
+                let parentRegistrations = ResizeArray<BranchId * BranchId>()
+
+                /// Records current-branch group registrations only when the refresh has local authority.
+                let registerCurrentBranch repositoryId branchId _ =
+                    currentRegistrations.Add(repositoryId, branchId)
+                    Task.CompletedTask
+
+                /// Records parent-branch group registrations only when the refresh has local authority.
+                let registerParentBranch branchId parentBranchId _ =
+                    parentRegistrations.Add(branchId, parentBranchId)
+                    Task.CompletedTask
+
+                let result =
+                    (Watch.registerCurrentSignalRParentBranchWithClientsForWatchTests
+                        getParentBranch
+                        registerCurrentBranch
+                        registerParentBranch
+                        CancellationToken.None)
+                        .GetAwaiter()
+                        .GetResult()
+
+                match result with
+                | Ok _ -> ()
+                | Error error -> Assert.Fail($"Expected stale refresh to return the parent lookup result without hub side effects: {error}")
+
+                currentRegistrations.ToArray()
+                |> should equal Array.empty<RepositoryId * BranchId>
+
+                parentRegistrations.ToArray()
+                |> should equal Array.empty<BranchId * BranchId>
 
                 let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -9,6 +9,7 @@ open Grace.Shared.Client.Configuration
 open Grace.Shared.Parameters.Branch
 open Grace.Shared.Services
 open Grace.Types.Common
+open Grace.Types.Reference
 open Grace.Shared.Utilities
 open Microsoft.AspNetCore.Http.Connections
 open Microsoft.AspNetCore.SignalR.Client
@@ -2814,12 +2815,37 @@ module Watch =
     let internal handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch envelope =
         handleSignalRAutomationEvent readStatus rebaseCurrentBranch envelope
 
+    /// Reports whether a same-branch Reference notification still matches the repository identity Watch has loaded.
+    let private currentBranchReferenceNotificationTargetsCurrentBranch (payload: CurrentBranchReferenceNotification) =
+        let current = Current()
+
+        payload.RepositoryId = current.RepositoryId
+        && payload.BranchId = current.BranchId
+
+    /// Handles same-branch Reference notifications that later WS7 slices can use for remote materialization.
+    let private handleCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
+        task {
+            try
+                if not
+                   <| currentBranchReferenceNotificationTargetsCurrentBranch payload then
+                    logToAnsiConsole
+                        Colors.Verbose
+                        $"Skipped current-branch reference notification {payload.ReferenceId} because it targets repository {payload.RepositoryId}, branch {payload.BranchId}, not current branch {Current().BranchId}."
+            with
+            | ex -> logToAnsiConsole Colors.Error $"Failed to process current-branch reference notification {payload.ReferenceId}: {Markup.Escape(ex.Message)}."
+        }
+
+    /// Exposes same-branch Reference notification identity matching to Watch tests without opening a HubConnection.
+    let internal currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests payload = currentBranchReferenceNotificationTargetsCurrentBranch payload
+
     /// Registers the current repository branch with its parent-branch SignalR group and refreshes local event trust.
     let private registerCurrentSignalRParentBranch (signalRConnection: HubConnection) cancellationToken =
         task {
             let refreshAuthority = beginSignalRBranchSubscriptionRefresh ()
 
             let current = Current()
+
+            do! signalRConnection.InvokeAsync("RegisterCurrentBranch", current.RepositoryId, refreshAuthority.BranchId, cancellationToken)
 
             let branchGetParameters =
                 GetBranchParameters(
@@ -4267,6 +4293,12 @@ module Watch =
                                         })
                                     envelope)
                                 :> Task
+                        )
+
+                    use notifyCurrentBranchReference =
+                        signalRConnection.On<CurrentBranchReferenceNotification>(
+                            "NotifyCurrentBranchReference",
+                            fun payload -> (handleCurrentBranchReferenceNotification payload) :> Task
                         )
 
                     use notifyOnSave =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -12,6 +12,7 @@ open Grace.Types.Common
 open Grace.Types.Reference
 open Grace.Shared.Utilities
 open Microsoft.AspNetCore.Http.Connections
+open Microsoft.AspNetCore.SignalR
 open Microsoft.AspNetCore.SignalR.Client
 open NodaTime
 open Spectre.Console
@@ -41,6 +42,7 @@ open System.Text
 open Grace.Shared.Parameters.Storage
 open Grace.CLI.Text
 open Grace.Types.Automation
+open Microsoft.Extensions.DependencyInjection
 
 /// Groups the watch command parser, handlers, and output helpers.
 module Watch =
@@ -724,6 +726,28 @@ module Watch =
     let private refreshSignalRSubscriptionsAfterTransitionCompletion () =
         let refresh = lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion)
         refresh ()
+
+    /// Refreshes SignalR branch groups after reconnect or branch transition recovery.
+    let private refreshSignalRSubscriptionsForActiveConnection (refresh: unit -> Task<Result<Grace.Types.Branch.BranchDto, GraceError>>) =
+        try
+            match refresh().GetAwaiter().GetResult() with
+            | Ok _ -> true
+            | Error error ->
+                completeSignalRBranchSubscriptionRefreshWithoutTrust ()
+                logToAnsiConsole Colors.Error $"Failed to refresh SignalR parent branch subscription: {Markup.Escape(error.ToString())}"
+                false
+        with
+        | ex ->
+            completeSignalRBranchSubscriptionRefreshWithoutTrust ()
+
+            logToAnsiConsole
+                Colors.Error
+                $"Failed to refresh SignalR parent branch subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}."
+
+            false
+
+    /// Exposes SignalR reconnect refresh behavior to Watch tests without opening a HubConnection.
+    let internal refreshSignalRSubscriptionsForActiveConnectionForWatchTests refresh = refreshSignalRSubscriptionsForActiveConnection refresh
 
     /// Installs the SignalR parent-branch refresh operation used by transition-completion tests.
     let internal setSignalRSubscriptionRefreshForWatchTests refresh =
@@ -2722,6 +2746,12 @@ module Watch =
         Error(GraceError.Create message (getCorrelationId parseResult))
         |> renderOutput parseResult
 
+    /// Applies Grace's F#-aware JSON serializer options to the SignalR protocol used by Watch.
+    let private configureGraceSignalRJsonProtocol (options: JsonHubProtocolOptions) = options.PayloadSerializerOptions <- Constants.JsonSerializerOptions
+
+    /// Exposes SignalR JSON protocol configuration to Watch tests without opening a connection.
+    let internal configureGraceSignalRJsonProtocolForWatchTests options = configureGraceSignalRJsonProtocol options
+
     /// Opens the SignalR connection Grace Watch uses to receive server-side notifications.
     let private createSignalRConnection (signalRUrl: Uri) =
         HubConnectionBuilder()
@@ -2741,6 +2771,7 @@ module Watch =
                                 | Error message -> return raise (InvalidOperationException(message))
                             })
             )
+            .AddJsonProtocol(configureGraceSignalRJsonProtocol)
             .Build()
 
     /// Reads a GUID-valued property from a SignalR automation event payload without throwing on unsupported input.
@@ -4250,22 +4281,8 @@ module Watch =
 
                     use refreshSignalRSubscriptions =
                         registerSignalRSubscriptionRefresh (fun () ->
-                            try
-                                match (registerCurrentSignalRParentBranch signalRConnection cancellationToken)
-                                    .GetAwaiter()
-                                    .GetResult()
-                                    with
-                                | Ok _ -> ()
-                                | Error error ->
-                                    completeSignalRBranchSubscriptionRefreshWithoutTrust ()
-                                    logToAnsiConsole Colors.Error $"Failed to refresh SignalR parent branch subscription: {Markup.Escape(error.ToString())}"
-                            with
-                            | ex ->
-                                completeSignalRBranchSubscriptionRefreshWithoutTrust ()
-
-                                logToAnsiConsole
-                                    Colors.Error
-                                    $"Failed to refresh SignalR parent branch subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}.")
+                            refreshSignalRSubscriptionsForActiveConnection (fun () -> registerCurrentSignalRParentBranch signalRConnection cancellationToken)
+                            |> ignore)
 
                     use notifyRepository =
                         signalRConnection.On<RepositoryId, ReferenceId>(
@@ -4342,7 +4359,12 @@ module Watch =
                     signalRConnection.add_Reconnecting (fun ex -> task { logToAnsiConsole Colors.Important $"SignalR connection reconnecting: {ex.Message}." })
 
                     signalRConnection.add_Reconnected (fun connectionId ->
-                        task { logToAnsiConsole Colors.Important $"SignalR connection reconnected: {connectionId}." })
+                        task {
+                            logToAnsiConsole Colors.Important $"SignalR connection reconnected: {connectionId}."
+
+                            refreshSignalRSubscriptionsForActiveConnection (fun () -> registerCurrentSignalRParentBranch signalRConnection cancellationToken)
+                            |> ignore
+                        })
 
                     do! signalRConnection.StartAsync(cancellationToken)
                     // Repository-wide notifications are keyed only by RepositoryId, so same-process branch switches do not change this group.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -616,6 +616,7 @@ module Watch =
     let mutable private signalRBranchSubscription = emptySignalRBranchSubscription 0L
     let mutable private signalRBranchSubscriptionRefreshNeededAfterTransition = false
     let private signalRSubscriptionRefreshLock = obj ()
+    let private signalRBranchSubscriptionRefreshSemaphore = new SemaphoreSlim(1, 1)
     let mutable private refreshSignalRBranchSubscriptionsForTransitionCompletion = ignore
 
     /// Clears branch-scoped SignalR trust while preserving whether transition recovery still owes a refresh attempt.
@@ -2869,45 +2870,83 @@ module Watch =
     /// Exposes same-branch Reference notification identity matching to Watch tests without opening a HubConnection.
     let internal currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests payload = currentBranchReferenceNotificationTargetsCurrentBranch payload
 
+    /// Registers SignalR branch groups only after the local refresh still has authority for the active branch.
+    let private registerCurrentSignalRParentBranchWithClients
+        connectionState
+        connectionId
+        (getParentBranch: GetBranchParameters -> Task<Result<GraceReturnValue<Grace.Types.Branch.BranchDto>, GraceError>>)
+        (registerCurrentBranch: RepositoryId -> BranchId -> CancellationToken -> Task)
+        (registerParentBranch: BranchId -> BranchId -> CancellationToken -> Task)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            do! signalRBranchSubscriptionRefreshSemaphore.WaitAsync(cancellationToken)
+
+            try
+                let refreshAuthority = beginSignalRBranchSubscriptionRefresh ()
+
+                let current = Current()
+
+                let branchGetParameters =
+                    GetBranchParameters(
+                        OwnerId = $"{current.OwnerId}",
+                        OrganizationId = $"{current.OrganizationId}",
+                        RepositoryId = $"{current.RepositoryId}",
+                        BranchId = $"{current.BranchId}"
+                    )
+
+                match! getParentBranch branchGetParameters with
+                | Ok returnValue ->
+                    let parentBranchDto = returnValue.ReturnValue
+
+                    if trySetSignalRBranchSubscription refreshAuthority parentBranchDto.BranchId then
+                        try
+                            do! registerCurrentBranch current.RepositoryId refreshAuthority.BranchId cancellationToken
+                            do! registerParentBranch refreshAuthority.BranchId parentBranchDto.BranchId cancellationToken
+
+                            logToAnsiConsole
+                                Colors.Highlighted
+                                $"SignalR Hub connection state: {connectionState ()}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {connectionId ()}."
+                        with
+                        | ex ->
+                            clearSignalRBranchSubscription ()
+                            raise ex
+
+                        return Ok parentBranchDto
+                    else
+                        logToAnsiConsole
+                            Colors.Important
+                            $"Grace Watch ignored stale SignalR parent subscription refresh for branch {refreshAuthority.BranchId}; current branch identity changed before registration completed."
+
+                        return Ok parentBranchDto
+                | Error error ->
+                    completeSignalRBranchSubscriptionRefreshWithoutTrust ()
+                    return Error error
+            finally
+                signalRBranchSubscriptionRefreshSemaphore.Release()
+                |> ignore
+        }
+
+    /// Exposes SignalR branch registration ordering to Watch tests without opening a HubConnection.
+    let internal registerCurrentSignalRParentBranchWithClientsForWatchTests getParentBranch registerCurrentBranch registerParentBranch cancellationToken =
+        registerCurrentSignalRParentBranchWithClients
+            (fun () -> "Test")
+            (fun () -> "test-connection")
+            getParentBranch
+            registerCurrentBranch
+            registerParentBranch
+            cancellationToken
+
     /// Registers the current repository branch with its parent-branch SignalR group and refreshes local event trust.
     let private registerCurrentSignalRParentBranch (signalRConnection: HubConnection) cancellationToken =
-        task {
-            let refreshAuthority = beginSignalRBranchSubscriptionRefresh ()
-
-            let current = Current()
-
-            do! signalRConnection.InvokeAsync("RegisterCurrentBranch", current.RepositoryId, refreshAuthority.BranchId, cancellationToken)
-
-            let branchGetParameters =
-                GetBranchParameters(
-                    OwnerId = $"{current.OwnerId}",
-                    OrganizationId = $"{current.OrganizationId}",
-                    RepositoryId = $"{current.RepositoryId}",
-                    BranchId = $"{current.BranchId}"
-                )
-
-            match! Branch.GetParentBranch branchGetParameters with
-            | Ok returnValue ->
-                let parentBranchDto = returnValue.ReturnValue
-
-                do! signalRConnection.InvokeAsync("RegisterParentBranch", refreshAuthority.BranchId, parentBranchDto.BranchId, cancellationToken)
-
-                if trySetSignalRBranchSubscription refreshAuthority parentBranchDto.BranchId then
-                    logToAnsiConsole
-                        Colors.Highlighted
-                        $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {signalRConnection.ConnectionId}."
-
-                    return Ok parentBranchDto
-                else
-                    logToAnsiConsole
-                        Colors.Important
-                        $"Grace Watch ignored stale SignalR parent subscription refresh for branch {refreshAuthority.BranchId}; current branch identity changed before registration completed."
-
-                    return Ok parentBranchDto
-            | Error error ->
-                completeSignalRBranchSubscriptionRefreshWithoutTrust ()
-                return Error error
-        }
+        registerCurrentSignalRParentBranchWithClients
+            (fun () -> $"{signalRConnection.State}")
+            (fun () -> $"{signalRConnection.ConnectionId}")
+            Branch.GetParentBranch
+            (fun repositoryId branchId cancellationToken -> signalRConnection.InvokeAsync("RegisterCurrentBranch", repositoryId, branchId, cancellationToken))
+            (fun branchId parentBranchId cancellationToken ->
+                signalRConnection.InvokeAsync("RegisterParentBranch", branchId, parentBranchId, cancellationToken))
+            cancellationToken
 
     /// Evaluates is grace status artifact against parsed options and command state.
     let private isGraceStatusArtifact (fullPath: string) =

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -2,7 +2,9 @@ namespace Grace.Server.Tests
 
 open Grace.Server.Notification
 open Grace.Types.Common
+open Grace.Types.Reference
 open NUnit.Framework
+open System
 
 /// Covers notification Server behavior in no-Aspire server unit tests.
 [<Parallelizable(ParallelScope.All)>]
@@ -19,3 +21,103 @@ type NotificationServerTests() =
     member _.BranchNameGlobMatchingIsCaseInsensitiveAndSupportsWildcard(branchName: string, glob: string, expected: bool) =
         let actual = Subscriber.matchesBranchGlob (BranchName branchName) glob
         Assert.That(actual, Is.EqualTo(expected))
+
+    /// Verifies that current branch SignalR group keys cannot collide with legacy raw GUID groups.
+    [<Test>]
+    member _.CurrentBranchGroupKeyIsDistinctFromRepositoryAndParentBranchGroups() =
+        let repositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+        let branchId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+        let groupKey = currentBranchGroupKey repositoryId branchId
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(groupKey, Is.EqualTo("current-branch:11111111111111111111111111111111:22222222222222222222222222222222"))
+                Assert.That(groupKey, Is.Not.EqualTo($"{repositoryId}"))
+                Assert.That(groupKey, Is.Not.EqualTo($"{branchId}")))
+        )
+
+    /// Verifies that current-branch Reference notifications are restricted to materializable branch history events.
+    [<Test>]
+    member _.CurrentBranchReferenceEligibilityExcludesPromotionTagExternalAndRebase() =
+        let eligible =
+            [|
+                ReferenceType.Commit
+                ReferenceType.Checkpoint
+                ReferenceType.Save
+            |]
+
+        let ineligible =
+            [|
+                ReferenceType.Promotion
+                ReferenceType.Tag
+                ReferenceType.External
+                ReferenceType.Rebase
+            |]
+
+        Assert.Multiple(
+            Action (fun () ->
+                for referenceType in eligible do
+                    Assert.That(Subscriber.shouldNotifyCurrentBranchReference referenceType, Is.True, $"Expected {referenceType} current-branch emission.")
+
+                for referenceType in ineligible do
+                    Assert.That(
+                        Subscriber.shouldNotifyCurrentBranchReference referenceType,
+                        Is.False,
+                        $"Did not expect {referenceType} current-branch emission."
+                    ))
+        )
+
+    /// Verifies that the current-branch payload preserves the lookup identity clients need after server recomputation.
+    [<Test>]
+    member _.CurrentBranchReferencePayloadCarriesBranchAndReferenceLookupIdentity() =
+        let referenceId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+        let ownerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+        let organizationId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+        let repositoryId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+        let branchId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+        let directoryId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+
+        let payload =
+            Subscriber.createCurrentBranchReferenceNotification
+                referenceId
+                ownerId
+                organizationId
+                repositoryId
+                branchId
+                (BranchName "feature/watch")
+                directoryId
+                (Sha256Hash "sha")
+                (Blake3Hash "blake3")
+                ReferenceType.Checkpoint
+                (ReferenceText "checkpoint")
+                "corr-current"
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(payload.ReferenceId, Is.EqualTo(referenceId))
+                Assert.That(payload.OwnerId, Is.EqualTo(ownerId))
+                Assert.That(payload.OrganizationId, Is.EqualTo(organizationId))
+                Assert.That(payload.RepositoryId, Is.EqualTo(repositoryId))
+                Assert.That(payload.BranchId, Is.EqualTo(branchId))
+                Assert.That(payload.BranchName, Is.EqualTo(BranchName "feature/watch"))
+                Assert.That(payload.DirectoryId, Is.EqualTo(directoryId))
+                Assert.That(payload.ReferenceType, Is.EqualTo(ReferenceType.Checkpoint))
+                Assert.That(payload.ReferenceText, Is.EqualTo(ReferenceText "checkpoint"))
+                Assert.That(payload.CorrelationId, Is.EqualTo("corr-current")))
+        )
+
+    /// Verifies that the additive current-branch contract does not remove parent-branch notification methods.
+    [<Test>]
+    member _.SignalRClientContractKeepsParentBranchNotificationsWithCurrentBranchPayload() =
+        let methodNames =
+            typeof<IGraceClientConnection>.GetMethods ()
+            |> Array.map (fun methodInfo -> methodInfo.Name)
+            |> Set.ofArray
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(methodNames, Does.Contain("NotifyOnSave"))
+                Assert.That(methodNames, Does.Contain("NotifyOnCheckpoint"))
+                Assert.That(methodNames, Does.Contain("NotifyOnCommit"))
+                Assert.That(methodNames, Does.Contain("NotifyCurrentBranchReference")))
+        )

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -406,6 +406,68 @@ type NotificationServerTests() =
                 ))
         )
 
+    /// Verifies that checkpoint current-branch broadcasts are ordered after branch-specific diff readiness.
+    [<Test>]
+    member _.CheckpointCurrentBranchNotificationRunsAfterDiffReadiness() =
+        let notificationServerPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Notification.Server.fs"))
+        let notificationSource = File.ReadAllText notificationServerPath
+        let checkpointStart = notificationSource.IndexOf("| ReferenceType.Checkpoint ->", StringComparison.Ordinal)
+        let saveStart = notificationSource.IndexOf("| ReferenceType.Save ->", checkpointStart, StringComparison.Ordinal)
+
+        Assert.That(checkpointStart, Is.GreaterThanOrEqualTo(0), "Notification subscriber must handle Checkpoint references.")
+        Assert.That(saveStart, Is.GreaterThan(checkpointStart), "Checkpoint branch must be bounded by the Save branch.")
+
+        let checkpointBranch = notificationSource.Substring(checkpointStart, saveStart - checkpointStart)
+        let parentNotificationIndex = checkpointBranch.IndexOf(".NotifyOnCheckpoint(", StringComparison.Ordinal)
+        let checkpointDiffIndex = checkpointBranch.IndexOf("let! checkpoints = getCheckpoints repositoryId branchId 2 correlationId", StringComparison.Ordinal)
+        let commitDiffIndex = checkpointBranch.IndexOf("match! getLatestCommit repositoryId branchId", StringComparison.Ordinal)
+        let currentBranchNotificationIndex = checkpointBranch.IndexOf("do! emitCurrentBranchReference branchDto.BranchName", StringComparison.Ordinal)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(parentNotificationIndex, Is.GreaterThanOrEqualTo(0), "Checkpoint handling must preserve parent notification.")
+                Assert.That(checkpointDiffIndex, Is.GreaterThan(parentNotificationIndex), "Checkpoint diff work should remain in the checkpoint branch.")
+                Assert.That(commitDiffIndex, Is.GreaterThan(checkpointDiffIndex), "Commit comparison work should remain after checkpoint diff setup.")
+
+                Assert.That(
+                    currentBranchNotificationIndex,
+                    Is.GreaterThan(commitDiffIndex),
+                    "Current-branch checkpoint payloads must not run before checkpoint diff readiness."
+                ))
+        )
+
+    /// Verifies that save current-branch broadcasts are ordered after branch-specific diff readiness.
+    [<Test>]
+    member _.SaveCurrentBranchNotificationRunsAfterDiffReadiness() =
+        let notificationServerPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Notification.Server.fs"))
+        let notificationSource = File.ReadAllText notificationServerPath
+        let saveStart = notificationSource.IndexOf("| ReferenceType.Save ->", StringComparison.Ordinal)
+        let tagStart = notificationSource.IndexOf("| ReferenceType.Tag", saveStart, StringComparison.Ordinal)
+
+        Assert.That(saveStart, Is.GreaterThanOrEqualTo(0), "Notification subscriber must handle Save references.")
+        Assert.That(tagStart, Is.GreaterThan(saveStart), "Save branch must be bounded by non-materialized reference handling.")
+
+        let saveBranch = notificationSource.Substring(saveStart, tagStart - saveStart)
+        let parentNotificationIndex = saveBranch.IndexOf(".NotifyOnSave(", StringComparison.Ordinal)
+        let saveDiffIndex = saveBranch.IndexOf("let! latestTwoSaves = getSaves branchDto.RepositoryId branchId 2 correlationId", StringComparison.Ordinal)
+        let commitDiffIndex = saveBranch.IndexOf("match! getLatestCommit branchDto.RepositoryId branchDto.BranchId", StringComparison.Ordinal)
+        let checkpointDiffIndex = saveBranch.IndexOf("match! getLatestCheckpoint branchDto.RepositoryId branchDto.BranchId", StringComparison.Ordinal)
+        let currentBranchNotificationIndex = saveBranch.IndexOf("do! emitCurrentBranchReference branchDto.BranchName", StringComparison.Ordinal)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(parentNotificationIndex, Is.GreaterThanOrEqualTo(0), "Save handling must preserve parent notification.")
+                Assert.That(saveDiffIndex, Is.GreaterThan(parentNotificationIndex), "Save-to-save diff work should remain in the Save branch.")
+                Assert.That(commitDiffIndex, Is.GreaterThan(saveDiffIndex), "Save-to-commit diff work should remain after save diff setup.")
+                Assert.That(checkpointDiffIndex, Is.GreaterThan(commitDiffIndex), "Save-to-checkpoint diff work should remain after commit comparison.")
+
+                Assert.That(
+                    currentBranchNotificationIndex,
+                    Is.GreaterThan(checkpointDiffIndex),
+                    "Current-branch save payloads must not run before save diff readiness."
+                ))
+        )
+
     /// Verifies that the additive current-branch contract does not remove parent-branch notification methods.
     [<Test>]
     member _.SignalRClientContractKeepsParentBranchNotificationsWithCurrentBranchPayload() =

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -8,6 +8,8 @@ open Grace.Types.Reference
 open Microsoft.AspNetCore.SignalR
 open NUnit.Framework
 open System
+open System.Collections.Generic
+open System.IO
 open System.Security.Claims
 open System.Threading
 open System.Threading.Tasks
@@ -76,6 +78,18 @@ type NotificationServerTests() =
             member _.Groups = groups
         }
 
+    /// Creates a fake SignalR group manager that records add/remove operations in order.
+    let recordingGroupManager (operations: ResizeArray<string * string>) =
+        { new IGroupManager with
+            member _.AddToGroupAsync(_, groupName, _: CancellationToken) =
+                operations.Add("add", groupName)
+                Task.CompletedTask
+
+            member _.RemoveFromGroupAsync(_, groupName, _: CancellationToken) =
+                operations.Add("remove", groupName)
+                Task.CompletedTask
+        }
+
     /// Verifies that branch Name Glob Matching Is Case Insensitive And Supports Wildcard.
     [<TestCase("main", "main", true)>]
     [<TestCase("MAIN", "main", true)>]
@@ -101,6 +115,50 @@ type NotificationServerTests() =
                 Assert.That(groupKey, Is.Not.EqualTo($"{repositoryId}"))
                 Assert.That(groupKey, Is.Not.EqualTo($"{branchId}")))
         )
+
+    /// Verifies that current-branch registration replaces stale group membership for a reused connection.
+    [<Test>]
+    member _.CurrentBranchRegistrationReplacesPriorCurrentBranchGroup() =
+        task {
+            let repositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let oldBranchId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let newBranchId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let items = Dictionary<obj, obj>()
+            let operations = ResizeArray<string * string>()
+            let groups = recordingGroupManager operations
+
+            do! replaceCurrentBranchGroupMembership groups "connection-1" items repositoryId oldBranchId CancellationToken.None
+            do! replaceCurrentBranchGroupMembership groups "connection-1" items repositoryId newBranchId CancellationToken.None
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(operations, Has.Count.EqualTo(3))
+                    Assert.That(operations[0], Is.EqualTo(("add", currentBranchGroupKey repositoryId oldBranchId)))
+                    Assert.That(operations[1], Is.EqualTo(("remove", currentBranchGroupKey repositoryId oldBranchId)))
+                    Assert.That(operations[2], Is.EqualTo(("add", currentBranchGroupKey repositoryId newBranchId))))
+            )
+        }
+
+    /// Verifies that repeating current-branch registration for the same branch does not churn group membership.
+    [<Test>]
+    member _.CurrentBranchRegistrationDoesNotRemoveWhenBranchIsUnchanged() =
+        task {
+            let repositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let branchId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let items = Dictionary<obj, obj>()
+            let operations = ResizeArray<string * string>()
+            let groups = recordingGroupManager operations
+
+            do! replaceCurrentBranchGroupMembership groups "connection-1" items repositoryId branchId CancellationToken.None
+            do! replaceCurrentBranchGroupMembership groups "connection-1" items repositoryId branchId CancellationToken.None
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(operations, Has.Count.EqualTo(2))
+                    Assert.That(operations[0], Is.EqualTo(("add", currentBranchGroupKey repositoryId branchId)))
+                    Assert.That(operations[1], Is.EqualTo(("add", currentBranchGroupKey repositoryId branchId))))
+            )
+        }
 
     /// Verifies that current-branch SignalR subscriptions require branch read authorization.
     [<Test>]
@@ -307,6 +365,46 @@ type NotificationServerTests() =
                     Assert.That(observedPayloads[0], Is.EqualTo(payload)))
             )
         }
+
+    /// Verifies that commit current-branch broadcasts are ordered after zip generation and derived diff work.
+    [<Test>]
+    member _.CommitCurrentBranchNotificationRunsAfterZipAndDiffReadiness() =
+        let notificationServerPath = Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Server", "Notification.Server.fs"))
+        let notificationSource = File.ReadAllText notificationServerPath
+        let commitStart = notificationSource.IndexOf("| ReferenceType.Commit ->", StringComparison.Ordinal)
+        let checkpointStart = notificationSource.IndexOf("| ReferenceType.Checkpoint ->", commitStart, StringComparison.Ordinal)
+
+        Assert.That(commitStart, Is.GreaterThanOrEqualTo(0), "Notification subscriber must handle Commit references.")
+        Assert.That(checkpointStart, Is.GreaterThan(commitStart), "Commit branch must be bounded by the Checkpoint branch.")
+
+        let commitBranch = notificationSource.Substring(commitStart, checkpointStart - commitStart)
+        let zipIndex = commitBranch.IndexOf("directoryVersionActorProxy.GetZipFileUri correlationId", StringComparison.Ordinal)
+        let commitDiffIndex = commitBranch.IndexOf("let! latestTwoCommits = getCommits repositoryId branchId 2 correlationId", StringComparison.Ordinal)
+
+        let parentPromotionDiffIndex =
+            commitBranch.IndexOf("match! getLatestPromotion branchDto.RepositoryId branchDto.ParentBranchId", StringComparison.Ordinal)
+
+        let parentNotificationIndex = commitBranch.IndexOf(".NotifyOnCommit(", StringComparison.Ordinal)
+        let currentBranchNotificationIndex = commitBranch.IndexOf("do! emitCurrentBranchReference branchDto.BranchName", StringComparison.Ordinal)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(zipIndex, Is.GreaterThanOrEqualTo(0), "Commit handling must create the directory-version zip before notifying Watch.")
+                Assert.That(commitDiffIndex, Is.GreaterThan(zipIndex), "Commit diff work should remain after zip generation.")
+                Assert.That(parentPromotionDiffIndex, Is.GreaterThan(commitDiffIndex), "Parent-promotion diff work should remain before notifications.")
+
+                Assert.That(
+                    parentNotificationIndex,
+                    Is.GreaterThan(parentPromotionDiffIndex),
+                    "Parent-branch commit notifications must not run before commit artifact and diff readiness."
+                )
+
+                Assert.That(
+                    currentBranchNotificationIndex,
+                    Is.GreaterThan(parentNotificationIndex),
+                    "Current-branch commit payloads must not run before commit notifications are ready."
+                ))
+        )
 
     /// Verifies that the additive current-branch contract does not remove parent-branch notification methods.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -5,9 +5,11 @@ open Grace.Server.Security
 open Grace.Types.Common
 open Grace.Types.Authorization
 open Grace.Types.Reference
+open Microsoft.AspNetCore.SignalR
 open NUnit.Framework
 open System
 open System.Security.Claims
+open System.Threading
 open System.Threading.Tasks
 
 /// Covers notification Server behavior in no-Aspire server unit tests.
@@ -25,6 +27,54 @@ type NotificationServerTests() =
     /// Creates a branch dto with stable identity for subscription authorization tests.
     let subscriptionBranch ownerId organizationId repositoryId branchId : Grace.Types.Branch.BranchDto =
         { Grace.Types.Branch.BranchDto.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; BranchId = branchId }
+
+    /// Creates a fake SignalR hub context that records current-branch group sends without a hosted server.
+    let recordingHubContext (observedGroups: ResizeArray<string>) (observedPayloads: ResizeArray<CurrentBranchReferenceNotification>) =
+        let client =
+            { new IGraceClientConnection with
+                member _.RegisterRepository _ = Task.CompletedTask
+                member _.RegisterParentBranch _ _ = Task.CompletedTask
+                member _.RegisterCurrentBranch _ _ = Task.CompletedTask
+                member _.NotifyRepository(_, _) = Task.CompletedTask
+
+                member _.NotifyCurrentBranchReference payload =
+                    observedPayloads.Add payload
+                    Task.CompletedTask
+
+                member _.NotifyOnCommit(_, _, _, _) = Task.CompletedTask
+                member _.NotifyOnCheckpoint(_, _, _, _) = Task.CompletedTask
+                member _.NotifyOnSave(_, _, _, _) = Task.CompletedTask
+                member _.NotifyAutomationEvent _ = Task.CompletedTask
+                member _.ServerToClientMessage _ = Task.CompletedTask
+            }
+
+        let clients =
+            { new IHubClients<IGraceClientConnection> with
+                member _.All = client
+                member _.AllExcept _ = client
+                member _.Client _ = client
+                member _.Clients _ = client
+
+                member _.Group groupName =
+                    observedGroups.Add groupName
+                    client
+
+                member _.GroupExcept(_, _) = client
+                member _.Groups _ = client
+                member _.User _ = client
+                member _.Users _ = client
+            }
+
+        let groups =
+            { new IGroupManager with
+                member _.AddToGroupAsync(_, _, _: CancellationToken) = Task.CompletedTask
+                member _.RemoveFromGroupAsync(_, _, _: CancellationToken) = Task.CompletedTask
+            }
+
+        { new IHubContext<NotificationHub, IGraceClientConnection> with
+            member _.Clients = clients
+            member _.Groups = groups
+        }
 
     /// Verifies that branch Name Glob Matching Is Case Insensitive And Supports Wildcard.
     [<TestCase("main", "main", true)>]
@@ -217,6 +267,46 @@ type NotificationServerTests() =
                 Assert.That(payload.ReferenceText, Is.EqualTo(ReferenceText "checkpoint"))
                 Assert.That(payload.CorrelationId, Is.EqualTo("corr-current")))
         )
+
+    /// Verifies that clients cannot forge current-branch Reference broadcasts through a public hub method.
+    [<Test>]
+    member _.NotificationHubDoesNotExposeCurrentBranchBroadcastAsClientInvokableMethod() =
+        let hubMethodNames =
+            typeof<NotificationHub>.GetMethods ()
+            |> Array.map (fun methodInfo -> methodInfo.Name)
+            |> Set.ofArray
+
+        Assert.That(hubMethodNames, Does.Not.Contain("NotifyCurrentBranchReference"))
+
+    /// Verifies that trusted server-side code can still emit current-branch Reference notifications.
+    [<Test>]
+    member _.ServerSideCurrentBranchBroadcastTargetsCurrentBranchGroup() =
+        task {
+            let observedGroups = ResizeArray<string>()
+            let observedPayloads = ResizeArray<CurrentBranchReferenceNotification>()
+            let repositoryId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let branchId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = repositoryId
+                    BranchId = branchId
+                    ReferenceId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                    ReferenceType = ReferenceType.Save
+                }
+
+            let hubContext = recordingHubContext observedGroups observedPayloads
+
+            do! notifyCurrentBranchReferenceClients hubContext payload
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(observedGroups, Has.Count.EqualTo(1))
+                    Assert.That(observedGroups[0], Is.EqualTo(currentBranchGroupKey repositoryId branchId))
+                    Assert.That(observedPayloads, Has.Count.EqualTo(1))
+                    Assert.That(observedPayloads[0], Is.EqualTo(payload)))
+            )
+        }
 
     /// Verifies that the additive current-branch contract does not remove parent-branch notification methods.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -1,14 +1,30 @@
 namespace Grace.Server.Tests
 
 open Grace.Server.Notification
+open Grace.Server.Security
 open Grace.Types.Common
+open Grace.Types.Authorization
 open Grace.Types.Reference
 open NUnit.Framework
 open System
+open System.Security.Claims
+open System.Threading.Tasks
 
 /// Covers notification Server behavior in no-Aspire server unit tests.
 [<Parallelizable(ParallelScope.All)>]
 type NotificationServerTests() =
+
+    /// Creates a fake permission evaluator that records the requested authorization resource.
+    let evaluatorReturning decision (observed: ResizeArray<Operation * Resource>) =
+        { new IGracePermissionEvaluator with
+            member _.CheckAsync(_, _, operation, resource) =
+                observed.Add(operation, resource)
+                Task.FromResult decision
+        }
+
+    /// Creates a branch dto with stable identity for subscription authorization tests.
+    let subscriptionBranch ownerId organizationId repositoryId branchId : Grace.Types.Branch.BranchDto =
+        { Grace.Types.Branch.BranchDto.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; BranchId = branchId }
 
     /// Verifies that branch Name Glob Matching Is Case Insensitive And Supports Wildcard.
     [<TestCase("main", "main", true)>]
@@ -35,6 +51,102 @@ type NotificationServerTests() =
                 Assert.That(groupKey, Is.Not.EqualTo($"{repositoryId}"))
                 Assert.That(groupKey, Is.Not.EqualTo($"{branchId}")))
         )
+
+    /// Verifies that current-branch SignalR subscriptions require branch read authorization.
+    [<Test>]
+    member _.CurrentBranchSubscriptionRequiresBranchReadAuthorization() =
+        task {
+            let ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+            let branchId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+            let observed = ResizeArray<Operation * Resource>()
+            let evaluator = evaluatorReturning (Allowed "allowed") observed
+
+            let principal =
+                ClaimsPrincipal(
+                    ClaimsIdentity(
+                        [|
+                            Claim(PrincipalMapper.GraceUserIdClaim, "watch-user")
+                        |],
+                        "test"
+                    )
+                )
+
+            let branchDto = subscriptionBranch ownerId organizationId repositoryId branchId
+
+            let! allowed = canRegisterCurrentBranchSubscription evaluator principal repositoryId branchId branchDto
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(allowed, Is.True)
+                    Assert.That(observed, Has.Count.EqualTo(1))
+
+                    let operation, resource = observed[0]
+                    Assert.That(operation, Is.EqualTo(Operation.BranchRead))
+                    Assert.That(resource, Is.EqualTo(Resource.Branch(ownerId, organizationId, repositoryId, branchId))))
+            )
+        }
+
+    /// Verifies that denied branch read permission blocks current-branch SignalR subscriptions.
+    [<Test>]
+    member _.CurrentBranchSubscriptionRejectsDeniedBranchRead() =
+        task {
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let observed = ResizeArray<Operation * Resource>()
+            let evaluator = evaluatorReturning (Denied "denied") observed
+
+            let principal =
+                ClaimsPrincipal(
+                    ClaimsIdentity(
+                        [|
+                            Claim(PrincipalMapper.GraceUserIdClaim, "watch-user")
+                        |],
+                        "test"
+                    )
+                )
+
+            let branchDto = subscriptionBranch (Guid.NewGuid()) (Guid.NewGuid()) repositoryId branchId
+
+            let! allowed = canRegisterCurrentBranchSubscription evaluator principal repositoryId branchId branchDto
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(allowed, Is.False)
+                    Assert.That(observed, Has.Count.EqualTo(1)))
+            )
+        }
+
+    /// Verifies that caller-supplied ids cannot authorize a different stored branch identity.
+    [<Test>]
+    member _.CurrentBranchSubscriptionRejectsMismatchedStoredBranchIdentity() =
+        task {
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let observed = ResizeArray<Operation * Resource>()
+            let evaluator = evaluatorReturning (Allowed "allowed") observed
+
+            let principal =
+                ClaimsPrincipal(
+                    ClaimsIdentity(
+                        [|
+                            Claim(PrincipalMapper.GraceUserIdClaim, "watch-user")
+                        |],
+                        "test"
+                    )
+                )
+
+            let branchDto = subscriptionBranch (Guid.NewGuid()) (Guid.NewGuid()) repositoryId (Guid.NewGuid())
+
+            let! allowed = canRegisterCurrentBranchSubscription evaluator principal repositoryId branchId branchDto
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(allowed, Is.False)
+                    Assert.That(observed, Has.Count.EqualTo(0)))
+            )
+        }
 
     /// Verifies that current-branch Reference notifications are restricted to materializable branch history events.
     [<Test>]

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -8,7 +8,9 @@ open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Services
 open Grace.Server.ApplicationContext
 open Grace.Server.DerivedComputation
+open Grace.Server.Security
 open Grace.Shared
+open Grace.Shared.Authorization
 open Grace.Shared.AzureEnvironment
 open Grace.Shared.Constants
 open Grace.Shared.Utilities
@@ -18,6 +20,7 @@ open Grace.Types.Events
 open Grace.Types.Queue
 open Grace.Types.Reference
 open Grace.Types.Common
+open Grace.Types.Authorization
 open Grace.Types.Validation
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.SignalR
@@ -40,6 +43,29 @@ module Notification =
 
     /// Builds the SignalR group key for same-branch Reference notifications without colliding with raw GUID groups.
     let internal currentBranchGroupKey (repositoryId: RepositoryId) (branchId: BranchId) = $"current-branch:{repositoryId:N}:{branchId:N}"
+
+    /// Checks whether the caller can subscribe to same-branch notifications for the stored branch identity.
+    let internal canRegisterCurrentBranchSubscription
+        (evaluator: IGracePermissionEvaluator)
+        principal
+        (repositoryId: RepositoryId)
+        (branchId: BranchId)
+        (branchDto: Branch.BranchDto)
+        =
+        task {
+            if obj.ReferenceEquals(evaluator, null)
+               || branchDto.RepositoryId <> repositoryId
+               || branchDto.BranchId <> branchId then
+                return false
+            else
+                let principals = PrincipalMapper.getPrincipals principal
+                let claims = PrincipalMapper.getEffectiveClaims principal
+                let resource = Resource.Branch(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId, branchDto.BranchId)
+
+                match! evaluator.CheckAsync(principals, claims, Operation.BranchRead, resource) with
+                | Allowed _ -> return true
+                | Denied _ -> return false
+        }
 
     /// Defines the contract for igrace client connection.
     type IGraceClientConnection =
@@ -118,6 +144,30 @@ module Notification =
                     branchId,
                     repositoryId
                 )
+
+                let correlationId = generateCorrelationId ()
+                let branchActorProxy = Branch.CreateActorProxy branchId repositoryId correlationId
+                let! branchDto = branchActorProxy.Get correlationId
+
+                let evaluator =
+                    this
+                        .Context
+                        .GetHttpContext()
+                        .RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+                let! allowed = canRegisterCurrentBranchSubscription evaluator this.Context.User repositoryId branchId branchDto
+
+                if not allowed then
+                    log.LogWarning(
+                        "{CurrentInstant}: Node: {HostName}; ConnectionId: {ConnectionId} denied current-branch SignalR registration for BranchId: {BranchId} in RepositoryId: {RepositoryId}.",
+                        getCurrentInstantExtended (),
+                        getMachineName,
+                        this.Context.ConnectionId,
+                        branchId,
+                        repositoryId
+                    )
+
+                    raise (HubException("Current-branch SignalR registration requires branch read permission."))
 
                 do! this.Groups.AddToGroupAsync(this.Context.ConnectionId, currentBranchGroupKey repositoryId branchId)
             }

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -191,27 +191,6 @@ module Notification =
             }
             :> Task
 
-        /// Broadcasts a same-branch Reference payload to clients registered for the current branch group.
-        member this.NotifyCurrentBranchReference(payload: Reference.CurrentBranchReferenceNotification) =
-            task {
-                log.LogInformation(
-                    "{CurrentInstant}: Node: {HostName}; Notifying current-branch clients in RepositoryId {RepositoryId}, BranchId {BranchId} of {ReferenceType} ReferenceId: {ReferenceId}.",
-                    getCurrentInstantExtended (),
-                    getMachineName,
-                    payload.RepositoryId,
-                    payload.BranchId,
-                    payload.ReferenceType,
-                    payload.ReferenceId
-                )
-
-                do!
-                    this
-                        .Clients
-                        .Group(currentBranchGroupKey payload.RepositoryId payload.BranchId)
-                        .NotifyCurrentBranchReference(payload)
-            }
-            :> Task
-
         /// Broadcasts a save notification to clients watching the affected repository or branch.
         member this.NotifyOnSave((branchName: BranchName), (parentBranchName: BranchName), (parentBranchId: BranchId), (referenceId: ReferenceId)) =
             task {
@@ -309,6 +288,20 @@ module Notification =
                     logToConsole $"No SignalR clients connected."
             }
             :> Task
+
+    /// Broadcasts a same-branch Reference payload from trusted server-side event processing only.
+    let internal notifyCurrentBranchReferenceClients
+        (hubContext: IHubContext<NotificationHub, IGraceClientConnection>)
+        (payload: Reference.CurrentBranchReferenceNotification)
+        =
+        task {
+            if not <| isNull hubContext then
+                do!
+                    hubContext
+                        .Clients
+                        .Group(currentBranchGroupKey payload.RepositoryId payload.BranchId)
+                        .NotifyCurrentBranchReference(payload)
+        }
 
     /// Implements route automation event for the server request pipeline.
     let routeAutomationEvent (serviceProvider: IServiceProvider) (envelope: AutomationEventEnvelope) =
@@ -845,29 +838,25 @@ module Notification =
                         let emitCurrentBranchReference branchName =
                             task {
                                 if shouldNotifyCurrentBranchReference referenceType then
-                                    if not <| isNull hubContext then
-                                        let payload =
-                                            createCurrentBranchReferenceNotification
-                                                referenceId
-                                                ownerId
-                                                organizationId
-                                                repositoryId
-                                                branchId
-                                                branchName
-                                                directoryId
-                                                sha256Hash
-                                                blake3Hash
-                                                referenceType
-                                                referenceText
-                                                correlationId
+                                    let payload =
+                                        createCurrentBranchReferenceNotification
+                                            referenceId
+                                            ownerId
+                                            organizationId
+                                            repositoryId
+                                            branchId
+                                            branchName
+                                            directoryId
+                                            sha256Hash
+                                            blake3Hash
+                                            referenceType
+                                            referenceText
+                                            correlationId
 
-                                        do!
-                                            hubContext
-                                                .Clients
-                                                .Group(currentBranchGroupKey repositoryId branchId)
-                                                .NotifyCurrentBranchReference(payload)
-                                    else
+                                    if isNull hubContext then
                                         log.LogWarning("No SignalR hub context available; cannot notify current branch clients of reference.")
+                                    else
+                                        do! notifyCurrentBranchReferenceClients hubContext payload
                             }
 
                         match referenceType with

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -38,14 +38,21 @@ module Notification =
     let log = loggerFactory.CreateLogger("Notification.Server")
     let private defaultAzureCredential = lazy (DefaultAzureCredential())
 
+    /// Builds the SignalR group key for same-branch Reference notifications without colliding with raw GUID groups.
+    let internal currentBranchGroupKey (repositoryId: RepositoryId) (branchId: BranchId) = $"current-branch:{repositoryId:N}:{branchId:N}"
+
     /// Defines the contract for igrace client connection.
     type IGraceClientConnection =
         /// Defines the register repository operation for implementers.
         abstract member RegisterRepository: RepositoryId -> Task
         /// Defines the register parent branch operation for implementers.
         abstract member RegisterParentBranch: BranchId -> BranchId -> Task
+        /// Defines the register current branch operation for implementers.
+        abstract member RegisterCurrentBranch: RepositoryId -> BranchId -> Task
         /// Defines the notify repository operation for implementers.
         abstract member NotifyRepository: RepositoryId * ReferenceId -> Task
+        /// Defines the notify current branch reference operation for implementers.
+        abstract member NotifyCurrentBranchReference: Reference.CurrentBranchReferenceNotification -> Task
         /// Defines the notify on commit operation for implementers.
         abstract member NotifyOnCommit: BranchName * BranchName * BranchId * ReferenceId -> Task
         /// Defines the notify on checkpoint operation for implementers.
@@ -100,6 +107,21 @@ module Notification =
                 do! this.Groups.AddToGroupAsync(this.Context.ConnectionId, $"{parentBranchId}")
             }
 
+        /// Adds the current SignalR connection to the current-branch group used for same-branch Reference notifications.
+        member this.RegisterCurrentBranch(repositoryId: RepositoryId, branchId: BranchId) =
+            task {
+                log.LogInformation(
+                    "{CurrentInstant}: Node: {HostName}; ConnectionId: {ConnectionId} registering for current BranchId: {BranchId} in RepositoryId: {RepositoryId}.",
+                    getCurrentInstantExtended (),
+                    getMachineName,
+                    this.Context.ConnectionId,
+                    branchId,
+                    repositoryId
+                )
+
+                do! this.Groups.AddToGroupAsync(this.Context.ConnectionId, currentBranchGroupKey repositoryId branchId)
+            }
+
         /// Broadcasts repository-scoped notifications to clients registered for the repository group.
         member this.NotifyRepository((repositoryId: RepositoryId), (referenceId: ReferenceId)) =
             task {
@@ -116,6 +138,27 @@ module Notification =
                         .Clients
                         .Group($"{repositoryId}")
                         .NotifyRepository(repositoryId, referenceId)
+            }
+            :> Task
+
+        /// Broadcasts a same-branch Reference payload to clients registered for the current branch group.
+        member this.NotifyCurrentBranchReference(payload: Reference.CurrentBranchReferenceNotification) =
+            task {
+                log.LogInformation(
+                    "{CurrentInstant}: Node: {HostName}; Notifying current-branch clients in RepositoryId {RepositoryId}, BranchId {BranchId} of {ReferenceType} ReferenceId: {ReferenceId}.",
+                    getCurrentInstantExtended (),
+                    getMachineName,
+                    payload.RepositoryId,
+                    payload.BranchId,
+                    payload.ReferenceType,
+                    payload.ReferenceId
+                )
+
+                do!
+                    this
+                        .Clients
+                        .Group(currentBranchGroupKey payload.RepositoryId payload.BranchId)
+                        .NotifyCurrentBranchReference(payload)
             }
             :> Task
 
@@ -409,6 +452,39 @@ module Notification =
                 RegexOptions.IgnoreCase
                 ||| RegexOptions.CultureInvariant
             )
+
+        /// Reports whether a Reference creation should wake clients watching that same branch.
+        let internal shouldNotifyCurrentBranchReference referenceType = Reference.CurrentBranchReferenceNotification.IsEligibleReferenceType referenceType
+
+        /// Builds the same-branch Reference notification payload after branch state has been recomputed.
+        let internal createCurrentBranchReferenceNotification
+            referenceId
+            ownerId
+            organizationId
+            repositoryId
+            branchId
+            branchName
+            directoryId
+            sha256Hash
+            blake3Hash
+            referenceType
+            referenceText
+            correlationId
+            =
+            { Reference.CurrentBranchReferenceNotification.Default with
+                ReferenceId = referenceId
+                OwnerId = ownerId
+                OrganizationId = organizationId
+                RepositoryId = repositoryId
+                BranchId = branchId
+                BranchName = branchName
+                DirectoryId = directoryId
+                Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
+                ReferenceType = referenceType
+                ReferenceText = referenceText
+                CorrelationId = correlationId
+            }
 
         /// Gets try get promotion set id from metadata data needed by the server flow.
         let private tryGetPromotionSetIdFromMetadata (metadata: EventMetadata) =
@@ -715,6 +791,35 @@ module Notification =
                                                   referenceType,
                                                   referenceText,
                                                   links) ->
+                        /// Emits the same-branch notification after Reference replay and branch recomputation complete.
+                        let emitCurrentBranchReference branchName =
+                            task {
+                                if shouldNotifyCurrentBranchReference referenceType then
+                                    if not <| isNull hubContext then
+                                        let payload =
+                                            createCurrentBranchReferenceNotification
+                                                referenceId
+                                                ownerId
+                                                organizationId
+                                                repositoryId
+                                                branchId
+                                                branchName
+                                                directoryId
+                                                sha256Hash
+                                                blake3Hash
+                                                referenceType
+                                                referenceText
+                                                correlationId
+
+                                        do!
+                                            hubContext
+                                                .Clients
+                                                .Group(currentBranchGroupKey repositoryId branchId)
+                                                .NotifyCurrentBranchReference(payload)
+                                    else
+                                        log.LogWarning("No SignalR hub context available; cannot notify current branch clients of reference.")
+                            }
+
                         match referenceType with
                         | ReferenceType.Promotion ->
                             let! branchDto = getBranchDto branchId repositoryId correlationId
@@ -760,6 +865,8 @@ module Notification =
                             else
                                 log.LogWarning("No SignalR hub context available; cannot notify clients of commit.")
 
+                            do! emitCurrentBranchReference branchDto.BranchName
+
                             let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId correlationId
                             let! exists = directoryVersionActorProxy.Exists correlationId
 
@@ -803,6 +910,8 @@ module Notification =
                                         .Group($"{branchDto.ParentBranchId}")
                                         .NotifyOnCheckpoint(branchDto.BranchName, parentBranchDto.BranchName, parentBranchDto.ParentBranchId, referenceId)
 
+                            do! emitCurrentBranchReference branchDto.BranchName
+
                             // Create the diff between the two most recent checkpoints.
                             let! checkpoints = getCheckpoints repositoryId branchId 2 correlationId
 
@@ -841,6 +950,8 @@ module Notification =
                                         .NotifyOnSave(branchDto.BranchName, parentBranchDto.BranchName, parentBranchDto.ParentBranchId, referenceId)
                             else
                                 log.LogWarning("No SignalR hub context available; cannot notify clients of save.")
+
+                            do! emitCurrentBranchReference branchDto.BranchName
 
                             // Create the diff between the new save and the previous save.
                             let! latestTwoSaves = getSaves branchDto.RepositoryId branchId 2 correlationId

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -1003,8 +1003,6 @@ module Notification =
                                         .Group($"{branchDto.ParentBranchId}")
                                         .NotifyOnCheckpoint(branchDto.BranchName, parentBranchDto.BranchName, parentBranchDto.ParentBranchId, referenceId)
 
-                            do! emitCurrentBranchReference branchDto.BranchName
-
                             // Create the diff between the two most recent checkpoints.
                             let! checkpoints = getCheckpoints repositoryId branchId 2 correlationId
 
@@ -1031,6 +1029,8 @@ module Notification =
                                         correlationId
                             | None -> ()
 
+                            do! emitCurrentBranchReference branchDto.BranchName
+
                         | ReferenceType.Save ->
                             let! branchDto = getBranchDto branchId repositoryId correlationId
                             let! parentBranchDto = getBranchDto branchDto.ParentBranchId repositoryId correlationId
@@ -1043,8 +1043,6 @@ module Notification =
                                         .NotifyOnSave(branchDto.BranchName, parentBranchDto.BranchName, parentBranchDto.ParentBranchId, referenceId)
                             else
                                 log.LogWarning("No SignalR hub context available; cannot notify clients of save.")
-
-                            do! emitCurrentBranchReference branchDto.BranchName
 
                             // Create the diff between the new save and the previous save.
                             let! latestTwoSaves = getSaves branchDto.RepositoryId branchId 2 correlationId
@@ -1090,6 +1088,8 @@ module Notification =
                                             branchDto.RepositoryId
                                             correlationId
                             | None -> ()
+
+                            do! emitCurrentBranchReference branchDto.BranchName
 
                         | ReferenceType.Tag
                         | ReferenceType.Rebase

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -28,7 +28,9 @@ open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
+open Microsoft.Extensions.Logging.Abstractions
 open System
+open System.Collections.Generic
 open System.Linq
 open System.Text.Json
 open System.Text.RegularExpressions
@@ -38,11 +40,63 @@ open System.Threading.Tasks
 /// Contains Grace Server notification behavior and supporting helpers.
 module Notification =
 
-    let log = loggerFactory.CreateLogger("Notification.Server")
+    let private nullNotificationLogger = NullLoggerFactory.Instance.CreateLogger("Notification.Server")
+
+    /// Resolves notification logging lazily so unit-shaped helpers do not require full server configuration at import time.
+    let private notificationLogger () =
+        try
+            if isNull loggerFactory then
+                nullNotificationLogger
+            else
+                loggerFactory.CreateLogger("Notification.Server")
+        with
+        | _ -> nullNotificationLogger
+
+    let log =
+        { new ILogger with
+            /// Delegates logging scope creation to the configured application logger when one is available.
+            member _.BeginScope<'TState>(state: 'TState) = (notificationLogger ()).BeginScope(state)
+            /// Reports whether notification diagnostics are enabled for the configured application logger.
+            member _.IsEnabled(logLevel) = (notificationLogger ()).IsEnabled(logLevel)
+
+            /// Writes notification diagnostics through the configured application logger when possible.
+            member _.Log(logLevel, eventId, state, ex, formatter) =
+                (notificationLogger ())
+                    .Log(logLevel, eventId, state, ex, formatter)
+        }
+
     let private defaultAzureCredential = lazy (DefaultAzureCredential())
 
     /// Builds the SignalR group key for same-branch Reference notifications without colliding with raw GUID groups.
     let internal currentBranchGroupKey (repositoryId: RepositoryId) (branchId: BranchId) = $"current-branch:{repositoryId:N}:{branchId:N}"
+
+    [<Literal>]
+    let private CurrentBranchGroupItemKey = "Grace.Notification.CurrentBranchGroup"
+
+    /// Replaces the current-branch SignalR group for a connection so branch changes cannot retain stale memberships.
+    let internal replaceCurrentBranchGroupMembership
+        (groups: IGroupManager)
+        connectionId
+        (items: IDictionary<obj, obj>)
+        repositoryId
+        branchId
+        cancellationToken
+        =
+        task {
+            let nextGroupKey = currentBranchGroupKey repositoryId branchId
+
+            let previousGroupKey =
+                match items.TryGetValue CurrentBranchGroupItemKey with
+                | true, (:? string as groupKey) when not (String.IsNullOrWhiteSpace(groupKey)) -> Some groupKey
+                | _ -> None
+
+            match previousGroupKey with
+            | Some groupKey when groupKey <> nextGroupKey -> do! groups.RemoveFromGroupAsync(connectionId, groupKey, cancellationToken)
+            | _ -> ()
+
+            do! groups.AddToGroupAsync(connectionId, nextGroupKey, cancellationToken)
+            items[CurrentBranchGroupItemKey] <- nextGroupKey
+        }
 
     /// Checks whether the caller can subscribe to same-branch notifications for the stored branch identity.
     let internal canRegisterCurrentBranchSubscription
@@ -169,7 +223,7 @@ module Notification =
 
                     raise (HubException("Current-branch SignalR registration requires branch read permission."))
 
-                do! this.Groups.AddToGroupAsync(this.Context.ConnectionId, currentBranchGroupKey repositoryId branchId)
+                do! replaceCurrentBranchGroupMembership this.Groups this.Context.ConnectionId this.Context.Items repositoryId branchId CancellationToken.None
             }
 
         /// Broadcasts repository-scoped notifications to clients registered for the repository group.
@@ -895,17 +949,6 @@ module Notification =
                             let! branchDto = getBranchDto branchId repositoryId correlationId
                             let! parentBranchDto = getBranchDto branchDto.ParentBranchId repositoryId correlationId
 
-                            if not <| isNull hubContext then
-                                do!
-                                    hubContext
-                                        .Clients
-                                        .Group($"{branchDto.ParentBranchId}")
-                                        .NotifyOnCommit(branchDto.BranchName, parentBranchDto.BranchName, parentBranchDto.ParentBranchId, referenceId)
-                            else
-                                log.LogWarning("No SignalR hub context available; cannot notify clients of commit.")
-
-                            do! emitCurrentBranchReference branchDto.BranchName
-
                             let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy directoryId repositoryId correlationId
                             let! exists = directoryVersionActorProxy.Exists correlationId
 
@@ -938,6 +981,17 @@ module Notification =
                                             branchDto.RepositoryId
                                             correlationId
                                 | None -> ()
+
+                            if not <| isNull hubContext then
+                                do!
+                                    hubContext
+                                        .Clients
+                                        .Group($"{branchDto.ParentBranchId}")
+                                        .NotifyOnCommit(branchDto.BranchName, parentBranchDto.BranchName, parentBranchDto.ParentBranchId, referenceId)
+                            else
+                                log.LogWarning("No SignalR hub context available; cannot notify clients of commit.")
+
+                            do! emitCurrentBranchReference branchDto.BranchName
                         | ReferenceType.Checkpoint ->
                             let! branchDto = getBranchDto branchId repositoryId correlationId
                             let! parentBranchDto = getBranchDto branchDto.ParentBranchId repositoryId correlationId

--- a/src/Grace.Types.Tests/Reference.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Reference.Types.Tests.fs
@@ -94,6 +94,73 @@ type ReferenceDtoTests() =
         let roundTripWithoutCreator = deserialize<ReferenceDto> withoutCreatorJson
         Assert.That(roundTripWithoutCreator.CreatedBy, Is.EqualTo(Option.None))
 
+    /// Verifies that current-branch notification JSON carries lookup fields without transport details.
+    [<Test>]
+    member _.CurrentBranchReferenceNotificationJsonCarriesLookupFieldsOnly() =
+        let payload =
+            { CurrentBranchReferenceNotification.Default with
+                ReferenceId = referenceId
+                OwnerId = ownerId
+                OrganizationId = organizationId
+                RepositoryId = repositoryId
+                BranchId = branchId
+                BranchName = BranchName "feature/current"
+                DirectoryId = directoryId
+                Sha256Hash = rootSha256Hash
+                Blake3Hash = rootBlake3Hash
+                ReferenceType = ReferenceType.Save
+                ReferenceText = ReferenceText "watch save"
+                CorrelationId = "corr-current-branch"
+            }
+
+        let json = serialize payload
+        let roundTrip = deserialize<CurrentBranchReferenceNotification> json
+
+        Assert.Multiple(
+            System.Action (fun () ->
+                Assert.That(roundTrip.ReferenceId, Is.EqualTo(referenceId))
+                Assert.That(roundTrip.RepositoryId, Is.EqualTo(repositoryId))
+                Assert.That(roundTrip.BranchId, Is.EqualTo(branchId))
+                Assert.That(roundTrip.BranchName, Is.EqualTo(BranchName "feature/current"))
+                Assert.That(roundTrip.DirectoryId, Is.EqualTo(directoryId))
+                Assert.That(roundTrip.ReferenceType, Is.EqualTo(ReferenceType.Save))
+                Assert.That(roundTrip.CorrelationId, Is.EqualTo("corr-current-branch"))
+                Assert.That(json, Does.Not.Contain("Sas"))
+                Assert.That(json, Does.Not.Contain("Download"))
+                Assert.That(json, Does.Not.Contain("BlobUri")))
+        )
+
+    /// Verifies that current-branch notifications stay limited to Reference kinds Watch can materialize later.
+    [<Test>]
+    member _.CurrentBranchReferenceNotificationEligibilityExcludesPromotionAndMetadataReferences() =
+        let eligible =
+            [|
+                ReferenceType.Commit
+                ReferenceType.Checkpoint
+                ReferenceType.Save
+            |]
+
+        let ineligible =
+            [|
+                ReferenceType.Promotion
+                ReferenceType.Tag
+                ReferenceType.External
+                ReferenceType.Rebase
+            |]
+
+        Assert.Multiple(
+            System.Action (fun () ->
+                for referenceType in eligible do
+                    Assert.That(CurrentBranchReferenceNotification.IsEligibleReferenceType referenceType, Is.True, $"Expected {referenceType} to be eligible.")
+
+                for referenceType in ineligible do
+                    Assert.That(
+                        CurrentBranchReferenceNotification.IsEligibleReferenceType referenceType,
+                        Is.False,
+                        $"Expected {referenceType} to be ineligible."
+                    ))
+        )
+
     /// Verifies that update events do not overwrite created by.
     [<Test>]
     member _.UpdateEventsDoNotOverwriteCreatedBy() =

--- a/src/Grace.Types/Reference.Types.fs
+++ b/src/Grace.Types/Reference.Types.fs
@@ -210,3 +210,49 @@ module Reference =
                 | Undeleted -> { currentReferenceDto with DeletedAt = None; DeleteReason = String.Empty }
 
             { newReferenceDto with UpdatedAt = Some referenceEvent.Metadata.Timestamp }
+
+    /// Describes a same-branch Reference that current-branch Watch clients may inspect after server-side recomputation.
+    [<CLIMutable; GenerateSerializer>]
+    type CurrentBranchReferenceNotification =
+        {
+            ReferenceId: ReferenceId
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            BranchId: BranchId
+            BranchName: BranchName
+            DirectoryId: DirectoryVersionId
+            Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
+            ReferenceType: ReferenceType
+            ReferenceText: ReferenceText
+            CorrelationId: CorrelationId
+        }
+
+        /// Represents an initialized notification payload for serializers and tests.
+        static member Default =
+            {
+                ReferenceId = ReferenceId.Empty
+                OwnerId = OwnerId.Empty
+                OrganizationId = OrganizationId.Empty
+                RepositoryId = RepositoryId.Empty
+                BranchId = BranchId.Empty
+                BranchName = BranchName String.Empty
+                DirectoryId = DirectoryVersionId.Empty
+                Sha256Hash = Sha256Hash String.Empty
+                Blake3Hash = Blake3Hash String.Empty
+                ReferenceType = ReferenceType.Save
+                ReferenceText = ReferenceText String.Empty
+                CorrelationId = String.Empty
+            }
+
+        /// Reports whether the Reference can wake same-branch Watch clients for remote materialization.
+        static member IsEligibleReferenceType referenceType =
+            match referenceType with
+            | ReferenceType.Commit
+            | ReferenceType.Checkpoint
+            | ReferenceType.Save -> true
+            | ReferenceType.Promotion
+            | ReferenceType.Tag
+            | ReferenceType.External
+            | ReferenceType.Rebase -> false


### PR DESCRIPTION
## Summary

Implements WS7.1 current-branch SignalR contract and server emission:

- Adds a typed current-branch Reference notification payload for Watch clients.
- Adds a prefixed current-branch SignalR group and registration method distinct from repository-wide and parent-branch
  groups.
- Emits current-branch notifications for eligible created References after server-side Reference persistence and derived
  recomputation have run.
- Keeps Promotion, Tag, External, and Rebase References ineligible for current-branch materialization notifications in
  this leaf.
- Preserves existing parent-branch automation notifications and repository-wide notifications.
- Registers `grace watch` for the current-branch payload with stale repository/branch identity filtering, while keeping
  the matching-payload behavior silent until later WS7 materialization leaves.

Related to #502.
Part of #473.

## Why This Matters

Grace Watch needs a precise server-to-client contract before it can safely materialize clean current-branch updates from
another machine or agent. This slice establishes the routing and typed payload without introducing conflict resolution,
local Saves, remote materialization, or durable journal replay semantics.

## Validation

- Targeted Fantomas on touched F# files: passed.
- Focused Release builds passed:

  ```powershell
  dotnet build --configuration Release src\Grace.Types.Tests\Grace.Types.Tests.fsproj
  dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj
  dotnet build --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj
  ```

- Focused tests passed:

  ```powershell
  dotnet test --configuration Release --no-build src\Grace.Types.Tests\Grace.Types.Tests.fsproj --filter "FullyQualifiedName~ReferenceDtoTests"
  dotnet test --configuration Release --no-build src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~NotificationServerTests"
  dotnet test --configuration Release --no-build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "Name~WatchCurrentBranchSignalRPayloadRejectsStaleRepositoryOrBranchIdentity"
  ```

- Focused evidence included Reference DTO tests 7/7, Notification server tests 11/11, and the focused Watch stale
  identity test 1/1.
- `git diff --check`: passed.
- Final gate passed:

  ```powershell
  pwsh ./scripts/validate.ps1 -Fast
  ```

  Fast-profile evidence included `Grace.Types.Tests` 135/135, `Grace.Authorization.Tests` 53/53,
  `Grace.Server.Unit.Tests` 727/727, and `Grace.CLI.Tests` 930/930.

## Acceptance Mapping

- Current-branch group is distinct: group keys are prefixed and covered by collision-resistant server tests.
- Typed payload added: `CurrentBranchReferenceNotification` carries repository, branch, Reference, directory, hash,
  type, text, and correlation identity without SAS or direct download details.
- Emission timing: server emission occurs after `DerivedComputation.handleReferenceEvent` in the Reference-created
  notification path.
- Eligible References: Save, Commit, and Checkpoint are eligible; Promotion, Tag, External, and Rebase are ineligible.
- Parent-branch notifications preserved: existing parent branch Save, Checkpoint, Commit, and repository notifications
  remain covered by focused server tests.
- Watch subscription: `grace watch` registers for the current branch and rejects stale repository or branch payloads.

## Path Expansion

- `src/Grace.Types/Reference.Types.fs`: shared DTO and eligibility helper required by the server/CLI typed SignalR
  contract.
- `src/Grace.Types.Tests/Reference.Types.Tests.fs`: focused DTO and eligibility proof.
- `src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs`: focused server routing and eligibility proof.

## Docs Impact

No docs were updated. Waiver: this leaf adds internal server/client SignalR routing and a silent Watch subscription
contract, but does not introduce user-facing command behavior, materialization behavior, command syntax, or a
maintainer-visible workflow change.

## Residual Risks

- This PR does not implement remote materialization or conflict resolution; later WS7 leaves own those behaviors.
- Server emission proof is unit-focused plus `validate -Fast`, not a full Aspire SignalR integration scenario.

## Review Status

- Current head: `e479364af6182aab3697339a328f38850c6ae944`.
- Codex review session 1 completed on `84e8ffea05e6766d591ab44166bc40a6ad8a432c` with 3 fresh findings; all were
  fixed in `a659410a80a787dadb264bd81ff5d5cb206c462e`, replied to, and resolved.
- Codex review session 2 completed on `a659410a80a787dadb264bd81ff5d5cb206c462e` with 1 fresh finding; it was fixed in
  `868c9ecc78d779843d14d8c1517c18049be3cdd8`, replied to, and resolved.
- Codex review session 3 completed on `868c9ecc78d779843d14d8c1517c18049be3cdd8` with 2 fresh findings; both were fixed
  in `6578eea756d8c558c46598b7091a8fa01d5f8fc9`, replied to, and resolved.
- Codex review session 4 completed on `6578eea756d8c558c46598b7091a8fa01d5f8fc9` with 2 fresh findings; both were fixed
  in `e479364af6182aab3697339a328f38850c6ae944`, replied to, and resolved.
- Session 4 finding `3524637494`: stale in-flight refreshes can no longer replace active current-branch group
  membership because current-branch hub registration now runs only after local refresh authority is accepted. Reply
  `3524658545`.
- Session 4 finding `3524637495`: Save and Checkpoint current-branch notifications now emit after branch-specific
  derived diff work, matching the Commit artifact-readiness invariant. Reply `3524658582`.
- Review Stabilization Ledger posted to
  [PR #547](https://github.com/ScottArbeit/Grace/pull/547#issuecomment-4885565122) and
  [issue #502](https://github.com/ScottArbeit/Grace/issues/502#issuecomment-4885565177).
- Validation for `e479364af6182aab3697339a328f38850c6ae944`: targeted Fantomas passed; Release builds for
  `Grace.CLI.Tests` and `Grace.Server.Unit.Tests` passed; focused Watch tests passed 228/228; focused Notification
  server tests passed 21/21; `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed.
- GitHub `full` passed for `e479364af6182aab3697339a328f38850c6ae944`.
- Codex Code Review Bot reported no issues for `e479364af6182aab3697339a328f38850c6ae944` with a 👍 reaction, and no
  unresolved bot review threads remain.
- Prevention: local subscription authority and artifact readiness are now explicit stabilization invariants, with proof
  coverage before merge.
- Review sessions: 5 completed on this PR including the final no-issues latest-head pass; substantive cycle count is 3.
- Current gate: satisfied for merge into `epic/473-grace-watch-incremental-sync`.
