### PR TITLE
F1.1: Keep Operations out of root solution

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,8 +27,10 @@ jobs:
         with:
           global-json-file: global.json
       - name: Restore NuGet packages
-        run: dotnet restore "src/Grace.slnx"
-      - name: Pre-pull Aspire images and build the solution
+        run: |
+          dotnet restore "src/Grace.slnx"
+          dotnet restore "src/Grace.Operations/Grace.Operations.slnx"
+      - name: Pre-pull Aspire images and build the solutions
         shell: bash
         run: |
           set -uo pipefail
@@ -39,17 +41,36 @@ jobs:
             -p:GraceBuildKind="${GraceBuildKind}" \
             -p:GraceBuildNumber="${GraceBuildNumber}" \
             -p:GraceSourceRevisionId="${GraceSourceRevisionId}" &
-          build_pid=$!
+          root_build_pid=$!
+
+          dotnet build "src/Grace.Operations/Grace.Operations.slnx" \
+            --configuration Release \
+            --no-restore \
+            -p:GraceBuildKind="${GraceBuildKind}" \
+            -p:GraceBuildNumber="${GraceBuildNumber}" \
+            -p:GraceSourceRevisionId="${GraceSourceRevisionId}" &
+          operations_build_pid=$!
+
+          wait_for_builds() {
+            root_build_exit=0
+            operations_build_exit=0
+
+            wait "${root_build_pid}" || root_build_exit=$?
+            wait "${operations_build_pid}" || operations_build_exit=$?
+
+            if [ "${root_build_exit}" -ne 0 ]; then
+              echo "Root solution build failed with exit code ${root_build_exit}" >&2
+            fi
+
+            if [ "${operations_build_exit}" -ne 0 ]; then
+              echo "Operations solution build failed with exit code ${operations_build_exit}" >&2
+            fi
+          }
 
           docker info
           docker_info_exit=$?
           if [ "${docker_info_exit}" -ne 0 ]; then
-            build_exit=0
-            wait "${build_pid}" || build_exit=$?
-            if [ "${build_exit}" -ne 0 ]; then
-              echo "Build failed with exit code ${build_exit}" >&2
-            fi
-
+            wait_for_builds
             exit "${docker_info_exit}"
           fi
 
@@ -68,8 +89,7 @@ jobs:
             pids+=("$!")
           done
 
-          build_exit=0
-          wait "${build_pid}" || build_exit=$?
+          wait_for_builds
 
           pull_failed=0
           for index in "${!pids[@]}"; do
@@ -84,13 +104,18 @@ jobs:
             fi
           done
 
-          if [ "${build_exit}" -ne 0 ]; then
-            echo "Build failed with exit code ${build_exit}" >&2
-            exit "${build_exit}"
+          if [ "${root_build_exit}" -ne 0 ]; then
+            exit "${root_build_exit}"
+          fi
+
+          if [ "${operations_build_exit}" -ne 0 ]; then
+            exit "${operations_build_exit}"
           fi
 
           exit "${pull_failed}"
       - name: Test
         env:
           GRACE_TEST_SERVER_CLEANUP: "0"
-        run: dotnet test "src/Grace.slnx" --configuration Release --no-build --no-restore
+        run: |
+          dotnet test "src/Grace.slnx" --configuration Release --no-build --no-restore
+          dotnet test "src/Grace.Operations/Grace.Operations.slnx" --configuration Release --no-build --no-restore

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,42 +35,9 @@ jobs:
         run: |
           set -uo pipefail
 
-          dotnet build "src/Grace.slnx" \
-            --configuration Release \
-            --no-restore \
-            -p:GraceBuildKind="${GraceBuildKind}" \
-            -p:GraceBuildNumber="${GraceBuildNumber}" \
-            -p:GraceSourceRevisionId="${GraceSourceRevisionId}" &
-          root_build_pid=$!
-
-          dotnet build "src/Grace.Operations/Grace.Operations.slnx" \
-            --configuration Release \
-            --no-restore \
-            -p:GraceBuildKind="${GraceBuildKind}" \
-            -p:GraceBuildNumber="${GraceBuildNumber}" \
-            -p:GraceSourceRevisionId="${GraceSourceRevisionId}" &
-          operations_build_pid=$!
-
-          wait_for_builds() {
-            root_build_exit=0
-            operations_build_exit=0
-
-            wait "${root_build_pid}" || root_build_exit=$?
-            wait "${operations_build_pid}" || operations_build_exit=$?
-
-            if [ "${root_build_exit}" -ne 0 ]; then
-              echo "Root solution build failed with exit code ${root_build_exit}" >&2
-            fi
-
-            if [ "${operations_build_exit}" -ne 0 ]; then
-              echo "Operations solution build failed with exit code ${operations_build_exit}" >&2
-            fi
-          }
-
           docker info
           docker_info_exit=$?
           if [ "${docker_info_exit}" -ne 0 ]; then
