### PR TITLE
Adopt EF Core operations SQL foundation

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -12,6 +12,11 @@
 
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="OperationsUsageSql.fs" />
+    <Compile Include="OperationsEntities.fs" />
+    <Compile Include="OperationsDbContext.fs" />
+    <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
+    <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
   </ItemGroup>
 
@@ -21,6 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
     <PackageReference Update="FSharp.Core" Version="10.1.301" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -1,0 +1,23 @@
+# Operations Data Migrations
+
+`Grace.Operations.Data` owns the EF Core model and migrations for the Azure SQL operations store. The current baseline
+schema is intentionally narrow:
+
+- `ops.RawUsageFact` stores immutable `UsageFact` rows with `UsageFactId` as the duplicate-delivery boundary.
+- `ops.UsageAggregateMinute` stores one aggregate row per fact kind, Grace scope, storage pool, and UTC minute.
+- The EF migrations history table lives in `ops.__EFMigrationsHistory` so operations schema state stays with the
+  operations schema.
+
+The ingestion hot path still uses reviewed raw SQL for the durable insert and aggregate update. That path preserves the
+`UsageFactId` idempotency lock and the aggregate `MERGE ... WITH (HOLDLOCK)` behavior that the worker depends on.
+
+## Raw SQL Escape Hatch
+
+Use EF migration builder APIs for ordinary tables, columns, keys, and indexes. Raw SQL is allowed only inside migration
+classes or reviewed helper modules used directly by migrations when SQL Server or Azure SQL physical design needs a
+shape EF cannot express clearly. Valid examples include provider-specific index options, partitioning, compression,
+online rebuild options, lock hints for data backfills, and guarded data movement for a future reviewed migration.
+
+Do not put SQL Server physical-design choices in worker startup, request handlers, or ad hoc runtime bootstrap code.
+When raw SQL is used in a migration, keep it deterministic, name the Grace invariant it protects, and cover the emitted
+schema or behavior with Operations migration tests.

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260705234500_InitialOperationsSchema.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260705234500_InitialOperationsSchema.fs
@@ -114,4 +114,160 @@ END;
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
-        OperationsModel.configure modelBuilder
+        // Deliberately keep this migration target model frozen with literals so future runtime model edits
+        // cannot rewrite the reviewed baseline migration point.
+        modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable("UsageAggregateMinute", "ops")
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260705234500_InitialOperationsSchema.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260705234500_InitialOperationsSchema.fs
@@ -108,3 +108,10 @@ END;
 
         migrationBuilder.Sql("IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NOT NULL DROP TABLE ops.RawUsageFact;")
         |> ignore
