### PR TITLE
Harden Operations worker ingestion validation

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -99,6 +99,43 @@ type private RecordingMessageActions(events: List<string>) =
             settlements.Add("dead-letter", Some reason)
             Task.CompletedTask
 
+/// Blocks message completion so tests can interleave another receive after durable storage succeeds.
+type private BlockingCompleteMessageActions(events: List<string>) =
+    let completeStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let completeRelease = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let settlements = ResizeArray<string * string option>()
+
+    /// Completes when the processor reaches message completion after durable storage succeeded.
+    member _.CompleteStarted = completeStarted.Task
+
+    /// Allows the blocked completion to finish.
+    member _.ReleaseComplete() = completeRelease.SetResult(())
+
+    /// Returns the settlements recorded by the fake actions.
+    member _.Settlements = settlements |> Seq.toList
+
+    interface IOperationsUsageMessageActions with
+
+        member _.CompleteAsync(_cancellationToken) =
+            task {
+                events.Add("complete-waiting")
+                completeStarted.SetResult(())
+                do! completeRelease.Task
+                events.Add("complete")
+                settlements.Add("complete", None)
+            }
+            :> Task
+
+        member _.AbandonAsync(_cancellationToken) =
+            events.Add("abandon")
+            settlements.Add("abandon", None)
+            Task.CompletedTask
+
+        member _.DeadLetterAsync(reason, _description, _cancellationToken) =
+            events.Add("dead-letter")
+            settlements.Add("dead-letter", Some reason)
+            Task.CompletedTask
+
 /// Fakes the operations data-layer boundary for deterministic processor tests.
 type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>, events: List<string>) =
     let storedFacts = ResizeArray<UsageFact>()
@@ -822,6 +859,77 @@ type OperationsWorkerIngestionTests() =
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon|complete"))
                     Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
                     Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException)."))
+                    Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None)))
+            )
+        }
+
+    /// Verifies an older in-flight success cannot clear a newer runtime dependency failure.
+    [<Test>]
+    member _.StaleInFlightSuccessDoesNotClearNewerDependencyFailure() =
+        task {
+            let olderSuccessFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("1a1a1a1a-1a1a-4a1a-8a1a-1a1a1a1a1a1a"))
+
+            let newerFailureFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("1b1b1b1b-1b1b-4b1b-8b1b-1b1b1b1b1b1b"))
+
+            let newerSuccessFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("1c1c1c1c-1c1c-4c1c-8c1c-1c1c1c1c1c1c"))
+
+            let processor, _store, _actions, events, readiness =
+                createProcessorWithReadiness (fun storedFact _ ->
+                    if storedFact.UsageFactId = newerFailureFact.UsageFactId then
+                        Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("newer SQL failure"))
+                    else
+                        Task.FromResult(Ok(accepted storedFact)))
+
+            (readiness :> IOperationsUsageReadinessRecorder)
+                .MarkReady()
+
+            let olderActions = BlockingCompleteMessageActions(events)
+            let newerFailureActions = RecordingMessageActions(events)
+            let newerSuccessActions = RecordingMessageActions(events)
+
+            let olderMessage =
+                olderSuccessFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let newerFailureMessage =
+                newerFailureFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let newerSuccessMessage =
+                newerSuccessFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let olderProcessing = processor.ProcessMessageAsync(olderMessage, olderActions, CancellationToken.None)
+
+            do! olderActions.CompleteStarted
+
+            do! processor.ProcessMessageAsync(newerFailureMessage, newerFailureActions, CancellationToken.None)
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            olderActions.ReleaseComplete()
+            do! olderProcessing
+
+            let staleCompletionSnapshot = readinessSnapshot readiness
+
+            do! processor.ProcessMessageAsync(newerSuccessMessage, newerSuccessActions, CancellationToken.None)
+
+            let recoveredSnapshot = readinessSnapshot readiness
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("store|complete-waiting|store|abandon|complete|store|complete"))
+                    Assert.That(settlementText olderActions.Settlements, Is.EqualTo("complete"))
+                    Assert.That(settlementText newerFailureActions.Settlements, Is.EqualTo("abandon"))
+                    Assert.That(settlementText newerSuccessActions.Settlements, Is.EqualTo("complete"))
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException)."))
+                    Assert.That(staleCompletionSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(staleCompletionSnapshot.DependencyFailure, Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException)."))
                     Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
                     Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None)))
             )

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -591,9 +591,9 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
-    /// Verifies future schemas with new enum tokens classify as unsupported schema before v1 enum deserialization.
+    /// Verifies future schemas with lenient JSON classify as unsupported schema before v1 enum deserialization.
     [<Test>]
-    member _.FutureSchemaWithUnknownEnumsIsDeadLetteredAsUnsupportedSchema() =
+    member _.FutureSchemaWithTrailingCommaAndUnknownEnumsIsDeadLetteredAsUnsupportedSchema() =
         task {
             let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("17171717-1717-4717-8717-171717171717"))
 
@@ -608,7 +608,14 @@ type OperationsWorkerIngestionTests() =
                 document["SchemaVersion"] <- JsonValue.Create(UsageFactSchemaVersion + 1)
                 document["FactKind"] <- JsonValue.Create("futureUsageFactKind")
                 document["Confidence"] <- JsonValue.Create("futureConfidence")
-                document.ToJsonString(Constants.JsonSerializerOptions)
+
+                let json =
+                    document
+                        .ToJsonString(Constants.JsonSerializerOptions)
+                        .TrimEnd()
+
+                json.Substring(0, json.Length - 1)
+                + $",{Environment.NewLine}  // future producers may send JSON accepted by Grace reader options{Environment.NewLine}}}"
 
             let message =
                 futureSchemaJson

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -8,6 +8,7 @@ open Grace.Types.Common
 open Grace.Types.Usage
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.Diagnostics.HealthChecks
+open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
 open NodaTime
 open NUnit.Framework
@@ -15,6 +16,7 @@ open System
 open System.Collections.Generic
 open System.Text
 open System.Text.Json
+open System.Text.Json.Nodes
 open System.Threading
 open System.Threading.Tasks
 
@@ -110,6 +112,24 @@ type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Ta
             storedFacts.Add fact
             events.Add("store")
             storeAsync fact cancellationToken
+
+/// Records formatted log output from worker infrastructure tests.
+type private RecordingLogger<'T>() =
+    let messages = ResizeArray<string>()
+
+    /// Returns formatted log messages written through this logger.
+    member _.Messages = messages |> Seq.toList
+
+    interface ILogger<'T> with
+
+        member _.BeginScope<'TState>(_state: 'TState) =
+            { new IDisposable with
+                member _.Dispose() = ()
+            }
+
+        member _.IsEnabled(_logLevel) = true
+
+        member _.Log<'TState>(_logLevel, _eventId, state: 'TState, ex: exn, formatter: Func<'TState, exn, string>) = messages.Add(formatter.Invoke(state, ex))
 
 /// Fails if deterministic validation lets an invalid fact reach a storage transaction.
 type private FailingOperationsUsageTransactionScope() =
@@ -386,6 +406,43 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies the worker health publisher makes readiness log-visible without publishing payloads or secrets.
+    [<Test>]
+    member _.ReadinessHealthPublisherLogsRedactedStatus() =
+        task {
+            let data = Dictionary<string, obj>()
+            data["supportedUsageFactSchemaVersion"] <- box UsageFactSchemaVersion
+            data["dependencyFailure"] <- box "Dependency startup failed (SqlException)."
+            data["lastUnsupportedContract"] <- box "UsageFact SchemaVersion '2' is not supported. Expected '1'."
+            data["messageBody"] <- box "message-body-secret"
+            data["connectionString"] <- box "Endpoint=sb://example/;SharedAccessKey=secret"
+
+            let entry = HealthReportEntry(HealthStatus.Unhealthy, "Dependency startup failed (SqlException).", TimeSpan.Zero, null, data)
+
+            let entries = Dictionary<string, HealthReportEntry>()
+            entries["operations-usage-ingestion"] <- entry
+            let report = HealthReport(entries, TimeSpan.Zero)
+
+            let logger = RecordingLogger<OperationsUsageReadinessHealthCheckPublisher>()
+            let publisher = OperationsUsageReadinessHealthCheckPublisher(logger)
+
+            do!
+                (publisher :> IHealthCheckPublisher)
+                    .PublishAsync(report, CancellationToken.None)
+
+            let loggedText = String.Join("\n", logger.Messages)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(loggedText, Does.Contain("Operations usage readiness published"))
+                    Assert.That(loggedText, Does.Contain("Unhealthy"))
+                    Assert.That(loggedText, Does.Contain("Dependency startup failed (SqlException)."))
+                    Assert.That(loggedText, Does.Contain($"UsageFact SchemaVersion '2' is not supported. Expected '{UsageFactSchemaVersion}'."))
+                    Assert.That(loggedText, Does.Not.Contain("message-body-secret"))
+                    Assert.That(loggedText, Does.Not.Contain("SharedAccessKey=secret")))
+            )
+        }
+
     /// Verifies valid messages complete only after the data layer reports durable persistence.
     [<Test>]
     member _.ValidMessageIsPersistedBeforeCompletion() =
@@ -521,6 +578,41 @@ type OperationsWorkerIngestionTests() =
             let message =
                 fact
                 |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:UnsupportedUsageFactSchema"))
+                    Assert.That(lastUnsupportedContract readiness, Does.Contain("SchemaVersion '2' is not supported")))
+            )
+        }
+
+    /// Verifies future schemas with new enum tokens classify as unsupported schema before v1 enum deserialization.
+    [<Test>]
+    member _.FutureSchemaWithUnknownEnumsIsDeadLetteredAsUnsupportedSchema() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("17171717-1717-4717-8717-171717171717"))
+
+            let processor, store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let futureSchemaJson =
+                let document =
+                    JsonNode
+                        .Parse(JsonSerializer.Serialize(fact, Constants.JsonSerializerOptions))
+                        .AsObject()
+
+                document["SchemaVersion"] <- JsonValue.Create(UsageFactSchemaVersion + 1)
+                document["FactKind"] <- JsonValue.Create("futureUsageFactKind")
+                document["Confidence"] <- JsonValue.Create("futureConfidence")
+                document.ToJsonString(Constants.JsonSerializerOptions)
+
+            let message =
+                futureSchemaJson
+                |> Encoding.UTF8.GetBytes
                 |> OperationsWorkerIngestionTestData.message
 
             do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -915,6 +915,60 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies a later received message clears a Service Bus receive/link readiness failure before storage or settlement succeeds.
+    [<Test>]
+    member _.LaterReceiveClearsServiceBusReceiveFaultReadiness() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("20202020-2020-4020-8020-202020202020"))
+
+            let storeStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let durableSuccess = TaskCompletionSource<Result<UsageFactPersistenceResult, string list>>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let processor, _store, actions, events, readiness =
+                createProcessorWithReadiness (fun _ _ ->
+                    storeStarted.SetResult(())
+                    durableSuccess.Task)
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                Azure.Messaging.ServiceBus.ServiceBusErrorSource.Receive
+                (InvalidOperationException("receive-link-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let processing = processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            do! storeStarted.Task
+
+            let receiveRecoveredSnapshot = readinessSnapshot readiness
+
+            durableSuccess.SetResult(Ok(accepted fact))
+            do! processing
+
+            let completedSnapshot = readinessSnapshot readiness
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                    Assert.That(receiveRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(receiveRecoveredSnapshot.DependencyFailure, Is.EqualTo(None))
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete"))
+                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(None)))
+            )
+        }
+
     /// Verifies an older in-flight success cannot clear a newer runtime dependency failure.
     [<Test>]
     member _.StaleInFlightSuccessDoesNotClearNewerDependencyFailure() =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -1568,6 +1568,108 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies successful poison-message dead-lettering proves callback invocation recovered.
+    [<Test>]
+    member _.SuccessfulDeadLetterClearsProcessMessageCallbackFailure() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("32323232-3232-4232-8232-323232323232"))
+
+            let processor, store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                ServiceBusErrorSource.ProcessMessageCallback
+                (InvalidOperationException("callback-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+                |> fun value -> { value with Subject = "FutureOperationalFact" }
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            let recoveredSnapshot = readinessSnapshot readiness
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+
+                    Assert.That(
+                        failedSnapshot.DependencyFailure,
+                        Is.EqualTo(Some "Service Bus processor fault (ProcessMessageCallback, InvalidOperationException).")
+                    )
+
+                    Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None))
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:UnsupportedOperationalFactEnvelope")))
+            )
+        }
+
+    /// Verifies callback recovery from dead-lettering does not clear unrelated settlement failures.
+    [<Test>]
+    member _.SuccessfulDeadLetterKeepsUnrelatedSettlementFailureActive() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("33333333-3333-4333-8333-333333333333"))
+
+            let processor, store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                ServiceBusErrorSource.ProcessMessageCallback
+                (InvalidOperationException("callback-secret"))
+
+            OperationsUsageReadinessTransitions.recordServiceBusSettlementFailure
+                recorder
+                OperationsUsageReadinessTransitions.CompleteSettlementRecoveryKey
+                (InvalidOperationException("complete-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+                |> fun value -> { value with Subject = "FutureOperationalFact" }
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            let recoveredSnapshot = readinessSnapshot readiness
+
+            let failedDependency =
+                failedSnapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            let recoveredDependency =
+                recoveredSnapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedDependency, Does.Contain("Service Bus processor fault (ProcessMessageCallback, InvalidOperationException)."))
+                    Assert.That(failedDependency, Does.Contain("Service Bus settlement failed (complete, InvalidOperationException)."))
+                    Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(recoveredDependency, Does.Not.Contain("Service Bus processor fault (ProcessMessageCallback, InvalidOperationException)."))
+                    Assert.That(recoveredDependency, Does.Contain("Service Bus settlement failed (complete, InvalidOperationException)."))
+                    Assert.That(recoveredDependency, Does.Not.Contain("callback-secret"))
+                    Assert.That(recoveredDependency, Does.Not.Contain("complete-secret"))
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:UnsupportedOperationalFactEnvelope")))
+            )
+        }
+
     /// Verifies a successful abandon settlement clears a prior abandon-side Service Bus processor failure.
     [<Test>]
     member _.SuccessfulAbandonClearsServiceBusProcessorFailureAfterSettlement() =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -1478,6 +1478,96 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies settlement recovery clears only the matching settlement failure when multiple owners are active.
+    [<Test>]
+    member _.SettlementRecoveryKeepsEarlierDifferentSettlementFailureActive() =
+        let readiness = OperationsUsageReadinessState()
+        let recorder = readiness :> IOperationsUsageReadinessRecorder
+        recorder.MarkReady()
+
+        OperationsUsageReadinessTransitions.recordServiceBusSettlementFailure
+            recorder
+            OperationsUsageReadinessTransitions.CompleteSettlementRecoveryKey
+            (InvalidOperationException("complete-secret"))
+
+        OperationsUsageReadinessTransitions.recordServiceBusSettlementFailure
+            recorder
+            OperationsUsageReadinessTransitions.AbandonSettlementRecoveryKey
+            (InvalidOperationException("abandon-secret"))
+
+        let failedSnapshot = readinessSnapshot readiness
+        let recoveryAttempt = recorder.BeginProcessingAttempt()
+
+        OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess
+            recorder
+            recoveryAttempt
+            OperationsUsageReadinessTransitions.AbandonSettlementRecoveryKey
+
+        let recoveredSnapshot = readinessSnapshot readiness
+
+        let failedDependency =
+            failedSnapshot.DependencyFailure
+            |> Option.defaultValue String.Empty
+
+        let recoveredDependency =
+            recoveredSnapshot.DependencyFailure
+            |> Option.defaultValue String.Empty
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                Assert.That(failedDependency, Does.Contain("Service Bus settlement failed (complete, InvalidOperationException)."))
+                Assert.That(failedDependency, Does.Contain("Service Bus settlement failed (abandon, InvalidOperationException)."))
+                Assert.That(failedDependency, Does.Not.Contain("complete-secret"))
+                Assert.That(failedDependency, Does.Not.Contain("abandon-secret"))
+                Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                Assert.That(recoveredDependency, Does.Contain("Service Bus settlement failed (complete, InvalidOperationException)."))
+                Assert.That(recoveredDependency, Does.Not.Contain("Service Bus settlement failed (abandon, InvalidOperationException).")))
+        )
+
+    /// Verifies ordinary message completion does not clear a lock-renewal processor fault.
+    [<Test>]
+    member _.OrdinaryCompletionDoesNotClearRenewLockProcessorFailure() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("31313131-3131-4131-8131-313131313131"))
+
+            let processor, _store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                ServiceBusErrorSource.RenewLock
+                (InvalidOperationException("renew-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            let completedSnapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                completedSnapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (RenewLock, InvalidOperationException)."))
+                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (RenewLock, InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("renew-secret"))
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
     /// Verifies a successful abandon settlement clears a prior abandon-side Service Bus processor failure.
     [<Test>]
     member _.SuccessfulAbandonClearsServiceBusProcessorFailureAfterSettlement() =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -969,6 +969,176 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies receive-side recovery cannot hide an unresolved runtime storage failure.
