### PR TITLE
WS7.6: Clarify deliberate server restart progress

### DIFF
--- a/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
+++ b/src/Grace.Server.Tests/AgentSession.Server.Tests.fs
@@ -14,8 +14,8 @@ open System.Threading.Tasks
 /// Groups shared helpers for agent session test helpers.
 module private AgentSessionTestHelpers =
 
-    /// Restarts grace server to verify durability across process restarts.
-    let restartGraceServerAsync () =
+    /// Restarts Grace.Server with a scenario label for process-local state assertions.
+    let restartGraceServerAsync restartContext =
         let state =
             match App with
             | Some app ->
@@ -32,7 +32,7 @@ module private AgentSessionTestHelpers =
                 Assert.Fail("Aspire test host was not started by the shared setup fixture.")
                 Unchecked.defaultof<TestHostState>
 
-        AspireTestHost.restartGraceServerAsync state
+        AspireTestHost.restartGraceServerAsync state restartContext
 
     /// Posts session to the running test server.
     let private postSessionAsync<'TResponse> (path: string) (parameters: obj) =
@@ -286,7 +286,7 @@ type AgentSessionServerTests() =
             Assert.That(activeBeforeRestart.ReturnValue.Session.SessionId, Is.EqualTo(startOperationId))
             Assert.That(activeBeforeRestart.ReturnValue.Session.LifecycleState, Is.EqualTo(AgentSessionLifecycleState.Active))
 
-            do! AgentSessionTestHelpers.restartGraceServerAsync ()
+            do! AgentSessionTestHelpers.restartGraceServerAsync "AgentSession.ActiveAgentSessionsAreProcessLocalAcrossRestart"
 
             // Contract: active agent sessions are process-local coordination state and are intentionally lost on restart.
             let! statusAfterRestart =

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -16,8 +16,8 @@ open System.Threading.Tasks
 /// Groups shared helpers for approval test helpers.
 module private ApprovalTestHelpers =
 
-    /// Restarts grace server to verify durability across process restarts.
-    let restartGraceServerAsync () =
+    /// Restarts Grace.Server with a scenario label for process-local approval assertions.
+    let restartGraceServerAsync restartContext =
         let state =
             match App with
             | Some app ->
@@ -34,7 +34,7 @@ module private ApprovalTestHelpers =
                 Assert.Fail("Aspire test host was not started by the shared setup fixture.")
                 Unchecked.defaultof<TestHostState>
 
-        AspireTestHost.restartGraceServerAsync state
+        AspireTestHost.restartGraceServerAsync state restartContext
 
     /// Builds a deterministic authenticated client for integration setup fixture for the server integration approval assertions.
     let createAuthenticatedClient (userId: string) =
@@ -335,7 +335,7 @@ type ApprovalApiIntegrationTests() =
                 Does.Contain(created.ApprovalPolicyId)
             )
 
-            do! ApprovalTestHelpers.restartGraceServerAsync ()
+            do! ApprovalTestHelpers.restartGraceServerAsync "Approval.ApprovalPolicyStoreIsProcessLocalWhileGeneratedRequestsRemainActorBackedAcrossRestart"
 
             // Contract: approval policies are process-local configuration and are intentionally lost on Grace.Server restart.
             let! listPoliciesAfterRestart =

--- a/src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs
@@ -120,3 +120,47 @@ type AspireTestHostDiagnosticsTests() =
                 Assert.That(message, Does.Contain("unsupported for Grace.Server.Tests"))
                 Assert.That(message, Does.Contain("Owner Created event")))
         )
