### PR TITLE
Expand UsageFact v1 contract coverage

### DIFF
--- a/src/Grace.Types.Tests/Fixtures/UsageFacts/v1/repository-storage-bytes-minute.json
+++ b/src/Grace.Types.Tests/Fixtures/UsageFacts/v1/repository-storage-bytes-minute.json
@@ -1,0 +1,19 @@
+{
+  "Class": "UsageFact",
+  "SchemaVersion": 1,
+  "UsageFactId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "CorrelationId": "corr-usage-tracer-bullet",
+  "FactKind": "repositoryStorageBytesMinute",
+  "Scope": {
+    "OwnerId": "11111111-1111-1111-1111-111111111111",
+    "OrganizationId": "22222222-2222-2222-2222-222222222222",
+    "RepositoryId": "33333333-3333-3333-3333-333333333333"
+  },
+  "Resource": {
+    "StoragePoolId": "storage-pool-main"
+  },
+  "Source": "Grace.Server",
+  "Confidence": "observed",
+  "Quantity": 4096,
+  "ObservedAt": "2026-07-04T12:34:00Z"
+}

--- a/src/Grace.Types.Tests/Usage.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Usage.Types.Tests.fs
@@ -7,6 +7,7 @@ open Grace.Types.Usage
 open NodaTime
 open NUnit.Framework
 open System
+open System.IO
 open System.Text.Json
 
 /// Contains usage fact test helpers.
@@ -59,6 +60,49 @@ type UsageFactContractTests() =
         | Ok () -> Assert.Fail($"Usage fact should fail validation with '{expected}'.")
         | Error errors -> Assert.That(errors, Has.Some.Contains(expected))
 
+    /// Builds the deterministic usage fact fixture for a supported v1 fact kind.
+    let supportedV1Fact kind =
+        match kind with
+        | UsageFactKind.RepositoryStorageBytesMinute -> UsageFactTestData.validFact ()
+        | _ -> invalidArg (nameof kind) $"Unsupported v1 UsageFactKind '{kind}'."
+
+    /// Finds the golden JSON fixture for a supported v1 fact kind.
+    let goldenFixturePath kind =
+        match kind with
+        | UsageFactKind.RepositoryStorageBytesMinute ->
+            Path.Combine(__SOURCE_DIRECTORY__, "Fixtures", "UsageFacts", "v1", "repository-storage-bytes-minute.json")
+        | _ -> invalidArg (nameof kind) $"Unsupported v1 UsageFactKind '{kind}'."
+
+    /// Normalizes newline and final-newline differences before comparing golden JSON fixtures.
+    let normalizeJsonText (json: string) = json.ReplaceLineEndings("\n").TrimEnd()
+
+    /// Verifies that every supported v1 fact kind has a stable golden JSON fixture.
+    [<Test>]
+    member _.SupportedV1UsageFactKindsHaveGoldenJsonFixtures() =
+        Assert.That(
+            UsageFact.SupportedV1FactKinds,
+            Is.EquivalentTo(
+                [|
+                    UsageFactKind.RepositoryStorageBytesMinute
+                |]
+            )
+        )
+
+        for factKind in UsageFact.SupportedV1FactKinds do
+            let fact = supportedV1Fact factKind
+            let actual = serialize fact
+            let expected = File.ReadAllText(goldenFixturePath factKind)
+
+            Assert.That(normalizeJsonText actual, Is.EqualTo(normalizeJsonText expected), $"Golden JSON drifted for {factKind}.")
+
+            let roundTrip = deserialize<UsageFact> expected
+
+            match UsageFact.Validate roundTrip with
+            | Ok () -> Assert.That(roundTrip, Is.EqualTo(fact), $"Golden JSON no longer round trips for {factKind}.")
+            | Error errors ->
+                let errorText = String.Join("; ", errors)
+                Assert.Fail($"Golden JSON for {factKind} should validate, but failed with: {errorText}")
+
     /// Verifies that a valid repository storage fact serializes with the expected JSON field names and values.
     [<Test>]
     member _.RepositoryStorageUsageFactSerializesWithExpectedJsonShape() =
