### PR TITLE
GV-03: Add visibility authorization helpers

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="General.Server.Unit.Tests.fs" />
     <Compile Include="Slop.Server.Unit.Tests.fs" />
     <Compile Include="MetricsAuthorization.Unit.Tests.fs" />
+    <Compile Include="VisibilityAuthorization.Unit.Tests.fs" />
     <Compile Include="StorageAuthorizationResources.Unit.Tests.fs" />
     <Compile Include="ValidateIds.Decisions.Tests.fs" />
     <Compile Include="Storage.Server.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs
@@ -1,0 +1,121 @@
+namespace Grace.Server.Unit.Tests
+
+open Grace.Server.Security
+open Grace.Server.Security.VisibilityAuthorization
+open Grace.Types.Common
+open Grace.Types.Visibility
+open NUnit.Framework
+open System
+
+/// Covers server-side visibility helper behavior without HTTP hosting or Aspire resources.
+[<Parallelizable(ParallelScope.All)>]
+type VisibilityAuthorizationUnitTests() =
+
+    /// Constructs a test user id from stable text so failed assertions are easy to read.
+    let userId (value: string) = UserId value
+
+    /// Constructs visibility resource facts used by the helper assertions.
+    let resource visibility ownership creator = { Visibility = visibility; Ownership = ownership; CreatorUserId = creator }
+
+    /// Constructs an authenticated low-privilege audience.
+    let caller userId = { VisibilityCallerAudience.Anonymous with UserId = Some userId }
+
+    /// Verifies that authorized contributor and elevated audiences can observe contributor-owned private branches.
+    [<Test>]
+    member _.``canObserveBranch allows contributor reviewer maintainer and elevated administrators``() =
+        let owner = userId "creator"
+        let hiddenBranch = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some owner)
+
+        let creatorCaller = caller owner
+
+        let reviewerCaller = { caller (userId "reviewer") with IsExplicitReviewer = true }
+
+        let maintainerCaller = { caller (userId "maintainer") with IsExplicitMaintainer = true }
+
+        let repositoryAdminCaller = { caller (userId "repo-admin") with HasRepositoryAdministration = true }
+
+        let securityAdminCaller = { caller (userId "security-admin") with HasSecurityAdministration = true }
+
+        Assert.That(canObserveBranch creatorCaller hiddenBranch, Is.True)
+        Assert.That(canObserveBranch reviewerCaller hiddenBranch, Is.True)
+        Assert.That(canObserveBranch maintainerCaller hiddenBranch, Is.True)
+        Assert.That(canObserveBranch repositoryAdminCaller hiddenBranch, Is.True)
+        Assert.That(canObserveBranch securityAdminCaller hiddenBranch, Is.True)
+
+    /// Verifies that anonymous and low-privilege callers do not inherit elevated contributor-owned branch observability.
+    [<Test>]
+    member _.``canObserveBranch fails closed for anonymous and low privilege callers``() =
+        let hiddenBranch = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+
+        Assert.That(canObserveBranch VisibilityCallerAudience.Anonymous hiddenBranch, Is.False)
+        Assert.That(canObserveBranch (caller (userId "other-user")) hiddenBranch, Is.False)
+
+    /// Verifies that hidden branches use the same route model that nonexistent branches use.
+    [<Test>]
+    member _.``requireObservableBranch returns route equivalent missing for hidden branch``() =
+        let hiddenBranch = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+
+        let missingModel = { Missing = "branch-id-does-not-exist" }
+
+        let hiddenResult = requireObservableBranch (caller (userId "other-user")) missingModel hiddenBranch
+
+        match hiddenResult with
+        | Observable _ -> Assert.Fail("Expected hidden branch to use the route-equivalent missing model.")
+        | RouteEquivalentMissing routeModel -> Assert.That(routeModel, Is.EqualTo(missingModel))
+
+    /// Verifies that filtering happens before public list limits and counts are calculated.
+    [<Test>]
+    member _.``filterVisibleWindow filters before limit and count``() =
+        let hidden1 = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden-1"))
+        let visible1 = resource ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible-1"))
+        let hidden2 = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden-2"))
+        let visible2 = resource ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible-2"))
+
+        let window =
+            [ hidden1; visible1; hidden2; visible2 ]
+            |> filterVisibleWindow (Some 1) (canObserveBranch VisibilityCallerAudience.Anonymous)
+
+        Assert.That(window.Items.Length, Is.EqualTo(1))
+        Assert.That(window.Items.Head, Is.EqualTo(visible1))
+        Assert.That(window.VisibleCount, Is.EqualTo(2))
+        Assert.That(window.Latest, Is.EqualTo(Some visible1))
+        Assert.That(window.HasMoreVisible, Is.True)
+
+        let negativeLimitWindow =
+            [ hidden1; visible1; visible2 ]
+            |> filterVisibleWindow (Some -1) (canObserveBranch VisibilityCallerAudience.Anonymous)
+
+        Assert.That(negativeLimitWindow.Items, Is.Empty)
+        Assert.That(negativeLimitWindow.VisibleCount, Is.EqualTo(2))
+
+    /// Verifies that count and latest helpers ignore hidden rows before reducing public output.
+    [<Test>]
+    member _.``countVisible and tryLatestVisible ignore hidden candidates``() =
+        let hidden = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden"))
+        let latestVisible = resource ResourceVisibility.Public ResourceOwnership.RepositoryOwned None
+        let olderVisible = resource ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible"))
+        let canObserve = canObserveBranch VisibilityCallerAudience.Anonymous
+
+        Assert.That(countVisible canObserve [ hidden; latestVisible; olderVisible ], Is.EqualTo(2))
+        Assert.That(tryLatestVisible canObserve [ hidden; latestVisible; olderVisible ], Is.EqualTo(Some latestVisible))
+
+    /// Verifies that projection gating and traversal seams do not leak hidden resources.
+    [<Test>]
+    member _.``projection and root traversal gates reject hidden resources``() =
+        let hidden = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden"))
+        let visible = resource ResourceVisibility.Public ResourceOwnership.RepositoryOwned None
+        let canObserve = canObserveBranch VisibilityCallerAudience.Anonymous
+
+        Assert.That(gateProjection canObserve (fun item -> item.Visibility.ToString()) hidden, Is.EqualTo(None))
+        Assert.That(gateProjection canObserve (fun item -> item.Visibility.ToString()) visible, Is.EqualTo(Some "Public"))
+        Assert.That(canTraverseRoot canObserve [ visible; hidden ], Is.False)
+        Assert.That(canTraverseRoot canObserve [ visible ], Is.True)
+
+    /// Verifies reference and promotion-set seams share the same fail-closed contributor-owned model.
+    [<Test>]
+    member _.``reference and promotion set helpers share branch visibility semantics``() =
+        let hidden = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+        let anonymous = VisibilityCallerAudience.Anonymous
+
+        Assert.That(canObserveReference anonymous hidden, Is.False)
+        Assert.That(canObservePromotionSet anonymous hidden, Is.False)

