### PR TITLE
WS7.3: Decide latest current-branch sync actions

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13578,6 +13578,148 @@ module WatchTests =
             Watch.currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests { payload with BranchId = Guid.NewGuid() }
             |> should equal false)
 
+    /// Verifies that same-root same-branch References do not schedule remote materialization.
+    [<Test>]
+    let ``latest current branch decision no-ops when remote root matches local status`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let localRootId = Guid.NewGuid()
+            let status = liveWatchStatus localRootId
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = localRootId
+                    Sha256Hash = status.RootDirectorySha256Hash
+                    Blake3Hash = status.RootDirectoryBlake3Hash
+                    ReferenceType = ReferenceType.Save
+                }
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) [| payload |]
+
+            decision.NeedsMaterialization
+            |> should equal false
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.SameRoot
+
+            decision.Reference
+            |> Option.map (fun reference -> reference.ReferenceId)
+            |> should equal (Some payload.ReferenceId))
+
+    /// Verifies that the helper chooses the latest applicable current-branch Reference without scans or remote lookups.
+    [<Test>]
+    let ``latest current branch decision collapses notifications to latest applicable reference`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let olderApplicable =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "older-root"
+                    Blake3Hash = Blake3Hash "older-root-blake3"
+                    ReferenceType = ReferenceType.Save
+                }
+
+            let staleBranch =
+                { olderApplicable with
+                    ReferenceId = Guid.NewGuid()
+                    BranchId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "stale-branch-root"
+                    Blake3Hash = Blake3Hash "stale-branch-root-blake3"
+                }
+
+            let latestApplicable =
+                { olderApplicable with
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "latest-root"
+                    Blake3Hash = Blake3Hash "latest-root-blake3"
+                }
+
+            let decision =
+                Services.decideLatestCurrentBranchReferenceMaterialization
+                    currentRepositoryId
+                    currentBranchId
+                    (Some status)
+                    [|
+                        olderApplicable
+                        staleBranch
+                        latestApplicable
+                    |]
+
+            decision.NeedsMaterialization |> should equal true
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired
+
+            decision.Reference
+            |> Option.map (fun reference -> reference.ReferenceId)
+            |> should equal (Some latestApplicable.ReferenceId))
+
+    /// Verifies that root-hash equality is enough to make a deterministic no-op decision.
+    [<Test>]
+    let ``latest current branch decision compares local root hashes without scanning`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = status.RootDirectorySha256Hash
+                    Blake3Hash = status.RootDirectoryBlake3Hash
+                    ReferenceType = ReferenceType.Checkpoint
+                }
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) [| payload |]
+
+            decision.NeedsMaterialization
+            |> should equal false
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.SameRoot)
+
+    /// Verifies that dirty or pending local status cannot fall back to unsafe scan-oriented materialization.
+    [<Test>]
+    let ``latest current branch decision rejects materialization when local status has pending work`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let status = { liveWatchStatus (Guid.NewGuid()) with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            Services.isGraceWatchScanLegal status.Mode
+            |> should equal false
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "remote-root"
+                    Blake3Hash = Blake3Hash "remote-root-blake3"
+                    ReferenceType = ReferenceType.Commit
+                }
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) [| payload |]
+
+            decision.NeedsMaterialization
+            |> should equal false
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync)
+
     /// Verifies that stale non-empty ids cannot be rescued by matching display names.
     [<Test>]
     let ``watch status rejects mismatched ids even when display names match`` () =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -502,6 +502,88 @@ module Services =
         | GraceWatchRuntimeMode.Stopping
         | _ -> false
 