+
+    /// Captures the raw fact and aggregate model that future migrations diff against.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260705234500_InitialOperationsSchema.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260705234500_InitialOperationsSchema.fs
@@ -1,0 +1,110 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Migrations
+
+/// Creates the baseline Operations SQL Server schema for raw usage facts and minute aggregates.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260705234500_InitialOperationsSchema")>]
+type InitialOperationsSchema() =
+    inherit Migration()
+
+    /// Applies the first reviewed Operations SQL Server schema.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.EnsureSchema(OperationsUsageSql.SchemaName)
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL
+BEGIN
+    CREATE TABLE ops.RawUsageFact
+    (
+        UsageFactId uniqueidentifier NOT NULL,
+        CorrelationId nvarchar(200) NOT NULL,
+        FactKind int NOT NULL,
+        OwnerId uniqueidentifier NOT NULL,
+        OrganizationId uniqueidentifier NOT NULL,
+        RepositoryId uniqueidentifier NOT NULL,
+        StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
+        Quantity bigint NOT NULL,
+        ObservedAtUtc datetime2(7) NOT NULL,
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_RawUsageFact_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)
+    );
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL
+BEGIN
+    CREATE TABLE ops.UsageAggregateMinute
+    (
+        FactKind int NOT NULL,
+        OwnerId uniqueidentifier NOT NULL,
+        OrganizationId uniqueidentifier NOT NULL,
+        RepositoryId uniqueidentifier NOT NULL,
+        StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
+        BucketStartUtc datetime2(7) NOT NULL,
+        Quantity bigint NOT NULL,
+        UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_UsageAggregateMinute_UpdatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_UsageAggregateMinute PRIMARY KEY CLUSTERED
+        (
+            FactKind,
+            OwnerId,
+            OrganizationId,
+            RepositoryId,
+            StoragePoolId,
+            BucketStartUtc
+        )
+    );
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_ops_RawUsageFact_ScopeKindObservedAt'
+      AND object_id = OBJECT_ID(N'ops.RawUsageFact')
+)
+BEGIN
+    CREATE INDEX IX_ops_RawUsageFact_ScopeKindObservedAt
+    ON ops.RawUsageFact (OwnerId, OrganizationId, RepositoryId, FactKind, ObservedAtUtc);
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_ops_UsageAggregateMinute_ScopeKindBucket'
+      AND object_id = OBJECT_ID(N'ops.UsageAggregateMinute')
+)
+BEGIN
+    CREATE INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket
+    ON ops.UsageAggregateMinute (OwnerId, OrganizationId, RepositoryId, FactKind, BucketStartUtc);
+END;
+"""
+        )
+        |> ignore
+
+    /// Removes the baseline Operations schema objects in reverse dependency order.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql("IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NOT NULL DROP TABLE ops.UsageAggregateMinute;")
+        |> ignore
+
+        migrationBuilder.Sql("IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NOT NULL DROP TABLE ops.RawUsageFact;")
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -1,0 +1,17 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+
+/// Captures the current Operations EF model so future migrations can detect reviewed schema drift.
+[<DbContextAttribute(typeof<OperationsDbContext>)>]
+type OperationsDbContextModelSnapshot() =
+    inherit ModelSnapshot()
+
+    /// Rebuilds the Operations model represented by the latest migration.
+    override _.BuildModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -14,4 +14,160 @@ type OperationsDbContextModelSnapshot() =
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
-        OperationsModel.configure modelBuilder
+        // Deliberately keep this snapshot frozen with literals so future runtime model edits
+        // cannot change the latest reviewed migration point before a new migration updates it.
+        modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable("UsageAggregateMinute", "ops")
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -306,10 +306,22 @@ type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsU
             | _ -> return ()
         }
 
+    /// Opens the target database and creates the operations schema before EF migrations touch history state.
+    let ensureSchemaCreatedAsync cancellationToken =
+        task {
+            use! connection = openConnectionAsync bootstrapPlan.SchemaConnectionString cancellationToken
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+            command.CommandText <- OperationsUsageSql.CreateSchemaIfMissing
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
     /// Applies reviewed EF Core migrations for the operations usage schema.
     member _.EnsureCreatedAsync(cancellationToken: CancellationToken) =
         task {
             do! ensureDatabaseCreatedAsync cancellationToken
+            do! ensureSchemaCreatedAsync cancellationToken
             use context = OperationsDbContextFactory.create bootstrapPlan.SchemaConnectionString
             do! context.Database.MigrateAsync cancellationToken
         }

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -2,6 +2,7 @@ namespace Grace.Operations.Data
 
 open Grace.Types.Common
 open Grace.Types.Usage
+open Microsoft.EntityFrameworkCore
 open Microsoft.Data.SqlClient
 open NodaTime
 open System
@@ -98,185 +99,6 @@ module internal OperationsUsageSchemaBootstrapPlan =
             SchemaConnectionString = connectionString
             DatabaseCreationConnectionString = databaseCreationConnectionString
         }
-
-/// Provides SQL Server schema and command text for the operations usage fact tables.
-[<RequireQualifiedAccess>]
-module OperationsUsageSql =
-
-    /// Names the SQL schema used by Grace operations data.
-    [<Literal>]
-    let SchemaName = "ops"
-
-    /// Names the raw immutable fact table.
-    [<Literal>]
-    let RawUsageFactTable = "ops.RawUsageFact"
-
-    /// Names the minute aggregate table derived from accepted raw facts.
-    [<Literal>]
-    let UsageAggregateMinuteTable = "ops.UsageAggregateMinute"
-
-    /// Keeps storage-pool identities case-sensitive even when the database default collation is case-insensitive.
-    [<Literal>]
-    let CaseSensitiveStoragePoolIdCollation = "Latin1_General_100_BIN2"
-
-    /// Limits correlation identifiers to the raw fact column width used by the operations store.
-    [<Literal>]
-    let CorrelationIdMaxLength = 200
-
-    /// Limits storage-pool identifiers to the aggregate key column width used by the operations store.
-    [<Literal>]
-    let StoragePoolIdMaxLength = 256
-
-    /// Creates the operations schema when it is absent.
-    [<Literal>]
-    let CreateSchema = "IF SCHEMA_ID(N'ops') IS NULL EXEC(N'CREATE SCHEMA ops');"
-
-    /// Creates the configured operations database when SQL Server does not already contain it.
-    [<Literal>]
-    let CreateDatabaseIfMissing =
-        """
-IF DB_ID(@DatabaseName) IS NULL
-BEGIN
-    DECLARE @CreateDatabaseSql nvarchar(max) = N'CREATE DATABASE ' + QUOTENAME(@DatabaseName);
-    EXEC(@CreateDatabaseSql);
-END;
-"""
-
-    /// Creates `ops.RawUsageFact` with `UsageFactId` as the durable dedupe key.
-    [<Literal>]
-    let CreateRawUsageFactTable =
-        """
-IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL
-BEGIN
-    CREATE TABLE ops.RawUsageFact
-    (
-        UsageFactId uniqueidentifier NOT NULL,
-        CorrelationId nvarchar(200) NOT NULL,
-        FactKind int NOT NULL,
-        OwnerId uniqueidentifier NOT NULL,
-        OrganizationId uniqueidentifier NOT NULL,
-        RepositoryId uniqueidentifier NOT NULL,
-        StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
-        Quantity bigint NOT NULL,
-        ObservedAtUtc datetime2(7) NOT NULL,
-        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_RawUsageFact_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
-        CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)
-    );
-END;
-"""
-
-    /// Creates `ops.UsageAggregateMinute` with one row per repository resource and UTC minute.
-    [<Literal>]
-    let CreateUsageAggregateMinuteTable =
-        """
-IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL
-BEGIN
-    CREATE TABLE ops.UsageAggregateMinute
-    (
-        FactKind int NOT NULL,
-        OwnerId uniqueidentifier NOT NULL,
-        OrganizationId uniqueidentifier NOT NULL,
-        RepositoryId uniqueidentifier NOT NULL,
-        StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
-        BucketStartUtc datetime2(7) NOT NULL,
-        Quantity bigint NOT NULL,
-        UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_UsageAggregateMinute_UpdatedAtUtc DEFAULT SYSUTCDATETIME(),
-        CONSTRAINT PK_ops_UsageAggregateMinute PRIMARY KEY CLUSTERED
-        (
-            FactKind,
-            OwnerId,
-            OrganizationId,
-            RepositoryId,
-            StoragePoolId,
-            BucketStartUtc
-        )
-    );
-END;
-"""
-
-    /// Inserts one raw usage fact only when its durable identity has not already been accepted.
-    [<Literal>]
-    let TryInsertRawUsageFact =
-        """
-INSERT INTO ops.RawUsageFact
-(
-    UsageFactId,
-    CorrelationId,
-    FactKind,
-    OwnerId,
-    OrganizationId,
-    RepositoryId,
-    StoragePoolId,
-    Quantity,
-    ObservedAtUtc
-)
-SELECT
-    @UsageFactId,
-    @CorrelationId,
-    @FactKind,
-    @OwnerId,
-    @OrganizationId,
-    @RepositoryId,
-    @StoragePoolId,
-    @Quantity,
-    @ObservedAtUtc
-WHERE NOT EXISTS
-(
-    SELECT 1
-    FROM ops.RawUsageFact WITH (UPDLOCK, HOLDLOCK)
-    WHERE UsageFactId = @UsageFactId
-);
-"""
-
-    /// Adds a quantity to the minute aggregate row associated with a newly accepted raw fact.
-    [<Literal>]
-    let AddToUsageAggregateMinute =
-        """
-MERGE ops.UsageAggregateMinute WITH (HOLDLOCK) AS target
-USING
-(
-    SELECT
-        @FactKind AS FactKind,
-        @OwnerId AS OwnerId,
-        @OrganizationId AS OrganizationId,
-        @RepositoryId AS RepositoryId,
-        CAST(@StoragePoolId AS nvarchar(256)) COLLATE Latin1_General_100_BIN2 AS StoragePoolId,
-        @BucketStartUtc AS BucketStartUtc,
-        @Quantity AS Quantity
-) AS source
-ON
-    target.FactKind = source.FactKind
-    AND target.OwnerId = source.OwnerId
-    AND target.OrganizationId = source.OrganizationId
-    AND target.RepositoryId = source.RepositoryId
-    AND target.StoragePoolId = source.StoragePoolId
-    AND target.BucketStartUtc = source.BucketStartUtc
-WHEN MATCHED THEN
-    UPDATE SET
-        Quantity = target.Quantity + source.Quantity,
-        UpdatedAtUtc = SYSUTCDATETIME()
-WHEN NOT MATCHED THEN
-    INSERT
-    (
-        FactKind,
-        OwnerId,
-        OrganizationId,
-        RepositoryId,
-        StoragePoolId,
-        BucketStartUtc,
-        Quantity
-    )
-    VALUES
-    (
-        source.FactKind,
-        source.OwnerId,
-        source.OrganizationId,
-        source.RepositoryId,
-        source.StoragePoolId,
-        source.BucketStartUtc,
-        source.Quantity
-    );
-"""
 
 /// Builds deterministic raw fact and aggregate projection plans from the shared usage contract.
 [<RequireQualifiedAccess>]
@@ -467,16 +289,6 @@ type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsU
             return connection
         }
 
-    /// Executes a schema command against the operations database.
-    let executeCommandAsync (connection: SqlConnection) commandText cancellationToken =
-        task {
-            use command = connection.CreateCommand()
-            command.CommandType <- CommandType.Text
-            command.CommandText <- commandText
-            let! _ = command.ExecuteNonQueryAsync cancellationToken
-            return ()
-        }
-
     /// Creates the configured operations database when the connection string points at a database that is absent.
     let ensureDatabaseCreatedAsync cancellationToken =
         task {
@@ -494,14 +306,12 @@ type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsU
             | _ -> return ()
         }
 
-    /// Creates the operations usage schema, raw fact table, and minute aggregate table when they are absent.
+    /// Applies reviewed EF Core migrations for the operations usage schema.
     member _.EnsureCreatedAsync(cancellationToken: CancellationToken) =
         task {
             do! ensureDatabaseCreatedAsync cancellationToken
-            use! connection = openConnectionAsync bootstrapPlan.SchemaConnectionString cancellationToken
-            do! executeCommandAsync connection OperationsUsageSql.CreateSchema cancellationToken
-            do! executeCommandAsync connection OperationsUsageSql.CreateRawUsageFactTable cancellationToken
-            do! executeCommandAsync connection OperationsUsageSql.CreateUsageAggregateMinuteTable cancellationToken
+            use context = OperationsDbContextFactory.create bootstrapPlan.SchemaConnectionString
+            do! context.Database.MigrateAsync cancellationToken
         }
 
 /// Persists usage facts through a transaction-scoped raw insert and aggregate projection.

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -3,6 +3,8 @@ namespace Grace.Operations.Data
 open Microsoft.EntityFrameworkCore
 open Microsoft.EntityFrameworkCore.Design
 open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
 open System
 
 /// Configures the Operations EF Core model without opening a database connection.
@@ -194,12 +196,42 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     /// Configures the Operations SQL Server schema shape that migrations must preserve.
     override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder
 
+/// Ensures EF-generated scripts create the Operations schema before SQL Server receives history-table DDL.
+type OperationsSqlServerHistoryRepository(dependencies: HistoryRepositoryDependencies) =
+    inherit SqlServerHistoryRepository(dependencies)
+
+    let withOpsSchemaPreamble (script: string) =
+        if String.IsNullOrWhiteSpace script then
+            script
+        else
+            $"{OperationsUsageSql.CreateSchemaIfMissing.Trim()}{Environment.NewLine}{Environment.NewLine}{script}"
+
+    /// Creates the Operations schema before EF creates `[ops].[__EFMigrationsHistory]` in non-idempotent scripts.
+    override _.GetCreateScript() = base.GetCreateScript() |> withOpsSchemaPreamble
+
+    /// Creates the Operations schema before EF creates `[ops].[__EFMigrationsHistory]` in idempotent scripts and bundles.
+    override _.GetCreateIfNotExistsScript() =
+        base.GetCreateIfNotExistsScript()
+        |> withOpsSchemaPreamble
+
 /// Builds configured Operations EF contexts for runtime schema migration and tests.
 [<RequireQualifiedAccess>]
 module OperationsDbContextFactory =
 
     /// Provides the SQL Server connection string used when EF tooling builds migrations without opening the database.
     let private defaultDesignTimeConnectionString = "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsDesignTime;Integrated Security=true;"
+
+    /// Names the documented Operations SQL environment variable shared with `Grace.Operations.Worker`.
+    let private documentedSqlConnectionStringEnvironmentVariable = "grace__operations__sql__connectionstring"
+
+    /// Names the legacy design-time SQL environment variable retained for local developer compatibility.
+    let private legacySqlConnectionStringEnvironmentVariable = "GRACE_OPERATIONS_SQL_CONNECTION_STRING"
+
+    /// Reads the first non-empty environment variable from the supplied precedence order.
+    let private firstEnvironmentConnectionString variableNames =
+        variableNames
+        |> Seq.map Environment.GetEnvironmentVariable
+        |> Seq.tryFind (fun value -> not (String.IsNullOrWhiteSpace value))
 
     /// Resolves the design-time SQL Server connection string from EF command arguments, environment, or LocalDB.
     let designTimeConnectionString (args: string array) =
@@ -208,16 +240,17 @@ module OperationsDbContextFactory =
             with
         | Some connectionString -> connectionString
         | None ->
-            let environmentConnectionString = Environment.GetEnvironmentVariable("GRACE_OPERATIONS_SQL_CONNECTION_STRING")
-
-            if String.IsNullOrWhiteSpace environmentConnectionString then
-                defaultDesignTimeConnectionString
-            else
-                environmentConnectionString
+            [|
+                documentedSqlConnectionStringEnvironmentVariable
+                legacySqlConnectionStringEnvironmentVariable
+            |]
+            |> firstEnvironmentConnectionString
+            |> Option.defaultValue defaultDesignTimeConnectionString
 
     /// Creates EF Core options for the Operations SQL Server database.
     let options (connectionString: string) =
         DbContextOptionsBuilder<OperationsDbContext>()
+            .ReplaceService<IHistoryRepository, OperationsSqlServerHistoryRepository>()
             .UseSqlServer(
             connectionString,
             System.Action<SqlServerDbContextOptionsBuilder> (fun sql ->

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -1,7 +1,9 @@
 namespace Grace.Operations.Data
 
 open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Design
 open Microsoft.EntityFrameworkCore.Infrastructure
+open System
 
 /// Configures the Operations EF Core model without opening a database connection.
 [<RequireQualifiedAccess>]
@@ -196,6 +198,23 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
 [<RequireQualifiedAccess>]
 module OperationsDbContextFactory =
 
+    /// Provides the SQL Server connection string used when EF tooling builds migrations without opening the database.
+    let private defaultDesignTimeConnectionString = "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsDesignTime;Integrated Security=true;"
+
+    /// Resolves the design-time SQL Server connection string from EF command arguments, environment, or LocalDB.
+    let designTimeConnectionString (args: string array) =
+        match args
+              |> Array.tryFind (fun value -> not (String.IsNullOrWhiteSpace value))
+            with
+        | Some connectionString -> connectionString
+        | None ->
+            let environmentConnectionString = Environment.GetEnvironmentVariable("GRACE_OPERATIONS_SQL_CONNECTION_STRING")
+
+            if String.IsNullOrWhiteSpace environmentConnectionString then
+                defaultDesignTimeConnectionString
+            else
+                environmentConnectionString
+
     /// Creates EF Core options for the Operations SQL Server database.
     let options (connectionString: string) =
         DbContextOptionsBuilder<OperationsDbContext>()
@@ -209,3 +228,13 @@ module OperationsDbContextFactory =
 
     /// Creates a configured Operations EF context for the supplied SQL Server connection string.
     let create connectionString = new OperationsDbContext(options connectionString)
+
+/// Provides the discoverable EF Core design-time factory used by `dotnet ef migrations add`.
+type OperationsDesignTimeDbContextFactory() =
+
+    interface IDesignTimeDbContextFactory<OperationsDbContext> with
+
+        /// Creates an Operations context without relying on F# module discovery.
+        member _.CreateDbContext(args: string array) =
+            OperationsDbContextFactory.designTimeConnectionString args
+            |> OperationsDbContextFactory.create

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -1,0 +1,211 @@
+namespace Grace.Operations.Data
+
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+
+/// Configures the Operations EF Core model without opening a database connection.
+[<RequireQualifiedAccess>]
+module OperationsModel =
+
+    /// Configures the raw fact and minute aggregate tables that form the Operations usage foundation.
+    let configure (modelBuilder: ModelBuilder) =
+        modelBuilder.HasDefaultSchema(OperationsUsageSql.SchemaName)
+        |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable(OperationsUsageSql.RawUsageFactTableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(OperationsUsageSql.CorrelationIdMaxLength)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(OperationsUsageSql.StoragePoolIdMaxLength)
+            .UseCollation(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable(OperationsUsageSql.UsageAggregateMinuteTableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(OperationsUsageSql.StoragePoolIdMaxLength)
+            .UseCollation(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation)
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore
+
+/// Owns the EF Core model for Grace Operations SQL Server schema evolution.
+type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
+    inherit DbContext(options)
+
+    /// Exposes immutable usage facts for EF migrations and schema inspection.
+    [<DefaultValue>]
+    val mutable private rawUsageFacts: DbSet<RawUsageFactEntity>
+
+    /// Exposes UTC minute aggregates for EF migrations and schema inspection.
+    [<DefaultValue>]
+    val mutable private usageAggregateMinutes: DbSet<UsageAggregateMinuteEntity>
+
+    /// Provides the EF set for immutable usage fact rows.
+    member this.RawUsageFacts
+        with get () = this.rawUsageFacts
+        and set value = this.rawUsageFacts <- value
+
+    /// Provides the EF set for repository resource minute aggregate rows.
+    member this.UsageAggregateMinutes
+        with get () = this.usageAggregateMinutes
+        and set value = this.usageAggregateMinutes <- value
+
+    /// Configures the Operations SQL Server schema shape that migrations must preserve.
+    override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder
+
+/// Builds configured Operations EF contexts for runtime schema migration and tests.
+[<RequireQualifiedAccess>]
+module OperationsDbContextFactory =
+
+    /// Creates EF Core options for the Operations SQL Server database.
+    let options (connectionString: string) =
+        DbContextOptionsBuilder<OperationsDbContext>()
+            .UseSqlServer(
+            connectionString,
+            System.Action<SqlServerDbContextOptionsBuilder> (fun sql ->
+                sql.MigrationsHistoryTable("__EFMigrationsHistory", OperationsUsageSql.SchemaName)
+                |> ignore)
+        )
+            .Options
+
+    /// Creates a configured Operations EF context for the supplied SQL Server connection string.
+    let create connectionString = new OperationsDbContext(options connectionString)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -1,0 +1,65 @@
+namespace Grace.Operations.Data
+
+open System
+
+/// Represents an immutable operational usage fact row managed by the Operations EF model.
+[<AllowNullLiteral>]
+type RawUsageFactEntity() =
+
+    /// Stores the durable idempotency key supplied by the UsageFact contract.
+    member val UsageFactId = Guid.Empty with get, set
+
+    /// Stores the request or workflow correlation identifier associated with the fact.
+    member val CorrelationId = String.Empty with get, set
+
+    /// Stores the persisted integer representation of the UsageFact kind.
+    member val FactKind = 0 with get, set
+
+    /// Stores the Grace owner scope for the measured repository resource.
+    member val OwnerId = Guid.Empty with get, set
+
+    /// Stores the Grace organization scope for the measured repository resource.
+    member val OrganizationId = Guid.Empty with get, set
+
+    /// Stores the Grace repository scope for the measured resource.
+    member val RepositoryId = Guid.Empty with get, set
+
+    /// Stores the storage pool identity using the Operations case-sensitive collation.
+    member val StoragePoolId = String.Empty with get, set
+
+    /// Stores the measured resource quantity for the fact.
+    member val Quantity = 0L with get, set
+
+    /// Stores the UTC minute timestamp associated with the fact.
+    member val ObservedAtUtc = DateTime.MinValue with get, set
+
+    /// Stores the SQL-created UTC timestamp for the raw fact row.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+/// Represents one repository resource aggregate row for a UTC minute.
+[<AllowNullLiteral>]
+type UsageAggregateMinuteEntity() =
+
+    /// Stores the persisted integer representation of the UsageFact kind.
+    member val FactKind = 0 with get, set
+
+    /// Stores the Grace owner scope for the aggregate row.
+    member val OwnerId = Guid.Empty with get, set
+
+    /// Stores the Grace organization scope for the aggregate row.
+    member val OrganizationId = Guid.Empty with get, set
+
+    /// Stores the Grace repository scope for the aggregate row.
+    member val RepositoryId = Guid.Empty with get, set
+
+    /// Stores the storage pool identity using the Operations case-sensitive collation.
+    member val StoragePoolId = String.Empty with get, set
+
+    /// Stores the UTC minute bucket represented by this aggregate row.
+    member val BucketStartUtc = DateTime.MinValue with get, set
+
+    /// Stores the accumulated resource quantity for the aggregate key.
+    member val Quantity = 0L with get, set
+
+    /// Stores the SQL-created or SQL-updated UTC timestamp for the aggregate row.
+    member val UpdatedAtUtc = DateTime.MinValue with get, set

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -47,6 +47,16 @@ BEGIN
 END;
 """
 