-            wait_for_builds
             exit "${docker_info_exit}"
           fi
 
@@ -89,7 +56,22 @@ jobs:
             pids+=("$!")
           done
 
-          wait_for_builds
+          root_build_exit=0
+          operations_build_exit=0
+
+          dotnet build "src/Grace.slnx" \
+            --configuration Release \
+            --no-restore \
+            -p:GraceBuildKind="${GraceBuildKind}" \
+            -p:GraceBuildNumber="${GraceBuildNumber}" \
+            -p:GraceSourceRevisionId="${GraceSourceRevisionId}" || root_build_exit=$?
+
+          dotnet build "src/Grace.Operations/Grace.Operations.slnx" \
+            --configuration Release \
+            --no-restore \
+            -p:GraceBuildKind="${GraceBuildKind}" \
+            -p:GraceBuildNumber="${GraceBuildNumber}" \
+            -p:GraceSourceRevisionId="${GraceSourceRevisionId}" || operations_build_exit=$?
 
           pull_failed=0
           for index in "${!pids[@]}"; do
@@ -103,6 +85,14 @@ jobs:
               pull_failed=1
             fi
           done
+
+          if [ "${root_build_exit}" -ne 0 ]; then
+            echo "Root solution build failed with exit code ${root_build_exit}" >&2
+          fi
+
+          if [ "${operations_build_exit}" -ne 0 ]; then
+            echo "Operations solution build failed with exit code ${operations_build_exit}" >&2
+          fi
 
           if [ "${root_build_exit}" -ne 0 ]; then
             exit "${root_build_exit}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ Commands:
 - `pwsh ./scripts/bootstrap.ps1`
 - `pwsh ./scripts/validate.ps1 -Fast`
 
-Use `pwsh ./scripts/validate.ps1 -Full` for Aspire integration coverage.
+Use `pwsh ./scripts/validate.ps1 -Full` for Aspire integration coverage. Both validation profiles restore, build, and
+test the root Grace solution and the Operations-local solution separately.
 Optional: `pwsh ./scripts/install-githooks.ps1` to add a pre-commit `validate -Fast` hook.
 
 More context:
@@ -104,7 +105,9 @@ so links stay traceable without relying on epic-branch auto-close behavior.
   issues, or current `origin/epic/...` for sub-issues under the required epic integration branch.
 - When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
   absolute path under the assigned worktree. After the first patch, verify git status in both locations.
-- Prefer vertical slices with focused tests and `pwsh ./scripts/validate.ps1 -Fast` as the normal validation gate.
+- Prefer vertical slices with focused tests and `pwsh ./scripts/validate.ps1 -Fast` as the normal validation gate. The
+  validate script builds/tests `src/Grace.slnx` and `src/Grace.Operations/Grace.Operations.slnx` as separate solution
+  targets.
 - Use `pwsh ./scripts/validate.ps1 -Full` when Aspire, emulators, storage, Service Bus, Cosmos DB, Redis,
   deployment/runtime behavior, or cross-service integration is affected.
 - Order validation to avoid duplicate builds. Run targeted Fantomas formatting or checks before validation for touched

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -924,10 +924,12 @@ Avoid duplicate builds. The validation ladder is:
 3. Choose exactly one final build/test gate.
 4. Run `git diff --check`.
 