--- a/src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs
@@ -15,65 +15,106 @@ type VisibilityAuthorizationUnitTests() =
     let userId (value: string) = UserId value
 
     /// Constructs visibility resource facts used by the helper assertions.
-    let resource visibility ownership creator = { Visibility = visibility; Ownership = ownership; CreatorUserId = creator }
+    let resource key visibility ownership creator = { AuthorityKey = key; Visibility = visibility; Ownership = ownership; CreatorUserId = creator }
 
     /// Constructs an authenticated low-privilege audience.
     let caller userId = { VisibilityCallerAudience.Anonymous with UserId = Some userId }
 
+    /// Resolves no resource-scoped reviewer, maintainer, or branch-admin authority for a candidate.
+    let noResourceAudience _ = VisibilityResourceAudience.None
+
     /// Verifies that authorized contributor and elevated audiences can observe contributor-owned private branches.
     [<Test>]
-    member _.``canObserveBranch allows contributor reviewer maintainer and elevated administrators``() =
+    member _.``canObserveBranch allows contributor branch admin reviewer maintainer and elevated administrators``() =
         let owner = userId "creator"
-        let hiddenBranch = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some owner)
+        let hiddenBranch = resource "branch-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some owner)
 
         let creatorCaller = caller owner
 
-        let reviewerCaller = { caller (userId "reviewer") with IsExplicitReviewer = true }
+        let reviewerAudience _ = { VisibilityResourceAudience.None with IsExplicitReviewer = true }
 