+    [<Test>]
+    member _.ReceiveRecoveryKeepsStorageFailureUntilLaterDurableSuccess() =
+        task {
+            let failingFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("21212121-2121-4121-8121-212121212121"))
+
+            let blockedSuccessFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("22222222-2222-4222-8222-222222222222"))
+
+            let mutable shouldFail = true
+
+            let storeStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let durableSuccess = TaskCompletionSource<Result<UsageFactPersistenceResult, string list>>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let processor, _store, actions, events, readiness =
+                createProcessorWithReadiness (fun storedFact _ ->
+                    if shouldFail then
+                        shouldFail <- false
+                        Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("forced SQL failure"))
+                    else
+                        storeStarted.SetResult(())
+                        durableSuccess.Task)
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            let failingMessage =
+                failingFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(failingMessage, actions, CancellationToken.None)
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                Azure.Messaging.ServiceBus.ServiceBusErrorSource.Receive
+                (InvalidOperationException("receive-link-secret"))
+
+            let combinedFailureSnapshot = readinessSnapshot readiness
+
+            let blockedSuccessMessage =
+                blockedSuccessFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let processing = processor.ProcessMessageAsync(blockedSuccessMessage, actions, CancellationToken.None)
+
+            do! storeStarted.Task
+
+            let receiveRecoveredSnapshot = readinessSnapshot readiness
+
+            durableSuccess.SetResult(Ok(accepted blockedSuccessFact))
+            do! processing
+
+            let storageRecoveredSnapshot = readinessSnapshot readiness
+
+            let combinedFailure =
+                combinedFailureSnapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(combinedFailureSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(combinedFailure, Does.Contain("Runtime processing dependency failed (InvalidOperationException)."))
+                    Assert.That(combinedFailure, Does.Contain("Service Bus processor fault (Receive, InvalidOperationException)."))
+                    Assert.That(combinedFailure, Does.Not.Contain("receive-link-secret"))
+                    Assert.That(receiveRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+
+                    Assert.That(
+                        receiveRecoveredSnapshot.DependencyFailure,
+                        Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException).")
+                    )
+
+                    Assert.That(storageRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(storageRecoveredSnapshot.DependencyFailure, Is.EqualTo(None))
+                    Assert.That(eventText events, Is.EqualTo("store|abandon|store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon|complete")))
+            )
+        }
+
+    /// Verifies startup-ready proof clears only startup-owned dependency failure state.
+    [<Test>]
+    member _.StartupReadyDoesNotClearCallbackFailureRecordedAfterProcessorStart() =
+        let readiness = OperationsUsageReadinessState()
+        let recorder = readiness :> IOperationsUsageReadinessRecorder
+
+        OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+            recorder
+            Azure.Messaging.ServiceBus.ServiceBusErrorSource.ProcessMessageCallback
+            (InvalidOperationException("callback-secret"))
+
+        recorder.MarkReady()
+
+        let snapshot = readinessSnapshot readiness
+
+        let dependencyFailure =
+            snapshot.DependencyFailure
+            |> Option.defaultValue String.Empty
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (ProcessMessageCallback, InvalidOperationException)."))
+                Assert.That(dependencyFailure, Does.Not.Contain("callback-secret")))
+        )
+
+    /// Verifies a settlement-side Service Bus processor failure is not cleared by receive-side recovery.
+    [<Test>]
+    member _.ReceiveRecoveryDoesNotClearNonReceiveServiceBusProcessorFailure() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("23232323-2323-4323-8323-232323232323"))
+
+            let storeStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let durableSuccess = TaskCompletionSource<Result<UsageFactPersistenceResult, string list>>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let processor, _store, actions, events, readiness =
+                createProcessorWithReadiness (fun storedFact _ ->
+                    storeStarted.SetResult(())
+                    durableSuccess.Task)
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                Azure.Messaging.ServiceBus.ServiceBusErrorSource.Complete
+                (InvalidOperationException("settlement-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let processing = processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            do! storeStarted.Task
+
+            let receiveRecoveredSnapshot = readinessSnapshot readiness
+
+            durableSuccess.SetResult(Ok(accepted fact))
+            do! processing
+
+            let completedSnapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                completedSnapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException)."))
+                    Assert.That(receiveRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+
+                    Assert.That(
+                        receiveRecoveredSnapshot.DependencyFailure,
+                        Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException).")
+                    )
+
+                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("settlement-secret"))
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
     /// Verifies an older in-flight success cannot clear a newer runtime dependency failure.
     [<Test>]
     member _.StaleInFlightSuccessDoesNotClearNewerDependencyFailure() =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -1,5 +1,6 @@
 namespace Grace.Operations.Tests
 
+open Azure.Messaging.ServiceBus
 open Grace.Operations.Data
 open Grace.Operations.Worker
 open Grace.Shared
@@ -68,6 +69,21 @@ module OperationsWorkerIngestionTestData =
             ApplicationProperties = applicationProperties ()
             Body = body
         }
+
+    /// Creates the Azure SDK message shape delivered by the production Service Bus processor.
+    let receivedServiceBusMessage (body: byte array) =
+        let properties = Dictionary<string, obj>()
+        properties[OperationalFactEnvelope.UsageFactMessageTypeProperty] <- box OperationalFactEnvelope.UsageFactMessageType
+        properties[OperationalFactEnvelope.UsageFactKindProperty] <- box "RepositoryStorageBytesMinute"
+
+        ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body = BinaryData(body),
+            messageId = "message-1",
+            correlationId = "message-correlation",
+            subject = OperationalFactEnvelope.UsageFactSubject,
+            properties = properties,
+            deliveryCount = 2
+        )
 
     /// Builds the aggregate projected by the data layer for a valid fact.
     let aggregateFor fact =
@@ -943,6 +959,82 @@ type OperationsWorkerIngestionTests() =
                 Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None)))
         )
 
+    /// Verifies the production Service Bus receive handler clears a prior receive/link readiness failure.
+    [<Test>]
+    member _.ProductionReceiveProofClearsServiceBusReceiveFaultReadiness() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("24242424-2424-4424-8424-242424242424"))
+
+            let processor, _store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                ServiceBusErrorSource.Receive
+                (InvalidOperationException("receive-link-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.receivedServiceBusMessage
+
+            do! OperationsUsageServiceBusMessage.processReceivedMessageAsync recorder processor true message actions CancellationToken.None
+
+            let recoveredSnapshot = readinessSnapshot readiness
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                    Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None))
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
+    /// Verifies a production callback cannot clear receive/link readiness when the worker may be draining prefetch.
+    [<Test>]
+    member _.ProductionPrefetchedCallbackDoesNotClearServiceBusReceiveFaultReadiness() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("26262626-2626-4626-8626-262626262626"))
+
+            let processor, _store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                ServiceBusErrorSource.Receive
+                (InvalidOperationException("receive-link-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.receivedServiceBusMessage
+
+            do! OperationsUsageServiceBusMessage.processReceivedMessageAsync recorder processor false message actions CancellationToken.None
+
+            let completedSnapshot = readinessSnapshot readiness
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
     /// Verifies a prefetched callback after a receive/link fault does not prove receive-side recovery.
     [<Test>]
     member _.PrefetchedCallbackDoesNotClearServiceBusReceiveFaultReadiness() =
@@ -1113,9 +1205,9 @@ type OperationsWorkerIngestionTests() =
                 Assert.That(dependencyFailure, Does.Not.Contain("callback-secret")))
         )
 
-    /// Verifies a settlement-side Service Bus processor failure clears after later successful runtime processing.
+    /// Verifies storage success does not clear a settlement-side Service Bus processor failure before settlement succeeds.
     [<Test>]
-    member _.NonReceiveServiceBusProcessorFailureClearsAfterLaterRuntimeSuccess() =
+    member _.SettlementFailureDoesNotClearAfterStorageSuccessBeforeSettlement() =
         task {
             let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("23232323-2323-4323-8323-232323232323"))
 
@@ -1123,11 +1215,12 @@ type OperationsWorkerIngestionTests() =
 
             let durableSuccess = TaskCompletionSource<Result<UsageFactPersistenceResult, string list>>(TaskCreationOptions.RunContinuationsAsynchronously)
 
-            let processor, _store, actions, events, readiness =
+            let processor, _store, _actions, events, readiness =
                 createProcessorWithReadiness (fun storedFact _ ->
                     storeStarted.SetResult(())
                     durableSuccess.Task)
 
+            let actions = BlockingCompleteMessageActions(events)
             let recorder = readiness :> IOperationsUsageReadinessRecorder
             recorder.MarkReady()
 
@@ -1150,6 +1243,12 @@ type OperationsWorkerIngestionTests() =
             let callbackStartedSnapshot = readinessSnapshot readiness
 
             durableSuccess.SetResult(Ok(accepted fact))
+
+            do! actions.CompleteStarted
+
+            let storageSucceededSnapshot = readinessSnapshot readiness
+
+            actions.ReleaseComplete()
             do! processing
 
             let completedSnapshot = readinessSnapshot readiness
@@ -1169,11 +1268,63 @@ type OperationsWorkerIngestionTests() =
                         Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException).")
                     )
 
+                    Assert.That(storageSucceededSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+
+                    Assert.That(
+                        storageSucceededSnapshot.DependencyFailure,
+                        Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException).")
+                    )
+
                     Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
                     Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(None))
                     Assert.That(dependencyFailure, Does.Not.Contain("settlement-secret"))
-                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(eventText events, Is.EqualTo("store|complete-waiting|complete"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
+    /// Verifies a successful abandon settlement clears a prior abandon-side Service Bus processor failure.
+    [<Test>]
+    member _.SuccessfulAbandonClearsServiceBusProcessorFailureAfterSettlement() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("25252525-2525-4525-8525-252525252525"))
+
+            let processor, _store, actions, events, readiness =
+                createProcessorWithReadiness (fun _ _ ->
+                    Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("forced SQL failure")))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                ServiceBusErrorSource.Abandon
+                (InvalidOperationException("abandon-secret"))
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            let settledSnapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                settledSnapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Abandon, InvalidOperationException)."))
+                    Assert.That(settledSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(settledSnapshot.DependencyFailure, Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("abandon-secret"))
+                    Assert.That(eventText events, Is.EqualTo("store|abandon"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon")))
             )
         }
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -915,9 +915,37 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
-    /// Verifies a later received message clears a Service Bus receive/link readiness failure before storage or settlement succeeds.
+    /// Verifies explicit receive-link proof clears a Service Bus receive/link readiness failure.
     [<Test>]
-    member _.LaterReceiveClearsServiceBusReceiveFaultReadiness() =
+    member _.ExplicitReceiveLinkProofClearsServiceBusReceiveFaultReadiness() =
+        let readiness = OperationsUsageReadinessState()
+        let recorder = readiness :> IOperationsUsageReadinessRecorder
+
+        recorder.MarkReady()
+
+        OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+            recorder
+            Azure.Messaging.ServiceBus.ServiceBusErrorSource.Receive
+            (InvalidOperationException("receive-link-secret"))
+
+        let failedSnapshot = readinessSnapshot readiness
+
+        let receiveProofAttempt = recorder.BeginProcessingAttempt()
+        OperationsUsageReadinessTransitions.recordServiceBusReceiveSuccess recorder receiveProofAttempt
+
+        let recoveredSnapshot = readinessSnapshot readiness
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None)))
+        )
+
+    /// Verifies a prefetched callback after a receive/link fault does not prove receive-side recovery.
+    [<Test>]
+    member _.PrefetchedCallbackDoesNotClearServiceBusReceiveFaultReadiness() =
         task {
             let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("20202020-2020-4020-8020-202020202020"))
 
@@ -949,7 +977,7 @@ type OperationsWorkerIngestionTests() =
 
             do! storeStarted.Task
 
-            let receiveRecoveredSnapshot = readinessSnapshot readiness
+            let callbackStartedSnapshot = readinessSnapshot readiness
 
             durableSuccess.SetResult(Ok(accepted fact))
             do! processing
@@ -960,18 +988,20 @@ type OperationsWorkerIngestionTests() =
                 Action (fun () ->
                     Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
                     Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
-                    Assert.That(receiveRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
-                    Assert.That(receiveRecoveredSnapshot.DependencyFailure, Is.EqualTo(None))
+                    Assert.That(callbackStartedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+
+                    Assert.That(callbackStartedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+
                     Assert.That(eventText events, Is.EqualTo("store|complete"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("complete"))
-                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
-                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(None)))
+                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException).")))
             )
         }
 
-    /// Verifies receive-side recovery cannot hide an unresolved runtime storage failure.
+    /// Verifies callback success cannot hide unresolved runtime storage and receive-link failures.
     [<Test>]
-    member _.ReceiveRecoveryKeepsStorageFailureUntilLaterDurableSuccess() =
+    member _.CallbackSuccessKeepsStorageAndReceiveFailuresUntilOwnerRecovery() =
         task {
             let failingFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("21212121-2121-4121-8121-212121212121"))
 
@@ -1018,7 +1048,7 @@ type OperationsWorkerIngestionTests() =
 
             do! storeStarted.Task
 
-            let receiveRecoveredSnapshot = readinessSnapshot readiness
+            let callbackStartedSnapshot = readinessSnapshot readiness
 
             durableSuccess.SetResult(Ok(accepted blockedSuccessFact))
             do! processing
@@ -1035,15 +1065,23 @@ type OperationsWorkerIngestionTests() =
                     Assert.That(combinedFailure, Does.Contain("Runtime processing dependency failed (InvalidOperationException)."))
                     Assert.That(combinedFailure, Does.Contain("Service Bus processor fault (Receive, InvalidOperationException)."))
                     Assert.That(combinedFailure, Does.Not.Contain("receive-link-secret"))
-                    Assert.That(receiveRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(callbackStartedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
 
                     Assert.That(
-                        receiveRecoveredSnapshot.DependencyFailure,
-                        Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException).")
+                        callbackStartedSnapshot.DependencyFailure,
+                        Is.EqualTo(
+                            Some
+                                "Runtime processing dependency failed (InvalidOperationException).; Service Bus processor fault (Receive, InvalidOperationException)."
+                        )
                     )
 
-                    Assert.That(storageRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
-                    Assert.That(storageRecoveredSnapshot.DependencyFailure, Is.EqualTo(None))
+                    Assert.That(storageRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+
+                    Assert.That(
+                        storageRecoveredSnapshot.DependencyFailure,
+                        Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException).")
+                    )
+
                     Assert.That(eventText events, Is.EqualTo("store|abandon|store|complete"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon|complete")))
             )
@@ -1075,9 +1113,9 @@ type OperationsWorkerIngestionTests() =
                 Assert.That(dependencyFailure, Does.Not.Contain("callback-secret")))
         )
 
-    /// Verifies a settlement-side Service Bus processor failure is not cleared by receive-side recovery.
+    /// Verifies a settlement-side Service Bus processor failure clears after later successful runtime processing.
     [<Test>]
-    member _.ReceiveRecoveryDoesNotClearNonReceiveServiceBusProcessorFailure() =
+    member _.NonReceiveServiceBusProcessorFailureClearsAfterLaterRuntimeSuccess() =
         task {
             let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("23232323-2323-4323-8323-232323232323"))
 
@@ -1109,7 +1147,7 @@ type OperationsWorkerIngestionTests() =
 
             do! storeStarted.Task
 
-            let receiveRecoveredSnapshot = readinessSnapshot readiness
+            let callbackStartedSnapshot = readinessSnapshot readiness
 
             durableSuccess.SetResult(Ok(accepted fact))
             do! processing
@@ -1124,15 +1162,15 @@ type OperationsWorkerIngestionTests() =
                 Action (fun () ->
                     Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
                     Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException)."))
-                    Assert.That(receiveRecoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(callbackStartedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
 
                     Assert.That(
-                        receiveRecoveredSnapshot.DependencyFailure,
+                        callbackStartedSnapshot.DependencyFailure,
                         Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException).")
                     )
 
-                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
-                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Complete, InvalidOperationException)."))
+                    Assert.That(completedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(completedSnapshot.DependencyFailure, Is.EqualTo(None))
                     Assert.That(dependencyFailure, Does.Not.Contain("settlement-secret"))
                     Assert.That(eventText events, Is.EqualTo("store|complete"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -152,6 +152,42 @@ type private BlockingCompleteMessageActions(events: List<string>) =
             settlements.Add("dead-letter", Some reason)
             Task.CompletedTask
 
+/// Throws from one configured settlement path while recording any fallback settlement attempts.
+type private ThrowingSettlementMessageActions(events: List<string>, operationToThrow: string) =
+    let settlements = ResizeArray<string * string option>()
+
+    /// Returns the settlements recorded by the fake actions.
+    member _.Settlements = settlements |> Seq.toList
+
+    interface IOperationsUsageMessageActions with
+
+        member _.CompleteAsync(_cancellationToken) =
+            if operationToThrow = "complete" then
+                events.Add("complete-failed")
+                Task.FromException(InvalidOperationException("forced complete failure with SharedAccessKey=secret"))
+            else
+                events.Add("complete")
+                settlements.Add("complete", None)
+                Task.CompletedTask
+
+        member _.AbandonAsync(_cancellationToken) =
+            if operationToThrow = "abandon" then
+                events.Add("abandon-failed")
+                Task.FromException(InvalidOperationException("forced abandon failure with SharedAccessKey=secret"))
+            else
+                events.Add("abandon")
+                settlements.Add("abandon", None)
+                Task.CompletedTask
+
+        member _.DeadLetterAsync(reason, _description, _cancellationToken) =
+            if operationToThrow = "dead-letter" then
+                events.Add("dead-letter-failed")
+                Task.FromException(InvalidOperationException("forced dead-letter failure with SharedAccessKey=secret"))
+            else
+                events.Add("dead-letter")
+                settlements.Add("dead-letter", Some reason)
+                Task.CompletedTask
+
 /// Fakes the operations data-layer boundary for deterministic processor tests.
 type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>, events: List<string>) =
     let storedFacts = ResizeArray<UsageFact>()
@@ -299,8 +335,8 @@ type OperationsWorkerIngestionTests() =
                                          getConfigKey Constants.EnvironmentVariables.AzureServiceBusConnectionString,
                                          "Endpoint=sb://operations.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=fake"
                                      )
-                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.MaxConcurrentCallsEnvironmentVariable, "7")
-                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.PrefetchCountEnvironmentVariable, "29") ]
+                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.MaxConcurrentCallsEnvironmentVariable, "1")
+                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.PrefetchCountEnvironmentVariable, "0") ]
 
         let settings = OperationsWorkerSettings.fromConfiguration configuration
 
@@ -316,10 +352,44 @@ type OperationsWorkerIngestionTests() =
                         Is.EqualTo("Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;")
                     )
 
-                    Assert.That(value.MaxConcurrentCalls, Is.EqualTo(7))
-                    Assert.That(value.PrefetchCount, Is.EqualTo(29)))
+                    Assert.That(value.MaxConcurrentCalls, Is.EqualTo(1))
+                    Assert.That(value.PrefetchCount, Is.EqualTo(0)))
             )
         | Error errors -> Assert.Fail(String.Join("; ", errors))
+
+    /// Verifies receive recovery is configured only for modes where callback start cannot be stale.
+    [<Test>]
+    member _.WorkerSettingsRejectUnsafeReceiveRecoveryModes() =
+        let configuration =
+            configurationFromPairs [ KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic,
+                                         "operations-topic"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.ProcessorSubscriptionEnvironmentVariable,
+                                         OperationsWorkerSettings.DefaultProcessorSubscriptionName
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey OperationsWorkerSettings.SqlConnectionStringEnvironmentVariable,
+                                         "Server=tcp:sql.example.net;Database=GraceOperations;Authentication=Active Directory Default;"
+                                     )
+                                     KeyValuePair<string, string>(
+                                         getConfigKey Constants.EnvironmentVariables.AzureServiceBusConnectionString,
+                                         "Endpoint=sb://operations.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=fake"
+                                     )
+                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.MaxConcurrentCallsEnvironmentVariable, "2")
+                                     KeyValuePair<string, string>(getConfigKey OperationsWorkerSettings.PrefetchCountEnvironmentVariable, "1") ]
+
+        match OperationsWorkerSettings.fromConfiguration configuration with
+        | Ok _ -> Assert.Fail("Unsafe receive recovery settings must be rejected.")
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(errorText, Does.Contain($"{OperationsWorkerSettings.MaxConcurrentCallsEnvironmentVariable} must be '1'"))
+                    Assert.That(errorText, Does.Contain($"{OperationsWorkerSettings.PrefetchCountEnvironmentVariable} must be '0'")))
+            )
 
     /// Verifies DebugLocal opts into admin bootstrap so fresh local SQL containers get the operations database.
     [<Test>]
