### PR TITLE
GV-02: Private contributor-owned branch tracer bullet

### DIFF
--- a/src/Grace.Actors/Branch.Actor.fs
+++ b/src/Grace.Actors/Branch.Actor.fs
@@ -140,7 +140,7 @@ module Branch =
                 try
                     // If the branchEvent is Created or Rebased, we need to get the reference that the branch is based on for updating the branchDto.
                     match branchEvent.Event with
-                    | Created (branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, branchPermissions) ->
+                    | Created (branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, branchPermissions, _, _, _) ->
                         let! basedOnReferenceDto =
                             if basedOn <> ReferenceId.Empty then
                                 task {
@@ -308,7 +308,17 @@ module Branch =
                             return Error(GraceError.Create (getErrorMessage BranchError.DuplicateCorrelationId) metadata.CorrelationId)
                         else
                             match command with
-                            | BranchCommand.Create (branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, branchPermissions) ->
+                            | BranchCommand.Create (branchId,
+                                                    branchName,
+                                                    parentBranchId,
+                                                    basedOn,
+                                                    ownerId,
+                                                    organizationId,
+                                                    repositoryId,
+                                                    branchPermissions,
+                                                    _,
+                                                    _,
+                                                    _) ->
                                 match branchDto.UpdatedAt with
                                 | Some _ -> return Error(GraceError.Create (BranchError.getErrorMessage BranchAlreadyExists) metadata.CorrelationId)
                                 | None -> return Ok command
@@ -355,7 +365,17 @@ module Branch =
                             let! event =
                                 task {
                                     match command with
-                                    | Create (branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, branchPermissions) ->
+                                    | Create (branchId,
+                                              branchName,
+                                              parentBranchId,
+                                              basedOn,
+                                              ownerId,
+                                              organizationId,
+                                              repositoryId,
+                                              branchPermissions,
+                                              visibility,
+                                              ownership,
+                                              creatorUserId) ->
                                         // Add an initial Rebase reference to this branch that points to the BasedOn reference, unless we're creating `main`.
                                         if branchName <> InitialBranchName then
                                             // We need to get the reference that we're rebasing on, so we can get the DirectoryId and root hashes.
@@ -387,7 +407,21 @@ module Branch =
                                         memoryCache.CreateBranchNameEntry(repositoryId, branchName, branchId)
 
                                         return
-                                            Ok(Created(branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, branchPermissions))
+                                            Ok(
+                                                Created(
+                                                    branchId,
+                                                    branchName,
+                                                    parentBranchId,
+                                                    basedOn,
+                                                    ownerId,
+                                                    organizationId,
+                                                    repositoryId,
+                                                    branchPermissions,
+                                                    visibility,
+                                                    ownership,
+                                                    creatorUserId
+                                                )
+                                            )
                                     | BranchCommand.Rebase referenceId ->
                                         metadata.Properties[ "BasedOn" ] <- $"{referenceId}"
                                         metadata.Properties[ nameof ReferenceId ] <- $"{referenceId}"

--- a/src/Grace.Actors/Repository.Actor.fs
+++ b/src/Grace.Actors/Repository.Actor.fs
@@ -18,6 +18,7 @@ open Grace.Types.Branch
 open Grace.Types.DirectoryVersion
 open Grace.Types.Reminder
 open Grace.Types.Repository
+open Grace.Types.Visibility
 open Grace.Types.Events
 open Grace.Types.Common
 open Grace.Shared.Utilities
@@ -115,7 +116,10 @@ module Repository =
                                         ownerId,
                                         organizationId,
                                         repositoryId,
-                                        initialBranchPermissions
+                                        initialBranchPermissions,
+                                        ResourceVisibility.Private,
+                                        ResourceOwnership.RepositoryOwned,
+                                        UserId String.Empty
                                     )
 
                                 match! branchActor.Handle createInitialBranchCommand repositoryEvent.Metadata with

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -201,6 +201,51 @@ module BranchServerTestHelpers =
     let getBranchResponseAsync (client: HttpClient) repositoryId branchId =
         client.PostAsync("/branch/get", createJsonContent (getBranchParameters repositoryId branchId))
 
+    /// Gets branch response by branch name through the supplied test client.
+    let getBranchByNameResponseAsync (client: HttpClient) repositoryId branchName =
+        let parameters = Parameters.Branch.GetBranchParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchName <- branchName
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        client.PostAsync("/branch/get", createJsonContent parameters)
+
+    /// Posts a branch id scoped query route through the supplied test client.
+    let postBranchIdRouteAsync (client: HttpClient) (route: string) repositoryId branchId =
+        let parameters = Parameters.Branch.GetBranchParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        client.PostAsync(route, createJsonContent parameters)
+
+    /// Posts a branch reference-list query route through the supplied test client.
+    let postBranchReferencesRouteAsync (client: HttpClient) (route: string) repositoryId branchId =
+        let parameters = Parameters.Branch.GetReferencesParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.MaxCount <- 10
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        client.PostAsync(route, createJsonContent parameters)
+
+    /// Posts a branch version route through the supplied test client.
+    let postBranchVersionRouteAsync (client: HttpClient) repositoryId branchId =
+        let parameters = Parameters.Branch.GetBranchVersionParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        client.PostAsync("/branch/getVersion", createJsonContent parameters)
+
     /// Gets repository branches through the supplied test client.
     let getRepositoryBranchesWithClientAsync (client: HttpClient) repositoryId =
         task {
@@ -212,6 +257,39 @@ module BranchServerTestHelpers =
             parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = client.PostAsync("/repository/getBranches", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Branch.BranchDto array>> response
+            return returnValue.ReturnValue
+        }
+
+    /// Gets a limited repository branch list through the supplied test client.
+    let getRepositoryBranchesWithLimitAsync (client: HttpClient) repositoryId maxCount =
+        task {
+            let parameters = Parameters.Repository.GetBranchesParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.MaxCount <- maxCount
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/repository/getBranches", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Branch.BranchDto array>> response
+            return returnValue.ReturnValue
+        }
+
+    /// Gets repository branches by branch id through the supplied test client.
+    let getRepositoryBranchesByBranchIdWithClientAsync (client: HttpClient) repositoryId branchIds =
+        task {
+            let parameters = Parameters.Repository.GetBranchesByBranchIdParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchIds <- branchIds
+            parameters.MaxCount <- 100
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/repository/getBranchesByBranchId", createJsonContent parameters)
             do! assertOk response
             let! returnValue = deserializeContent<GraceReturnValue<Branch.BranchDto array>> response
             return returnValue.ReturnValue
@@ -1073,14 +1151,17 @@ type BranchServer() =
         task {
             let creatorUserId = $"{Guid.NewGuid()}"
             let observerUserId = $"{Guid.NewGuid()}"
+            let adminUserId = $"{Guid.NewGuid()}"
             let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityPublic"
 
             do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
             do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
             do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId adminUserId "RepositoryAdmin"
 
             use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
             use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+            use adminClient = BranchServerTestHelpers.createClientWithUserId adminUserId
 
             let! observerBefore = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
             let parentBranch = observerBefore |> Array.exactlyOne
@@ -1101,6 +1182,25 @@ type BranchServer() =
             let! observerGet = BranchServerTestHelpers.getBranchResponseAsync observerClient repositoryId branchId
             do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerGet
 
+            let! observerGetByName = BranchServerTestHelpers.getBranchByNameResponseAsync observerClient repositoryId branchName
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerGetByName
+            let! observerGetByNameBody = observerGetByName.Content.ReadAsStringAsync()
+            let observerGetByNameError = deserialize<GraceError> observerGetByNameBody
+
+            Assert.That(observerGetByNameError.Properties.ContainsKey(nameof BranchId), Is.False)
+
+            let! observerEvents = BranchServerTestHelpers.postBranchIdRouteAsync observerClient "/branch/getEvents" repositoryId branchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerEvents
+
+            let! observerReferences = BranchServerTestHelpers.postBranchReferencesRouteAsync observerClient "/branch/getReferences" repositoryId branchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerReferences
+
+            let! observerPromotions = BranchServerTestHelpers.postBranchReferencesRouteAsync observerClient "/branch/getPromotions" repositoryId branchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerPromotions
+
+            let! observerVersion = BranchServerTestHelpers.postBranchVersionRouteAsync observerClient repositoryId branchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerVersion
+
             let! observerAfter = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
 
             Assert.That(observerAfter.Length, Is.EqualTo(observerBefore.Length))
@@ -1109,6 +1209,37 @@ type BranchServer() =
                 observerAfter
                 |> Array.exists (fun branch -> branch.BranchId = creatorBranch.BranchId),
                 Is.False
+            )
+
+            let! observerByBranchId =
+                BranchServerTestHelpers.getRepositoryBranchesByBranchIdWithClientAsync observerClient repositoryId [| creatorBranch.BranchId |]
+
+            Assert.That(observerByBranchId, Is.Empty)
+
+            let visibleBranchName = $"VisibleRepositoryOwned{Guid.NewGuid():N}"
+
+            let! visibleBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync creatorClient repositoryId parentBranch visibleBranchName "Public" "RepositoryOwned"
+
+            let! visibleBranch = BranchServerTestHelpers.waitForBranchAsync repositoryId visibleBranchId
+            let! observerLimited = BranchServerTestHelpers.getRepositoryBranchesWithLimitAsync observerClient repositoryId 2
+            Assert.That(observerLimited.Length, Is.EqualTo(2))
+
+            Assert.That(
+                observerLimited
+                |> Array.exists (fun branch -> branch.BranchId = visibleBranch.BranchId),
+                Is.True
+            )
+
+            let! adminGet = BranchServerTestHelpers.getBranchResponseAsync adminClient repositoryId branchId
+            do! BranchServerTestHelpers.assertOk adminGet
+
+            let! adminBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync adminClient repositoryId
+
+            Assert.That(
+                adminBranches
+                |> Array.exists (fun branch -> branch.BranchId = creatorBranch.BranchId),
+                Is.True
             )
         }
 

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -13,6 +13,7 @@ open Grace.Types
 open Grace.Types.Annotation
 open Grace.Types.Common
 open Grace.Types.PersonalAccessToken
+open Grace.Types.Visibility
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -27,20 +28,76 @@ open System.Threading.Tasks
 /// Groups shared helpers for branch server test helpers.
 module BranchServerTestHelpers =
     /// Asserts ok for integration responses.
-    let private assertOk (response: HttpResponseMessage) =
+    let assertOk (response: HttpResponseMessage) =
         task {
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
         }
 
     /// Asserts bad request grace error for integration responses.
-    let private assertBadRequestGraceError (expectedError: string) (response: HttpResponseMessage) =
+    let assertBadRequestGraceError (expectedError: string) (response: HttpResponseMessage) =
         task {
             let! body = response.Content.ReadAsStringAsync()
             Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), body)
             let error = deserialize<GraceError> body
             Assert.That(error.Error, Is.EqualTo(expectedError))
             Assert.That(error.CorrelationId, Is.Not.Empty)
+        }
+
+    /// Builds an authenticated test client for a specific Grace user id.
+    let createClientWithUserId (userId: string) =
+        let client = new HttpClient(BaseAddress = Client.BaseAddress, Timeout = Client.Timeout)
+        client.DefaultRequestHeaders.Add("x-grace-user-id", userId)
+        client
+
+    /// Grants a repository-scoped role to a test user.
+    let grantRepositoryRoleAsync repositoryId principalId roleId =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- "repo"
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
+            do! assertOk response
+        }
+
+    /// Creates an isolated repository for branch visibility route tests.
+    let createRepositoryAsync repositoryNamePrefix =
+        task {
+            let repositoryId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Repository.CreateRepositoryParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.RepositoryName <- $"{repositoryNamePrefix}{Guid.NewGuid():N}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/repository/create", createJsonContent parameters)
+            do! assertOk response
+            return repositoryId
+        }
+
+    /// Sets repository visibility through the public route.
+    let setRepositoryVisibilityAsync repositoryId visibility =
+        task {
+            let parameters = Parameters.Repository.SetRepositoryVisibilityParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.Visibility <- visibility
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            do! grantRepositoryRoleAsync repositoryId testUserId "RepositoryAdmin"
+
+            let! response = Client.PostAsync("/repository/setVisibility", createJsonContent parameters)
+            do! assertOk response
         }
 
     /// Builds get branch parameters for route calls.