-        let maintainerCaller = { caller (userId "maintainer") with IsExplicitMaintainer = true }
+        let maintainerAudience _ = { VisibilityResourceAudience.None with IsExplicitMaintainer = true }
+
+        let branchAdminAudience _ = { VisibilityResourceAudience.None with HasBranchAdministration = true }
 
         let repositoryAdminCaller = { caller (userId "repo-admin") with HasRepositoryAdministration = true }
 
         let securityAdminCaller = { caller (userId "security-admin") with HasSecurityAdministration = true }
 
-        Assert.That(canObserveBranch creatorCaller hiddenBranch, Is.True)
-        Assert.That(canObserveBranch reviewerCaller hiddenBranch, Is.True)
-        Assert.That(canObserveBranch maintainerCaller hiddenBranch, Is.True)
-        Assert.That(canObserveBranch repositoryAdminCaller hiddenBranch, Is.True)
-        Assert.That(canObserveBranch securityAdminCaller hiddenBranch, Is.True)
+        Assert.That(canObserveBranch creatorCaller noResourceAudience hiddenBranch, Is.True)
+        Assert.That(canObserveBranch (caller (userId "branch-admin")) branchAdminAudience hiddenBranch, Is.True)
+        Assert.That(canObserveBranch (caller (userId "reviewer")) reviewerAudience hiddenBranch, Is.True)
+        Assert.That(canObserveBranch (caller (userId "maintainer")) maintainerAudience hiddenBranch, Is.True)
+        Assert.That(canObserveBranch repositoryAdminCaller noResourceAudience hiddenBranch, Is.True)
+        Assert.That(canObserveBranch securityAdminCaller noResourceAudience hiddenBranch, Is.True)
 
     /// Verifies that anonymous and low-privilege callers do not inherit elevated contributor-owned branch observability.
     [<Test>]
     member _.``canObserveBranch fails closed for anonymous and low privilege callers``() =
-        let hiddenBranch = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+        let hiddenBranch = resource "branch-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
 
-        Assert.That(canObserveBranch VisibilityCallerAudience.Anonymous hiddenBranch, Is.False)
-        Assert.That(canObserveBranch (caller (userId "other-user")) hiddenBranch, Is.False)
+        Assert.That(canObserveBranch VisibilityCallerAudience.Anonymous noResourceAudience hiddenBranch, Is.False)
+        Assert.That(canObserveBranch (caller (userId "other-user")) noResourceAudience hiddenBranch, Is.False)
+
+    /// Verifies that branch administration authority does not authorize non-branch hidden resources.
+    [<Test>]
+    member _.``canObserveReference and canObservePromotionSet ignore branch administration authority``() =
+        let hiddenResource = resource "reference-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+        let branchAdminAudience _ = { VisibilityResourceAudience.None with HasBranchAdministration = true }
+
+        let branchAdminCaller = caller (userId "branch-admin")
+
+        Assert.That(canObserveReference branchAdminCaller branchAdminAudience hiddenResource, Is.False)
+        Assert.That(canObservePromotionSet branchAdminCaller branchAdminAudience hiddenResource, Is.False)
 
     /// Verifies that hidden branches use the same route model that nonexistent branches use.
     [<Test>]
     member _.``requireObservableBranch returns route equivalent missing for hidden branch``() =
-        let hiddenBranch = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+        let hiddenBranch = resource "branch-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
 
         let missingModel = { Missing = "branch-id-does-not-exist" }
 
-        let hiddenResult = requireObservableBranch (caller (userId "other-user")) missingModel hiddenBranch
+        let hiddenResult = requireObservableBranch (caller (userId "other-user")) noResourceAudience missingModel hiddenBranch
 
         match hiddenResult with
         | Observable _ -> Assert.Fail("Expected hidden branch to use the route-equivalent missing model.")
         | RouteEquivalentMissing routeModel -> Assert.That(routeModel, Is.EqualTo(missingModel))
 
