### PR TITLE
WS4.5: Block Watch transitions on pending durable journal evidence

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -821,6 +821,49 @@ module BranchCommandTests =
             inspected |> should equal true
             inspectedJournal |> should equal true)
 
+    /// Verifies branch switch treats a missing local-state DB as uninspectable durable evidence, not zero pending rows.
+    [<Test>]
+    let ``branch switch Watch preflight refuses missing local-state database after clean IPC`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let mutable inspected = false
+            let mutable inspectedJournal = false
+            let localStatePath = Current().GraceStatusFile
+
+            if File.Exists(localStatePath) then File.Delete(localStatePath)
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> false
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary =
+                        fun () ->
+                            inspectedJournal <- true
+                            LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck localStatePath
+                }
+
+            let result =
+                (Branch.runBranchSwitchWatchCleanPreflight operations correlationId)
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before mutation"
+
+                error.Error
+                |> should contain "durable journal pending-work evidence could not be inspected"
+
+                error.Error
+                |> should contain "local-state database is missing"
+            | Ok _ -> Assert.Fail("Expected missing durable journal evidence to refuse branch switch.")
+
+            inspected |> should equal true
+            inspectedJournal |> should equal true)
+
     /// Verifies that untrusted Watch states refuse before branch switch marker creation.
     [<Test>]
     let ``branch switch Watch preflight refuses untrusted Watch states before marker creation`` () =

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -136,6 +136,10 @@ module BranchCommandTests =
     let private branchSwitchWatchInspection persistedMode status =
         { Exists = true; Status = Some status; PersistedMode = persistedMode; SafetyFlags = status.SafetyFlags; ReadError = None }
 
+    /// Builds clean durable journal evidence for branch switch preflight tests.
+    let private cleanPendingJournalSummary () : LocalStateDb.WatchJournalPendingWorkSummary =
+        { DbPath = Current().GraceStatusFile; AppliedThroughSequence = 0L; PendingRowCount = 0L }
+
     /// Writes a Watch IPC status snapshot for branch switch preflight tests.
     let private writeBranchSwitchWatchStatus (fileName: string) status =
         Directory.CreateDirectory(Path.GetDirectoryName(fileName))
@@ -154,6 +158,7 @@ module BranchCommandTests =
                     fun () ->
                         inspected <- true
                         Task.FromResult inspection
+                ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
             }
 
         let result =
@@ -260,6 +265,7 @@ module BranchCommandTests =
                             |> should equal false
 
                             Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let result =
@@ -310,6 +316,7 @@ module BranchCommandTests =
                             File.Exists(switchLeaseFile) |> should equal true
 
                             Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let result =
@@ -359,6 +366,7 @@ module BranchCommandTests =
                         fun () ->
                             inspected <- true
                             Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let result =
@@ -422,6 +430,7 @@ module BranchCommandTests =
                         fun () ->
                             inspected <- true
                             Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let result =
@@ -500,6 +509,7 @@ module BranchCommandTests =
                             |> should equal false
 
                             Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) dirtyStatus)
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let result =
@@ -539,6 +549,7 @@ module BranchCommandTests =
                     UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
                     InspectWatchStatus =
                         fun () -> Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let operation =
@@ -582,6 +593,7 @@ module BranchCommandTests =
                             false
                     InspectWatchStatus =
                         fun () -> Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let updateTask =
@@ -616,6 +628,7 @@ module BranchCommandTests =
                     UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
                     InspectWatchStatus =
                         fun () -> Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
                 }
 
             let operation =
@@ -767,6 +780,46 @@ module BranchCommandTests =
                 inspected |> should equal true
             finally
                 if File.Exists(currentIpcFile) then File.Delete(currentIpcFile))
+
+    /// Verifies durable journal evidence blocks branch switch even before Watch republishes dirty IPC.
+    [<Test>]
+    let ``branch switch Watch preflight refuses durable pending rows after clean IPC`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let mutable inspected = false
+            let mutable inspectedJournal = false
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> false
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary =
+                        fun () ->
+                            inspectedJournal <- true
+
+                            Task.FromResult(
+                                { DbPath = Current().GraceStatusFile; AppliedThroughSequence = 7L; PendingRowCount = 2L }: LocalStateDb.WatchJournalPendingWorkSummary
+                            )
+                }
+
+            let result =
+                (Branch.runBranchSwitchWatchCleanPreflight operations correlationId)
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before mutation"
+
+                error.Error
+                |> should contain "unresolved durable journal rows"
+            | Ok _ -> Assert.Fail("Expected durable pending journal evidence to refuse branch switch.")
+
+            inspected |> should equal true
+            inspectedJournal |> should equal true)
 
     /// Verifies that untrusted Watch states refuse before branch switch marker creation.
     [<Test>]

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -291,6 +291,77 @@ module BranchCommandTests =
             File.Exists(updateMarkerFile)
             |> should equal false)
 
+    /// Verifies that durable rows appended after clean preflight still block mutation once the update marker exists.
+    [<Test>]
+    let ``branch switch working tree update rechecks durable rows after marker creation`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
+            let mutationFile = Path.Combine(Current().RootDirectory, "must-not-be-written-after-marker.txt")
+            let mutable inspected = false
+            let mutable journalReadCount = 0
+            let mutable markerSeenByPostMarkerJournalRead = false
+            let mutable operationRan = false
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspected <- true
+
+                            File.Exists(updateMarkerFile)
+                            |> should equal false
+
+                            Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary =
+                        fun () ->
+                            journalReadCount <- journalReadCount + 1
+
+                            if journalReadCount = 1 then
+                                Task.FromResult(cleanPendingJournalSummary ())
+                            else
+                                markerSeenByPostMarkerJournalRead <- File.Exists(updateMarkerFile)
+
+                                Task.FromResult(
+                                    { DbPath = Current().GraceStatusFile; AppliedThroughSequence = 7L; PendingRowCount = 1L }: LocalStateDb.WatchJournalPendingWorkSummary
+                                )
+                }
+
+            let result =
+                (Branch.runBranchSwitchWorkingTreeUpdateWithMarker operations correlationId updateMarkerFile markerText (fun () ->
+                    task {
+                        operationRan <- true
+                        File.WriteAllText(mutationFile, "must not be written")
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before mutation"
+
+                error.Error
+                |> should contain "after update marker creation"
+
+                error.Error
+                |> should contain "unresolved durable journal rows"
+            | Ok _ -> Assert.Fail("Expected post-marker durable journal evidence to refuse branch switch.")
+
+            inspected |> should equal true
+            journalReadCount |> should equal 2
+
+            markerSeenByPostMarkerJournalRead
+            |> should equal true
+
+            operationRan |> should equal false
+
+            File.Exists(mutationFile) |> should equal false
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
     /// Verifies that the switch workflow lease serializes precomputation without creating the Watch suppression marker.
     [<Test>]
     let ``branch switch workflow lease serializes before precompute without update marker`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -838,6 +838,19 @@ module LocalStateDbTests =
                 cleanSummary.HasPendingRows |> should equal false
             })
 
+    /// Verifies that transition checks fail closed instead of trusting a missing local-state database as clean.
+    [<Test>]
+    let ``watch journal transition summary treats missing local-state database as uninspectable`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let operation = Func<Task>(fun () -> LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck configuration.GraceStatusFile :> Task)
+
+                let ex = Assert.ThrowsAsync<InvalidDataException>(operation)
+
+                ex.Message
+                |> should contain "local-state database is missing"
+            })
+
     /// Verifies the pending-work summary avoids full diagnostic schema/index inspection in Watch hot paths.
     [<Test>]
     let ``watch journal pending work summary ignores unrelated diagnostic index drift`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -838,6 +838,24 @@ module LocalStateDbTests =
                 cleanSummary.HasPendingRows |> should equal false
             })
 
