### PR TITLE
GC-02: Add Grace Cache implementation audit scaffold

### DIFF
--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -1,0 +1,232 @@
+# Grace Cache Implementation Audit
+
+Issue #609 creates this scaffold for the Grace Cache materialization epic. The scaffold records
+requirement classification, proof seams, and residual risk as implementation PRs land. It is not a
+second task tracker.
+
+GitHub issues and pull requests remain the active tracker and the source of implementation truth.
+Update this document only when the related issue or PR can cite current evidence. Do not use this
+document to claim completion without an owning issue, PR, commit, or validation result.
+
+## Scope
+
+- Parent epic: #597, Grace Cache and Server-Resolved Materialization Plans.
+- Governance mini-epic: #598, Grace Cache governance, docs, and review-prevention.
+- Scaffold issue: #609, GC-02.
+- Branch family: `epic/598-grace-cache-governance-docs-review-prevention` and its leaf PRs.
+
+This document audits Grace Cache implementation evidence only. It does not authorize broad support
+claims, create follow-up buckets, or replace the dependency graph in GitHub.
+
+## Status Vocabulary
+
+Use exactly one of these status classifications for each audit entry:
+
+- `implemented and proven`: the implementation exists and current proof evidence is recorded.
+- `implemented but proof incomplete`: the implementation exists, but proof is partial, stale, or
+  intentionally deferred to a named issue or PR gate.
+- `deferred`: the requirement is real, but it is blocked by a named dependency or future issue.
+- `out of scope`: the requirement is outside the accepted scope for this epic or milestone.
+- `rejected`: the requirement or implementation shape is intentionally not accepted.
+- `not applicable`: the requirement does not apply to this surface, with rationale.
+
+Do not use checkbox state as the status. If an entry changes status, cite the issue or PR that
+changed it and the evidence that makes the classification current.
+
+## Required Entry Fields
+
+Every audit entry must keep these fields:
+
+- Implementation seam: the component, route, command, contract, actor, storage shape, doc, or
+  generated artifact that owns the behavior.
+- Proof seam: the test, validation command, static proof, generated freshness check, manual audit,
+  or external dependency that proves the seam.
+- Status classification: one status from the vocabulary above.
+- Issue or PR evidence: GitHub issue, pull request, commit, or validation artifact that owns the
+  current claim.
+- Residual risk or rationale: remaining risk, blocked dependency, rejected shape, or reason the
+  entry is not applicable.
+
+## Final Audit Categories
+
+The final epic audit should classify these categories before the release-candidate PR is treated as
+review-ready:
+
+- User-selected materialization mode and fallback behavior.
+- Server-resolved content scope and RecursiveDirectoryVersions authority.
+- ContentAccessGrant issuance, binding, validation, and expiry.
+- Grace Cache service registration and identity.
+- Read-through behavior and cache-hit enforcement.
+- Prefetch behavior and retention refresh.
+- Cache metadata, cleanup, and chunk-store liveness.
+- Watch dependency impact for #473 and #552.
+- Operations dependency impact for #554.
+- Public docs and generated contracts.
+- Validation evidence and residual risks.
+
+## Requirement Group Scaffold
+
+Each group starts as a scaffold entry for #609. Future implementation PRs should replace the
+docs-only classification with current evidence for the behavior they own.
+
+### Direct Materialization
+
+- Implementation seam: client and server path that bypasses Grace Cache and reads from Grace Server
+  or storage through the existing authorized materialization flow.
+- Proof seam: focused tests or validation that show Direct mode does not require Grace Cache
+  registration, cache rows, or ContentAccessGrant validation.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; the owning implementation issue or PR must add
+  the current proof before claiming Direct support.
+- Residual risk or rationale: Direct must remain a first-class non-cache path, not an accidental
+  fallback from failed CacheRequired behavior.
+
+### CachePreferred Materialization
+
+- Implementation seam: mode selection and materialization path that tries Grace Cache first and can
+  fall back to Direct only when the accepted contract allows it.
+- Proof seam: positive and negative tests for cache hit, cache miss, grant failure, cache outage,
+  and fallback observability.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; the owning implementation issue or PR must add
+  current behavior and validation evidence.
+- Residual risk or rationale: do not claim CachePreferred support unless fallback rules and
+  user-visible status are proven together.
+
+### CacheRequired Materialization
+
+- Implementation seam: mode selection and materialization path that fails closed when Grace Cache
+  cannot serve the authorized content.
+- Proof seam: tests proving no Direct source is used when CacheRequired cannot satisfy the request,
+  including cache miss, stale grant, malformed grant, and unavailable cache cases.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; the owning implementation issue or PR must add
+  current proof before any CacheRequired support claim.
+- Residual risk or rationale: CacheRequired is a high-risk trust contract because a silent Direct
+  fallback would violate the mode name and caller expectations.
+
+### ContentAccessGrant Issuance And Validation
+
+- Implementation seam: Grace Server grant issuance, grant binding, grant expiry, resolved content
+  scope, resolved path scope, and Grace Cache local validation.
+- Proof seam: tests for caller binding, cache audience binding, expired grants, wrong repository,
+  wrong reference or DirectoryVersion, narrowed path scope, and malformed grant data.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; later grant work must cite the issue or PR that
+  owns the current grant contract.
+- Residual risk or rationale: possession of cached chunks or a bearer-like token must not become
+  authorization to serve content.
+
+### Cache Service Registration And Identity
+
+- Implementation seam: cache service registration, health or capability publication, configured
+  cache audience, and Cache Service Identity for prefetch subscriptions.
+- Proof seam: tests or static validation for unregistered cache rejection, wrong audience rejection,
+  duplicate registration handling, identity rotation, and disabled-cache behavior.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; registration work must cite its owning issue or
+  PR and validation.
+- Residual risk or rationale: Cache Service Identity authorizes configured cache behavior only; it
+  must not become a global chunk reader claim.
+
+### Read-Through Behavior
+
+- Implementation seam: Grace Cache request handling that serves chunks only when a current
+  ContentAccessGrant authorizes RecursiveDirectoryVersions containing those ChunkAddresses.
+- Proof seam: tests for authorized hit, unauthorized hit, stale metadata, missing chunk, wrong path
+  scope, and server-authority refresh where the contract requires it.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; read-through work must add current proof before
+  claiming cache reads.
+- Residual risk or rationale: physical chunk presence in the Cache Chunk Store is not permission or
+  liveness.
+
+### Prefetch Behavior
+
+- Implementation seam: configured prefetch subscriptions, source resolution, fetch scheduling,
+  cache metadata writes, retention refresh, and failure reporting.
+- Proof seam: tests for authorized prefetch, denied prefetch, duplicate subscription, partial fetch,
+  retry, cancellation, and retention refresh without creating separate retention classes.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; prefetch work must cite the owning issue or PR.
+- Residual risk or rationale: prefetch can place chunks in cache before a requester needs them, but
+  serving still requires per-call authorization.
+
+### Cache Metadata And Cleanup
+
+- Implementation seam: Cache Reference Metadata, Cache Retention, Cache Chunk Store liveness, expiry
+  decisions, and cleanup side effects.
+- Proof seam: tests for metadata creation, retention refresh, expiry, cleanup after partial failure,
+  shared chunk retention, and no pinning in v1.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; cleanup work must cite its owning issue or PR.
+- Residual risk or rationale: cache cleanup must not infer global content liveness from chunk
+  presence alone.
+
+### Watch Dependencies
+
+- Implementation seam: Watch integration points that consume or publish cache-related materialization
+  status after #473 and #552 establish their required boundaries.
+- Proof seam: dependency evidence from #473 and #552 plus focused tests that prove Watch does not use
+  stale materialization mode, grant, reference, or cache-status snapshots.
+- Status classification: `deferred`.
+- Issue or PR evidence: dependency-gated by #473 and #552; #609 records the audit slot only.
+- Residual risk or rationale: Watch impact must not silently disappear. Do not mark this entry
+  implemented until current Watch dependency evidence exists.
+
+### Operations Dependencies
+
+- Implementation seam: Operations surfaces that observe, configure, validate, or report Grace Cache
+  materialization behavior after the #554 Operations branch defines the relevant contracts.
+- Proof seam: dependency evidence from #554 plus Operations-local validation for any exposed command,
+  worker, report, or status surface.
+- Status classification: `deferred`.
+- Issue or PR evidence: dependency-gated by #554; #609 records the audit slot only.
+- Residual risk or rationale: Operations support is not claimed by core cache docs alone. Any
+  Operations impact needs current #554 evidence before completion language is allowed.
+
+### Public Documentation
+
+- Implementation seam: user, operator, contributor, and architecture docs that describe Grace Cache
+  modes, grants, registration, prefetch, read-through, cleanup, and dependency limits.
+- Proof seam: MarkdownLint, manual rendered review, link checks when practical, and comparison
+  against the accepted product spec and implementation issues.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates this audit scaffold; later docs PRs must cite their owning
+  issues and validation.
+- Residual risk or rationale: docs must distinguish proven support, incomplete proof, deferrals, and
+  non-claims instead of using broad supported wording.
+
+### Generated Contracts
+
+- Implementation seam: OpenAPI, SDK generated clients, generated metadata, CLI machine-readable
+  output, or other generated artifacts that expose Grace Cache requests, statuses, grants, or modes.
+- Proof seam: generated freshness checks, OpenAPI proof checks, SDK generation checks, contract
+  tests, and static scans for stale schema or enum values.
+- Status classification: `not applicable` to this docs-only scaffold.
+- Issue or PR evidence: #609 creates the audit slot; generated-contract work must cite the issue or
+  PR that updates artifacts and proof.
+- Residual risk or rationale: generated drift is a release risk. Do not rely on source-only changes
+  when public or SDK-visible cache contracts change.
+
+## Final Audit Update Rules
+
+- Update an entry only from current branch evidence, not from memory or older dependency snapshots.
+- Preserve the exact status vocabulary so the final audit can be searched and compared mechanically.
+- Replace the #609 scaffold evidence with the owning issue or PR evidence when implementation lands.
+- Keep dependency-gated Watch and Operations entries until their named dependency evidence is current.
+- Record rejected or out-of-scope decisions with rationale, not as anonymous follow-up work.
+- Keep unproven support language narrow: name the seam, proof, and residual risk.
+
+## Docs-Only Validation For This Scaffold
+
+The #609 worker should validate this document with:
+
+```powershell
+npx --yes markdownlint-cli2 "docs/Grace Cache implementation audit.md"
+git diff --check
+```
+
+Manual review must also confirm that the scaffold covers Direct, CachePreferred, CacheRequired,
+grants, registration, read-through, prefetch, cleanup, Watch, Operations, docs, and generated
+contracts.


### PR DESCRIPTION
## Summary

- Adds the Grace Cache implementation audit scaffold.
- Defines status vocabulary and evidence fields for future implementation PRs.
- Covers Direct, CachePreferred, CacheRequired, grants, registration, read-through, prefetch, cleanup, Watch, Operations, docs, and generated contract surfaces.

## Related Issue

Related to #609. Part of #598 and #597.

## Validation

- Passed: `npx --yes markdownlint-cli2 "docs/Grace Cache implementation audit.md"`.
- Passed: PowerShell coverage check for required groups, required entry fields, and allowed statuses.
- Passed: manual Markdown/text inspection.
- Passed: `git diff --check` before staging.
- Passed: `git diff --cached --check` after staging.
- Skipped code tests: docs-only change; issue forbids product code changes.

## Review Status

- Awaiting Codex Code Review Bot on the current PR head.