@@ -1280,6 +1350,131 @@ type OperationsWorkerIngestionTests() =
                     Assert.That(dependencyFailure, Does.Not.Contain("settlement-secret"))
                     Assert.That(eventText events, Is.EqualTo("store|complete-waiting|complete"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
+            )
+        }
+
+    /// Verifies completion failures are owned by Service Bus settlement readiness, not runtime storage readiness.
+    [<Test>]
+    member _.CompleteFailureRecordsServiceBusSettlementFailureWithoutFallbackAbandon() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("27272727-2727-4727-8727-272727272727"))
+
+            let processor, _store, _actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let actions = ThrowingSettlementMessageActions(events, "complete")
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            let snapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                snapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("store|complete-failed"))
+                    Assert.That(actions.Settlements, Is.Empty)
+                    Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Service Bus settlement failed (complete, InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("Runtime processing dependency failed"))
+                    Assert.That(dependencyFailure, Does.Not.Contain("SharedAccessKey=secret")))
+            )
+        }
+
+    /// Verifies dead-letter failures are owned by Service Bus settlement readiness, not runtime storage readiness.
+    [<Test>]
+    member _.DeadLetterFailureRecordsServiceBusSettlementFailureWithoutFallbackAbandon() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("28282828-2828-4828-8828-282828282828"))
+
+            let processor, store, _actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let actions = ThrowingSettlementMessageActions(events, "dead-letter")
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+                |> fun value -> { value with Subject = "FutureOperationalFact" }
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            let snapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                snapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter-failed"))
+                    Assert.That(actions.Settlements, Is.Empty)
+                    Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Service Bus settlement failed (dead-letter, InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("Runtime processing dependency failed"))
+                    Assert.That(dependencyFailure, Does.Not.Contain("SharedAccessKey=secret")))
+            )
+        }
+
+    /// Verifies fallback abandon success cannot clear a settlement failure from a different Service Bus operation.
+    [<Test>]
+    member _.FallbackAbandonSuccessDoesNotClearCompleteSettlementFailure() =
+        task {
+            let completeFailureFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("29292929-2929-4929-8929-292929292929"))
+
+            let storageFailureFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("30303030-3030-4030-8030-303030303030"))
+
+            let processor, _store, _actions, events, readiness =
+                createProcessorWithReadiness (fun storedFact _ ->
+                    if storedFact.UsageFactId = storageFailureFact.UsageFactId then
+                        Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("forced SQL failure"))
+                    else
+                        Task.FromResult(Ok(accepted storedFact)))
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            let completeFailureActions = ThrowingSettlementMessageActions(events, "complete")
+            let storageFailureActions = RecordingMessageActions(events)
+
+            let completeFailureMessage =
+                completeFailureFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let storageFailureMessage =
+                storageFailureFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(completeFailureMessage, completeFailureActions, CancellationToken.None)
+            do! processor.ProcessMessageAsync(storageFailureMessage, storageFailureActions, CancellationToken.None)
+
+            let snapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                snapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("store|complete-failed|store|abandon"))
+                    Assert.That(completeFailureActions.Settlements, Is.Empty)
+                    Assert.That(settlementText storageFailureActions.Settlements, Is.EqualTo("abandon"))
+                    Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(dependencyFailure, Does.Contain("Service Bus settlement failed (complete, InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Contain("Runtime processing dependency failed (InvalidOperationException).")))
             )
         }
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -7,6 +7,7 @@ open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.Usage
 open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Diagnostics.HealthChecks
 open Microsoft.Extensions.Logging.Abstractions
 open NodaTime
 open NUnit.Framework
@@ -128,16 +129,26 @@ type OperationsWorkerIngestionTests() =
             .AddInMemoryCollection(pairs)
             .Build()
 
-    /// Creates a processor with deterministic fake dependencies.
-    let createProcessor storeAsync =
+    /// Creates a processor with deterministic fake dependencies and an inspectable readiness state.
+    let createProcessorWithReadiness storeAsync =
         let events = List<string>()
         let store = StubUsageFactStore(storeAsync, events)
+        let readiness = OperationsUsageReadinessState()
 
         let logger =
             NullLogger<OperationsUsageIngestionProcessor>
                 .Instance
 
-        OperationsUsageIngestionProcessor(store, logger), store, RecordingMessageActions(events), events
+        OperationsUsageIngestionProcessor(store, logger, readiness :> IOperationsUsageReadinessRecorder),
+        store,
+        RecordingMessageActions(events),
+        events,
+        readiness
+
+    /// Creates a processor with deterministic fake dependencies.
+    let createProcessor storeAsync =
+        let processor, store, actions, events, _readiness = createProcessorWithReadiness storeAsync
+        processor, store, actions, events
 
     /// Creates a processor backed by the real data-layer validation path.
     let createProcessorWithRealStore () =
@@ -164,6 +175,15 @@ type OperationsWorkerIngestionTests() =
             | Some value -> $"{action}:{value}"
             | None -> action)
         |> fun values -> String.Join("|", values)
+
+    /// Returns the latest unsupported contract readiness note for focused worker assertions.
+    let lastUnsupportedContract (readiness: OperationsUsageReadinessState) =
+        let snapshot =
+            (readiness :> IOperationsUsageReadinessProbe)
+                .GetSnapshot()
+
+        snapshot.LastUnsupportedContract
+        |> Option.defaultValue String.Empty
 
     /// Creates an accepted persistence result for a fact.
     let accepted fact =
@@ -299,6 +319,73 @@ type OperationsWorkerIngestionTests() =
             )
         | Error errors -> Assert.Fail(String.Join("; ", errors))
 
+    /// Verifies readiness reports the supported UsageFact contract and dependency startup state.
+    [<Test>]
+    member _.ReadinessSnapshotReportsSupportedContractAndDependencyFailure() =
+        let readiness = OperationsUsageReadinessState()
+        let recorder = readiness :> IOperationsUsageReadinessRecorder
+
+        recorder.MarkDependencyFailure("Dependency startup failed (SqlException).")
+        recorder.MarkUnsupportedContract("UsageFact SchemaVersion '2' is not supported. Expected '1'.")
+
+        let snapshot =
+            (readiness :> IOperationsUsageReadinessProbe)
+                .GetSnapshot()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                Assert.That(snapshot.SupportedUsageFactSchemaVersion, Is.EqualTo(UsageFactSchemaVersion))
+                Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Dependency startup failed (SqlException)."))
+                Assert.That(snapshot.LastUnsupportedContract, Is.EqualTo(Some "UsageFact SchemaVersion '2' is not supported. Expected '1'.")))
+        )
+
+    /// Verifies readiness clears dependency failure after the worker proves startup dependencies.
+    [<Test>]
+    member _.ReadinessSnapshotMarksWorkerReadyAfterDependencyStartup() =
+        let readiness = OperationsUsageReadinessState()
+        let recorder = readiness :> IOperationsUsageReadinessRecorder
+
+        recorder.MarkDependencyFailure("Dependency startup failed (ServiceBusException).")
+        recorder.MarkReady()
+
+        let snapshot =
+            (readiness :> IOperationsUsageReadinessProbe)
+                .GetSnapshot()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                Assert.That(snapshot.SupportedUsageFactSchemaVersion, Is.EqualTo(UsageFactSchemaVersion))
+                Assert.That(snapshot.DependencyFailure, Is.EqualTo(None)))
+        )
+
+    /// Verifies the standard health-check adapter exposes redacted readiness data.
+    [<Test>]
+    member _.ReadinessHealthCheckReportsDependencyFailureAndSupportedContract() =
+        task {
+            let readiness = OperationsUsageReadinessState()
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+
+            recorder.MarkDependencyFailure("Dependency startup failed (SqlException).")
+            recorder.MarkUnsupportedContract("UsageFact SchemaVersion '2' is not supported. Expected '1'.")
+
+            let healthCheck = OperationsUsageReadinessHealthCheck(readiness :> IOperationsUsageReadinessProbe)
+
+            let! result =
+                (healthCheck :> IHealthCheck)
+                    .CheckHealthAsync(HealthCheckContext(), CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(result.Status, Is.EqualTo(HealthStatus.Unhealthy))
+                    Assert.That(result.Description, Is.EqualTo("Dependency startup failed (SqlException)."))
+                    Assert.That(result.Data["supportedUsageFactSchemaVersion"], Is.EqualTo(UsageFactSchemaVersion))
+                    Assert.That(result.Data["dependencyFailure"], Is.EqualTo("Dependency startup failed (SqlException)."))
+                    Assert.That(result.Data["lastUnsupportedContract"], Is.EqualTo("UsageFact SchemaVersion '2' is not supported. Expected '1'.")))
+            )
+        }
+
     /// Verifies valid messages complete only after the data layer reports durable persistence.
     [<Test>]
     member _.ValidMessageIsPersistedBeforeCompletion() =
@@ -345,6 +432,60 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies unsupported Service Bus envelopes dead-letter before the worker reads the body.
+    [<Test>]
+    member _.UnsupportedEnvelopeIsDeadLetteredWithoutStorage() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("12121212-1212-4212-8212-121212121212"))
+
+            let processor, store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+                |> fun value -> { value with Subject = "FutureOperationalFact" }
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:UnsupportedOperationalFactEnvelope"))
+                    Assert.That(lastUnsupportedContract readiness, Does.Contain("Unsupported Service Bus envelope")))
+            )
+        }
+
+    /// Verifies unsupported message type properties dead-letter as unsupported envelopes.
+    [<Test>]
+    member _.UnsupportedMessageTypeIsDeadLetteredWithoutStorage() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("16161616-1616-4616-8616-161616161616"))
+
+            let processor, store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let applicationProperties = Dictionary<string, obj>()
+            applicationProperties[OperationalFactEnvelope.UsageFactMessageTypeProperty] <- box "FutureUsageFact"
+            applicationProperties[OperationalFactEnvelope.UsageFactKindProperty] <- box "RepositoryStorageBytesMinute"
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+                |> fun value -> { value with ApplicationProperties = applicationProperties }
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:UnsupportedOperationalFactEnvelope"))
+                    Assert.That(lastUnsupportedContract readiness, Does.Contain("Unsupported Service Bus envelope")))
+            )
+        }
+
     /// Verifies malformed JSON dead-letters without calling the data layer.
     [<Test>]
     member _.MalformedJsonIsDeadLetteredWithoutStorage() =
@@ -363,6 +504,79 @@ type OperationsWorkerIngestionTests() =
                     Assert.That(store.StoredFacts, Is.Empty)
                     Assert.That(eventText events, Is.EqualTo("dead-letter"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:MalformedUsageFactJson")))
+            )
+        }
+
+    /// Verifies future UsageFact schemas dead-letter with a deterministic reason before storage.
+    [<Test>]
+    member _.UnsupportedUsageFactSchemaIsDeadLetteredWithoutStorage() =
+        task {
+            let fact =
+                { OperationsWorkerIngestionTestData.usageFact (Guid.Parse("13131313-1313-4313-8313-131313131313")) with
+                    SchemaVersion = UsageFactSchemaVersion + 1
+                }
+
+            let processor, store, actions, events, readiness = createProcessorWithReadiness (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:UnsupportedUsageFactSchema"))
+                    Assert.That(lastUnsupportedContract readiness, Does.Contain("SchemaVersion '2' is not supported")))
+            )
+        }
+
+    /// Verifies missing UsageFact identity is treated as impossible poison input.
+    [<Test>]
+    member _.MissingUsageFactIdIsDeadLetteredWithoutStorage() =
+        task {
+            let fact = { OperationsWorkerIngestionTestData.usageFact (Guid.Parse("14141414-1414-4414-8414-141414141414")) with UsageFactId = Guid.Empty }
+
+            let processor, store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:InvalidUsageFact")))
+            )
+        }
+
+    /// Verifies non-positive quantities are treated as impossible poison input.
+    [<Test>]
+    member _.InvalidQuantityIsDeadLetteredWithoutStorage() =
+        task {
+            let fact = { OperationsWorkerIngestionTestData.usageFact (Guid.Parse("15151515-1515-4515-8515-151515151515")) with Quantity = 0L }
+
+            let processor, store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(store.StoredFacts, Is.Empty)
+                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:InvalidUsageFact")))
             )
         }
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -205,6 +205,11 @@ type OperationsWorkerIngestionTests() =
         snapshot.LastUnsupportedContract
         |> Option.defaultValue String.Empty
 
+    /// Returns the current readiness snapshot for state-transition assertions.
+    let readinessSnapshot (readiness: OperationsUsageReadinessState) =
+        (readiness :> IOperationsUsageReadinessProbe)
+            .GetSnapshot()
+
     /// Creates an accepted persistence result for a fact.
     let accepted fact =
         { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = fact.UsageFactId; Aggregate = Some(OperationsWorkerIngestionTestData.aggregateFor fact) }
@@ -378,6 +383,32 @@ type OperationsWorkerIngestionTests() =
                 Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
                 Assert.That(snapshot.SupportedUsageFactSchemaVersion, Is.EqualTo(UsageFactSchemaVersion))
                 Assert.That(snapshot.DependencyFailure, Is.EqualTo(None)))
+        )
+
+    /// Verifies post-start Service Bus processor faults downgrade readiness through the shared worker state.
+    [<Test>]
+    member _.ServiceBusProcessorReceiveFaultDowngradesReadinessAfterStartup() =
+        let readiness = OperationsUsageReadinessState()
+        let recorder = readiness :> IOperationsUsageReadinessRecorder
+
+        recorder.MarkReady()
+
+        OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+            recorder
+            Azure.Messaging.ServiceBus.ServiceBusErrorSource.Receive
+            (InvalidOperationException("receive-link-secret"))
+
+        let snapshot = readinessSnapshot readiness
+
+        let dependencyFailure =
+            snapshot.DependencyFailure
+            |> Option.defaultValue String.Empty
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                Assert.That(dependencyFailure, Does.Not.Contain("receive-link-secret")))
         )
 
     /// Verifies the standard health-check adapter exposes redacted readiness data.
@@ -713,8 +744,14 @@ type OperationsWorkerIngestionTests() =
         task {
             let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"))
 
-            let processor, store, actions, events =
-                createProcessor (fun _ _ -> Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("forced SQL failure")))
+            let processor, store, actions, events, readiness =
+                createProcessorWithReadiness (fun _ _ ->
+                    Task.FromException<Result<UsageFactPersistenceResult, string list>>(
+                        InvalidOperationException("forced SQL failure with SharedAccessKey=secret")
+                    ))
+
+            (readiness :> IOperationsUsageReadinessRecorder)
+                .MarkReady()
 
             let message =
                 fact
@@ -723,11 +760,70 @@ type OperationsWorkerIngestionTests() =
 
             do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
 
+            let snapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                snapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
             Assert.Multiple(
                 Action (fun () ->
                     Assert.That(List.length store.StoredFacts, Is.EqualTo(1))
                     Assert.That(eventText events, Is.EqualTo("store|abandon"))
-                    Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon")))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon"))
+                    Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("SharedAccessKey=secret")))
+            )
+        }
+
+    /// Verifies a later durable success clears a runtime dependency failure recorded by an earlier storage exception.
+    [<Test>]
+    member _.StorageFailureReadinessClearsAfterLaterSuccess() =
+        task {
+            let firstFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("18181818-1818-4818-8818-181818181818"))
+
+            let secondFact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("19191919-1919-4919-8919-191919191919"))
+
+            let mutable shouldFail = true
+
+            let processor, _store, actions, events, readiness =
+                createProcessorWithReadiness (fun storedFact _ ->
+                    if shouldFail then
+                        shouldFail <- false
+                        Task.FromException<Result<UsageFactPersistenceResult, string list>>(InvalidOperationException("forced SQL failure"))
+                    else
+                        Task.FromResult(Ok(accepted storedFact)))
+
+            (readiness :> IOperationsUsageReadinessRecorder)
+                .MarkReady()
+
+            let firstMessage =
+                firstFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let secondMessage =
+                secondFact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            do! processor.ProcessMessageAsync(firstMessage, actions, CancellationToken.None)
+
+            let failedSnapshot = readinessSnapshot readiness
+
+            do! processor.ProcessMessageAsync(secondMessage, actions, CancellationToken.None)
+
+            let recoveredSnapshot = readinessSnapshot readiness
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("store|abandon|store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("abandon|complete"))
+                    Assert.That(failedSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(failedSnapshot.DependencyFailure, Is.EqualTo(Some "Runtime processing dependency failed (InvalidOperationException)."))
+                    Assert.That(recoveredSnapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.Ready))
+                    Assert.That(recoveredSnapshot.DependencyFailure, Is.EqualTo(None)))
             )
         }
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -864,6 +864,57 @@ type OperationsWorkerIngestionTests() =
             )
         }
 
+    /// Verifies in-flight message success cannot clear a Service Bus receive/link readiness failure.
+    [<Test>]
+    member _.InFlightSuccessDoesNotClearServiceBusReceiveFaultReadiness() =
+        task {
+            let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("1d1d1d1d-1d1d-4d1d-8d1d-1d1d1d1d1d1d"))
+
+            let storeStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let durableSuccess = TaskCompletionSource<Result<UsageFactPersistenceResult, string list>>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let processor, _store, actions, events, readiness =
+                createProcessorWithReadiness (fun storedFact _ ->
+                    storeStarted.SetResult(())
+                    durableSuccess.Task)
+
+            let recorder = readiness :> IOperationsUsageReadinessRecorder
+            recorder.MarkReady()
+
+            let message =
+                fact
+                |> OperationsWorkerIngestionTestData.serializeFact
+                |> OperationsWorkerIngestionTestData.message
+
+            let processing = processor.ProcessMessageAsync(message, actions, CancellationToken.None)
+
+            do! storeStarted.Task
+
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorFault
+                recorder
+                Azure.Messaging.ServiceBus.ServiceBusErrorSource.Receive
+                (InvalidOperationException("receive-link-secret"))
+
+            durableSuccess.SetResult(Ok(accepted fact))
+            do! processing
+
+            let snapshot = readinessSnapshot readiness
+
+            let dependencyFailure =
+                snapshot.DependencyFailure
+                |> Option.defaultValue String.Empty
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(eventText events, Is.EqualTo("store|complete"))
+                    Assert.That(settlementText actions.Settlements, Is.EqualTo("complete"))
+                    Assert.That(snapshot.Status, Is.EqualTo(OperationsUsageReadinessStatus.NotReady))
+                    Assert.That(snapshot.DependencyFailure, Is.EqualTo(Some "Service Bus processor fault (Receive, InvalidOperationException)."))
+                    Assert.That(dependencyFailure, Does.Not.Contain("receive-link-secret")))
+            )
+        }
+
     /// Verifies an older in-flight success cannot clear a newer runtime dependency failure.
     [<Test>]
     member _.StaleInFlightSuccessDoesNotClearNewerDependencyFailure() =