+    /// Verifies the pending-work summary avoids full diagnostic schema/index inspection in Watch hot paths.
+    [<Test>]
+    let ``watch journal pending work summary ignores unrelated diagnostic index drift`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let pendingObservation = watchJournalObservation DifferenceType.Change FileSystemEntryType.File "pending.txt"
+                let! _ = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile [ pendingObservation ]
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery connection "DROP INDEX IF EXISTS ix_status_files_sha256;"
+
+                let! summary = LocalStateDb.readWatchJournalPendingWorkSummary configuration.GraceStatusFile
+
+                summary.AppliedThroughSequence |> should equal 0L
+                summary.PendingRowCount |> should equal 1L
+                summary.HasPendingRows |> should equal true
+            })
+
     /// Verifies that startup recovery returns compatible pending rows without mutating them before Watch replays them.
     [<Test>]
     let ``watch journal startup recovery returns compatible pending rows`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -799,6 +799,45 @@ module LocalStateDbTests =
                     |]
             })
 
+    /// Verifies that pending-work summaries report only unresolved non-quarantined durable journal rows.
+    [<Test>]
+    let ``watch journal pending work summary ignores applied and quarantined rows`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let appliedObservation = watchJournalObservation DifferenceType.Change FileSystemEntryType.File "applied.txt"
+                let pendingObservation = watchJournalObservation DifferenceType.Change FileSystemEntryType.File "pending.txt"
+                let quarantinedObservation = watchJournalObservation DifferenceType.Delete FileSystemEntryType.File "quarantined.txt"
+
+                let! appliedSequences = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile [ appliedObservation ]
+                let! pendingSequences = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile [ pendingObservation ]
+                let! quarantinedSequences = LocalStateDb.appendWatchJournalObservations configuration.GraceStatusFile [ quarantinedObservation ]
+
+                let! appliedThrough = LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences configuration.GraceStatusFile appliedSequences
+                appliedThrough |> should equal 1L
+
+                let! quarantineBoundary =
+                    LocalStateDb.quarantineWatchJournalSequences configuration.GraceStatusFile quarantinedSequences "test quarantined stale identity"
+
+                quarantineBoundary |> should equal 1L
+
+                let! summary = LocalStateDb.readWatchJournalPendingWorkSummary configuration.GraceStatusFile
+
+                summary.AppliedThroughSequence |> should equal 1L
+                summary.PendingRowCount |> should equal 1L
+                summary.HasPendingRows |> should equal true
+
+                let! pendingAdvance = LocalStateDb.advanceWatchJournalAppliedThroughContiguousSequences configuration.GraceStatusFile pendingSequences
+                pendingAdvance |> should equal 3L
+
+                let! cleanSummary = LocalStateDb.readWatchJournalPendingWorkSummary configuration.GraceStatusFile
+
+                cleanSummary.AppliedThroughSequence
+                |> should equal 3L
+
+                cleanSummary.PendingRowCount |> should equal 0L
+                cleanSummary.HasPendingRows |> should equal false
+            })
+
     /// Verifies that startup recovery returns compatible pending rows without mutating them before Watch replays them.
     [<Test>]
     let ``watch journal startup recovery returns compatible pending rows`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -10766,6 +10766,54 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
