### PR TITLE
GC-03: Add Materialization Plan contracts

### DIFF
--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="Validation.Types.Tests.fs" />
     <Compile Include="Common.Types.Tests.fs" />
     <Compile Include="Usage.Types.Tests.fs" />
+    <Compile Include="MaterializationPlan.Types.Tests.fs" />
     <Compile Include="ContentBlockMetadata.Types.Tests.fs" />
     <Compile Include="StorageKeys.Shared.Tests.fs" />
     <Compile Include="ContentAddress.Types.Tests.fs" />

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -1,0 +1,427 @@
+namespace Grace.Types.Tests
+
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.MaterializationPlan
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Text.Json
+
+/// Contains deterministic Materialization Plan contract test data.
+module MaterializationPlanTestData =
+
+    /// Provides the immutable root directory version identity used by V1 plans.
+    let targetRootDirectoryVersionId = DirectoryVersionId.Parse("11111111-1111-1111-1111-111111111111")
+
+    /// Provides a second root identity used to prove descriptor/root mismatch handling.
+    let otherDirectoryVersionId = DirectoryVersionId.Parse("22222222-2222-2222-2222-222222222222")
+
+    /// Provides a deterministic reference id for selector serialization coverage.
+    let referenceId = ReferenceId.Parse("33333333-3333-3333-3333-333333333333")
+
+    /// Provides a deterministic branch name for selector serialization coverage.
+    let branchName = BranchName "feature/cache-plan"
+
+    /// Provides a deterministic storage pool id for CAS descriptor coverage.
+    let storagePoolId = StoragePoolId "storage-pool-main"
+
+    /// Provides a deterministic cache entry key that does not imply a direct source URL.
+    let cacheKey = "cache/materialization/11111111/root.zip"
+
+    /// Builds the V1 required target-root artifact descriptors for the supplied root.
+    let rootArtifacts targetRoot =
+        [
+            MaterializationArtifactDescriptor.DirectoryVersionZip(targetRoot, Some(MaterializationArtifactSource.CacheOnly cacheKey))
+            MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some MaterializationArtifactSource.Deferred)
+        ]
+
+    /// Builds a valid Materialization Plan with all current artifact descriptor kinds represented.
+    let validPlan () =
+        MaterializationPlan.Create(
+            targetRootDirectoryVersionId,
+            MaterializationExecutionMode.CacheRequired,
+            MaterializationCacheSelection.Required,
+            [
+                yield! rootArtifacts targetRootDirectoryVersionId
+                MaterializationArtifactDescriptor.WholeFileContent(
+                    targetRootDirectoryVersionId,
+                    RelativePath "src/app.fs",
+                    Some(Sha256Hash "sha256-file"),
+                    Some(Blake3Hash "blake3-file"),
+                    Some(MaterializationArtifactSource.CacheOnly "cache/file/src/app.fs")
+                )
+                MaterializationArtifactDescriptor.FileManifest(
+                    targetRootDirectoryVersionId,
+                    ManifestAddress "manifest-blake3-abc123",
+                    storagePoolId,
+                    Some(MaterializationArtifactSource.CacheOnly "cache/manifest/abc123")
+                )
+                MaterializationArtifactDescriptor.ContentBlock(
+                    targetRootDirectoryVersionId,
+                    ContentBlockAddress "block-blake3-def456",
+                    storagePoolId,
+                    Some(MaterializationArtifactSource.CacheOnly "cache/block/def456")
+                )
+            ]
+        )
+
+/// Contains tests covering Materialization Plan contract serialization and validation.
+[<Parallelizable(ParallelScope.All)>]
+type MaterializationPlanContractTests() =
+
+    /// Verifies that contract validation fails with a message containing the expected text.
+    let assertInvalid expected (validationResult: Result<unit, string list>) =
+        match validationResult with
+        | Ok () -> Assert.Fail($"Contract should fail validation with '{expected}'.")
+        | Error errors -> Assert.That(errors, Has.Some.Contains(expected))
+
+    /// Verifies that contract validation succeeds and reports validation errors on failure.
+    let assertValid (validationResult: Result<unit, string list>) =
+        match validationResult with
+        | Ok () -> ()
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            Assert.Fail($"Contract should pass validation, but failed with: {errorText}")
+
+    /// Reads a JSON property as a string for deterministic shape assertions.
+    let stringProperty (document: JsonDocument) (name: string) = document.RootElement.GetProperty(name).GetString()
+
+    /// Verifies that every supported execution mode serializes, deserializes, and validates as an explicit value.
+    [<TestCase(MaterializationExecutionMode.Direct)>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred)>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired)>]
+    member _.ExecutionModesRoundTripThroughJson(mode: MaterializationExecutionMode) =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                mode,
+                MaterializationCacheSelection.Preferred,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        let roundTrip = deserialize<MaterializationPlanRequest> (serialize request)
+
+        Assert.That(roundTrip.ExecutionMode, Is.EqualTo(mode))
+        assertValid (Validation.validateRequest roundTrip)
+
+    /// Verifies that each target selector shape round trips through Grace JSON serialization.
+    [<Test>]
+    member _.TargetSelectorsRoundTripThroughJson() =
+        let selectors =
+            [
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId
+                MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId
+                MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName
+            ]
+
+        for selector in selectors do
+            let roundTrip = deserialize<MaterializationTargetSelector> (serialize selector)
+
+            Assert.That(roundTrip, Is.EqualTo(selector))
+            assertValid (Validation.validateTargetSelector roundTrip)
+
+    /// Verifies that all artifact kinds and source shapes are represented in one valid plan response.
+    [<Test>]
+    member _.MaterializationPlanSerializesAllArtifactKindsAndSourceShapes() =
+        let plan = MaterializationPlanTestData.validPlan ()
+        let json = serialize plan
+        let roundTrip = deserialize<MaterializationPlan> json
+
+        use document = JsonDocument.Parse(json)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(stringProperty document "Class", Is.EqualTo(nameof MaterializationPlan))
+                Assert.That(stringProperty document "TargetRootDirectoryVersionId", Is.EqualTo("11111111-1111-1111-1111-111111111111"))
+                Assert.That(stringProperty document "ExecutionMode", Is.EqualTo("cacheRequired"))
+                Assert.That(roundTrip.RequiredArtifacts, Has.Count.EqualTo(5))
+
+                Assert.That(
+                    roundTrip.RequiredArtifacts
+                    |> Seq.map (fun artifact -> artifact.ArtifactKind),
+                    Is.EquivalentTo(Enum.GetValues<MaterializationArtifactKind>())
+                )
+
+                assertValid (Validation.validatePlan roundTrip))
+        )
+
+    /// Verifies that cache-required plans can point only at cache entries or deferred sources.
+    [<Test>]
+    member _.CacheRequiredPlanAllowsCacheOnlyArtifactSourcesWithoutDirectUris() =
+        let plan = MaterializationPlanTestData.validPlan ()
+
+        Assert.That(plan.ExecutionMode, Is.EqualTo(MaterializationExecutionMode.CacheRequired))
+        Assert.That(plan.CacheSelection.SelectionKind, Is.EqualTo(MaterializationCacheSelectionKind.RequireCache))
+        assertValid (Validation.validatePlan plan)
+
+        for descriptor in plan.RequiredArtifacts do
+            match descriptor.Source with
+            | Some source when source.SourceKind = MaterializationArtifactSourceKind.CacheEntry ->
+                Assert.That(source.DirectUri.IsNone, Is.True)
+                assertValid (Validation.validateArtifactSource source)
+            | Some source when source.SourceKind = MaterializationArtifactSourceKind.Deferred -> Assert.That(source.DirectUri.IsNone, Is.True)
+            | _ -> Assert.Fail("CacheRequired test plan should not require a direct artifact URI.")
+
+    /// Verifies that CacheRequired plans fail closed when a direct source URI is present.
+    [<Test>]
+    member _.CacheRequiredPlanWithDirectUriSourceFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
+                    )
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+                    )
+                ]
+            )
+
+        assertInvalid "CacheRequired plans must not require DirectUri artifact sources." (Validation.validatePlan plan)
+
+    /// Verifies that a plan response with an empty resolved root fails validation.
+    [<Test>]
+    member _.EmptyTargetRootFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                DirectoryVersionId.Empty,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                MaterializationPlanTestData.rootArtifacts DirectoryVersionId.Empty
+            )
+
+        assertInvalid "TargetRootDirectoryVersionId is required." (Validation.validatePlan plan)
+
+    /// Verifies that a null plan response fails validation instead of dereferencing.
+    [<Test>]
+    member _.NullPlanFailsValidationClearly() =
+        let plan = Unchecked.defaultof<MaterializationPlan>
+
+        Assert.DoesNotThrow(Action(fun () -> Validation.validatePlan plan |> ignore))
+        assertInvalid "MaterializationPlan is required." (Validation.validatePlan plan)
+
+    /// Verifies that descriptors must carry stable identity fields for their kind.
+    [<Test>]
+    member _.ArtifactDescriptorWithKindButNoStableIdentityFailsValidationClearly() =
+        let descriptor =
+            {
+                Class = nameof MaterializationArtifactDescriptor
+                ArtifactKind = MaterializationArtifactKind.WholeFileContent
+                TargetRootDirectoryVersionId = MaterializationPlanTestData.targetRootDirectoryVersionId
+                RelativePath = None
+                Sha256Hash = None
+                Blake3Hash = None
+                ManifestAddress = None
+                ContentBlockAddress = None
+                StoragePoolId = None
+                Source = None
+            }
+
+        let result = Validation.validateArtifactDescriptor descriptor
+
+        assertInvalid "Artifact RelativePath is required for WholeFileContent descriptors." result
+        assertInvalid "Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors." result
+
+    /// Verifies that CAS artifact descriptors require StoragePoolId.
+    [<TestCase(MaterializationArtifactKind.FileManifest)>]
+    [<TestCase(MaterializationArtifactKind.ContentBlock)>]
+    member _.CasArtifactMissingStoragePoolIdentityFailsValidationClearly(kind: MaterializationArtifactKind) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.FileManifest ->
+                { MaterializationArtifactDescriptor.FileManifest(
+                      MaterializationPlanTestData.targetRootDirectoryVersionId,
+                      ManifestAddress "manifest-blake3-abc123",
+                      MaterializationPlanTestData.storagePoolId,
+                      None
+                  ) with
+                    StoragePoolId = None
+                }
+            | MaterializationArtifactKind.ContentBlock ->
+                { MaterializationArtifactDescriptor.ContentBlock(
+                      MaterializationPlanTestData.targetRootDirectoryVersionId,
+                      ContentBlockAddress "block-blake3-def456",
+                      MaterializationPlanTestData.storagePoolId,
+                      None
+                  ) with
+                    StoragePoolId = None
+                }
+            | _ -> failwith "Unsupported test kind."
+
+        assertInvalid "Artifact StoragePoolId is required for CAS artifact descriptors." (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that invalid enum values fail validation rather than silently becoming accepted modes.
+    [<Test>]
+    member _.InvalidExecutionModeValueFailsValidationClearly() =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                enum<MaterializationExecutionMode> 999,
+                MaterializationCacheSelection.Preferred,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        assertInvalid "ExecutionMode '999' is not supported." (Validation.validateRequest request)
+
+    /// Verifies that invalid artifact kind values fail validation rather than silently becoming accepted artifacts.
+    [<Test>]
+    member _.InvalidArtifactKindValueFailsValidationClearly() =
+        let descriptor =
+            MaterializationArtifactDescriptor.DirectoryVersionZip(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                Some MaterializationArtifactSource.Deferred
+            )
+
+        let invalidDescriptor = { descriptor with ArtifactKind = enum<MaterializationArtifactKind> 999 }
+
+        assertInvalid "ArtifactKind '999' is not supported." (Validation.validateArtifactDescriptor invalidDescriptor)
+
+    /// Verifies that unknown future execution mode strings fail deserialization clearly.
+    [<Test>]
+    member _.UnknownExecutionModeStringFailsDeserializationClearly() =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        let json =
+            (serialize request)
+                .Replace("\"ExecutionMode\": \"direct\"", "\"ExecutionMode\": \"serverOnly\"")
+
+        let ex =
+            Assert.Throws<JsonException>(
+                Action (fun () ->
+                    deserialize<MaterializationPlanRequest> json
+                    |> ignore)
+            )
+
+        Assert.That(
+            ex.Message,
+            Does
+                .Contain("serverOnly")
+                .Or.Contains("MaterializationExecutionMode")
+        )
+
+    /// Verifies that unknown future artifact kind strings fail deserialization clearly.
+    [<Test>]
+    member _.UnknownArtifactKindStringFailsDeserializationClearly() =
+        let descriptor =
+            MaterializationArtifactDescriptor.DirectoryVersionZip(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                Some MaterializationArtifactSource.Deferred
+            )
+
+        let json =
+            (serialize descriptor)
+                .Replace("directoryVersionZip", "baselinePlusDelta")
+
+        let ex =
+            Assert.Throws<JsonException>(
+                Action (fun () ->
+                    deserialize<MaterializationArtifactDescriptor> json
+                    |> ignore)
+            )
+
+        Assert.That(
+            ex.Message,
+            Does
+                .Contain("baselinePlusDelta")
+                .Or.Contains("MaterializationArtifactKind")
+        )
+
+    /// Verifies that the V1 response requires both target-root artifacts for the resolved root.
+    [<Test>]
+    member _.PlanMissingV1RequiredRootArtifactFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some MaterializationArtifactSource.Deferred
+                    )
+                ]
+            )
+
+        assertInvalid "RequiredArtifacts must include RecursiveDirectoryMetadata for the target root." (Validation.validatePlan plan)
+
+    /// Verifies that every artifact descriptor in a response belongs to the resolved target root.
+    [<Test>]
+    member _.PlanArtifactForDifferentRootFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    yield! MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.otherDirectoryVersionId,
+                        Some MaterializationArtifactSource.Deferred
+                    )
+                ]
+            )
+
+        assertInvalid "Artifact TargetRootDirectoryVersionId must match the plan TargetRootDirectoryVersionId." (Validation.validatePlan plan)
+
+    /// Verifies that cache-entry sources require only cache identity, not direct source URLs.
+    [<Test>]
+    member _.CacheEntrySourceValidatesWithoutDirectUri() =
+        let source = MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey
+
+        Assert.That(source.DirectUri.IsNone, Is.True)
+        assertValid (Validation.validateArtifactSource source)
+
+    /// Verifies that direct URI sources carry a direct location and round trip through JSON.
+    [<Test>]
+    member _.DirectUriSourceRoundTripsThroughJson() =
+        let source = MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip"
+        let roundTrip = deserialize<MaterializationArtifactSource> (serialize source)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(roundTrip.SourceKind, Is.EqualTo(MaterializationArtifactSourceKind.DirectUri))
+                Assert.That(roundTrip.DirectUri, Is.EqualTo(Some "https://cache.example.test/artifacts/root.zip"))
+                Assert.That(roundTrip.CacheKey.IsNone, Is.True)
+                assertValid (Validation.validateArtifactSource roundTrip))
+        )
+
+    /// Verifies that cache-entry sources fail closed when cache identity is absent.
+    [<Test>]
+    member _.CacheEntrySourceWithoutCacheKeyFailsValidationClearly() =
+        let source = { MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey with CacheKey = None }
+
+        assertInvalid "Artifact CacheKey is required for CacheEntry sources." (Validation.validateArtifactSource source)
+
+    /// Verifies that all current artifact kinds are accepted in request artifact selection.
+    [<Test>]
+    member _.RequestArtifactKindSelectionAcceptsAllCurrentKinds() =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName,
+                MaterializationExecutionMode.CachePreferred,
+                MaterializationCacheSelection.Preferred,
+                Enum.GetValues<MaterializationArtifactKind>()
+            )
+
+        let roundTrip = deserialize<MaterializationPlanRequest> (serialize request)
+
+        Assert.That(roundTrip.RequestedArtifactKinds, Is.EquivalentTo(Enum.GetValues<MaterializationArtifactKind>()))
+        assertValid (Validation.validateRequest roundTrip)

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -288,6 +288,113 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "Artifact StoragePoolId is required for CAS artifact descriptors." (Validation.validateArtifactDescriptor descriptor)
 