+
+    /// Verifies ordinary resource health progress keeps the startup wording scenario.
+    [<Test>]
+    member _.ResourceHealthProgressKeepsOrdinaryStartupWording() =
+        let startMessage = AspireTestHost.FixtureDiagnostics.formatResourceHealthWaitStartMessage "azurite" None
+        let healthyMessage = AspireTestHost.FixtureDiagnostics.formatResourceHealthWaitHealthyMessage "azurite" None
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(startMessage, Is.EqualTo("waiting for resource 'azurite' to become healthy."))
+                Assert.That(healthyMessage, Is.EqualTo("resource 'azurite' is healthy."))
+                Assert.That(startMessage, Does.Not.Contain("restart"))
+                Assert.That(healthyMessage, Does.Not.Contain("restart")))
+        )
+
+    /// Verifies deliberate Grace.Server restart progress identifies the test operation scenario.
+    [<Test>]
+    member _.ResourceHealthProgressNamesIntentionalGraceServerRestartContext() =
+        let context = "RestartDurabilityServer.DurableActorStateRehydratesAcrossGraceServerProjectRestart"
+        let startMessage = AspireTestHost.FixtureDiagnostics.formatResourceHealthWaitStartMessage "grace-server" (Some context)
+        let healthyMessage = AspireTestHost.FixtureDiagnostics.formatResourceHealthWaitHealthyMessage "grace-server" (Some context)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(startMessage, Does.Contain("intentional Grace.Server restart"))
+                Assert.That(startMessage, Does.Contain(context))
+                Assert.That(startMessage, Does.Contain("waiting for resource 'grace-server' to become healthy"))
+                Assert.That(healthyMessage, Does.Contain("recovered after intentional Grace.Server restart"))
+                Assert.That(healthyMessage, Does.Contain(context)))
+        )
+
+    /// Verifies restart context does not relabel non Grace.Server resource waits scenario.
+    [<Test>]
+    member _.ResourceHealthProgressDoesNotRelabelNonGraceServerResourcesAsRestarts() =
+        let startMessage = AspireTestHost.FixtureDiagnostics.formatResourceHealthWaitStartMessage "servicebus-emulator" (Some "RestartDurability")
+        let healthyMessage = AspireTestHost.FixtureDiagnostics.formatResourceHealthWaitHealthyMessage "servicebus-emulator" (Some "RestartDurability")
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(startMessage, Is.EqualTo("waiting for resource 'servicebus-emulator' to become healthy."))
+                Assert.That(healthyMessage, Is.EqualTo("resource 'servicebus-emulator' is healthy."))
+                Assert.That(startMessage, Does.Not.Contain("Grace.Server restart"))
+                Assert.That(healthyMessage, Does.Not.Contain("Grace.Server restart")))
+        )

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -78,6 +78,31 @@ module AspireTestHost =
         Console.Error.WriteLine(progressMessage)
         Console.Error.Flush()
 
+    /// Normalizes a deliberate Grace.Server restart context for diagnostic progress messages.
+    let private normalizeRestartContext (restartContext: string) =
+        if String.IsNullOrWhiteSpace restartContext then
+            "unspecified test operation"
+        else
+            restartContext.Trim()
+
+    /// Resolves the deliberate restart context when the wait is for the Grace.Server Aspire resource.
+    let private tryGetGraceServerRestartContext (resourceName: string) (restartContext: string option) =
+        match restartContext with
+        | Some context when resourceName.Equals(graceServerResourceName, StringComparison.OrdinalIgnoreCase) -> Some(normalizeRestartContext context)
+        | _ -> None
+
+    /// Formats the progress message emitted before waiting for an Aspire resource to become healthy.
+    let private formatResourceHealthWaitStartProgress (resourceName: string) (restartContext: string option) =
+        match tryGetGraceServerRestartContext resourceName restartContext with
+        | Some context -> $"intentional Grace.Server restart '{context}': waiting for resource '{resourceName}' to become healthy."
+        | None -> $"waiting for resource '{resourceName}' to become healthy."
+
+    /// Formats the progress message emitted after an Aspire resource reports healthy.
+    let private formatResourceHealthWaitHealthyProgress (resourceName: string) (restartContext: string option) =
+        match tryGetGraceServerRestartContext resourceName restartContext with
+        | Some context -> $"resource '{resourceName}' recovered after intentional Grace.Server restart '{context}'."
+        | None -> $"resource '{resourceName}' is healthy."
+
     /// Defines ensure bootstrap compatible behavior for the surrounding tests used by the server integration aspire Test Host scenario.
     let private ensureBootstrapCompatible (bootstrapUserId: string) =
         match sharedBootstrapUserId with
@@ -448,17 +473,18 @@ module AspireTestHost =
                     return $"Docker containers:{Environment.NewLine}{containersSummary}{Environment.NewLine}{String.Join(Environment.NewLine, logBlocks)}"
         }
 
-    let private waitForResourceHealthyAsync
+    let private waitForResourceHealthyWithProgressContextAsync
         (notificationService: ResourceNotificationService)
         (app: DistributedApplication)
         (resourceName: string)
         (ct: CancellationToken)
+        (restartContext: string option)
         =
         task {
             try
-                logProgress $"waiting for resource '{resourceName}' to become healthy."
+                logProgress (formatResourceHealthWaitStartProgress resourceName restartContext)
                 let! _ = notificationService.WaitForResourceHealthyAsync(resourceName, ct)
-                logProgress $"resource '{resourceName}' is healthy."
+                logProgress (formatResourceHealthWaitHealthyProgress resourceName restartContext)
                 ()
             with
             | ex ->
@@ -481,8 +507,22 @@ module AspireTestHost =
                 raise (Exception($"{resourceName} failed to start. {details}{Environment.NewLine}{logDetails}", ex))
         }
 
+    let private waitForResourceHealthyAsync
+        (notificationService: ResourceNotificationService)
+        (app: DistributedApplication)
+        (resourceName: string)
+        (ct: CancellationToken)
+        =
+        waitForResourceHealthyWithProgressContextAsync notificationService app resourceName ct None
+
     /// Groups shared helpers for fixture diagnostics.
     module FixtureDiagnostics =