+    /// Verifies durable-only journal evidence does not enter the processable Watch work branch.
+    [<Test>]
+    let ``watch durable-only pending journal evidence publishes without processing`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let mutable uploads = 0
+            let mutable statusApplies = 0
+
+            try
+                Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                    Task.FromResult(
+                        { LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile; AppliedThroughSequence = 1L; PendingRowCount = 1L }
+                    ))
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                (Watch.processChangedFilesWithClients
+                    (fun () -> Task.FromResult(status))
+                    (fun () -> Task.FromResult(status))
+                    (fun _ _ ->
+                        uploads <- uploads + 1
+                        Task.FromResult(()))
+                    (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                    scannerHostileDifferenceDiscovery
+                    (fun currentStatus _ _ ->
+                        statusApplies <- statusApplies + 1
+                        Task.FromResult(Some currentStatus))
+                    (fun _ _ _ -> Task.FromResult(()))
+                    (fun currentStatus currentDirectoryIds -> Services.updateGraceWatchInterprocessFile currentStatus currentDirectoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                uploads |> should equal 0
+                statusApplies |> should equal 0
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal true
+
+                readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                |> should equal false
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that watch check JSON exposes durable-pending degradation without changing stdout/stderr routing.
     [<Test>]
     let ``watch check json reports durable pending journal evidence`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -10766,6 +10766,137 @@ module WatchTests =
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 
+    /// Verifies that durable-only journal evidence publishes non-incremental IPC instead of a healthy dirty snapshot.
+    [<Test>]
+    let ``watch durable-only pending journal evidence publishes resync-required transition`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            try
+                Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                    Task.FromResult(
+                        { LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile; AppliedThroughSequence = 1L; PendingRowCount = 1L }
+                    ))
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.IsUsable |> should equal false
+
+                inspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+
+                let publishedStatus =
+                    inspection.Status
+                    |> Option.defaultWith (fun () -> failwith "Expected durable-only IPC status.")
+
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+
+                publishedStatus.RootDirectoryId
+                |> should equal GraceStatus.Default.RootDirectoryId
+
+                publishedStatus.DirectoryIds.Count
+                |> should equal 0
+
+                let safetyFlags = inspection.SafetyFlags |> Set.ofArray
+
+                safetyFlags
+                |> Set.contains "pendingWatchWork"
+                |> should equal true
+
+                safetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal true
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that durable dirty-to-clean evidence republishes immediately during an idle timer pass.
+    [<Test>]
+    let ``watch durable pending journal evidence publishes clean transition after clearing`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let mutable pendingRows = 1L
+
+            try
+                Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                    Task.FromResult(
+                        {
+                            LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile
+                            AppliedThroughSequence = 1L
+                            PendingRowCount = pendingRows
+                        }
+                    ))
+
+                Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal true
+
+                pendingRows <- 0L
+
+                (Watch.processChangedFilesWithClients
+                    (fun () -> Task.FromResult(status))
+                    (fun () -> Task.FromResult(status))
+                    (fun _ _ -> Task.FromResult(()))
+                    (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                    scannerHostileDifferenceDiscovery
+                    (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                    (fun _ _ _ -> Task.FromResult(()))
+                    (fun currentStatus currentDirectoryIds -> Services.updateGraceWatchInterprocessFile currentStatus currentDirectoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal false
+
+                readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                |> should equal true
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.IsUsable |> should equal true
+
+                let safetyFlags = inspection.SafetyFlags |> Set.ofArray
+
+                safetyFlags
+                |> Set.contains "pendingWatchWork"
+                |> should equal false
+
+                safetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal false
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies durable-only journal evidence does not enter the processable Watch work branch.
     [<Test>]
     let ``watch durable-only pending journal evidence publishes without processing`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -10719,6 +10719,109 @@ module WatchTests =
             File.ReadAllText(Services.IpcFileName())
             |> should equal dirtyJson)
 
+    /// Verifies that durable journal evidence marks Watch status dirty even when process-local queues are empty.
+    [<Test>]
+    let ``watch durable pending journal evidence publishes dirty transition`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            try
+                Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                    Task.FromResult(
+                        { LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile; AppliedThroughSequence = 1L; PendingRowCount = 1L }
+                    ))
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                |> should equal true
+
+                readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                |> should equal false
+
+                let inspection =
+                    Services
+                        .inspectGraceWatchStatus()
+                        .GetAwaiter()
+                        .GetResult()
+
+                inspection.IsUsable |> should equal false
+
+                let safetyFlags = inspection.SafetyFlags |> Set.ofArray
+
+                safetyFlags
+                |> Set.contains "pendingWatchWork"
+                |> should equal true
+
+                safetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal true
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that watch check JSON exposes durable-pending degradation without changing stdout/stderr routing.
+    [<Test>]
+    let ``watch check json reports durable pending journal evidence`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            try
+                Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                    Task.FromResult(
+                        { LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile; AppliedThroughSequence = 1L; PendingRowCount = 1L }
+                    ))
+
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                let exitCode, standardOut, standardError =
+                    runWithCapturedStdoutAndStderr [| "--output"
+                                                      "Json"
+                                                      "watch"
+                                                      "--check" |]
+
+                exitCode |> should equal -1
+                standardError |> should equal String.Empty
+
+                use document = parseJsonOutput standardOut
+                let root = document.RootElement.GetProperty("ReturnValue")
+
+                root
+                    .GetProperty("CanUseIncrementalStatus")
+                    .GetBoolean()
+                |> should equal false
+
+                root.GetProperty("Reason").GetString()
+                |> should equal "resynchronizing"
+
+                let safetyFlags =
+                    root.GetProperty("SafetyFlags").EnumerateArray()
+                    |> Seq.map (fun flag -> flag.GetString())
+                    |> Set.ofSeq
+
+                safetyFlags
+                |> Set.contains "pendingWatchWork"
+                |> should equal true
+
+                safetyFlags
+                |> Set.contains "requiresExplicitResync"
+                |> should equal true
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that transient IPC write failures do not suppress the next dirty status publication attempt.
     [<Test>]
     let ``watch dirty status transition retries after ipc write failure`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -345,6 +345,10 @@ module WatchTests =
 
         let ipcFileName = Services.IpcFileName()
 
+        (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+            .GetAwaiter()
+            .GetResult()
+
         Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
         |> ignore
 
@@ -353,6 +357,22 @@ module WatchTests =
 
     /// Reads file if exists needed by the test scenario.
     let private readFileIfExists path = if File.Exists(path) then Some(File.ReadAllText(path)) else None
+
+    /// Deletes local-state database files so status trust tests can prove fail-closed durable inspection.
+    let private deleteLocalStateDbFiles () =
+        let dbPath = Current().GraceStatusFile
+
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools()
+        GC.Collect()
+        GC.WaitForPendingFinalizers()
+
+        [|
+            dbPath
+            dbPath + "-wal"
+            dbPath + "-shm"
+            dbPath + "-journal"
+        |]
+        |> Array.iter (fun path -> if File.Exists(path) then File.Delete(path))
 
     /// Builds delete watch status file if exists test data used to exercise CLI watch behavior.
     let private deleteWatchStatusFileIfExists () =
@@ -13792,6 +13812,121 @@ module WatchTests =
             let mutable error = Unchecked.defaultof<JsonElement>
 
             root.TryGetProperty("Error", &error)
+            |> should equal false
+
+            readFileIfExists ipcFileName
+            |> should equal originalContents)
+
+    /// Verifies that watch check fails closed when clean IPC exists but durable journal rows are still unapplied.
+    [<Test>]
+    let ``watch check json refuses clean status when durable journal rows are pending`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = writeLiveWatchStatusFile ()
+            let originalContents = readFileIfExists ipcFileName
+
+            (LocalStateDb.appendWatchJournalObservations
+                (Current().GraceStatusFile)
+                [|
+                    watchJournalObservation DifferenceType.Change FileSystemEntryType.File "pending-watch-check.txt"
+                |])
+                .GetAwaiter()
+                .GetResult()
+            |> ignore
+
+            /// Verifies that the CLI watch scenario exits with the expected process status.
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "watch"
+                                                  "--check" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement.GetProperty("ReturnValue")
+
+            root.GetProperty("IsRunning").GetBoolean()
+            |> should equal true
+
+            root
+                .GetProperty("CanUseIncrementalStatus")
+                .GetBoolean()
+            |> should equal false
+
+            root.GetProperty("Reason").GetString()
+            |> should equal "resynchronizing"
+
+            let safetyFlags =
+                root.GetProperty("SafetyFlags").EnumerateArray()
+                |> Seq.map (fun flag -> flag.GetString())
+                |> Set.ofSeq
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "incrementalSafe"
+            |> should equal false
+
+            readFileIfExists ipcFileName
+            |> should equal originalContents)
+
+    /// Verifies that watch check fails closed when clean IPC exists but durable local-state evidence is missing.
+    [<Test>]
+    let ``watch check json refuses clean status when local-state database is missing`` () =
+        withTempRepo (fun _ ->
+            let ipcFileName = writeLiveWatchStatusFile ()
+            let originalContents = readFileIfExists ipcFileName
+            deleteLocalStateDbFiles ()
+
+            /// Verifies that the CLI watch scenario exits with the expected process status.
+            let exitCode, standardOut, standardError =
+                runWithCapturedStdoutAndStderr [| "--output"
+                                                  "Json"
+                                                  "watch"
+                                                  "--check" |]
+
+            exitCode |> should equal -1
+            standardError |> should equal String.Empty
+
+            use document = parseJsonOutput standardOut
+            let root = document.RootElement.GetProperty("ReturnValue")
+
+            root.GetProperty("IsRunning").GetBoolean()
+            |> should equal true
+
+            root
+                .GetProperty("CanUseIncrementalStatus")
+                .GetBoolean()
+            |> should equal false
+
+            root.GetProperty("Reason").GetString()
+            |> should equal "durableStatusUnavailable"
+
+            root.GetProperty("Message").GetString()
+            |> should contain "durable local-state evidence could not be inspected"
+
+            let safetyFlags =
+                root.GetProperty("SafetyFlags").EnumerateArray()
+                |> Seq.map (fun flag -> flag.GetString())
+                |> Set.ofSeq
+
+            safetyFlags
+            |> Set.contains "durableJournalInspectionFailed"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "requiresExplicitResync"
+            |> should equal true
+
+            safetyFlags
+            |> Set.contains "incrementalSafe"
             |> should equal false
 
             readFileIfExists ipcFileName

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2877,7 +2877,12 @@ module Branch =
         member val ReferenceId: string = String.Empty with get, set
 
     /// Defines the injected side-effect boundary for branch-switch Watch-clean preflight tests.
-    type internal BranchSwitchWatchCleanPreflightOperations = { UpdateMarkerExists: unit -> bool; InspectWatchStatus: unit -> Task<GraceWatchStatusInspection> }
+    type internal BranchSwitchWatchCleanPreflightOperations =
+        {
+            UpdateMarkerExists: unit -> bool
+            InspectWatchStatus: unit -> Task<GraceWatchStatusInspection>
+            ReadPendingJournalSummary: unit -> Task<Grace.CLI.LocalStateDb.WatchJournalPendingWorkSummary>
+        }
 
     /// Builds the branch-switch refusal reason for an untrusted Watch IPC snapshot.
     let private branchSwitchWatchCleanPreflightRefusalReason updateMarkerExists (inspection: GraceWatchStatusInspection) =
@@ -2950,7 +2955,27 @@ module Branch =
 
                 match validateBranchSwitchWatchCleanPreflight false inspection with
                 | Error reason -> return Error(GraceError.Create $"Branch switch refused before mutation: {reason}" correlationId)
-                | Ok () -> return Ok()
+                | Ok () ->
+                    try
+                        let! pendingJournalSummary = operations.ReadPendingJournalSummary()
+
+                        if pendingJournalSummary.HasPendingRows then
+                            return
+                                Error(
+                                    GraceError.Create
+                                        $"Branch switch refused before mutation: Grace Watch has {pendingJournalSummary.PendingRowCount} unresolved durable journal rows that have not reached the applied boundary."
+                                        correlationId
+                                )
+                        else
+                            return Ok()
+                    with
+                    | ex ->
+                        return
+                            Error(
+                                GraceError.Create
+                                    $"Branch switch refused before mutation: Grace Watch durable journal pending-work evidence could not be inspected: {ex.Message}"
+                                    correlationId
+                            )
         }
 
     /// Writes branch-switch marker content through an injectable writer so failure cleanup can be tested deterministically.
@@ -3763,6 +3788,8 @@ module Branch =
                                         {
                                             UpdateMarkerExists = fun () -> File.Exists(workingTreeUpdateMarkerFileName)
                                             InspectWatchStatus = inspectGraceWatchStatus
+                                            ReadPendingJournalSummary =
+                                                fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummary (Current().GraceStatusFile)
                                         }
 
                                     let! workingTreeUpdateResult =
@@ -3927,7 +3954,12 @@ module Branch =
 
                 if parseResult |> verbose then printParseResult parseResult
 
-                let preflightOperations = { UpdateMarkerExists = (fun () -> File.Exists(updateMarkerFileName)); InspectWatchStatus = inspectGraceWatchStatus }
+                let preflightOperations =
+                    {
+                        UpdateMarkerExists = fun () -> File.Exists(updateMarkerFileName)
+                        InspectWatchStatus = inspectGraceWatchStatus
+                        ReadPendingJournalSummary = fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummary (Current().GraceStatusFile)
+                    }
 
                 let! switchResult =
                     runBranchSwitchWorkflowWithLease preflightOperations (getCorrelationId parseResult) switchLeaseFileName switchLeaseText (fun () ->

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -2940,6 +2940,31 @@ module Branch =
         | Some reason -> Error reason
         | None -> Ok()
 
+    /// Refuses branch switch mutation when durable Watch journal evidence cannot prove no unapplied rows exist.
+    let private validateBranchSwitchDurablePendingWorkSummary (operations: BranchSwitchWatchCleanPreflightOperations) correlationId boundaryDescription =
+        task {
+            try
+                let! pendingJournalSummary = operations.ReadPendingJournalSummary()
+
+                if pendingJournalSummary.HasPendingRows then
+                    return
+                        Error(
+                            GraceError.Create
+                                $"Branch switch refused before mutation: Grace Watch has {pendingJournalSummary.PendingRowCount} unresolved durable journal rows that have not reached the applied boundary{boundaryDescription}."
+                                correlationId
+                        )
+                else
+                    return Ok()
+            with
+            | ex ->
+                return
+                    Error(
+                        GraceError.Create
+                            $"Branch switch refused before mutation: Grace Watch durable journal pending-work evidence could not be inspected{boundaryDescription}: {ex.Message}"
+                            correlationId
+                    )
+        }
+
     /// Runs the branch-switch Watch-clean preflight without suppressing later filesystem observations.
     let internal runBranchSwitchWatchCleanPreflight (operations: BranchSwitchWatchCleanPreflightOperations) correlationId =
         task {
@@ -2955,27 +2980,7 @@ module Branch =
 
                 match validateBranchSwitchWatchCleanPreflight false inspection with
                 | Error reason -> return Error(GraceError.Create $"Branch switch refused before mutation: {reason}" correlationId)
-                | Ok () ->
-                    try
-                        let! pendingJournalSummary = operations.ReadPendingJournalSummary()
-
-                        if pendingJournalSummary.HasPendingRows then
-                            return
-                                Error(
-                                    GraceError.Create
-                                        $"Branch switch refused before mutation: Grace Watch has {pendingJournalSummary.PendingRowCount} unresolved durable journal rows that have not reached the applied boundary."
-                                        correlationId
-                                )
-                        else
-                            return Ok()
-                    with
-                    | ex ->
-                        return
-                            Error(
-                                GraceError.Create
-                                    $"Branch switch refused before mutation: Grace Watch durable journal pending-work evidence could not be inspected: {ex.Message}"
-                                    correlationId
-                            )
+                | Ok () -> return! validateBranchSwitchDurablePendingWorkSummary operations correlationId ""
         }
 
     /// Writes branch-switch marker content through an injectable writer so failure cleanup can be tested deterministically.
@@ -3160,9 +3165,12 @@ module Branch =
                 | Error error -> return Error error
                 | Ok () ->
                     try
-                        let! result = operation ()
-                        writeBranchSwitchUpdateMarkerCompleted updateMarkerFileName
-                        return Ok result
+                        match! validateBranchSwitchDurablePendingWorkSummary operations correlationId " after update marker creation" with
+                        | Error error -> return Error error
+                        | Ok () ->
+                            let! result = operation ()
+                            writeBranchSwitchUpdateMarkerCompleted updateMarkerFileName
+                            return Ok result
                     finally
                         if markerCreatedByThisInvocation then
                             deleteBranchSwitchUpdateMarkerIfOwned updateMarkerFileName markerText

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3789,7 +3789,8 @@ module Branch =
                                             UpdateMarkerExists = fun () -> File.Exists(workingTreeUpdateMarkerFileName)
                                             InspectWatchStatus = inspectGraceWatchStatus
                                             ReadPendingJournalSummary =
-                                                fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummary (Current().GraceStatusFile)
+                                                fun () ->
+                                                    Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck (Current().GraceStatusFile)
                                         }
 
                                     let! workingTreeUpdateResult =
@@ -3958,7 +3959,8 @@ module Branch =
                     {
                         UpdateMarkerExists = fun () -> File.Exists(updateMarkerFileName)
                         InspectWatchStatus = inspectGraceWatchStatus
-                        ReadPendingJournalSummary = fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummary (Current().GraceStatusFile)
+                        ReadPendingJournalSummary =
+                            fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck (Current().GraceStatusFile)
                     }
 
                 let! switchResult =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2108,17 +2108,21 @@ module Watch =
 
             true
 
-    /// Evaluates has pending watch work against parsed options and command state.
-    let private hasPendingWatchWork () =
+    /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
+    let private hasProcessablePendingWatchWork () =
         isGraceWatchResyncPending ()
         || graceStatusHasChanged
-        || hasPendingDurableWatchJournalEvidence ()
         || not (
             filesToProcess.IsEmpty
             && directoriesToProcess.IsEmpty
             && statusUpdateTriggers.IsEmpty
             && not (hasPendingStatusDifferences ())
         )
+
+    /// Evaluates has pending watch work against parsed options, process state, and durable journal evidence.
+    let private hasPendingWatchWork () =
+        hasProcessablePendingWatchWork ()
+        || hasPendingDurableWatchJournalEvidence ()
 
     /// Reads the generation for Grace Status DB refresh events observed from the filesystem.
     let private currentGraceStatusRefreshGeneration () = Volatile.Read(&graceStatusRefreshGeneration)
@@ -4115,7 +4119,7 @@ module Watch =
                     logToAnsiConsole
                         Colors.Error
                         $"Error in processChangedFiles resync: Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
-            elif hasPendingWatchWork () then
+            elif hasProcessablePendingWatchWork () then
                 try
                     let correlationId = generateCorrelationId ()
 
@@ -4397,6 +4401,8 @@ module Watch =
                     logToAnsiConsole
                         Colors.Error
                         $"Error in processChangedFiles: Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
+            elif hasPendingDurableWatchJournalEvidence () then
+                publishPendingWatchWorkTransitionIfNeeded ()
             // Refresh the file every (just under) 5 minutes to indicate that `grace watch` is still alive.
             elif
                 graceWatchStatusUpdateTime
@@ -4662,7 +4668,7 @@ module Watch =
             let mutable attemptedStartupCompletion = false
 
             if
-                not (hasPendingWatchWork ())
+                not (hasProcessablePendingWatchWork ())
                 && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.StartingUp
             then
                 attemptedStartupCompletion <- true

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -88,6 +88,9 @@ module Watch =
     let mutable private quarantineWatchJournalSequencesForWatch =
         fun sequences reason -> Grace.CLI.LocalStateDb.quarantineWatchJournalSequences (Current().GraceStatusFile) sequences reason
 
+    let mutable private readWatchJournalPendingWorkSummaryForWatch =
+        fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummary (Current().GraceStatusFile)
+
     let mutable private recordWatchLifecycleEventForWatch = fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
 
     /// Installs durable journal clients used by append-before-apply ordering tests.
@@ -104,6 +107,9 @@ module Watch =
     let internal setWatchJournalStartupClientsForWatchTests recoverStartup recordLifecycle =
         recoverWatchJournalForStartupForWatch <- recoverStartup
         recordWatchLifecycleEventForWatch <- recordLifecycle
+
+    /// Installs the durable journal status reader used by transition and status integration tests.
+    let internal setWatchJournalStatusClientForWatchTests readPendingWorkSummary = readWatchJournalPendingWorkSummaryForWatch <- readPendingWorkSummary
 
     /// Restores durable journal clients after tests replace append or boundary behavior.
     let internal resetWatchJournalClientsForWatchTests () =
@@ -126,6 +132,8 @@ module Watch =
 
         quarantineWatchJournalSequencesForWatch <-
             fun sequences reason -> Grace.CLI.LocalStateDb.quarantineWatchJournalSequences (Current().GraceStatusFile) sequences reason
+
+        readWatchJournalPendingWorkSummaryForWatch <- fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummary (Current().GraceStatusFile)
 
         recordWatchLifecycleEventForWatch <- fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
 
@@ -2085,10 +2093,26 @@ module Watch =
     /// Clears a specific resync attempt without losing a newer confidence-loss request.
     let private tryClearGraceWatchResyncAttempt attempt = Interlocked.CompareExchange(&graceWatchResyncGeneration, 0L, attempt) = attempt
 
+    /// Reports whether unresolved durable journal rows must keep Watch status dirty.
+    let private hasPendingDurableWatchJournalEvidence () =
+        try
+            readWatchJournalPendingWorkSummaryForWatch()
+                .GetAwaiter()
+                .GetResult()
+                .HasPendingRows
+        with
+        | ex ->
+            logToAnsiConsole
+                Colors.Error
+                $"Grace Watch could not inspect durable journal pending work; treating status as dirty until local state can be read: {Markup.Escape(ex.Message)}."
+
+            true
+
     /// Evaluates has pending watch work against parsed options and command state.
     let private hasPendingWatchWork () =
         isGraceWatchResyncPending ()
         || graceStatusHasChanged
+        || hasPendingDurableWatchJournalEvidence ()
         || not (
             filesToProcess.IsEmpty
             && directoriesToProcess.IsEmpty

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2888,6 +2888,39 @@ module Watch =
             RootDirectoryId: DirectoryVersionId option
         }
 
+    /// Combines IPC inspection with durable journal evidence that must fail closed before status shortcuts are trusted.
+    type private WatchCheckTrustInspection =
+        {
+            Inspection: GraceWatchStatusInspection
+            DurablePendingRows: int64 option
+            DurableInspectionError: string option
+        }
+
+        /// Reports whether Watch check may advertise incremental status shortcuts.
+        member this.CanUseIncrementalStatus =
+            this.Inspection.IsUsable
+            && this.DurableInspectionError.IsNone
+            && (this.DurablePendingRows |> Option.defaultValue 0L) = 0L
+
+        /// Reports whether durable local-state evidence blocks a clean IPC snapshot.
+        member this.HasDurablePendingRows =
+            this.DurablePendingRows
+            |> Option.exists (fun pendingRows -> pendingRows > 0L)
+
+    /// Reads durable journal evidence for `watch --check` without treating a missing local-state DB as clean.
+    let private inspectWatchCheckDurableTrust (inspection: GraceWatchStatusInspection) =
+        task {
+            if inspection.IsUsable then
+                try
+                    let! pendingJournalSummary = Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck (Current().GraceStatusFile)
+
+                    return { Inspection = inspection; DurablePendingRows = Some pendingJournalSummary.PendingRowCount; DurableInspectionError = None }
+                with
+                | ex -> return { Inspection = inspection; DurablePendingRows = None; DurableInspectionError = Some ex.Message }
+            else
+                return { Inspection = inspection; DurablePendingRows = None; DurableInspectionError = None }
+        }
+
     /// Reports whether a Watch IPC snapshot has the root identity needed by incremental status shortcuts.
     let private hasUsableRootSnapshotForCheck (status: GraceWatchStatus) =
         status.RootDirectoryId <> Guid.Empty
@@ -2900,26 +2933,38 @@ module Watch =
         && status.DirectoryIds.Count > 0
 
     /// Builds safety flags for `watch --check` after combining persisted and derived mode facts.
-    let private safetyFlagsForWatchCheck (inspection: GraceWatchStatusInspection) =
+    let private safetyFlagsForWatchCheck (trustInspection: WatchCheckTrustInspection) =
+        let inspection = trustInspection.Inspection
         let flags = HashSet<string>(inspection.SafetyFlags, StringComparer.Ordinal)
 
-        if not inspection.IsUsable then
-            flags.Remove("incrementalSafe") |> ignore
+        if trustInspection.HasDurablePendingRows then
+            flags.Add("pendingWatchWork") |> ignore
 
-            if not (flags.Contains("pendingWatchWork")) then
-                flags.Add("requiresExplicitResync") |> ignore
+        if trustInspection.DurableInspectionError.IsSome then
+            flags.Add("durableJournalInspectionFailed")
+            |> ignore
+
+        if not trustInspection.CanUseIncrementalStatus then
+            flags.Remove("incrementalSafe") |> ignore
+            flags.Remove("cleanWorkingTree") |> ignore
+
+            flags.Add("requiresExplicitResync") |> ignore
 
         flags |> Seq.sort |> Seq.toArray
 
     /// Maps a Watch IPC inspection result to the stable status reason emitted to humans and agents.
-    let private watchCheckReason (inspection: GraceWatchStatusInspection) =
+    let private watchCheckReason (trustInspection: WatchCheckTrustInspection) =
+        let inspection = trustInspection.Inspection
+
         match inspection.ReadError, inspection.Exists, inspection.Status, inspection.EffectiveMode with
         | Some _, _, _, _ -> "unreadableStatus"
         | None, false, _, _ -> "notRunning"
         | None, true, None, _ -> "unreadableStatus"
         | None, true, Some _, _ when not inspection.IsFresh -> "staleStatus"
         | None, true, Some status, _ when status.IsStartupClaim -> "startingUp"
-        | None, true, Some _, Some GraceWatchRuntimeMode.HealthyIncremental when inspection.IsUsable -> "running"
+        | None, true, Some _, Some GraceWatchRuntimeMode.HealthyIncremental when trustInspection.DurableInspectionError.IsSome -> "durableStatusUnavailable"
+        | None, true, Some _, Some GraceWatchRuntimeMode.HealthyIncremental when trustInspection.HasDurablePendingRows -> "resynchronizing"
+        | None, true, Some _, Some GraceWatchRuntimeMode.HealthyIncremental when trustInspection.CanUseIncrementalStatus -> "running"
         | None, true, Some _, Some GraceWatchRuntimeMode.Resynchronizing -> "resynchronizing"
         | None, true, Some _, Some GraceWatchRuntimeMode.Suspended -> "suspended"
         | None, true, Some _, Some GraceWatchRuntimeMode.Stopping -> "stopping"
@@ -2930,6 +2975,7 @@ module Watch =
     let private watchCheckMessage reason =
         match reason with
         | "running" -> "GraceWatch is running in HealthyIncremental mode. Incremental status shortcuts are available."
+        | "durableStatusUnavailable" -> "GraceWatch status cannot prove incremental shortcuts because durable local-state evidence could not be inspected."
         | "startingUp" -> "GraceWatch is starting and has not published a usable status snapshot yet."
         | "resynchronizing" -> "GraceWatch is resynchronizing trusted state; incremental status shortcuts are suspended until resync completes."
         | "suspended" -> "GraceWatch is suspended after confidence loss; restart watch or run an explicit resync before relying on incremental status."
@@ -2940,9 +2986,10 @@ module Watch =
         | _ -> "GraceWatch status is not ready for incremental shortcuts."
 
     /// Converts Watch IPC inspection into the public `watch --check` status payload.
-    let private toWatchCheckStatusDto (inspection: GraceWatchStatusInspection) =
+    let private toWatchCheckStatusDto (trustInspection: WatchCheckTrustInspection) =
+        let inspection = trustInspection.Inspection
         let status = inspection.Status
-        let reason = watchCheckReason inspection
+        let reason = watchCheckReason trustInspection
 
         let mode =
             inspection.EffectiveMode
@@ -2951,11 +2998,11 @@ module Watch =
 
         {
             IsRunning = inspection.IsLiveProcess
-            CanUseIncrementalStatus = inspection.IsUsable
+            CanUseIncrementalStatus = trustInspection.CanUseIncrementalStatus
             Mode = mode
             Reason = reason
             Message = watchCheckMessage reason
-            SafetyFlags = safetyFlagsForWatchCheck inspection
+            SafetyFlags = safetyFlagsForWatchCheck trustInspection
             IsFresh = inspection.IsFresh
             HasUsableRootSnapshot =
                 status
@@ -4771,7 +4818,8 @@ module Watch =
                 try
                     if isCheckRequested parseResult then
                         let! watchStatusInspection = inspectGraceWatchStatus ()
-                        let watchCheckStatus = toWatchCheckStatusDto watchStatusInspection
+                        let! trustInspection = inspectWatchCheckDurableTrust watchStatusInspection
+                        let watchCheckStatus = toWatchCheckStatusDto trustInspection
                         raise (WatchCommandExit(renderWatchCheckStatus parseResult watchCheckStatus))
 
                     let! claimedGraceWatchStatus = tryClaimGraceWatchInterprocessFile ()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2108,6 +2108,23 @@ module Watch =
 
             true
 
+    /// Describes pending Watch work without merging process-local queues and durable journal evidence.
+    type private PendingWatchWorkEvidence =
+        {
+            HasProcessablePendingWork: bool
+            HasDurableWatchJournalEvidence: bool
+        }
+
+        /// Reports whether any Watch work or durable journal evidence must keep IPC dirty.
+        member this.HasPendingWork =
+            this.HasProcessablePendingWork
+            || this.HasDurableWatchJournalEvidence
+
+        /// Reports whether durable journal evidence is the only reason IPC must be dirty.
+        member this.HasDurableOnlyPendingWork =
+            this.HasDurableWatchJournalEvidence
+            && not this.HasProcessablePendingWork
+
     /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
     let private hasProcessablePendingWatchWork () =
         isGraceWatchResyncPending ()
@@ -2123,6 +2140,12 @@ module Watch =
     let private hasPendingWatchWork () =
         hasProcessablePendingWatchWork ()
         || hasPendingDurableWatchJournalEvidence ()
+
+    /// Reads process-local and durable pending-work facts once for a single status publication decision.
+    let private readPendingWatchWorkEvidence () =
+        let hasProcessablePendingWork = hasProcessablePendingWatchWork ()
+
+        { HasProcessablePendingWork = hasProcessablePendingWork; HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence () }
 
     /// Reads the generation for Grace Status DB refresh events observed from the filesystem.
     let private currentGraceStatusRefreshGeneration () = Volatile.Read(&graceStatusRefreshGeneration)
@@ -2145,6 +2168,12 @@ module Watch =
 
     /// Records the pending-work flag that the next Watch IPC snapshot should publish.
     let private setGraceWatchPendingWorkStatusFlag hasPendingWork = lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
+
+    /// Reports whether the last verified IPC pending-work publication is stale against fresh evidence.
+    let private pendingWatchWorkTransitionNeedsPublication () =
+        File.Exists(IpcFileName())
+        && lastPublishedHasPendingWatchWork
+           <> Some((readPendingWatchWorkEvidence ()).HasPendingWork)
 
     /// Returns the root BLAKE3 hash that Watch expects to see in the IPC snapshot it just published.
     let private expectedRootDirectoryBlake3Hash (status: GraceStatus) =
@@ -2201,19 +2230,38 @@ module Watch =
 
             while pendingWorkChangedDuringWrite && attempts < 2 do
                 attempts <- attempts + 1
-                let hasPendingWork = hasPendingWatchWork ()
+                let pendingEvidence = readPendingWatchWorkEvidence ()
+                let hasPendingWork = pendingEvidence.HasPendingWork
                 setGraceWatchHasPendingWorkForStatus hasPendingWork
                 let publicationStartedAt = getCurrentInstant ()
 
+                let statusForVerification, directoryIdsForVerification =
+                    if pendingEvidence.HasDurableOnlyPendingWork then
+                        GraceStatus.Default, HashSet<DirectoryVersionId>()
+                    else
+                        expectedStatus, expectedDirectoryIds
+
                 try
-                    writeSnapshot().GetAwaiter().GetResult()
-                    transitionWasPublished <- cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt
+                    if pendingEvidence.HasDurableOnlyPendingWork then
+                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+
+                        match currentGraceWatchRuntimeMode () with
+                        | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds)
+                        | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some emptyDirectoryIds)
+                        |> fun writeTask -> writeTask.GetAwaiter().GetResult()
+                    else
+                        writeSnapshot().GetAwaiter().GetResult()
+
+                    transitionWasPublished <-
+                        cachePendingWatchWorkPublicationIfVerified statusForVerification directoryIdsForVerification hasPendingWork publicationStartedAt
                 with
                 | ex ->
                     lastPublishedHasPendingWatchWork <- None
                     logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
-                pendingWorkChangedDuringWrite <- hasPendingWatchWork () <> hasPendingWork
+                pendingWorkChangedDuringWrite <-
+                    (readPendingWatchWorkEvidence ()).HasPendingWork
+                    <> hasPendingWork
 
             transitionWasPublished)
 
@@ -2225,7 +2273,8 @@ module Watch =
     /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
     let private publishPendingWatchWorkTransitionIfNeeded () =
         lock watchStatusPublishLock (fun () ->
-            let hasPendingWork = hasPendingWatchWork ()
+            let pendingEvidence = readPendingWatchWorkEvidence ()
+            let hasPendingWork = pendingEvidence.HasPendingWork
 
             if
                 File.Exists(IpcFileName())
@@ -2237,7 +2286,9 @@ module Watch =
                 let runtimeMode = currentGraceWatchRuntimeMode ()
 
                 let shouldPublish, statusForPublish, directoryIdsForPublish =
-                    if
+                    if pendingEvidence.HasDurableOnlyPendingWork then
+                        true, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                    elif
                         runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                         && not (isGraceWatchResyncPending ())
                     then
@@ -4401,7 +4452,7 @@ module Watch =
                     logToAnsiConsole
                         Colors.Error
                         $"Error in processChangedFiles: Message: {ex.Message}{Environment.NewLine}{Environment.NewLine}{ex.StackTrace}"
-            elif hasPendingDurableWatchJournalEvidence () then
+            elif pendingWatchWorkTransitionNeedsPublication () then
                 publishPendingWatchWorkTransitionIfNeeded ()
             // Refresh the file every (just under) 5 minutes to indicate that `grace watch` is still alive.
             elif

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1659,6 +1659,25 @@ module LocalStateDb =
                 return { DbPath = normalizedPath; AppliedThroughSequence = appliedThroughSequence; PendingRowCount = pendingRowCount }
         }
 
+    /// Reads unresolved durable Watch journal evidence for branch transition trust checks that must fail closed.
+    let readWatchJournalPendingWorkSummaryForTransitionCheck (dbPath: string) =
+        task {
+            let normalizedPath = Path.GetFullPath(dbPath)
+
+            if
+                not (File.Exists(normalizedPath))
+                && not (Directory.Exists(normalizedPath))
+            then
+                return
+                    raise (
+                        InvalidDataException(
+                            "Watch journal pending-work inspection requires a readable local state database; the local-state database is missing."
+                        )
+                    )
+            else
+                return! readWatchJournalPendingWorkSummary normalizedPath
+        }
+
     /// Reads a bounded diagnostic snapshot of the durable Watch journal.
     let readWatchJournalSnapshot (dbPath: string) (stateFilter: string) (pathFilter: string option) (limit: int) =
         task {

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1625,29 +1625,34 @@ module LocalStateDb =
             then
                 return { DbPath = normalizedPath; AppliedThroughSequence = 0L; PendingRowCount = 0L }
             else
-                let inspection = inspectReadOnly normalizedPath
+                let missingPartialWalSidecars = missingPartialWalSidecars normalizedPath
 
-                if not inspection.OpenedReadOnly then
-                    let detail =
-                        inspection.OpenError
-                        |> Option.defaultValue "local state database does not exist or could not be opened read-only."
+                if missingPartialWalSidecars.Length > 0 then
+                    let missingNames = String.concat ", " missingPartialWalSidecars
 
-                    raise (InvalidDataException($"Watch journal pending-work inspection requires a readable local state database: {detail}"))
-
-                if inspection.SchemaVersion <> Some SchemaVersion
-                   || inspection.MissingRequiredTables.Length > 0
-                   || inspection.MissingRequiredIndexes.Length > 0
-                   || inspection.WatchJournalShapeValid <> Some true
-                   || inspection.WatchJournalAppliedThroughMetadataValid
-                      <> Some true then
-                    raise (
-                        InvalidDataException(
-                            "Watch journal pending-work inspection requires a healthy local state database; run grace doctor or a writable command to repair local state."
-                        )
-                    )
+                    raise (InvalidDataException($"Watch journal pending-work inspection requires a complete WAL sidecar set; missing: {missingNames}."))
 
                 let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
                 use connection = openReadOnlyConnection normalizedPath immutableSnapshot
+
+                let schemaVersion =
+                    try
+                        readSchemaVersionReadOnly connection
+                    with
+                    | _ -> None
+
+                if
+                    schemaVersion <> Some SchemaVersion
+                    || not (tableExists connection "watch_journal")
+                    || not (hasRequiredWatchJournalShape connection)
+                    || not (hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection)
+                then
+                    raise (
+                        InvalidDataException(
+                            "Watch journal pending-work inspection requires readable journal schema and applied-boundary metadata; run grace doctor or a writable command to repair local state."
+                        )
+                    )
+
                 let appliedThroughSequence = readWatchJournalAppliedThroughSequenceInternal connection
                 let pendingRowCount = countPendingWatchJournalRows connection appliedThroughSequence
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1347,6 +1347,17 @@ module LocalStateDb =
             Rows: WatchJournalRow array
         }
 
+    /// Summarizes unresolved durable Watch journal evidence without decoding replay payloads.
+    type WatchJournalPendingWorkSummary =
+        {
+            DbPath: string
+            AppliedThroughSequence: int64
+            PendingRowCount: int64
+        }
+
+        /// Reports whether any durable Watch observation still needs status/application convergence.
+        member this.HasPendingRows = this.PendingRowCount > 0L
+
     /// Models the result of explicitly resetting only durable Watch journal state.
     type ClearWatchJournalResult =
         {
@@ -1591,6 +1602,56 @@ module LocalStateDb =
             do! ensureDbInitialized dbPath
             use connection = openConnection dbPath
             return readWatchJournalAppliedThroughSequenceInternal connection
+        }
+
+    /// Counts non-quarantined Watch journal rows that remain beyond the durable applied boundary.
+    let private countPendingWatchJournalRows (connection: SqliteConnection) appliedThroughSequence =
+        use command = connection.CreateCommand()
+        command.CommandText <- "SELECT COUNT(*) FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NULL;"
+
+        command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
+        |> ignore
+
+        command.ExecuteScalar() |> Convert.ToInt64
+
+    /// Reads unresolved durable Watch journal evidence without repairing the database before transition checks.
+    let readWatchJournalPendingWorkSummary (dbPath: string) =
+        task {
+            let normalizedPath = Path.GetFullPath(dbPath)
+
+            if
+                not (File.Exists(normalizedPath))
+                && not (Directory.Exists(normalizedPath))
+            then
+                return { DbPath = normalizedPath; AppliedThroughSequence = 0L; PendingRowCount = 0L }
+            else
+                let inspection = inspectReadOnly normalizedPath
+
+                if not inspection.OpenedReadOnly then
+                    let detail =
+                        inspection.OpenError
+                        |> Option.defaultValue "local state database does not exist or could not be opened read-only."
+
+                    raise (InvalidDataException($"Watch journal pending-work inspection requires a readable local state database: {detail}"))
+
+                if inspection.SchemaVersion <> Some SchemaVersion
+                   || inspection.MissingRequiredTables.Length > 0
+                   || inspection.MissingRequiredIndexes.Length > 0
+                   || inspection.WatchJournalShapeValid <> Some true
+                   || inspection.WatchJournalAppliedThroughMetadataValid
+                      <> Some true then
+                    raise (
+                        InvalidDataException(
+                            "Watch journal pending-work inspection requires a healthy local state database; run grace doctor or a writable command to repair local state."
+                        )
+                    )
+
+                let immutableSnapshot = shouldUseImmutableReadOnlySnapshot normalizedPath
+                use connection = openReadOnlyConnection normalizedPath immutableSnapshot
+                let appliedThroughSequence = readWatchJournalAppliedThroughSequenceInternal connection
+                let pendingRowCount = countPendingWatchJournalRows connection appliedThroughSequence
+
+                return { DbPath = normalizedPath; AppliedThroughSequence = appliedThroughSequence; PendingRowCount = pendingRowCount }
         }
 
     /// Reads a bounded diagnostic snapshot of the durable Watch journal.


### PR DESCRIPTION
## Summary

Implements WS4.5 transition and status integration cleanup for the durable Watch journal:

- Adds lightweight read-only durable journal probes for Watch status, hot-path pending checks, and stricter transition
  trust checks.
- Keeps durable pending evidence separate from processable in-memory Watch queues, so durable-only rows degrade status
  without creating no-op processing loops.
- Publishes dirty and clean IPC transitions when durable evidence changes, including recovery after a fail-closed probe.
- Fails closed when local state cannot be inspected, so Watch status/check and branch-switch preflight do not trust a
  stale clean IPC snapshot.
- Publishes durable-only unresolved journal rows as explicit-resync/non-incremental degradation without changing the
  `watch --check --output Json` DTO shape.
- Rechecks durable journal evidence after the branch-switch update marker is created and before working-tree mutation.

Related to #501.
Part of #473.

## Why This Matters

Grace Watch transitions must not rely only on process-local queues after durable journal work lands. If local durable
journal evidence remains pending or cannot be inspected, branch/root transitions and status consumers need degraded state
before they trust incremental Watch results.

## Validation

- Worker validation for `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`: targeted Fantomas on touched F# files passed.

  ```powershell
  dotnet tool run fantomas `
    src\Grace.CLI\Command\Watch.CLI.fs `
    src\Grace.CLI\Command\Branch.CLI.fs `
    src\Grace.CLI.Tests\Watch.Tests.fs `
    src\Grace.CLI.Tests\Branch.CLI.Tests.fs
  ```

- Release build for `Grace.CLI.Tests` passed.

  ```powershell
  dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj
  ```

- Focused Branch/Watch CLI tests passed, 290/290.

  ```powershell
  dotnet test --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --no-build --filter "FullyQualifiedName~BranchCommandTests|FullyQualifiedName~WatchTests"
  ```

- Final fast gate passed.

  ```powershell
  pwsh ./scripts/validate.ps1 -Fast
  ```

- GitHub `full` passed for `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`.
- `git diff --check`: passed.

## Acceptance Mapping

- Pending durable evidence blocks unsafe transitions: branch preflight reads strict durable pending evidence and refuses
  mutation when local state is missing, unreadable, or has unresolved non-quarantined Watch journal rows.
- Durable source, not transient memory: Watch status and transition checks read LocalStateDb evidence for
  non-quarantined rows past `AppliedThroughSequence`, even when process-local queues are empty.
- Degraded status visible: durable-only rows publish explicit-resync/non-incremental IPC state so
  `watch --check --output Json` reports the existing degraded safety flags without DTO shape changes.
- Clean recovery visible: Watch republishes clean IPC promptly when a fresh durable predicate clears a prior dirty or
  fail-closed snapshot.
- Branch mutation race closed: branch switch repeats durable journal inspection after the update marker exists and
  before working-tree mutation.
- #500 startup replay/quarantine preserved: startup replay, payload decoding, quarantine classification, and boundary
  advancement logic were not weakened.
- #499 applied-boundary convergence preserved: the new summary paths read the existing durable boundary and quarantine
  columns.
- Negative/regression/boundary proof: Watch and Branch tests cover missing DB fail-closed status, durable-only
  explicit-resync degradation, dirty-to-clean IPC recovery, and the post-marker branch-switch durable recheck.

## Docs Impact

No docs were changed. Waiver: this slice does not add or rename public commands, options, DTO fields, or examples. It
changes when existing Watch safety flags/status become degraded, and existing `watch --check` plus
`maintenance show-journal` contracts already expose that state.

## Residual Risks

No worker residual risks remain after the stabilization pass. The PR had three substantive Codex review cycles on
Watch/Branch transition safety, so the acceptance target was converted into a stabilization ledger and proven before the
final latest-head review.

## Review Status

- Current head: `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`.
- Codex review session 1 completed on `a73fe326047de5f2f87483bb3bdd7d2eb1af059f` with 3 fresh findings; all three were
  fixed in `9c1a4941b1daffb49d4a618bfa6471a8a1b70381`, replied to, and resolved.
- Session 1 finding `3524720981`: lightweight read-only pending probe replaced full diagnostic inspection. Reply
  `3524739596`.
- Session 1 finding `3524720983`: durable dirty evidence was separated from processable in-memory Watch work. Reply
  `3524739675`.
- Session 1 finding `3524720985`: branch-switch preflight checks durable pending Watch journal evidence after clean IPC.
  Reply `3524739723`.
- Codex review session 2 completed on `9c1a4941b1daffb49d4a618bfa6471a8a1b70381` with 3 fresh findings; all three were
  fixed in `7b0788c6f1a9a0406f9a8476e4b93c4c277a1b5e`, replied to, and resolved.
- Session 2 finding `3524757135`: Watch republishes clean when fresh durable pending evidence clears after a dirty or
  fail-closed snapshot. Reply `3524809311`.
- Session 2 finding `3524757144`: missing local-state DB fails closed for transition/status trust decisions instead of
  reporting zero pending rows. Reply `3524809422`.
- Session 2 finding `3524757146`: durable-only unresolved journal rows publish explicit-resync/non-incremental
  degradation. Reply `3524809511`.
- Review Stabilization Ledger posted to
  [PR #548](https://github.com/ScottArbeit/Grace/pull/548#issuecomment-4885806483) and
  [issue #501](https://github.com/ScottArbeit/Grace/issues/501#issuecomment-4885806553).
- Validation for `7b0788c6f1a9a0406f9a8476e4b93c4c277a1b5e`: targeted Fantomas passed; focused CLI tests passed 54/54;
  `pwsh ./scripts/validate.ps1 -Fast` passed, including `Grace.CLI.Tests` 972/972; `git diff --check` passed; GitHub
  `full` passed.
- Codex review session 3 completed on `7b0788c6f1a9a0406f9a8476e4b93c4c277a1b5e` with 2 fresh findings; both were fixed
  in `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`, replied to, and resolved.
- Session 3 finding `3524822666`: Watch status/check now fails closed when the local-state DB is missing or durable rows
  cannot be inspected. Reply `3524848463`.
- Session 3 finding `3524822668`: branch switch now repeats durable pending-row validation after update marker creation
  and before working-tree mutation. Reply `3524848494`.
- Session-3 stabilization addendum posted to
  [PR #548](https://github.com/ScottArbeit/Grace/pull/548#issuecomment-4885895050) and
  [issue #501](https://github.com/ScottArbeit/Grace/issues/501#issuecomment-4885895114).
- Validation for `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`: targeted Fantomas passed; Release build for
  `Grace.CLI.Tests` passed; focused Branch/Watch tests passed 290/290; `pwsh ./scripts/validate.ps1 -Fast` passed;
  `git diff --check` passed.
- GitHub `full` passed for `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`.
- Codex Code Review Bot completed the latest-head review with a clean `THUMBS_UP` reaction on
  `9c8c14b3a400b7ef7f4726f113ad8b46f9e0f953`; all review threads are resolved.
- Stabilization status: session-2 and session-3 ledger invariants are implemented and proven; no residual risks reported
  by the worker.
- Prevention: #501 now includes fail-closed Watch status/check durable inspection and a post-marker branch-switch
  durable recheck as proven trust-boundary invariants.
- Review sessions: 4 completed on this PR, including the final no-issues latest-head pass; substantive cycle count is 3.
- Current gate: satisfied for merge into `epic/473-grace-watch-incremental-sync`.