+    /// Verifies that target-root artifact descriptors reject identity fields owned by file and CAS artifact shapes.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip)>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata)>]
+    member _.TargetRootArtifactDescriptorsRejectCrossKindIdentityFields(kind: MaterializationArtifactKind) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                MaterializationArtifactDescriptor.DirectoryVersionZip(MaterializationPlanTestData.targetRootDirectoryVersionId, None)
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(MaterializationPlanTestData.targetRootDirectoryVersionId, None)
+            | _ -> failwith "Unsupported test kind."
+
+        let ambiguousDescriptor =
+            { descriptor with
+                RelativePath = Some(RelativePath "src/app.fs")
+                Sha256Hash = Some(Sha256Hash "sha256-file")
+                Blake3Hash = Some(Blake3Hash "blake3-file")
+                ManifestAddress = Some(ManifestAddress "manifest-blake3-abc123")
+                ContentBlockAddress = Some(ContentBlockAddress "block-blake3-def456")
+                StoragePoolId = Some MaterializationPlanTestData.storagePoolId
+            }
+
+        let result = Validation.validateArtifactDescriptor ambiguousDescriptor
+
+        assertInvalid $"Artifact RelativePath must be empty for {string kind} descriptors." result
+        assertInvalid $"Artifact Sha256Hash must be empty for {string kind} descriptors." result
+        assertInvalid $"Artifact Blake3Hash must be empty for {string kind} descriptors." result
+        assertInvalid $"Artifact ManifestAddress must be empty for {string kind} descriptors." result
+        assertInvalid $"Artifact ContentBlockAddress must be empty for {string kind} descriptors." result
+        assertInvalid $"Artifact StoragePoolId must be empty for {string kind} descriptors." result
+
+    /// Verifies that file and CAS artifact descriptors reject identity fields owned by other descriptor shapes.
+    [<Test>]
+    member _.FileAndCasArtifactDescriptorsRejectCrossKindIdentityFields() =
+        let wholeFile =
+            { MaterializationArtifactDescriptor.WholeFileContent(
+                  MaterializationPlanTestData.targetRootDirectoryVersionId,
+                  RelativePath "src/app.fs",
+                  Some(Sha256Hash "sha256-file"),
+                  None,
+                  None
+              ) with
+                ManifestAddress = Some(ManifestAddress "manifest-blake3-abc123")
+                ContentBlockAddress = Some(ContentBlockAddress "block-blake3-def456")
+                StoragePoolId = Some MaterializationPlanTestData.storagePoolId
+            }
+
+        let fileManifest =
+            { MaterializationArtifactDescriptor.FileManifest(
+                  MaterializationPlanTestData.targetRootDirectoryVersionId,
+                  ManifestAddress "manifest-blake3-abc123",
+                  MaterializationPlanTestData.storagePoolId,
+                  None
+              ) with
+                RelativePath = Some(RelativePath "src/app.fs")
+                Sha256Hash = Some(Sha256Hash "sha256-file")
+                Blake3Hash = Some(Blake3Hash "blake3-file")
+                ContentBlockAddress = Some(ContentBlockAddress "block-blake3-def456")
+            }
+
+        let contentBlock =
+            { MaterializationArtifactDescriptor.ContentBlock(
+                  MaterializationPlanTestData.targetRootDirectoryVersionId,
+                  ContentBlockAddress "block-blake3-def456",
+                  MaterializationPlanTestData.storagePoolId,
+                  None
+              ) with
+                RelativePath = Some(RelativePath "src/app.fs")
+                Sha256Hash = Some(Sha256Hash "sha256-file")
+                Blake3Hash = Some(Blake3Hash "blake3-file")
+                ManifestAddress = Some(ManifestAddress "manifest-blake3-abc123")
+            }
+
+        assertInvalid "Artifact ManifestAddress must be empty for WholeFileContent descriptors." (Validation.validateArtifactDescriptor wholeFile)
+        assertInvalid "Artifact ContentBlockAddress must be empty for WholeFileContent descriptors." (Validation.validateArtifactDescriptor wholeFile)
+        assertInvalid "Artifact StoragePoolId must be empty for WholeFileContent descriptors." (Validation.validateArtifactDescriptor wholeFile)
+        assertInvalid "Artifact RelativePath must be empty for FileManifest descriptors." (Validation.validateArtifactDescriptor fileManifest)
+        assertInvalid "Artifact Sha256Hash must be empty for FileManifest descriptors." (Validation.validateArtifactDescriptor fileManifest)
+        assertInvalid "Artifact Blake3Hash must be empty for FileManifest descriptors." (Validation.validateArtifactDescriptor fileManifest)
+        assertInvalid "Artifact ContentBlockAddress must be empty for FileManifest descriptors." (Validation.validateArtifactDescriptor fileManifest)
+        assertInvalid "Artifact RelativePath must be empty for ContentBlock descriptors." (Validation.validateArtifactDescriptor contentBlock)
+        assertInvalid "Artifact Sha256Hash must be empty for ContentBlock descriptors." (Validation.validateArtifactDescriptor contentBlock)
+        assertInvalid "Artifact Blake3Hash must be empty for ContentBlock descriptors." (Validation.validateArtifactDescriptor contentBlock)
+        assertInvalid "Artifact ManifestAddress must be empty for ContentBlock descriptors." (Validation.validateArtifactDescriptor contentBlock)
+
+    /// Verifies that whole-file artifact paths must be normalized repository-relative paths.
+    [<TestCase("../app.fs")>]
+    [<TestCase("src/../app.fs")>]
+    [<TestCase("/src/app.fs")>]
+    [<TestCase("C:\\src\\app.fs")>]
+    [<TestCase("src\\app.fs")>]
+    [<TestCase("src//app.fs")>]
+    [<TestCase("./src/app.fs")>]
+    member _.WholeFileContentRejectsUnsafeRelativePath(relativePath: string) =
+        let descriptor =
+            MaterializationArtifactDescriptor.WholeFileContent(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                RelativePath relativePath,
+                Some(Sha256Hash "sha256-file"),
+                None,
+                None
+            )
+
+        assertInvalid
+            "Artifact RelativePath must be a normalized repository-relative path for WholeFileContent descriptors."
+            (Validation.validateArtifactDescriptor descriptor)
+
     /// Verifies that invalid enum values fail validation rather than silently becoming accepted modes.
     [<Test>]
     member _.InvalidExecutionModeValueFailsValidationClearly() =
@@ -432,6 +539,17 @@ type MaterializationPlanContractTests() =
         assertInvalid "Artifact DirectUri must be empty for CacheEntry sources." (Validation.validateArtifactSource cacheEntrySource)
         assertInvalid "Artifact DirectUri must be empty for Deferred sources." (Validation.validateArtifactSource deferredSource)
 
+    /// Verifies that non-cache-entry source kinds cannot smuggle cache-entry identity.
+    [<Test>]
+    member _.NonCacheEntryArtifactSourcesRejectCacheKey() =
+        let directSource =
+            { MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip" with CacheKey = Some MaterializationPlanTestData.cacheKey }
+
+        let deferredSource = { MaterializationArtifactSource.Deferred with CacheKey = Some MaterializationPlanTestData.cacheKey }
+
+        assertInvalid "Artifact CacheKey must be empty for DirectUri sources." (Validation.validateArtifactSource directSource)
+        assertInvalid "Artifact CacheKey must be empty for Deferred sources." (Validation.validateArtifactSource deferredSource)
+
     /// Verifies that direct URI sources carry a direct location and round trip through JSON.
     [<Test>]
     member _.DirectUriSourceRoundTripsThroughJson() =
@@ -468,6 +586,21 @@ type MaterializationPlanContractTests() =
 
         Assert.That(roundTrip.RequestedArtifactKinds, Is.EquivalentTo(Enum.GetValues<MaterializationArtifactKind>()))
         assertValid (Validation.validateRequest roundTrip)
+
+    /// Verifies that public request cache controls fail closed when cache-required mode tries to bypass cache.
+    [<Test>]
+    member _.CacheRequiredRequestWithBypassSelectionFailsValidationClearly() =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        assertInvalid "CacheRequired materialization must not use BypassCache selection." (Validation.validateRequest request)
 
     /// Verifies that each selector kind rejects identity fields owned by other selector kinds.
     [<Test>]

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -453,6 +453,30 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "ArtifactKind '999' is not supported." (Validation.validateArtifactDescriptor invalidDescriptor)
 
+    /// Verifies that invalid target selector kind values fail validation rather than choosing an identity shape.
+    [<Test>]
+    member _.InvalidTargetSelectorKindValueFailsValidationClearly() =
+        let selector =
+            { MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId with
+                SelectorKind = enum<MaterializationTargetSelectorKind> 999
+            }
+
+        assertInvalid "TargetSelector.SelectorKind '999' is not supported." (Validation.validateTargetSelector selector)
+
+    /// Verifies that invalid cache selection kind values fail validation rather than choosing cache authority.
+    [<Test>]
+    member _.InvalidCacheSelectionKindValueFailsValidationClearly() =
+        let cacheSelection = { MaterializationCacheSelection.Preferred with SelectionKind = enum<MaterializationCacheSelectionKind> 999 }
+
+        assertInvalid "CacheSelection.SelectionKind '999' is not supported." (Validation.validateCacheSelection cacheSelection)
+
+    /// Verifies that invalid artifact source kind values fail validation rather than choosing source identity.
+    [<Test>]
+    member _.InvalidArtifactSourceKindValueFailsValidationClearly() =
+        let source = { MaterializationArtifactSource.Deferred with SourceKind = enum<MaterializationArtifactSourceKind> 999 }
+
+        assertInvalid "Artifact SourceKind '999' is not supported." (Validation.validateArtifactSource source)
+
     /// Verifies that unknown future execution mode strings fail deserialization clearly.
     [<Test>]
     member _.UnknownExecutionModeStringFailsDeserializationClearly() =
@@ -529,6 +553,24 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "RequiredArtifacts must include RecursiveDirectoryMetadata for the target root." (Validation.validatePlan plan)
 
+    /// Verifies that the V1 response also fails when the target-root zip artifact is absent.
+    [<Test>]
+    member _.PlanMissingDirectoryVersionZipRootArtifactFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some MaterializationArtifactSource.Deferred
+                    )
+                ]
+            )
+
+        assertInvalid "RequiredArtifacts must include DirectoryVersionZip for the target root." (Validation.validatePlan plan)
+
     /// Verifies that every artifact descriptor in a response belongs to the resolved target root.
     [<Test>]
     member _.PlanArtifactForDifferentRootFailsValidationClearly() =
@@ -600,6 +642,38 @@ type MaterializationPlanContractTests() =
         let source = { MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey with CacheKey = None }
 
         assertInvalid "Artifact CacheKey is required for CacheEntry sources." (Validation.validateArtifactSource source)
+
+    /// Verifies that cache-entry sources reject blank, whitespace, and null cache identity.
+    [<Test>]
+    member _.CacheEntrySourceRejectsMalformedCacheKeys() =
+        let malformedSources =
+            [
+                "missing", None
+                "blank", Some ""
+                "whitespace", Some "   "
+                "null", Some Unchecked.defaultof<string>
+            ]
+
+        for _, cacheKey in malformedSources do
+            let source = { MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey with CacheKey = cacheKey }
+
+            assertInvalid "Artifact CacheKey is required for CacheEntry sources." (Validation.validateArtifactSource source)
+
+    /// Verifies that direct sources reject missing, blank, whitespace, and null direct URIs.
+    [<Test>]
+    member _.DirectUriSourceRejectsMissingBlankWhitespaceAndNullUris() =
+        let malformedSources =
+            [
+                "missing", None, "Artifact DirectUri is required for DirectUri sources."
+                "blank", Some "", "Artifact DirectUri must be an absolute http or https URI for DirectUri sources."
+                "whitespace", Some "   ", "Artifact DirectUri must be an absolute http or https URI for DirectUri sources."
+                "null", Some Unchecked.defaultof<string>, "Artifact DirectUri must be an absolute http or https URI for DirectUri sources."
+            ]
+
+        for _, directUri, expected in malformedSources do
+            let source = { MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip" with DirectUri = directUri }
+
+            assertInvalid expected (Validation.validateArtifactSource source)
 
     /// Verifies that cache-scope identity is either absent or a non-blank value.
     [<TestCase("")>]
@@ -902,6 +976,14 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "TargetSelector.BranchName is required." (Validation.validateTargetSelector selector)
 
+    /// Verifies that branch target selectors reject blank and whitespace-only selector identity.
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    member _.BranchTargetSelectorsRejectBlankAndWhitespaceNames(branchName: string) =
+        let selector = MaterializationTargetSelector.ForBranch(BranchName branchName)
+
+        assertInvalid "TargetSelector.BranchName is required." (Validation.validateTargetSelector selector)
+
     /// Verifies that direct plans reject cache-entry artifact sources even when the execution/cache pair is valid.
     [<Test>]
     member _.DirectBypassPlanRejectsCacheEntryArtifactSources() =
@@ -920,6 +1002,32 @@ type MaterializationPlanContractTests() =
                         Some MaterializationArtifactSource.Deferred
                     )
                 ]
+            )
+
+        assertInvalid "Direct/Bypass plans must not require CacheEntry artifact sources." (Validation.validatePlan plan)
+
+    /// Verifies that BypassCache selection alone rejects cache-entry sources even when execution mode is not Direct.
+    [<Test>]
+    member _.BypassSelectionRejectsCacheEntrySourcesWhenExecutionModeIsNotDirect() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                MaterializationCacheSelection.Bypass,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertInvalid "Direct/Bypass plans must not require CacheEntry artifact sources." (Validation.validatePlan plan)
+
+    /// Verifies that Direct execution rejects cache-entry sources even when cache selection is inconsistent.
+    [<Test>]
+    member _.DirectExecutionRejectsCacheEntrySourcesWhenSelectionIsInconsistent() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Preferred,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
             )
 
         assertInvalid "Direct/Bypass plans must not require CacheEntry artifact sources." (Validation.validatePlan plan)
@@ -1000,6 +1108,37 @@ type MaterializationPlanContractTests() =
                      Some MaterializationPlanTestData.blake3Hash
                  else
                      Some(Blake3Hash "")),