+    /// Creates the operations schema before EF Core touches the schema-scoped migration history table.
+    [<Literal>]
+    let CreateSchemaIfMissing =
+        """
+IF SCHEMA_ID(N'ops') IS NULL
+BEGIN
+    EXEC(N'CREATE SCHEMA [ops]');
+END;
+"""
+
     /// Inserts one raw usage fact only when its durable identity has not already been accepted.
     [<Literal>]
     let TryInsertRawUsageFact =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -1,0 +1,132 @@
+namespace Grace.Operations.Data
+
+/// Provides SQL Server schema names and command text for the operations usage fact tables.
+[<RequireQualifiedAccess>]
+module OperationsUsageSql =
+
+    /// Names the SQL schema used by Grace operations data.
+    [<Literal>]
+    let SchemaName = "ops"
+
+    /// Names the raw immutable fact table without schema qualification for EF migrations.
+    [<Literal>]
+    let RawUsageFactTableName = "RawUsageFact"
+
+    /// Names the raw immutable fact table.
+    [<Literal>]
+    let RawUsageFactTable = "ops.RawUsageFact"
+
+    /// Names the minute aggregate table without schema qualification for EF migrations.
+    [<Literal>]
+    let UsageAggregateMinuteTableName = "UsageAggregateMinute"
+
+    /// Names the minute aggregate table derived from accepted raw facts.
+    [<Literal>]
+    let UsageAggregateMinuteTable = "ops.UsageAggregateMinute"
+
+    /// Keeps storage-pool identities case-sensitive even when the database default collation is case-insensitive.
+    [<Literal>]
+    let CaseSensitiveStoragePoolIdCollation = "Latin1_General_100_BIN2"
+
+    /// Limits correlation identifiers to the raw fact column width used by the operations store.
+    [<Literal>]
+    let CorrelationIdMaxLength = 200
+
+    /// Limits storage-pool identifiers to the aggregate key column width used by the operations store.
+    [<Literal>]
+    let StoragePoolIdMaxLength = 256
+
+    /// Creates the configured operations database when SQL Server does not already contain it.
+    [<Literal>]
+    let CreateDatabaseIfMissing =
+        """
+IF DB_ID(@DatabaseName) IS NULL
+BEGIN
+    DECLARE @CreateDatabaseSql nvarchar(max) = N'CREATE DATABASE ' + QUOTENAME(@DatabaseName);
+    EXEC(@CreateDatabaseSql);
+END;
+"""
+
+    /// Inserts one raw usage fact only when its durable identity has not already been accepted.
+    [<Literal>]
+    let TryInsertRawUsageFact =
+        """
+INSERT INTO ops.RawUsageFact
+(
+    UsageFactId,
+    CorrelationId,
+    FactKind,
+    OwnerId,
+    OrganizationId,
+    RepositoryId,
+    StoragePoolId,
+    Quantity,
+    ObservedAtUtc
+)
+SELECT
+    @UsageFactId,
+    @CorrelationId,
+    @FactKind,
+    @OwnerId,
+    @OrganizationId,
+    @RepositoryId,
+    @StoragePoolId,
+    @Quantity,
+    @ObservedAtUtc
+WHERE NOT EXISTS
+(
+    SELECT 1
+    FROM ops.RawUsageFact WITH (UPDLOCK, HOLDLOCK)
+    WHERE UsageFactId = @UsageFactId
+);
+"""
+
+    /// Adds a quantity to the minute aggregate row associated with a newly accepted raw fact.
+    [<Literal>]
+    let AddToUsageAggregateMinute =
+        """
+MERGE ops.UsageAggregateMinute WITH (HOLDLOCK) AS target
+USING
+(
+    SELECT
+        @FactKind AS FactKind,
+        @OwnerId AS OwnerId,
+        @OrganizationId AS OrganizationId,
+        @RepositoryId AS RepositoryId,
+        CAST(@StoragePoolId AS nvarchar(256)) COLLATE Latin1_General_100_BIN2 AS StoragePoolId,
+        @BucketStartUtc AS BucketStartUtc,
+        @Quantity AS Quantity
+) AS source
+ON
+    target.FactKind = source.FactKind
+    AND target.OwnerId = source.OwnerId
+    AND target.OrganizationId = source.OrganizationId
+    AND target.RepositoryId = source.RepositoryId
+    AND target.StoragePoolId = source.StoragePoolId
+    AND target.BucketStartUtc = source.BucketStartUtc
+WHEN MATCHED THEN
+    UPDATE SET
+        Quantity = target.Quantity + source.Quantity,
+        UpdatedAtUtc = SYSUTCDATETIME()
+WHEN NOT MATCHED THEN
+    INSERT
+    (
+        FactKind,
+        OwnerId,
+        OrganizationId,
+        RepositoryId,
+        StoragePoolId,
+        BucketStartUtc,
+        Quantity
+    )
+    VALUES
+    (
+        source.FactKind,
+        source.OwnerId,
+        source.OrganizationId,
+        source.RepositoryId,
+        source.StoragePoolId,
+        source.BucketStartUtc,
+        source.Quantity
+    );
+"""

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -1,9 +1,11 @@
 namespace Grace.Operations.Tests
 
 open Grace.Operations.Data
