### PR TITLE
Harden operational fact publication

### DIFF
--- a/src/Grace.Actors/OperationalFactsPublisher.Actor.fs
+++ b/src/Grace.Actors/OperationalFactsPublisher.Actor.fs
@@ -104,6 +104,13 @@ module OperationalFactsPublisher =
         else
             Some(loggerFactory.CreateLogger("OperationalFactsPublisher.Actor"))
 
+    /// Describes unsupported operational fact publication providers without including the usage payload.
+    let private unsupportedPubSubProviderMessage pubSubSystem =
+        $"Grace pub-sub system {getDiscriminatedUnionCaseName pubSubSystem} cannot publish operational UsageFacts. Configure AzureServiceBus or disable operational fact publication explicitly."
+
+    /// Raises the fail-closed configuration error used when a configured provider cannot publish usage facts.
+    let internal rejectUnsupportedPubSubProvider pubSubSystem = invalidOp (unsupportedPubSubProviderMessage pubSubSystem)
+
     /// Publishes an immutable UsageFact to the dedicated operational facts Service Bus topic.
     let publishUsageFact (usageFact: UsageFact) (cancellationToken: CancellationToken) =
         task {
@@ -135,14 +142,12 @@ module OperationalFactsPublisher =
                     )
                 | None -> ()
             | otherSystem ->
+                let message = unsupportedPubSubProviderMessage otherSystem
+
                 match tryGetLogger () with
-                | Some log ->
-                    log.LogWarning(
-                        "Grace pub-sub system {System} not yet implemented for operational UsageFact {UsageFactId} with CorrelationId: {CorrelationId}.",
-                        getDiscriminatedUnionCaseName otherSystem,
-                        usageFact.UsageFactId,
-                        usageFact.CorrelationId
-                    )
+                | Some log -> log.LogError("{Message} System: {System}.", message, getDiscriminatedUnionCaseName otherSystem)
                 | None -> ()
+
+                rejectUnsupportedPubSubProvider otherSystem
         }
         :> Task

--- a/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs
@@ -80,6 +80,22 @@ type OperationalFactsPublisherActorTests() =
             Is.EqualTo(correlationId)
         )
 
+    /// Verifies recognized but unsupported pub-sub providers fail closed instead of silently dropping usage facts.
+    [<Test>]
+    member _.UnsupportedConfiguredProviderFailsOperationalFactPublication() =
+        let ex =
+            Assert.Throws<InvalidOperationException>(
+                Action (fun () ->
+                    OperationalFactsPublisher.rejectUnsupportedPubSubProvider GracePubSubSystem.AzureEventHubs
+                    |> ignore)
+            )
+
+        Assert.That(ex.Message, Does.Contain(nameof GracePubSubSystem.AzureEventHubs))
+        Assert.That(ex.Message, Does.Contain("cannot publish operational UsageFacts"))
+        Assert.That(ex.Message, Does.Not.Contain("UsageFactId"))
+        Assert.That(ex.Message, Does.Not.Contain("CorrelationId"))
+        Assert.That(ex.Message, Does.Not.Contain("RepositoryStorageBytesMinute"))
+
     /// Verifies that missing operational topic configuration fails before any event topic fallback can happen.
     [<Test>]
     [<NonParallelizable>]


### PR DESCRIPTION
Related to #568 under mini-epic #557 and parent epic #554.

## Why This Matters

At-least-once operational fact publication is acceptable only when producer identity and downstream idempotency are strong. This change hardens the UsageFact Service Bus envelope and failure behavior so Operations can trust `UsageFactId` as the duplicate-safe identity.

## Summary

- Hardened operational fact publication so recognized unsupported providers fail closed instead of being logged and dropped.
- Preserved deterministic Service Bus envelope identity: `MessageId` equals `UsageFactId`.
- Preserved correlation propagation, subject, content type, message type, and fact kind application properties.
- Kept operational facts separate from the product `GraceEvent` stream.
- Avoided logging secrets, full payloads, `UsageFactId`, `CorrelationId`, fact kind, or quantity in the new unsupported-provider failure path.

## Validation

- `dotnet tool run fantomas -- 'Grace.Actors/OperationalFactsPublisher.Actor.fs' 'Grace.Server.Unit.Tests/OperationalFactsPublisher.Actor.Tests.fs'`: passed.
- `dotnet test --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~OperationalFactsPublisherActorTests`: passed, 9 tests.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed.
  - `Grace.Types.Tests`: 159 passed.
  - `Grace.Authorization.Tests`: 53 passed.
  - `Grace.Server.Unit.Tests`: 732 passed.
  - `Grace.CLI.Tests`: 689 passed, 1 skipped.
  - `Grace.Server.Tests`: 243 passed.
  - `Grace.Operations.Tests`: 39 passed.
- GitHub Actions `full`: passed in 8m11s.

## Acceptance Proof

- `MessageId == UsageFactId`, `CorrelationId`, subject, content type, message type, and fact kind application properties are covered by `UsageFactMessageUsesOperationalTopicAndUsageEnvelope`.
- Topic separation and durable operational facts processor subscription naming remain covered by startup/config tests.
- Operational facts remain separated from the product `GraceEvent` stream through the existing regression assertion.
- Safe failure semantics now fail closed for recognized unsupported providers without logging secret or full-payload data.
- Duplicate-safe identity integration proof has no new waiver: the full gate includes the existing Service Bus/worker/SQL tracer-bullet test that sends first and duplicate deliveries with `MessageId = UsageFactId` and verifies raw fact plus aggregate single-counting.

## Review Status

Codex Code Review Bot gave 👍 on commit `ef5a4dd6527643be5c8e6c0bc0ecf5d0a1bf6a17` with zero unresolved review threads. GitHub Actions `full` passed on the same head.

Prevention note: worker self-review fixed a unit-proof path before the final validation rerun. The final diff stays inside the issue-owned publisher and publisher test paths.

## Residual Risks

No known residual risk. This leaf did not add a durable outbox, did not route facts into the product event stream, did not log secrets or full payloads, and did not implement provider diagnostic import or cost reconciliation behavior.