+                Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+            )
+
+        let expected =
+            if evaluateSha256 then
+                "Artifact Sha256Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors."
+            else
+                "Artifact Blake3Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors."
+
+        assertInvalid expected (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that whole-file descriptors require canonical lowercase 64-hex hash identity.
+    [<TestCase(true, "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")>]
+    [<TestCase(true, "0123456789abcdef")>]
+    [<TestCase(true, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg")>]
+    [<TestCase(false, "89ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01234567")>]
+    [<TestCase(false, "89abcdef01234567")>]
+    [<TestCase(false, "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456g")>]
+    member _.WholeFileContentRejectsMalformedHashOptions(evaluateSha256: bool, malformedHash: string) =
+        let descriptor =
+            MaterializationArtifactDescriptor.WholeFileContent(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                RelativePath "src/app.fs",
+                (if evaluateSha256 then
+                     Some(Sha256Hash malformedHash)
+                 else
+                     Some MaterializationPlanTestData.sha256Hash),
+                (if evaluateSha256 then
+                     Some MaterializationPlanTestData.blake3Hash
+                 else
+                     Some(Blake3Hash malformedHash)),
                 Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
             )
 
@@ -1153,6 +1292,47 @@ type MaterializationPlanContractTests() =
 
         assertValid (Validation.validatePlan plan)
 
+    /// Verifies that CAS uniqueness includes storage pool, allowing same addresses in distinct pools.
+    [<Test>]
+    member _.PlanAllowsCasDescriptorsWithSameAddressInDifferentStoragePools() =
+        let secondaryStoragePoolId = StoragePoolId "storage-pool-secondary"
+
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    yield! MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.FileManifest(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.manifestAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/manifest/main")
+                    )
+                    MaterializationArtifactDescriptor.FileManifest(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.manifestAddress,
+                        secondaryStoragePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/manifest/secondary")
+                    )
+                    MaterializationArtifactDescriptor.ContentBlock(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.contentBlockAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/block/main")
+                    )
+                    MaterializationArtifactDescriptor.ContentBlock(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.contentBlockAddress,
+                        secondaryStoragePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/block/secondary")
+                    )
+                ]
+            )
+
+        assertValid (Validation.validatePlan plan)
+
     /// Verifies that V1 plans reject duplicate singleton root artifact descriptors.
     [<Test>]
     member _.PlanRejectsDuplicateTargetRootSingletonArtifacts() =
@@ -1249,3 +1429,37 @@ type MaterializationPlanContractTests() =
         assertInvalid "TargetSelector.ReferenceId must be empty for DirectoryVersionId selectors." (Validation.validateTargetSelector directorySelector)
         assertInvalid "TargetSelector.BranchName must be empty for ReferenceId selectors." (Validation.validateTargetSelector referenceSelector)
         assertInvalid "TargetSelector.DirectoryVersionId must be empty for BranchName selectors." (Validation.validateTargetSelector branchSelector)
+
+    /// Verifies that every selector kind rejects each identity field owned by the other selector kinds.
+    [<Test>]
+    member _.TargetSelectorsRejectEveryOffKindIdentityField() =
+        let cases =
+            [
+                { MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId with
+                    ReferenceId = Some MaterializationPlanTestData.referenceId
+                },
+                "TargetSelector.ReferenceId must be empty for DirectoryVersionId selectors."
+                { MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId with
+                    BranchName = Some MaterializationPlanTestData.branchName
+                },
+                "TargetSelector.BranchName must be empty for DirectoryVersionId selectors."
+                { MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId with
+                    DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
+                },
+                "TargetSelector.DirectoryVersionId must be empty for ReferenceId selectors."
+                { MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId with
+                    BranchName = Some MaterializationPlanTestData.branchName
+                },
+                "TargetSelector.BranchName must be empty for ReferenceId selectors."
+                { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with
+                    DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
+                },
+                "TargetSelector.DirectoryVersionId must be empty for BranchName selectors."
+                { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with
+                    ReferenceId = Some MaterializationPlanTestData.referenceId
+                },
+                "TargetSelector.ReferenceId must be empty for BranchName selectors."
+            ]
+
+        for selector, expected in cases do
+            assertInvalid expected (Validation.validateTargetSelector selector)

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -29,6 +29,18 @@ module MaterializationPlanTestData =
     /// Provides a deterministic cache entry key that does not imply a direct source URL.
     let cacheKey = "cache/materialization/11111111/root.zip"
 
+    /// Provides a canonical lowercase BLAKE3 manifest address for descriptor validation.
+    let manifestAddress = ManifestAddress "5dd11fdb1534c0f1c4fecca3c07498f9b59a7dff26d69fe78e43f7ce50d90895"
+
+    /// Provides a canonical lowercase BLAKE3 content block address for descriptor validation.
+    let contentBlockAddress = ContentBlockAddress "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30f"
+
+    /// Provides a canonical lowercase SHA-256 hash value for whole-file descriptor validation.
+    let sha256Hash = Sha256Hash "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+    /// Provides a canonical lowercase BLAKE3 hash value for whole-file descriptor validation.
+    let blake3Hash = Blake3Hash "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+
     /// Builds the V1 required target-root artifact descriptors for the supplied root.
     let rootArtifacts targetRoot =
         [
@@ -47,19 +59,19 @@ module MaterializationPlanTestData =
                 MaterializationArtifactDescriptor.WholeFileContent(
                     targetRootDirectoryVersionId,
                     RelativePath "src/app.fs",
-                    Some(Sha256Hash "sha256-file"),
-                    Some(Blake3Hash "blake3-file"),
+                    Some sha256Hash,
+                    Some blake3Hash,
                     Some(MaterializationArtifactSource.CacheOnly "cache/file/src/app.fs")
                 )
                 MaterializationArtifactDescriptor.FileManifest(
                     targetRootDirectoryVersionId,
-                    ManifestAddress "manifest-blake3-abc123",
+                    manifestAddress,
                     storagePoolId,
                     Some(MaterializationArtifactSource.CacheOnly "cache/manifest/abc123")
                 )
                 MaterializationArtifactDescriptor.ContentBlock(
                     targetRootDirectoryVersionId,
-                    ContentBlockAddress "block-blake3-def456",
+                    contentBlockAddress,
                     storagePoolId,
                     Some(MaterializationArtifactSource.CacheOnly "cache/block/def456")
                 )
@@ -92,11 +104,17 @@ type MaterializationPlanContractTests() =
     [<TestCase(MaterializationExecutionMode.CachePreferred)>]
     [<TestCase(MaterializationExecutionMode.CacheRequired)>]
     member _.ExecutionModesRoundTripThroughJson(mode: MaterializationExecutionMode) =
+        let cacheSelection =
+            if mode = MaterializationExecutionMode.CacheRequired then
+                MaterializationCacheSelection.Required
+            else
+                MaterializationCacheSelection.Preferred
+
         let request =
             MaterializationPlanRequest.Create(
                 MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
                 mode,
-                MaterializationCacheSelection.Preferred,
+                cacheSelection,
                 [
                     MaterializationArtifactKind.DirectoryVersionZip
                 ]
@@ -377,7 +395,9 @@ type MaterializationPlanContractTests() =
     [<TestCase("../app.fs")>]
     [<TestCase("src/../app.fs")>]
     [<TestCase("/src/app.fs")>]
+    [<TestCase("C:/src/app.fs")>]
     [<TestCase("C:\\src\\app.fs")>]
+    [<TestCase("src:C/app.fs")>]
     [<TestCase("src\\app.fs")>]
     [<TestCase("src//app.fs")>]
     [<TestCase("./src/app.fs")>]
@@ -386,7 +406,7 @@ type MaterializationPlanContractTests() =
             MaterializationArtifactDescriptor.WholeFileContent(
                 MaterializationPlanTestData.targetRootDirectoryVersionId,
                 RelativePath relativePath,
-                Some(Sha256Hash "sha256-file"),
+                Some MaterializationPlanTestData.sha256Hash,
                 None,
                 None
             )
@@ -601,6 +621,157 @@ type MaterializationPlanContractTests() =
             )
 
         assertInvalid "CacheRequired materialization must not use BypassCache selection." (Validation.validateRequest request)
+
+    /// Verifies that cache-required request intent has one authoritative cache-required selection.
+    [<Test>]
+    member _.CacheRequiredRequestWithPreferCacheSelectionFailsValidationClearly() =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Preferred,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        assertInvalid "CacheRequired materialization must use RequireCache selection." (Validation.validateRequest request)
+
+    /// Verifies that cache-required plans have one authoritative cache-required selection.
+    [<Test>]
+    member _.CacheRequiredPlanWithPreferCacheSelectionFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Preferred,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertInvalid "CacheRequired materialization must use RequireCache selection." (Validation.validatePlan plan)
+
+    /// Verifies that whole-file descriptors reject blank hash fields even when the other hash is valid.
+    [<TestCase(true)>]
+    [<TestCase(false)>]
+    member _.WholeFileContentRejectsBlankHashOptions(evaluateSha256: bool) =
+        let descriptor =
+            MaterializationArtifactDescriptor.WholeFileContent(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                RelativePath "src/app.fs",
+                (if evaluateSha256 then
+                     Some(Sha256Hash "   ")
+                 else
+                     Some MaterializationPlanTestData.sha256Hash),
+                (if evaluateSha256 then
+                     Some MaterializationPlanTestData.blake3Hash
+                 else
+                     Some(Blake3Hash "")),
+                Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+            )
+
+        let expected =
+            if evaluateSha256 then
+                "Artifact Sha256Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors."
+            else
+                "Artifact Blake3Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors."
+
+        assertInvalid expected (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that cache-required root artifacts must carry an authoritative cache source.
+    [<Test>]
+    member _.CacheRequiredPlanRejectsMissingRootArtifactSources() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(MaterializationPlanTestData.targetRootDirectoryVersionId, None)
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+                    )
+                ]
+            )
+
+        assertInvalid "CacheRequired plans must include a non-direct artifact source for every required artifact." (Validation.validatePlan plan)
+
+    /// Verifies that V1 plans reject duplicate singleton root artifact descriptors.
+    [<Test>]
+    member _.PlanRejectsDuplicateTargetRootSingletonArtifacts() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
+                    )
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root-copy.zip")
+                    )
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some MaterializationArtifactSource.Deferred
+                    )
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/metadata.json")
+                    )
+                ]
+            )
+
+        let result = Validation.validatePlan plan
+
+        assertInvalid "RequiredArtifacts must include exactly one DirectoryVersionZip for the target root." result
+        assertInvalid "RequiredArtifacts must include exactly one RecursiveDirectoryMetadata for the target root." result
+
+    /// Verifies that CAS descriptors use canonical lowercase BLAKE3 addresses.
+    [<TestCase(MaterializationArtifactKind.FileManifest, "manifest-blake3-abc123")>]
+    [<TestCase(MaterializationArtifactKind.FileManifest, "5DD11FDB1534C0F1C4FECCA3C07498F9B59A7DFF26D69FE78E43F7CE50D90895")>]
+    [<TestCase(MaterializationArtifactKind.ContentBlock, "block-blake3-def456")>]
+    [<TestCase(MaterializationArtifactKind.ContentBlock, "75359c5d838dda90b12c6cbcdd9b71a1f193daf6c23fa2bfd496065bed57a30g")>]
+    member _.CasArtifactDescriptorsRejectMalformedAddresses(kind: MaterializationArtifactKind, address: string) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.FileManifest ->
+                MaterializationArtifactDescriptor.FileManifest(
+                    MaterializationPlanTestData.targetRootDirectoryVersionId,
+                    ManifestAddress address,
+                    MaterializationPlanTestData.storagePoolId,
+                    Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+                )
+            | MaterializationArtifactKind.ContentBlock ->
+                MaterializationArtifactDescriptor.ContentBlock(
+                    MaterializationPlanTestData.targetRootDirectoryVersionId,
+                    ContentBlockAddress address,
+                    MaterializationPlanTestData.storagePoolId,
+                    Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+                )
+            | _ -> failwith "Unsupported test kind."
+
+        let expected =
+            match kind with
+            | MaterializationArtifactKind.FileManifest ->
+                "Artifact ManifestAddress must be a canonical lowercase 64-character hexadecimal value for FileManifest descriptors."
+            | MaterializationArtifactKind.ContentBlock ->
+                "Artifact ContentBlockAddress must be a canonical lowercase 64-character hexadecimal value for ContentBlock descriptors."
+            | _ -> failwith "Unsupported test kind."
+
+        assertInvalid expected (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that direct sources require absolute fetch URIs with an allowed scheme.
+    [<TestCase("artifacts/root.zip")>]
+    [<TestCase("/artifacts/root.zip")>]
+    [<TestCase("file:///tmp/root.zip")>]
+    [<TestCase("ftp://cache.example.test/artifacts/root.zip")>]
+    member _.DirectUriSourceRejectsRelativeFileAndUnsupportedSchemes(uri: string) =
+        let source = MaterializationArtifactSource.Direct uri
+
+        assertInvalid "Artifact DirectUri must be an absolute http or https URI for DirectUri sources." (Validation.validateArtifactSource source)
 
     /// Verifies that each selector kind rejects identity fields owned by other selector kinds.
     [<Test>]

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -45,7 +45,7 @@ module MaterializationPlanTestData =
     let rootArtifacts targetRoot =
         [
             MaterializationArtifactDescriptor.DirectoryVersionZip(targetRoot, Some(MaterializationArtifactSource.CacheOnly cacheKey))
-            MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some MaterializationArtifactSource.Deferred)
+            MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some(MaterializationArtifactSource.CacheOnly $"{cacheKey}/metadata"))
         ]
 
     /// Builds V1 target-root artifact descriptors that are compatible with direct materialization.
@@ -177,9 +177,9 @@ type MaterializationPlanContractTests() =
                 assertValid (Validation.validatePlan roundTrip))
         )
 
-    /// Verifies that cache-required plans can point only at cache entries or deferred sources.
+    /// Verifies that cache-required plans can point only at cache entries.
     [<Test>]
-    member _.CacheRequiredPlanAllowsCacheOnlyArtifactSourcesWithoutDirectUris() =
+    member _.CacheRequiredPlanAllowsOnlyCacheEntryArtifactSourcesWithoutDirectUris() =
         let plan = MaterializationPlanTestData.validPlan ()
 
         Assert.That(plan.ExecutionMode, Is.EqualTo(MaterializationExecutionMode.CacheRequired))
@@ -191,8 +191,7 @@ type MaterializationPlanContractTests() =
             | Some source when source.SourceKind = MaterializationArtifactSourceKind.CacheEntry ->
                 Assert.That(source.DirectUri.IsNone, Is.True)
                 assertValid (Validation.validateArtifactSource source)
-            | Some source when source.SourceKind = MaterializationArtifactSourceKind.Deferred -> Assert.That(source.DirectUri.IsNone, Is.True)
-            | _ -> Assert.Fail("CacheRequired test plan should not require a direct artifact URI.")
+            | _ -> Assert.Fail("CacheRequired test plan should require cache-entry artifact sources.")
 
     /// Verifies that CacheRequired plans fail closed when a direct source URI is present.
     [<Test>]
@@ -214,7 +213,7 @@ type MaterializationPlanContractTests() =
                 ]
             )
 
-        assertInvalid "CacheRequired plans must not require DirectUri artifact sources." (Validation.validatePlan plan)
+        assertInvalid "CacheRequired plans must require CacheEntry artifact sources for every required artifact." (Validation.validatePlan plan)
 
     /// Verifies that CacheRequired execution mode fails closed even when cache selection is inconsistent.
     [<Test>]
@@ -236,7 +235,7 @@ type MaterializationPlanContractTests() =
                 ]
             )
 
-        assertInvalid "CacheRequired plans must not require DirectUri artifact sources." (Validation.validatePlan plan)
+        assertInvalid "CacheRequired plans must require CacheEntry artifact sources for every required artifact." (Validation.validatePlan plan)
 
     /// Verifies that malformed plan DTOs with missing cache selection fail validation without throwing.
     [<Test>]
@@ -602,6 +601,93 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "Artifact CacheKey is required for CacheEntry sources." (Validation.validateArtifactSource source)
 
+    /// Verifies that cache-scope identity is either absent or a non-blank value.
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    member _.CacheSelectionRejectsBlankCacheScope(cacheScope: string) =
+        let cacheSelection = { MaterializationCacheSelection.Preferred with CacheScope = Some cacheScope }
+
+        assertInvalid "CacheSelection.CacheScope must not be blank when specified." (Validation.validateCacheSelection cacheSelection)
+
+    /// Verifies that blank optional cache-scope identity fails before request and plan contracts validate.
+    [<TestCase("")>]
+    [<TestCase("   ")>]
+    member _.RequestAndPlanRejectBlankCacheScope(cacheScope: string) =
+        let cacheSelection = { MaterializationCacheSelection.Preferred with CacheScope = Some cacheScope }
+
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                cacheSelection,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                cacheSelection,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertInvalid "CacheSelection.CacheScope must not be blank when specified." (Validation.validateRequest request)
+        assertInvalid "CacheSelection.CacheScope must not be blank when specified." (Validation.validatePlan plan)
+
+    /// Verifies that null optional cache-scope identity fails before request and plan contracts validate.
+    [<Test>]
+    member _.RequestAndPlanRejectNullCacheScope() =
+        let cacheSelection = { MaterializationCacheSelection.Preferred with CacheScope = Some Unchecked.defaultof<string> }
+
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                cacheSelection,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                cacheSelection,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertInvalid "CacheSelection.CacheScope must not be blank when specified." (Validation.validateRequest request)
+        assertInvalid "CacheSelection.CacheScope must not be blank when specified." (Validation.validatePlan plan)
+
+    /// Verifies that a non-blank cache-scope identity remains valid at request and plan seams.
+    [<Test>]
+    member _.RequestAndPlanAllowNonBlankCacheScope() =
+        let cacheSelection = { MaterializationCacheSelection.Preferred with CacheScope = Some "scope/materialization-main" }
+
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                cacheSelection,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CachePreferred,
+                cacheSelection,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertValid (Validation.validateRequest request)
+        assertValid (Validation.validatePlan plan)
+
     /// Verifies that all current artifact kinds are accepted in request artifact selection.
     [<Test>]
     member _.RequestArtifactKindSelectionAcceptsAllCurrentKinds() =
@@ -942,7 +1028,130 @@ type MaterializationPlanContractTests() =
                 ]
             )
 