+    /// Verifies that reviewer and maintainer authority is resolved for each candidate before list shaping.
+    [<Test>]
+    member _.``filterVisibleWindow scopes reviewer and maintainer authority per resource``() =
+        let reviewed = resource "reviewed" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "reviewed-owner"))
+        let maintained = resource "maintained" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "maintained-owner"))
+        let unrelated = resource "unrelated" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "unrelated-owner"))
+
+        let resourceAudience candidate =
+            match candidate.AuthorityKey with
+            | "reviewed" -> { VisibilityResourceAudience.None with IsExplicitReviewer = true }
+            | "maintained" -> { VisibilityResourceAudience.None with IsExplicitMaintainer = true }
+            | _ -> VisibilityResourceAudience.None
+
+        let window =
+            [ reviewed; unrelated; maintained ]
+            |> filterVisibleWindow None (canObserveBranch (caller (userId "resource-audience")) resourceAudience)
+
+        Assert.That(window.Items.Length, Is.EqualTo(2))
+        Assert.That(window.Items[0], Is.EqualTo(reviewed))
+        Assert.That(window.Items[1], Is.EqualTo(maintained))
+        Assert.That(window.VisibleCount, Is.EqualTo(2))
+        Assert.That(window.Latest, Is.EqualTo(Some reviewed))
+        Assert.That(window.HasMoreVisible, Is.False)
+
     /// Verifies that filtering happens before public list limits and counts are calculated.
     [<Test>]
     member _.``filterVisibleWindow filters before limit and count``() =
-        let hidden1 = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden-1"))
-        let visible1 = resource ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible-1"))
-        let hidden2 = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden-2"))
-        let visible2 = resource ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible-2"))
+        let hidden1 = resource "hidden-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden-1"))
+        let visible1 = resource "visible-1" ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible-1"))
+        let hidden2 = resource "hidden-2" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden-2"))
+        let visible2 = resource "visible-2" ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible-2"))
 
         let window =
             [ hidden1; visible1; hidden2; visible2 ]
-            |> filterVisibleWindow (Some 1) (canObserveBranch VisibilityCallerAudience.Anonymous)
+            |> filterVisibleWindow (Some 1) (canObserveBranch VisibilityCallerAudience.Anonymous noResourceAudience)
 
         Assert.That(window.Items.Length, Is.EqualTo(1))
         Assert.That(window.Items.Head, Is.EqualTo(visible1))
@@ -83,7 +124,7 @@ type VisibilityAuthorizationUnitTests() =
 
         let negativeLimitWindow =
             [ hidden1; visible1; visible2 ]
-            |> filterVisibleWindow (Some -1) (canObserveBranch VisibilityCallerAudience.Anonymous)
+            |> filterVisibleWindow (Some -1) (canObserveBranch VisibilityCallerAudience.Anonymous noResourceAudience)
 
         Assert.That(negativeLimitWindow.Items, Is.Empty)
         Assert.That(negativeLimitWindow.VisibleCount, Is.EqualTo(2))
@@ -91,10 +132,10 @@ type VisibilityAuthorizationUnitTests() =
     /// Verifies that count and latest helpers ignore hidden rows before reducing public output.
     [<Test>]
     member _.``countVisible and tryLatestVisible ignore hidden candidates``() =
-        let hidden = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden"))
-        let latestVisible = resource ResourceVisibility.Public ResourceOwnership.RepositoryOwned None
-        let olderVisible = resource ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible"))
-        let canObserve = canObserveBranch VisibilityCallerAudience.Anonymous
+        let hidden = resource "hidden" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden"))
+        let latestVisible = resource "latest-visible" ResourceVisibility.Public ResourceOwnership.RepositoryOwned None
+        let olderVisible = resource "older-visible" ResourceVisibility.Public ResourceOwnership.ContributorOwned (Some(userId "visible"))
+        let canObserve = canObserveBranch VisibilityCallerAudience.Anonymous noResourceAudience
 
         Assert.That(countVisible canObserve [ hidden; latestVisible; olderVisible ], Is.EqualTo(2))
         Assert.That(tryLatestVisible canObserve [ hidden; latestVisible; olderVisible ], Is.EqualTo(Some latestVisible))
@@ -102,9 +143,9 @@ type VisibilityAuthorizationUnitTests() =
     /// Verifies that projection gating and traversal seams do not leak hidden resources.
     [<Test>]
     member _.``projection and root traversal gates reject hidden resources``() =