--- a/src/Grace.Operations/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageReference Update="FSharp.Core" Version="10.1.301" />

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -100,6 +100,21 @@ type OperationsUsageReadinessSnapshot =
         LastUnsupportedContract: string option
     }
 
+/// Identifies which dependency surface currently owns an Operations ingestion readiness failure.
+type internal OperationsUsageReadinessFailureSource =
+
+    /// Startup dependency failures are cleared only by a later successful startup pass.
+    | StartupDependency = 1
+
+    /// Runtime storage or processing failures are cleared by a later fresh durable message success.
+    | RuntimeProcessingDependency = 2
+
+    /// Service Bus receive/link failures are cleared only by receive-side recovery proof.
+    | ServiceBusProcessor = 3
+
+/// Captures the current readiness ordering point for one in-flight message.
+type OperationsUsageReadinessAttempt = { FailureVersion: int64 }
+
 /// Exposes a snapshot of the Operations ingestion readiness state.
 type IOperationsUsageReadinessProbe =
 
@@ -112,8 +127,20 @@ type IOperationsUsageReadinessRecorder =
     /// Marks ingestion dependencies as ready after SQL initialization and Service Bus processor startup succeed.
     abstract MarkReady: unit -> unit
 
+    /// Captures the readiness failure version visible when one message starts processing.
+    abstract BeginProcessingAttempt: unit -> OperationsUsageReadinessAttempt
+
     /// Records a redacted dependency failure that prevents the worker from being ready.
     abstract MarkDependencyFailure: description: string -> unit
+
+    /// Records a redacted runtime storage or processing failure that prevents the worker from being ready.
+    abstract MarkRuntimeProcessingFailure: description: string -> unit
+
+    /// Records a redacted Service Bus receive or link failure that prevents the worker from being ready.
+    abstract MarkServiceBusProcessorFailure: description: string -> unit
+
+    /// Clears a runtime storage or processing failure only when this success started after that failure.
+    abstract MarkRuntimeProcessingSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
     /// Records the latest unsupported ingestion contract observed at the broker boundary.
     abstract MarkUnsupportedContract: description: string -> unit
@@ -122,16 +149,33 @@ type IOperationsUsageReadinessRecorder =
 type OperationsUsageReadinessState() =
     let gate = obj ()
 
+    let mutable failureVersion = 0L
     let mutable status = OperationsUsageReadinessStatus.NotReady
-    let mutable dependencyFailure = Some "Operations usage worker has not completed dependency startup."
+
+    let mutable dependencyFailure =
+        Some
+            {|
+                Source = OperationsUsageReadinessFailureSource.StartupDependency
+                Description = "Operations usage worker has not completed dependency startup."
+                Version = failureVersion
+            |}
+
     let mutable lastUnsupportedContract: string option = None
+
+    let recordFailure source description =
+        failureVersion <- failureVersion + 1L
+        status <- OperationsUsageReadinessStatus.NotReady
+
+        dependencyFailure <- Some {| Source = source; Description = description; Version = failureVersion |}
 
     let snapshot () =
         lock gate (fun () ->
             {
                 Status = status
                 SupportedUsageFactSchemaVersion = UsageFactSchemaVersion
-                DependencyFailure = dependencyFailure
+                DependencyFailure =
+                    dependencyFailure
+                    |> Option.map (fun failure -> failure.Description)
                 LastUnsupportedContract = lastUnsupportedContract
             })
 
@@ -146,10 +190,27 @@ type OperationsUsageReadinessState() =
                 status <- OperationsUsageReadinessStatus.Ready
                 dependencyFailure <- None)
 
-        member _.MarkDependencyFailure(description) =
+        member _.BeginProcessingAttempt() = lock gate (fun () -> { FailureVersion = failureVersion })
+
+        member _.MarkDependencyFailure(description) = lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.StartupDependency description)
+
+        member _.MarkRuntimeProcessingFailure(description) =
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.RuntimeProcessingDependency description)
+
+        member _.MarkServiceBusProcessorFailure(description) =
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusProcessor description)
+
+        member _.MarkRuntimeProcessingSuccess(attempt) =
             lock gate (fun () ->
-                status <- OperationsUsageReadinessStatus.NotReady
-                dependencyFailure <- Some description)
+                match dependencyFailure with
+                | Some failure when
+                    failure.Source = OperationsUsageReadinessFailureSource.RuntimeProcessingDependency
+                    && failure.Version <= attempt.FailureVersion
+                    ->
+                    status <- OperationsUsageReadinessStatus.Ready
+                    dependencyFailure <- None
+                | None -> status <- OperationsUsageReadinessStatus.Ready
+                | Some _ -> ())
 
         member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
 
@@ -159,11 +220,11 @@ module internal OperationsUsageReadinessTransitions =
 
     /// Records a redacted Service Bus processor fault observed after startup.
     let recordServiceBusProcessorFault (readiness: IOperationsUsageReadinessRecorder) (errorSource: ServiceBusErrorSource) (ex: exn) =
-        readiness.MarkDependencyFailure($"Service Bus processor fault ({errorSource}, {ex.GetType().Name}).")
+        readiness.MarkServiceBusProcessorFailure($"Service Bus processor fault ({errorSource}, {ex.GetType().Name}).")
 
     /// Records a redacted runtime processing dependency failure that should recover after a later successful message.
     let recordRuntimeProcessingFailure (readiness: IOperationsUsageReadinessRecorder) (ex: exn) =
-        readiness.MarkDependencyFailure($"Runtime processing dependency failed ({ex.GetType().Name}).")
+        readiness.MarkRuntimeProcessingFailure($"Runtime processing dependency failed ({ex.GetType().Name}).")
 
 /// Adapts Operations ingestion readiness to the standard .NET health-check surface.
 type OperationsUsageReadinessHealthCheck(readiness: IOperationsUsageReadinessProbe) =
@@ -491,6 +552,8 @@ type OperationsUsageIngestionProcessor
     /// Processes a usage fact message and settles it only after the durable outcome is known.
     member _.ProcessMessageAsync(message: OperationsUsageMessage, actions: IOperationsUsageMessageActions, cancellationToken: CancellationToken) =
         task {
+            let readinessAttempt = readiness.BeginProcessingAttempt()
+
             try
                 cancellationToken.ThrowIfCancellationRequested()
 
@@ -576,7 +639,7 @@ type OperationsUsageIngestionProcessor
                                         |> Option.defaultValue Instant.MinValue
                                     )
 
-                                    readiness.MarkReady()
+                                    readiness.MarkRuntimeProcessingSuccess(readinessAttempt)
                                     do! actions.CompleteAsync cancellationToken
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -154,6 +154,9 @@ type IOperationsUsageReadinessRecorder =
     /// Clears runtime-owned processing failures only when this success started after that failure.
     abstract MarkRuntimeProcessingSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
+    /// Clears Service Bus processor-owned settlement failures only after a later settlement succeeds.
+    abstract MarkServiceBusProcessorSuccess: attempt: OperationsUsageReadinessAttempt -> unit
+
     /// Records the latest unsupported ingestion contract observed at the broker boundary.
     abstract MarkUnsupportedContract: description: string -> unit
 
@@ -237,9 +240,10 @@ type OperationsUsageReadinessState() =
             lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusReceiveLink attempt)
 
         member _.MarkRuntimeProcessingSuccess(attempt) =
-            lock gate (fun () ->
-                clearFailureWhenFresh OperationsUsageReadinessFailureSource.RuntimeProcessingDependency attempt
-                clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime attempt)
+            lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.RuntimeProcessingDependency attempt)
+
+        member _.MarkServiceBusProcessorSuccess(attempt) =
+            lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime attempt)
 
         member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
 
@@ -271,6 +275,10 @@ module internal OperationsUsageReadinessTransitions =
     /// Records a later receive-side proof that a Service Bus processor receive or link fault recovered.
     let recordServiceBusReceiveSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =
         readiness.MarkServiceBusReceiveSuccess(attempt)
+
+    /// Records a later settlement-side proof that a Service Bus processor settlement fault recovered.
+    let recordServiceBusProcessorSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =
+        readiness.MarkServiceBusProcessorSuccess(attempt)
 
     /// Records a redacted runtime processing dependency failure that should recover after a later successful message.
     let recordRuntimeProcessingFailure (readiness: IOperationsUsageReadinessRecorder) (ex: exn) =
@@ -434,6 +442,15 @@ module OperationsWorkerSettings =
             | _ -> defaultValue
         | None -> defaultValue
 
+    /// Reads a non-negative integer setting or returns the supplied default.
+    let private nonNegativeIntSetting configuration name defaultValue =
+        match optionalSetting configuration name with
+        | Some value ->
+            match Int32.TryParse value with
+            | true, parsed when parsed >= 0 -> parsed
+            | _ -> defaultValue
+        | None -> defaultValue
+
     /// Allows local SQL emulator runs to create the operations database while keeping Azure connections least-privilege.
     let private schemaBootstrapMode configuration =
         match optionalSetting configuration Constants.EnvironmentVariables.DebugEnvironment with
@@ -500,7 +517,7 @@ module OperationsWorkerSettings =
                             |> Option.orElseWith serviceBusNamespaceFromAzureEnvironment
                     SchemaBootstrapMode = schemaBootstrapMode configuration
                     MaxConcurrentCalls = positiveIntSetting configuration MaxConcurrentCallsEnvironmentVariable 4
-                    PrefetchCount = positiveIntSetting configuration PrefetchCountEnvironmentVariable 16
+                    PrefetchCount = nonNegativeIntSetting configuration PrefetchCountEnvironmentVariable 0
                 }
 
 /// Handles one usage fact message through validation, SQL persistence, and explicit Service Bus settlement.
@@ -522,8 +539,11 @@ type OperationsUsageIngestionProcessor
     let describeErrors (errors: string list) = String.Join("; ", errors)
 
     /// Dead-letters an invalid usage message with deterministic reason metadata.
-    let deadLetterAsync reason description (actions: IOperationsUsageMessageActions) cancellationToken =
-        actions.DeadLetterAsync(reason, description, cancellationToken)
+    let deadLetterAsync readinessAttempt reason description (actions: IOperationsUsageMessageActions) cancellationToken =
+        task {
+            do! actions.DeadLetterAsync(reason, description, cancellationToken)
+            OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt
+        }
 
     /// Configures lightweight schema pre-parsing to match Grace's shared JSON reader leniency.
     let usageFactSchemaDocumentOptions =
@@ -580,7 +600,7 @@ type OperationsUsageIngestionProcessor
     let unsupportedSchemaDescription schemaVersion = $"UsageFact SchemaVersion '{schemaVersion}' is not supported. Expected '{UsageFactSchemaVersion}'."
 
     /// Records unsupported schema readiness and dead-letters without exposing the message body.
-    let deadLetterUnsupportedSchemaAsync schemaVersion (message: OperationsUsageMessage) actions cancellationToken =
+    let deadLetterUnsupportedSchemaAsync readinessAttempt schemaVersion (message: OperationsUsageMessage) actions cancellationToken =
         let description = unsupportedSchemaDescription schemaVersion
 
         readiness.MarkUnsupportedContract(description)
@@ -594,7 +614,7 @@ type OperationsUsageIngestionProcessor
             UsageFactSchemaVersion
         )
 
-        deadLetterAsync "UnsupportedUsageFactSchema" description actions cancellationToken
+        deadLetterAsync readinessAttempt "UnsupportedUsageFactSchema" description actions cancellationToken
 
     /// Builds a processor with an isolated readiness state for tests that only inspect settlement behavior.
     new(store, logger) = OperationsUsageIngestionProcessor(store, logger, OperationsUsageReadinessState() :> IOperationsUsageReadinessRecorder)
@@ -626,6 +646,7 @@ type OperationsUsageIngestionProcessor
 
                     do!
                         deadLetterAsync
+                            readinessAttempt
                             "UnsupportedOperationalFactEnvelope"
                             "Message subject or graceMessageType is not supported by the operations usage worker."
                             actions
@@ -633,7 +654,7 @@ type OperationsUsageIngestionProcessor
                 else
                     match tryReadUsageFactSchemaVersion message.Body with
                     | Some schemaVersion when schemaVersion <> UsageFactSchemaVersion ->
-                        do! deadLetterUnsupportedSchemaAsync schemaVersion message actions cancellationToken
+                        do! deadLetterUnsupportedSchemaAsync readinessAttempt schemaVersion message actions cancellationToken
                     | _ ->
                         let usageFact = deserializeUsageFact message.Body
 
@@ -648,9 +669,9 @@ type OperationsUsageIngestionProcessor
                                 describeErrors errors
                             )
 
-                            do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                            do! deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
                         elif usageFact.SchemaVersion <> UsageFactSchemaVersion then
-                            do! deadLetterUnsupportedSchemaAsync usageFact.SchemaVersion message actions cancellationToken
+                            do! deadLetterUnsupportedSchemaAsync readinessAttempt usageFact.SchemaVersion message actions cancellationToken
                         else
                             match UsageFact.Validate usageFact with
                             | Error errors ->
@@ -662,7 +683,7 @@ type OperationsUsageIngestionProcessor
                                     describeErrors errors
                                 )
 
-                                do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                do! deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
                             | Ok () ->
                                 let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
 
@@ -676,7 +697,7 @@ type OperationsUsageIngestionProcessor
                                         describeErrors errors
                                     )
 
-                                    do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                    do! deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
                                 | Ok result ->
                                     logger.LogInformation(
                                         "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
@@ -691,6 +712,7 @@ type OperationsUsageIngestionProcessor
 
                                     readiness.MarkRuntimeProcessingSuccess(readinessAttempt)
                                     do! actions.CompleteAsync cancellationToken
+                                    OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                 logger.LogWarning(
@@ -708,7 +730,7 @@ type OperationsUsageIngestionProcessor
                     message.DeliveryCount
                 )
 
-                do! deadLetterAsync "MalformedUsageFactJson" "UsageFact JSON could not be deserialized." actions cancellationToken
+                do! deadLetterAsync readinessAttempt "MalformedUsageFactJson" "UsageFact JSON could not be deserialized." actions cancellationToken
             | ex ->
                 OperationsUsageReadinessTransitions.recordRuntimeProcessingFailure readiness ex
 
@@ -721,6 +743,7 @@ type OperationsUsageIngestionProcessor
                 )
 
                 do! actions.AbandonAsync cancellationToken
+                OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt
         }
 
 /// Adapts Azure Service Bus message settlement to the worker's fakeable action interface.
@@ -754,6 +777,21 @@ module internal OperationsUsageServiceBusMessage =
             ApplicationProperties = message.ApplicationProperties
             Body = message.Body.ToArray()
         }
+
+    /// Handles a delivered Azure Service Bus message after the processor proves receive-side delivery.
+    let processReceivedMessageAsync
+        (readiness: IOperationsUsageReadinessRecorder)
+        (processor: OperationsUsageIngestionProcessor)
+        canProveReceiveRecovery
+        (message: ServiceBusReceivedMessage)
+        (actions: IOperationsUsageMessageActions)
+        cancellationToken
+        =
+        if canProveReceiveRecovery then
+            let receiveAttempt = readiness.BeginProcessingAttempt()
+            OperationsUsageReadinessTransitions.recordServiceBusReceiveSuccess readiness receiveAttempt
+
+        processor.ProcessMessageAsync(fromReceivedMessage message, actions, cancellationToken)
 
 /// Runs the operational fact Service Bus processor for the Grace operations worker process.
 type OperationsUsageWorkerService
@@ -820,9 +858,15 @@ type OperationsUsageWorkerService
 
                         azureProcessor.add_ProcessMessageAsync (
                             Func<ProcessMessageEventArgs, Task> (fun args ->
-                                let message = OperationsUsageServiceBusMessage.fromReceivedMessage args.Message
                                 let actions = ServiceBusOperationsUsageMessageActions args
-                                processor.ProcessMessageAsync(message, actions, args.CancellationToken))
+
+                                OperationsUsageServiceBusMessage.processReceivedMessageAsync
+                                    readiness
+                                    processor
+                                    (settings.PrefetchCount = 0)
+                                    args.Message
+                                    actions
+                                    args.CancellationToken)
                         )
 
                         azureProcessor.add_ProcessErrorAsync (

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -576,8 +576,8 @@ type OperationsUsageIngestionProcessor
                                         |> Option.defaultValue Instant.MinValue
                                     )
 
-                                    do! actions.CompleteAsync cancellationToken
                                     readiness.MarkReady()