-        assertInvalid "CacheRequired plans must include a non-direct artifact source for every required artifact." (Validation.validatePlan plan)
+        assertInvalid "CacheRequired plans must require CacheEntry artifact sources for every required artifact." (Validation.validatePlan plan)
+
+    /// Verifies that cache-required plans fail closed unless each artifact source is an authoritative cache entry.
+    [<TestCase(MaterializationArtifactSourceKind.DirectUri)>]
+    [<TestCase(MaterializationArtifactSourceKind.Deferred)>]
+    member _.CacheRequiredPlanRequiresCacheEntryArtifactSources(sourceKind: MaterializationArtifactSourceKind) =
+        let source =
+            match sourceKind with
+            | MaterializationArtifactSourceKind.DirectUri -> MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip"
+            | MaterializationArtifactSourceKind.Deferred -> MaterializationArtifactSource.Deferred
+            | _ -> failwith "Unsupported source kind."
+
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(MaterializationPlanTestData.targetRootDirectoryVersionId, Some source)
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+                    )
+                ]
+            )
+
+        assertInvalid "CacheRequired plans must require CacheEntry artifact sources for every required artifact." (Validation.validatePlan plan)
+
+    /// Verifies that duplicate FileManifest identity cannot name multiple sources for one target root and storage pool.
+    [<Test>]
+    member _.PlanRejectsDuplicateFileManifestIdentityForSameRootStoragePoolAndAddress() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    yield! MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.FileManifest(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.manifestAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/manifest/first")
+                    )
+                    MaterializationArtifactDescriptor.FileManifest(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.manifestAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/manifest/second")
+                    )
+                ]
+            )
+
+        assertInvalid
+            "RequiredArtifacts must include at most one FileManifest for each target root, storage pool, and manifest address."
+            (Validation.validatePlan plan)
+
+    /// Verifies that duplicate ContentBlock identity cannot name multiple sources for one target root and storage pool.
+    [<Test>]
+    member _.PlanRejectsDuplicateContentBlockIdentityForSameRootStoragePoolAndAddress() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    yield! MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.ContentBlock(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.contentBlockAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/block/first")
+                    )
+                    MaterializationArtifactDescriptor.ContentBlock(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.contentBlockAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/block/second")
+                    )
+                ]
+            )
+
+        assertInvalid
+            "RequiredArtifacts must include at most one ContentBlock for each target root, storage pool, and content block address."
+            (Validation.validatePlan plan)
+
+    /// Verifies that distinct CAS descriptor identities remain valid in the same target root.
+    [<Test>]
+    member _.PlanAllowsDistinctCasDescriptorIdentities() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Required,
+                [
+                    yield! MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.FileManifest(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.manifestAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/manifest/first")
+                    )
+                    MaterializationArtifactDescriptor.FileManifest(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        ManifestAddress "1111111111111111111111111111111111111111111111111111111111111111",
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/manifest/second")
+                    )
+                    MaterializationArtifactDescriptor.ContentBlock(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        MaterializationPlanTestData.contentBlockAddress,
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/block/first")
+                    )
+                    MaterializationArtifactDescriptor.ContentBlock(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        ContentBlockAddress "2222222222222222222222222222222222222222222222222222222222222222",
+                        MaterializationPlanTestData.storagePoolId,
+                        Some(MaterializationArtifactSource.CacheOnly "cache/block/second")
+                    )
+                ]
+            )
+
+        assertValid (Validation.validatePlan plan)
 
     /// Verifies that V1 plans reject duplicate singleton root artifact descriptors.
     [<Test>]

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -187,6 +187,36 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "CacheRequired plans must not require DirectUri artifact sources." (Validation.validatePlan plan)
 
+    /// Verifies that CacheRequired execution mode fails closed even when cache selection is inconsistent.
+    [<Test>]
+    member _.CacheRequiredExecutionModeWithBypassSelectionRejectsDirectUriSource() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.CacheRequired,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
+                    )
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some MaterializationArtifactSource.Deferred
+                    )
+                ]
+            )
+
+        assertInvalid "CacheRequired plans must not require DirectUri artifact sources." (Validation.validatePlan plan)
+
+    /// Verifies that malformed plan DTOs with missing cache selection fail validation without throwing.
+    [<Test>]
+    member _.NullCacheSelectionFailsValidationWithoutDereferencing() =
+        let plan = { MaterializationPlanTestData.validPlan () with CacheSelection = Unchecked.defaultof<MaterializationCacheSelection> }
+
+        Assert.DoesNotThrow(Action(fun () -> Validation.validatePlan plan |> ignore))
+        assertInvalid "CacheSelection is required." (Validation.validatePlan plan)
+
     /// Verifies that a plan response with an empty resolved root fails validation.
     [<Test>]
     member _.EmptyTargetRootFailsValidationClearly() =
@@ -389,6 +419,19 @@ type MaterializationPlanContractTests() =
         Assert.That(source.DirectUri.IsNone, Is.True)
         assertValid (Validation.validateArtifactSource source)
 
+    /// Verifies that non-direct source kinds cannot smuggle direct fetch URLs.
+    [<Test>]
+    member _.NonDirectArtifactSourcesRejectDirectUri() =
+        let cacheEntrySource =
+            { MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey with
+                DirectUri = Some "https://cache.example.test/artifacts/root.zip"
+            }
+
+        let deferredSource = { MaterializationArtifactSource.Deferred with DirectUri = Some "https://cache.example.test/artifacts/root.zip" }
+
+        assertInvalid "Artifact DirectUri must be empty for CacheEntry sources." (Validation.validateArtifactSource cacheEntrySource)
+        assertInvalid "Artifact DirectUri must be empty for Deferred sources." (Validation.validateArtifactSource deferredSource)
+
     /// Verifies that direct URI sources carry a direct location and round trip through JSON.
     [<Test>]
     member _.DirectUriSourceRoundTripsThroughJson() =
@@ -425,3 +468,23 @@ type MaterializationPlanContractTests() =
 
         Assert.That(roundTrip.RequestedArtifactKinds, Is.EquivalentTo(Enum.GetValues<MaterializationArtifactKind>()))
         assertValid (Validation.validateRequest roundTrip)
+
+    /// Verifies that each selector kind rejects identity fields owned by other selector kinds.
+    [<Test>]
+    member _.TargetSelectorsRejectAmbiguousIdentityFields() =
+        let directorySelector =
+            { MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId with
+                ReferenceId = Some MaterializationPlanTestData.referenceId
+            }
+
+        let referenceSelector =
+            { MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId with BranchName = Some MaterializationPlanTestData.branchName }
+
+        let branchSelector =
+            { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with
+                DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
+            }
+
+        assertInvalid "TargetSelector.ReferenceId must be empty for DirectoryVersionId selectors." (Validation.validateTargetSelector directorySelector)
+        assertInvalid "TargetSelector.BranchName must be empty for ReferenceId selectors." (Validation.validateTargetSelector referenceSelector)
+        assertInvalid "TargetSelector.DirectoryVersionId must be empty for BranchName selectors." (Validation.validateTargetSelector branchSelector)

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -48,6 +48,16 @@ module MaterializationPlanTestData =
             MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some MaterializationArtifactSource.Deferred)
         ]
 
+    /// Builds V1 target-root artifact descriptors that are compatible with direct materialization.
+    let directRootArtifacts targetRoot =
+        [
+            MaterializationArtifactDescriptor.DirectoryVersionZip(
+                targetRoot,
+                Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
+            )
+            MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some MaterializationArtifactSource.Deferred)
+        ]
+
     /// Builds a valid Materialization Plan with all current artifact descriptor kinds represented.
     let validPlan () =
         MaterializationPlan.Create(
@@ -708,12 +718,17 @@ type MaterializationPlanContractTests() =
     [<TestCase(MaterializationExecutionMode.CachePreferred, MaterializationCacheSelectionKind.PreferCache)>]
     [<TestCase(MaterializationExecutionMode.CacheRequired, MaterializationCacheSelectionKind.RequireCache)>]
     member _.SupportedPlanExecutionCacheSelectionPairsValidate(mode: MaterializationExecutionMode, selectionKind: MaterializationCacheSelectionKind) =
+        let rootArtifacts =
+            match mode with
+            | MaterializationExecutionMode.Direct -> MaterializationPlanTestData.directRootArtifacts
+            | _ -> MaterializationPlanTestData.rootArtifacts
+
         let plan =
             MaterializationPlan.Create(
                 MaterializationPlanTestData.targetRootDirectoryVersionId,
                 mode,
                 { MaterializationCacheSelection.Preferred with SelectionKind = selectionKind },
-                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
             )
 
         assertValid (Validation.validatePlan plan)
@@ -787,6 +802,101 @@ type MaterializationPlanContractTests() =
         let selector = MaterializationTargetSelector.ForBranch(BranchName branchName)
 
         assertInvalid "TargetSelector.BranchName must be a valid Grace branch name." (Validation.validateTargetSelector selector)
+
+    /// Verifies that malformed branch target selector DTOs fail closed instead of reaching regex with a null input.
+    [<Test>]
+    member _.BranchTargetSelectorWithNullNameFailsValidationWithoutThrowing() =
+        let selector = { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with BranchName = Some Unchecked.defaultof<BranchName> }
+
+        Assert.DoesNotThrow(
+            Action (fun () ->
+                Validation.validateTargetSelector selector
+                |> ignore)
+        )
+
+        assertInvalid "TargetSelector.BranchName is required." (Validation.validateTargetSelector selector)
+
+    /// Verifies that direct plans reject cache-entry artifact sources even when the execution/cache pair is valid.
+    [<Test>]
+    member _.DirectBypassPlanRejectsCacheEntryArtifactSources() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
+                    )
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        Some MaterializationArtifactSource.Deferred
+                    )
+                ]
+            )
+
+        assertInvalid "Direct/Bypass plans must not require CacheEntry artifact sources." (Validation.validatePlan plan)
+
+    /// Verifies that whole-file artifact identity is unique by target root and repository-relative path.
+    [<Test>]
+    member _.PlanRejectsDuplicateWholeFileContentForSameRootAndRelativePath() =
+        let duplicatePath = RelativePath "src/app.fs"
+
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    yield! MaterializationPlanTestData.directRootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.WholeFileContent(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        duplicatePath,
+                        Some MaterializationPlanTestData.sha256Hash,
+                        None,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/src/app-v1.fs")
+                    )
+                    MaterializationArtifactDescriptor.WholeFileContent(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        duplicatePath,
+                        None,
+                        Some MaterializationPlanTestData.blake3Hash,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/src/app-v2.fs")
+                    )
+                ]
+            )
+
+        assertInvalid "RequiredArtifacts must include at most one WholeFileContent for each target root and relative path." (Validation.validatePlan plan)
+
+    /// Verifies that whole-file descriptors for distinct repository-relative paths remain valid in direct plans.
+    [<Test>]
+    member _.PlanAllowsWholeFileContentForDistinctRelativePaths() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Bypass,
+                [
+                    yield! MaterializationPlanTestData.directRootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+                    MaterializationArtifactDescriptor.WholeFileContent(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        RelativePath "src/app.fs",
+                        Some MaterializationPlanTestData.sha256Hash,
+                        None,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/src/app.fs")
+                    )
+                    MaterializationArtifactDescriptor.WholeFileContent(
+                        MaterializationPlanTestData.targetRootDirectoryVersionId,
+                        RelativePath "src/appsettings.json",
+                        Some(Sha256Hash "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+                        None,
+                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/src/appsettings.json")
+                    )
+                ]
+            )
+
+        assertValid (Validation.validatePlan plan)
 
     /// Verifies that whole-file descriptors reject blank hash fields even when the other hash is valid.
     [<TestCase(true)>]

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -21,7 +21,7 @@ module MaterializationPlanTestData =
     let referenceId = ReferenceId.Parse("33333333-3333-3333-3333-333333333333")
 
     /// Provides a deterministic branch name for selector serialization coverage.
-    let branchName = BranchName "feature/cache-plan"
+    let branchName = BranchName "feature-cache-plan"
 
     /// Provides a deterministic storage pool id for CAS descriptor coverage.
     let storagePoolId = StoragePoolId "storage-pool-main"
@@ -105,10 +105,11 @@ type MaterializationPlanContractTests() =
     [<TestCase(MaterializationExecutionMode.CacheRequired)>]
     member _.ExecutionModesRoundTripThroughJson(mode: MaterializationExecutionMode) =
         let cacheSelection =
-            if mode = MaterializationExecutionMode.CacheRequired then
-                MaterializationCacheSelection.Required
-            else
-                MaterializationCacheSelection.Preferred
+            match mode with
+            | MaterializationExecutionMode.Direct -> MaterializationCacheSelection.Bypass
+            | MaterializationExecutionMode.CachePreferred -> MaterializationCacheSelection.Preferred
+            | MaterializationExecutionMode.CacheRequired -> MaterializationCacheSelection.Required
+            | _ -> MaterializationCacheSelection.Preferred
 
         let request =
             MaterializationPlanRequest.Create(
@@ -649,6 +650,143 @@ type MaterializationPlanContractTests() =
             )
 
         assertInvalid "CacheRequired materialization must use RequireCache selection." (Validation.validatePlan plan)
+
+    /// Verifies that each supported public execution/cache-selection request pair is intentional.
+    [<TestCase(MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.BypassCache)>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred, MaterializationCacheSelectionKind.PreferCache)>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired, MaterializationCacheSelectionKind.RequireCache)>]
+    member _.SupportedRequestExecutionCacheSelectionPairsValidate(mode: MaterializationExecutionMode, selectionKind: MaterializationCacheSelectionKind) =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                mode,
+                { MaterializationCacheSelection.Preferred with SelectionKind = selectionKind },
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        assertValid (Validation.validateRequest request)
+
+    /// Verifies that unsupported public execution/cache-selection request pairs fail closed.
+    [<TestCase(MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.PreferCache, "Direct materialization must use BypassCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.Direct,
+               MaterializationCacheSelectionKind.RequireCache,
+               "Direct materialization must not use RequireCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred,
+               MaterializationCacheSelectionKind.BypassCache,
+               "CachePreferred materialization must use PreferCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred,
+               MaterializationCacheSelectionKind.RequireCache,
+               "CachePreferred materialization must use PreferCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired,
+               MaterializationCacheSelectionKind.BypassCache,
+               "CacheRequired materialization must not use BypassCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired,
+               MaterializationCacheSelectionKind.PreferCache,
+               "CacheRequired materialization must use RequireCache selection.")>]
+    member _.UnsupportedRequestExecutionCacheSelectionPairsFailValidation
+        (
+            mode: MaterializationExecutionMode,
+            selectionKind: MaterializationCacheSelectionKind,
+            expected: string
+        ) =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                mode,
+                { MaterializationCacheSelection.Preferred with SelectionKind = selectionKind },
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        assertInvalid expected (Validation.validateRequest request)
+
+    /// Verifies that each supported public execution/cache-selection plan pair is intentional.
+    [<TestCase(MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.BypassCache)>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred, MaterializationCacheSelectionKind.PreferCache)>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired, MaterializationCacheSelectionKind.RequireCache)>]
+    member _.SupportedPlanExecutionCacheSelectionPairsValidate(mode: MaterializationExecutionMode, selectionKind: MaterializationCacheSelectionKind) =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                mode,
+                { MaterializationCacheSelection.Preferred with SelectionKind = selectionKind },
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertValid (Validation.validatePlan plan)
+
+    /// Verifies that unsupported public execution/cache-selection plan pairs fail closed.
+    [<TestCase(MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.PreferCache, "Direct materialization must use BypassCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.Direct,
+               MaterializationCacheSelectionKind.RequireCache,
+               "Direct materialization must not use RequireCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred,
+               MaterializationCacheSelectionKind.BypassCache,
+               "CachePreferred materialization must use PreferCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CachePreferred,
+               MaterializationCacheSelectionKind.RequireCache,
+               "CachePreferred materialization must use PreferCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired,
+               MaterializationCacheSelectionKind.BypassCache,
+               "CacheRequired materialization must not use BypassCache selection.")>]
+    [<TestCase(MaterializationExecutionMode.CacheRequired,
+               MaterializationCacheSelectionKind.PreferCache,
+               "CacheRequired materialization must use RequireCache selection.")>]
+    member _.UnsupportedPlanExecutionCacheSelectionPairsFailValidation
+        (
+            mode: MaterializationExecutionMode,
+            selectionKind: MaterializationCacheSelectionKind,
+            expected: string
+        ) =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                mode,
+                { MaterializationCacheSelection.Preferred with SelectionKind = selectionKind },
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertInvalid expected (Validation.validatePlan plan)
+
+    /// Verifies that direct execution cannot also require Grace Cache artifact sourcing.
+    [<Test>]
+    member _.DirectRequestWithRequireCacheSelectionFailsValidationClearly() =
+        let request =
+            MaterializationPlanRequest.Create(
+                MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Required,
+                [
+                    MaterializationArtifactKind.DirectoryVersionZip
+                ]
+            )
+
+        assertInvalid "Direct materialization must not use RequireCache selection." (Validation.validateRequest request)
+
+    /// Verifies that direct plans cannot claim every artifact must come from Grace Cache.
+    [<Test>]
+    member _.DirectPlanWithRequireCacheSelectionFailsValidationClearly() =
+        let plan =
+            MaterializationPlan.Create(
+                MaterializationPlanTestData.targetRootDirectoryVersionId,
+                MaterializationExecutionMode.Direct,
+                MaterializationCacheSelection.Required,
+                MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
+            )
+
+        assertInvalid "Direct materialization must not use RequireCache selection." (Validation.validatePlan plan)
+
+    /// Verifies that branch target selectors use the same Grace object-name contract as branch commands.
+    [<TestCase("feature/cache-plan")>]
+    [<TestCase("1feature")>]
+    [<TestCase("f")>]
+    member _.BranchTargetSelectorsRejectNamesThatBranchCommandsReject(branchName: string) =
+        let selector = MaterializationTargetSelector.ForBranch(BranchName branchName)
+
+        assertInvalid "TargetSelector.BranchName must be a valid Grace branch name." (Validation.validateTargetSelector selector)
 
     /// Verifies that whole-file descriptors reject blank hash fields even when the other hash is valid.
     [<TestCase(true)>]

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -39,6 +39,7 @@
         <Compile Include="Review.Types.fs" />
         <Compile Include="Queue.Types.fs" />
         <Compile Include="Artifact.Types.fs" />