@@ -70,6 +114,7 @@ type UsageFactContractTests() =
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(stringProperty document "Class", Is.EqualTo(nameof UsageFact))
+                Assert.That((property document "SchemaVersion").GetInt32(), Is.EqualTo(UsageFactSchemaVersion))
                 Assert.That(guidProperty document "UsageFactId", Is.EqualTo(UsageFactTestData.usageFactId))
                 Assert.That(stringProperty document "CorrelationId", Is.EqualTo(UsageFactTestData.correlationId))
                 Assert.That(stringProperty document "FactKind", Is.EqualTo("repositoryStorageBytesMinute"))
@@ -102,6 +147,8 @@ type UsageFactContractTests() =
                     Is.EqualTo(UsageFactTestData.storagePoolId)
                 )
 
+                Assert.That(stringProperty document "Source", Is.EqualTo(DefaultUsageFactSource))
+                Assert.That(stringProperty document "Confidence", Is.EqualTo("observed"))
                 Assert.That((property document "Quantity").GetInt64(), Is.EqualTo(4096L))
                 Assert.That(stringProperty document "ObservedAt", Is.EqualTo("2026-07-04T12:34:00Z")))
         )
@@ -157,6 +204,26 @@ type UsageFactContractTests() =
                     Assert.That(errors, Has.Some.Contains("Scope.RepositoryId is required.")))
             )
 
+    /// Verifies that unsupported schema versions fail validation instead of becoming accepted contract drift.
+    [<TestCase(0)>]
+    [<TestCase(2)>]
+    member _.UnsupportedSchemaVersionFailsValidationClearly(schemaVersion: int) =
+        let fact = { UsageFactTestData.validFact () with SchemaVersion = schemaVersion }
+
+        assertInvalid $"SchemaVersion '{schemaVersion}' is not supported. Expected '{UsageFactSchemaVersion}'." fact
+
+    /// Verifies that serialized future schema versions deserialize but still fail contract validation.
+    [<Test>]
+    member _.UnsupportedSchemaVersionJsonFailsValidationClearly() =
+        let futureSchemaJson =
+            File
+                .ReadAllText(goldenFixturePath UsageFactKind.RepositoryStorageBytesMinute)
+                .Replace("\"SchemaVersion\": 1", "\"SchemaVersion\": 2")
+
+        let fact = deserialize<UsageFact> futureSchemaJson
+
+        assertInvalid $"SchemaVersion '2' is not supported. Expected '{UsageFactSchemaVersion}'." fact
+
     /// Verifies that missing identity JSON fields fail before becoming a partial contract value.
     [<Test>]
     member _.MissingRequiredIdentityJsonFieldsFailDeserializationClearly() =
@@ -164,12 +231,15 @@ type UsageFactContractTests() =
             """
 {
   "Class": "UsageFact",
+  "SchemaVersion": 1,
   "CorrelationId": "corr-usage-tracer-bullet",
   "FactKind": "repositoryStorageBytesMinute",
   "Scope": {},
   "Resource": {
     "StoragePoolId": "storage-pool-main"
   },
+  "Source": "Grace.Server",
+  "Confidence": "observed",
   "Quantity": 4096,
   "ObservedAt": "2026-07-04T12:34:00Z"
 }
@@ -196,6 +266,7 @@ type UsageFactContractTests() =
             """
 {
   "Class": "UsageFact",
+  "SchemaVersion": 1,
   "UsageFactId": "not-a-guid",
   "CorrelationId": "corr-usage-tracer-bullet",
   "FactKind": "repositoryStorageBytesMinute",
@@ -207,6 +278,8 @@ type UsageFactContractTests() =
   "Resource": {
     "StoragePoolId": "storage-pool-main"
   },
+  "Source": "Grace.Server",
+  "Confidence": "observed",
   "Quantity": 4096,
   "ObservedAt": "2026-07-04T12:34:00Z"
 }
@@ -216,11 +289,12 @@ type UsageFactContractTests() =
         Assert.That(ex.Message, Does.Contain("not-a-guid").Or.Contains("Guid"))
 
     /// Verifies that unsupported future fact kind values are not accepted as known facts.