+                                    do! actions.CompleteAsync cancellationToken
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                 logger.LogWarning(

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -190,6 +190,50 @@ type OperationsUsageReadinessHealthCheck(readiness: IOperationsUsageReadinessPro
 
             Task.FromResult result
 
+/// Publishes the Operations ingestion readiness check through worker-host health publishing.
+type OperationsUsageReadinessHealthCheckPublisher(logger: ILogger<OperationsUsageReadinessHealthCheckPublisher>) =
+
+    /// Reads one redacted health-check data field for structured publishing.
+    let tryReadDataField name (data: IReadOnlyDictionary<string, obj>) =
+        match data.TryGetValue name with
+        | true, value when not (isNull value) -> Some(string value)
+        | _ -> None
+
+    interface IHealthCheckPublisher with
+
+        /// Logs the readiness health-check result so worker hosts expose readiness without HTTP endpoints.
+        member _.PublishAsync(report, cancellationToken) =
+            cancellationToken.ThrowIfCancellationRequested()
+
+            match report.Entries.TryGetValue "operations-usage-ingestion" with
+            | true, entry ->
+                let supportedSchemaVersion =
+                    tryReadDataField "supportedUsageFactSchemaVersion" entry.Data
+                    |> Option.defaultValue "<unknown>"
+
+                let dependencyFailure =
+                    tryReadDataField "dependencyFailure" entry.Data
+                    |> Option.defaultValue "<none>"
+
+                let lastUnsupportedContract =
+                    tryReadDataField "lastUnsupportedContract" entry.Data
+                    |> Option.defaultValue "<none>"
+
+                logger.LogInformation(
+                    "Operations usage readiness published. Status: {HealthStatus}; SupportedUsageFactSchemaVersion: {SupportedUsageFactSchemaVersion}; DependencyFailure: {DependencyFailure}; LastUnsupportedContract: {LastUnsupportedContract}.",
+                    entry.Status,
+                    supportedSchemaVersion,
+                    dependencyFailure,
+                    lastUnsupportedContract
+                )
+            | false, _ ->
+                logger.LogWarning(
+                    "Operations usage readiness health check was not present in the published worker health report. OverallStatus: {HealthStatus}.",
+                    report.Status
+                )
+
+            Task.CompletedTask
+
 /// Reads Service Bus settings required by the operational usage ingestion worker.
 type OperationsWorkerSettings =
     {
@@ -358,10 +402,59 @@ type OperationsUsageIngestionProcessor
     let deadLetterAsync reason description (actions: IOperationsUsageMessageActions) cancellationToken =
         actions.DeadLetterAsync(reason, description, cancellationToken)
 
+    /// Reads the schema version before binding the body to the v1 UsageFact enum contract.
+    let tryReadUsageFactSchemaVersion (body: byte array) =
+        use document = JsonDocument.Parse(ReadOnlyMemory<byte>(body))
+        let root = document.RootElement
+
+        let tryGetProperty (name: string) =
+            let mutable property = Unchecked.defaultof<JsonElement>
+
+            if
+                root.ValueKind = JsonValueKind.Object
+                && root.TryGetProperty(name, &property)
+            then
+                Some property
+            else
+                None
+
+        match tryGetProperty "schemaVersion"
+              |> Option.orElseWith (fun () -> tryGetProperty "SchemaVersion")
+            with
+        | Some property when property.ValueKind = JsonValueKind.Number ->
+            match property.TryGetInt32() with
+            | true, value -> Some value
+            | false, _ -> None
+        | Some property when property.ValueKind = JsonValueKind.String ->
+            match Int32.TryParse(property.GetString()) with
+            | true, value -> Some value
+            | false, _ -> None
+        | _ -> None
+
     /// Deserializes a usage fact using the shared Grace JSON contract options.
     let deserializeUsageFact (body: byte array) =
         use stream = new MemoryStream(body)
         JsonSerializer.Deserialize<UsageFact>(stream, Constants.JsonSerializerOptions)
+
+    /// Builds the deterministic unsupported-schema description used for settlement and readiness.
+    let unsupportedSchemaDescription schemaVersion = $"UsageFact SchemaVersion '{schemaVersion}' is not supported. Expected '{UsageFactSchemaVersion}'."
+
+    /// Records unsupported schema readiness and dead-letters without exposing the message body.
+    let deadLetterUnsupportedSchemaAsync schemaVersion (message: OperationsUsageMessage) actions cancellationToken =
+        let description = unsupportedSchemaDescription schemaVersion
+
+        readiness.MarkUnsupportedContract(description)
+
+        logger.LogWarning(
+            "Dead-lettering unsupported UsageFact schema. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; SchemaVersion: {SchemaVersion}; SupportedSchemaVersion: {SupportedSchemaVersion}.",
+            message.MessageId,
+            message.CorrelationId,
+            message.DeliveryCount,
+            schemaVersion,
+            UsageFactSchemaVersion
+        )
+
+        deadLetterAsync "UnsupportedUsageFactSchema" description actions cancellationToken
 
     /// Builds a processor with an isolated readiness state for tests that only inspect settlement behavior.
     new(store, logger) = OperationsUsageIngestionProcessor(store, logger, OperationsUsageReadinessState() :> IOperationsUsageReadinessRecorder)
@@ -396,38 +489,15 @@ type OperationsUsageIngestionProcessor
                             actions
                             cancellationToken
                 else
-                    let usageFact = deserializeUsageFact message.Body
+                    match tryReadUsageFactSchemaVersion message.Body with
+                    | Some schemaVersion when schemaVersion <> UsageFactSchemaVersion ->
+                        do! deadLetterUnsupportedSchemaAsync schemaVersion message actions cancellationToken
+                    | _ ->
+                        let usageFact = deserializeUsageFact message.Body
 
-                    if isNull (box usageFact) then
-                        let errors = [ "UsageFact is required." ]
+                        if isNull (box usageFact) then
+                            let errors = [ "UsageFact is required." ]
 
-                        logger.LogWarning(
-                            "Dead-lettering invalid UsageFact. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
-                            message.MessageId,
-                            message.CorrelationId,
-                            message.DeliveryCount,
-                            describeErrors errors
-                        )
-
-                        do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
-                    elif usageFact.SchemaVersion <> UsageFactSchemaVersion then
-                        let description = $"UsageFact SchemaVersion '{usageFact.SchemaVersion}' is not supported. Expected '{UsageFactSchemaVersion}'."
-
-                        readiness.MarkUnsupportedContract(description)
-
-                        logger.LogWarning(
-                            "Dead-lettering unsupported UsageFact schema. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; SchemaVersion: {SchemaVersion}; SupportedSchemaVersion: {SupportedSchemaVersion}.",
-                            message.MessageId,
-                            message.CorrelationId,
-                            message.DeliveryCount,
-                            usageFact.SchemaVersion,
-                            UsageFactSchemaVersion
-                        )
-
-                        do! deadLetterAsync "UnsupportedUsageFactSchema" description actions cancellationToken
-                    else
-                        match UsageFact.Validate usageFact with
-                        | Error errors ->
                             logger.LogWarning(
                                 "Dead-lettering invalid UsageFact. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
                                 message.MessageId,
@@ -437,33 +507,47 @@ type OperationsUsageIngestionProcessor
                             )
 
                             do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
-                        | Ok () ->
-                            let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
-
-                            match stored with
+                        elif usageFact.SchemaVersion <> UsageFactSchemaVersion then
+                            do! deadLetterUnsupportedSchemaAsync usageFact.SchemaVersion message actions cancellationToken
+                        else
+                            match UsageFact.Validate usageFact with
                             | Error errors ->
                                 logger.LogWarning(
-                                    "Dead-lettering UsageFact rejected by operations storage validation. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
-                                    usageFact.UsageFactId,
-                                    usageFact.CorrelationId,
+                                    "Dead-lettering invalid UsageFact. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
+                                    message.MessageId,
+                                    message.CorrelationId,
                                     message.DeliveryCount,
                                     describeErrors errors
                                 )
 
                                 do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
-                            | Ok result ->
-                                logger.LogInformation(
-                                    "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
-                                    result.UsageFactId,
-                                    usageFact.CorrelationId,
-                                    message.DeliveryCount,
-                                    result.Status,
-                                    result.Aggregate
-                                    |> Option.map (fun aggregate -> aggregate.Key.BucketStart)
-                                    |> Option.defaultValue Instant.MinValue
-                                )
+                            | Ok () ->
+                                let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
 
-                                do! actions.CompleteAsync cancellationToken
+                                match stored with
+                                | Error errors ->
+                                    logger.LogWarning(
+                                        "Dead-lettering UsageFact rejected by operations storage validation. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
+                                        usageFact.UsageFactId,
+                                        usageFact.CorrelationId,
+                                        message.DeliveryCount,
+                                        describeErrors errors
+                                    )
+
+                                    do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                | Ok result ->
+                                    logger.LogInformation(
+                                        "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
+                                        result.UsageFactId,
+                                        usageFact.CorrelationId,
+                                        message.DeliveryCount,
+                                        result.Status,
+                                        result.Aggregate
+                                        |> Option.map (fun aggregate -> aggregate.Key.BucketStart)
+                                        |> Option.defaultValue Instant.MinValue
+                                    )
+
+                                    do! actions.CompleteAsync cancellationToken
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                 logger.LogWarning(

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -153,6 +153,18 @@ type OperationsUsageReadinessState() =
 
         member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
 
+/// Records runtime readiness transitions that must stay visible through the shared health-check state.
+[<RequireQualifiedAccess>]
+module internal OperationsUsageReadinessTransitions =
+
+    /// Records a redacted Service Bus processor fault observed after startup.
+    let recordServiceBusProcessorFault (readiness: IOperationsUsageReadinessRecorder) (errorSource: ServiceBusErrorSource) (ex: exn) =
+        readiness.MarkDependencyFailure($"Service Bus processor fault ({errorSource}, {ex.GetType().Name}).")
+
+    /// Records a redacted runtime processing dependency failure that should recover after a later successful message.
+    let recordRuntimeProcessingFailure (readiness: IOperationsUsageReadinessRecorder) (ex: exn) =
+        readiness.MarkDependencyFailure($"Runtime processing dependency failed ({ex.GetType().Name}).")
+
 /// Adapts Operations ingestion readiness to the standard .NET health-check surface.
 type OperationsUsageReadinessHealthCheck(readiness: IOperationsUsageReadinessProbe) =
 
@@ -565,6 +577,7 @@ type OperationsUsageIngestionProcessor
                                     )
 
                                     do! actions.CompleteAsync cancellationToken
+                                    readiness.MarkReady()
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                 logger.LogWarning(
@@ -584,6 +597,8 @@ type OperationsUsageIngestionProcessor
 
                 do! deadLetterAsync "MalformedUsageFactJson" "UsageFact JSON could not be deserialized." actions cancellationToken
             | ex ->
+                OperationsUsageReadinessTransitions.recordRuntimeProcessingFailure readiness ex
+
                 logger.LogError(
                     ex,
                     "Abandoning operational UsageFact message after transient processing failure. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}.",
@@ -699,6 +714,8 @@ type OperationsUsageWorkerService
 
                         azureProcessor.add_ProcessErrorAsync (
                             Func<ProcessErrorEventArgs, Task> (fun args ->
+                                OperationsUsageReadinessTransitions.recordServiceBusProcessorFault readiness args.ErrorSource args.Exception
+
                                 logger.LogError(
                                     args.Exception,
                                     "Operations usage Service Bus processor fault. ErrorSource: {ErrorSource}; EntityPath: {EntityPath}; FullyQualifiedNamespace: {FullyQualifiedNamespace}.",

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -402,9 +402,17 @@ type OperationsUsageIngestionProcessor
     let deadLetterAsync reason description (actions: IOperationsUsageMessageActions) cancellationToken =
         actions.DeadLetterAsync(reason, description, cancellationToken)
 
+    /// Configures lightweight schema pre-parsing to match Grace's shared JSON reader leniency.
+    let usageFactSchemaDocumentOptions =
+        JsonDocumentOptions(
+            AllowTrailingCommas = Constants.JsonSerializerOptions.AllowTrailingCommas,
+            CommentHandling = Constants.JsonSerializerOptions.ReadCommentHandling,
+            MaxDepth = Constants.JsonSerializerOptions.MaxDepth
+        )
+
     /// Reads the schema version before binding the body to the v1 UsageFact enum contract.
     let tryReadUsageFactSchemaVersion (body: byte array) =
-        use document = JsonDocument.Parse(ReadOnlyMemory<byte>(body))
+        use document = JsonDocument.Parse(ReadOnlyMemory<byte>(body), usageFactSchemaDocumentOptions)
         let root = document.RootElement
 
         let tryGetProperty (name: string) =
@@ -418,8 +426,17 @@ type OperationsUsageIngestionProcessor
             else
                 None
 
+        let tryGetPropertyCaseInsensitive (name: string) =
+            if root.ValueKind = JsonValueKind.Object then
+                root.EnumerateObject()
+                |> Seq.tryFind (fun property -> String.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                |> Option.map (fun property -> property.Value)
+            else
+                None
+
         match tryGetProperty "schemaVersion"
               |> Option.orElseWith (fun () -> tryGetProperty "SchemaVersion")
+              |> Option.orElseWith (fun () -> tryGetPropertyCaseInsensitive "schemaVersion")
             with
         | Some property when property.ValueKind = JsonValueKind.Number ->
             match property.TryGetInt32() with

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -124,6 +124,9 @@ type internal OperationsUsageReadinessFailure =
         RecoveryKey: string option
     }
 
+/// Identifies one independently recoverable readiness failure within a dependency surface.
+type internal OperationsUsageReadinessFailureKey = { Source: OperationsUsageReadinessFailureSource; RecoveryKey: string option }
+
 /// Captures the current readiness ordering point for one in-flight message.
 type OperationsUsageReadinessAttempt = { FailureVersion: int64 }
 
@@ -172,16 +175,19 @@ type OperationsUsageReadinessState() =
 
     let mutable failureVersion = 0L
 
-    let dependencyFailures = Dictionary<OperationsUsageReadinessFailureSource, OperationsUsageReadinessFailure>()
+    let dependencyFailures = Dictionary<OperationsUsageReadinessFailureKey, OperationsUsageReadinessFailure>()
+
+    let failureKey source recoveryKey = { Source = source; RecoveryKey = recoveryKey }
 
     do
-        dependencyFailures[OperationsUsageReadinessFailureSource.StartupDependency] <- {
-                                                                                           Source = OperationsUsageReadinessFailureSource.StartupDependency
-                                                                                           Description =
-                                                                                               "Operations usage worker has not completed dependency startup."
-                                                                                           Version = failureVersion
-                                                                                           RecoveryKey = None
-                                                                                       }
+        let startupKey = failureKey OperationsUsageReadinessFailureSource.StartupDependency None
+
+        dependencyFailures[startupKey] <- {
+                                              Source = OperationsUsageReadinessFailureSource.StartupDependency
+                                              Description = "Operations usage worker has not completed dependency startup."
+                                              Version = failureVersion
+                                              RecoveryKey = None
+                                          }
 
     let mutable lastUnsupportedContract: string option = None
 
@@ -196,7 +202,10 @@ type OperationsUsageReadinessState() =
             None
         else
             dependencyFailures.Values
-            |> Seq.sortBy (fun failure -> int failure.Source)
+            |> Seq.sortBy (fun failure ->
+                int failure.Source,
+                failure.RecoveryKey
+                |> Option.defaultValue String.Empty)
             |> Seq.map (fun failure -> failure.Description)
             |> fun descriptions -> String.Join("; ", descriptions)
             |> Some
@@ -204,22 +213,25 @@ type OperationsUsageReadinessState() =
     let recordFailure source description recoveryKey =
         failureVersion <- failureVersion + 1L
 
-        dependencyFailures[source] <- { Source = source; Description = description; Version = failureVersion; RecoveryKey = recoveryKey }
+        dependencyFailures[failureKey source recoveryKey] <- { Source = source; Description = description; Version = failureVersion; RecoveryKey = recoveryKey }
 
-    let clearFailure source = dependencyFailures.Remove source |> ignore
+    let clearFailure source recoveryKey =
+        dependencyFailures.Remove(failureKey source recoveryKey)
+        |> ignore
 
     let clearFailureWhenFresh source attempt =
-        match dependencyFailures.TryGetValue source with
-        | true, failure when failure.Version <= attempt.FailureVersion -> clearFailure source
+        let key = failureKey source None
+
+        match dependencyFailures.TryGetValue key with
+        | true, failure when failure.Version <= attempt.FailureVersion -> clearFailure source None
         | _ -> ()
 
     let clearServiceBusProcessorFailureWhenFresh attempt recoveryKey =
-        match dependencyFailures.TryGetValue OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime with
-        | true, failure when
-            failure.Version <= attempt.FailureVersion
-            && failure.RecoveryKey = Some recoveryKey
-            ->
-            clearFailure OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime
+        let key = failureKey OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime (Some recoveryKey)
+
+        match dependencyFailures.TryGetValue key with
+        | true, failure when failure.Version <= attempt.FailureVersion ->
+            clearFailure OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime (Some recoveryKey)
         | _ -> ()
 
     let snapshot () =
@@ -237,7 +249,7 @@ type OperationsUsageReadinessState() =
 
     interface IOperationsUsageReadinessRecorder with
 
-        member _.MarkReady() = lock gate (fun () -> clearFailure OperationsUsageReadinessFailureSource.StartupDependency)
+        member _.MarkReady() = lock gate (fun () -> clearFailure OperationsUsageReadinessFailureSource.StartupDependency None)
 
         member _.BeginProcessingAttempt() = lock gate (fun () -> { FailureVersion = failureVersion })
 
@@ -279,6 +291,10 @@ module internal OperationsUsageReadinessTransitions =
     [<Literal>]
     let DeadLetterSettlementRecoveryKey = "dead-letter"
 
+    /// Identifies lock-renewal failures that require renewal-side recovery proof instead of ordinary message completion.
+    [<Literal>]
+    let RenewLockRecoveryKey = "renew-lock"
+
     /// Identifies processor sources where a later receive proves broker receive/session-link recovery.
     let private isReceiveRecoverySource errorSource =
         match errorSource with
@@ -295,9 +311,9 @@ module internal OperationsUsageReadinessTransitions =
     let private serviceBusProcessorRecoveryKey errorSource =
         match errorSource with
         | ServiceBusErrorSource.Complete
-        | ServiceBusErrorSource.ProcessMessageCallback
-        | ServiceBusErrorSource.RenewLock -> Some CompleteSettlementRecoveryKey
+        | ServiceBusErrorSource.ProcessMessageCallback -> Some CompleteSettlementRecoveryKey
         | ServiceBusErrorSource.Abandon -> Some AbandonSettlementRecoveryKey
+        | ServiceBusErrorSource.RenewLock -> Some RenewLockRecoveryKey
         | _ -> None
 
     /// Records a redacted Service Bus processor fault observed after startup.

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -163,7 +163,7 @@ type IOperationsUsageReadinessRecorder =
     /// Clears runtime-owned processing failures only when this success started after that failure.
     abstract MarkRuntimeProcessingSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
-    /// Clears Service Bus processor-owned settlement failures only after the same settlement path succeeds later.
+    /// Clears one Service Bus processor-owned failure after the matching processor proof succeeds later.
     abstract MarkServiceBusProcessorSuccess: attempt: OperationsUsageReadinessAttempt * recoveryKey: string -> unit
 
     /// Records the latest unsupported ingestion contract observed at the broker boundary.
@@ -291,6 +291,10 @@ module internal OperationsUsageReadinessTransitions =
     [<Literal>]
     let DeadLetterSettlementRecoveryKey = "dead-letter"
 
+    /// Identifies callback invocation failures that recover after any later explicit settlement succeeds.
+    [<Literal>]
+    let CallbackRuntimeRecoveryKey = "callback"
+
     /// Identifies lock-renewal failures that require renewal-side recovery proof instead of ordinary message completion.
     [<Literal>]
     let RenewLockRecoveryKey = "renew-lock"
@@ -310,8 +314,8 @@ module internal OperationsUsageReadinessTransitions =
     /// Maps Azure Service Bus error sources to the concrete settlement proof that may recover them later.
     let private serviceBusProcessorRecoveryKey errorSource =
         match errorSource with
-        | ServiceBusErrorSource.Complete
-        | ServiceBusErrorSource.ProcessMessageCallback -> Some CompleteSettlementRecoveryKey
+        | ServiceBusErrorSource.Complete -> Some CompleteSettlementRecoveryKey
+        | ServiceBusErrorSource.ProcessMessageCallback -> Some CallbackRuntimeRecoveryKey
         | ServiceBusErrorSource.Abandon -> Some AbandonSettlementRecoveryKey
         | ServiceBusErrorSource.RenewLock -> Some RenewLockRecoveryKey
         | _ -> None
@@ -337,6 +341,10 @@ module internal OperationsUsageReadinessTransitions =
     /// Records a later settlement-side proof that a Service Bus processor settlement fault recovered.
     let recordServiceBusProcessorSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) recoveryKey =
         readiness.MarkServiceBusProcessorSuccess(attempt, recoveryKey)
+
+    /// Records that a later callback reached explicit settlement, proving callback invocation recovered.
+    let recordServiceBusCallbackSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =
+        readiness.MarkServiceBusProcessorSuccess(attempt, CallbackRuntimeRecoveryKey)
 
     /// Records a redacted runtime processing dependency failure that should recover after a later successful message.
     let recordRuntimeProcessingFailure (readiness: IOperationsUsageReadinessRecorder) (ex: exn) =
@@ -613,12 +621,13 @@ type OperationsUsageIngestionProcessor
     /// Builds a bounded diagnostic description without including the message body.
     let describeErrors (errors: string list) = String.Join("; ", errors)
 
-    /// Runs one explicit Service Bus settlement call and records only matching settlement recovery proof.
+    /// Runs one explicit Service Bus settlement call and records matching settlement and callback recovery proofs.
     let settleAsync readinessAttempt recoveryKey settlementName (settle: unit -> Task) (cancellationToken: CancellationToken) =
         task {
             try
                 do! settle ()
                 OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt recoveryKey
+                OperationsUsageReadinessTransitions.recordServiceBusCallbackSuccess readiness readinessAttempt
                 return true
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> return false

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -151,7 +151,7 @@ type IOperationsUsageReadinessRecorder =
     /// Clears a Service Bus receive or link failure only when a later received message proves the link recovered.
     abstract MarkServiceBusReceiveSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
-    /// Clears a runtime storage or processing failure only when this success started after that failure.
+    /// Clears runtime-owned processing failures only when this success started after that failure.
     abstract MarkRuntimeProcessingSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
     /// Records the latest unsupported ingestion contract observed at the broker boundary.
@@ -237,7 +237,9 @@ type OperationsUsageReadinessState() =
             lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusReceiveLink attempt)
 
         member _.MarkRuntimeProcessingSuccess(attempt) =
-            lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.RuntimeProcessingDependency attempt)
+            lock gate (fun () ->
+                clearFailureWhenFresh OperationsUsageReadinessFailureSource.RuntimeProcessingDependency attempt
+                clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime attempt)
 
         member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
 
@@ -601,7 +603,6 @@ type OperationsUsageIngestionProcessor
     member _.ProcessMessageAsync(message: OperationsUsageMessage, actions: IOperationsUsageMessageActions, cancellationToken: CancellationToken) =
         task {
             let readinessAttempt = readiness.BeginProcessingAttempt()
-            OperationsUsageReadinessTransitions.recordServiceBusReceiveSuccess readiness readinessAttempt
 
             try
                 cancellationToken.ThrowIfCancellationRequested()

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -110,7 +110,13 @@ type internal OperationsUsageReadinessFailureSource =
     | RuntimeProcessingDependency = 2
 
     /// Service Bus receive/link failures are cleared only by receive-side recovery proof.
-    | ServiceBusProcessor = 3
+    | ServiceBusReceiveLink = 3
+
+    /// Service Bus processor callback, settlement, or lock failures remain visible until their owner proves recovery.
+    | ServiceBusProcessorRuntime = 4
+
+/// Tracks one active readiness failure and the ordering point needed for source-owned recovery.
+type internal OperationsUsageReadinessFailure = { Source: OperationsUsageReadinessFailureSource; Description: string; Version: int64 }
 
 /// Captures the current readiness ordering point for one in-flight message.
 type OperationsUsageReadinessAttempt = { FailureVersion: int64 }
@@ -136,7 +142,10 @@ type IOperationsUsageReadinessRecorder =
     /// Records a redacted runtime storage or processing failure that prevents the worker from being ready.
     abstract MarkRuntimeProcessingFailure: description: string -> unit
 
-    /// Records a redacted Service Bus receive or link failure that prevents the worker from being ready.
+    /// Records a redacted Service Bus receive or session-link failure that prevents the worker from being ready.
+    abstract MarkServiceBusReceiveFailure: description: string -> unit
+
+    /// Records a redacted Service Bus callback, settlement, or lock failure that prevents the worker from being ready.
     abstract MarkServiceBusProcessorFailure: description: string -> unit
 
     /// Clears a Service Bus receive or link failure only when a later received message proves the link recovered.
@@ -153,32 +162,53 @@ type OperationsUsageReadinessState() =
     let gate = obj ()
 
     let mutable failureVersion = 0L
-    let mutable status = OperationsUsageReadinessStatus.NotReady
 
-    let mutable dependencyFailure =
-        Some
-            {|
-                Source = OperationsUsageReadinessFailureSource.StartupDependency
-                Description = "Operations usage worker has not completed dependency startup."
-                Version = failureVersion
-            |}
+    let dependencyFailures = Dictionary<OperationsUsageReadinessFailureSource, OperationsUsageReadinessFailure>()
+
+    do
+        dependencyFailures[OperationsUsageReadinessFailureSource.StartupDependency] <- {
+                                                                                           Source = OperationsUsageReadinessFailureSource.StartupDependency
+                                                                                           Description =
+                                                                                               "Operations usage worker has not completed dependency startup."
+                                                                                           Version = failureVersion
+                                                                                       }
 
     let mutable lastUnsupportedContract: string option = None
 
+    let readinessStatus () =
+        if dependencyFailures.Count = 0 then
+            OperationsUsageReadinessStatus.Ready
+        else
+            OperationsUsageReadinessStatus.NotReady
+
+    let dependencyFailureDescription () =
+        if dependencyFailures.Count = 0 then
+            None
+        else
+            dependencyFailures.Values
+            |> Seq.sortBy (fun failure -> int failure.Source)
+            |> Seq.map (fun failure -> failure.Description)
+            |> fun descriptions -> String.Join("; ", descriptions)
+            |> Some
+
     let recordFailure source description =
         failureVersion <- failureVersion + 1L
-        status <- OperationsUsageReadinessStatus.NotReady
 
-        dependencyFailure <- Some {| Source = source; Description = description; Version = failureVersion |}
+        dependencyFailures[source] <- { Source = source; Description = description; Version = failureVersion }
+
+    let clearFailure source = dependencyFailures.Remove source |> ignore
+
+    let clearFailureWhenFresh source attempt =
+        match dependencyFailures.TryGetValue source with
+        | true, failure when failure.Version <= attempt.FailureVersion -> clearFailure source
+        | _ -> ()
 
     let snapshot () =
         lock gate (fun () ->
             {
-                Status = status
+                Status = readinessStatus ()
                 SupportedUsageFactSchemaVersion = UsageFactSchemaVersion
-                DependencyFailure =
-                    dependencyFailure
-                    |> Option.map (fun failure -> failure.Description)
+                DependencyFailure = dependencyFailureDescription ()
                 LastUnsupportedContract = lastUnsupportedContract
             })
 
@@ -188,10 +218,7 @@ type OperationsUsageReadinessState() =
 
     interface IOperationsUsageReadinessRecorder with
 
-        member _.MarkReady() =
-            lock gate (fun () ->
-                status <- OperationsUsageReadinessStatus.Ready
-                dependencyFailure <- None)
+        member _.MarkReady() = lock gate (fun () -> clearFailure OperationsUsageReadinessFailureSource.StartupDependency)
 
         member _.BeginProcessingAttempt() = lock gate (fun () -> { FailureVersion = failureVersion })
 
@@ -200,32 +227,17 @@ type OperationsUsageReadinessState() =
         member _.MarkRuntimeProcessingFailure(description) =
             lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.RuntimeProcessingDependency description)
 
+        member _.MarkServiceBusReceiveFailure(description) =
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusReceiveLink description)
+
         member _.MarkServiceBusProcessorFailure(description) =
-            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusProcessor description)
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime description)
 
         member _.MarkServiceBusReceiveSuccess(attempt) =
-            lock gate (fun () ->
-                match dependencyFailure with
-                | Some failure when
-                    failure.Source = OperationsUsageReadinessFailureSource.ServiceBusProcessor
-                    && failure.Version <= attempt.FailureVersion
-                    ->
-                    status <- OperationsUsageReadinessStatus.Ready
-                    dependencyFailure <- None
-                | None -> status <- OperationsUsageReadinessStatus.Ready
-                | Some _ -> ())
+            lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusReceiveLink attempt)
 
         member _.MarkRuntimeProcessingSuccess(attempt) =
-            lock gate (fun () ->
-                match dependencyFailure with
-                | Some failure when
-                    failure.Source = OperationsUsageReadinessFailureSource.RuntimeProcessingDependency
-                    && failure.Version <= attempt.FailureVersion
-                    ->
-                    status <- OperationsUsageReadinessStatus.Ready
-                    dependencyFailure <- None
-                | None -> status <- OperationsUsageReadinessStatus.Ready
-                | Some _ -> ())
+            lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.RuntimeProcessingDependency attempt)
 
         member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
 
@@ -233,9 +245,26 @@ type OperationsUsageReadinessState() =
 [<RequireQualifiedAccess>]
 module internal OperationsUsageReadinessTransitions =
 
+    /// Identifies processor sources where a later receive proves broker receive/session-link recovery.
+    let private isReceiveRecoverySource errorSource =
+        match errorSource with
+        | ServiceBusErrorSource.Receive
+        | ServiceBusErrorSource.AcceptSession
+        | ServiceBusErrorSource.CloseSession -> true
+        | ServiceBusErrorSource.Complete
+        | ServiceBusErrorSource.Abandon
+        | ServiceBusErrorSource.ProcessMessageCallback
+        | ServiceBusErrorSource.RenewLock -> false
+        | _ -> false
+
     /// Records a redacted Service Bus processor fault observed after startup.
     let recordServiceBusProcessorFault (readiness: IOperationsUsageReadinessRecorder) (errorSource: ServiceBusErrorSource) (ex: exn) =
-        readiness.MarkServiceBusProcessorFailure($"Service Bus processor fault ({errorSource}, {ex.GetType().Name}).")
+        let description = $"Service Bus processor fault ({errorSource}, {ex.GetType().Name})."
+
+        if isReceiveRecoverySource errorSource then
+            readiness.MarkServiceBusReceiveFailure(description)
+        else
+            readiness.MarkServiceBusProcessorFailure(description)
 
     /// Records a later receive-side proof that a Service Bus processor receive or link fault recovered.
     let recordServiceBusReceiveSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -9,6 +9,7 @@ open Grace.Shared.Utilities
 open Grace.Types.Usage
 open Microsoft.Data.SqlClient
 open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Diagnostics.HealthChecks
 open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 open NodaTime
@@ -80,6 +81,114 @@ type OperationsUsageFactStoreAdapter(store: OperationsUsageStore) =
     interface IOperationsUsageFactStore with
 
         member _.StoreUsageFactAsync(fact, cancellationToken) = store.StoreUsageFactAsync(fact, cancellationToken)
+
+/// Reports whether the operations usage worker is ready to consume durable ingestion messages.
+type OperationsUsageReadinessStatus =
+
+    /// Indicates the worker has started its ingestion dependencies successfully.
+    | Ready = 1
+
+    /// Indicates the worker has not yet proven that ingestion dependencies are available.
+    | NotReady = 2
+
+/// Describes the current ingestion readiness state without exposing secrets or message payloads.
+type OperationsUsageReadinessSnapshot =
+    {
+        Status: OperationsUsageReadinessStatus
+        SupportedUsageFactSchemaVersion: int
+        DependencyFailure: string option
+        LastUnsupportedContract: string option
+    }
+
+/// Exposes a snapshot of the Operations ingestion readiness state.
+type IOperationsUsageReadinessProbe =
+
+    /// Returns the latest readiness state recorded by the worker process.
+    abstract GetSnapshot: unit -> OperationsUsageReadinessSnapshot
+
+/// Records readiness signals from dependency startup and message contract classification.
+type IOperationsUsageReadinessRecorder =
+
+    /// Marks ingestion dependencies as ready after SQL initialization and Service Bus processor startup succeed.
+    abstract MarkReady: unit -> unit
+
+    /// Records a redacted dependency failure that prevents the worker from being ready.
+    abstract MarkDependencyFailure: description: string -> unit
+
+    /// Records the latest unsupported ingestion contract observed at the broker boundary.
+    abstract MarkUnsupportedContract: description: string -> unit
+
+/// Maintains the redacted readiness snapshot exposed by the Operations worker process.
+type OperationsUsageReadinessState() =
+    let gate = obj ()
+
+    let mutable status = OperationsUsageReadinessStatus.NotReady
+    let mutable dependencyFailure = Some "Operations usage worker has not completed dependency startup."
+    let mutable lastUnsupportedContract: string option = None
+
+    let snapshot () =
+        lock gate (fun () ->
+            {
+                Status = status
+                SupportedUsageFactSchemaVersion = UsageFactSchemaVersion
+                DependencyFailure = dependencyFailure
+                LastUnsupportedContract = lastUnsupportedContract
+            })
+
+    interface IOperationsUsageReadinessProbe with
+
+        member _.GetSnapshot() = snapshot ()
+
+    interface IOperationsUsageReadinessRecorder with
+
+        member _.MarkReady() =
+            lock gate (fun () ->
+                status <- OperationsUsageReadinessStatus.Ready
+                dependencyFailure <- None)
+
+        member _.MarkDependencyFailure(description) =
+            lock gate (fun () ->
+                status <- OperationsUsageReadinessStatus.NotReady
+                dependencyFailure <- Some description)
+
+        member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
+
+/// Adapts Operations ingestion readiness to the standard .NET health-check surface.
+type OperationsUsageReadinessHealthCheck(readiness: IOperationsUsageReadinessProbe) =
+
+    /// Builds redacted health-check data that operators can inspect without seeing payloads or secrets.
+    let healthData (snapshot: OperationsUsageReadinessSnapshot) =
+        let data = Dictionary<string, obj>()
+        data["supportedUsageFactSchemaVersion"] <- box snapshot.SupportedUsageFactSchemaVersion
+
+        match snapshot.DependencyFailure with
+        | Some dependencyFailure -> data["dependencyFailure"] <- box dependencyFailure
+        | None -> ()
+
+        match snapshot.LastUnsupportedContract with
+        | Some unsupportedContract -> data["lastUnsupportedContract"] <- box unsupportedContract
+        | None -> ()
+
+        data :> IReadOnlyDictionary<string, obj>
+
+    /// Builds the unhealthy readiness description without repeating sensitive dependency configuration.
+    let unhealthyDescription (snapshot: OperationsUsageReadinessSnapshot) =
+        snapshot.DependencyFailure
+        |> Option.defaultValue "Operations usage ingestion dependencies have not reported ready."
+
+    interface IHealthCheck with
+
+        /// Reports healthy only after the worker records successful SQL and Service Bus startup.
+        member _.CheckHealthAsync(_context, _cancellationToken) =
+            let snapshot = readiness.GetSnapshot()
+            let data = healthData snapshot
+
+            let result =
+                match snapshot.Status with
+                | OperationsUsageReadinessStatus.Ready -> HealthCheckResult(HealthStatus.Healthy, "Operations usage ingestion is ready.", null, data)
+                | _ -> HealthCheckResult(HealthStatus.Unhealthy, unhealthyDescription snapshot, null, data)
+
+            Task.FromResult result
 
 /// Reads Service Bus settings required by the operational usage ingestion worker.
 type OperationsWorkerSettings =
@@ -228,7 +337,12 @@ module OperationsWorkerSettings =
                 }
 
 /// Handles one usage fact message through validation, SQL persistence, and explicit Service Bus settlement.