@@ -116,6 +173,48 @@ module BranchServerTestHelpers =
             Assert.That(returnedBranchId, Is.EqualTo(Guid.Parse(branchId)))
 
             return! waitForBranchAsync repositoryId branchId
+        }
+
+    /// Creates a branch with optional visibility and ownership route inputs.
+    let createBranchWithVisibilityAsync (client: HttpClient) (repositoryId: string) (parentBranch: Branch.BranchDto) (branchName: string) visibility ownership =
+        task {
+            let branchId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Branch.CreateBranchParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.BranchName <- branchName
+            parameters.ParentBranchId <- $"{parentBranch.BranchId}"
+            parameters.ParentBranchName <- $"{parentBranch.BranchName}"
+            parameters.Visibility <- visibility
+            parameters.Ownership <- ownership
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/branch/create", createJsonContent parameters)
+            do! assertOk response
+
+            return branchId
+        }
+
+    /// Gets branch response through the supplied test client.
+    let getBranchResponseAsync (client: HttpClient) repositoryId branchId =
+        client.PostAsync("/branch/get", createJsonContent (getBranchParameters repositoryId branchId))
+
+    /// Gets repository branches through the supplied test client.
+    let getRepositoryBranchesWithClientAsync (client: HttpClient) repositoryId =
+        task {
+            let parameters = Parameters.Repository.GetBranchesParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.MaxCount <- 100
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/repository/getBranches", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<Branch.BranchDto array>> response
+            return returnValue.ReturnValue
         }
 
     /// Gets repository branches from the running test server.
@@ -966,6 +1065,122 @@ type BranchServer() =
 
             do! BranchServerTestHelpers.assertMissingRepositoryAsync ()
             do! BranchServerTestHelpers.assertMissingBranchAsync repositoryId