-    [<Test>]
-    member _.UnsupportedFutureFactKindValueFailsValidationClearly() =
-        let fact = { UsageFactTestData.validFact () with FactKind = enum<UsageFactKind> 999 }
+    [<TestCase(0)>]
+    [<TestCase(999)>]
+    member _.UnsupportedFutureFactKindValueFailsValidationClearly(factKind: int) =
+        let fact = { UsageFactTestData.validFact () with FactKind = enum<UsageFactKind> factKind }
 
-        assertInvalid "FactKind '999' is not supported." fact
+        assertInvalid $"FactKind '{factKind}' is not supported." fact
 
     /// Verifies that unknown future fact kind strings do not deserialize as known facts.
     [<Test>]
@@ -237,6 +311,23 @@ type UsageFactContractTests() =
                 .Contain("futureUsageFactKind")
                 .Or.Contains("UsageFactKind")
         )
+
+    /// Verifies that missing source values fail validation instead of entering the durable fact stream.
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    member _.MissingSourceFailsValidationClearly(source: string) =
+        let fact = { UsageFactTestData.validFact () with Source = source }
+
+        assertInvalid "Source is required." fact
+
+    /// Verifies that unknown confidence values fail validation instead of weakening fact evidence semantics.
+    [<TestCase(0)>]
+    [<TestCase(2)>]
+    [<TestCase(999)>]
+    member _.UnsupportedConfidenceFailsValidationClearly(confidence: int) =
+        let fact = { UsageFactTestData.validFact () with Confidence = enum<UsageFactConfidence> confidence }
+
+        assertInvalid $"Confidence '{confidence}' is not supported." fact
 
     /// Verifies that zero and negative quantities are rejected by the contract validator.
     [<TestCase(0L)>]

--- a/src/Grace.Types/Usage.Types.fs
+++ b/src/Grace.Types/Usage.Types.fs
@@ -9,12 +9,24 @@ open System
 /// Contains immutable usage fact contracts for Grace operations telemetry.
 module Usage =
 
+    /// Identifies the only UsageFact schema version supported by this Grace.Types contract.
+    [<Literal>]
+    let UsageFactSchemaVersion = 1
+
+    /// Identifies Grace Server as the source for repository storage usage facts emitted in v1.
+    [<Literal>]
+    let DefaultUsageFactSource = "Grace.Server"
+
     /// The durable identity of an immutable usage fact.
     type UsageFactId = Guid
 
     /// Identifies the known operational usage measurement carried by a usage fact.
     type UsageFactKind =
         | RepositoryStorageBytesMinute = 1
+
+    /// Identifies the evidence confidence attached to a usage fact.
+    type UsageFactConfidence =
+        | Observed = 1
 
     /// Identifies the Grace repository scope that owns a usage fact.
     [<GenerateSerializer>]
@@ -43,11 +55,14 @@ module Usage =
     type UsageFact =
         {
             Class: string
+            SchemaVersion: int
             UsageFactId: UsageFactId
             CorrelationId: CorrelationId
             FactKind: UsageFactKind
             Scope: UsageFactScope
             Resource: UsageFactResource
+            Source: string
+            Confidence: UsageFactConfidence
             Quantity: int64
             ObservedAt: Instant
         }
@@ -56,14 +71,23 @@ module Usage =
         static member Empty =
             {
                 Class = nameof UsageFact
+                SchemaVersion = UsageFactSchemaVersion
                 UsageFactId = UsageFactId.Empty
                 CorrelationId = String.Empty
                 FactKind = UsageFactKind.RepositoryStorageBytesMinute
                 Scope = UsageFactScope.Empty
                 Resource = UsageFactResource.Empty
+                Source = String.Empty
+                Confidence = UsageFactConfidence.Observed
                 Quantity = 0L
                 ObservedAt = Constants.DefaultTimestamp
             }
+
+        /// Lists the fact kinds that v1 consumers must understand before accepting a usage fact.
+        static member SupportedV1FactKinds =
+            [|
+                UsageFactKind.RepositoryStorageBytesMinute
+            |]
 
         /// Normalizes an observation timestamp to the minute bucket used by repository storage facts.
         static member NormalizeObservedAtToMinute(observedAt: Instant) =
