### PR TITLE
WS7.2: Refresh Watch current-branch SignalR subscriptions safely

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1122,6 +1122,64 @@ module WatchTests =
             finally
                 Watch.resetSignalRSubscriptionRefreshForWatchTests ())
 
+    /// Verifies that a successful SignalR refresh joins the current-branch group before the parent-branch group.
+    [<Test>]
+    let ``signalr refresh registers current branch before parent branch`` () =
+        withTempRepo (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let parentId = Guid.NewGuid()
+            let repositoryName = "signalr-registration-order-repo"
+
+            writeRepositoryConfiguration root repositoryId repositoryName branchId "feature/current-registration"
+            resetConfiguration ()
+            Current() |> ignore
+
+            let parentBranchDto = { Grace.Types.Branch.BranchDto.Default with RepositoryId = repositoryId; BranchId = parentId; BranchName = BranchName "main" }
+
+            /// Returns parent metadata for the active branch without changing local branch identity.
+            let getParentBranch (_: GetBranchParameters) = Task.FromResult(Ok(GraceReturnValue.Create parentBranchDto "registration-order-test"))
+
+            let registrations = ResizeArray<string * Guid * Guid>()
+
+            /// Records current-branch group registration in call order.
+            let registerCurrentBranch repositoryId branchId _ =
+                registrations.Add("current", repositoryId, branchId)
+                Task.CompletedTask
+
+            /// Records parent-branch group registration in call order.
+            let registerParentBranch branchId parentBranchId _ =
+                registrations.Add("parent", branchId, parentBranchId)
+                Task.CompletedTask
+
+            let result =
+                (Watch.registerCurrentSignalRParentBranchWithClientsForWatchTests
+                    getParentBranch
+                    registerCurrentBranch
+                    registerParentBranch
+                    CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult()
+
+            match result with
+            | Ok parentBranch -> parentBranch.BranchId |> should equal parentId
+            | Error error -> Assert.Fail($"Expected successful SignalR branch registration: {error}")
+
+            registrations.ToArray()
+            |> should
+                equal
+                [|
+                    "current", repositoryId, branchId
+                    "parent", branchId, parentId
+                |]
+
+            let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+
+            subscription.BranchId |> should equal branchId
+
+            subscription.ParentBranchId
+            |> should equal parentId)
+
     /// Verifies that reconnect refresh invokes registration and clears local trust when registration fails.
     [<Test>]
     let ``signalr reconnect refresh reruns current branch registration and fails closed`` () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -746,6 +746,17 @@ module Watch =
     let private signalRBranchSubscriptionStillTrusted trustedSubscription =
         lock signalRBranchSubscriptionLock (fun () -> signalRBranchSubscription = trustedSubscription)
 
+    /// Clears branch-scoped SignalR trust only when the failing refresh still owns the local subscription authority.
+    let private clearSignalRBranchSubscriptionIfStillTrusted trustedSubscription =
+        lock signalRBranchSubscriptionLock (fun () ->
+            if signalRBranchSubscription = trustedSubscription then
+                let generation = signalRBranchSubscription.Generation + 1L
+                signalRBranchSubscription <- emptySignalRBranchSubscription generation
+                signalRBranchSubscriptionRefreshNeededAfterTransition <- false
+                true
+            else
+                false)
+
     /// Installs the active SignalR parent-branch refresh operation used after branch identity changes.
     let private registerSignalRSubscriptionRefresh refresh =
         lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- refresh)
@@ -3220,16 +3231,36 @@ module Watch =
                     let parentBranchDto = returnValue.ReturnValue
 
                     if trySetSignalRBranchSubscription refreshAuthority parentBranchDto.BranchId then
-                        try
-                            do! registerCurrentBranch current.RepositoryId refreshAuthority.BranchId cancellationToken
-                            do! registerParentBranch refreshAuthority.BranchId parentBranchDto.BranchId cancellationToken
+                        let trustedSubscription =
+                            { BranchId = refreshAuthority.BranchId; ParentBranchId = parentBranchDto.BranchId; Generation = refreshAuthority.Generation }
 