+        /// Formats the progress message emitted before waiting for an Aspire resource to become healthy.
+        let formatResourceHealthWaitStartMessage resourceName restartContext = formatResourceHealthWaitStartProgress resourceName restartContext
+
+        /// Formats the progress message emitted after an Aspire resource reports healthy.
+        let formatResourceHealthWaitHealthyMessage resourceName restartContext = formatResourceHealthWaitHealthyProgress resourceName restartContext
+
         /// Defines redact connection string segments behavior for the surrounding tests used by the server integration aspire Test Host scenario.
         let private redactConnectionStringSegments (sensitivePrefixes: string list) (connectionString: string) =
             if String.IsNullOrWhiteSpace connectionString then
@@ -1295,13 +1335,14 @@ module AspireTestHost =
                 Console.WriteLine("Aspire host shutdown skipped to avoid test host teardown crashes.")
         }
 
-    /// Restarts grace server to verify durability across process restarts.
-    let restartGraceServerAsync (state: TestHostState) =
+    /// Restarts Grace.Server with a scenario label for deliberate restart diagnostics.
+    let restartGraceServerAsync (state: TestHostState) (restartContext: string) =
         task {
             do! sharedStateLock.WaitAsync()
 
             try
-                Console.WriteLine("Restarting Grace.Server Aspire project resource...")
+                let normalizedRestartContext = normalizeRestartContext restartContext
+                Console.WriteLine($"Restarting Grace.Server Aspire project resource for {normalizedRestartContext}...")
                 let commandService = state.App.Services.GetRequiredService<ResourceCommandService>()
                 use cts = new CancellationTokenSource(defaultWaitTimeout)
 
@@ -1313,12 +1354,21 @@ module AspireTestHost =
                         elif result.Canceled then "Restart command was canceled."
                         else "Restart command failed without details."
 
-                    raise (InvalidOperationException($"Grace.Server restart failed: {errorMessage}"))
+                    raise (InvalidOperationException($"Grace.Server restart failed during {normalizedRestartContext}: {errorMessage}"))
 
                 let notificationService = state.App.Services.GetRequiredService<ResourceNotificationService>()
-                do! waitForResourceHealthyAsync notificationService state.App graceServerResourceName cts.Token
+
+                do!
+                    waitForResourceHealthyWithProgressContextAsync
+                        notificationService
+                        state.App
+                        graceServerResourceName
+                        cts.Token
+                        (Some normalizedRestartContext)
+
                 do! waitForGraceServerHttpReadyAsync state.Client cts.Token
-                Console.WriteLine("Grace.Server Aspire project resource restart completed.")
+                logProgress $"Grace.Server HTTP readiness recovered after intentional restart '{normalizedRestartContext}'."
+                Console.WriteLine($"Grace.Server Aspire project resource restart completed for {normalizedRestartContext}.")
             finally
                 sharedStateLock.Release() |> ignore
         }

--- a/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
@@ -82,8 +82,8 @@ module private RestartDurabilityHelpers =
             Assert.Fail("Aspire test host was not started by the shared setup fixture.")
             Unchecked.defaultof<TestHostState>
 
-    /// Restarts grace server to verify durability across process restarts.
-    let restartGraceServerAsync () = AspireTestHost.restartGraceServerAsync (getSharedHostState ())
+    /// Restarts Grace.Server with a scenario label for durability assertions.
+    let restartGraceServerAsync restartContext = AspireTestHost.restartGraceServerAsync (getSharedHostState ()) restartContext
 
     /// Builds a deterministic repository for integration setup fixture for the server integration restart Durability assertions.
     let createRepositoryAsync repositoryNamePrefix =
@@ -376,7 +376,7 @@ type RestartDurabilityServer() =
             let! before = Client.GetAsync("/healthz")
             Assert.That(before.StatusCode, Is.EqualTo(HttpStatusCode.OK))
 
-            do! RestartDurabilityHelpers.restartGraceServerAsync ()
+            do! RestartDurabilityHelpers.restartGraceServerAsync "RestartDurabilityServer.GraceServerProjectResourceRestartsAndReturnsHealthyResponses"
 
             let! after = Client.GetAsync("/healthz")
             Assert.That(after.StatusCode, Is.EqualTo(HttpStatusCode.OK))
@@ -399,7 +399,7 @@ type RestartDurabilityServer() =
             let reminderFireAt = Instant.FromUtc(2035, 6, 1, 12, 0, 0)
             let! reminderId = RestartDurabilityHelpers.createReminderAsync reminderActorName reminderActorId reminderFireAt
 