+open Grace.Operations.Data.Migrations
 open Grace.Types.Common
 open Grace.Types.Usage
 open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Design
 open Microsoft.EntityFrameworkCore.Infrastructure
 open Microsoft.EntityFrameworkCore.Migrations
 open Microsoft.EntityFrameworkCore.Metadata
@@ -174,6 +176,24 @@ type OperationsUsageStorageTests() =
 
         context.Model.FindEntityType(typeof<UsageAggregateMinuteEntity>)
 
+    /// Verifies EF tooling can discover a concrete design-time context factory for reviewed migrations.
+    [<Test>]
+    member _.OperationsDesignTimeFactoryCreatesSqlServerContext() =
+        let factory = OperationsDesignTimeDbContextFactory() :> IDesignTimeDbContextFactory<OperationsDbContext>
+
+        use context =
+            factory.CreateDbContext(
+                [|
+                    "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsDesignTimeTests;Integrated Security=true;"
+                |]
+            )
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(context, Is.InstanceOf<OperationsDbContext>())
+                Assert.That(context.Database.ProviderName, Is.EqualTo("Microsoft.EntityFrameworkCore.SqlServer")))
+        )
+
     /// Verifies the EF model keeps raw fact identity as the durable dedupe boundary.
     [<Test>]
     member _.OperationsEfModelUsesUsageFactIdAsRawFactPrimaryKey() =