-                            logToAnsiConsole
-                                Colors.Highlighted
-                                $"SignalR Hub connection state: {connectionState ()}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {connectionId ()}."
+                        try
+                            let mutable registeredParentBranch = false
+
+                            if signalRBranchSubscriptionStillTrusted trustedSubscription then
+                                do! registerCurrentBranch current.RepositoryId refreshAuthority.BranchId cancellationToken
+
+                                if signalRBranchSubscriptionStillTrusted trustedSubscription then
+                                    do! registerParentBranch refreshAuthority.BranchId parentBranchDto.BranchId cancellationToken
+                                    registeredParentBranch <- true
+                                else
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch skipped stale SignalR parent subscription registration for branch {refreshAuthority.BranchId}; current branch identity changed after current-branch registration."
+                            else
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Grace Watch skipped stale SignalR current-branch subscription registration for branch {refreshAuthority.BranchId}; current branch identity changed before hub registration."
+
+                            if registeredParentBranch then
+                                logToAnsiConsole
+                                    Colors.Highlighted
+                                    $"SignalR Hub connection state: {connectionState ()}. Listening for changes in parent branch {parentBranchDto.BranchName} ({parentBranchDto.BranchId}); connectionId: {connectionId ()}."
                         with
                         | ex ->
-                            clearSignalRBranchSubscription ()
+                            clearSignalRBranchSubscriptionIfStillTrusted trustedSubscription
+                            |> ignore
+
                             raise ex
 
                         return Ok parentBranchDto

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -160,6 +160,31 @@ type NotificationServerTests() =
             )
         }
 
+    /// Verifies that disconnect cleanup removes only server-side current-branch bookkeeping for the connection.
+    [<Test>]
+    member _.CurrentBranchDisconnectClearsPerConnectionState() =
+        task {
+            let repositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            let branchId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            let items = Dictionary<obj, obj>()
+            let operations = ResizeArray<string * string>()
+            let groups = recordingGroupManager operations
+
+            do! replaceCurrentBranchGroupMembership groups "connection-1" items repositoryId branchId CancellationToken.None
+
+            let cleared = clearCurrentBranchGroupMembershipState items
+            let clearedAgain = clearCurrentBranchGroupMembershipState items
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(cleared, Is.True)
+                    Assert.That(clearedAgain, Is.False)
+                    Assert.That(items, Is.Empty)
+                    Assert.That(operations, Has.Count.EqualTo(1))
+                    Assert.That(operations[0], Is.EqualTo(("add", currentBranchGroupKey repositoryId branchId))))
+            )
+        }
+
     /// Verifies that current-branch SignalR subscriptions require branch read authorization.
     [<Test>]
     member _.CurrentBranchSubscriptionRequiresBranchReadAuthorization() =

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -98,6 +98,12 @@ module Notification =
             items[CurrentBranchGroupItemKey] <- nextGroupKey
         }
 
+    /// Clears per-connection current-branch bookkeeping while leaving SignalR to clean up group membership on disconnect.
+    let internal clearCurrentBranchGroupMembershipState (items: IDictionary<obj, obj>) =
+        match isNull items with
+        | true -> false
+        | false -> items.Remove CurrentBranchGroupItemKey
+
     /// Checks whether the caller can subscribe to same-branch notifications for the stored branch identity.
     let internal canRegisterCurrentBranchSubscription
         (evaluator: IGracePermissionEvaluator)
@@ -158,6 +164,22 @@ module Notification =
                     this.Context.ConnectionId
                 )
             }
+
+        /// Clears per-connection current-branch bookkeeping during normal SignalR disconnect.
+        override this.OnDisconnectedAsync(ex: Exception) =
+            let items = this.Context.Items
+            let connectionId = this.Context.ConnectionId
+            let cleared = clearCurrentBranchGroupMembershipState items
+
+            if cleared then
+                log.LogInformation(
+                    "{CurrentInstant}: Node: {HostName}; ConnectionId: {ConnectionId} cleared current-branch SignalR subscription state on disconnect.",
+                    getCurrentInstantExtended (),
+                    getMachineName,
+                    connectionId
+                )
+
+            ``base``.OnDisconnectedAsync(ex)
 
         /// Adds the current SignalR connection to the repository group used for repository-wide notifications.
         member this.RegisterRepository(repositoryId: RepositoryId) =


### PR DESCRIPTION
## Summary

Implements WS7.2 Watch subscription lifecycle and normal SignalR shutdown:

- Guards Watch SignalR subscription refreshes so stale in-flight refreshes cannot replace the currently authoritative
  branch membership.
- Rechecks local branch subscription authority before current-branch registration and again before parent-branch
  registration.
- Registers current-branch membership before parent-branch membership for successful refreshes.
- Cleans Grace server per-connection current-branch bookkeeping on disconnect while leaving SignalR group cleanup to
  SignalR's normal disconnect behavior.
- Preserves the WS7.1 current-branch notification payload and artifact-readiness semantics.

Related to #503.
Part of #473.

## Why This Matters

Current-branch auto-sync needs Watch to keep its SignalR group membership aligned with the active local branch across
startup, reconnect, branch switch, and normal shutdown. If a stale refresh can overwrite newer branch authority, Watch
can listen to the wrong current-branch stream and make later remote materialization unsafe.

## Validation

Worker validation for `f6f6572b757152ffd595f5f9876fc7bef9e15e56`:

- Targeted Fantomas on touched F# files passed.

  ```powershell
  dotnet tool run fantomas `
  'Grace.CLI/Command/Watch.CLI.fs' `
  'Grace.CLI.Tests/Watch.Tests.fs' `
  'Grace.Server/Notification.Server.fs' `
  'Grace.Server.Unit.Tests/Notification.Server.Tests.fs'
  ```

- Focused CLI Watch tests passed, 261/261.

  ```powershell
  dotnet test --configuration Release `
  'src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj' `
  --filter 'FullyQualifiedName~Watch'
  ```

- Focused Notification server unit tests passed, 22/22.

  ```powershell
  dotnet test --configuration Release `
  'src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj' `
  --filter 'FullyQualifiedName~NotificationServerTests'
  ```

- Final gate passed.

  ```powershell
  pwsh ./scripts/validate.ps1 -Full
  ```

  Full-profile evidence: build 0 warnings and 0 errors; Types 135/135; Authorization 53/53; Server.Unit 738/738;
  CLI 976/976; Server integration 239/239.

- `git diff --check`: passed.

## Acceptance Mapping

- Startup/connection registration: Watch now registers current-branch membership through the existing SignalR lifecycle
  path after the connection is available.
- Branch switch refresh: successful branch authority refreshes re-register current-branch membership before parent-branch
  membership.
- Reconnect refresh: local subscription trust is cleared only when the refresh still owns active authority, so stale
  in-flight refreshes cannot replace newer branch membership after reconnect/branch churn.
- Normal shutdown/disconnect: server-side current-branch connection bookkeeping is removed during disconnect; SignalR
  still owns normal group cleanup.
- WS7.1 preservation: current-branch payload shape, eligibility, and artifact-readiness semantics are unchanged.
- Negative proof: focused server unit coverage proves Grace does not retain meaningful per-connection current-branch
  bookkeeping after disconnect beyond SignalR's own group cleanup.

## Path Expansion

No path expansion beyond #503 owned paths was needed. The worker touched:

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`
- `src/Grace.Server/Notification.Server.fs`
- `src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs`

## Docs Impact

No docs were changed. Waiver: this leaf changes internal Watch/SignalR lifecycle handling and focused tests for existing
behavior. It does not change CLI output, public command syntax, SDK/OpenAPI contracts, or user-facing Watch docs.

## Residual Risks

No worker residual risks were reported for #503.

## Review Status

- Current head: `f6f6572b757152ffd595f5f9876fc7bef9e15e56`.
- Worker: Ramanujan.
- Worker handoff reported a bot-prevention self-review over stale local subscription authority, misleading registration
  diagnostics, WS7.1 payload/artifact contract drift, XML-doc coverage, and scope expansion.
- Worker fixed one self-review finding before final validation: `OnDisconnectedAsync` now keeps the base call in the
  direct override path.
- Validation: targeted Fantomas passed; focused CLI Watch tests passed 261/261; focused Notification server unit tests
  passed 22/22; worker `pwsh ./scripts/validate.ps1 -Full` passed; GitHub `full` passed; `git diff --check`
  passed.
- Codex Code Review Bot state: completed latest-head review with clean `THUMBS_UP`.
- Manual trigger: not attempted. Do not manually trigger while the bot may acknowledge or review this head; use
  `scripts/guard-codex-review-trigger.ps1 -PullRequest <number>` only if the documented missed-ack exception is reached.