+        <Compile Include="MaterializationPlan.Types.fs" />
         <Compile Include="Automation.Types.fs" />
         <Compile Include="Validation.Types.fs" />
         <Compile Include="Diff.Types.fs" />

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -449,6 +449,10 @@ module MaterializationPlan =
                 if not (isSupportedCacheSelectionKind cacheSelection.SelectionKind) then
                     errors.Add($"CacheSelection.SelectionKind '{int cacheSelection.SelectionKind}' is not supported.")
 
+                match cacheSelection.CacheScope with
+                | Some cacheScope when String.IsNullOrWhiteSpace cacheScope -> errors.Add("CacheSelection.CacheScope must not be blank when specified.")
+                | _ -> ()
+
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
 
         /// Validates that a source shape is explicit and does not invent direct URLs for cache-only artifacts.
@@ -684,6 +688,8 @@ module MaterializationPlan =
                     let mutable targetRootZipCount = 0
                     let mutable recursiveMetadataCount = 0
                     let wholeFileIdentities = HashSet<DirectoryVersionId * RelativePath>()
+                    let fileManifestIdentities = HashSet<DirectoryVersionId * StoragePoolId * ManifestAddress>()
+                    let contentBlockIdentities = HashSet<DirectoryVersionId * StoragePoolId * ContentBlockAddress>()
                     let cacheRequiredByExecutionMode = plan.ExecutionMode = MaterializationExecutionMode.CacheRequired
                     let cacheBypassedByExecutionMode = plan.ExecutionMode = MaterializationExecutionMode.Direct
 
@@ -714,15 +720,18 @@ module MaterializationPlan =
                             if cacheRequiredByExecutionMode
                                || cacheRequiredBySelection then
                                 match descriptor.Source with
-                                | Some source when isNull (box source) ->
-                                    errors.Add("CacheRequired plans must include a non-direct artifact source for every required artifact.")
+                                | Some source when
+                                    not (isNull (box source))
+                                    && source.SourceKind = MaterializationArtifactSourceKind.CacheEntry
+                                    ->
+                                    ()
                                 | Some source when
                                     not (isNull (box source))
                                     && source.SourceKind = MaterializationArtifactSourceKind.DirectUri
                                     ->
-                                    errors.Add("CacheRequired plans must not require DirectUri artifact sources.")
-                                | Some _ -> ()
-                                | None -> errors.Add("CacheRequired plans must include a non-direct artifact source for every required artifact.")
+                                    errors.Add("CacheRequired plans must require CacheEntry artifact sources for every required artifact.")
+                                | Some _ -> errors.Add("CacheRequired plans must require CacheEntry artifact sources for every required artifact.")
+                                | None -> errors.Add("CacheRequired plans must require CacheEntry artifact sources for every required artifact.")
 
                             if descriptor.TargetRootDirectoryVersionId
                                <> plan.TargetRootDirectoryVersionId then
@@ -743,6 +752,30 @@ module MaterializationPlan =
                                     && not (wholeFileIdentities.Add(descriptor.TargetRootDirectoryVersionId, relativePath))
                                     ->
                                     errors.Add("RequiredArtifacts must include at most one WholeFileContent for each target root and relative path.")
+                                | _ -> ()
+
+                            if descriptor.ArtifactKind = MaterializationArtifactKind.FileManifest then
+                                match descriptor.StoragePoolId, descriptor.ManifestAddress with
+                                | Some storagePoolId, Some manifestAddress when
+                                    not (String.IsNullOrWhiteSpace storagePoolId)
+                                    && not (String.IsNullOrWhiteSpace manifestAddress)
+                                    && not (fileManifestIdentities.Add(descriptor.TargetRootDirectoryVersionId, storagePoolId, manifestAddress))
+                                    ->
+                                    errors.Add(
+                                        "RequiredArtifacts must include at most one FileManifest for each target root, storage pool, and manifest address."
+                                    )
+                                | _ -> ()
+
+                            if descriptor.ArtifactKind = MaterializationArtifactKind.ContentBlock then
+                                match descriptor.StoragePoolId, descriptor.ContentBlockAddress with
+                                | Some storagePoolId, Some contentBlockAddress when
+                                    not (String.IsNullOrWhiteSpace storagePoolId)
+                                    && not (String.IsNullOrWhiteSpace contentBlockAddress)
+                                    && not (contentBlockIdentities.Add(descriptor.TargetRootDirectoryVersionId, storagePoolId, contentBlockAddress))
+                                    ->
+                                    errors.Add(
+                                        "RequiredArtifacts must include at most one ContentBlock for each target root, storage pool, and content block address."
+                                    )
                                 | _ -> ()
 
                     if targetRootZipCount = 0 then

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -1,5 +1,6 @@
 namespace Grace.Types
 
+open Grace.Shared
 open Grace.Types.Common
 open Orleans
 open System
@@ -358,22 +359,26 @@ module MaterializationPlan =
                    && segment <> "."
                    && segment <> "..")
 
-        /// Rejects public cache controls where cache-required mode is not paired with RequireCache selection.
-        let rejectCacheRequiredSelectionMismatch
+        /// Rejects public execution/cache-selection combinations that have contradictory cache authority.
+        let rejectUnsupportedExecutionCacheSelectionPair
             (executionMode: MaterializationExecutionMode)
             (cacheSelection: MaterializationCacheSelection)
             (errors: ResizeArray<string>)
             =
-            if
-                executionMode = MaterializationExecutionMode.CacheRequired
-                && not (isNull (box cacheSelection))
-            then
-                if cacheSelection.SelectionKind
-                   <> MaterializationCacheSelectionKind.RequireCache then
-                    errors.Add("CacheRequired materialization must use RequireCache selection.")
-
-                if cacheSelection.SelectionKind = MaterializationCacheSelectionKind.BypassCache then
+            if not (isNull (box cacheSelection)) then
+                match executionMode, cacheSelection.SelectionKind with
+                | MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.BypassCache -> ()
+                | MaterializationExecutionMode.CachePreferred, MaterializationCacheSelectionKind.PreferCache -> ()
+                | MaterializationExecutionMode.CacheRequired, MaterializationCacheSelectionKind.RequireCache -> ()
+                | MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.RequireCache ->
+                    errors.Add("Direct materialization must not use RequireCache selection.")
+                | MaterializationExecutionMode.Direct, MaterializationCacheSelectionKind.PreferCache ->
+                    errors.Add("Direct materialization must use BypassCache selection.")
+                | MaterializationExecutionMode.CacheRequired, MaterializationCacheSelectionKind.BypassCache ->
                     errors.Add("CacheRequired materialization must not use BypassCache selection.")
+                | MaterializationExecutionMode.CacheRequired, _ -> errors.Add("CacheRequired materialization must use RequireCache selection.")
+                | MaterializationExecutionMode.CachePreferred, _ -> errors.Add("CachePreferred materialization must use PreferCache selection.")
+                | _ -> ()
 
         /// Validates the target selector before server-side target-root resolution.
         let validateTargetSelector (selector: MaterializationTargetSelector) =
@@ -412,7 +417,9 @@ module MaterializationPlan =
                             errors.Add("TargetSelector.BranchName must be empty for ReferenceId selectors.")
                     | MaterializationTargetSelectorKind.BranchName ->
                         match selector.BranchName with
-                        | Some branchName when not (String.IsNullOrWhiteSpace branchName) -> ()
+                        | Some branchName when Constants.GraceNameRegex.IsMatch(branchName) -> ()
+                        | Some branchName when not (String.IsNullOrWhiteSpace branchName) ->
+                            errors.Add("TargetSelector.BranchName must be a valid Grace branch name.")
                         | _ -> errors.Add("TargetSelector.BranchName is required.")
 
                         if selector.DirectoryVersionId.IsSome then
@@ -628,7 +635,7 @@ module MaterializationPlan =
                 | Ok () -> ()
                 | Error cacheErrors -> errors.AddRange(cacheErrors)
 
-                rejectCacheRequiredSelectionMismatch request.ExecutionMode request.CacheSelection errors
+                rejectUnsupportedExecutionCacheSelectionPair request.ExecutionMode request.CacheSelection errors
 
                 if
                     isNull (box request.RequestedArtifactKinds)
@@ -662,7 +669,7 @@ module MaterializationPlan =
                 | Ok () -> ()
                 | Error cacheErrors -> errors.AddRange(cacheErrors)
 
-                rejectCacheRequiredSelectionMismatch plan.ExecutionMode plan.CacheSelection errors
+                rejectUnsupportedExecutionCacheSelectionPair plan.ExecutionMode plan.CacheSelection errors
 
                 if
                     isNull (box plan.RequiredArtifacts)

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -5,6 +5,7 @@ open Orleans
 open System
 open System.Collections.Generic
 open System.IO
+open System.Text.RegularExpressions
 
 /// Contains Materialization Plan request, response, artifact, and cache-selection contracts.
 module MaterializationPlan =
@@ -322,27 +323,57 @@ module MaterializationPlan =
         /// Returns true when the supplied enum value is one of the known public artifact source kinds.
         let isSupportedArtifactSourceKind (kind: MaterializationArtifactSourceKind) = Enum.IsDefined(typeof<MaterializationArtifactSourceKind>, kind)
 