@@ -270,6 +290,33 @@ type OperationsUsageStorageTests() =
                 Assert.That(script, Does.Contain("CREATE INDEX IX_ops_RawUsageFact_ScopeKindObservedAt"))
                 Assert.That(script, Does.Contain("CREATE INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket"))
                 Assert.That(script, Does.Contain("[ops].[__EFMigrationsHistory]")))
+        )
+
+    /// Verifies the initial migration records the target model used by future migration diffs.
+    [<Test>]
+    member _.BaselineMigrationTargetModelContainsOperationsEntities() =
+        let migration = InitialOperationsSchema()
+        let rawFact = migration.TargetModel.FindEntityType(typeof<RawUsageFactEntity>)
+        let aggregate = migration.TargetModel.FindEntityType(typeof<UsageAggregateMinuteEntity>)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(rawFact, Is.Not.Null)
+                Assert.That(rawFact.GetSchema(), Is.EqualTo(OperationsUsageSql.SchemaName))
+                Assert.That(rawFact.GetTableName(), Is.EqualTo(OperationsUsageSql.RawUsageFactTableName))
+                Assert.That(aggregate, Is.Not.Null)
+                Assert.That(aggregate.GetSchema(), Is.EqualTo(OperationsUsageSql.SchemaName))
+                Assert.That(aggregate.GetTableName(), Is.EqualTo(OperationsUsageSql.UsageAggregateMinuteTableName)))
+        )
+
+    /// Verifies schema bootstrap creates the schema before EF creates the schema-scoped history table.
+    [<Test>]
+    member _.SchemaBootstrapPreCreatesOpsSchemaWithoutCreatingDatabases() =
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(OperationsUsageSql.CreateSchemaIfMissing, Does.Contain("SCHEMA_ID(N'ops') IS NULL"))
+                Assert.That(OperationsUsageSql.CreateSchemaIfMissing, Does.Contain("CREATE SCHEMA [ops]"))
+                Assert.That(OperationsUsageSql.CreateSchemaIfMissing, Does.Not.Contain("CREATE DATABASE")))
         )
 
     /// Verifies SQL storage-pool keys stay case-sensitive under Azure SQL default collations.

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -3,6 +3,10 @@ namespace Grace.Operations.Tests
 open Grace.Operations.Data
 open Grace.Types.Common
 open Grace.Types.Usage
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata
 open NodaTime
 open NUnit.Framework
 open System