-type OperationsUsageIngestionProcessor(store: IOperationsUsageFactStore, logger: ILogger<OperationsUsageIngestionProcessor>) =
+type OperationsUsageIngestionProcessor
+    (
+        store: IOperationsUsageFactStore,
+        logger: ILogger<OperationsUsageIngestionProcessor>,
+        readiness: IOperationsUsageReadinessRecorder
+    ) =
 
     /// Reads a string application property without exposing untrusted payload values in logs.
     let tryGetStringProperty propertyName (properties: IReadOnlyDictionary<string, obj>) =
@@ -249,6 +363,9 @@ type OperationsUsageIngestionProcessor(store: IOperationsUsageFactStore, logger:
         use stream = new MemoryStream(body)
         JsonSerializer.Deserialize<UsageFact>(stream, Constants.JsonSerializerOptions)
 
+    /// Builds a processor with an isolated readiness state for tests that only inspect settlement behavior.
+    new(store, logger) = OperationsUsageIngestionProcessor(store, logger, OperationsUsageReadinessState() :> IOperationsUsageReadinessRecorder)
+
     /// Processes a usage fact message and settles it only after the durable outcome is known.
     member _.ProcessMessageAsync(message: OperationsUsageMessage, actions: IOperationsUsageMessageActions, cancellationToken: CancellationToken) =
         task {
@@ -261,6 +378,8 @@ type OperationsUsageIngestionProcessor(store: IOperationsUsageFactStore, logger:
                    <> OperationalFactEnvelope.UsageFactSubject
                    || messageType
                       <> Some OperationalFactEnvelope.UsageFactMessageType then
+                    readiness.MarkUnsupportedContract("Unsupported Service Bus envelope for operations UsageFact ingestion.")
+
                     logger.LogWarning(
                         "Dead-lettering unsupported operational fact envelope. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Subject: {Subject}; MessageType: {MessageType}.",
                         message.MessageId,
@@ -279,8 +398,9 @@ type OperationsUsageIngestionProcessor(store: IOperationsUsageFactStore, logger:
                 else
                     let usageFact = deserializeUsageFact message.Body
 
-                    match UsageFact.Validate usageFact with
-                    | Error errors ->
+                    if isNull (box usageFact) then
+                        let errors = [ "UsageFact is required." ]
+
                         logger.LogWarning(
                             "Dead-lettering invalid UsageFact. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
                             message.MessageId,
@@ -290,33 +410,60 @@ type OperationsUsageIngestionProcessor(store: IOperationsUsageFactStore, logger:
                         )
 
                         do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
-                    | Ok () ->
-                        let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
+                    elif usageFact.SchemaVersion <> UsageFactSchemaVersion then
+                        let description = $"UsageFact SchemaVersion '{usageFact.SchemaVersion}' is not supported. Expected '{UsageFactSchemaVersion}'."
 
-                        match stored with
+                        readiness.MarkUnsupportedContract(description)
+
+                        logger.LogWarning(
+                            "Dead-lettering unsupported UsageFact schema. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; SchemaVersion: {SchemaVersion}; SupportedSchemaVersion: {SupportedSchemaVersion}.",
+                            message.MessageId,
+                            message.CorrelationId,
+                            message.DeliveryCount,
+                            usageFact.SchemaVersion,
+                            UsageFactSchemaVersion
+                        )
+
+                        do! deadLetterAsync "UnsupportedUsageFactSchema" description actions cancellationToken
+                    else
+                        match UsageFact.Validate usageFact with
                         | Error errors ->
                             logger.LogWarning(
-                                "Dead-lettering UsageFact rejected by operations storage validation. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
-                                usageFact.UsageFactId,
-                                usageFact.CorrelationId,
+                                "Dead-lettering invalid UsageFact. MessageId: {MessageId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
+                                message.MessageId,
+                                message.CorrelationId,
                                 message.DeliveryCount,
                                 describeErrors errors
                             )
 
                             do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
-                        | Ok result ->
-                            logger.LogInformation(
-                                "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
-                                result.UsageFactId,
-                                usageFact.CorrelationId,
-                                message.DeliveryCount,
-                                result.Status,
-                                result.Aggregate
-                                |> Option.map (fun aggregate -> aggregate.Key.BucketStart)
-                                |> Option.defaultValue Instant.MinValue
-                            )
+                        | Ok () ->
+                            let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
 
-                            do! actions.CompleteAsync cancellationToken
+                            match stored with
+                            | Error errors ->
+                                logger.LogWarning(
+                                    "Dead-lettering UsageFact rejected by operations storage validation. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Errors: {ValidationErrors}.",
+                                    usageFact.UsageFactId,
+                                    usageFact.CorrelationId,
+                                    message.DeliveryCount,
+                                    describeErrors errors
+                                )
+
+                                do! deadLetterAsync "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                            | Ok result ->
+                                logger.LogInformation(
+                                    "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
+                                    result.UsageFactId,
+                                    usageFact.CorrelationId,
+                                    message.DeliveryCount,
+                                    result.Status,
+                                    result.Aggregate
+                                    |> Option.map (fun aggregate -> aggregate.Key.BucketStart)
+                                    |> Option.defaultValue Instant.MinValue
+                                )
+
+                                do! actions.CompleteAsync cancellationToken
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                 logger.LogWarning(
@@ -385,6 +532,7 @@ type OperationsUsageWorkerService
         settings: OperationsWorkerSettings,
         schema: OperationsUsageSchema,
         processor: OperationsUsageIngestionProcessor,
+        readiness: IOperationsUsageReadinessRecorder,
         logger: ILogger<OperationsUsageWorkerService>
     ) =
     let credential = lazy (DefaultAzureCredential() :> TokenCredential)
@@ -473,6 +621,7 @@ type OperationsUsageWorkerService
                             settings.SubscriptionName
                         )
 
+                        readiness.MarkReady()
                         ready <- true
                     with
                     | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> ()
@@ -484,6 +633,8 @@ type OperationsUsageWorkerService
                         match createdClient with
                         | Some client -> do! client.DisposeAsync()
                         | None -> ()
+
+                        readiness.MarkDependencyFailure($"Dependency startup failed ({ex.GetType().Name}).")
 
                         logger.LogWarning(
                             ex,

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -116,7 +116,13 @@ type internal OperationsUsageReadinessFailureSource =
     | ServiceBusProcessorRuntime = 4
 
 /// Tracks one active readiness failure and the ordering point needed for source-owned recovery.
-type internal OperationsUsageReadinessFailure = { Source: OperationsUsageReadinessFailureSource; Description: string; Version: int64 }
+type internal OperationsUsageReadinessFailure =
+    {
+        Source: OperationsUsageReadinessFailureSource
+        Description: string
+        Version: int64
+        RecoveryKey: string option
+    }
 
 /// Captures the current readiness ordering point for one in-flight message.
 type OperationsUsageReadinessAttempt = { FailureVersion: int64 }
@@ -146,7 +152,7 @@ type IOperationsUsageReadinessRecorder =
     abstract MarkServiceBusReceiveFailure: description: string -> unit
 
     /// Records a redacted Service Bus callback, settlement, or lock failure that prevents the worker from being ready.
-    abstract MarkServiceBusProcessorFailure: description: string -> unit
+    abstract MarkServiceBusProcessorFailure: description: string * recoveryKey: string option -> unit
 
     /// Clears a Service Bus receive or link failure only when a later received message proves the link recovered.
     abstract MarkServiceBusReceiveSuccess: attempt: OperationsUsageReadinessAttempt -> unit
@@ -154,8 +160,8 @@ type IOperationsUsageReadinessRecorder =
     /// Clears runtime-owned processing failures only when this success started after that failure.
     abstract MarkRuntimeProcessingSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
-    /// Clears Service Bus processor-owned settlement failures only after a later settlement succeeds.
-    abstract MarkServiceBusProcessorSuccess: attempt: OperationsUsageReadinessAttempt -> unit
+    /// Clears Service Bus processor-owned settlement failures only after the same settlement path succeeds later.
+    abstract MarkServiceBusProcessorSuccess: attempt: OperationsUsageReadinessAttempt * recoveryKey: string -> unit
 
     /// Records the latest unsupported ingestion contract observed at the broker boundary.
     abstract MarkUnsupportedContract: description: string -> unit
@@ -174,6 +180,7 @@ type OperationsUsageReadinessState() =
                                                                                            Description =
                                                                                                "Operations usage worker has not completed dependency startup."
                                                                                            Version = failureVersion
+                                                                                           RecoveryKey = None
                                                                                        }
 
     let mutable lastUnsupportedContract: string option = None
@@ -194,16 +201,25 @@ type OperationsUsageReadinessState() =
             |> fun descriptions -> String.Join("; ", descriptions)
             |> Some
 
-    let recordFailure source description =
+    let recordFailure source description recoveryKey =
         failureVersion <- failureVersion + 1L
 
-        dependencyFailures[source] <- { Source = source; Description = description; Version = failureVersion }
+        dependencyFailures[source] <- { Source = source; Description = description; Version = failureVersion; RecoveryKey = recoveryKey }
 
     let clearFailure source = dependencyFailures.Remove source |> ignore
 
     let clearFailureWhenFresh source attempt =
         match dependencyFailures.TryGetValue source with
         | true, failure when failure.Version <= attempt.FailureVersion -> clearFailure source
+        | _ -> ()
+
+    let clearServiceBusProcessorFailureWhenFresh attempt recoveryKey =
+        match dependencyFailures.TryGetValue OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime with
+        | true, failure when
+            failure.Version <= attempt.FailureVersion
+            && failure.RecoveryKey = Some recoveryKey
+            ->
+            clearFailure OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime
         | _ -> ()
 
     let snapshot () =
@@ -225,16 +241,17 @@ type OperationsUsageReadinessState() =
 
         member _.BeginProcessingAttempt() = lock gate (fun () -> { FailureVersion = failureVersion })
 
-        member _.MarkDependencyFailure(description) = lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.StartupDependency description)
+        member _.MarkDependencyFailure(description) =
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.StartupDependency description None)
 
         member _.MarkRuntimeProcessingFailure(description) =
-            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.RuntimeProcessingDependency description)
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.RuntimeProcessingDependency description None)
 
         member _.MarkServiceBusReceiveFailure(description) =
-            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusReceiveLink description)
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusReceiveLink description None)
 