-`validate.ps1 -Fast` and `validate.ps1 -Full` already restore, build the solution, and run the selected test projects.
-If a worker is going to run `validate -Fast` or `validate -Full`, do not also prompt it to routinely run a
-project-specific `dotnet build` plus `dotnet test --no-build`. The selected `validate` command is the final build/test
-gate.
+`validate.ps1 -Fast` and `validate.ps1 -Full` already restore, build, and test both solution targets:
+`src/Grace.slnx` for the root Grace surface and `src/Grace.Operations/Grace.Operations.slnx` for the Operations-local
+surface. The script keeps those solution builds/tests separate, so do not collapse Operations projects back into the
+root solution to make validation find them. If a worker is going to run `validate -Fast` or `validate -Full`, do not
+also prompt it to routinely run a project-specific `dotnet build` plus `dotnet test --no-build`. The selected
+`validate` command is the final build/test gate.
 
 Focused project build/test is still appropriate when it is the right evidence for the slice:
 

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -214,7 +214,6 @@ function Get-FastTestFilterTerms {
     $terms = @(
         "FullyQualifiedName~Grace.Authorization.Tests",
         "FullyQualifiedName~Grace.CLI.Tests",
-        "FullyQualifiedName~Grace.Operations.Tests",
         "FullyQualifiedName~Grace.Types.Tests"
     )
 
@@ -231,7 +230,11 @@ function Get-TestFilter([bool]$IncludeFullTests) {
     Join-TestFilter $terms
 }
 
-function Invoke-SolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
+function Get-OperationsTestFilter {
+    Join-TestFilter @("FullyQualifiedName~Grace.Operations.Tests")
+}
+
+function Invoke-RootSolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
     $testFilter = Get-TestFilter $IncludeFullTests
 
     Write-Host "Test target: src/Grace.slnx"
@@ -263,6 +266,18 @@ function Invoke-SolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
                 $env:GRACE_TEST_SERVER_CLEANUP = $previousServerCleanup
             }
         }
+    }
+}
+
+function Invoke-OperationsSolutionTests([string]$Configuration) {
+    $testFilter = Get-OperationsTestFilter
+
+    Write-Host "Test target: src/Grace.Operations/Grace.Operations.slnx"
+    Write-Host ("Test filter: {0}" -f $testFilter)
+    Write-Host ("Running: dotnet test `"src/Grace.Operations/Grace.Operations.slnx`" -c {0} --no-build --filter `"{1}`"" -f $Configuration, $testFilter)
+
+    Invoke-External "Grace Operations solution tests" {
+        dotnet test "src/Grace.Operations/Grace.Operations.slnx" -c $Configuration --no-build --filter $testFilter
     }
 }
 
@@ -324,7 +339,8 @@ try {
             }
         }
         Write-Host ""