+        }
+
+    /// Verifies that private contributor-owned branches are durable for the creator and hidden from repository readers.
+    [<Test>]
+    member _.PrivateContributorOwnedBranchInPublicRepositoryIsHiddenFromObserver() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityPublic"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBefore = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBefore |> Array.exactlyOne
+            let branchName = $"PrivateContributor{Guid.NewGuid():N}"
+
+            let! branchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync creatorClient repositoryId parentBranch branchName "Private" "ContributorOwned"
+
+            let! creatorResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId branchId
+            do! BranchServerTestHelpers.assertOk creatorResponse
+            let! creatorReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> creatorResponse
+            let creatorBranch = creatorReturnValue.ReturnValue
+
+            Assert.That(creatorBranch.Visibility, Is.EqualTo(ResourceVisibility.Private))
+            Assert.That(creatorBranch.Ownership, Is.EqualTo(ResourceOwnership.ContributorOwned))
+            Assert.That(creatorBranch.UserId, Is.EqualTo(UserId creatorUserId))
+
+            let! observerGet = BranchServerTestHelpers.getBranchResponseAsync observerClient repositoryId branchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerGet
+
+            let! observerAfter = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+
+            Assert.That(observerAfter.Length, Is.EqualTo(observerBefore.Length))
+
+            Assert.That(
+                observerAfter
+                |> Array.exists (fun branch -> branch.BranchId = creatorBranch.BranchId),
+                Is.False
+            )
+        }
+
+    /// Verifies that regular branches in public repositories default to public repository-owned visibility.
+    [<Test>]
+    member _.RegularPublicRepositoryBranchDefaultsPublicRepositoryOwned() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityDefaultPublic"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBefore = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBefore |> Array.exactlyOne
+            let branchName = $"PublicDefault{Guid.NewGuid():N}"
+
+            let! branchId = BranchServerTestHelpers.createBranchWithVisibilityAsync creatorClient repositoryId parentBranch branchName String.Empty String.Empty
+
+            let! observerResponse = BranchServerTestHelpers.getBranchResponseAsync observerClient repositoryId branchId
+            do! BranchServerTestHelpers.assertOk observerResponse
+            let! observerReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> observerResponse
+            let branch = observerReturnValue.ReturnValue
+
+            Assert.That(branch.Visibility, Is.EqualTo(ResourceVisibility.Public))
+            Assert.That(branch.Ownership, Is.EqualTo(ResourceOwnership.RepositoryOwned))
+
+            let! observerAfter = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            Assert.That(observerAfter.Length, Is.EqualTo(observerBefore.Length + 1))
+
+            Assert.That(
+                observerAfter
+                |> Array.exists (fun candidate -> candidate.BranchId = branch.BranchId),
+                Is.True
+            )
+        }
+
+    /// Verifies that regular branches in private repositories default to private repository-owned visibility.
+    [<Test>]
+    member _.RegularPrivateRepositoryBranchDefaultsPrivateRepositoryOwned() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityDefaultPrivate"
+
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBefore = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBefore |> Array.exactlyOne
+            let branchName = $"PrivateDefault{Guid.NewGuid():N}"
+
+            let! branchId = BranchServerTestHelpers.createBranchWithVisibilityAsync creatorClient repositoryId parentBranch branchName String.Empty String.Empty
+
+            let! observerResponse = BranchServerTestHelpers.getBranchResponseAsync observerClient repositoryId branchId
+            do! BranchServerTestHelpers.assertOk observerResponse
+            let! observerReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> observerResponse
+            let branch = observerReturnValue.ReturnValue
+
+            Assert.That(branch.Visibility, Is.EqualTo(ResourceVisibility.Private))
+            Assert.That(branch.Ownership, Is.EqualTo(ResourceOwnership.RepositoryOwned))
+
+            let! observerAfter = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            Assert.That(observerAfter.Length, Is.EqualTo(observerBefore.Length + 1))
         }
 
     /// Verifies the save with directory version ID and SHA prefix hydrates full root hashes scenario.

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -13,12 +13,15 @@ open Grace.Shared
 open Grace.Shared.AnnotationLineCore
 open Grace.Shared.Extensions
 open Grace.Shared.Parameters.Branch
+open Grace.Shared.Parameters.Visibility
 open Grace.Types
 open Grace.Types.Annotation
 open Grace.Types.Authorization
 open Grace.Types.Branch
 open Grace.Types.Diff
 open Grace.Types.Common
+open Grace.Types.Repository
+open Grace.Types.Visibility
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Common
 open Grace.Shared.Validation.Errors
@@ -148,6 +151,57 @@ module Branch =
             | Denied _ -> return false
         }
 
+    /// Checks whether the already-authorized caller can observe the stored branch visibility boundary.
+    let internal canObserveBranch (context: HttpContext) (branchDto: BranchDto) =
+        match branchDto.Visibility, branchDto.Ownership with
+        | ResourceVisibility.Public, _ -> true
+        | _, ResourceOwnership.RepositoryOwned -> true
+        | _, ResourceOwnership.ContributorOwned ->
+            PrincipalMapper.tryGetUserId context.User
+            |> Option.map UserId
+            |> Option.exists ((=) branchDto.UserId)
+
+    /// Creates the hidden-as-missing response used when a private contributor branch exists but is not observable.
+    let internal hiddenBranchError context branchId =
+        (GraceError.Create (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) (getCorrelationId context))
+            .enhance(nameof BranchId, branchId)
+            .enhance ("Path", context.Request.Path.Value)
+
+    /// Validates an optional visibility input without accepting deferred values.
+    let private visibilityInputIsImplemented (visibility: string) =
+        ValueTask<Result<unit, BranchError>>(
+            if String.IsNullOrWhiteSpace visibility
+               || (tryParseVisibilityInput visibility).IsSome then
+                Ok()
+            else
+                Error BranchError.InvalidReferenceType
+        )
+
+    /// Validates an optional ownership input without accepting arbitrary contributor owner identifiers.
+    let private ownershipInputIsImplemented (ownership: string) =
+        ValueTask<Result<unit, BranchError>>(
+            if String.IsNullOrWhiteSpace ownership
+               || (tryParseOwnershipInput ownership).IsSome then
+                Ok()
+            else
+                Error BranchError.InvalidReferenceType
+        )
+
+    /// Resolves the branch visibility default from repository policy and explicit route input.
+    let private resolveBranchVisibility (repositoryType: RepositoryType) (ownership: ResourceOwnership) (visibilityInput: string) =
+        match tryParseVisibilityInput visibilityInput with
+        | Some visibility -> visibility
+        | None ->
+            match ownership, repositoryType with
+            | ResourceOwnership.ContributorOwned, _ -> ResourceVisibility.Private
+            | _, RepositoryType.Public -> ResourceVisibility.Public
+            | _, RepositoryType.Private -> ResourceVisibility.Private
+
+    /// Resolves the branch ownership default from explicit route input.
+    let private resolveBranchOwnership ownershipInput =
+        tryParseOwnershipInput ownershipInput
+        |> Option.defaultValue ResourceOwnership.RepositoryOwned
+
     /// Gets try get based on reference id data needed by the server flow.
     let tryGetBasedOnReferenceId (referenceDto: Reference.ReferenceDto) =
         referenceDto.Links