-        member _.MarkServiceBusProcessorFailure(description) =
-            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime description)
+        member _.MarkServiceBusProcessorFailure(description, recoveryKey) =
+            lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime description recoveryKey)
 
         member _.MarkServiceBusReceiveSuccess(attempt) =
             lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusReceiveLink attempt)
@@ -242,14 +259,25 @@ type OperationsUsageReadinessState() =
         member _.MarkRuntimeProcessingSuccess(attempt) =
             lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.RuntimeProcessingDependency attempt)
 
-        member _.MarkServiceBusProcessorSuccess(attempt) =
-            lock gate (fun () -> clearFailureWhenFresh OperationsUsageReadinessFailureSource.ServiceBusProcessorRuntime attempt)
+        member _.MarkServiceBusProcessorSuccess(attempt, recoveryKey) = lock gate (fun () -> clearServiceBusProcessorFailureWhenFresh attempt recoveryKey)
 
         member _.MarkUnsupportedContract(description) = lock gate (fun () -> lastUnsupportedContract <- Some description)
 
 /// Records runtime readiness transitions that must stay visible through the shared health-check state.
 [<RequireQualifiedAccess>]
 module internal OperationsUsageReadinessTransitions =
+
+    /// Identifies the Service Bus settlement operation that proves a matching processor failure recovered.
+    [<Literal>]
+    let CompleteSettlementRecoveryKey = "complete"
+
+    /// Identifies the Service Bus abandon operation that proves a matching processor failure recovered.
+    [<Literal>]
+    let AbandonSettlementRecoveryKey = "abandon"
+
+    /// Identifies the Service Bus dead-letter operation that proves a matching processor failure recovered.
+    [<Literal>]
+    let DeadLetterSettlementRecoveryKey = "dead-letter"
 
     /// Identifies processor sources where a later receive proves broker receive/session-link recovery.
     let private isReceiveRecoverySource errorSource =
@@ -263,6 +291,15 @@ module internal OperationsUsageReadinessTransitions =
         | ServiceBusErrorSource.RenewLock -> false
         | _ -> false
 
+    /// Maps Azure Service Bus error sources to the concrete settlement proof that may recover them later.
+    let private serviceBusProcessorRecoveryKey errorSource =
+        match errorSource with
+        | ServiceBusErrorSource.Complete
+        | ServiceBusErrorSource.ProcessMessageCallback
+        | ServiceBusErrorSource.RenewLock -> Some CompleteSettlementRecoveryKey
+        | ServiceBusErrorSource.Abandon -> Some AbandonSettlementRecoveryKey
+        | _ -> None
+
     /// Records a redacted Service Bus processor fault observed after startup.
     let recordServiceBusProcessorFault (readiness: IOperationsUsageReadinessRecorder) (errorSource: ServiceBusErrorSource) (ex: exn) =
         let description = $"Service Bus processor fault ({errorSource}, {ex.GetType().Name})."
@@ -270,15 +307,20 @@ module internal OperationsUsageReadinessTransitions =
         if isReceiveRecoverySource errorSource then
             readiness.MarkServiceBusReceiveFailure(description)
         else
-            readiness.MarkServiceBusProcessorFailure(description)
+            readiness.MarkServiceBusProcessorFailure(description, serviceBusProcessorRecoveryKey errorSource)
+
+    /// Records a redacted Service Bus settlement failure observed inside explicit worker settlement calls.
+    let recordServiceBusSettlementFailure (readiness: IOperationsUsageReadinessRecorder) recoveryKey (ex: exn) =
+        let description = $"Service Bus settlement failed ({recoveryKey}, {ex.GetType().Name})."
+        readiness.MarkServiceBusProcessorFailure(description, Some recoveryKey)
 
     /// Records a later receive-side proof that a Service Bus processor receive or link fault recovered.
     let recordServiceBusReceiveSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =
         readiness.MarkServiceBusReceiveSuccess(attempt)
 
     /// Records a later settlement-side proof that a Service Bus processor settlement fault recovered.
-    let recordServiceBusProcessorSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =
-        readiness.MarkServiceBusProcessorSuccess(attempt)
+    let recordServiceBusProcessorSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) recoveryKey =
+        readiness.MarkServiceBusProcessorSuccess(attempt, recoveryKey)
 
     /// Records a redacted runtime processing dependency failure that should recover after a later successful message.
     let recordRuntimeProcessingFailure (readiness: IOperationsUsageReadinessRecorder) (ex: exn) =
@@ -465,6 +507,18 @@ module OperationsWorkerSettings =
         | :? InvalidOperationException
         | :? TypeInitializationException -> None
 
+    /// Adds a validation error when the worker is configured for a receive mode that cannot prove recovery safely.
+    let private validateReceiveProofMode maxConcurrentCalls prefetchCount (errors: ResizeArray<string>) =
+        if maxConcurrentCalls <> 1 then
+            errors.Add(
+                $"{MaxConcurrentCallsEnvironmentVariable} must be '1' because callback start ordering cannot prove Service Bus receive/link recovery when concurrent callbacks are enabled."
+            )
+
+        if prefetchCount <> 0 then
+            errors.Add(
+                $"{PrefetchCountEnvironmentVariable} must be '0' because prefetched callbacks cannot prove Service Bus receive/link recovery after a later receive fault."
+            )
+
     /// Builds validated worker settings from configuration.
     let fromConfiguration (configuration: IConfiguration) =
         let topicName = settingOrDefault configuration Constants.EnvironmentVariables.AzureServiceBusOperationalFactsTopic Constants.GraceOperationalFactsTopic
@@ -500,6 +554,11 @@ module OperationsWorkerSettings =
                 $"{Constants.EnvironmentVariables.AzureServiceBusConnectionString} or {Constants.EnvironmentVariables.AzureServiceBusNamespace} is required."
             )
 
+        let maxConcurrentCalls = positiveIntSetting configuration MaxConcurrentCallsEnvironmentVariable 1
+        let prefetchCount = nonNegativeIntSetting configuration PrefetchCountEnvironmentVariable 0
+
+        validateReceiveProofMode maxConcurrentCalls prefetchCount errors
+
         if errors.Count > 0 then
             Error(List.ofSeq errors)
         else
@@ -516,8 +575,8 @@ module OperationsWorkerSettings =
                             serviceBusNamespace
                             |> Option.orElseWith serviceBusNamespaceFromAzureEnvironment
                     SchemaBootstrapMode = schemaBootstrapMode configuration
-                    MaxConcurrentCalls = positiveIntSetting configuration MaxConcurrentCallsEnvironmentVariable 4
-                    PrefetchCount = nonNegativeIntSetting configuration PrefetchCountEnvironmentVariable 0
+                    MaxConcurrentCalls = maxConcurrentCalls
+                    PrefetchCount = prefetchCount
                 }
 
 /// Handles one usage fact message through validation, SQL persistence, and explicit Service Bus settlement.
@@ -538,12 +597,36 @@ type OperationsUsageIngestionProcessor
     /// Builds a bounded diagnostic description without including the message body.
     let describeErrors (errors: string list) = String.Join("; ", errors)
 
+    /// Runs one explicit Service Bus settlement call and records only matching settlement recovery proof.
+    let settleAsync readinessAttempt recoveryKey settlementName (settle: unit -> Task) (cancellationToken: CancellationToken) =
+        task {
+            try
+                do! settle ()
+                OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt recoveryKey
+                return true
+            with
+            | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> return false
+            | ex ->
+                OperationsUsageReadinessTransitions.recordServiceBusSettlementFailure readiness recoveryKey ex
+
+                logger.LogError(
+                    ex,
+                    "Service Bus settlement failed during operations UsageFact processing. Settlement: {Settlement}; RecoveryKey: {RecoveryKey}.",
+                    settlementName,
+                    recoveryKey
+                )
+
+                return false
+        }
+
     /// Dead-letters an invalid usage message with deterministic reason metadata.
     let deadLetterAsync readinessAttempt reason description (actions: IOperationsUsageMessageActions) cancellationToken =
-        task {
-            do! actions.DeadLetterAsync(reason, description, cancellationToken)
-            OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt
-        }
+        settleAsync
+            readinessAttempt
+            OperationsUsageReadinessTransitions.DeadLetterSettlementRecoveryKey
+            "dead-letter"
+            (fun () -> actions.DeadLetterAsync(reason, description, cancellationToken))
+            cancellationToken
 
     /// Configures lightweight schema pre-parsing to match Grace's shared JSON reader leniency.
     let usageFactSchemaDocumentOptions =
@@ -644,17 +727,20 @@ type OperationsUsageIngestionProcessor
                         messageType |> Option.defaultValue "<missing>"
                     )
 
-                    do!
+                    let! _ =
                         deadLetterAsync
                             readinessAttempt
                             "UnsupportedOperationalFactEnvelope"
                             "Message subject or graceMessageType is not supported by the operations usage worker."
                             actions
                             cancellationToken
+
+                    ()
                 else
                     match tryReadUsageFactSchemaVersion message.Body with
                     | Some schemaVersion when schemaVersion <> UsageFactSchemaVersion ->
-                        do! deadLetterUnsupportedSchemaAsync readinessAttempt schemaVersion message actions cancellationToken
+                        let! _ = deadLetterUnsupportedSchemaAsync readinessAttempt schemaVersion message actions cancellationToken
+                        ()
                     | _ ->
                         let usageFact = deserializeUsageFact message.Body
 
@@ -669,9 +755,11 @@ type OperationsUsageIngestionProcessor
                                 describeErrors errors
                             )
 
-                            do! deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                            let! _ = deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                            ()
                         elif usageFact.SchemaVersion <> UsageFactSchemaVersion then
-                            do! deadLetterUnsupportedSchemaAsync readinessAttempt usageFact.SchemaVersion message actions cancellationToken
+                            let! _ = deadLetterUnsupportedSchemaAsync readinessAttempt usageFact.SchemaVersion message actions cancellationToken
+                            ()
                         else
                             match UsageFact.Validate usageFact with
                             | Error errors ->
@@ -683,7 +771,8 @@ type OperationsUsageIngestionProcessor
                                     describeErrors errors
                                 )
 
-                                do! deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                let! _ = deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                ()
                             | Ok () ->
                                 let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
 
@@ -697,7 +786,8 @@ type OperationsUsageIngestionProcessor
                                         describeErrors errors
                                     )
 