+    /// Names the reason Watch either should or should not materialize a same-branch remote Reference.
+    type LatestCurrentBranchReferenceDecisionReason =
+        /// No supplied Reference notification applies to the requested repository, branch, and eligible Reference types.
+        | NoApplicableReference = 0
+        /// The latest applicable Reference does not include the remote root identity required for safe materialization.
+        | ReferenceRootIdentityUnavailable = 1
+        /// The local Watch status is unavailable, so remote materialization cannot proceed from a trusted boundary.
+        | LocalStatusUnavailable = 2
+        /// The local Watch status belongs to a different repository or branch than the chosen Reference.
+        | LocalStatusIdentityMismatch = 3
+        /// The local Watch status is not a clean healthy-incremental snapshot.
+        | LocalStatusRequiresResync = 4
+        /// The remote Reference already matches the local root identity, so materialization would be a no-op.
+        | SameRoot = 5
+        /// The remote Reference is the latest applicable current-branch Reference and differs from the local root.
+        | RemoteMaterializationRequired = 6
+
+    /// Carries the Watch decision for the latest applicable current-branch Reference notification.
+    type LatestCurrentBranchReferenceDecision =
+        {
+            NeedsMaterialization: bool
+            Reason: LatestCurrentBranchReferenceDecisionReason
+            Reference: CurrentBranchReferenceNotification option
+        }
+
+        /// Defines the deterministic no-reference decision used when all candidates are stale or unsupported.
+        static member NoApplicableReference =
+            { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.NoApplicableReference; Reference = None }
+
+    /// Reports whether a current-branch Reference notification has enough root identity for a deterministic decision.
+    let private currentBranchReferenceHasRootIdentity (payload: CurrentBranchReferenceNotification) =
+        payload.DirectoryId <> DirectoryVersionId.Empty
+        && not (String.IsNullOrWhiteSpace($"{payload.Sha256Hash}"))
+        && not (String.IsNullOrWhiteSpace($"{payload.Blake3Hash}"))
+
+    /// Reports whether a current-branch Reference notification applies to this Watch repository and branch.
+    let private currentBranchReferenceAppliesToWatch repositoryId branchId (payload: CurrentBranchReferenceNotification) =
+        payload.RepositoryId = repositoryId
+        && payload.BranchId = branchId
+        && CurrentBranchReferenceNotification.IsEligibleReferenceType payload.ReferenceType
+
+    /// Reports whether a remote Reference points at the same root already held by the local Watch status.
+    let private currentBranchReferenceMatchesLocalRoot (status: GraceWatchStatus) (payload: CurrentBranchReferenceNotification) =
+        status.RootDirectoryId = payload.DirectoryId
+        || (status.RootDirectorySha256Hash = payload.Sha256Hash
+            && status.RootDirectoryBlake3Hash = payload.Blake3Hash)
+
+    /// Chooses whether the latest applicable current-branch Reference requires remote materialization.
+    let decideLatestCurrentBranchReferenceMaterialization
+        repositoryId
+        branchId
+        (localStatus: GraceWatchStatus option)
+        (payloads: CurrentBranchReferenceNotification seq)
+        =
+        let latestApplicable =
+            payloads
+            |> Seq.filter (currentBranchReferenceAppliesToWatch repositoryId branchId)
+            |> Seq.tryLast
+
+        match latestApplicable with
+        | None -> LatestCurrentBranchReferenceDecision.NoApplicableReference
+        | Some payload when not (currentBranchReferenceHasRootIdentity payload) ->
+            { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable; Reference = Some payload }
+        | Some payload ->
+            match localStatus with
+            | None -> { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.LocalStatusUnavailable; Reference = Some payload }
+            | Some status when
+                status.RepositoryId <> repositoryId
+                || status.BranchId <> branchId
+                ->
+                { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.LocalStatusIdentityMismatch; Reference = Some payload }
+            | Some status when
+                status.SafetyFlags
+                |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal))
+                |> not
+                ->
+                { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync; Reference = Some payload }
+            | Some status when currentBranchReferenceMatchesLocalRoot status payload ->
+                { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.SameRoot; Reference = Some payload }
+            | Some _ ->
+                { NeedsMaterialization = true; Reason = LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired; Reference = Some payload }
+
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
     let private toGraceWatchStatusContractWithPersistedMode persistedModeOverride (status: GraceWatchStatus) =
         {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3194,6 +3194,25 @@ module Watch =
                     logToAnsiConsole
                         Colors.Verbose
                         $"Skipped current-branch reference notification {payload.ReferenceId} because it targets repository {payload.RepositoryId}, branch {payload.BranchId}, not current branch {Current().BranchId}."
+                else
+                    let current = Current()
+                    let! localStatus = getGraceWatchStatus ()
+
+                    let decision = decideLatestCurrentBranchReferenceMaterialization current.RepositoryId current.BranchId localStatus [| payload |]
+
+                    match decision.Reason with
+                    | LatestCurrentBranchReferenceDecisionReason.SameRoot ->
+                        logToAnsiConsole
+                            Colors.Verbose
+                            $"Skipped current-branch reference notification {payload.ReferenceId} because local Watch status already has root {payload.DirectoryId}."
+                    | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
+                        logToAnsiConsole
+                            Colors.Highlighted
+                            $"Current-branch reference notification {payload.ReferenceId} requires remote materialization for root {payload.DirectoryId}."
+                    | reason ->
+                        logToAnsiConsole
+                            Colors.Verbose
+                            $"Skipped current-branch reference notification {payload.ReferenceId} because latest-current-branch decision was {reason}."
             with
             | ex -> logToAnsiConsole Colors.Error $"Failed to process current-branch reference notification {payload.ReferenceId}: {Markup.Escape(ex.Message)}."
         }