@@ -167,7 +221,7 @@ module Branch =
     /// Implements materialize annotation document for the server request pipeline.
     let private materializeAnnotationDocument
         (context: HttpContext)
-        (repositoryDto: Repository.RepositoryDto)
+        (repositoryDto: Grace.Types.Repository.RepositoryDto)
         (path: RelativePath)
         (referenceDto: Reference.ReferenceDto)
         =
@@ -223,7 +277,7 @@ module Branch =
     /// Materializes annotation history across references while preserving unreadable ancestor boundaries for the caller.
     let internal buildEffectiveHistory
         (context: HttpContext)
-        (repositoryDto: Repository.RepositoryDto)
+        (repositoryDto: Grace.Types.Repository.RepositoryDto)
         (path: RelativePath)
         (targetReferenceId: ReferenceId)
         (references: Reference.ReferenceDto array)
@@ -446,7 +500,10 @@ module Branch =
                 return Error(annotationError correlationId (BranchError.getErrorMessage BranchError.InvalidReferenceId))
             | Ok () ->
                 let normalizedPath = normalizeAnnotationPath parameters.Path
-                let repositoryActorProxy = Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
+
+                let repositoryActorProxy =
+                    Grace.Actors.Extensions.ActorProxy.Repository.CreateActorProxy graceIds.OrganizationId graceIds.RepositoryId correlationId
+
                 let! repositoryDto = repositoryActorProxy.Get correlationId
 
                 let referenceActorProxy = Reference.CreateActorProxy parameters.TargetReferenceId graceIds.RepositoryId correlationId
@@ -845,6 +902,8 @@ module Branch =
                             parameters.BranchName
                             parameters.CorrelationId
                             BranchError.BranchNameAlreadyExists
+                        visibilityInputIsImplemented parameters.Visibility
+                        ownershipInputIsImplemented parameters.Ownership
                     |]
 
                 /// Implements command for the server request pipeline.
@@ -860,12 +919,28 @@ module Branch =
                             with
                         | Some parentBranchId ->
                             let repositoryId = Guid.Parse(parameters.RepositoryId)
+
+                            let repositoryActorProxy =
+                                Grace.Actors.Extensions.ActorProxy.Repository.CreateActorProxy
+                                    graceIds.OrganizationId
+                                    graceIds.RepositoryId
+                                    parameters.CorrelationId
+
+                            let! repositoryDto = repositoryActorProxy.Get parameters.CorrelationId
+                            let ownership = resolveBranchOwnership parameters.Ownership
+                            let visibility = resolveBranchVisibility repositoryDto.RepositoryType ownership parameters.Visibility
+
+                            let creatorUserId =
+                                PrincipalMapper.tryGetUserId context.User
+                                |> Option.map UserId
+                                |> Option.defaultValue (UserId String.Empty)
+
                             let parentBranchActorProxy = Branch.CreateActorProxy parentBranchId repositoryId parameters.CorrelationId
 
                             let! parentBranch = parentBranchActorProxy.Get parameters.CorrelationId
 
                             return
-                                Create(
+                                BranchCommand.Create(
                                     graceIds.BranchId,
                                     (BranchName parameters.BranchName),
                                     parentBranchId,
@@ -873,11 +948,14 @@ module Branch =
                                     graceIds.OwnerId,
                                     graceIds.OrganizationId,
                                     graceIds.RepositoryId,
-                                    parameters.InitialPermissions
+                                    parameters.InitialPermissions,
+                                    visibility,
+                                    ownership,
+                                    creatorUserId
                                 )
                         | None ->
                             return
-                                Create(
+                                BranchCommand.Create(
                                     graceIds.BranchId,
                                     (BranchName parameters.BranchName),
                                     Constants.DefaultParentBranchId,
@@ -885,7 +963,10 @@ module Branch =
                                     graceIds.OwnerId,
                                     graceIds.OrganizationId,
                                     graceIds.RepositoryId,
-                                    parameters.InitialPermissions
+                                    parameters.InitialPermissions,
+                                    ResourceVisibility.Private,
+                                    ResourceOwnership.RepositoryOwned,
+                                    UserId String.Empty
                                 )
                     }
                     |> ValueTask<BranchCommand>
@@ -1462,7 +1543,7 @@ module Branch =
                                     return None
                             }
 
-                        return DeleteLogical(parameters.Force, parameters.DeleteReason, parameters.ReassignChildBranches, newParentBranchIdOption)
+                        return BranchCommand.DeleteLogical(parameters.Force, parameters.DeleteReason, parameters.ReassignChildBranches, newParentBranchIdOption)
                     }
                     |> ValueTask<BranchCommand>
 
@@ -1541,14 +1622,25 @@ module Branch =
                 let graceIds = getGraceIds context
 
                 try
-                    /// Implements validations for the server request pipeline.
-                    let validations (parameters: GetBranchParameters) = [||]
-
-                    /// Implements query for the server request pipeline.
-                    let query (context: HttpContext) maxCount (actorProxy: IBranchActor) = actorProxy.Get(getCorrelationId context)
-
                     let! parameters = context |> parse<GetBranchParameters>
-                    let! result = processQuery context parameters validations 1 query
+                    let actorProxy = Branch.CreateActorProxy graceIds.BranchId graceIds.RepositoryId (getCorrelationId context)
+                    let! branchDto = actorProxy.Get(getCorrelationId context)
+
+                    let! result =
+                        if canObserveBranch context branchDto then
+                            let graceReturnValue =
+                                (GraceReturnValue.Create branchDto (getCorrelationId context))
+                                    .enhance(getParametersAsDictionary parameters)
+                                    .enhance(nameof OwnerId, graceIds.OwnerId)
+                                    .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                    .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                    .enhance(nameof BranchId, graceIds.BranchId)
+                                    .enhance ("Path", context.Request.Path.Value)
+
+                            context |> result200Ok graceReturnValue
+                        else
+                            context
+                            |> result400BadRequest (hiddenBranchError context graceIds.BranchId)
 
                     let duration_ms = getDurationRightAligned_ms startTime
 

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -41,6 +41,7 @@ open System.Threading.Tasks
 module Branch =
 
     let private branchHashLookupErrorItemKey = "BranchHashLookupError"
+    let private callerSuppliedBranchIdItemKey = "CallerSuppliedBranchId"
 
     /// Implements branch hash lookup description for the server request pipeline.
     let private branchHashLookupDescription (sha256Hash: Sha256Hash) (blake3Hash: Blake3Hash) =
@@ -151,21 +152,72 @@ module Branch =
             | Denied _ -> return false
         }
 
-    /// Checks whether the already-authorized caller can observe the stored branch visibility boundary.
+    /// Checks whether RBAC already grants the caller elevated authority over the branch.
+    let private canAdministerBranch (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let principals = PrincipalMapper.getPrincipals context.User
+            let claims = PrincipalMapper.getEffectiveClaims context.User
+            let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+            let resource = Resource.Branch(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId, branchDto.BranchId)
+
+            match! evaluator.CheckAsync(principals, claims, Operation.BranchAdmin, resource) with
+            | Allowed _ -> return true
+            | Denied _ -> return false
+        }
+
+    /// Checks whether the already-authenticated caller can observe the stored branch visibility boundary.
     let internal canObserveBranch (context: HttpContext) (branchDto: BranchDto) =