-                                    do! deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                    let! _ = deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
+                                    ()
                                 | Ok result ->
                                     logger.LogInformation(
                                         "Processed operational UsageFact. UsageFactId: {UsageFactId}; CorrelationId: {CorrelationId}; DeliveryCount: {DeliveryCount}; Status: {Status}; BucketStart: {BucketStart}.",
@@ -711,8 +801,16 @@ type OperationsUsageIngestionProcessor
                                     )
 
                                     readiness.MarkRuntimeProcessingSuccess(readinessAttempt)
-                                    do! actions.CompleteAsync cancellationToken
-                                    OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt
+
+                                    let! _ =
+                                        settleAsync
+                                            readinessAttempt
+                                            OperationsUsageReadinessTransitions.CompleteSettlementRecoveryKey
+                                            "complete"
+                                            (fun () -> actions.CompleteAsync cancellationToken)
+                                            cancellationToken
+
+                                    ()
             with
             | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                 logger.LogWarning(
@@ -730,7 +828,8 @@ type OperationsUsageIngestionProcessor
                     message.DeliveryCount
                 )
 
-                do! deadLetterAsync readinessAttempt "MalformedUsageFactJson" "UsageFact JSON could not be deserialized." actions cancellationToken
+                let! _ = deadLetterAsync readinessAttempt "MalformedUsageFactJson" "UsageFact JSON could not be deserialized." actions cancellationToken
+                ()
             | ex ->
                 OperationsUsageReadinessTransitions.recordRuntimeProcessingFailure readiness ex
 
@@ -742,8 +841,15 @@ type OperationsUsageIngestionProcessor
                     message.DeliveryCount
                 )
 
-                do! actions.AbandonAsync cancellationToken
-                OperationsUsageReadinessTransitions.recordServiceBusProcessorSuccess readiness readinessAttempt
+                let! _ =
+                    settleAsync
+                        readinessAttempt
+                        OperationsUsageReadinessTransitions.AbandonSettlementRecoveryKey
+                        "abandon"
+                        (fun () -> actions.AbandonAsync cancellationToken)
+                        cancellationToken
+
+                ()
         }
 
 /// Adapts Azure Service Bus message settlement to the worker's fakeable action interface.
@@ -863,7 +969,8 @@ type OperationsUsageWorkerService
                                 OperationsUsageServiceBusMessage.processReceivedMessageAsync
                                     readiness
                                     processor
-                                    (settings.PrefetchCount = 0)
+                                    (settings.MaxConcurrentCalls = 1
+                                     && settings.PrefetchCount = 0)
                                     args.Message
                                     actions
                                     args.CancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -139,6 +139,9 @@ type IOperationsUsageReadinessRecorder =
     /// Records a redacted Service Bus receive or link failure that prevents the worker from being ready.
     abstract MarkServiceBusProcessorFailure: description: string -> unit
 
+    /// Clears a Service Bus receive or link failure only when a later received message proves the link recovered.
+    abstract MarkServiceBusReceiveSuccess: attempt: OperationsUsageReadinessAttempt -> unit
+
     /// Clears a runtime storage or processing failure only when this success started after that failure.
     abstract MarkRuntimeProcessingSuccess: attempt: OperationsUsageReadinessAttempt -> unit
 
@@ -200,6 +203,18 @@ type OperationsUsageReadinessState() =
         member _.MarkServiceBusProcessorFailure(description) =
             lock gate (fun () -> recordFailure OperationsUsageReadinessFailureSource.ServiceBusProcessor description)
 
+        member _.MarkServiceBusReceiveSuccess(attempt) =
+            lock gate (fun () ->
+                match dependencyFailure with
+                | Some failure when
+                    failure.Source = OperationsUsageReadinessFailureSource.ServiceBusProcessor
+                    && failure.Version <= attempt.FailureVersion
+                    ->
+                    status <- OperationsUsageReadinessStatus.Ready
+                    dependencyFailure <- None
+                | None -> status <- OperationsUsageReadinessStatus.Ready
+                | Some _ -> ())
+
         member _.MarkRuntimeProcessingSuccess(attempt) =
             lock gate (fun () ->
                 match dependencyFailure with
@@ -221,6 +236,10 @@ module internal OperationsUsageReadinessTransitions =
     /// Records a redacted Service Bus processor fault observed after startup.
     let recordServiceBusProcessorFault (readiness: IOperationsUsageReadinessRecorder) (errorSource: ServiceBusErrorSource) (ex: exn) =
         readiness.MarkServiceBusProcessorFailure($"Service Bus processor fault ({errorSource}, {ex.GetType().Name}).")
+
+    /// Records a later receive-side proof that a Service Bus processor receive or link fault recovered.
+    let recordServiceBusReceiveSuccess (readiness: IOperationsUsageReadinessRecorder) (attempt: OperationsUsageReadinessAttempt) =
+        readiness.MarkServiceBusReceiveSuccess(attempt)
 
     /// Records a redacted runtime processing dependency failure that should recover after a later successful message.
     let recordRuntimeProcessingFailure (readiness: IOperationsUsageReadinessRecorder) (ex: exn) =
@@ -553,6 +572,7 @@ type OperationsUsageIngestionProcessor
     member _.ProcessMessageAsync(message: OperationsUsageMessage, actions: IOperationsUsageMessageActions, cancellationToken: CancellationToken) =
         task {
             let readinessAttempt = readiness.BeginProcessingAttempt()
+            OperationsUsageReadinessTransitions.recordServiceBusReceiveSuccess readiness readinessAttempt
 
             try
                 cancellationToken.ThrowIfCancellationRequested()

--- a/src/Grace.Operations/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/Program.fs
@@ -2,6 +2,7 @@ namespace Grace.Operations.Worker
 
 open Grace.Operations.Data
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Diagnostics.HealthChecks
 open Microsoft.Extensions.Hosting
 open System
 
@@ -39,6 +40,14 @@ module Program =
                     services
                         .AddHealthChecks()
                         .AddCheck<OperationsUsageReadinessHealthCheck>("operations-usage-ingestion")
+                    |> ignore
+
+                    services.Configure<HealthCheckPublisherOptions> (fun (options: HealthCheckPublisherOptions) ->
+                        options.Delay <- TimeSpan.Zero
+                        options.Period <- TimeSpan.FromSeconds(30.0))
+                    |> ignore
+
+                    services.AddSingleton<IHealthCheckPublisher, OperationsUsageReadinessHealthCheckPublisher>()
                     |> ignore
 
                     services.AddSingleton<IOperationsUsageFactStore> (fun _ ->

--- a/src/Grace.Operations/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/Program.fs
@@ -25,6 +25,22 @@ module Program =
                     services.AddSingleton(OperationsUsageSchema(settings.SqlConnectionString, settings.SchemaBootstrapMode))
                     |> ignore
 
+                    services.AddSingleton<OperationsUsageReadinessState>()
+                    |> ignore
+
+                    services.AddSingleton<IOperationsUsageReadinessProbe> (fun serviceProvider ->
+                        serviceProvider.GetRequiredService<OperationsUsageReadinessState>() :> IOperationsUsageReadinessProbe)
+                    |> ignore
+
+                    services.AddSingleton<IOperationsUsageReadinessRecorder> (fun serviceProvider ->
+                        serviceProvider.GetRequiredService<OperationsUsageReadinessState>() :> IOperationsUsageReadinessRecorder)
+                    |> ignore
+
+                    services
+                        .AddHealthChecks()
+                        .AddCheck<OperationsUsageReadinessHealthCheck>("operations-usage-ingestion")
+                    |> ignore
+
                     services.AddSingleton<IOperationsUsageFactStore> (fun _ ->
                         let transactionScope = SqlOperationsUsageTransactionScope(settings.SqlConnectionString)
                         let store = OperationsUsageStore transactionScope

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -200,9 +200,11 @@ These capture failure classification, retryability, cleanup notes, and runtime m
   usage facts and minute aggregates. Aspire local run mode points this at the local SQL Server container and database
   `GraceOperations`.
 - `grace__operations_worker__max_concurrent_calls`: Optional Service Bus processor concurrency override. Defaults to
-  `4`.
-- `grace__operations_worker__prefetch_count`: Optional Service Bus processor prefetch override. Defaults to `0` so
-  receive/link readiness recovery is not proven by callbacks draining prefetched messages.
+  `1`. The worker rejects values above `1` because concurrent callback start ordering cannot prove receive/link
+  readiness recovery after a later Service Bus receive fault.
+- `grace__operations_worker__prefetch_count`: Optional Service Bus processor prefetch override. Defaults to `0`. The
+  worker rejects positive values because prefetched callbacks cannot prove receive/link readiness recovery after a later
+  Service Bus receive fault.
 
 The operations worker reads from `grace__azure_service_bus__operational_facts_topic` and requires
 `grace__azure_service_bus__operational_facts_processor_subscription` to be exactly `operational-facts-processor`.

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -201,7 +201,8 @@ These capture failure classification, retryability, cleanup notes, and runtime m
   `GraceOperations`.
 - `grace__operations_worker__max_concurrent_calls`: Optional Service Bus processor concurrency override. Defaults to
   `4`.
-- `grace__operations_worker__prefetch_count`: Optional Service Bus processor prefetch override. Defaults to `16`.
+- `grace__operations_worker__prefetch_count`: Optional Service Bus processor prefetch override. Defaults to `0` so
+  receive/link readiness recovery is not proven by callbacks draining prefetched messages.
 
 The operations worker reads from `grace__azure_service_bus__operational_facts_topic` and requires
 `grace__azure_service_bus__operational_facts_processor_subscription` to be exactly `operational-facts-processor`.


### PR DESCRIPTION
Related to #569 under mini-epic #558 and parent epic #554.

## Why This Matters

The Operations worker is the durable boundary between broker delivery and accounting storage. Invalid input must be classified visibly without blocking valid ingestion, while transient dependency failures must not be mistaken for poison messages.

## Summary

- Hardened Operations worker message classification for malformed JSON, invalid contracts, unsupported schema and envelope cases, and transient failures.
- Preserved explicit Service Bus settlement semantics: impossible poison input is dead-lettered, while transient dependency failures are not dead-lettered.
- Added ingestion readiness and health-check coverage for supported contract version and dependency state.
- Kept message bodies, secrets, and full payloads out of failure logging.
- Stabilized readiness ownership across storage, Service Bus receive/link, settlement, callback, lock-renewal, startup, and runtime processing proof points.

## Validation

Latest worker validation on `589d7519352be1a9a398fda0bf5fcc6a611fbc5a`:

- `dotnet tool run fantomas -- 'src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs' 'src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs'`: passed.
- `dotnet test --configuration Release src\Grace.Operations\Grace.Operations.Tests\Grace.Operations.Tests.fsproj --filter OperationsWorkerIngestionTests`: passed, 42/42.
- `pwsh ./scripts/validate.ps1 -Full`: passed on rerun in `00:04:48.5210059`.
  - First attempt failed during build before tests because a stale local `testhost.exe` from this worktree locked `Grace.Server.Tests` output DLLs. The stale `testhost` was stopped and the rerun passed.
  - Rerun passed: `Grace.Types.Tests` 159/159, `Grace.Authorization.Tests` 53/53, `Grace.Server.Unit.Tests` 732/732, `Grace.CLI.Tests` 689 passed / 1 skipped, `Grace.Server.Tests` 243/243, `Grace.Operations.Tests` 69/69.
- `git diff --check`: passed.

Current GitHub validation for `589d7519352be1a9a398fda0bf5fcc6a611fbc5a`:

- GitHub `full`: running.

## Review Status

The structural stabilization ledger and all addenda are implemented through `589d7519352be1a9a398fda0bf5fcc6a611fbc5a`.

Resolved review threads from earlier passes:

- `discussion_r3526457331`: fixed in `7effcf6263393b70153b0ee429d8db42413b3acf`; exposed Operations worker readiness through a worker-compatible `IHealthCheckPublisher` path with redacted readiness logging and regression coverage.
- `discussion_r3526457333`: fixed in `7effcf6263393b70153b0ee429d8db42413b3acf`; moved schema-version inspection ahead of v1 `UsageFact` deserialization and added a future schema plus unknown enum regression.
- `discussion_r3526523349`: fixed in `ab493499e06fc8611036c2ecc9a230de14086338`; aligned raw schema pre-parse with Grace JSON options for comments, trailing commas, max depth, and case-insensitive schema-property lookup.
- `discussion_r3526588390`: fixed in `f700ff0e89f96f58df47bb0c1a4092fe32e476dd`; Service Bus `ProcessErrorAsync` receive/link failures now update the shared readiness recorder after startup with redacted dependency state.
- `discussion_r3526588392`: fixed in `f700ff0e89f96f58df47bb0c1a4092fe32e476dd`; runtime processing/storage failures now mark readiness not ready before retry settlement, and a later durable success clears the dependency failure.
- `discussion_r3533134738`: fixed in `2b4b47eb2c3070ac73ec62ed426c05082fb5288f`; readiness recovery now happens at the durable storage-success proof point, and the stale in-flight completion regression proves older handlers cannot clear newer dependency failures.
- `discussion_r3533190865`: fixed in `c8eb52d06d35338bb1d3e840213ce53b94264f72`; readiness failure ownership is now source-aware, so storage or settlement success cannot clear an active Service Bus receive/link failure without a receive-side recovery proof.
- `discussion_r3533297694`: fixed in `638e460b40489836d123027c9de21c136b150fdc`; a later message receipt now provides the Service Bus receive-side recovery proof and clears eligible Service Bus receive/link failures before storage or settlement can be the explanation.
- `discussion_r3533445443`: fixed in `c5bd219a7febf226d7d2b124303acb323133f353`; readiness now tracks active failures by source, so storage failures and Service Bus receive/link failures can coexist and clear independently.
- `discussion_r3533445449`: fixed in `c5bd219a7febf226d7d2b124303acb323133f353`; startup readiness now clears only startup-owned dependency state and cannot erase runtime/callback failures recorded after the processor starts.
- `discussion_r3533445454`: fixed in `c5bd219a7febf226d7d2b124303acb323133f353`; Service Bus error sources are now classified so receive-side proof clears only receive/session-link failures, not settlement, callback, or lock-renewal failures.
- `discussion_r3533524667`: fixed in `09f365a02877ea8ad7d2087f2fd9af109e55992f`; fresh successful runtime processing now clears non-receive Service Bus processor runtime failures while preserving stale-success ordering.
- `discussion_r3533524672`: fixed in `09f365a02877ea8ad7d2087f2fd9af109e55992f`; callback entry no longer records receive/link recovery, so prefetched or already-received callbacks cannot clear receive/link failures.
- `discussion_r3533580239`: fixed in `01269043ad149489ad99daf1fa6a8d6a891eb028`; receive/link recovery is now wired through the production Azure Service Bus received-message handler, not the reusable processor callback entry point.
- `discussion_r3533580242`: fixed in `01269043ad149489ad99daf1fa6a8d6a891eb028`; settlement/processor recovery now happens only after `CompleteAsync`, `AbandonAsync`, or `DeadLetterAsync` returns successfully.
- `discussion_r3533824720`: fixed in `d14e0253dd260aef71708482a4250424bf7bfe69`; settlement failures from `CompleteAsync`, `AbandonAsync`, and `DeadLetterAsync` are recorded as Service Bus settlement/processor failures instead of runtime storage failures.
- `discussion_r3533824723`: fixed in `d14e0253dd260aef71708482a4250424bf7bfe69`; positive `grace__operations_worker__prefetch_count` is rejected because callback timing cannot safely prove receive recovery in that mode.
- `discussion_r3533824727`: fixed in `d14e0253dd260aef71708482a4250424bf7bfe69`; `grace__operations_worker__max_concurrent_calls` above `1` is rejected and receive proof remains gated on the safe single-callback/no-prefetch invariant.
- `discussion_r3534494241`: fixed in `4d355724dfab32943ea5bc9ab2edad247bd604f9`; processor/runtime readiness failures are keyed by failure source and recovery key, so settlement failures requiring different recovery proofs coexist.
- `discussion_r3534494246`: fixed in `4d355724dfab32943ea5bc9ab2edad247bd604f9`; `RenewLock` faults use a renewal-specific recovery key and ordinary completion no longer clears renewal-path readiness failures.
- `discussion_r3534726686`: fixed in `589d7519352be1a9a398fda0bf5fcc6a611fbc5a`; callback/runtime faults use a callback recovery key and successful dead-letter handling clears callback readiness without clearing unrelated settlement failures.

Final ledger invariant status map:

- Poison input classification is deterministic and does not call storage: implemented and proven.
- Future unsupported schemas are classified before v1 enum binding, using Grace JSON options: implemented and proven.
- Worker readiness is visible outside DI without leaking message bodies or secrets: implemented and proven.
- Service Bus processor receive/link failures downgrade readiness after startup: implemented and proven.
- Runtime SQL/storage failures downgrade readiness after startup and clear after later success: implemented and proven.
- Transient dependency failures are retried, not dead-lettered: implemented and proven.
- Stale in-flight successes do not clear newer dependency failures: implemented and proven.
- Storage success does not clear Service Bus receive/link failures: implemented and proven.
- Receive/link recovery has a production caller tied to a true receive-side proof: implemented and proven.
- Runtime/storage failures and Service Bus processor failures coexist while active: implemented and proven.
- Startup readiness clears only startup-owned dependency state: implemented and proven.
- Non-receive Service Bus source classification remains correct: implemented and proven.
- Settlement-related processor failures do not clear on storage success: implemented and proven.
- Settlement-related processor failures clear only after the matching settlement/processor operation succeeds: implemented and proven.
- Settlement call failures classify as Service Bus settlement/processor failures, not runtime storage failures: implemented and proven.
- Fallback abandon success does not clear a different settlement owner: implemented and proven.
- Positive prefetch and unsafe receive concurrency are rejected when no reliable receive-side proof exists: implemented and proven.
- Stale concurrent callbacks cannot clear receive/link failures: implemented and proven.
- Multiple active Service Bus processor/runtime failures coexist by recovery key: implemented and proven.
- `RenewLock` readiness failures require a renewal-specific proof and are not cleared by ordinary completion: implemented and proven.
- Callback/runtime failures recover from successful callback execution, including poison or unsupported messages that are successfully dead-lettered: implemented and proven.
- Dead-letter callback recovery does not clear unrelated settlement failures: implemented and proven.
- Redaction, unsupported schema classification, runtime storage recovery, and transient retry behavior remain proven by the focused ingestion suite and full validation.

Prevention note: callback readiness recovery is tied to successful callback execution, while settlement readiness recovery remains tied to the concrete settlement path whose success proves that path recovered.

## Residual Risks

No known blocking code risk in this leaf. This leaf intentionally does not implement archive lag, billing lag, provider import lag, operator dashboards, archive movement, charge previews, customer APIs, provider joins, or partitioning.