@@ -88,11 +112,14 @@ module Usage =
             ) =
             {
                 Class = nameof UsageFact
+                SchemaVersion = UsageFactSchemaVersion
                 UsageFactId = usageFactId
                 CorrelationId = correlationId
                 FactKind = UsageFactKind.RepositoryStorageBytesMinute
                 Scope = { OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId }
                 Resource = { StoragePoolId = storagePoolId }
+                Source = DefaultUsageFactSource
+                Confidence = UsageFactConfidence.Observed
                 Quantity = quantity
                 ObservedAt = UsageFact.NormalizeObservedAtToMinute observedAt
             }
@@ -106,13 +133,16 @@ module Usage =
             else
                 if fact.Class <> nameof UsageFact then errors.Add("Class must be UsageFact.")
 
+                if fact.SchemaVersion <> UsageFactSchemaVersion then
+                    errors.Add($"SchemaVersion '{fact.SchemaVersion}' is not supported. Expected '{UsageFactSchemaVersion}'.")
+
                 if fact.UsageFactId = UsageFactId.Empty then
                     errors.Add("UsageFactId is required.")
 
                 if String.IsNullOrWhiteSpace fact.CorrelationId then
                     errors.Add("CorrelationId is required.")
 
-                if not (Enum.IsDefined(typeof<UsageFactKind>, fact.FactKind)) then
+                if not (Array.contains fact.FactKind UsageFact.SupportedV1FactKinds) then
                     errors.Add($"FactKind '{int fact.FactKind}' is not supported.")
 
                 if isNull (box fact.Scope) then
@@ -131,6 +161,11 @@ module Usage =
                     errors.Add("Resource is required.")
                 else if String.IsNullOrWhiteSpace fact.Resource.StoragePoolId then
                     errors.Add("Resource.StoragePoolId is required.")
+
+                if String.IsNullOrWhiteSpace fact.Source then errors.Add("Source is required.")
+
+                if not (Enum.IsDefined(typeof<UsageFactConfidence>, fact.Confidence)) then
+                    errors.Add($"Confidence '{int fact.Confidence}' is not supported.")
 
                 if fact.Quantity <= 0L then errors.Add("Quantity must be greater than zero.")
 


### PR DESCRIPTION
Related to #567 under mini-epic #557 and parent epic #554.

## Why This Matters

Grace Server and Grace.Operations deploy lockstep for usage fact contracts. This change makes the v1 UsageFact contract explicit, serialized, and validation-backed so drift fails before ingestion instead of surfacing as ambiguous Operations data.

## Summary

- Expanded the v1 `UsageFact` contract with explicit schema versioning, supported fact kind validation, source, confidence, and repository storage payload shape.
- Added deterministic validation failures for unsupported schema versions, unknown fact kinds, missing source, invalid confidence, and invalid repository storage payloads.
- Added golden JSON coverage for the supported v1 repository storage bytes/minute fact.
- Kept contract ownership in `Grace.Types`; no Operations storage models, billing DTOs, customer API DTOs, diagnostic observation models, or later-leaf behavior were added.

## Validation

- `dotnet tool run fantomas ...`: passed on touched F# files.
- Focused Release build: passed.
- Focused `Grace.Types.Tests`: passed, 159 tests.
- `pwsh ./scripts/validate.ps1 -Fast`: passed after self-review fixes.
  - `Grace.Types.Tests`: 159 passed.
  - `Grace.Authorization.Tests`: 53 passed.
  - `Grace.Server.Unit.Tests`: 731 passed.
  - `Grace.CLI.Tests`: 689 passed, 1 skipped.
  - `Grace.Operations.Tests`: 39 passed.
  - Root and Operations builds completed with 0 warnings and 0 errors.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before commit.
- GitHub Actions `full`: passed in 8m15s.

## Review Status

Codex Code Review Bot gave 👍 on commit `e526a704de67d79bc91f6d1e348305132ae74409` with zero unresolved review threads. GitHub Actions `full` passed on the same head.

Prevention note: worker self-review tightened confidence and schema JSON behavior before the final validation rerun. The final diff stays inside the issue-owned contract, test, and fixture paths.

## Residual Risks

No known residual risk. The leaf intentionally does not add billing rates, diagnostic observation models, customer API DTOs, Operations storage models, archive behavior, provider diagnostics, audit behavior, or reset behavior.