-        match branchDto.Visibility, branchDto.Ownership with
-        | ResourceVisibility.Public, _ -> true
-        | _, ResourceOwnership.RepositoryOwned -> true
-        | _, ResourceOwnership.ContributorOwned ->
-            PrincipalMapper.tryGetUserId context.User
-            |> Option.map UserId
-            |> Option.exists ((=) branchDto.UserId)
+        task {
+            match branchDto.Visibility, branchDto.Ownership with
+            | ResourceVisibility.Public, _ -> return true
+            | _, ResourceOwnership.RepositoryOwned -> return true
+            | _, ResourceOwnership.ContributorOwned ->
+                let isCreator =
+                    PrincipalMapper.tryGetUserId context.User
+                    |> Option.map UserId
+                    |> Option.exists ((=) branchDto.UserId)
+
+                if isCreator then return true else return! canAdministerBranch context branchDto
+        }
 
     /// Creates the hidden-as-missing response used when a private contributor branch exists but is not observable.
     let internal hiddenBranchError context branchId =
-        (GraceError.Create (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) (getCorrelationId context))
-            .enhance(nameof BranchId, branchId)
-            .enhance ("Path", context.Request.Path.Value)
+        let error = GraceError.Create (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) (getCorrelationId context)
+
+        branchId
+        |> Option.iter (fun callerSuppliedBranchId ->
+            error.enhance (nameof BranchId, callerSuppliedBranchId)
+            |> ignore)
+
+        error.enhance ("Path", context.Request.Path.Value)
+
+    /// Returns a caller-supplied branch id without exposing ids resolved from branch-name-only requests.
+    let private callerSuppliedBranchId (context: HttpContext) (parameters: #BranchParameters) =
+        let mutable callerSuppliedBranchIdItem = null
+
+        let branchId =
+            if context.Items.TryGetValue(callerSuppliedBranchIdItemKey, &callerSuppliedBranchIdItem) then
+                callerSuppliedBranchIdItem :?> string
+            else
+                parameters.BranchId
+
+        if String.IsNullOrWhiteSpace branchId then None else Some(Guid.Parse branchId)
+
+    /// Loads the branch selected by middleware and enforces hidden-as-missing visibility before route data is returned.
+    let private requireObservableBranch (context: HttpContext) (parameters: #BranchParameters) =
+        task {
+            let graceIds = getGraceIds context
+            let actorProxy = Branch.CreateActorProxy graceIds.BranchId graceIds.RepositoryId (getCorrelationId context)
+            let! branchDto = actorProxy.Get(getCorrelationId context)
+            let! isObservable = canObserveBranch context branchDto
+
+            if isObservable then
+                return Ok(actorProxy, branchDto)
+            else
+                return Error(hiddenBranchError context (callerSuppliedBranchId context parameters))
+        }
+
 
     /// Validates an optional visibility input without accepting deferred values.
     let private visibilityInputIsImplemented (visibility: string) =
@@ -866,6 +918,20 @@ module Branch =
                         .enhance ("Path", context.Request.Path.Value)
 
                 return! context |> result500ServerError graceError
+        }
+
+    /// Runs the normal branch query pipeline only after the target branch is observable to the caller.
+    let private processObservableQuery<'T, 'U when 'T :> BranchParameters>
+        (context: HttpContext)
+        (parameters: 'T)
+        (validations: Validations<'T>)
+        maxCount
+        (query: QueryResult<IBranchActor, 'U>)
+        =
+        task {
+            match! requireObservableBranch context parameters with
+            | Ok _ -> return! processQuery context parameters validations maxCount query
+            | Error error -> return! context |> result400BadRequest error
         }
 
     /// Creates a new branch.
@@ -1625,9 +1691,11 @@ module Branch =
                     let! parameters = context |> parse<GetBranchParameters>
                     let actorProxy = Branch.CreateActorProxy graceIds.BranchId graceIds.RepositoryId (getCorrelationId context)
                     let! branchDto = actorProxy.Get(getCorrelationId context)
+                    let! isObservable = canObserveBranch context branchDto
 
                     let! result =
-                        if canObserveBranch context branchDto then
+                        match isObservable with
+                        | true ->
                             let graceReturnValue =
                                 (GraceReturnValue.Create branchDto (getCorrelationId context))
                                     .enhance(getParametersAsDictionary parameters)
@@ -1638,9 +1706,9 @@ module Branch =
                                     .enhance ("Path", context.Request.Path.Value)
 
                             context |> result200Ok graceReturnValue
-                        else
+                        | false ->
                             context
-                            |> result400BadRequest (hiddenBranchError context graceIds.BranchId)
+                            |> result400BadRequest (hiddenBranchError context (callerSuppliedBranchId context parameters))
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -1695,7 +1763,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetBranchParameters>
-                    let! result = processQuery context parameters validations 1 query
+                    let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -1749,7 +1817,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<BranchParameters>
-                    let! result = processQuery context parameters validations 1 query
+                    let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -1809,7 +1877,7 @@ module Branch =
 
                     let! parameters = context |> parse<GetReferenceParameters>
                     context.Items[ "ReferenceId" ] <- parameters.ReferenceId
-                    let! result = processQuery context parameters validations 1 query
+                    let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -1867,7 +1935,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2005,7 +2073,7 @@ module Branch =
                         |> parse<GetLatestReferencesByReferenceTypeParameters>
 
                     context.Items.Add("ReferenceTypes", serialize parameters.ReferenceTypes)
-                    let! result = processQuery context parameters validations 1 query
+                    let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2111,7 +2179,7 @@ module Branch =
                         |> parse<GetDiffsForReferenceTypeParameters>
 
                     context.Items.Add(nameof ReferenceType, parameters.ReferenceType)
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2169,7 +2237,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2227,7 +2295,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2285,7 +2353,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2344,7 +2412,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2402,7 +2470,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2460,7 +2528,7 @@ module Branch =
                         }
 
                     let! parameters = context |> parse<GetReferencesParameters>
-                    let! result = processQuery context parameters validations (parameters.MaxCount) query
+                    let! result = processObservableQuery context parameters validations (parameters.MaxCount) query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2570,7 +2638,7 @@ module Branch =
 
                     let! parameters = context |> parse<ListContentsParameters>
                     context.Items[ "ListContentsParameters" ] <- parameters
-                    let! result = processQuery context parameters validations 1 query
+                    let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2684,7 +2752,7 @@ module Branch =
 
                     let! parameters = context |> parse<ListContentsParameters>
                     context.Items[ "ListContentsParameters" ] <- parameters
-                    let! result = processQuery context parameters validations 1 query
+                    let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
 
@@ -2872,6 +2940,7 @@ module Branch =
             let repositoryIdFromRoute = graceIds.RepositoryId
 
             let! parameters = context |> parse<GetBranchVersionParameters>
+            context.Items[ callerSuppliedBranchIdItemKey ] <- parameters.BranchId
 
             let! repositoryIdOption =
                 resolveRepositoryId graceIds.OwnerId graceIds.OrganizationId parameters.RepositoryId parameters.RepositoryName parameters.CorrelationId
@@ -2880,7 +2949,7 @@ module Branch =
 
             // Now that we've populated BranchId for sure...
             context.Items.Add("GetVersionParameters", parameters)
-            return! processQuery context parameters getVersionValidations 1 getVersionQuery
+            return! processObservableQuery context parameters getVersionValidations 1 getVersionQuery
         }
 
     /// Handles the Grace Server get version request.

--- a/src/Grace.Server/Repository.Server.fs
+++ b/src/Grace.Server/Repository.Server.fs
@@ -13,8 +13,10 @@ open Grace.Server.Validations
 open Grace.Shared
 open Grace.Shared.Extensions
 open Grace.Shared.Parameters.Repository
+open Grace.Types.Branch
 open Grace.Types.Repository
 open Grace.Types.Common
+open Grace.Types.Visibility
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Common
 open Grace.Shared.Validation.Errors
@@ -43,6 +45,16 @@ module Repository =
     let activitySource = new ActivitySource("Repository")
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Repository.Server")
+
+    /// Determines whether the caller may observe a branch in repository branch list materialization.
+    let internal canObserveBranch (context: HttpContext) (branchDto: BranchDto) =
+        match branchDto.Visibility, branchDto.Ownership with
+        | ResourceVisibility.Public, _ -> true
+        | _, ResourceOwnership.RepositoryOwned -> true
+        | _, ResourceOwnership.ContributorOwned ->
+            PrincipalMapper.tryGetUserId context.User
+            |> Option.map UserId
+            |> Option.exists ((=) branchDto.UserId)
 
     /// Coordinates process command with post success processing for Grace Server.
     let processCommandWithPostSuccess<'T when 'T :> RepositoryParameters>
@@ -821,8 +833,12 @@ module Repository =
                             let graceIds = context.Items[nameof GraceIds] :?> GraceIds
                             let includeDeleted = context.Items["IncludeDeleted"] :?> bool
 
-                            return!
+                            let! branches =
                                 getBranches graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId maxCount includeDeleted (getCorrelationId context)
+
+                            return
+                                branches
+                                |> Array.filter (canObserveBranch context)
                         }
 
                     let! parameters = context |> parse<GetBranchesParameters>

--- a/src/Grace.Server/Repository.Server.fs
+++ b/src/Grace.Server/Repository.Server.fs
@@ -11,8 +11,10 @@ open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
+open Grace.Shared.Authorization
 open Grace.Shared.Extensions
 open Grace.Shared.Parameters.Repository
+open Grace.Types.Authorization
 open Grace.Types.Branch
 open Grace.Types.Repository
 open Grace.Types.Common
@@ -24,6 +26,7 @@ open Grace.Shared.Validation
 open Grace.Shared.Validation.Utilities
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Mvc
+open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
 open NodaTime
 open OpenTelemetry.Trace
@@ -46,15 +49,56 @@ module Repository =
 
     let log = ApplicationContext.loggerFactory.CreateLogger("Repository.Server")
 
+    /// Checks whether RBAC grants elevated branch administration authority for repository branch materialization.
+    let private canAdministerBranch (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let principals = PrincipalMapper.getPrincipals context.User
+            let claims = PrincipalMapper.getEffectiveClaims context.User
+            let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+            let resource = Resource.Branch(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId, branchDto.BranchId)
+
+            match! evaluator.CheckAsync(principals, claims, Operation.BranchAdmin, resource) with
+            | Allowed _ -> return true
+            | Denied _ -> return false
+        }
+
     /// Determines whether the caller may observe a branch in repository branch list materialization.
     let internal canObserveBranch (context: HttpContext) (branchDto: BranchDto) =
-        match branchDto.Visibility, branchDto.Ownership with
-        | ResourceVisibility.Public, _ -> true
-        | _, ResourceOwnership.RepositoryOwned -> true
-        | _, ResourceOwnership.ContributorOwned ->
-            PrincipalMapper.tryGetUserId context.User
-            |> Option.map UserId
-            |> Option.exists ((=) branchDto.UserId)
+        task {
+            match branchDto.Visibility, branchDto.Ownership with
+            | ResourceVisibility.Public, _ -> return true
+            | _, ResourceOwnership.RepositoryOwned -> return true
+            | _, ResourceOwnership.ContributorOwned ->
+                let isCreator =
+                    PrincipalMapper.tryGetUserId context.User
+                    |> Option.map UserId
+                    |> Option.exists ((=) branchDto.UserId)
+
+                if isCreator then return true else return! canAdministerBranch context branchDto
+        }
+
+    /// Applies branch visibility before route-level limits so hidden branches do not create observable list gaps.
+    let private filterObservableBranches (context: HttpContext) maxCount (branches: BranchDto seq) =
+        task {
+            let visibleBranches = List<BranchDto>()
+            use enumerator = branches.GetEnumerator()
+
+            let mutable keepScanning =
+                visibleBranches.Count < maxCount
+                && enumerator.MoveNext()
+
+            while keepScanning do
+                let! isObservable = canObserveBranch context enumerator.Current
+
+                if isObservable then visibleBranches.Add enumerator.Current
+
+                keepScanning <-
+                    visibleBranches.Count < maxCount
+                    && enumerator.MoveNext()
+
+            return visibleBranches.ToArray()
+        }
 
     /// Coordinates process command with post success processing for Grace Server.
     let processCommandWithPostSuccess<'T when 'T :> RepositoryParameters>
@@ -834,11 +878,15 @@ module Repository =
                             let includeDeleted = context.Items["IncludeDeleted"] :?> bool
 
                             let! branches =
-                                getBranches graceIds.OwnerId graceIds.OrganizationId graceIds.RepositoryId maxCount includeDeleted (getCorrelationId context)
+                                getBranches
+                                    graceIds.OwnerId
+                                    graceIds.OrganizationId
+                                    graceIds.RepositoryId
+                                    Int32.MaxValue
+                                    includeDeleted
+                                    (getCorrelationId context)
 
-                            return
-                                branches
-                                |> Array.filter (canObserveBranch context)
+                            return! filterObservableBranches context maxCount branches
                         }
 
                     let! parameters = context |> parse<GetBranchesParameters>