@@ -151,34 +155,132 @@ type OperationsUsageStorageTests() =
             let errorText = String.Join("; ", errors)
             failwith $"Persistence plan failed validation: {errorText}"
 
-    /// Verifies the SQL DDL keeps raw fact identity as the durable dedupe boundary.
+    /// Generates the Operations migration script without connecting to SQL Server.
+    let migrationScript () =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsMigrationScript;Integrated Security=true;"
+
+        let migrator = context.GetService<IMigrator>()
+        migrator.GenerateScript(options = MigrationsSqlGenerationOptions.Idempotent)
+
+    /// Reads the EF entity metadata that future migrations use for raw fact schema drift.
+    let rawFactEntityType () : IEntityType =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsMigrationModel;Integrated Security=true;"
+
+        context.Model.FindEntityType(typeof<RawUsageFactEntity>)
+
+    /// Reads the EF entity metadata that future migrations use for minute aggregate schema drift.
+    let aggregateEntityType () : IEntityType =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsMigrationModel;Integrated Security=true;"
+
+        context.Model.FindEntityType(typeof<UsageAggregateMinuteEntity>)
+
+    /// Verifies the EF model keeps raw fact identity as the durable dedupe boundary.
     [<Test>]
-    member _.SqlSchemaUsesUsageFactIdAsRawFactPrimaryKey() =
+    member _.OperationsEfModelUsesUsageFactIdAsRawFactPrimaryKey() =
+        let rawFact = rawFactEntityType ()
+        let primaryKey = rawFact.FindPrimaryKey()
+
+        let hasScopeIndex =
+            rawFact.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = "IX_ops_RawUsageFact_ScopeKindObservedAt")
+
         Assert.Multiple(
             Action (fun () ->
-                Assert.That(OperationsUsageSql.CreateSchema, Does.Contain("CREATE SCHEMA ops"))
+                Assert.That(rawFact.GetSchema(), Is.EqualTo(OperationsUsageSql.SchemaName))
+                Assert.That(rawFact.GetTableName(), Is.EqualTo(OperationsUsageSql.RawUsageFactTableName))
+                Assert.That(primaryKey.GetName(), Is.EqualTo("PK_ops_RawUsageFact"))
+
+                Assert.That(
+                    primaryKey.Properties
+                    |> Seq.map (fun property -> property.Name),
+                    Is.EquivalentTo([| "UsageFactId" |])
+                )
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("CorrelationId")
+                        .GetMaxLength(),
+                    Is.EqualTo(Nullable OperationsUsageSql.CorrelationIdMaxLength)
+                )
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("StoragePoolId")
+                        .GetMaxLength(),
+                    Is.EqualTo(Nullable OperationsUsageSql.StoragePoolIdMaxLength)
+                )
+
+                Assert.That(hasScopeIndex, Is.True)
                 Assert.That(OperationsUsageSql.CreateDatabaseIfMissing, Does.Contain("DB_ID(@DatabaseName) IS NULL"))
                 Assert.That(OperationsUsageSql.CreateDatabaseIfMissing, Does.Contain("QUOTENAME(@DatabaseName)"))
-                Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("ops.RawUsageFact"))
-                Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("PRIMARY KEY CLUSTERED (UsageFactId)"))
                 Assert.That(OperationsUsageSql.TryInsertRawUsageFact, Does.Contain("WITH (UPDLOCK, HOLDLOCK)"))
-                Assert.That(OperationsUsageSql.CreateUsageAggregateMinuteTable, Does.Contain("ops.UsageAggregateMinute"))
                 Assert.That(OperationsUsageSql.AddToUsageAggregateMinute, Does.Contain("MERGE ops.UsageAggregateMinute WITH (HOLDLOCK)")))
+        )
+
+    /// Verifies the EF model keeps minute aggregates keyed by Grace scope, storage pool, fact kind, and UTC minute.
+    [<Test>]
+    member _.OperationsEfModelUsesScopedMinuteAggregatePrimaryKey() =
+        let aggregate = aggregateEntityType ()
+        let primaryKey = aggregate.FindPrimaryKey()
+
+        let expectedKey =
+            [|
+                "FactKind"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "StoragePoolId"
+                "BucketStartUtc"
+            |]
+
+        let actualKey =
+            primaryKey.Properties
+            |> Seq.map (fun property -> property.Name)
+            |> fun names -> String.Join("|", names)
+
+        let hasScopeIndex =
+            aggregate.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = "IX_ops_UsageAggregateMinute_ScopeKindBucket")
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(aggregate.GetSchema(), Is.EqualTo(OperationsUsageSql.SchemaName))
+                Assert.That(aggregate.GetTableName(), Is.EqualTo(OperationsUsageSql.UsageAggregateMinuteTableName))
+                Assert.That(primaryKey.GetName(), Is.EqualTo("PK_ops_UsageAggregateMinute"))
+
+                Assert.That(actualKey, Is.EqualTo(String.Join("|", expectedKey)))
+
+                Assert.That(hasScopeIndex, Is.True))
+        )
+
+    /// Verifies the baseline migration creates the reviewed operations tables, keys, and indexes.
+    [<Test>]
+    member _.BaselineMigrationScriptContainsExpectedOperationsSchema() =
+        let script = migrationScript ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(script, Does.Contain("CREATE SCHEMA [ops]"))
+                Assert.That(script, Does.Contain("IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL"))
+                Assert.That(script, Does.Contain("CREATE TABLE ops.RawUsageFact"))
+                Assert.That(script, Does.Contain("CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)"))
+                Assert.That(script, Does.Contain("IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL"))
+                Assert.That(script, Does.Contain("CREATE TABLE ops.UsageAggregateMinute"))
+                Assert.That(script, Does.Contain("CONSTRAINT PK_ops_UsageAggregateMinute PRIMARY KEY CLUSTERED"))
+                Assert.That(script, Does.Contain("CREATE INDEX IX_ops_RawUsageFact_ScopeKindObservedAt"))
+                Assert.That(script, Does.Contain("CREATE INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket"))
+                Assert.That(script, Does.Contain("[ops].[__EFMigrationsHistory]")))
         )
 
     /// Verifies SQL storage-pool keys stay case-sensitive under Azure SQL default collations.
     [<Test>]
     member _.SqlSchemaUsesBinaryCollationForStoragePoolAggregateKeys() =