-        let hidden = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden"))
-        let visible = resource ResourceVisibility.Public ResourceOwnership.RepositoryOwned None
-        let canObserve = canObserveBranch VisibilityCallerAudience.Anonymous
+        let hidden = resource "hidden" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "hidden"))
+        let visible = resource "visible" ResourceVisibility.Public ResourceOwnership.RepositoryOwned None
+        let canObserve = canObserveBranch VisibilityCallerAudience.Anonymous noResourceAudience
 
         Assert.That(gateProjection canObserve (fun item -> item.Visibility.ToString()) hidden, Is.EqualTo(None))
         Assert.That(gateProjection canObserve (fun item -> item.Visibility.ToString()) visible, Is.EqualTo(Some "Public"))
@@ -114,8 +155,8 @@ type VisibilityAuthorizationUnitTests() =
     /// Verifies reference and promotion-set seams share the same fail-closed contributor-owned model.
     [<Test>]
     member _.``reference and promotion set helpers share branch visibility semantics``() =
-        let hidden = resource ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
+        let hidden = resource "resource-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
         let anonymous = VisibilityCallerAudience.Anonymous
 
-        Assert.That(canObserveReference anonymous hidden, Is.False)
-        Assert.That(canObservePromotionSet anonymous hidden, Is.False)
+        Assert.That(canObserveReference anonymous noResourceAudience hidden, Is.False)
+        Assert.That(canObservePromotionSet anonymous noResourceAudience hidden, Is.False)

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -65,6 +65,7 @@
 		<Compile Include="Security\PermissionEvaluator.Server.fs" />
 		<Compile Include="Security\CreatorScopeAdminGrant.Server.fs" />
 		<Compile Include="Security\MetricsAuthorization.Server.fs" />
+		<Compile Include="Security\VisibilityAuthorization.Server.fs" />
 		<Compile Include="Security\AuthorizationMiddleware.Server.fs" />
 		<Compile Include="Security\EndpointAuthorizationManifest.Server.fs" />
 		<Compile Include="Security\StorageAuthorizationResources.Server.fs" />