@@ -970,7 +1018,8 @@ module Repository =
                                     .Select(fun branchId -> Guid.Parse(branchId))
 
                             let includeDeleted = context.Items["IncludeDeleted"] :?> bool
-                            return! getBranchesByBranchId repositoryId branchIds maxCount includeDeleted
+                            let! branches = getBranchesByBranchId repositoryId branchIds maxCount includeDeleted
+                            return! filterObservableBranches context maxCount branches
                         }
 
                     let! parameters = context |> parse<GetBranchesByBranchIdParameters>

--- a/src/Grace.Shared/Parameters/Branch.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Branch.Parameters.fs
@@ -38,6 +38,8 @@ module Branch =
         member val public ParentBranchId = String.Empty with get, set
         member val public ParentBranchName: BranchName = String.Empty with get, set
         member val public InitialPermissions: ReferenceType seq = [ Commit; Checkpoint; Save; Tag ] with get, set
+        member val public Visibility = String.Empty with get, set
+        member val public Ownership = String.Empty with get, set
 
     /// Parameters for the /branch/assign endpoint.
     type AssignParameters() =

--- a/src/Grace.Types.Tests/Branch.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Branch.Types.Tests.fs
@@ -1,9 +1,11 @@
 namespace Grace.Types.Tests
 
 open Grace.Shared