### PR DESCRIPTION
## Summary

Implements WS7.3 latest-current-branch decision handling:

- Adds a pure latest-current-branch decision helper for current-branch Reference notifications and future catch-up
  inputs.
- Filters stale repository/branch notifications and unsupported Reference types before any materialization decision.
- Collapses multiple candidates to the latest applicable Reference.
- Requires trusted clean healthy-incremental local Watch status before trusting root equality or deciding to materialize.
- Treats same local/remote root identity or root hash as a no-op.
- Wires Watch to consume the helper for same-branch Reference SignalR payloads without changing current-branch SignalR
  routing, payload shape, eligibility, registration ordering, or disconnect cleanup.

Related to #504.
Part of #473.

## Why This Matters

Current-branch remote sync needs a deterministic decision point before any later materialization work can be safe. Watch
must ignore stale/self/no-op notifications, collapse bursts to the latest applicable Reference, and refuse to trust root
comparisons when local status is dirty, pending, or otherwise untrusted.

## Validation

Worker validation for `9c19ba299bf3547a7b0fb56521f5c6d723d139ed`:

- Targeted Fantomas on touched F# files passed.

  ```powershell
  dotnet tool run fantomas `
    src\Grace.CLI\Command\Services.CLI.fs `
    src\Grace.CLI\Command\Watch.CLI.fs `
    src\Grace.CLI.Tests\Watch.Tests.fs
  ```

- Release build for `Grace.CLI.Tests` passed.

  ```powershell
  dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj
  ```

- Focused CLI tests passed, 980/980.

  ```powershell
  dotnet test --configuration Release --no-build src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj
  ```

- Final fast gate passed.

  ```powershell
  pwsh ./scripts/validate.ps1 -Fast
  ```

- `git diff --check`: passed.

## Acceptance Mapping

- Same-root no-op: covered by focused Watch tests for matching local root id and deterministic root-hash comparison.
- Latest applicable Reference selection: helper filters stale/unsupported candidates and chooses the newest applicable
  same-branch Reference.
- Cheap deterministic local comparison: decision uses local status/root identity and hash values instead of scans or
  materialization probes.
- Unsafe status rejection: pending/dirty/untrusted local Watch status blocks materialization decisions before root
  equality is trusted.
- Upstream contract preservation: #502 current-branch SignalR payload/routing/eligibility and #503 subscription
  authority/disconnect cleanup were consumed without rework.
- Materialization deferred: actual remote materialization remains intentionally out of scope for this leaf and belongs to
  later WS7 leaves.

## Path Expansion

No path expansion beyond #504 owned paths was needed. The worker touched:

- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Docs Impact

No docs were changed. Waiver: this leaf adds an internal Watch decision/helper slice and does not change user-facing CLI
JSON/stdout/stderr, public API contracts, command syntax, or documented SignalR contract shape.

## Residual Risks

No worker residual risks were reported for #504.

## Review Status

- Current head: `9c19ba299bf3547a7b0fb56521f5c6d723d139ed`.
- Worker: Kuhn.
- Worker handoff reported a bot-prevention self-review over decision ordering, upstream contract preservation, stale
  identity filtering, trusted-local-status gating, validation, and scope.
- Worker fixed one self-review finding before push: same-root no-op can no longer return before proving the local Watch
  status is a trusted clean incremental snapshot.
- Validation: targeted Fantomas passed; Release build for `Grace.CLI.Tests` passed; focused CLI tests passed 980/980;
  worker `pwsh ./scripts/validate.ps1 -Fast` passed; GitHub `full` passed; `git diff --check` passed.
- Codex Code Review Bot state: completed latest-head review with clean `THUMBS_UP`.
- Manual trigger: not attempted. Do not manually trigger while the bot may acknowledge or review this head; use
  `scripts/guard-codex-review-trigger.ps1 -PullRequest <number>` only if the documented missed-ack exception is reached.