-        Invoke-External "Grace solution build" { dotnet build "src/Grace.slnx" -c $Configuration @graceBuildProperties }
+        Invoke-External "Grace root solution build" { dotnet build "src/Grace.slnx" -c $Configuration @graceBuildProperties }
+        Invoke-External "Grace Operations solution build" { dotnet build "src/Grace.Operations/Grace.Operations.slnx" -c $Configuration @graceBuildProperties }
     } else {
         Write-Section "Build"
         Write-Host "Skipped (-SkipBuild)."
@@ -332,7 +348,8 @@ try {
 
     if (-not $SkipTests) {
         Write-Section "Test"
-        Invoke-SolutionTests $Configuration $Full
+        Invoke-RootSolutionTests $Configuration $Full
+        Invoke-OperationsSolutionTests $Configuration
     } else {
         Write-Section "Test"
         Write-Host "Skipped (-SkipTests)."

--- a/skills/grace/references/workflow.md
+++ b/skills/grace/references/workflow.md
@@ -167,9 +167,10 @@ Run `-Full` for Aspire integration, emulators, storage, Cosmos DB, Service Bus, 
 cross-service behavior.
 
 Use the validation ladder from `docs/Development process.md`: run targeted Fantomas formatting or checks before
-validation for touched F# files, run freshness checks when needed, then choose exactly one final build/test gate. If
-`validate -Fast` or `validate -Full` will run, do not also ask workers to routinely run project-specific
-`dotnet build` plus `dotnet test --no-build`; `validate` is the final build/test gate.
+validation for touched F# files, run freshness checks when needed, then choose exactly one final build/test gate.
+`validate -Fast` and `validate -Full` build and test the root Grace solution and the Operations-local solution as
+separate targets. If `validate -Fast` or `validate -Full` will run, do not also ask workers to routinely run
+project-specific `dotnet build` plus `dotnet test --no-build`; `validate` is the final build/test gate.
 
 Focused project build/test remains appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
 outside the selected validate profile, or explicitly focused-only issues. Freshness/update workers follow the same

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -8,6 +8,9 @@ Treat this file as the canonical high-level brief; each project folder contains 
 - `pwsh ./scripts/bootstrap.ps1`
 - `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration tests)
 
+Both validation profiles restore, build, and test `src/Grace.slnx` and
+`src/Grace.Operations/Grace.Operations.slnx` as separate solution targets.
+
 Optional: `pwsh ./scripts/install-githooks.ps1` to add a pre-commit `validate -Fast` hook.
 
 ## Work Tracking
@@ -51,7 +54,8 @@ update the issue before editing the new paths.
 - When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
   absolute path under the assigned worktree. After the first patch, verify git status in both locations.
 - Prefer vertical slices that prove one public behavior at a time through the closest stable boundary.
-- Validate changes with `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration coverage).
+- Validate changes with `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration coverage). The
+  validation script covers the root Grace solution and the Operations-local solution as separate build/test targets.
 - Order validation to avoid duplicate builds. Run targeted Fantomas formatting or checks before validation for touched
   F# files, then choose exactly one final build/test gate. If `validate -Fast` or `validate -Full` will run, do not also
   ask workers to routinely run project-specific `dotnet build` plus `dotnet test --no-build`; `validate` is the final
@@ -156,8 +160,10 @@ update the issue before editing the new paths.
 
 ## Test Parallelization And Validation
 
-- `pwsh ./scripts/validate.ps1 -Fast` and `-Full` run one solution-level `dotnet test "src/Grace.slnx"` command with
-  selection filters. Fast selects Authorization, CLI, Types, and Server.Unit tests. Full adds Server integration tests.
+- `pwsh ./scripts/validate.ps1 -Fast` and `-Full` restore and build `src/Grace.slnx` and
+  `src/Grace.Operations/Grace.Operations.slnx` as separate solution targets. The test phase runs root-solution tests
+  with selection filters, then runs Operations-local tests from the Operations solution. Fast selects Authorization,
+  CLI, Types, Server.Unit, and Operations tests. Full adds Server integration tests.
 - Do not reintroduce custom per-project process fan-out into validation unless a future issue owns that runner change.
 - Assembly-level NUnit parallel defaults are intentionally limited. `Grace.Authorization.Tests` and `Grace.Types.Tests`
   have bounded defaults. `Grace.Server.Unit.Tests` is deferred while process-static approval-store mutation remains in

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
@@ -104,6 +104,17 @@ type ``Operations skeleton project graph``() =
 
         Assert.That(projectPaths, Is.EquivalentTo(expectedPaths))
 
+    /// Proves the root solution does not reabsorb Operations projects from the local Operations solution boundary.
+    [<Test>]
+    member _.``Root solution excludes Operations projects``() =
+        let solutionPath = ProjectStructureTestPaths.srcRelativePath "" "Grace.slnx"
+
+        let operationsProjectPaths =
+            ProjectStructureXml.solutionProjectPaths solutionPath
+            |> Array.filter (fun (projectPath: string) -> projectPath.Contains("Grace.Operations", StringComparison.OrdinalIgnoreCase))
+
+        Assert.That(operationsProjectPaths, Is.Empty)
+
     /// Proves Grace Server does not take a direct dependency on Operations application projects.
     [<Test>]
     member _.``Grace Server project does not reference Operations projects``() =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
@@ -50,6 +50,59 @@ module private ProjectStructureXml =
             | includePath -> Some includePath.Value)
         |> Seq.toArray
 
+/// Walks solution project references so root-solution isolation includes transitive dependencies.
+module private ProjectStructureGraph =
+
+    /// Describes a project-reference edge discovered while walking a solution's project graph.
+    type ProjectDependency = { ReferencingProject: string; ReferencedProject: string; ReferencePath: string }
+
+    /// Converts an absolute project path into a stable repository `src`-relative path.
+    let srcRelativeProjectPath (projectPath: string) =
+        Path
+            .GetRelativePath(ProjectStructureTestPaths.srcDirectory (), projectPath)
+            .Replace(Path.DirectorySeparatorChar, '/')
+
+    /// Resolves a solution project entry relative to the repository `src` directory.
+    let solutionProjectPath (projectPath: string) = Path.GetFullPath(Path.Combine(ProjectStructureTestPaths.srcDirectory (), projectPath))
+
+    /// Resolves a project reference relative to the project file that declares it.
+    let projectReferencePath (projectPath: string) (referencePath: string) =
+        let projectDirectory =
+            match Path.GetDirectoryName projectPath with
+            | null -> failwith $"Project path has no directory: {projectPath}"
+            | directory -> directory
+
+        Path.GetFullPath(Path.Combine(projectDirectory, referencePath))
+
+    /// Returns every project-reference edge reachable from the supplied root solution projects.
+    let projectReferenceClosure (rootProjects: string array) =
+        let visited = Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        let dependencies = Collections.Generic.List<ProjectDependency>()
+
+        let rec visit projectPath =
+            let projectPath = Path.GetFullPath projectPath
+
+            if visited.Add projectPath then
+                if not (File.Exists projectPath) then
+                    failwith $"Project reference does not exist: {projectPath}"
+
+                ProjectStructureXml.projectReferenceIncludes projectPath
+                |> Array.iter (fun referencePath ->
+                    let referencedProjectPath = projectReferencePath projectPath referencePath
+
+                    dependencies.Add(
+                        {
+                            ReferencingProject = srcRelativeProjectPath projectPath
+                            ReferencedProject = srcRelativeProjectPath referencedProjectPath
+                            ReferencePath = referencePath
+                        }
+                    )
+
+                    visit referencedProjectPath)
+
+        rootProjects |> Array.iter visit
+        dependencies |> Seq.toArray
+
 /// Verifies that the operations skeleton projects compile into distinct assemblies.
 [<TestFixture>]
 type ``Operations skeleton project graph``() =
@@ -114,6 +167,22 @@ type ``Operations skeleton project graph``() =
             |> Array.filter (fun (projectPath: string) -> projectPath.Contains("Grace.Operations", StringComparison.OrdinalIgnoreCase))
 
         Assert.That(operationsProjectPaths, Is.Empty)
+
+    /// Proves root validation cannot pull Operations projects through transitive project references.
+    [<Test>]
+    member _.``Root solution project graph excludes Operations project references``() =
+        let solutionPath = ProjectStructureTestPaths.srcRelativePath "" "Grace.slnx"
+
+        let rootProjects =
+            ProjectStructureXml.solutionProjectPaths solutionPath
+            |> Array.map ProjectStructureGraph.solutionProjectPath
+
+        let operationsReferences =
+            ProjectStructureGraph.projectReferenceClosure rootProjects
+            |> Array.filter (fun dependency -> dependency.ReferencedProject.Contains("Grace.Operations", StringComparison.OrdinalIgnoreCase))
+            |> Array.map (fun dependency -> $"{dependency.ReferencingProject} -> {dependency.ReferencedProject} ({dependency.ReferencePath})")
+
+        Assert.That(operationsReferences, Is.Empty)
 
     /// Proves Grace Server does not take a direct dependency on Operations application projects.
     [<Test>]

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
@@ -65,6 +65,12 @@ module private ProjectStructureGraph =
     /// Resolves a solution project entry relative to the repository `src` directory.
     let solutionProjectPath (projectPath: string) = Path.GetFullPath(Path.Combine(ProjectStructureTestPaths.srcDirectory (), projectPath))
 
+    /// Normalizes MSBuild project-reference separators before platform-specific path resolution.
+    let normalizeProjectReferencePath (referencePath: string) =
+        referencePath
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar)
+
     /// Resolves a project reference relative to the project file that declares it.
     let projectReferencePath (projectPath: string) (referencePath: string) =
         let projectDirectory =
@@ -72,7 +78,7 @@ module private ProjectStructureGraph =
             | null -> failwith $"Project path has no directory: {projectPath}"
             | directory -> directory
 
-        Path.GetFullPath(Path.Combine(projectDirectory, referencePath))
+        Path.GetFullPath(Path.Combine(projectDirectory, normalizeProjectReferencePath referencePath))
 
     /// Returns every project-reference edge reachable from the supplied root solution projects.
     let projectReferenceClosure (rootProjects: string array) =
@@ -183,6 +189,17 @@ type ``Operations skeleton project graph``() =
             |> Array.map (fun dependency -> $"{dependency.ReferencingProject} -> {dependency.ReferencedProject} ({dependency.ReferencePath})")
 
         Assert.That(operationsReferences, Is.Empty)
+
+    /// Proves project-reference graph walking handles Windows-style MSBuild includes on every runner OS.
+    [<Test>]
+    member _.``Project reference resolution normalizes Windows separators``() =
+        let projectPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, "RootProject", "RootProject.fsproj")
+
+        let resolvedPath = ProjectStructureGraph.projectReferencePath projectPath @"..\Grace.Operations\Grace.Operations.fsproj"
+
+        let expectedPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.WorkDirectory, "Grace.Operations", "Grace.Operations.fsproj"))
+
+        Assert.That(resolvedPath, Is.EqualTo(expectedPath))
 
     /// Proves Grace Server does not take a direct dependency on Operations application projects.
     [<Test>]

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -70,7 +70,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Grace.Operations\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj" />
     <ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
     <ProjectReference Include="..\Grace.Server\Grace.Server.fsproj" />

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -1,7 +1,6 @@
 namespace Grace.Server.Tests
 
 open Azure.Messaging.ServiceBus
-open Grace.Operations.Data
 open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Types.Common
@@ -44,6 +43,18 @@ type OperationsTracerBulletServerTests() =
     /// Application property that records the specific usage fact kind without parsing the payload.
     [<Literal>]
     let usageFactKindProperty = "usageFactKind"
+
+    /// External operations raw-fact table verified by the server integration tracer bullet.
+    [<Literal>]
+    let operationsRawUsageFactTable = "ops.RawUsageFact"
+
+    /// External operations aggregate table verified by the server integration tracer bullet.
+    [<Literal>]
+    let operationsUsageAggregateMinuteTable = "ops.UsageAggregateMinute"
+
+    /// Storage pool identifier width enforced by the operations database schema.
+    [<Literal>]
+    let operationsStoragePoolIdMaxLength = 256
 
     /// Bounded wait used while the worker consumes Service Bus messages and commits SQL rows.
     let proofTimeout = TimeSpan.FromSeconds(45.0)
@@ -196,7 +207,7 @@ type OperationsTracerBulletServerTests() =
         task {
             use! connection = openOperationsSqlAsync ()
             use command = connection.CreateCommand()
-            command.CommandText <- $"SELECT COUNT_BIG(1) FROM {OperationsUsageSql.RawUsageFactTable} WHERE UsageFactId = @UsageFactId;"
+            command.CommandText <- $"SELECT COUNT_BIG(1) FROM {operationsRawUsageFactTable} WHERE UsageFactId = @UsageFactId;"
             addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
             let! scalar = command.ExecuteScalarAsync()
             return Convert.ToInt64 scalar
@@ -211,7 +222,7 @@ type OperationsTracerBulletServerTests() =
             command.CommandText <-
                 $"""
 SELECT COALESCE(SUM(Quantity), 0)
-FROM {OperationsUsageSql.UsageAggregateMinuteTable}
+FROM {operationsUsageAggregateMinuteTable}
 WHERE FactKind = @FactKind
   AND OwnerId = @OwnerId
   AND OrganizationId = @OrganizationId
@@ -225,7 +236,7 @@ WHERE FactKind = @FactKind
             addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier fact.Scope.OrganizationId
             addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier fact.Scope.RepositoryId
 
-            let storagePoolParameter = command.Parameters.Add("@StoragePoolId", SqlDbType.NVarChar, OperationsUsageSql.StoragePoolIdMaxLength)
+            let storagePoolParameter = command.Parameters.Add("@StoragePoolId", SqlDbType.NVarChar, operationsStoragePoolIdMaxLength)
 
             storagePoolParameter.Value <- fact.Resource.StoragePoolId
             addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (fact.ObservedAt.ToDateTimeUtc())

--- a/src/Grace.slnx
+++ b/src/Grace.slnx
@@ -15,10 +15,6 @@
   <Project Path="Grace.CLI/Grace.CLI.fsproj" />
   <Project Path="Grace.Load/Grace.Load.fsproj" />
   <Project Path="Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj" />
-  <Project Path="Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj" />
-  <Project Path="Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj" />
-  <Project Path="Grace.Operations/Grace.Operations.Worker/Grace.Operations.Worker.fsproj" />
-  <Project Path="Grace.Operations/Grace.Operations.fsproj" />
   <Project Path="Grace.SDK/Grace.SDK.fsproj" />
   <Project Path="Grace.Server.Tests/Grace.Server.Tests.fsproj" />
   <Project Path="Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj" />


### PR DESCRIPTION
## Summary

Related to #565 under mini-epic #557 and parent epic #554.

This fixes the post-merge product-spec regression from PR #590: root `src/Grace.slnx` reabsorbed the Operations projects even though the accepted Grace.Operations shape is the Operations-local solution at `src/Grace.Operations/Grace.Operations.slnx`.

## Why This Matters

Grace.Operations is supposed to remain its own operational platform boundary. Keeping Operations projects out of the root solution prevents the old tracer-bullet layout from becoming the final shape again, while still preserving explicit build/test coverage through the Operations-local solution.

## Root Cause

Issue #565 and the implementation prompt named `src/Grace.slnx` as an owned path and used ambiguous wording around "solution builds with Operations projects under the new layout." The worker interpreted that as updating root solution entries to the relocated paths. The existing tests proved the Operations-local solution had the right projects and Grace Server did not reference Operations, but they did not prove root `Grace.slnx` excluded Operations projects or transitive Operations references from root-solution tests.

## Fix

- Removed all `Grace.Operations` project entries from root `src/Grace.slnx`.
- Kept `src/Grace.Operations/Grace.Operations.slnx` as the Operations build/test entrypoint.
- Updated `scripts/validate.ps1` and CI to build and test both solutions separately:
  - root `src/Grace.slnx`
  - Operations-local `src/Grace.Operations/Grace.Operations.slnx`
- Removed `Grace.Operations.Tests` from the root solution test filter so Operations tests do not silently depend on root solution membership.
- Removed the transitive `Grace.Operations.Data` reference from `Grace.Server.Tests`.
- Added executable regression guards that prove root `Grace.slnx` excludes direct and transitive Operations project references, including Windows-style `ProjectReference Include` separators on Linux runners.
- Updated the Grace workflow docs and agent guidance so future validation keeps the root and Operations solutions separate.

## Validation

- RED proof before fix: `dotnet test "src/Grace.Operations/Grace.Operations.slnx" -c Release --filter "FullyQualifiedName~Grace.Operations.Tests"` failed as expected on the new root-solution exclusion test, showing the four root `Grace.Operations` paths.
- Initial green proof: `pwsh ./scripts/validate.ps1 -Fast`: passed in `00:02:40`; it built/tested root and Operations-local solutions separately.
- Review-fix proof on `5cf118d2c8629d571baed265fb66b3424e123494`: Fantomas passed; MarkdownLint passed; focused Operations-local tests passed 30/30; `pwsh ./scripts/validate.ps1 -Fast` passed in `00:02:43.4124272`; `git diff --check` passed.
- Latest separator-fix proof on `63ad6576be906271874e090c75a0651183b1fd3e`: Fantomas passed; focused Operations-local tests passed 31/31; `pwsh ./scripts/validate.ps1 -Fast` passed; `git diff --check` passed.
- PR body MarkdownLint: `npx --yes markdownlint-cli2 --config .markdownlint.jsonc $env:TEMP/pr-591-body.md`: passed with 0 errors.
- GitHub Actions `full`: passed in 7m51s on head `63ad6576be906271874e090c75a0651183b1fd3e`.

## Review Status

- Current head: `63ad6576be906271874e090c75a0651183b1fd3e`.
- Codex Code Review Bot: 👍 on the latest head, with zero unresolved review threads.
- Latest fix: `63ad6576be906271874e090c75a0651183b1fd3e` normalizes both `\\` and `/` in `ProjectReference Include` values before resolving referenced project paths, with focused regression coverage for Windows-style separators.
- Prevention: root solution isolation is now enforced by direct root-solution membership checks, transitive project-reference closure checks, Operations-local validation, CI, and workflow guidance.
- CI: GitHub Actions `full` passed on the latest head.

## Docs Impact

Updated Grace process docs and agent guidance to document that validation must cover both root and Operations-local solutions without making Operations projects members of root `src/Grace.slnx`.

## Residual Risk

No known residual risk. This changes solution membership, validation routing, CI validation, and process guidance only; no Operations runtime or persistence behavior changed.