-            do! RestartDurabilityHelpers.restartGraceServerAsync ()
+            do! RestartDurabilityHelpers.restartGraceServerAsync "RestartDurabilityServer.DurableActorStateRehydratesAcrossGraceServerProjectRestart"
 
             let! ownerAfterRestart = RestartDurabilityHelpers.getOwnerAsync ()
             Assert.That(ownerAfterRestart.OwnerId, Is.EqualTo(Guid.Parse(ownerId)))

--- a/src/Grace.Server.Tests/Webhook.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Webhook.Server.Tests.fs
@@ -14,8 +14,8 @@ open System.Net.Http
 /// Groups shared helpers for webhook test helpers.
 module private WebhookTestHelpers =
 
-    /// Restarts grace server to verify durability across process restarts.
-    let restartGraceServerAsync () =
+    /// Restarts Grace.Server with a scenario label for process-local webhook assertions.
+    let restartGraceServerAsync restartContext =
         let state =
             match App with
             | Some app ->
@@ -32,7 +32,7 @@ module private WebhookTestHelpers =
                 Assert.Fail("Aspire test host was not started by the shared setup fixture.")
                 Unchecked.defaultof<TestHostState>
 
-        AspireTestHost.restartGraceServerAsync state
+        AspireTestHost.restartGraceServerAsync state restartContext
 
     /// Builds a deterministic authenticated client for integration setup fixture for the server integration webhook assertions.
     let createAuthenticatedClient (userId: string) =
@@ -326,7 +326,7 @@ type WebhookApiIntegrationTests() =
                 Does.Contain(createdDelivery.WebhookDeliveryId)
             )
 
-            do! WebhookTestHelpers.restartGraceServerAsync ()
+            do! WebhookTestHelpers.restartGraceServerAsync "Webhook.WebhookRuleAndHttpObservableDeliveriesAreProcessLocalAcrossRestart"
 
             // Contract: webhook rules are process-local. HTTP-observable pending deliveries are intentionally
             // unavailable after restart; retry-scheduled deliveries share the same process-local store by


### PR DESCRIPTION
## Summary

- Clarifies `Grace.Server.Tests progress:` health-wait output for deliberate `grace-server` restart scenarios.
- Keeps ordinary startup and non-`grace-server` resource health waits distinct from intentional restart recovery waits.
- Adds focused diagnostics assertions for the progress-message formatter and passes scenario labels through current
  deliberate restart callers.

## Related Issue

- References #549.
- Parent mini-epic: #479.
- Epic: #473.

## Why This Matters

When `Grace.Server.Tests` deliberately stops and restarts Grace.Server, repeated generic wait/healthy lines can look
flaky to a new contributor or operator. This PR makes those waits explain that the restart is intentional and names the
owning scenario, while keeping real unhealthy-resource failures visible.

## Owned Paths

- `src/Grace.Server.Tests/AspireTestHost.fs`
- `src/Grace.Server.Tests/AspireTestHost.Diagnostics.Tests.fs`
- `src/Grace.Server.Tests/AgentSession.Server.Tests.fs`
- `src/Grace.Server.Tests/Approval.Server.Tests.fs`
- `src/Grace.Server.Tests/Webhook.Server.Tests.fs`
- `src/Grace.Server.Tests/RestartDurability.Server.Tests.fs`

## Validation

- Passed: `dotnet tool run fantomas -- <six touched .fs files>`.
- Passed: `dotnet test --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~Grace.Server.TestDiagnostics.AspireTestHostDiagnosticsTests"`.
  - Result: 7 passed.
- Passed: `git diff --check`.
- Did not pass locally: `pwsh ./scripts/validate.ps1 -Full`.
  - Build phase succeeded with 0 warnings and 0 errors.
  - Completed before the server cascade: `Grace.Types.Tests` 135 passed, `Grace.Authorization.Tests` 53 passed,
    `Grace.Server.Unit.Tests` 738 passed, and `Grace.CLI.Tests` 979 passed / 1 skipped.
  - First actionable failure: `Grace.Server restart failed during
    AgentSession.ActiveAgentSessionsAreProcessLocalAcrossRestart: Failed to stop resource 'grace-server-vaqkpzkd'.`
  - The worker interrupted the already-failed run after cascading shared-server HTTP timeouts began.
  - The failure occurred before the modified deliberate-restart health-wait recovery messages could run. Remote CI
    remains the required full-gate confirmation for this PR.

## Docs Impact

- Docs waiver: this changes test diagnostics/progress output only. No documented command, setup, API, or user workflow
  changed.

## Review Status

- Current head: `e00fb370deee3c8960c20c303decbecf3e15ab06`.
- Worker bot-prevention self-review completed over the actual diff.
- Codex Code Review Bot returned 👍 for the current head.
- GitHub `full` validation passed on the current head.
- Ready to merge into `epic/473-grace-watch-incremental-sync`.