+        let script = migrationScript ()
+
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation, Is.EqualTo("Latin1_General_100_BIN2"))
-
-                Assert.That(OperationsUsageSql.CreateRawUsageFactTable, Does.Contain("StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL"))
-
-                Assert.That(
-                    OperationsUsageSql.CreateUsageAggregateMinuteTable,
-                    Does.Contain("StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL")
-                )
+                Assert.That(script, Does.Contain("StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL"))
 
                 Assert.That(
                     OperationsUsageSql.AddToUsageAggregateMinute,

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -141,6 +141,9 @@ type OperationsUsageStorageTests() =
         let transactionScope = InMemoryOperationsUsageTransactionScope()
         OperationsUsageStore transactionScope, transactionScope
 
+    /// Restores a process environment variable after a design-time configuration test mutates it.
+    let restoreEnvironmentVariable name value = Environment.SetEnvironmentVariable(name, value)
+
     /// Extracts a successful storage result from the data-layer result shape.
     let requireStored (result: Result<UsageFactPersistenceResult, string list>) =
         match result with
@@ -193,6 +196,49 @@ type OperationsUsageStorageTests() =
                 Assert.That(context, Is.InstanceOf<OperationsDbContext>())
                 Assert.That(context.Database.ProviderName, Is.EqualTo("Microsoft.EntityFrameworkCore.SqlServer")))
         )
+
+    /// Verifies EF tooling honors the documented Operations SQL environment variable before legacy aliases.
+    [<Test>]
+    [<NonParallelizable>]
+    member _.OperationsDesignTimeFactoryPrefersDocumentedSqlEnvironmentVariable() =
+        let documentedName = "grace__operations__sql__connectionstring"
+        let legacyName = "GRACE_OPERATIONS_SQL_CONNECTION_STRING"
+        let documentedConnectionString = "Server=tcp:documented.example.net;Database=GraceOperationsDocumented;"
+        let legacyConnectionString = "Server=tcp:legacy.example.net;Database=GraceOperationsLegacy;"
+        let previousDocumented = Environment.GetEnvironmentVariable(documentedName)
+        let previousLegacy = Environment.GetEnvironmentVariable(legacyName)
+
+        try
+            Environment.SetEnvironmentVariable(documentedName, documentedConnectionString)
+            Environment.SetEnvironmentVariable(legacyName, legacyConnectionString)
+
+            let actual = OperationsDbContextFactory.designTimeConnectionString [|  |]
+
+            Assert.That(actual, Is.EqualTo(documentedConnectionString))
+        finally
+            restoreEnvironmentVariable documentedName previousDocumented
+            restoreEnvironmentVariable legacyName previousLegacy
+
+    /// Verifies EF tooling still honors the previous design-time SQL environment variable as a fallback.
+    [<Test>]
+    [<NonParallelizable>]
+    member _.OperationsDesignTimeFactoryKeepsLegacySqlEnvironmentVariableFallback() =
+        let documentedName = "grace__operations__sql__connectionstring"
+        let legacyName = "GRACE_OPERATIONS_SQL_CONNECTION_STRING"
+        let legacyConnectionString = "Server=tcp:legacy.example.net;Database=GraceOperationsLegacy;"
+        let previousDocumented = Environment.GetEnvironmentVariable(documentedName)
+        let previousLegacy = Environment.GetEnvironmentVariable(legacyName)
+
+        try
+            Environment.SetEnvironmentVariable(documentedName, null)
+            Environment.SetEnvironmentVariable(legacyName, legacyConnectionString)
+
+            let actual = OperationsDbContextFactory.designTimeConnectionString [|  |]
+
+            Assert.That(actual, Is.EqualTo(legacyConnectionString))
+        finally
+            restoreEnvironmentVariable documentedName previousDocumented
+            restoreEnvironmentVariable legacyName previousLegacy
 
     /// Verifies the EF model keeps raw fact identity as the durable dedupe boundary.
     [<Test>]
@@ -277,10 +323,14 @@ type OperationsUsageStorageTests() =
     [<Test>]
     member _.BaselineMigrationScriptContainsExpectedOperationsSchema() =
         let script = migrationScript ()
+        let schemaPreambleIndex = script.IndexOf("IF SCHEMA_ID(N'ops') IS NULL", StringComparison.Ordinal)
+        let historyTableIndex = script.IndexOf("[ops].[__EFMigrationsHistory]", StringComparison.Ordinal)
 
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(script, Does.Contain("CREATE SCHEMA [ops]"))
+                Assert.That(schemaPreambleIndex, Is.GreaterThanOrEqualTo(0))
+                Assert.That(historyTableIndex, Is.GreaterThan(schemaPreambleIndex))
                 Assert.That(script, Does.Contain("IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.RawUsageFact"))
                 Assert.That(script, Does.Contain("CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)"))
@@ -298,6 +348,23 @@ type OperationsUsageStorageTests() =
         let migration = InitialOperationsSchema()
         let rawFact = migration.TargetModel.FindEntityType(typeof<RawUsageFactEntity>)
         let aggregate = migration.TargetModel.FindEntityType(typeof<UsageAggregateMinuteEntity>)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(rawFact, Is.Not.Null)