--- a/src/Grace.Server/Security/VisibilityAuthorization.Server.fs
+++ b/src/Grace.Server/Security/VisibilityAuthorization.Server.fs
@@ -1,0 +1,120 @@
+namespace Grace.Server.Security
+
+open Grace.Types.Common
+open Grace.Types.Visibility
+
+/// Describes the caller facts that server visibility helpers need after route authentication and RBAC evaluation.
+type VisibilityCallerAudience =
+    {
+        /// Authenticated Grace user id, when the route has one.
+        UserId: UserId option
+        /// Caller has the repository-level administrative audience that may observe contributor-owned hidden resources.
+        HasRepositoryAdministration: bool
+        /// Caller has the security-maintainer audience that may observe contributor-owned hidden resources.
+        HasSecurityAdministration: bool
+        /// Caller is an explicit reviewer for the resource being considered.
+        IsExplicitReviewer: bool
+        /// Caller is an explicit maintainer for the resource being considered.
+        IsExplicitMaintainer: bool
+    }
+
+    /// Anonymous caller with no elevated or explicit resource audience.
+    static member Anonymous =
+        { UserId = None; HasRepositoryAdministration = false; HasSecurityAdministration = false; IsExplicitReviewer = false; IsExplicitMaintainer = false }
+
+/// Carries the persisted visibility facts shared by branches, references, and promotion sets.
+type VisibilityResource =
+    {
+        /// Public or private visibility recorded on the authoritative resource.
+        Visibility: ResourceVisibility
+        /// Repository-owned or contributor-owned visibility boundary recorded on the authoritative resource.
+        Ownership: ResourceOwnership
+        /// User that created or owns the contributor-owned resource, when known.
+        CreatorUserId: UserId option
+    }
+
+/// Represents a route-specific missing response without forcing every route into the same 404 payload.
+type RouteMissingModel<'Missing> =
+    {
+        /// Missing value that the owning route already returns for nonexistent resources.
+        Missing: 'Missing
+    }
+
+/// Represents the route-aware result after applying hidden-as-missing visibility.
+type HiddenAsMissingResult<'Resource, 'Missing> =
+    /// The caller may observe the loaded resource.
+    | Observable of 'Resource
+    /// The route should return its existing missing-resource response.
+    | RouteEquivalentMissing of RouteMissingModel<'Missing>
+
+/// Describes the public list window after hidden candidates have been removed.
+type VisibleWindow<'Resource> =
+    {
+        /// Visible items after the route limit is applied.
+        Items: 'Resource list
+        /// Count of visible candidates before route limit is applied.
+        VisibleCount: int
+        /// Latest visible candidate from the input order, when any exists.
+        Latest: 'Resource option
+        /// Indicates that more visible candidates exist beyond the returned item limit.
+        HasMoreVisible: bool
+    }
+
+/// Contains reusable server-side helpers for Grace visibility authorization and no-oracle list shaping.
+module VisibilityAuthorization =
+
+    /// Determines whether the caller is part of the explicit or elevated audience for a contributor-owned hidden resource.
+    let hasContributorAudience (caller: VisibilityCallerAudience) (resource: VisibilityResource) =
+        let isCreator =
+            match caller.UserId, resource.CreatorUserId with
+            | Some callerUserId, Some creatorUserId -> callerUserId = creatorUserId
+            | _ -> false
+
+        isCreator
+        || caller.IsExplicitReviewer
+        || caller.IsExplicitMaintainer
+        || caller.HasRepositoryAdministration
+        || caller.HasSecurityAdministration
+
+    /// Determines whether a caller may observe a branch after the route has loaded the authoritative branch facts.
+    let canObserveBranch (caller: VisibilityCallerAudience) (branch: VisibilityResource) =
+        match branch.Visibility, branch.Ownership with
+        | ResourceVisibility.Public, _ -> true
+        | _, ResourceOwnership.RepositoryOwned -> true
+        | _, ResourceOwnership.ContributorOwned -> hasContributorAudience caller branch
+
+    /// Determines whether a caller may observe a reference after the route has loaded its authoritative visibility facts.
+    let canObserveReference (caller: VisibilityCallerAudience) (reference: VisibilityResource) = canObserveBranch caller reference
+
+    /// Determines whether a caller may observe a promotion set after the route has loaded its authoritative visibility facts.
+    let canObservePromotionSet (caller: VisibilityCallerAudience) (promotionSet: VisibilityResource) = canObserveBranch caller promotionSet
+
+    /// Applies a route-specific missing model when an existing resource must be hidden from the caller.
+    let hiddenAsMissing missingModel canObserve resource = if canObserve then Observable resource else RouteEquivalentMissing missingModel
+
+    /// Applies branch visibility and returns the route's existing missing shape for hidden branches.
+    let requireObservableBranch caller missingModel branch = hiddenAsMissing missingModel (canObserveBranch caller branch) branch
+
+    /// Filters candidates before list limits, visible counts, and latest selection are calculated.
+    let filterVisibleWindow limit canObserve candidates =
+        let visible = candidates |> Seq.filter canObserve |> Seq.toList
+
+        let limited: 'Resource list =
+            match limit with
+            | Some value when value > 0 -> visible |> List.truncate value
+            | Some _ -> []
+            | _ -> visible
+
+        { Items = limited; VisibleCount = visible.Length; Latest = visible |> List.tryHead; HasMoreVisible = limited.Length < visible.Length }
+
+    /// Counts only observable candidates so hidden rows cannot affect public count surfaces.
+    let countVisible canObserve candidates = candidates |> Seq.filter canObserve |> Seq.length
+
+    /// Selects the latest observable candidate from an already latest-ordered candidate sequence.
+    let tryLatestVisible canObserve candidates = candidates |> Seq.tryFind canObserve
+
+    /// Gates a projection so hidden resources cannot materialize into public DTOs, search rows, or event payloads.
+    let gateProjection canObserve project resource = if canObserve resource then Some(project resource) else None
+
+    /// Verifies that every resource on a traversal path remains observable before a downstream route follows it.
+    let canTraverseRoot canObserve resources = resources |> Seq.forall canObserve

--- a/src/Grace.Server/Security/VisibilityAuthorization.Server.fs
+++ b/src/Grace.Server/Security/VisibilityAuthorization.Server.fs
@@ -12,19 +12,30 @@ type VisibilityCallerAudience =
         HasRepositoryAdministration: bool
         /// Caller has the security-maintainer audience that may observe contributor-owned hidden resources.
         HasSecurityAdministration: bool