+        let private canonicalLowercaseHexAddressRegex =
+            Regex(
+                "^[0-9a-f]{64}$",
+                RegexOptions.Compiled
+                ||| RegexOptions.CultureInvariant
+            )
+
+        /// Returns true when a contract hash or CAS address is a canonical lowercase 64-hex BLAKE3/SHA value.
+        let isCanonicalLowercaseHexAddress (address: string) =
+            not (String.IsNullOrWhiteSpace address)
+            && canonicalLowercaseHexAddressRegex.IsMatch(address)
+
+        /// Returns true when a direct artifact source can be fetched through a public HTTP(S) URI.
+        let isAllowedDirectUri (uri: string) =
+            let mutable parsedUri = Unchecked.defaultof<Uri>
+
+            not (String.IsNullOrWhiteSpace uri)
+            && Uri.TryCreate(uri, UriKind.Absolute, &parsedUri)
+            && (parsedUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                || parsedUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+
         /// Returns true when a whole-file artifact path is normalized for repository-relative materialization.
         let isNormalizedRepositoryRelativePath (relativePath: string) =
             not (String.IsNullOrWhiteSpace relativePath)
             && not (Path.IsPathRooted relativePath)
+            && not (relativePath.StartsWith("/", StringComparison.Ordinal))
+            && not (relativePath.StartsWith("\\", StringComparison.Ordinal))
             && not (relativePath.Contains('\\'))
+            && not (relativePath.Contains(':'))
             && relativePath.Split('/', StringSplitOptions.None)
                |> Array.forall (fun segment ->
                    not (String.IsNullOrWhiteSpace segment)
                    && segment <> "."
                    && segment <> "..")
 
-        /// Rejects public cache controls that require cache use while also asking Grace to bypass cache entries.
-        let rejectCacheRequiredBypass
+        /// Rejects public cache controls where cache-required mode is not paired with RequireCache selection.
+        let rejectCacheRequiredSelectionMismatch
             (executionMode: MaterializationExecutionMode)
             (cacheSelection: MaterializationCacheSelection)
             (errors: ResizeArray<string>)
             =
-            if executionMode = MaterializationExecutionMode.CacheRequired
-               && not (isNull (box cacheSelection))
-               && cacheSelection.SelectionKind = MaterializationCacheSelectionKind.BypassCache then
-                errors.Add("CacheRequired materialization must not use BypassCache selection.")
+            if
+                executionMode = MaterializationExecutionMode.CacheRequired
+                && not (isNull (box cacheSelection))
+            then
+                if cacheSelection.SelectionKind
+                   <> MaterializationCacheSelectionKind.RequireCache then
+                    errors.Add("CacheRequired materialization must use RequireCache selection.")
+
+                if cacheSelection.SelectionKind = MaterializationCacheSelectionKind.BypassCache then
+                    errors.Add("CacheRequired materialization must not use BypassCache selection.")
 
         /// Validates the target selector before server-side target-root resolution.
         let validateTargetSelector (selector: MaterializationTargetSelector) =
@@ -426,7 +457,8 @@ module MaterializationPlan =
                     match source.SourceKind with
                     | MaterializationArtifactSourceKind.DirectUri ->
                         match source.DirectUri with
-                        | Some uri when not (String.IsNullOrWhiteSpace uri) -> ()
+                        | Some uri when isAllowedDirectUri uri -> ()
+                        | Some _ -> errors.Add("Artifact DirectUri must be an absolute http or https URI for DirectUri sources.")
                         | _ -> errors.Add("Artifact DirectUri is required for DirectUri sources.")
 
                         if source.CacheKey.IsSome then
@@ -460,6 +492,18 @@ module MaterializationPlan =
                 match descriptor.StoragePoolId with
                 | Some storagePoolId when not (String.IsNullOrWhiteSpace storagePoolId) -> ()
                 | _ -> errors.Add("Artifact StoragePoolId is required for CAS artifact descriptors.")
+
+            let requireCanonicalSha256Hash () =
+                match descriptor.Sha256Hash with
+                | Some sha256Hash when isCanonicalLowercaseHexAddress sha256Hash -> ()
+                | Some _ -> errors.Add("Artifact Sha256Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors.")
+                | None -> ()
+
+            let requireCanonicalBlake3Hash () =
+                match descriptor.Blake3Hash with
+                | Some blake3Hash when isCanonicalLowercaseHexAddress blake3Hash -> ()
+                | Some _ -> errors.Add("Artifact Blake3Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors.")
+                | None -> ()
 
             let rejectRelativePath artifactKind =
                 if descriptor.RelativePath.IsSome then
@@ -514,10 +558,12 @@ module MaterializationPlan =
                         | Some _ -> errors.Add("Artifact RelativePath must be a normalized repository-relative path for WholeFileContent descriptors.")
                         | _ -> errors.Add("Artifact RelativePath is required for WholeFileContent descriptors.")
 
-                        match descriptor.Sha256Hash, descriptor.Blake3Hash with
-                        | Some sha256Hash, _ when not (String.IsNullOrWhiteSpace sha256Hash) -> ()
-                        | _, Some blake3Hash when not (String.IsNullOrWhiteSpace blake3Hash) -> ()
-                        | _ -> errors.Add("Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors.")
+                        requireCanonicalSha256Hash ()
+                        requireCanonicalBlake3Hash ()
+
+                        if descriptor.Sha256Hash.IsNone
+                           && descriptor.Blake3Hash.IsNone then
+                            errors.Add("Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors.")
 
                         rejectManifestAddress (string descriptor.ArtifactKind)
                         rejectContentBlockAddress (string descriptor.ArtifactKind)
@@ -526,7 +572,9 @@ module MaterializationPlan =
                         requireTargetRoot ()
 
                         match descriptor.ManifestAddress with
-                        | Some manifestAddress when not (String.IsNullOrWhiteSpace manifestAddress) -> ()
+                        | Some manifestAddress when isCanonicalLowercaseHexAddress manifestAddress -> ()
+                        | Some _ ->
+                            errors.Add("Artifact ManifestAddress must be a canonical lowercase 64-character hexadecimal value for FileManifest descriptors.")
                         | _ -> errors.Add("Artifact ManifestAddress is required for FileManifest descriptors.")
 
                         requireStoragePool ()
@@ -537,7 +585,11 @@ module MaterializationPlan =
                         requireTargetRoot ()
 
                         match descriptor.ContentBlockAddress with
-                        | Some contentBlockAddress when not (String.IsNullOrWhiteSpace contentBlockAddress) -> ()
+                        | Some contentBlockAddress when isCanonicalLowercaseHexAddress contentBlockAddress -> ()
+                        | Some _ ->
+                            errors.Add(
+                                "Artifact ContentBlockAddress must be a canonical lowercase 64-character hexadecimal value for ContentBlock descriptors."
+                            )
                         | _ -> errors.Add("Artifact ContentBlockAddress is required for ContentBlock descriptors.")
 
                         requireStoragePool ()
@@ -576,7 +628,7 @@ module MaterializationPlan =
                 | Ok () -> ()
                 | Error cacheErrors -> errors.AddRange(cacheErrors)
 
-                rejectCacheRequiredBypass request.ExecutionMode request.CacheSelection errors
+                rejectCacheRequiredSelectionMismatch request.ExecutionMode request.CacheSelection errors
 
                 if
                     isNull (box request.RequestedArtifactKinds)
@@ -610,7 +662,7 @@ module MaterializationPlan =
                 | Ok () -> ()
                 | Error cacheErrors -> errors.AddRange(cacheErrors)
 
-                rejectCacheRequiredBypass plan.ExecutionMode plan.CacheSelection errors
+                rejectCacheRequiredSelectionMismatch plan.ExecutionMode plan.CacheSelection errors
 
                 if
                     isNull (box plan.RequiredArtifacts)
@@ -618,8 +670,8 @@ module MaterializationPlan =
                 then
                     errors.Add("RequiredArtifacts must include the V1 target-root artifacts.")
                 else
-                    let mutable hasTargetRootZip = false
-                    let mutable hasRecursiveMetadata = false
+                    let mutable targetRootZipCount = 0
+                    let mutable recursiveMetadataCount = 0
                     let cacheRequiredByExecutionMode = plan.ExecutionMode = MaterializationExecutionMode.CacheRequired
 
                     let cacheRequiredBySelection =
@@ -635,12 +687,15 @@ module MaterializationPlan =
                             if cacheRequiredByExecutionMode
                                || cacheRequiredBySelection then
                                 match descriptor.Source with
+                                | Some source when isNull (box source) ->
+                                    errors.Add("CacheRequired plans must include a non-direct artifact source for every required artifact.")
                                 | Some source when
                                     not (isNull (box source))
                                     && source.SourceKind = MaterializationArtifactSourceKind.DirectUri
                                     ->
                                     errors.Add("CacheRequired plans must not require DirectUri artifact sources.")
-                                | _ -> ()
+                                | Some _ -> ()
+                                | None -> errors.Add("CacheRequired plans must include a non-direct artifact source for every required artifact.")
 
                             if descriptor.TargetRootDirectoryVersionId
                                <> plan.TargetRootDirectoryVersionId then
@@ -648,16 +703,20 @@ module MaterializationPlan =
 
                             if descriptor.ArtifactKind = MaterializationArtifactKind.DirectoryVersionZip
                                && descriptor.TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId then
-                                hasTargetRootZip <- true
+                                targetRootZipCount <- targetRootZipCount + 1
 
                             if descriptor.ArtifactKind = MaterializationArtifactKind.RecursiveDirectoryMetadata
                                && descriptor.TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId then
-                                hasRecursiveMetadata <- true
+                                recursiveMetadataCount <- recursiveMetadataCount + 1
 
-                    if not hasTargetRootZip then
+                    if targetRootZipCount = 0 then
                         errors.Add("RequiredArtifacts must include DirectoryVersionZip for the target root.")
+                    elif targetRootZipCount > 1 then
+                        errors.Add("RequiredArtifacts must include exactly one DirectoryVersionZip for the target root.")
 
-                    if not hasRecursiveMetadata then
+                    if recursiveMetadataCount = 0 then
                         errors.Add("RequiredArtifacts must include RecursiveDirectoryMetadata for the target root.")
+                    elif recursiveMetadataCount > 1 then
+                        errors.Add("RequiredArtifacts must include exactly one RecursiveDirectoryMetadata for the target root.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -340,14 +340,32 @@ module MaterializationPlan =
                         match selector.DirectoryVersionId with
                         | Some directoryVersionId when directoryVersionId <> DirectoryVersionId.Empty -> ()
                         | _ -> errors.Add("TargetSelector.DirectoryVersionId is required.")
+
+                        if selector.ReferenceId.IsSome then
+                            errors.Add("TargetSelector.ReferenceId must be empty for DirectoryVersionId selectors.")
+
+                        if selector.BranchName.IsSome then
+                            errors.Add("TargetSelector.BranchName must be empty for DirectoryVersionId selectors.")
                     | MaterializationTargetSelectorKind.ReferenceId ->
                         match selector.ReferenceId with
                         | Some referenceId when referenceId <> ReferenceId.Empty -> ()
                         | _ -> errors.Add("TargetSelector.ReferenceId is required.")
+
+                        if selector.DirectoryVersionId.IsSome then
+                            errors.Add("TargetSelector.DirectoryVersionId must be empty for ReferenceId selectors.")
+
+                        if selector.BranchName.IsSome then
+                            errors.Add("TargetSelector.BranchName must be empty for ReferenceId selectors.")
                     | MaterializationTargetSelectorKind.BranchName ->
                         match selector.BranchName with
                         | Some branchName when not (String.IsNullOrWhiteSpace branchName) -> ()
                         | _ -> errors.Add("TargetSelector.BranchName is required.")
+
+                        if selector.DirectoryVersionId.IsSome then
+                            errors.Add("TargetSelector.DirectoryVersionId must be empty for BranchName selectors.")
+
+                        if selector.ReferenceId.IsSome then
+                            errors.Add("TargetSelector.ReferenceId must be empty for BranchName selectors.")
                     | _ -> errors.Add($"TargetSelector.SelectorKind '{int selector.SelectorKind}' is not supported.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
@@ -391,7 +409,12 @@ module MaterializationPlan =
                         match source.CacheKey with
                         | Some cacheKey when not (String.IsNullOrWhiteSpace cacheKey) -> ()
                         | _ -> errors.Add("Artifact CacheKey is required for CacheEntry sources.")
-                    | MaterializationArtifactSourceKind.Deferred -> ()
+
+                        if source.DirectUri.IsSome then
+                            errors.Add("Artifact DirectUri must be empty for CacheEntry sources.")
+                    | MaterializationArtifactSourceKind.Deferred ->
+                        if source.DirectUri.IsSome then
+                            errors.Add("Artifact DirectUri must be empty for Deferred sources.")
                     | _ -> errors.Add($"Artifact SourceKind '{int source.SourceKind}' is not supported.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
@@ -521,6 +544,11 @@ module MaterializationPlan =
                 else
                     let mutable hasTargetRootZip = false
                     let mutable hasRecursiveMetadata = false
+                    let cacheRequiredByExecutionMode = plan.ExecutionMode = MaterializationExecutionMode.CacheRequired
+
+                    let cacheRequiredBySelection =
+                        not (isNull (box plan.CacheSelection))
+                        && plan.CacheSelection.SelectionKind = MaterializationCacheSelectionKind.RequireCache
 
                     for descriptor in plan.RequiredArtifacts do
                         match validateArtifactDescriptor descriptor with
@@ -528,9 +556,13 @@ module MaterializationPlan =
                         | Error descriptorErrors -> errors.AddRange(descriptorErrors)
 
                         if not (isNull (box descriptor)) then
-                            if plan.CacheSelection.SelectionKind = MaterializationCacheSelectionKind.RequireCache then
+                            if cacheRequiredByExecutionMode
+                               || cacheRequiredBySelection then
                                 match descriptor.Source with
-                                | Some source when source.SourceKind = MaterializationArtifactSourceKind.DirectUri ->
+                                | Some source when
+                                    not (isNull (box source))
+                                    && source.SourceKind = MaterializationArtifactSourceKind.DirectUri
+                                    ->
                                     errors.Add("CacheRequired plans must not require DirectUri artifact sources.")
                                 | _ -> ()
 

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -1,0 +1,555 @@
+namespace Grace.Types
+
+open Grace.Types.Common
+open Orleans
+open System
+open System.Collections.Generic
+
+/// Contains Materialization Plan request, response, artifact, and cache-selection contracts.
+module MaterializationPlan =
+
+    /// Identifies how Grace may satisfy a Materialization Plan request.
+    type MaterializationExecutionMode =
+        | Direct = 1
+        | CachePreferred = 2
+        | CacheRequired = 3
+
+    /// Identifies the public target selector shape supplied before Grace resolves the immutable target root.
+    type MaterializationTargetSelectorKind =
+        | DirectoryVersionId = 1
+        | ReferenceId = 2
+        | BranchName = 3
+
+    /// Identifies the cache behavior requested for artifact source selection.
+    type MaterializationCacheSelectionKind =
+        | BypassCache = 1
+        | PreferCache = 2
+        | RequireCache = 3
+
+    /// Identifies the artifact contract vocabulary that a Materialization Plan may require.
+    type MaterializationArtifactKind =
+        | DirectoryVersionZip = 1
+        | RecursiveDirectoryMetadata = 2
+        | WholeFileContent = 3
+        | FileManifest = 4
+        | ContentBlock = 5
+
+    /// Identifies where a planned artifact can be fetched or resolved from.
+    type MaterializationArtifactSourceKind =
+        | DirectUri = 1
+        | CacheEntry = 2
+        | Deferred = 3
+
+    /// Selects a target before server-side resolution to one immutable root DirectoryVersionId.
+    [<CLIMutable; GenerateSerializer>]
+    type MaterializationTargetSelector =
+        {
+            Class: string
+            SelectorKind: MaterializationTargetSelectorKind
+            DirectoryVersionId: DirectoryVersionId option
+            ReferenceId: ReferenceId option
+            BranchName: BranchName option
+        }
+
+        /// Selects a known immutable directory version root directly.
+        static member ForDirectoryVersion(directoryVersionId: DirectoryVersionId) =
+            {
+                Class = nameof MaterializationTargetSelector
+                SelectorKind = MaterializationTargetSelectorKind.DirectoryVersionId
+                DirectoryVersionId = Some directoryVersionId
+                ReferenceId = None
+                BranchName = None
+            }
+
+        /// Selects the directory version reached by a stored Grace reference.
+        static member ForReference(referenceId: ReferenceId) =
+            {
+                Class = nameof MaterializationTargetSelector
+                SelectorKind = MaterializationTargetSelectorKind.ReferenceId
+                DirectoryVersionId = None
+                ReferenceId = Some referenceId
+                BranchName = None
+            }
+
+        /// Selects the directory version reached by the current branch tip at resolution time.
+        static member ForBranch(branchName: BranchName) =
+            {
+                Class = nameof MaterializationTargetSelector
+                SelectorKind = MaterializationTargetSelectorKind.BranchName
+                DirectoryVersionId = None
+                ReferenceId = None
+                BranchName = Some branchName
+            }
+
+        /// Represents an empty selector used before caller input contributes target identity.
+        static member Empty =
+            {
+                Class = nameof MaterializationTargetSelector
+                SelectorKind = MaterializationTargetSelectorKind.DirectoryVersionId
+                DirectoryVersionId = None
+                ReferenceId = None
+                BranchName = None
+            }
+
+    /// Records cache-selection intent separately from artifact source details.
+    [<CLIMutable; GenerateSerializer>]
+    type MaterializationCacheSelection =
+        {
+            Class: string
+            SelectionKind: MaterializationCacheSelectionKind
+            CacheScope: string option
+        }
+
+        /// Requests direct materialization without consulting cache entries.
+        static member Bypass =
+            { Class = nameof MaterializationCacheSelection; SelectionKind = MaterializationCacheSelectionKind.BypassCache; CacheScope = None }
+
+        /// Allows Grace to prefer cache entries while still permitting direct artifact sources.
+        static member Preferred =
+            { Class = nameof MaterializationCacheSelection; SelectionKind = MaterializationCacheSelectionKind.PreferCache; CacheScope = None }
+
+        /// Requires Grace to satisfy planned artifacts from cache sources only.
+        static member Required =
+            { Class = nameof MaterializationCacheSelection; SelectionKind = MaterializationCacheSelectionKind.RequireCache; CacheScope = None }
+
+    /// Describes a fetchable or deferred location for one planned artifact.
+    [<CLIMutable; GenerateSerializer>]
+    type MaterializationArtifactSource =
+        {
+            Class: string
+            SourceKind: MaterializationArtifactSourceKind
+            DirectUri: string option
+            CacheKey: string option
+        }
+
+        /// Points to a direct source URI produced by a materialization-capable server path.
+        static member Direct(uri: string) =
+            { Class = nameof MaterializationArtifactSource; SourceKind = MaterializationArtifactSourceKind.DirectUri; DirectUri = Some uri; CacheKey = None }
+
+        /// Points to a cache entry without requiring Grace to expose a direct source URI.
+        static member CacheOnly(cacheKey: string) =
+            {
+                Class = nameof MaterializationArtifactSource
+                SourceKind = MaterializationArtifactSourceKind.CacheEntry
+                DirectUri = None
+                CacheKey = Some cacheKey
+            }
+
+        /// Records that a later slice will resolve the artifact source during execution.
+        static member Deferred =
+            { Class = nameof MaterializationArtifactSource; SourceKind = MaterializationArtifactSourceKind.Deferred; DirectUri = None; CacheKey = None }
+
+    /// Describes one stable artifact identity required to materialize a resolved target root.
+    [<CLIMutable; GenerateSerializer>]
+    type MaterializationArtifactDescriptor =
+        {
+            Class: string
+            ArtifactKind: MaterializationArtifactKind
+            TargetRootDirectoryVersionId: DirectoryVersionId
+            RelativePath: RelativePath option
+            Sha256Hash: Sha256Hash option
+            Blake3Hash: Blake3Hash option
+            ManifestAddress: ManifestAddress option
+            ContentBlockAddress: ContentBlockAddress option
+            StoragePoolId: StoragePoolId option
+            Source: MaterializationArtifactSource option
+        }
+
+        /// Describes the target-root zip artifact for a resolved immutable directory root.
+        static member DirectoryVersionZip(targetRootDirectoryVersionId: DirectoryVersionId, source: MaterializationArtifactSource option) =
+            {
+                Class = nameof MaterializationArtifactDescriptor
+                ArtifactKind = MaterializationArtifactKind.DirectoryVersionZip
+                TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                RelativePath = None
+                Sha256Hash = None
+                Blake3Hash = None
+                ManifestAddress = None
+                ContentBlockAddress = None
+                StoragePoolId = None
+                Source = source
+            }
+
+        /// Describes recursive metadata for the same immutable target root as the plan response.
+        static member RecursiveDirectoryMetadata(targetRootDirectoryVersionId: DirectoryVersionId, source: MaterializationArtifactSource option) =
+            {
+                Class = nameof MaterializationArtifactDescriptor
+                ArtifactKind = MaterializationArtifactKind.RecursiveDirectoryMetadata
+                TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                RelativePath = None
+                Sha256Hash = None
+                Blake3Hash = None
+                ManifestAddress = None
+                ContentBlockAddress = None
+                StoragePoolId = None
+                Source = source
+            }
+
+        /// Describes whole-file bytes by path plus stable content hash evidence.
+        static member WholeFileContent
+            (
+                targetRootDirectoryVersionId: DirectoryVersionId,
+                relativePath: RelativePath,
+                sha256Hash: Sha256Hash option,
+                blake3Hash: Blake3Hash option,
+                source: MaterializationArtifactSource option
+            ) =
+            {
+                Class = nameof MaterializationArtifactDescriptor
+                ArtifactKind = MaterializationArtifactKind.WholeFileContent
+                TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                RelativePath = Some relativePath
+                Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
+                ManifestAddress = None
+                ContentBlockAddress = None
+                StoragePoolId = None
+                Source = source
+            }
+
+        /// Describes a manifest-backed file by its CAS manifest identity and storage pool.
+        static member FileManifest
+            (
+                targetRootDirectoryVersionId: DirectoryVersionId,
+                manifestAddress: ManifestAddress,
+                storagePoolId: StoragePoolId,
+                source: MaterializationArtifactSource option
+            ) =
+            {
+                Class = nameof MaterializationArtifactDescriptor
+                ArtifactKind = MaterializationArtifactKind.FileManifest
+                TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                RelativePath = None
+                Sha256Hash = None
+                Blake3Hash = None
+                ManifestAddress = Some manifestAddress
+                ContentBlockAddress = None
+                StoragePoolId = Some storagePoolId
+                Source = source
+            }
+
+        /// Describes one reusable content block by its CAS block identity and storage pool.
+        static member ContentBlock
+            (
+                targetRootDirectoryVersionId: DirectoryVersionId,
+                contentBlockAddress: ContentBlockAddress,
+                storagePoolId: StoragePoolId,
+                source: MaterializationArtifactSource option
+            ) =
+            {
+                Class = nameof MaterializationArtifactDescriptor
+                ArtifactKind = MaterializationArtifactKind.ContentBlock
+                TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                RelativePath = None
+                Sha256Hash = None
+                Blake3Hash = None
+                ManifestAddress = None
+                ContentBlockAddress = Some contentBlockAddress
+                StoragePoolId = Some storagePoolId
+                Source = source
+            }
+
+    /// Requests a Materialization Plan for a selected target and execution/cache behavior.
+    [<CLIMutable; GenerateSerializer>]
+    type MaterializationPlanRequest =
+        {
+            Class: string
+            TargetSelector: MaterializationTargetSelector
+            ExecutionMode: MaterializationExecutionMode
+            CacheSelection: MaterializationCacheSelection
+            RequestedArtifactKinds: List<MaterializationArtifactKind>
+        }
+
+        /// Builds a request with a defensive copy of the requested artifact kind list.
+        static member Create
+            (
+                targetSelector: MaterializationTargetSelector,
+                executionMode: MaterializationExecutionMode,
+                cacheSelection: MaterializationCacheSelection,
+                requestedArtifactKinds: MaterializationArtifactKind seq
+            ) =
+            {
+                Class = nameof MaterializationPlanRequest
+                TargetSelector = targetSelector
+                ExecutionMode = executionMode
+                CacheSelection = cacheSelection
+                RequestedArtifactKinds = List<MaterializationArtifactKind>(requestedArtifactKinds)
+            }
+
+    /// Responds with the resolved immutable target root and the artifacts required to materialize it.
+    [<CLIMutable; GenerateSerializer>]
+    type MaterializationPlan =
+        {
+            Class: string
+            TargetRootDirectoryVersionId: DirectoryVersionId
+            ExecutionMode: MaterializationExecutionMode
+            CacheSelection: MaterializationCacheSelection
+            RequiredArtifacts: List<MaterializationArtifactDescriptor>
+        }
+
+        /// Builds a response with a defensive copy of the required artifact descriptor list.
+        static member Create
+            (
+                targetRootDirectoryVersionId: DirectoryVersionId,
+                executionMode: MaterializationExecutionMode,
+                cacheSelection: MaterializationCacheSelection,
+                requiredArtifacts: MaterializationArtifactDescriptor seq
+            ) =
+            {
+                Class = nameof MaterializationPlan
+                TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                ExecutionMode = executionMode
+                CacheSelection = cacheSelection
+                RequiredArtifacts = List<MaterializationArtifactDescriptor>(requiredArtifacts)
+            }
+
+    /// Contains validation helpers for Materialization Plan contract invariants.
+    module Validation =
+
+        /// Returns true when the supplied enum value is one of the known public materialization execution modes.
+        let isSupportedExecutionMode (mode: MaterializationExecutionMode) = Enum.IsDefined(typeof<MaterializationExecutionMode>, mode)
+
+        /// Returns true when the supplied enum value is one of the known public materialization artifact kinds.
+        let isSupportedArtifactKind (kind: MaterializationArtifactKind) = Enum.IsDefined(typeof<MaterializationArtifactKind>, kind)
+
+        /// Returns true when the supplied enum value is one of the known public target selector kinds.
+        let isSupportedTargetSelectorKind (kind: MaterializationTargetSelectorKind) = Enum.IsDefined(typeof<MaterializationTargetSelectorKind>, kind)
+
+        /// Returns true when the supplied enum value is one of the known public cache selection kinds.
+        let isSupportedCacheSelectionKind (kind: MaterializationCacheSelectionKind) = Enum.IsDefined(typeof<MaterializationCacheSelectionKind>, kind)
+
+        /// Returns true when the supplied enum value is one of the known public artifact source kinds.
+        let isSupportedArtifactSourceKind (kind: MaterializationArtifactSourceKind) = Enum.IsDefined(typeof<MaterializationArtifactSourceKind>, kind)
+
+        /// Validates the target selector before server-side target-root resolution.
+        let validateTargetSelector (selector: MaterializationTargetSelector) =
+            let errors = ResizeArray<string>()
+
+            if isNull (box selector) then
+                errors.Add("TargetSelector is required.")
+            else
+                if selector.Class
+                   <> nameof MaterializationTargetSelector then
+                    errors.Add("TargetSelector.Class must be MaterializationTargetSelector.")
+
+                if not (isSupportedTargetSelectorKind selector.SelectorKind) then
+                    errors.Add($"TargetSelector.SelectorKind '{int selector.SelectorKind}' is not supported.")
+                else
+                    match selector.SelectorKind with
+                    | MaterializationTargetSelectorKind.DirectoryVersionId ->
+                        match selector.DirectoryVersionId with
+                        | Some directoryVersionId when directoryVersionId <> DirectoryVersionId.Empty -> ()
+                        | _ -> errors.Add("TargetSelector.DirectoryVersionId is required.")
+                    | MaterializationTargetSelectorKind.ReferenceId ->
+                        match selector.ReferenceId with
+                        | Some referenceId when referenceId <> ReferenceId.Empty -> ()
+                        | _ -> errors.Add("TargetSelector.ReferenceId is required.")
+                    | MaterializationTargetSelectorKind.BranchName ->
+                        match selector.BranchName with
+                        | Some branchName when not (String.IsNullOrWhiteSpace branchName) -> ()
+                        | _ -> errors.Add("TargetSelector.BranchName is required.")
+                    | _ -> errors.Add($"TargetSelector.SelectorKind '{int selector.SelectorKind}' is not supported.")
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
+
+        /// Validates cache-selection intent without assuming any server runtime behavior.
+        let validateCacheSelection (cacheSelection: MaterializationCacheSelection) =
+            let errors = ResizeArray<string>()
+
+            if isNull (box cacheSelection) then
+                errors.Add("CacheSelection is required.")
+            else
+                if cacheSelection.Class
+                   <> nameof MaterializationCacheSelection then
+                    errors.Add("CacheSelection.Class must be MaterializationCacheSelection.")
+
+                if not (isSupportedCacheSelectionKind cacheSelection.SelectionKind) then
+                    errors.Add($"CacheSelection.SelectionKind '{int cacheSelection.SelectionKind}' is not supported.")
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
+
+        /// Validates that a source shape is explicit and does not invent direct URLs for cache-only artifacts.
+        let validateArtifactSource (source: MaterializationArtifactSource) =
+            let errors = ResizeArray<string>()
+
+            if isNull (box source) then
+                errors.Add("Artifact Source is required.")
+            else
+                if source.Class
+                   <> nameof MaterializationArtifactSource then
+                    errors.Add("Artifact Source Class must be MaterializationArtifactSource.")
+
+                if not (isSupportedArtifactSourceKind source.SourceKind) then
+                    errors.Add($"Artifact SourceKind '{int source.SourceKind}' is not supported.")
+                else
+                    match source.SourceKind with
+                    | MaterializationArtifactSourceKind.DirectUri ->
+                        match source.DirectUri with
+                        | Some uri when not (String.IsNullOrWhiteSpace uri) -> ()
+                        | _ -> errors.Add("Artifact DirectUri is required for DirectUri sources.")
+                    | MaterializationArtifactSourceKind.CacheEntry ->
+                        match source.CacheKey with
+                        | Some cacheKey when not (String.IsNullOrWhiteSpace cacheKey) -> ()
+                        | _ -> errors.Add("Artifact CacheKey is required for CacheEntry sources.")
+                    | MaterializationArtifactSourceKind.Deferred -> ()
+                    | _ -> errors.Add($"Artifact SourceKind '{int source.SourceKind}' is not supported.")
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
+
+        /// Validates that an artifact descriptor carries the stable identity required by its kind.
+        let validateArtifactDescriptor (descriptor: MaterializationArtifactDescriptor) =
+            let errors = ResizeArray<string>()
+
+            let requireTargetRoot () =
+                if descriptor.TargetRootDirectoryVersionId = DirectoryVersionId.Empty then
+                    errors.Add("Artifact TargetRootDirectoryVersionId is required.")
+
+            let requireStoragePool () =
+                match descriptor.StoragePoolId with
+                | Some storagePoolId when not (String.IsNullOrWhiteSpace storagePoolId) -> ()
+                | _ -> errors.Add("Artifact StoragePoolId is required for CAS artifact descriptors.")
+
+            if isNull (box descriptor) then
+                errors.Add("Artifact descriptor is required.")
+            else
+                if descriptor.Class
+                   <> nameof MaterializationArtifactDescriptor then
+                    errors.Add("Artifact Class must be MaterializationArtifactDescriptor.")
+
+                if not (isSupportedArtifactKind descriptor.ArtifactKind) then
+                    errors.Add($"ArtifactKind '{int descriptor.ArtifactKind}' is not supported.")
+                else
+                    match descriptor.ArtifactKind with
+                    | MaterializationArtifactKind.DirectoryVersionZip
+                    | MaterializationArtifactKind.RecursiveDirectoryMetadata -> requireTargetRoot ()
+                    | MaterializationArtifactKind.WholeFileContent ->
+                        requireTargetRoot ()
+
+                        match descriptor.RelativePath with
+                        | Some relativePath when not (String.IsNullOrWhiteSpace relativePath) -> ()
+                        | _ -> errors.Add("Artifact RelativePath is required for WholeFileContent descriptors.")
+
+                        match descriptor.Sha256Hash, descriptor.Blake3Hash with
+                        | Some sha256Hash, _ when not (String.IsNullOrWhiteSpace sha256Hash) -> ()
+                        | _, Some blake3Hash when not (String.IsNullOrWhiteSpace blake3Hash) -> ()
+                        | _ -> errors.Add("Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors.")
+                    | MaterializationArtifactKind.FileManifest ->
+                        requireTargetRoot ()
+
+                        match descriptor.ManifestAddress with
+                        | Some manifestAddress when not (String.IsNullOrWhiteSpace manifestAddress) -> ()
+                        | _ -> errors.Add("Artifact ManifestAddress is required for FileManifest descriptors.")
+
+                        requireStoragePool ()
+                    | MaterializationArtifactKind.ContentBlock ->
+                        requireTargetRoot ()
+
+                        match descriptor.ContentBlockAddress with
+                        | Some contentBlockAddress when not (String.IsNullOrWhiteSpace contentBlockAddress) -> ()
+                        | _ -> errors.Add("Artifact ContentBlockAddress is required for ContentBlock descriptors.")
+
+                        requireStoragePool ()
+                    | _ -> errors.Add($"ArtifactKind '{int descriptor.ArtifactKind}' is not supported.")
+
+                match descriptor.Source with
+                | Some source ->
+                    match validateArtifactSource source with
+                    | Ok () -> ()
+                    | Error sourceErrors -> errors.AddRange(sourceErrors)
+                | None -> ()
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
+
+        /// Validates that a Materialization Plan request only accepts supported modes, selectors, and artifact kinds.
+        let validateRequest (request: MaterializationPlanRequest) =
+            let errors = ResizeArray<string>()
+
+            if isNull (box request) then
+                errors.Add("MaterializationPlanRequest is required.")
+            else
+                if request.Class <> nameof MaterializationPlanRequest then
+                    errors.Add("Class must be MaterializationPlanRequest.")
+
+                if not (isSupportedExecutionMode request.ExecutionMode) then
+                    errors.Add($"ExecutionMode '{int request.ExecutionMode}' is not supported.")
+
+                match validateTargetSelector request.TargetSelector with
+                | Ok () -> ()
+                | Error selectorErrors -> errors.AddRange(selectorErrors)
+
+                match validateCacheSelection request.CacheSelection with
+                | Ok () -> ()
+                | Error cacheErrors -> errors.AddRange(cacheErrors)
+
+                if
+                    isNull (box request.RequestedArtifactKinds)
+                    || request.RequestedArtifactKinds.Count = 0
+                then
+                    errors.Add("RequestedArtifactKinds must include at least one artifact kind.")
+                else
+                    for kind in request.RequestedArtifactKinds do
+                        if not (isSupportedArtifactKind kind) then
+                            errors.Add($"Requested ArtifactKind '{int kind}' is not supported.")
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
+
+        /// Validates that a Materialization Plan resolves one root and includes the V1 required root artifacts.
+        let validatePlan (plan: MaterializationPlan) =
+            let errors = ResizeArray<string>()
+
+            if isNull (box plan) then
+                errors.Add("MaterializationPlan is required.")
+            else
+                if plan.Class <> nameof MaterializationPlan then
+                    errors.Add("Class must be MaterializationPlan.")
+
+                if plan.TargetRootDirectoryVersionId = DirectoryVersionId.Empty then
+                    errors.Add("TargetRootDirectoryVersionId is required.")
+
+                if not (isSupportedExecutionMode plan.ExecutionMode) then
+                    errors.Add($"ExecutionMode '{int plan.ExecutionMode}' is not supported.")
+
+                match validateCacheSelection plan.CacheSelection with
+                | Ok () -> ()
+                | Error cacheErrors -> errors.AddRange(cacheErrors)
+
+                if
+                    isNull (box plan.RequiredArtifacts)
+                    || plan.RequiredArtifacts.Count = 0
+                then
+                    errors.Add("RequiredArtifacts must include the V1 target-root artifacts.")
+                else
+                    let mutable hasTargetRootZip = false
+                    let mutable hasRecursiveMetadata = false
+
+                    for descriptor in plan.RequiredArtifacts do
+                        match validateArtifactDescriptor descriptor with
+                        | Ok () -> ()
+                        | Error descriptorErrors -> errors.AddRange(descriptorErrors)
+
+                        if not (isNull (box descriptor)) then
+                            if plan.CacheSelection.SelectionKind = MaterializationCacheSelectionKind.RequireCache then
+                                match descriptor.Source with
+                                | Some source when source.SourceKind = MaterializationArtifactSourceKind.DirectUri ->
+                                    errors.Add("CacheRequired plans must not require DirectUri artifact sources.")
+                                | _ -> ()
+
+                            if descriptor.TargetRootDirectoryVersionId
+                               <> plan.TargetRootDirectoryVersionId then
+                                errors.Add("Artifact TargetRootDirectoryVersionId must match the plan TargetRootDirectoryVersionId.")
+
+                            if descriptor.ArtifactKind = MaterializationArtifactKind.DirectoryVersionZip
+                               && descriptor.TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId then
+                                hasTargetRootZip <- true
+
+                            if descriptor.ArtifactKind = MaterializationArtifactKind.RecursiveDirectoryMetadata
+                               && descriptor.TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId then
+                                hasRecursiveMetadata <- true
+
+                    if not hasTargetRootZip then
+                        errors.Add("RequiredArtifacts must include DirectoryVersionZip for the target root.")
+
+                    if not hasRecursiveMetadata then
+                        errors.Add("RequiredArtifacts must include RecursiveDirectoryMetadata for the target root.")
+
+            if errors.Count = 0 then Ok() else Error(List.ofSeq errors)

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -417,7 +417,11 @@ module MaterializationPlan =
                             errors.Add("TargetSelector.BranchName must be empty for ReferenceId selectors.")
                     | MaterializationTargetSelectorKind.BranchName ->
                         match selector.BranchName with
-                        | Some branchName when Constants.GraceNameRegex.IsMatch(branchName) -> ()
+                        | Some branchName when
+                            not (String.IsNullOrWhiteSpace branchName)
+                            && Constants.GraceNameRegex.IsMatch(branchName)
+                            ->
+                            ()
                         | Some branchName when not (String.IsNullOrWhiteSpace branchName) ->
                             errors.Add("TargetSelector.BranchName must be a valid Grace branch name.")
                         | _ -> errors.Add("TargetSelector.BranchName is required.")
@@ -679,11 +683,17 @@ module MaterializationPlan =
                 else
                     let mutable targetRootZipCount = 0
                     let mutable recursiveMetadataCount = 0
+                    let wholeFileIdentities = HashSet<DirectoryVersionId * RelativePath>()
                     let cacheRequiredByExecutionMode = plan.ExecutionMode = MaterializationExecutionMode.CacheRequired
+                    let cacheBypassedByExecutionMode = plan.ExecutionMode = MaterializationExecutionMode.Direct
 
                     let cacheRequiredBySelection =
                         not (isNull (box plan.CacheSelection))
                         && plan.CacheSelection.SelectionKind = MaterializationCacheSelectionKind.RequireCache
+
+                    let cacheBypassedBySelection =
+                        not (isNull (box plan.CacheSelection))
+                        && plan.CacheSelection.SelectionKind = MaterializationCacheSelectionKind.BypassCache
 
                     for descriptor in plan.RequiredArtifacts do
                         match validateArtifactDescriptor descriptor with
@@ -691,6 +701,16 @@ module MaterializationPlan =
                         | Error descriptorErrors -> errors.AddRange(descriptorErrors)
 
                         if not (isNull (box descriptor)) then
+                            if cacheBypassedByExecutionMode
+                               || cacheBypassedBySelection then
+                                match descriptor.Source with
+                                | Some source when
+                                    not (isNull (box source))
+                                    && source.SourceKind = MaterializationArtifactSourceKind.CacheEntry
+                                    ->
+                                    errors.Add("Direct/Bypass plans must not require CacheEntry artifact sources.")
+                                | _ -> ()
+
                             if cacheRequiredByExecutionMode
                                || cacheRequiredBySelection then
                                 match descriptor.Source with
@@ -715,6 +735,15 @@ module MaterializationPlan =
                             if descriptor.ArtifactKind = MaterializationArtifactKind.RecursiveDirectoryMetadata
                                && descriptor.TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId then
                                 recursiveMetadataCount <- recursiveMetadataCount + 1
+
+                            if descriptor.ArtifactKind = MaterializationArtifactKind.WholeFileContent then
+                                match descriptor.RelativePath with
+                                | Some relativePath when
+                                    not (String.IsNullOrWhiteSpace relativePath)
+                                    && not (wholeFileIdentities.Add(descriptor.TargetRootDirectoryVersionId, relativePath))
+                                    ->
+                                    errors.Add("RequiredArtifacts must include at most one WholeFileContent for each target root and relative path.")
+                                | _ -> ()
 
                     if targetRootZipCount = 0 then
                         errors.Add("RequiredArtifacts must include DirectoryVersionZip for the target root.")

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -4,6 +4,7 @@ open Grace.Types.Common
 open Orleans
 open System
 open System.Collections.Generic
+open System.IO
 
 /// Contains Materialization Plan request, response, artifact, and cache-selection contracts.
 module MaterializationPlan =
@@ -321,6 +322,28 @@ module MaterializationPlan =
         /// Returns true when the supplied enum value is one of the known public artifact source kinds.
         let isSupportedArtifactSourceKind (kind: MaterializationArtifactSourceKind) = Enum.IsDefined(typeof<MaterializationArtifactSourceKind>, kind)
 
+        /// Returns true when a whole-file artifact path is normalized for repository-relative materialization.
+        let isNormalizedRepositoryRelativePath (relativePath: string) =
+            not (String.IsNullOrWhiteSpace relativePath)
+            && not (Path.IsPathRooted relativePath)
+            && not (relativePath.Contains('\\'))
+            && relativePath.Split('/', StringSplitOptions.None)
+               |> Array.forall (fun segment ->
+                   not (String.IsNullOrWhiteSpace segment)
+                   && segment <> "."
+                   && segment <> "..")
+
+        /// Rejects public cache controls that require cache use while also asking Grace to bypass cache entries.
+        let rejectCacheRequiredBypass
+            (executionMode: MaterializationExecutionMode)
+            (cacheSelection: MaterializationCacheSelection)
+            (errors: ResizeArray<string>)
+            =
+            if executionMode = MaterializationExecutionMode.CacheRequired
+               && not (isNull (box cacheSelection))
+               && cacheSelection.SelectionKind = MaterializationCacheSelectionKind.BypassCache then
+                errors.Add("CacheRequired materialization must not use BypassCache selection.")
+
         /// Validates the target selector before server-side target-root resolution.
         let validateTargetSelector (selector: MaterializationTargetSelector) =
             let errors = ResizeArray<string>()
@@ -405,6 +428,9 @@ module MaterializationPlan =
                         match source.DirectUri with
                         | Some uri when not (String.IsNullOrWhiteSpace uri) -> ()
                         | _ -> errors.Add("Artifact DirectUri is required for DirectUri sources.")
+
+                        if source.CacheKey.IsSome then
+                            errors.Add("Artifact CacheKey must be empty for DirectUri sources.")
                     | MaterializationArtifactSourceKind.CacheEntry ->
                         match source.CacheKey with
                         | Some cacheKey when not (String.IsNullOrWhiteSpace cacheKey) -> ()
@@ -415,6 +441,9 @@ module MaterializationPlan =
                     | MaterializationArtifactSourceKind.Deferred ->
                         if source.DirectUri.IsSome then
                             errors.Add("Artifact DirectUri must be empty for Deferred sources.")
+
+                        if source.CacheKey.IsSome then
+                            errors.Add("Artifact CacheKey must be empty for Deferred sources.")
                     | _ -> errors.Add($"Artifact SourceKind '{int source.SourceKind}' is not supported.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)
@@ -432,6 +461,36 @@ module MaterializationPlan =
                 | Some storagePoolId when not (String.IsNullOrWhiteSpace storagePoolId) -> ()
                 | _ -> errors.Add("Artifact StoragePoolId is required for CAS artifact descriptors.")
 
+            let rejectRelativePath artifactKind =
+                if descriptor.RelativePath.IsSome then
+                    errors.Add($"Artifact RelativePath must be empty for {artifactKind} descriptors.")
+
+            let rejectHashes artifactKind =
+                if descriptor.Sha256Hash.IsSome then
+                    errors.Add($"Artifact Sha256Hash must be empty for {artifactKind} descriptors.")
+
+                if descriptor.Blake3Hash.IsSome then
+                    errors.Add($"Artifact Blake3Hash must be empty for {artifactKind} descriptors.")
+
+            let rejectManifestAddress artifactKind =
+                if descriptor.ManifestAddress.IsSome then
+                    errors.Add($"Artifact ManifestAddress must be empty for {artifactKind} descriptors.")
+
+            let rejectContentBlockAddress artifactKind =
+                if descriptor.ContentBlockAddress.IsSome then
+                    errors.Add($"Artifact ContentBlockAddress must be empty for {artifactKind} descriptors.")
+
+            let rejectStoragePool artifactKind =
+                if descriptor.StoragePoolId.IsSome then
+                    errors.Add($"Artifact StoragePoolId must be empty for {artifactKind} descriptors.")
+
+            let rejectNonRootDescriptorIdentity artifactKind =
+                rejectRelativePath artifactKind
+                rejectHashes artifactKind
+                rejectManifestAddress artifactKind
+                rejectContentBlockAddress artifactKind
+                rejectStoragePool artifactKind
+
             if isNull (box descriptor) then
                 errors.Add("Artifact descriptor is required.")
             else
@@ -444,18 +503,25 @@ module MaterializationPlan =
                 else
                     match descriptor.ArtifactKind with
                     | MaterializationArtifactKind.DirectoryVersionZip
-                    | MaterializationArtifactKind.RecursiveDirectoryMetadata -> requireTargetRoot ()
+                    | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                        requireTargetRoot ()
+                        rejectNonRootDescriptorIdentity (string descriptor.ArtifactKind)
                     | MaterializationArtifactKind.WholeFileContent ->
                         requireTargetRoot ()
 
                         match descriptor.RelativePath with
-                        | Some relativePath when not (String.IsNullOrWhiteSpace relativePath) -> ()
+                        | Some relativePath when isNormalizedRepositoryRelativePath relativePath -> ()
+                        | Some _ -> errors.Add("Artifact RelativePath must be a normalized repository-relative path for WholeFileContent descriptors.")
                         | _ -> errors.Add("Artifact RelativePath is required for WholeFileContent descriptors.")
 
                         match descriptor.Sha256Hash, descriptor.Blake3Hash with
                         | Some sha256Hash, _ when not (String.IsNullOrWhiteSpace sha256Hash) -> ()
                         | _, Some blake3Hash when not (String.IsNullOrWhiteSpace blake3Hash) -> ()
                         | _ -> errors.Add("Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors.")
+
+                        rejectManifestAddress (string descriptor.ArtifactKind)
+                        rejectContentBlockAddress (string descriptor.ArtifactKind)
+                        rejectStoragePool (string descriptor.ArtifactKind)
                     | MaterializationArtifactKind.FileManifest ->
                         requireTargetRoot ()
 
@@ -464,6 +530,9 @@ module MaterializationPlan =
                         | _ -> errors.Add("Artifact ManifestAddress is required for FileManifest descriptors.")
 
                         requireStoragePool ()
+                        rejectRelativePath (string descriptor.ArtifactKind)
+                        rejectHashes (string descriptor.ArtifactKind)
+                        rejectContentBlockAddress (string descriptor.ArtifactKind)
                     | MaterializationArtifactKind.ContentBlock ->
                         requireTargetRoot ()
 
@@ -472,6 +541,9 @@ module MaterializationPlan =
                         | _ -> errors.Add("Artifact ContentBlockAddress is required for ContentBlock descriptors.")
 
                         requireStoragePool ()
+                        rejectRelativePath (string descriptor.ArtifactKind)
+                        rejectHashes (string descriptor.ArtifactKind)
+                        rejectManifestAddress (string descriptor.ArtifactKind)
                     | _ -> errors.Add($"ArtifactKind '{int descriptor.ArtifactKind}' is not supported.")
 
                 match descriptor.Source with
@@ -504,6 +576,8 @@ module MaterializationPlan =
                 | Ok () -> ()
                 | Error cacheErrors -> errors.AddRange(cacheErrors)
 
+                rejectCacheRequiredBypass request.ExecutionMode request.CacheSelection errors
+
                 if
                     isNull (box request.RequestedArtifactKinds)
                     || request.RequestedArtifactKinds.Count = 0
@@ -535,6 +609,8 @@ module MaterializationPlan =
                 match validateCacheSelection plan.CacheSelection with
                 | Ok () -> ()
                 | Error cacheErrors -> errors.AddRange(cacheErrors)
+
+                rejectCacheRequiredBypass plan.ExecutionMode plan.CacheSelection errors
 
                 if
                     isNull (box plan.RequiredArtifacts)


### PR DESCRIPTION
## Summary

- Adds shared Materialization Plan contract DTOs and validation helpers in `Grace.Types`.
- Covers execution modes, target selectors, cache selection, artifact kinds, artifact sources, request/response DTOs, and V1 plan validation.
- Adds focused serialization and fail-closed validation tests for the contract slice.

## Related Issue

Related to #610. Part of #599 and #597.

## Validation

- Passed: `dotnet tool run fantomas ...` on touched F# files.
- Passed: `dotnet build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj`.
- Passed: `dotnet test --no-build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj` (`171/171`).
- Passed: `pwsh ./scripts/validate.ps1 -Fast`.
- Passed: `git diff --check`.

## Contract Propagation

- `Grace.Types` DTOs/validators: updated with additive public contracts and XML documentation.
- `Grace.Shared` parameters/helpers: N/A; no shared helper or parameter surface was needed for this contract-only slice.
- Server routes/validation/auth/error envelopes: N/A; no CLI/server behavior change in #610.
- CLI parser/output/help/examples: N/A; explicitly deferred by issue scope.
- SDK/generated clients: N/A; no public route exists yet for these DTOs.
- OpenAPI/static generated artifacts: N/A; no endpoint/component generation was required by the current contract-only change.
- Events/webhooks/SignalR/watch/search/projections: N/A; no runtime publication or durable event shape added.
- Tests: updated in `Grace.Types.Tests`.

## Stale Authority

Runtime stale-authority handling is N/A for this contracts-only slice because no materialization read, mutation, cache lookup, publication, or execution behavior was added. The target-root invariant is encoded in `MaterializationPlan.Validation.validatePlan`.

## Review Status

- Codex Code Review Bot reviewed `ad5ab675cbf48d5403d07ecab1b0455eba942fa2` through `c44884468741e349eb4cc962f675baf2a06d2770` across repeated fail-closed Materialization Plan contract validation cycles.
- Stabilization ledger and addenda 1-4 were posted to #610 and this PR.
- Addendum 4 was addressed in `c44884468741e349eb4cc962f675baf2a06d2770` with a test-only stabilization proof pass in `src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs`.
- Worker validation for `c44884468741e349eb4cc962f675baf2a06d2770` passed: targeted Fantomas, focused `MaterializationPlanContractTests` (`110` passed), `git diff --check`, and `pwsh ./scripts/validate.ps1 -Fast`.
- GitHub Actions `full` passed on `c44884468741e349eb4cc962f675baf2a06d2770` in run `28849286482`.
- Codex Code Review Bot completed review on `c44884468741e349eb4cc962f675baf2a06d2770` and reported no major issues.
- All eight addendum-4 proof gaps are `implemented and proven` at the `Grace.Types` public contract validation seam; all related review threads were replied to and resolved.

| Addendum 4 proof row | Status | Proof seam | Residual risk |
| --- | --- | --- | --- |
| Malformed whole-file hashes include uppercase, short, and non-hex `Sha256Hash` / `Blake3Hash` | implemented and proven | `MaterializationPlanContractTests` malformed whole-file hash cases | Contract-level only; runtime consumers are later leaves |
| Blank and whitespace branch selector names | implemented and proven | `MaterializationPlanContractTests` branch selector malformed-name cases | Contract-level only |
| Every off-kind target selector identity combination | implemented and proven | `MaterializationPlanContractTests` directory/reference/branch cross-kind identity matrix | Contract-level only |
| CAS uniqueness includes storage pool in identity | implemented and proven | `MaterializationPlanContractTests` same-address/different-storage-pool positives for `FileManifest` and `ContentBlock` | Contract-level only |
| Malformed source identity boundaries | implemented and proven | `MaterializationPlanContractTests` missing/blank/whitespace/null cache keys and direct URIs | Contract-level only |
| Both missing root artifacts | implemented and proven | `MaterializationPlanContractTests` missing `DirectoryVersionZip` plus existing missing `RecursiveDirectoryMetadata` proof | Contract-level only |
| Cache-bypass authority isolates `Direct` and `BypassCache` inputs | implemented and proven | `MaterializationPlanContractTests` source-specific inconsistent authority cases | Contract-level only |
| Unsupported DTO enum values fail closed | implemented and proven | `MaterializationPlanContractTests` unsupported `TargetSelectorKind`, `CacheSelectionKind`, and `ArtifactSourceKind` cases | Contract-level only |