+                Assert.That(rawFact.GetSchema(), Is.EqualTo(OperationsUsageSql.SchemaName))
+                Assert.That(rawFact.GetTableName(), Is.EqualTo(OperationsUsageSql.RawUsageFactTableName))
+                Assert.That(aggregate, Is.Not.Null)
+                Assert.That(aggregate.GetSchema(), Is.EqualTo(OperationsUsageSql.SchemaName))
+                Assert.That(aggregate.GetTableName(), Is.EqualTo(OperationsUsageSql.UsageAggregateMinuteTableName)))
+        )
+
+    /// Verifies the checked-in model snapshot carries the reviewed schema shape for future migration diffs.
+    [<Test>]
+    member _.BaselineModelSnapshotContainsOperationsEntities() =
+        let snapshot = OperationsDbContextModelSnapshot()
+        let rawFact = snapshot.Model.FindEntityType(typeof<RawUsageFactEntity>)
+        let aggregate = snapshot.Model.FindEntityType(typeof<UsageAggregateMinuteEntity>)
 
         Assert.Multiple(
             Action (fun () ->


### PR DESCRIPTION
Related to #566.

## Why this matters

This moves the Operations SQL foundation from ad hoc bootstrap DDL to reviewed EF Core migrations for SQL Server/Azure SQL. Grace and its users get explicit, testable schema evolution for usage ingestion while retaining the duplicate-delivery protection that keeps cost facts idempotent.

## Summary

- Added an EF Core `OperationsDbContext`, SQL Server design-time factory, migration snapshot, and baseline Operations schema migration under `src/Grace.Operations/Grace.Operations.Data`.
- Preserved the existing `ops.RawUsageFact` duplicate `UsageFactId` semantics and hot-path raw SQL insert/aggregate update behavior.
- Added migration/schema regression coverage for expected tables, keys, indexes, collation, migration history placement, generated script preambles, design-time connection resolution, and duplicate usage fact idempotency.
- Documented the reviewed raw-SQL escape hatch for SQL Server physical design and hot-path persistence.
- Kept Operations coverage in `src/Grace.Operations/Grace.Operations.slnx`; root `src/Grace.slnx` remains free of Operations project references.

## Validation

Implementation head `69db7857071a051040396f7dcd88e646f1760cd4`:

- `dotnet tool run fantomas ...`: passed.
- `npx --yes markdownlint-cli2 "src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md"`: passed.
- `dotnet build --configuration Release src\Grace.Operations\Grace.Operations.slnx`: passed.
- `dotnet test --no-build --configuration Release src\Grace.Operations\Grace.Operations.Tests\Grace.Operations.Tests.fsproj`: passed, 33 tests.
- `pwsh ./scripts/validate.ps1 -Full`: passed in 00:03:38.5220676.
- `git diff --check` and `git diff --cached --check`: passed.
- GitHub Actions `full`: passed.

First review-fix head `6b30ac09e2974338738df515ef9e9bab12605c00`:

- `dotnet tool run fantomas ...`: passed.
- `dotnet test .\src\Grace.Operations\Grace.Operations.Tests\Grace.Operations.Tests.fsproj --configuration Release --filter "FullyQualifiedName~OperationsUsageStorageTests"`: passed, 16 tests.
- `pwsh ./scripts/validate.ps1 -Full`: passed in `00:05:41.4714443`.
- `git diff --check`: passed.
- GitHub Actions `full`: passed.

Second review-fix head `c8e0020fad4fc06c6e8b86b622cff58df940793d`:

- `dotnet tool run fantomas ...`: passed.
- `dotnet build src\Grace.Operations\Grace.Operations.slnx --configuration Release`: passed with 0 warnings and 0 errors.
- `dotnet test src\Grace.Operations\Grace.Operations.Tests\Grace.Operations.Tests.fsproj --configuration Release --no-build --filter FullyQualifiedName~OperationsUsageStorageTests`: passed, 19 tests.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed in `00:05:15.6668209`; root and Operations builds succeeded; Operations.Tests passed 39 tests; Server.Tests passed 243 tests.
- GitHub Actions `full`: passed in 7m41s.

## Review Status

Current head: `c8e0020fad4fc06c6e8b86b622cff58df940793d`.

Codex Code Review Bot first pass on `69db7857071a051040396f7dcd88e646f1760cd4` found four fresh findings. All four were fixed in `6b30ac09e2974338738df515ef9e9bab12605c00`, replied to, and resolved:

- `discussion_r3526105750` / `PRRT_kwDOILVrb86Od4K3`: public `OperationsDesignTimeDbContextFactory` implementing `IDesignTimeDbContextFactory<OperationsDbContext>`, with focused interface construction coverage.
- `discussion_r3526105751` / `PRRT_kwDOILVrb86Od4K5`: pre-create the `ops` schema before `MigrateAsync` can touch `ops.__EFMigrationsHistory`.
- `discussion_r3526105753` / `PRRT_kwDOILVrb86Od4K6`: open the configured target database before migration so `TargetDatabaseOnly` does not let EF create a missing database; explicit creation remains gated behind `CreateDatabaseIfMissing`.
- `discussion_r3526105756` / `PRRT_kwDOILVrb86Od4K8`: add `BuildTargetModel` to the initial migration through `OperationsModel.configure`, with focused baseline target-model coverage.

Codex Code Review Bot second pass on `6b30ac09e2974338738df515ef9e9bab12605c00` found three fresh P2 findings. All three were fixed in `c8e0020fad4fc06c6e8b86b622cff58df940793d`, replied to, and resolved:

- `discussion_r3526163788` / `PRRT_kwDOILVrb86OeCgc`: freeze the baseline migration target model and snapshot with literal schema metadata rather than delegating to live `OperationsModel.configure`.
- `discussion_r3526163791` / `PRRT_kwDOILVrb86OeCge`: honor documented `grace__operations__sql__connectionstring` before legacy `GRACE_OPERATIONS_SQL_CONNECTION_STRING` and LocalDB fallback, with focused precedence coverage.
- `discussion_r3526163795` / `PRRT_kwDOILVrb86OeCgh`: register `OperationsSqlServerHistoryRepository` so generated scripts/bundles emit the `ops` schema preamble before `[ops].[__EFMigrationsHistory]`, with generated-script ordering coverage.

Final gate: Codex Code Review Bot gave 👍 on the latest head with zero unresolved review threads. GitHub Actions `full` passed on the latest head.

Prevention note: self-review checked root solution isolation, migration idempotency/adoption guards, duplicate `UsageFactId` protection, aggregate key coverage, raw SQL documentation, target-only database semantics, design-time EF discovery, baseline target-model storage, frozen snapshot behavior, documented environment variable resolution, generated script history-table preamble ordering, and forbidden later-leaf table scope.

## Residual Risks

- `dotnet ef` was not run because `dotnet-ef` is not present in the repo tool manifest. The new design-time factory is covered by compile, by direct `IDesignTimeDbContextFactory<OperationsDbContext>` tests, generated script ordering tests, and full validation.
- This slice intentionally does not add billing, archive, provider diagnostic, audit, or reset behavior.