+open Grace.Shared.Utilities
 open Grace.Types.Branch
 open Grace.Types.Common
 open Grace.Types.Reference
+open Grace.Types.Visibility
 open NodaTime
 open NUnit.Framework
 open System
@@ -20,6 +22,9 @@ type BranchDtoHashTests() =
     let sha256Hash = Sha256Hash "root-sha256"
     let blake3Hash = Blake3Hash "root-blake3"
     let referenceText = ReferenceText "root reference"
+    let ownerId = Guid.Parse("44444444-aaaa-4444-8888-444444444444")
+    let organizationId = Guid.Parse("55555555-aaaa-4444-8888-555555555555")
+    let repositoryId = Guid.Parse("66666666-aaaa-4444-8888-666666666666")
 
     let metadata =
         {
@@ -44,7 +49,31 @@ type BranchDtoHashTests() =
         }
 
     /// Exercises branch event coverage for the types branch contract.
-    let branchEvent (eventType: BranchEventType) : BranchEvent = { Event = eventType; Metadata = metadata }
+    let branchEvent (eventType: Grace.Types.Branch.BranchEventType) : Grace.Types.Branch.BranchEvent = { Event = eventType; Metadata = metadata }
+
+    /// Exercises created branch event coverage with based-on reference projection metadata.
+    let createdBranchEvent visibility ownership creatorUserId : Grace.Types.Branch.BranchEvent =
+        let createdMetadata = { metadata with Properties = Dictionary<string, string>() }
+
+        createdMetadata.Properties[ "basedOnReferenceDto" ] <- serialize ReferenceDto.Default
+
+        {
+            Event =
+                BranchEventType.Created(
+                    branchId,
+                    BranchName "private-contributor",
+                    Guid.Parse("77777777-aaaa-4444-8888-777777777777"),
+                    ReferenceId.Empty,
+                    ownerId,
+                    organizationId,
+                    repositoryId,
+                    [ ReferenceType.Commit ],
+                    visibility,
+                    ownership,
+                    creatorUserId
+                )
+            Metadata = createdMetadata
+        }
 
     /// Verifies that reference producing commands carry both root hashes.
     [<Test>]
@@ -131,3 +160,20 @@ type BranchDtoHashTests() =
         Assert.That(saved.LatestSave.Sha256Hash, Is.EqualTo(sha256Hash))
         Assert.That(saved.LatestSave.Blake3Hash, Is.EqualTo(blake3Hash))
         Assert.That(saved.LatestCommit.Blake3Hash, Is.EqualTo(blake3Hash))
+
+    /// Verifies that branch creation replay reconstructs visibility ownership and creator state.
+    [<Test>]
+    member _.ReplayProjectionKeepsVisibilityOwnershipAndCreatorState() =
+        let creatorUserId = UserId "creator-user"
+
+        let branch = BranchDto.UpdateDto (createdBranchEvent ResourceVisibility.Private ResourceOwnership.ContributorOwned creatorUserId) BranchDto.Default
+
+        Assert.That(branch.Visibility, Is.EqualTo(ResourceVisibility.Private))
+        Assert.That(branch.Ownership, Is.EqualTo(ResourceOwnership.ContributorOwned))
+        Assert.That(branch.UserId, Is.EqualTo(creatorUserId))
+
+    /// Verifies that the branch DTO default fails closed before repository policy is applied.
+    [<Test>]
+    member _.BranchDtoDefaultVisibilityFailsClosed() =
+        Assert.That(BranchDto.Default.Visibility, Is.EqualTo(ResourceVisibility.Private))
+        Assert.That(BranchDto.Default.Ownership, Is.EqualTo(ResourceOwnership.RepositoryOwned))

--- a/src/Grace.Types.Tests/Visibility.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Visibility.Types.Tests.fs
@@ -26,11 +26,11 @@ type private BranchCreateVisibilityParameters() =
 [<Parallelizable(ParallelScope.All)>]
 type VisibilityContractTests() =
 
-    /// Verifies that branch, reference, and promotion-set DTOs defer serialized visibility and ownership fields.
+    /// Verifies that branch DTOs now expose implemented visibility fields while later surfaces still defer them.
     [<Test>]
-    member _.CurrentDtosDoNotExposeDeferredVisibilityOrOwnershipFields() =
-        Assert.That(typeof<Grace.Types.Branch.BranchDto>.GetProperty ("Visibility"), Is.Null)
-        Assert.That(typeof<Grace.Types.Branch.BranchDto>.GetProperty ("Ownership"), Is.Null)
+    member _.CurrentDtosExposeOnlyImplementedBranchVisibilityAndOwnershipFields() =
+        Assert.That(typeof<Grace.Types.Branch.BranchDto>.GetProperty ("Visibility"), Is.Not.Null)
+        Assert.That(typeof<Grace.Types.Branch.BranchDto>.GetProperty ("Ownership"), Is.Not.Null)
         Assert.That(typeof<Grace.Types.Reference.ReferenceDto>.GetProperty ("Visibility"), Is.Null)
         Assert.That(typeof<Grace.Types.Reference.ReferenceDto>.GetProperty ("Ownership"), Is.Null)
         Assert.That(typeof<Grace.Types.PromotionSet.PromotionSetDto>.GetProperty ("Visibility"), Is.Null)
@@ -44,11 +44,11 @@ type VisibilityContractTests() =
         Assert.That(typeof<DirectoryVersion>.GetProperty ("Visibility"), Is.Null)
         Assert.That(typeof<DirectoryVersion>.GetProperty ("Ownership"), Is.Null)
 
-    /// Verifies that current create endpoints do not expose no-op visibility inputs before route behavior exists.
+    /// Verifies that branch create exposes implemented visibility inputs while later routes do not accept no-ops.
     [<Test>]
-    member _.CurrentCreateParametersDoNotExposeVisibilityOrOwnershipFields() =
-        Assert.That(typeof<CreateBranchParameters>.GetProperty ("Visibility"), Is.Null)
-        Assert.That(typeof<CreateBranchParameters>.GetProperty ("Ownership"), Is.Null)
+    member _.CurrentCreateParametersExposeOnlyImplementedBranchVisibilityAndOwnershipFields() =
+        Assert.That(typeof<CreateBranchParameters>.GetProperty ("Visibility"), Is.Not.Null)
+        Assert.That(typeof<CreateBranchParameters>.GetProperty ("Ownership"), Is.Not.Null)
         Assert.That(typeof<CreatePromotionSetParameters>.GetProperty ("Visibility"), Is.Null)
         Assert.That(typeof<CreatePromotionSetParameters>.GetProperty ("Ownership"), Is.Null)
 