-        /// Caller is an explicit reviewer for the resource being considered.
+    }
+
+    /// Anonymous caller with no elevated audience.
+    static member Anonymous = { UserId = None; HasRepositoryAdministration = false; HasSecurityAdministration = false }
+
+/// Describes caller authority that must be evaluated against the exact resource being considered.
+type VisibilityResourceAudience =
+    {
+        /// Caller has branch-scoped administration authority for this branch.
+        HasBranchAdministration: bool
+        /// Caller is an explicit reviewer for this resource.
         IsExplicitReviewer: bool
-        /// Caller is an explicit maintainer for the resource being considered.
+        /// Caller is an explicit maintainer for this resource.
         IsExplicitMaintainer: bool
     }
 
-    /// Anonymous caller with no elevated or explicit resource audience.
-    static member Anonymous =
-        { UserId = None; HasRepositoryAdministration = false; HasSecurityAdministration = false; IsExplicitReviewer = false; IsExplicitMaintainer = false }
+    /// No resource-specific authority has been established for the candidate.
+    static member None = { HasBranchAdministration = false; IsExplicitReviewer = false; IsExplicitMaintainer = false }
 
 /// Carries the persisted visibility facts shared by branches, references, and promotion sets.
-type VisibilityResource =
+type VisibilityResource<'AuthorityKey> =
     {
+        /// Route-local identifier used to evaluate reviewer, maintainer, or branch administration authority per candidate.
+        AuthorityKey: 'AuthorityKey
         /// Public or private visibility recorded on the authoritative resource.
         Visibility: ResourceVisibility
         /// Repository-owned or contributor-owned visibility boundary recorded on the authoritative resource.
@@ -64,36 +75,49 @@ type VisibleWindow<'Resource> =
 module VisibilityAuthorization =
 
     /// Determines whether the caller is part of the explicit or elevated audience for a contributor-owned hidden resource.
-    let hasContributorAudience (caller: VisibilityCallerAudience) (resource: VisibilityResource) =
+    let private hasContributorAudience includeBranchAdministration (caller: VisibilityCallerAudience) resolveResourceAudience resource =
+        let resourceAudience = resolveResourceAudience resource
+
         let isCreator =
             match caller.UserId, resource.CreatorUserId with
             | Some callerUserId, Some creatorUserId -> callerUserId = creatorUserId
             | _ -> false
 
         isCreator
-        || caller.IsExplicitReviewer
-        || caller.IsExplicitMaintainer
+        || resourceAudience.IsExplicitReviewer
+        || resourceAudience.IsExplicitMaintainer
+        || (includeBranchAdministration
+            && resourceAudience.HasBranchAdministration)
         || caller.HasRepositoryAdministration
         || caller.HasSecurityAdministration
 
     /// Determines whether a caller may observe a branch after the route has loaded the authoritative branch facts.
-    let canObserveBranch (caller: VisibilityCallerAudience) (branch: VisibilityResource) =
+    let canObserveBranch (caller: VisibilityCallerAudience) resolveResourceAudience branch =
         match branch.Visibility, branch.Ownership with
         | ResourceVisibility.Public, _ -> true
         | _, ResourceOwnership.RepositoryOwned -> true
-        | _, ResourceOwnership.ContributorOwned -> hasContributorAudience caller branch
+        | _, ResourceOwnership.ContributorOwned -> hasContributorAudience true caller resolveResourceAudience branch
 
     /// Determines whether a caller may observe a reference after the route has loaded its authoritative visibility facts.
-    let canObserveReference (caller: VisibilityCallerAudience) (reference: VisibilityResource) = canObserveBranch caller reference
+    let canObserveReference (caller: VisibilityCallerAudience) resolveResourceAudience reference =
+        match reference.Visibility, reference.Ownership with
+        | ResourceVisibility.Public, _ -> true
+        | _, ResourceOwnership.RepositoryOwned -> true
+        | _, ResourceOwnership.ContributorOwned -> hasContributorAudience false caller resolveResourceAudience reference
 
     /// Determines whether a caller may observe a promotion set after the route has loaded its authoritative visibility facts.
-    let canObservePromotionSet (caller: VisibilityCallerAudience) (promotionSet: VisibilityResource) = canObserveBranch caller promotionSet
+    let canObservePromotionSet (caller: VisibilityCallerAudience) resolveResourceAudience promotionSet =
+        match promotionSet.Visibility, promotionSet.Ownership with
+        | ResourceVisibility.Public, _ -> true
+        | _, ResourceOwnership.RepositoryOwned -> true
+        | _, ResourceOwnership.ContributorOwned -> hasContributorAudience false caller resolveResourceAudience promotionSet
 
     /// Applies a route-specific missing model when an existing resource must be hidden from the caller.
     let hiddenAsMissing missingModel canObserve resource = if canObserve then Observable resource else RouteEquivalentMissing missingModel
 
     /// Applies branch visibility and returns the route's existing missing shape for hidden branches.
-    let requireObservableBranch caller missingModel branch = hiddenAsMissing missingModel (canObserveBranch caller branch) branch
+    let requireObservableBranch caller resolveResourceAudience missingModel branch =
+        hiddenAsMissing missingModel (canObserveBranch caller resolveResourceAudience branch) branch
 
     /// Filters candidates before list limits, visible counts, and latest selection are calculated.
     let filterVisibleWindow limit canObserve candidates =


### PR DESCRIPTION
## Summary

- Adds a pure server-side visibility authorization helper module that later route issues can cite for hidden-as-missing behavior, caller audience checks, filtered windows, projection gating, and reachability seams.
- Adds focused Server.Unit tests for contributor/elevated observability, anonymous and low-privilege fail-closed behavior, route-aware missing results, filtering before public reduction, projection gating, traversal gating, and reference/promotion-set seams.
- Wires the new helper and tests into the existing F# compile order without adopting every downstream route in this slice.

## Related Issue

Related to #642.

## Why This Matters

The tracer in #641 proved the first private contributor branch behavior, but it also showed that route-local visibility predicates would drift quickly. This slice gives Grace one reusable fail-closed helper contract so branch, reference, promotion-set, projection, traversal, and reachability work can reuse the same security model instead of reimplementing it per route.

## Touched Paths

- `src/Grace.Server/Security/VisibilityAuthorization.Server.fs`
- `src/Grace.Server/Grace.Server.fsproj`
- `src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs`
- `src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`

## Validation

- `dotnet tool run fantomas -- src\Grace.Server\Security\VisibilityAuthorization.Server.fs src\Grace.Server.Unit.Tests\VisibilityAuthorization.Unit.Tests.fs`: passed.
- `dotnet build --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~VisibilityAuthorizationUnitTests`: passed, 7/7.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed. Fast tests passed across Operations, Types, Authorization, Server.Unit, and CLI. Existing CLI skip remained: `multi-process writers do not crash or corrupt database`.

## Review Status

- Current head: `902bebe14441c705896fc501a82e14b9ed1614d6`.
- Codex Code Review Bot state for current head: no-issues gate satisfied with thumbs-up on the latest head and zero unresolved review threads.
- Manual trigger decision: not attempted.
- Manual trigger lock: no manual trigger may be used while bot state is pending, acknowledged with eyes, completed with no-issues, or ambiguous. Use `pwsh ./scripts/guard-codex-review-trigger.ps1 -PullRequest 662` only if the documented missed-ack exception is reached.
- Prior fresh findings from head `f30907fedea1bf12acb6cbc25a65f703a2bba131`:
  - `PRRT_kwDOILVrb86Oyb-Y`: fixed in `902bebe1`; replied and resolved.
  - `PRRT_kwDOILVrb86Oyb-a`: fixed in `902bebe1`; replied and resolved.
- Substantive review cycle count: 1. Theme: helper authority must remain resource-scoped before list/window/traversal reuse.
- Fix commits: `902bebe14441c705896fc501a82e14b9ed1614d6`.
- Current-head CI: `Validate / full` passed.
- Final no-issues state: satisfied on current head.

## Docs Impact

No user-facing docs changed. This slice adds internal server helper APIs and focused tests only. Downstream route adoption, CLI, SDK, OpenAPI, generated-client, and external behavior documentation remain with later #638 child issues.

## Residual Risk

This slice intentionally does not remove the existing route-local `Grace.Server.Branch.canObserveBranch` adapter or wire routes to the new helper. #643 owns replacing that route-local predicate for branch read surfaces; later route issues under #638 should adopt the reference, promotion-set, projection, and reachability seams.