--- a/src/Grace.Types/Branch.Types.fs
+++ b/src/Grace.Types/Branch.Types.fs
@@ -5,6 +5,7 @@ open Grace.Shared.Constants
 open Grace.Shared.Utilities
 open Grace.Types.Reference
 open Grace.Types.Common
+open Grace.Types.Visibility
 open NodaTime
 open Orleans
 open System
@@ -36,7 +37,10 @@ module Branch =
             ownerId: OwnerId *
             organizationId: OrganizationId *
             repositoryId: RepositoryId *
-            initialPermissions: ReferenceType seq
+            initialPermissions: ReferenceType seq *
+            visibility: ResourceVisibility *
+            ownership: ResourceOwnership *
+            creatorUserId: UserId
         | Rebase of basedOn: ReferenceId
         | SetName of newName: BranchName
         | Assign of directoryVersionId: DirectoryVersionId * sha256Hash: Sha256Hash * blake3Hash: Blake3Hash * referenceText: ReferenceText
@@ -75,7 +79,10 @@ module Branch =
             ownerId: OwnerId *
             organizationId: OrganizationId *
             repositoryId: RepositoryId *
-            initialPermissions: ReferenceType seq
+            initialPermissions: ReferenceType seq *
+            visibility: ResourceVisibility *
+            ownership: ResourceOwnership *
+            creatorUserId: UserId
         | Rebased of basedOn: ReferenceId
         | NameSet of newName: BranchName
         | Assigned of
@@ -159,6 +166,8 @@ module Branch =
             RepositoryId: RepositoryId
             BasedOn: ReferenceDto
             UserId: UserId
+            Visibility: ResourceVisibility
+            Ownership: ResourceOwnership
             AssignEnabled: bool
             PromotionEnabled: bool
             CommitEnabled: bool
@@ -192,6 +201,8 @@ module Branch =
                 RepositoryId = RepositoryId.Empty
                 BasedOn = ReferenceDto.Default
                 UserId = UserId String.Empty
+                Visibility = ResourceVisibility.Private
+                Ownership = ResourceOwnership.RepositoryOwned
                 AssignEnabled = false
                 PromotionEnabled = false
                 CommitEnabled = false
@@ -219,7 +230,17 @@ module Branch =
 
             let newBranchDto =
                 match branchEventType with
-                | Created (branchId, branchName, parentBranchId, basedOn, ownerId, organizationId, repositoryId, initialPermissions) ->
+                | Created (branchId,
+                           branchName,
+                           parentBranchId,
+                           basedOn,
+                           ownerId,
+                           organizationId,
+                           repositoryId,
+                           initialPermissions,
+                           visibility,
+                           ownership,
+                           creatorUserId) ->
                     let basedOnReferenceDto =
                         deserialize<ReferenceDto> (
                             branchEvent
@@ -237,6 +258,9 @@ module Branch =
                             OwnerId = ownerId
                             OrganizationId = organizationId
                             RepositoryId = repositoryId
+                            UserId = creatorUserId
+                            Visibility = visibility
+                            Ownership = ownership
                             CreatedAt = branchEvent.Metadata.Timestamp
                         }
 


### PR DESCRIPTION
## Summary

- Implements the GV-02 tracer bullet for private contributor-owned branches in public repositories.
- Adds durable Branch visibility/ownership state and create-parameter support backed by focused replay and server tests.
- Filters branch direct get and repository branch list/count visibility so public or low-privilege observers cannot infer hidden branches.

## Related Issue

Related to #641.

## Why This Matters

This proves the first user-visible vertical slice for the visibility epic before broader work fans out. It crosses the shared contract, actor persistence/replay, server authorization/filtering, and tests that later Branch, Reference, PromotionSet, storage, CLI, SDK, and eventing slices will reuse.

## Touched Paths

- `src/Grace.Types/Branch.Types.fs`
- `src/Grace.Shared/Parameters/Branch.Parameters.fs`
- `src/Grace.Actors/Branch.Actor.fs`
- `src/Grace.Actors/Repository.Actor.fs`
- `src/Grace.Server/Branch.Server.fs`
- `src/Grace.Server/Repository.Server.fs`
- `src/Grace.Types.Tests/Branch.Types.Tests.fs`
- `src/Grace.Types.Tests/Visibility.Types.Tests.fs`
- `src/Grace.Server.Tests/Branch.Server.Tests.fs`

## Write-Set Expansion

`src/Grace.Server/Repository.Server.fs` was added to the issue-owned write set and recorded on #641 before server list/count edits. The expansion is limited to repository `getBranches` visibility filtering required by the tracer acceptance criteria.

## Validation

- `dotnet tool run fantomas <touched F# files>`: passed.
- `dotnet build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj`: passed, 169 tests.
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~PrivateContributorOwnedBranchInPublicRepositoryIsHiddenFromObserver|FullyQualifiedName~RegularPublicRepositoryBranchDefaultsPublicRepositoryOwned|FullyQualifiedName~RegularPrivateRepositoryBranchDefaultsPrivateRepositoryOwned"`: passed, 3 tests. Teardown logged canceled cleanup calls for isolated owner/org cleanup, but the command exited 0.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.
- PR check `Validate / full`: passed on current head `53eb2c1c942d45f0b45347401e20d4a1e46915cc`.

## Review Status

- Current head: `53eb2c1c942d45f0b45347401e20d4a1e46915cc`.
- Codex Code Review Bot state for current head: no-issues gate satisfied; current-head check found a thumbs-up reaction and zero unresolved latest-head review threads.
- Manual trigger decision: not attempted.
- Manual trigger lock: no manual trigger may be used while bot state is pending, acknowledged with eyes, completed with no-issues, or ambiguous. Use `pwsh ./scripts/guard-codex-review-trigger.ps1 -PullRequest 660` only if the documented missed-ack exception is reached.
- Prior fresh findings from head `0c7f2bc98d4964b48f1f5f232d7eea8a5a1bc344`:
  - `PRRT_kwDOILVrb86Ox-VT`: fixed in `53eb2c1c`; replied and resolved.
  - `PRRT_kwDOILVrb86Ox-Vc`: fixed in `53eb2c1c`; replied and resolved.
  - `PRRT_kwDOILVrb86Ox-Vg`: fixed in `53eb2c1c`; replied and resolved.
  - `PRRT_kwDOILVrb86Ox-Vi`: fixed in `53eb2c1c`; replied and resolved.
  - `PRRT_kwDOILVrb86Ox-Vk`: fixed in `53eb2c1c`; replied and resolved.
- Substantive review cycle count: 1. Theme: hidden BranchId and list/read surfaces must all share the same fail-closed observability model.
- Fix commits: `53eb2c1c942d45f0b45347401e20d4a1e46915cc`.
- Current-head CI: `Validate / full` passed.
- Final no-issues state: satisfied on current head.

## Docs Impact

No user-facing docs changed in this tracer. CLI, SDK, OpenAPI, and generated-client propagation are intentionally deferred to GV-12 unless a later slice changes those contracts.

## Residual Risk

Repository branch-list filtering duplicates the branch observability predicate locally in `Repository.Server.fs` to keep this tracer scoped. Downstream helper centralization is expected in #642 and later visibility hardening issues.
