### PR TITLE
GV-04: Filter branch reference visibility

### DIFF
--- a/src/Grace.Actors/Branch.Actor.fs
+++ b/src/Grace.Actors/Branch.Actor.fs
@@ -349,7 +349,15 @@ module Branch =
                                 links
                             )
 
+                        /// Adds inherited branch visibility metadata without overwriting create-time command facts.
+                        let addInheritedMetadataIfMissing key value =
+                            if not (metadata.Properties.ContainsKey key) then
+                                metadata.Properties[ key ] <- value
+
                         metadata.Properties[ nameof (RepositoryId) ] <- $"{repositoryId}"
+                        addInheritedMetadataIfMissing "InheritedVisibility" $"{branchDto.Visibility}"
+                        addInheritedMetadataIfMissing "InheritedOwnership" $"{branchDto.Ownership}"
+                        addInheritedMetadataIfMissing "InheritedCreatorUserId" $"{branchDto.UserId}"
                         return! referenceActor.Handle referenceCommand metadata
                     }
 
@@ -378,6 +386,9 @@ module Branch =
                                               creatorUserId) ->
                                         // Add an initial Rebase reference to this branch that points to the BasedOn reference, unless we're creating `main`.
                                         if branchName <> InitialBranchName then
+                                            metadata.Properties[ "InheritedVisibility" ] <- $"{visibility}"
+                                            metadata.Properties[ "InheritedOwnership" ] <- $"{ownership}"
+                                            metadata.Properties[ "InheritedCreatorUserId" ] <- $"{creatorUserId}"
                                             // We need to get the reference that we're rebasing on, so we can get the DirectoryId and root hashes.
                                             let referenceActorProxy = Reference.CreateActorProxy basedOn repositoryId this.correlationId
                                             let! promotionDto = referenceActorProxy.Get this.correlationId

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -2303,6 +2303,12 @@ type BranchServer() =
                         secondRoot
                     ]
 
+            let! firstSaveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch firstRoot.DirectoryVersionId firstRoot.Sha256Hash
+            do! BranchServerTestHelpers.assertOk firstSaveResponse
+
+            let! secondSaveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch secondRoot.DirectoryVersionId secondRoot.Sha256Hash
+            do! BranchServerTestHelpers.assertOk secondSaveResponse
+
             /// Asserts ambiguous for integration responses.
             let assertAmbiguous (response: HttpResponseMessage) =
                 task {

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -1816,9 +1816,9 @@ type BranchServer() =
     [<Test>]
     member _.AssignWithShaOnlyRootPrefixIgnoresNewerChildDirectoryMatch() =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
-            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "AssignRootPrefix"
+            let! repositoryBranches = BranchServerTestHelpers.getRepositoryBranchesAsync repositoryId
+            let parentBranch = repositoryBranches |> Array.exactlyOne
             let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"AssignRootPrefix{Guid.NewGuid():N}"
 
             /// Defines child behavior for the surrounding tests used by the server integration branch scenario.
@@ -2236,9 +2236,10 @@ type BranchServer() =
     [<Test>]
     member _.GetRecursiveSizeWithChildDirectoryBlake3MatchesShaLookup() =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
-            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "RecursiveSizeHash"
+            let! repositoryBranches = BranchServerTestHelpers.getRepositoryBranchesAsync repositoryId
+            let parentBranch = repositoryBranches |> Array.exactlyOne
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"RecursiveSizeHash{Guid.NewGuid():N}"
             let payload = Encoding.UTF8.GetBytes($"recursive-size-child-{Guid.NewGuid():N}")
             let childPath = RelativePath $"recursive-size/{Guid.NewGuid():N}"
             let filePath = RelativePath $"{childPath}/sample.txt"
@@ -2257,10 +2258,10 @@ type BranchServer() =
 
             do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId payload fileVersion
             do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ child; root ]
-            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId parentBranch root.DirectoryVersionId root.Sha256Hash
+            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch root.DirectoryVersionId root.Sha256Hash
             do! BranchServerTestHelpers.assertOk saveResponse
 
-            let! shaResponse = BranchServerTestHelpers.getRecursiveSizeBySha256HashResponseAsync repositoryId parentBranch child.Sha256Hash
+            let! shaResponse = BranchServerTestHelpers.getRecursiveSizeBySha256HashResponseAsync repositoryId branch child.Sha256Hash
             let! shaBody = shaResponse.Content.ReadAsStringAsync()
             Assert.That(shaResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), shaBody)
 
@@ -2268,7 +2269,7 @@ type BranchServer() =
                 (deserialize<GraceReturnValue<int64>> shaBody)
                     .ReturnValue
 
-            let! blake3Response = BranchServerTestHelpers.getRecursiveSizeByBlake3HashResponseAsync repositoryId parentBranch child.Blake3Hash
+            let! blake3Response = BranchServerTestHelpers.getRecursiveSizeByBlake3HashResponseAsync repositoryId branch child.Blake3Hash
             let! blake3Body = blake3Response.Content.ReadAsStringAsync()
             Assert.That(blake3Response.StatusCode, Is.EqualTo(HttpStatusCode.OK), blake3Body)
 
@@ -2344,9 +2345,10 @@ type BranchServer() =
     [<Test>]
     member _.HashReadQueriesUseShaToDisambiguateSharedBlake3RootPrefix() =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
-            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId branchId
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "ReadPairedHash"
+            let! repositoryBranches = BranchServerTestHelpers.getRepositoryBranchesAsync repositoryId
+            let parentBranch = repositoryBranches |> Array.exactlyOne
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"ReadPairedHash{Guid.NewGuid():N}"
 
             /// Defines first child behavior for the surrounding tests used by the server integration branch scenario.
             let firstChild, firstRoot, secondChild, secondRoot, sharedPrefix =
@@ -2362,12 +2364,12 @@ type BranchServer() =
                         secondRoot
                     ]
 
-            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId parentBranch firstRoot.DirectoryVersionId firstRoot.Sha256Hash
+            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch firstRoot.DirectoryVersionId firstRoot.Sha256Hash
 
             do! BranchServerTestHelpers.assertOk saveResponse
 
             let! listContentsResponse =
-                BranchServerTestHelpers.listContentsByShaAndBlake3HashResponseAsync repositoryId parentBranch firstRoot.Sha256Hash (Blake3Hash sharedPrefix)
+                BranchServerTestHelpers.listContentsByShaAndBlake3HashResponseAsync repositoryId branch firstRoot.Sha256Hash (Blake3Hash sharedPrefix)
 
             let! listContentsBody = listContentsResponse.Content.ReadAsStringAsync()
             Assert.That(listContentsResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), listContentsBody)
@@ -2383,7 +2385,7 @@ type BranchServer() =
             )
 
             let! getVersionResponse =
-                BranchServerTestHelpers.getVersionByShaAndBlake3HashResponseAsync repositoryId parentBranch firstRoot.Sha256Hash (Blake3Hash sharedPrefix)
+                BranchServerTestHelpers.getVersionByShaAndBlake3HashResponseAsync repositoryId branch firstRoot.Sha256Hash (Blake3Hash sharedPrefix)
 
             let! getVersionBody = getVersionResponse.Content.ReadAsStringAsync()
             Assert.That(getVersionResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), getVersionBody)

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -608,6 +608,22 @@ module BranchServerTestHelpers =
             return! Client.PostAsync("/branch/save", createJsonContent parameters)
         }
 
+    /// Saves reference response through the supplied authenticated client.
+    let saveReferenceWithClientResponseAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) directoryVersionId sha256Hash =
+        task {
+            let parameters = Parameters.Branch.CreateReferenceParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.DirectoryVersionId <- directoryVersionId
+            parameters.Sha256Hash <- sha256Hash
+            parameters.Message <- "Private hash ownership proof save"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/branch/save", createJsonContent parameters)
+        }
+
     /// Defines assign reference response behavior for the surrounding tests used by the server integration branch scenario.
     let assignReferenceResponseAsync repositoryId (branch: Branch.BranchDto) directoryVersionId sha256Hash =
         task {
@@ -702,6 +718,20 @@ module BranchServerTestHelpers =
             return! Client.PostAsync("/branch/listContents", createJsonContent parameters)
         }
 
+    /// Lists contents by SHA hash through the supplied authenticated client.
+    let listContentsByShaHashWithClientResponseAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) sha256Hash =
+        task {
+            let parameters = Parameters.Branch.ListContentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.Sha256Hash <- sha256Hash
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/branch/listContents", createJsonContent parameters)
+        }
+
     /// Gets version by SHA and BLAKE3 hash response from the running test server.
     let getVersionByShaAndBlake3HashResponseAsync repositoryId (branch: Branch.BranchDto) sha256Hash blake3Hash =
         task {
@@ -717,6 +747,20 @@ module BranchServerTestHelpers =
             return! Client.PostAsync("/branch/getVersion", createJsonContent parameters)
         }
 
+    /// Gets version by SHA hash through the supplied authenticated client.
+    let getVersionByShaHashWithClientResponseAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) sha256Hash =
+        task {
+            let parameters = Parameters.Branch.GetBranchVersionParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.Sha256Hash <- sha256Hash
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/branch/getVersion", createJsonContent parameters)
+        }
+
     /// Gets recursive size by SHA256 hash response from the running test server.
     let getRecursiveSizeBySha256HashResponseAsync repositoryId (branch: Branch.BranchDto) sha256Hash =
         task {
@@ -729,6 +773,20 @@ module BranchServerTestHelpers =
             parameters.CorrelationId <- generateCorrelationId ()
 
             return! Client.PostAsync("/branch/getRecursiveSize", createJsonContent parameters)
+        }
+
+    /// Gets recursive size by SHA hash through the supplied authenticated client.
+    let getRecursiveSizeByShaHashWithClientResponseAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) sha256Hash =
+        task {
+            let parameters = Parameters.Branch.ListContentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.Sha256Hash <- sha256Hash
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/branch/getRecursiveSize", createJsonContent parameters)
         }
 
     /// Gets recursive size by BLAKE3 hash response from the running test server.
@@ -1413,6 +1471,140 @@ type BranchServer() =
             Assert.That(branchAdminSaveBucketBody, Does.Contain($"{privateReferenceId}"))
         }
 
+    /// Verifies hash-based content reads require an observable reference owner and do not treat known hashes as capabilities.
+    [<Test>]
+    member _.HashOwnedPrivateBranchContentIsHiddenFromRepositoryReaderAndVisibleToBranchAdmin() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let branchAdminUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityHashReads"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+            use branchAdminClient = BranchServerTestHelpers.createClientWithUserId branchAdminUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+            let branchName = $"PrivateHashRead{Guid.NewGuid():N}"
+
+            let! privateBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync creatorClient repositoryId parentBranch branchName "Private" "ContributorOwned"
+
+            let! creatorBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk creatorBranchResponse
+            let! creatorBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> creatorBranchResponse
+            let creatorBranch = creatorBranchReturnValue.ReturnValue
+
+            let payload = Encoding.UTF8.GetBytes($"private-hash-owned-content-{Guid.NewGuid():N}")
+
+            let fileVersion =
+                FileVersion.CreateWithHashes
+                    (RelativePath $"private/hash/{Guid.NewGuid():N}.txt")
+                    (BranchServerTestHelpers.sha256Hex payload)
+                    (BranchServerTestHelpers.blake3Hex payload)
+                    String.Empty
+                    false
+                    (int64 payload.Length)
+
+            let privateRoot = BranchServerTestHelpers.createRootDirectoryVersion repositoryId fileVersion
+
+            do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId payload fileVersion
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ privateRoot ]
+
+            let! privateSaveResponse =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    creatorBranch
+                    privateRoot.DirectoryVersionId
+                    privateRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk privateSaveResponse
+
+            let! observerListContents =
+                BranchServerTestHelpers.listContentsByShaHashWithClientResponseAsync observerClient repositoryId parentBranch privateRoot.Sha256Hash
+
+            let! observerListContentsBody = observerListContents.Content.ReadAsStringAsync()
+            Assert.That(observerListContents.StatusCode, Is.EqualTo(HttpStatusCode.OK), observerListContentsBody)
+
+            let observerContents =
+                (deserialize<GraceReturnValue<DirectoryVersion.DirectoryVersionDto array>> observerListContentsBody)
+                    .ReturnValue
+
+            Assert.That(observerContents, Is.Empty)
+
+            let! observerRecursiveSize =
+                BranchServerTestHelpers.getRecursiveSizeByShaHashWithClientResponseAsync observerClient repositoryId parentBranch privateRoot.Sha256Hash
+
+            let! observerRecursiveSizeBody = observerRecursiveSize.Content.ReadAsStringAsync()
+            Assert.That(observerRecursiveSize.StatusCode, Is.EqualTo(HttpStatusCode.OK), observerRecursiveSizeBody)
+
+            let observerSize =
+                (deserialize<GraceReturnValue<int64>> observerRecursiveSizeBody)
+                    .ReturnValue
+
+            Assert.That(observerSize, Is.EqualTo(Constants.InitialDirectorySize))
+
+            let! observerVersion =
+                BranchServerTestHelpers.getVersionByShaHashWithClientResponseAsync observerClient repositoryId parentBranch privateRoot.Sha256Hash
+
+            let! observerVersionBody = observerVersion.Content.ReadAsStringAsync()
+            Assert.That(observerVersion.StatusCode, Is.EqualTo(HttpStatusCode.OK), observerVersionBody)
+
+            let observerDirectoryIds =
+                (deserialize<GraceReturnValue<Guid array>> observerVersionBody)
+                    .ReturnValue
+
+            Assert.That(observerDirectoryIds, Is.Empty)
+
+            do! BranchServerTestHelpers.grantBranchRoleAsync repositoryId privateBranchId branchAdminUserId "BranchAdmin"
+
+            let! branchAdminListContents =
+                BranchServerTestHelpers.listContentsByShaHashWithClientResponseAsync branchAdminClient repositoryId creatorBranch privateRoot.Sha256Hash
+
+            let! branchAdminListContentsBody = branchAdminListContents.Content.ReadAsStringAsync()
+            Assert.That(branchAdminListContents.StatusCode, Is.EqualTo(HttpStatusCode.OK), branchAdminListContentsBody)
+
+            let branchAdminContents =
+                (deserialize<GraceReturnValue<DirectoryVersion.DirectoryVersionDto array>> branchAdminListContentsBody)
+                    .ReturnValue
+
+            Assert.That(
+                branchAdminContents
+                |> Array.exists (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.DirectoryVersionId = privateRoot.DirectoryVersionId),
+                Is.True
+            )
+
+            let! branchAdminRecursiveSize =
+                BranchServerTestHelpers.getRecursiveSizeByShaHashWithClientResponseAsync branchAdminClient repositoryId creatorBranch privateRoot.Sha256Hash
+
+            let! branchAdminRecursiveSizeBody = branchAdminRecursiveSize.Content.ReadAsStringAsync()
+            Assert.That(branchAdminRecursiveSize.StatusCode, Is.EqualTo(HttpStatusCode.OK), branchAdminRecursiveSizeBody)
+
+            let branchAdminSize =
+                (deserialize<GraceReturnValue<int64>> branchAdminRecursiveSizeBody)
+                    .ReturnValue
+
+            Assert.That(branchAdminSize, Is.EqualTo(fileVersion.Size))
+
+            let! branchAdminVersion =
+                BranchServerTestHelpers.getVersionByShaHashWithClientResponseAsync branchAdminClient repositoryId creatorBranch privateRoot.Sha256Hash
+
+            let! branchAdminVersionBody = branchAdminVersion.Content.ReadAsStringAsync()
+            Assert.That(branchAdminVersion.StatusCode, Is.EqualTo(HttpStatusCode.OK), branchAdminVersionBody)
+
+            let branchAdminDirectoryIds =
+                (deserialize<GraceReturnValue<Guid array>> branchAdminVersionBody)
+                    .ReturnValue
+
+            Assert.That(branchAdminDirectoryIds, Does.Contain(privateRoot.DirectoryVersionId))
+        }
+
     /// Verifies that regular branches in public repositories default to public repository-owned visibility.
     [<Test>]
     member _.RegularPublicRepositoryBranchDefaultsPublicRepositoryOwned() =
@@ -2065,6 +2257,8 @@ type BranchServer() =
 
             do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId payload fileVersion
             do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ child; root ]
+            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId parentBranch root.DirectoryVersionId root.Sha256Hash
+            do! BranchServerTestHelpers.assertOk saveResponse
 
             let! shaResponse = BranchServerTestHelpers.getRecursiveSizeBySha256HashResponseAsync repositoryId parentBranch child.Sha256Hash
             let! shaBody = shaResponse.Content.ReadAsStringAsync()
@@ -2167,6 +2361,10 @@ type BranchServer() =
                         secondChild
                         secondRoot
                     ]
+
+            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId parentBranch firstRoot.DirectoryVersionId firstRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk saveResponse
 
             let! listContentsResponse =
                 BranchServerTestHelpers.listContentsByShaAndBlake3HashResponseAsync repositoryId parentBranch firstRoot.Sha256Hash (Blake3Hash sharedPrefix)

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -68,6 +68,25 @@ module BranchServerTestHelpers =
             do! assertOk response
         }
 
+    /// Grants a branch-scoped role to a test user.
+    let grantBranchRoleAsync repositoryId branchId principalId roleId =
+        task {
+            let parameters = Parameters.Access.GrantRoleParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- branchId
+            parameters.PrincipalType <- "User"
+            parameters.PrincipalId <- principalId
+            parameters.ScopeKind <- "branch"
+            parameters.RoleId <- roleId
+            parameters.Source <- "test"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/authorize/grant-role", createJsonContent parameters)
+            do! assertOk response
+        }
+
     /// Creates an isolated repository for branch visibility route tests.
     let createRepositoryAsync repositoryNamePrefix =
         task {
@@ -235,6 +254,30 @@ module BranchServerTestHelpers =
 
         client.PostAsync(route, createJsonContent parameters)
 
+    /// Posts a branch reference-list query route with an explicit max count through the supplied test client.
+    let postBranchReferencesRouteWithMaxCountAsync (client: HttpClient) (route: string) repositoryId branchId maxCount =
+        let parameters = Parameters.Branch.GetReferencesParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.MaxCount <- maxCount
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        client.PostAsync(route, createJsonContent parameters)
+
+    /// Posts a direct branch reference lookup through the supplied test client.
+    let postBranchReferenceLookupAsync (client: HttpClient) repositoryId branchId referenceId =
+        let parameters = Parameters.Branch.GetReferenceParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.BranchId <- branchId
+        parameters.ReferenceId <- referenceId
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        client.PostAsync("/branch/getReference", createJsonContent parameters)
+
     /// Posts a branch version route through the supplied test client.
     let postBranchVersionRouteAsync (client: HttpClient) repositoryId branchId =
         let parameters = Parameters.Branch.GetBranchVersionParameters()
@@ -325,6 +368,29 @@ module BranchServerTestHelpers =
             parameters.CorrelationId <- generateCorrelationId ()
 
             let! response = Client.PostAsync("/branch/save", createJsonContent parameters)
+            do! assertOk response
+            let! returnValue = deserializeContent<GraceReturnValue<string>> response
+
+            Assert.That(returnValue.Properties.ContainsKey(nameof BranchId), Is.True)
+            Assert.That(returnValue.Properties.ContainsKey(nameof RepositoryId), Is.True)
+
+            return returnValue
+        }
+
+    /// Saves branch through the supplied authenticated client.
+    let saveBranchWithClientAsync (client: HttpClient) (repositoryId: string) (branch: Branch.BranchDto) =
+        task {
+            let parameters = Parameters.Branch.CreateReferenceParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.DirectoryVersionId <- branch.BasedOn.DirectoryId
+            parameters.Sha256Hash <- $"{branch.BasedOn.Sha256Hash}"
+            parameters.Message <- "Hosted private branch visibility proof save"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = client.PostAsync("/branch/save", createJsonContent parameters)
             do! assertOk response
             let! returnValue = deserializeContent<GraceReturnValue<string>> response
 
@@ -1241,6 +1307,110 @@ type BranchServer() =
                 |> Array.exists (fun branch -> branch.BranchId = creatorBranch.BranchId),
                 Is.True
             )
+        }
+
+    /// Verifies private branch reference read surfaces hide leaked reference ids while branch admins retain observability.
+    [<Test>]
+    member _.PrivateContributorBranchReferencesAreHiddenFromObserverAndVisibleToBranchAdmin() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let branchAdminUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityReferences"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+            use branchAdminClient = BranchServerTestHelpers.createClientWithUserId branchAdminUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+            let branchName = $"PrivateReference{Guid.NewGuid():N}"
+
+            let! privateBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync creatorClient repositoryId parentBranch branchName "Private" "ContributorOwned"
+
+            let! creatorBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk creatorBranchResponse
+            let! creatorBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> creatorBranchResponse
+            let creatorBranch = creatorBranchReturnValue.ReturnValue
+
+            let! _saveReturnValue = BranchServerTestHelpers.saveBranchWithClientAsync creatorClient repositoryId creatorBranch
+            let! savedCreatorBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk savedCreatorBranchResponse
+            let! savedCreatorBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> savedCreatorBranchResponse
+            let savedCreatorBranch = savedCreatorBranchReturnValue.ReturnValue
+            let privateReferenceId = savedCreatorBranch.LatestSave.ReferenceId
+
+            Assert.That(privateReferenceId, Is.Not.EqualTo(ReferenceId.Empty))
+
+            do! BranchServerTestHelpers.grantBranchRoleAsync repositoryId privateBranchId branchAdminUserId "BranchAdmin"
+
+            let! observerEvents = BranchServerTestHelpers.postBranchIdRouteAsync observerClient "/branch/getEvents" repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerEvents
+
+            let! observerReferences = BranchServerTestHelpers.postBranchReferencesRouteAsync observerClient "/branch/getReferences" repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertBadRequestGraceError (BranchError.getErrorMessage BranchError.BranchIdDoesNotExist) observerReferences
+
+            let! observerDirectHidden =
+                BranchServerTestHelpers.postBranchReferenceLookupAsync observerClient repositoryId $"{parentBranch.BranchId}" $"{privateReferenceId}"
+
+            let! observerDirectHiddenBody = observerDirectHidden.Content.ReadAsStringAsync()
+            Assert.That(observerDirectHidden.StatusCode, Is.EqualTo(HttpStatusCode.OK), observerDirectHiddenBody)
+
+            let observerHiddenReference =
+                (deserialize<GraceReturnValue<Reference.ReferenceDto>> observerDirectHiddenBody)
+                    .ReturnValue
+
+            Assert.That(observerHiddenReference.ReferenceId, Is.EqualTo(ReferenceId.Empty))
+
+            let! observerDirectMissing =
+                BranchServerTestHelpers.postBranchReferenceLookupAsync observerClient repositoryId $"{parentBranch.BranchId}" $"{ReferenceId.NewGuid()}"
+
+            let! observerDirectMissingBody = observerDirectMissing.Content.ReadAsStringAsync()
+            Assert.That(observerDirectMissing.StatusCode, Is.EqualTo(HttpStatusCode.OK), observerDirectMissingBody)
+
+            let observerMissingReference =
+                (deserialize<GraceReturnValue<Reference.ReferenceDto>> observerDirectMissingBody)
+                    .ReturnValue
+
+            Assert.That(observerMissingReference.ReferenceId, Is.EqualTo(observerHiddenReference.ReferenceId))
+            Assert.That(observerMissingReference.DirectoryId, Is.EqualTo(observerHiddenReference.DirectoryId))
+
+            let! branchAdminReferences =
+                BranchServerTestHelpers.postBranchReferencesRouteWithMaxCountAsync branchAdminClient "/branch/getReferences" repositoryId privateBranchId 1
+
+            let! branchAdminReferencesBody = branchAdminReferences.Content.ReadAsStringAsync()
+            Assert.That(branchAdminReferences.StatusCode, Is.EqualTo(HttpStatusCode.OK), branchAdminReferencesBody)
+
+            let branchAdminReferenceWindow =
+                (deserialize<GraceReturnValue<Reference.ReferenceDto array>> branchAdminReferencesBody)
+                    .ReturnValue
+
+            Assert.That(branchAdminReferenceWindow, Has.Length.EqualTo(1))
+            Assert.That(branchAdminReferenceWindow[0].ReferenceId, Is.EqualTo(privateReferenceId))
+
+            let! branchAdminDirect =
+                BranchServerTestHelpers.postBranchReferenceLookupAsync branchAdminClient repositoryId privateBranchId $"{privateReferenceId}"
+
+            let! branchAdminDirectBody = branchAdminDirect.Content.ReadAsStringAsync()
+            Assert.That(branchAdminDirect.StatusCode, Is.EqualTo(HttpStatusCode.OK), branchAdminDirectBody)
+
+            let branchAdminReference =
+                (deserialize<GraceReturnValue<Reference.ReferenceDto>> branchAdminDirectBody)
+                    .ReturnValue
+
+            Assert.That(branchAdminReference.ReferenceId, Is.EqualTo(privateReferenceId))
+
+            let! branchAdminSaveBucket =
+                BranchServerTestHelpers.postBranchReferencesRouteWithMaxCountAsync branchAdminClient "/branch/getSaves" repositoryId privateBranchId 1
+
+            let! branchAdminSaveBucketBody = branchAdminSaveBucket.Content.ReadAsStringAsync()
+            Assert.That(branchAdminSaveBucket.StatusCode, Is.EqualTo(HttpStatusCode.OK), branchAdminSaveBucketBody)
+            Assert.That(branchAdminSaveBucketBody, Does.Contain($"{privateReferenceId}"))
         }
 
     /// Verifies that regular branches in public repositories default to public repository-owned visibility.

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -4,6 +4,7 @@ open Azure.Storage.Blobs.Models
 open Azure.Storage.Blobs.Specialized
 open Grace.Server.Tests.Services
 open Grace.Shared
+open Grace.Shared.Constants
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Services
 open Grace.Shared.Utilities
@@ -13,7 +14,9 @@ open Grace.Types
 open Grace.Types.Annotation
 open Grace.Types.Common
 open Grace.Types.PersonalAccessToken
+open Grace.Types.Reference
 open Grace.Types.Visibility
+open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -727,6 +730,20 @@ module BranchServerTestHelpers =
             parameters.RepositoryId <- repositoryId
             parameters.BranchId <- $"{branch.BranchId}"
             parameters.Sha256Hash <- sha256Hash
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/branch/listContents", createJsonContent parameters)
+        }
+
+    /// Lists contents by BLAKE3 hash through the supplied authenticated client.
+    let listContentsByBlake3HashWithClientResponseAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) blake3Hash =
+        task {
+            let parameters = Parameters.Branch.ListContentsParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.Blake3Hash <- blake3Hash
             parameters.CorrelationId <- generateCorrelationId ()
 
             return! client.PostAsync("/branch/listContents", createJsonContent parameters)
@@ -1604,6 +1621,149 @@ type BranchServer() =
 
             Assert.That(branchAdminDirectoryIds, Does.Contain(privateRoot.DirectoryVersionId))
         }
+
+    /// Verifies public hash reads resolve after visibility filtering when a hidden root shares the requested prefix.
+    [<Test>]
+    member _.PublicBranchHashLookupIgnoresHiddenSamePrefixRoot() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityHashPrefix"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+
+            let! visibleBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"VisibleHashPrefix{Guid.NewGuid():N}"
+                    "Public"
+                    "RepositoryOwned"
+
+            let! hiddenBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"HiddenHashPrefix{Guid.NewGuid():N}"
+                    "Private"
+                    "ContributorOwned"
+
+            let! visibleBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId visibleBranchId
+            do! BranchServerTestHelpers.assertOk visibleBranchResponse
+            let! visibleBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> visibleBranchResponse
+            let visibleBranch = visibleBranchReturnValue.ReturnValue
+
+            let! hiddenBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId hiddenBranchId
+            do! BranchServerTestHelpers.assertOk hiddenBranchResponse
+            let! hiddenBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> hiddenBranchResponse
+            let hiddenBranch = hiddenBranchReturnValue.ReturnValue
+
+            let visibleChild, visibleRoot, hiddenChild, hiddenRoot, sharedPrefix =
+                BranchServerTestHelpers.createSameBlake3PrefixRootPair repositoryId $"visibility-filtered-prefix/{Guid.NewGuid():N}"
+
+            do!
+                BranchServerTestHelpers.saveDirectoryVersionsAsync
+                    repositoryId
+                    [
+                        visibleChild
+                        visibleRoot
+                        hiddenChild
+                        hiddenRoot
+                    ]
+
+            let! visibleSaveResponse =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    visibleBranch
+                    visibleRoot.DirectoryVersionId
+                    visibleRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk visibleSaveResponse
+
+            let! hiddenSaveResponse =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    hiddenBranch
+                    hiddenRoot.DirectoryVersionId
+                    hiddenRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk hiddenSaveResponse
+
+            let! listContentsResponse =
+                BranchServerTestHelpers.listContentsByBlake3HashWithClientResponseAsync observerClient repositoryId visibleBranch (Blake3Hash sharedPrefix)
+
+            let! listContentsBody = listContentsResponse.Content.ReadAsStringAsync()
+            Assert.That(listContentsResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), listContentsBody)
+
+            let listContents =
+                (deserialize<GraceReturnValue<DirectoryVersion.DirectoryVersionDto array>> listContentsBody)
+                    .ReturnValue
+
+            Assert.That(
+                listContents
+                |> Array.exists (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.DirectoryVersionId = visibleRoot.DirectoryVersionId),
+                Is.True
+            )
+
+            Assert.That(
+                listContents
+                |> Array.exists (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.DirectoryVersionId = hiddenRoot.DirectoryVersionId),
+                Is.False
+            )
+        }
+
+    /// Verifies branch reference windows discard deleted newest rows before applying visible latest/list limits.
+    [<Test>]
+    member _.BranchReferenceWindowOrdersActiveRowsPastDeletedNewestRows() =
+        let baseInstant = getCurrentInstant ()
+
+        let olderVisibleReference = { Reference.ReferenceDto.Default with ReferenceId = ReferenceId.NewGuid(); CreatedAt = baseInstant }
+
+        let deletedNewestReferences =
+            [|
+                for index in 1..35 ->
+                    { Reference.ReferenceDto.Default with
+                        ReferenceId = ReferenceId.NewGuid()
+                        CreatedAt = baseInstant.Plus(Duration.FromSeconds(float index))
+                        DeletedAt = Some(baseInstant.Plus(Duration.FromSeconds(float (index + 100))))
+                    }
+            |]
+
+        let activeReferences =
+            Array.append [| olderVisibleReference |] deletedNewestReferences
+            |> Grace.Server.Branch.activeReferencesLatestFirst
+
+        Assert.That(activeReferences, Has.Length.EqualTo(1))
+        Assert.That(activeReferences[0].ReferenceId, Is.EqualTo(olderVisibleReference.ReferenceId))
+
+    /// Verifies public reference-window scan math does not cap legitimate MaxCount values below the caller request.
+    [<Test>]
+    member _.BranchReferenceScanLimitsHonorMaxCountAboveRefillCap() =
+        let requestedMaxCount = 1500
+
+        Assert.That(Grace.Server.Branch.visibleReferenceScanLimitCap requestedMaxCount, Is.EqualTo(requestedMaxCount))
+        Assert.That(Grace.Server.Branch.initialVisibleReferenceScanLimit requestedMaxCount, Is.EqualTo(requestedMaxCount))
+        Assert.That(Grace.Server.Branch.nextVisibleReferenceScanLimit requestedMaxCount 1024, Is.EqualTo(requestedMaxCount))
+
+    /// Verifies the branch reference-list helper accepts branch authority once instead of owning a per-row branch load seam.
+    [<Test>]
+    member _.BranchReferenceFilteringUsesSingleBranchAuthorityShape() =
+        let filter: Microsoft.AspNetCore.Http.HttpContext -> Branch.BranchDto -> int -> Reference.ReferenceDto seq -> Task<Reference.ReferenceDto array> =
+            Grace.Server.Branch.filterVisibleReferenceWindowForBranch
+
+        Assert.That(box filter, Is.Not.Null)
 
     /// Verifies that regular branches in public repositories default to public repository-owned visibility.
     [<Test>]

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -152,34 +152,62 @@ module Branch =
             | Denied _ -> return false
         }
 
-    /// Checks whether RBAC already grants the caller elevated authority over the branch.
-    let private canAdministerBranch (context: HttpContext) (branchDto: BranchDto) =
+    /// Checks whether RBAC grants the requested operation over an authoritative Grace resource.
+    let private canPerformOperation (context: HttpContext) operation resource =
         task {
             let principals = PrincipalMapper.getPrincipals context.User
             let claims = PrincipalMapper.getEffectiveClaims context.User
             let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
 
-            let resource = Resource.Branch(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId, branchDto.BranchId)
-
-            match! evaluator.CheckAsync(principals, claims, Operation.BranchAdmin, resource) with
+            match! evaluator.CheckAsync(principals, claims, operation, resource) with
             | Allowed _ -> return true
             | Denied _ -> return false
+        }
+
+    /// Checks whether RBAC already grants the caller elevated authority over the branch.
+    let private canAdministerBranch (context: HttpContext) (branchDto: BranchDto) =
+        let resource = Resource.Branch(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId, branchDto.BranchId)
+        canPerformOperation context Operation.BranchAdmin resource
+
+    /// Converts the authenticated HTTP principal into the reusable visibility audience facts.
+    let private getVisibilityCallerAudience (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let callerUserId =
+                PrincipalMapper.tryGetUserId context.User
+                |> Option.map UserId
+
+            let resource = Resource.Repository(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId)
+            let! hasRepositoryAdministration = canPerformOperation context Operation.RepositoryAdmin resource
+
+            return { VisibilityCallerAudience.Anonymous with UserId = callerUserId; HasRepositoryAdministration = hasRepositoryAdministration }
+        }
+
+    /// Projects branch durable visibility facts into the shared visibility helper resource shape.
+    let private branchVisibilityResource (branchDto: BranchDto) =
+        let creatorUserId = if branchDto.UserId = UserId String.Empty then None else Some branchDto.UserId
+
+        { AuthorityKey = branchDto.BranchId; Visibility = branchDto.Visibility; Ownership = branchDto.Ownership; CreatorUserId = creatorUserId }
+
+    /// Builds branch-scoped authority only after checking the exact branch resource being considered.
+    let private getBranchResourceAudience (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let! hasBranchAdministration = canAdministerBranch context branchDto
+
+            return { VisibilityResourceAudience.None with HasBranchAdministration = hasBranchAdministration }
         }
 
     /// Checks whether the already-authenticated caller can observe the stored branch visibility boundary.
     let internal canObserveBranch (context: HttpContext) (branchDto: BranchDto) =
         task {
-            match branchDto.Visibility, branchDto.Ownership with
-            | ResourceVisibility.Public, _ -> return true
-            | _, ResourceOwnership.RepositoryOwned -> return true
-            | _, ResourceOwnership.ContributorOwned ->
-                let isCreator =
-                    PrincipalMapper.tryGetUserId context.User
-                    |> Option.map UserId
-                    |> Option.exists ((=) branchDto.UserId)
-
-                if isCreator then return true else return! canAdministerBranch context branchDto
+            let! caller = getVisibilityCallerAudience context branchDto
+            let! branchAudience = getBranchResourceAudience context branchDto
+            let resource = branchVisibilityResource branchDto
+            return VisibilityAuthorization.canObserveBranch caller (fun _ -> branchAudience) resource
         }
+
+    /// Checks inherited branch visibility for reference projections that have no independent visibility contract yet.
+    let private canObserveReferenceInBranch (context: HttpContext) (branchDto: BranchDto) (_referenceDto: Reference.ReferenceDto) =
+        canObserveBranch context branchDto
 
     /// Creates the hidden-as-missing response used when a private contributor branch exists but is not observable.
     let internal hiddenBranchError context branchId =
@@ -932,6 +960,113 @@ module Branch =
             match! requireObservableBranch context parameters with
             | Ok _ -> return! processQuery context parameters validations maxCount query
             | Error error -> return! context |> result400BadRequest error
+        }
+
+    /// Loads the branch that owns a reference so inherited visibility is evaluated from the durable branch state.
+    let private loadReferenceBranch (referenceDto: Reference.ReferenceDto) correlationId =
+        task {
+            let branchActorProxy = Branch.CreateActorProxy referenceDto.BranchId referenceDto.RepositoryId correlationId
+            return! branchActorProxy.Get correlationId
+        }
+
+    /// Filters a latest-first reference sequence before applying route limits, then restores the established response order.
+    let private filterVisibleReferenceWindow (context: HttpContext) maxCount (references: Reference.ReferenceDto seq) =
+        task {
+            if maxCount = 0 then
+                return Array.empty<Reference.ReferenceDto>
+            else
+                let correlationId = getCorrelationId context
+                let visibleReferences = List<Reference.ReferenceDto>()
+
+                let latestFirst =
+                    references
+                        .Where(fun referenceDto -> referenceDto.DeletedAt.IsNone)
+                        .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
+                        .ToArray()
+
+                let mutable index = 0
+
+                let mutable keepScanning =
+                    index < latestFirst.Length
+                    && (maxCount < 0 || visibleReferences.Count < maxCount)
+
+                while keepScanning do
+                    let referenceDto = latestFirst[index]
+                    let! branchDto = loadReferenceBranch referenceDto correlationId
+                    let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
+
+                    if isObservable then visibleReferences.Add referenceDto
+
+                    index <- index + 1
+
+                    keepScanning <-
+                        index < latestFirst.Length
+                        && (maxCount < 0 || visibleReferences.Count < maxCount)
+
+                return
+                    visibleReferences
+                        .OrderBy(fun referenceDto -> referenceDto.CreatedAt)
+                        .ToArray()
+        }
+
+    /// Reads a branch reference window with hidden rows removed before max-count projection.
+    let private getVisibleReferences (context: HttpContext) (branchDto: BranchDto) maxCount =
+        task {
+            let queryLimit = if maxCount = 0 then 0 else Int32.MaxValue
+
+            let! references = getReferences branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context)
+            return! filterVisibleReferenceWindow context maxCount references
+        }
+
+    /// Reads a typed branch reference window with hidden rows removed before max-count projection.
+    let private getVisibleReferencesByType (context: HttpContext) (branchDto: BranchDto) referenceType maxCount =
+        task {
+            let queryLimit = if maxCount = 0 then 0 else Int32.MaxValue
+
+            let! references = getReferencesByType referenceType branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context)
+            return! filterVisibleReferenceWindow context maxCount references
+        }
+
+    /// Selects the latest reference that remains observable after inherited branch visibility is applied.
+    let private getLatestVisibleReference (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let! references = getVisibleReferences context branchDto 1
+            return references |> Array.tryLast
+        }
+
+    /// Builds latest reference buckets from visible rows only so hidden rows cannot occupy a requested type bucket.
+    let private getLatestVisibleReferencesByTypes (context: HttpContext) (branchDto: BranchDto) (referenceTypes: ReferenceType array) =
+        task {
+            let! references = getVisibleReferences context branchDto Int32.MaxValue
+            let buckets = Dictionary<ReferenceType, Reference.ReferenceDto>()
+
+            let mutable index = 0
+
+            while index < referenceTypes.Length do
+                let referenceType = referenceTypes[index]
+
+                references
+                    .Where(fun referenceDto -> referenceDto.ReferenceType = referenceType)
+                    .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
+                    .FirstOrDefault(Reference.ReferenceDto.Default)
+                |> fun referenceDto ->
+                    if referenceDto.ReferenceId <> ReferenceId.Empty then
+                        buckets[referenceType] <- referenceDto
+
+                index <- index + 1
+
+            return buckets :> IReadOnlyDictionary<ReferenceType, Reference.ReferenceDto>
+        }
+
+    /// Applies hidden-as-missing behavior to direct reference lookups after loading the reference's owning branch.
+    let private getObservableReferenceOrDefault (context: HttpContext) (referenceDto: Reference.ReferenceDto) =
+        task {
+            if referenceDto.ReferenceId = ReferenceId.Empty then
+                return Reference.ReferenceDto.Default
+            else
+                let! branchDto = loadReferenceBranch referenceDto (getCorrelationId context)
+                let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
+                return if isObservable then referenceDto else Reference.ReferenceDto.Default
         }
 
     /// Creates a new branch.
@@ -1871,8 +2006,8 @@ module Branch =
 
                             let referenceActorProxy = Reference.CreateActorProxy referenceGuid repositoryId (getCorrelationId context)
 
-                            let referenceDto = referenceActorProxy.Get(getCorrelationId context)
-                            return referenceDto
+                            let! referenceDto = referenceActorProxy.Get(getCorrelationId context)
+                            return! getObservableReferenceOrDefault context referenceDto
                         }
 
                     let! parameters = context |> parse<GetReferenceParameters>
@@ -1930,7 +2065,7 @@ module Branch =
                     let query (context: HttpContext) (maxCount: int) (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getReferences branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferences context branchDto maxCount
                             return results
                         }
 
@@ -2065,14 +2200,15 @@ module Branch =
                                 serialize referenceTypes
                             )
 
-                            return! getLatestReferenceByReferenceTypes referenceTypes graceIds.RepositoryId graceIds.BranchId
+                            let! branchDto = actorProxy.Get(getCorrelationId context)
+                            return! getLatestVisibleReferencesByTypes context branchDto referenceTypes
                         }
 
                     let! parameters =
                         context
                         |> parse<GetLatestReferencesByReferenceTypeParameters>
 
-                    context.Items.Add("ReferenceTypes", serialize parameters.ReferenceTypes)
+                    context.Items.Add("ReferenceTypes", parameters.ReferenceTypes)
                     let! result = processObservableQuery context parameters validations 1 query
 
                     let duration_ms = getDurationRightAligned_ms startTime
@@ -2135,8 +2271,7 @@ module Branch =
                                 (context.Items[nameof ReferenceType] :?> String)
                                 |> discriminatedUnionFromString<ReferenceType>
 
-                            let! references =
-                                getReferencesByType referenceType.Value branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! references = getVisibleReferencesByType context branchDto referenceType.Value maxCount
 
                             let sortedRefs =
                                 references
@@ -2232,7 +2367,7 @@ module Branch =
                     let query (context: HttpContext) maxCount (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getPromotions branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferencesByType context branchDto ReferenceType.Promotion maxCount
                             return results
                         }
 
@@ -2290,7 +2425,7 @@ module Branch =
                     let query (context: HttpContext) maxCount (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getCommits branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferencesByType context branchDto ReferenceType.Commit maxCount
                             return results
                         }
 
@@ -2348,7 +2483,7 @@ module Branch =
                     let query (context: HttpContext) maxCount (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getCheckpoints branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferencesByType context branchDto ReferenceType.Checkpoint maxCount
                             return results
                         }
 
@@ -2407,7 +2542,7 @@ module Branch =
                     let query (context: HttpContext) maxCount (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getSaves branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferencesByType context branchDto ReferenceType.Save maxCount
                             return results
                         }
 
@@ -2465,7 +2600,7 @@ module Branch =
                     let query (context: HttpContext) maxCount (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getTags branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferencesByType context branchDto ReferenceType.Tag maxCount
                             return results
                         }
 
@@ -2523,7 +2658,7 @@ module Branch =
                     let query (context: HttpContext) maxCount (actorProxy: IBranchActor) =
                         task {
                             let! branchDto = actorProxy.Get(getCorrelationId context)
-                            let! results = getExternals branchDto.RepositoryId branchDto.BranchId maxCount (getCorrelationId context)
+                            let! results = getVisibleReferencesByType context branchDto ReferenceType.External maxCount
                             return results
                         }
 
@@ -2593,7 +2728,7 @@ module Branch =
                             then
                                 // If we don't have a referenceId or sha256Hash, we'll get the contents of the most recent reference in the branch.
                                 let! branchDto = actorProxy.Get correlationId
-                                let! latestReference = getLatestReference branchDto.RepositoryId branchDto.BranchId
+                                let! latestReference = getLatestVisibleReference context branchDto
 
                                 match latestReference with
                                 | Some latestReference ->
@@ -2611,11 +2746,15 @@ module Branch =
                                 let referenceActorProxy = Reference.CreateActorProxy referenceGuid repositoryId correlationId
 
                                 let! referenceDto = referenceActorProxy.Get correlationId
+                                let! referenceDto = getObservableReferenceOrDefault context referenceDto
 
-                                let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
+                                if referenceDto.ReferenceId = ReferenceId.Empty then
+                                    return Constants.InitialDirectorySize
+                                else
+                                    let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
 
-                                let! recursiveSize = directoryActorProxy.GetRecursiveSize correlationId
-                                return recursiveSize
+                                    let! recursiveSize = directoryActorProxy.GetRecursiveSize correlationId
+                                    return recursiveSize
                             else
                                 match!
                                     Services.getDirectoryVersionResolutionByHashQuery
@@ -2703,7 +2842,7 @@ module Branch =
                             then
                                 // If we don't have a referenceId or sha256Hash, we'll get the contents of the most recent reference in the branch.
                                 let! branchDto = actorProxy.Get correlationId
-                                let! latestReference = getLatestReference branchDto.RepositoryId branchDto.BranchId
+                                let! latestReference = getLatestVisibleReference context branchDto
 
                                 match latestReference with
                                 | Some latestReference ->
@@ -2723,12 +2862,16 @@ module Branch =
                                 let referenceActorProxy = Reference.CreateActorProxy referenceGuid repositoryId correlationId
 
                                 let! referenceDto = referenceActorProxy.Get correlationId
+                                let! referenceDto = getObservableReferenceOrDefault context referenceDto
 
-                                let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
+                                if referenceDto.ReferenceId = ReferenceId.Empty then
+                                    return Array.Empty<DirectoryVersion.DirectoryVersionDto>()
+                                else
+                                    let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
 
-                                let! contents = directoryActorProxy.GetRecursiveDirectoryVersions listContentsParameters.ForceRecompute correlationId
+                                    let! contents = directoryActorProxy.GetRecursiveDirectoryVersions listContentsParameters.ForceRecompute correlationId
 
-                                return contents
+                                    return contents
                             else
                                 match!
                                     Services.getRootDirectoryVersionResolutionByHashQuery
@@ -2818,10 +2961,17 @@ module Branch =
                 not
                 <| String.IsNullOrEmpty(parameters.ReferenceId)
             then
-                return! getRootDirectoryVersionByReferenceId repositoryId (Guid.Parse(parameters.ReferenceId)) correlationId
+                let referenceActorProxy = Reference.CreateActorProxy (Guid.Parse(parameters.ReferenceId)) repositoryId correlationId
+                let! referenceDto = referenceActorProxy.Get correlationId
+                let! referenceDto = getObservableReferenceOrDefault context referenceDto
+
+                if referenceDto.ReferenceId = ReferenceId.Empty then
+                    return None
+                else
+                    return! getRootDirectoryVersionByReferenceId repositoryId referenceDto.ReferenceId correlationId
             else
                 let! branchDto = actorProxy.Get(getCorrelationId context)
-                let! latestReference = getLatestReference branchDto.RepositoryId branchDto.BranchId
+                let! latestReference = getLatestVisibleReference context branchDto
 
                 match latestReference with
                 | Some referenceDto -> return! getRootDirectoryVersionByReferenceId repositoryId referenceDto.ReferenceId correlationId

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -42,6 +42,8 @@ module Branch =
 
     let private branchHashLookupErrorItemKey = "BranchHashLookupError"
     let private callerSuppliedBranchIdItemKey = "CallerSuppliedBranchId"
+    let private visibleReferenceInitialScanLimit = 32
+    let private visibleReferenceMaxScanLimit = 1024
 
     /// Implements branch hash lookup description for the server request pipeline.
     let private branchHashLookupDescription (sha256Hash: Sha256Hash) (blake3Hash: Blake3Hash) =
@@ -1009,22 +1011,63 @@ module Branch =
                         .ToArray()
         }
 
+    /// Chooses the first bounded reference-history scan size for a public reference window.
+    let private initialVisibleReferenceScanLimit maxCount =
+        if maxCount <= 0 then
+            0
+        else
+            Math.Min(visibleReferenceMaxScanLimit, Math.Max(visibleReferenceInitialScanLimit, maxCount))
+
+    /// Chooses the next bounded reference-history scan size for a public reference window refill.
+    let private nextVisibleReferenceScanLimit currentLimit =
+        if currentLimit >= visibleReferenceMaxScanLimit then
+            currentLimit
+        else
+            Math.Min(visibleReferenceMaxScanLimit, currentLimit * 2)
+
+    /// Reads and refills a bounded branch reference-history window before public max-count projection.
+    let private getVisibleReferencesWithLoader (context: HttpContext) maxCount (loadReferences: int -> Task<Reference.ReferenceDto array>) =
+        task {
+            if maxCount <= 0 then
+                return Array.empty<Reference.ReferenceDto>
+            else
+                let mutable queryLimit = initialVisibleReferenceScanLimit maxCount
+                let mutable visibleReferences = Array.empty<Reference.ReferenceDto>
+                let mutable lastFetchedCount = 0
+                let mutable keepScanning = true
+
+                while keepScanning do
+                    let! references = loadReferences queryLimit
+                    lastFetchedCount <- references.Length
+                    let! filteredReferences = filterVisibleReferenceWindow context maxCount references
+                    visibleReferences <- filteredReferences
+
+                    let nextQueryLimit = nextVisibleReferenceScanLimit queryLimit
+
+                    keepScanning <-
+                        filteredReferences.Length < maxCount
+                        && lastFetchedCount >= queryLimit
+                        && nextQueryLimit > queryLimit
+
+                    queryLimit <- nextQueryLimit
+
+                return visibleReferences
+        }
+
     /// Reads a branch reference window with hidden rows removed before max-count projection.
     let private getVisibleReferences (context: HttpContext) (branchDto: BranchDto) maxCount =
         task {
-            let queryLimit = if maxCount = 0 then 0 else Int32.MaxValue
-
-            let! references = getReferences branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context)
-            return! filterVisibleReferenceWindow context maxCount references
+            return!
+                getVisibleReferencesWithLoader context maxCount (fun queryLimit ->
+                    getReferences branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context))
         }
 
     /// Reads a typed branch reference window with hidden rows removed before max-count projection.
     let private getVisibleReferencesByType (context: HttpContext) (branchDto: BranchDto) referenceType maxCount =
         task {
-            let queryLimit = if maxCount = 0 then 0 else Int32.MaxValue
-
-            let! references = getReferencesByType referenceType branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context)
-            return! filterVisibleReferenceWindow context maxCount references
+            return!
+                getVisibleReferencesWithLoader context maxCount (fun queryLimit ->
+                    getReferencesByType referenceType branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context))
         }
 
     /// Selects the latest reference that remains observable after inherited branch visibility is applied.
@@ -1037,18 +1080,15 @@ module Branch =
     /// Builds latest reference buckets from visible rows only so hidden rows cannot occupy a requested type bucket.
     let private getLatestVisibleReferencesByTypes (context: HttpContext) (branchDto: BranchDto) (referenceTypes: ReferenceType array) =
         task {
-            let! references = getVisibleReferences context branchDto Int32.MaxValue
             let buckets = Dictionary<ReferenceType, Reference.ReferenceDto>()
 
             let mutable index = 0
 
             while index < referenceTypes.Length do
                 let referenceType = referenceTypes[index]
+                let! references = getVisibleReferencesByType context branchDto referenceType 1
 
-                references
-                    .Where(fun referenceDto -> referenceDto.ReferenceType = referenceType)
-                    .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
-                    .FirstOrDefault(Reference.ReferenceDto.Default)
+                references.FirstOrDefault(Reference.ReferenceDto.Default)
                 |> fun referenceDto ->
                     if referenceDto.ReferenceId <> ReferenceId.Empty then
                         buckets[referenceType] <- referenceDto
@@ -1067,6 +1107,75 @@ module Branch =
                 let! branchDto = loadReferenceBranch referenceDto (getCorrelationId context)
                 let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
                 return if isObservable then referenceDto else Reference.ReferenceDto.Default
+        }
+
+    /// Checks whether an observable reference's root directory owns the requested directory version.
+    let private referenceOwnsDirectoryVersion
+        (repositoryId: RepositoryId)
+        (correlationId: CorrelationId)
+        (targetDirectoryVersionId: DirectoryVersionId)
+        (referenceDto: Reference.ReferenceDto)
+        =
+        task {
+            if referenceDto.DirectoryId = targetDirectoryVersionId then
+                return true
+            else
+                let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
+                let! directoryVersionDtos = directoryActorProxy.GetRecursiveDirectoryVersions false correlationId
+
+                return directoryVersionDtos.Any(fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.DirectoryVersionId = targetDirectoryVersionId)
+        }
+
+    /// Finds an observable branch reference that owns a directory resolved by caller-supplied hash evidence.
+    let private tryFindObservableDirectoryOwnerReference (context: HttpContext) (branchDto: BranchDto) (targetDirectoryVersionId: DirectoryVersionId) =
+        task {
+            let correlationId = getCorrelationId context
+            let! references = getVisibleReferences context branchDto visibleReferenceMaxScanLimit
+            let mutable index = 0
+            let mutable ownerReference = Reference.ReferenceDto.Default
+
+            while index < references.Length
+                  && ownerReference.ReferenceId = ReferenceId.Empty do
+                let! ownsDirectory = referenceOwnsDirectoryVersion branchDto.RepositoryId correlationId targetDirectoryVersionId references[index]
+
+                if ownsDirectory then ownerReference <- references[index]
+
+                index <- index + 1
+
+            if ownerReference.ReferenceId = ReferenceId.Empty then
+                return None
+            else
+                return Some ownerReference
+        }
+
+    /// Resolves hash-addressed directory data only when the requested branch has an observable owning reference.
+    let private tryResolveObservableDirectoryVersionByHash
+        (context: HttpContext)
+        (actorProxy: IBranchActor)
+        (repositoryId: RepositoryId)
+        (sha256Hash: Sha256Hash)
+        (blake3Hash: Blake3Hash)
+        (resolveByHash: RepositoryId
+                            -> Sha256Hash
+                            -> Blake3Hash
+                            -> CorrelationId
+                            -> Task<Services.VersionHashPrefixResolution<Grace.Types.Common.DirectoryVersion>>)
+        =
+        task {
+            let correlationId = getCorrelationId context
+
+            match! resolveByHash repositoryId sha256Hash blake3Hash correlationId with
+            | Services.UniqueMatch directoryVersion ->
+                let! branchDto = actorProxy.Get correlationId
+                let! ownerReference = tryFindObservableDirectoryOwnerReference context branchDto directoryVersion.DirectoryVersionId
+
+                match ownerReference with
+                | Some _ -> return Some directoryVersion
+                | None -> return None
+            | Services.NoMatches -> return None
+            | Services.AmbiguousMatches _ ->
+                setAmbiguousBranchHashLookupError context sha256Hash blake3Hash correlationId
+                return None
         }
 
     /// Creates a new branch.
@@ -2757,22 +2866,20 @@ module Branch =
                                     return recursiveSize
                             else
                                 match!
-                                    Services.getDirectoryVersionResolutionByHashQuery
+                                    tryResolveObservableDirectoryVersionByHash
+                                        context
+                                        actorProxy
                                         graceIds.RepositoryId
                                         listContentsParameters.Sha256Hash
                                         listContentsParameters.Blake3Hash
-                                        correlationId
+                                        Services.getDirectoryVersionResolutionByHashQuery
                                     with
-                                | Services.UniqueMatch directoryVersion ->
+                                | Some directoryVersion ->
                                     let directoryActorProxy = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
 
                                     let! recursiveSize = directoryActorProxy.GetRecursiveSize correlationId
                                     return recursiveSize
-                                | Services.NoMatches -> return Constants.InitialDirectorySize
-                                | Services.AmbiguousMatches _ ->
-                                    setAmbiguousBranchHashLookupError context listContentsParameters.Sha256Hash listContentsParameters.Blake3Hash correlationId
-
-                                    return Constants.InitialDirectorySize
+                                | None -> return Constants.InitialDirectorySize
                         }
 
                     let! parameters = context |> parse<ListContentsParameters>
@@ -2874,23 +2981,21 @@ module Branch =
                                     return contents
                             else
                                 match!
-                                    Services.getRootDirectoryVersionResolutionByHashQuery
+                                    tryResolveObservableDirectoryVersionByHash
+                                        context
+                                        actorProxy
                                         graceIds.RepositoryId
                                         listContentsParameters.Sha256Hash
                                         listContentsParameters.Blake3Hash
-                                        correlationId
+                                        Services.getRootDirectoryVersionResolutionByHashQuery
                                     with
-                                | Services.UniqueMatch directoryVersion ->
+                                | Some directoryVersion ->
                                     let directoryActorProxy = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
 
                                     let! contents = directoryActorProxy.GetRecursiveDirectoryVersions listContentsParameters.ForceRecompute correlationId
 
                                     return contents
-                                | Services.NoMatches -> return Array.Empty<DirectoryVersion.DirectoryVersionDto>()
-                                | Services.AmbiguousMatches _ ->
-                                    setAmbiguousBranchHashLookupError context listContentsParameters.Sha256Hash listContentsParameters.Blake3Hash correlationId
-
-                                    return Array.Empty<DirectoryVersion.DirectoryVersionDto>()
+                                | None -> return Array.Empty<DirectoryVersion.DirectoryVersionDto>()
                         }
 
                     let! parameters = context |> parse<ListContentsParameters>
@@ -2951,12 +3056,14 @@ module Branch =
                 not (String.IsNullOrEmpty(parameters.Sha256Hash))
                 || not (String.IsNullOrEmpty(parameters.Blake3Hash))
             then
-                match! Services.getRootDirectoryVersionResolutionByHashQuery repositoryId parameters.Sha256Hash parameters.Blake3Hash correlationId with
-                | Services.UniqueMatch directoryVersion -> return Some directoryVersion
-                | Services.NoMatches -> return None
-                | Services.AmbiguousMatches _ ->
-                    setAmbiguousBranchHashLookupError context parameters.Sha256Hash parameters.Blake3Hash correlationId
-                    return None
+                return!
+                    tryResolveObservableDirectoryVersionByHash
+                        context
+                        actorProxy
+                        repositoryId
+                        parameters.Sha256Hash
+                        parameters.Blake3Hash
+                        Services.getRootDirectoryVersionResolutionByHashQuery
             elif
                 not
                 <| String.IsNullOrEmpty(parameters.ReferenceId)

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -971,20 +971,21 @@ module Branch =
             return! branchActorProxy.Get correlationId
         }
 
-    /// Filters a latest-first reference sequence before applying route limits, then restores the established response order.
-    let private filterVisibleReferenceWindow (context: HttpContext) maxCount (references: Reference.ReferenceDto seq) =
+    /// Orders non-deleted references newest-first so public windows can refill past deleted rows before applying MaxCount.
+    let internal activeReferencesLatestFirst (references: Reference.ReferenceDto seq) =
+        references
+            .Where(fun referenceDto -> referenceDto.DeletedAt.IsNone)
+            .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
+            .ToArray()
+
+    /// Filters references for one already-authorized branch without reloading branch authority for every returned row.
+    let internal filterVisibleReferenceWindowForBranch (context: HttpContext) (branchDto: BranchDto) maxCount (references: Reference.ReferenceDto seq) =
         task {
             if maxCount = 0 then
                 return Array.empty<Reference.ReferenceDto>
             else
-                let correlationId = getCorrelationId context
                 let visibleReferences = List<Reference.ReferenceDto>()
-
-                let latestFirst =
-                    references
-                        .Where(fun referenceDto -> referenceDto.DeletedAt.IsNone)
-                        .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
-                        .ToArray()
+                let latestFirst = activeReferencesLatestFirst references
 
                 let mutable index = 0
 
@@ -994,7 +995,6 @@ module Branch =
 
                 while keepScanning do
                     let referenceDto = latestFirst[index]
-                    let! branchDto = loadReferenceBranch referenceDto correlationId
                     let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
 
                     if isObservable then visibleReferences.Add referenceDto
@@ -1011,22 +1011,38 @@ module Branch =
                         .ToArray()
         }
 
+    /// Chooses the maximum bounded reference-history scan size for a public reference window.
+    let internal visibleReferenceScanLimitCap maxCount =
+        if maxCount < 0 then
+            Int32.MaxValue
+        else
+            Math.Max(visibleReferenceMaxScanLimit, maxCount)
+
     /// Chooses the first bounded reference-history scan size for a public reference window.
-    let private initialVisibleReferenceScanLimit maxCount =
+    let internal initialVisibleReferenceScanLimit maxCount =
         if maxCount <= 0 then
             0
         else
-            Math.Min(visibleReferenceMaxScanLimit, Math.Max(visibleReferenceInitialScanLimit, maxCount))
+            Math.Min(visibleReferenceScanLimitCap maxCount, Math.Max(visibleReferenceInitialScanLimit, maxCount))
 
     /// Chooses the next bounded reference-history scan size for a public reference window refill.
-    let private nextVisibleReferenceScanLimit currentLimit =
-        if currentLimit >= visibleReferenceMaxScanLimit then
+    let internal nextVisibleReferenceScanLimit maxCount currentLimit =
+        let scanLimitCap = visibleReferenceScanLimitCap maxCount
+
+        if currentLimit >= scanLimitCap then
             currentLimit
         else
-            Math.Min(visibleReferenceMaxScanLimit, currentLimit * 2)
+            let doubled = if currentLimit > Int32.MaxValue / 2 then Int32.MaxValue else currentLimit * 2
+
+            Math.Min(scanLimitCap, doubled)
 
     /// Reads and refills a bounded branch reference-history window before public max-count projection.
-    let private getVisibleReferencesWithLoader (context: HttpContext) maxCount (loadReferences: int -> Task<Reference.ReferenceDto array>) =
+    let private getVisibleReferencesWithLoader
+        (context: HttpContext)
+        (branchDto: BranchDto)
+        maxCount
+        (loadReferences: int -> Task<Reference.ReferenceDto array>)
+        =
         task {
             if maxCount <= 0 then
                 return Array.empty<Reference.ReferenceDto>
@@ -1039,10 +1055,10 @@ module Branch =
                 while keepScanning do
                     let! references = loadReferences queryLimit
                     lastFetchedCount <- references.Length
-                    let! filteredReferences = filterVisibleReferenceWindow context maxCount references
+                    let! filteredReferences = filterVisibleReferenceWindowForBranch context branchDto maxCount references
                     visibleReferences <- filteredReferences
 
-                    let nextQueryLimit = nextVisibleReferenceScanLimit queryLimit
+                    let nextQueryLimit = nextVisibleReferenceScanLimit maxCount queryLimit
 
                     keepScanning <-
                         filteredReferences.Length < maxCount
@@ -1058,7 +1074,7 @@ module Branch =
     let private getVisibleReferences (context: HttpContext) (branchDto: BranchDto) maxCount =
         task {
             return!
-                getVisibleReferencesWithLoader context maxCount (fun queryLimit ->
+                getVisibleReferencesWithLoader context branchDto maxCount (fun queryLimit ->
                     getReferences branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context))
         }
 
@@ -1066,7 +1082,7 @@ module Branch =
     let private getVisibleReferencesByType (context: HttpContext) (branchDto: BranchDto) referenceType maxCount =
         task {
             return!
-                getVisibleReferencesWithLoader context maxCount (fun queryLimit ->
+                getVisibleReferencesWithLoader context branchDto maxCount (fun queryLimit ->
                     getReferencesByType referenceType branchDto.RepositoryId branchDto.BranchId queryLimit (getCorrelationId context))
         }
 
@@ -1126,11 +1142,79 @@ module Branch =
                 return directoryVersionDtos.Any(fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.DirectoryVersionId = targetDirectoryVersionId)
         }
 
+    /// Checks whether a directory version satisfies the caller's optional SHA-256 and BLAKE3 prefix evidence.
+    let private directoryVersionMatchesHashQuery (sha256Hash: Sha256Hash) (blake3Hash: Blake3Hash) (directoryVersion: Grace.Types.Common.DirectoryVersion) =
+        let requestedSha256Hash = string sha256Hash
+        let requestedBlake3Hash = string blake3Hash
+
+        let shaMatches =
+            String.IsNullOrEmpty requestedSha256Hash
+            || (string directoryVersion.Sha256Hash)
+                .StartsWith(requestedSha256Hash, StringComparison.OrdinalIgnoreCase)
+
+        let blake3Matches =
+            String.IsNullOrEmpty requestedBlake3Hash
+            || (string directoryVersion.Blake3Hash)
+                .StartsWith(requestedBlake3Hash, StringComparison.OrdinalIgnoreCase)
+
+        shaMatches && blake3Matches
+
+    /// Checks whether a directory version is a root suitable for reference-root hash lookups.
+    let private isReferenceRootDirectoryVersion (directoryVersion: Grace.Types.Common.DirectoryVersion) =
+        directoryVersion.RelativePath = Constants.RootDirectoryPath
+        || directoryVersion.RelativePath = "/"
+
+    /// Resolves caller-supplied hash evidence only across directories owned by observable references in the requested branch.
+    let private resolveObservableDirectoryVersionByHash
+        (context: HttpContext)
+        (branchDto: BranchDto)
+        includeOnlyReferenceRoots
+        (sha256Hash: Sha256Hash)
+        (blake3Hash: Blake3Hash)
+        =
+        task {
+            let correlationId = getCorrelationId context
+            let! branchReferences = getReferences branchDto.RepositoryId branchDto.BranchId Int32.MaxValue correlationId
+            let! visibleReferences = filterVisibleReferenceWindowForBranch context branchDto -1 branchReferences
+            let matchesByDirectoryVersionId = Dictionary<DirectoryVersionId, Grace.Types.Common.DirectoryVersion>()
+            let mutable referenceIndex = 0
+
+            while referenceIndex < visibleReferences.Length do
+                let referenceDto = visibleReferences[referenceIndex]
+                let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId branchDto.RepositoryId correlationId
+                let! directoryVersionDtos = directoryActorProxy.GetRecursiveDirectoryVersions false correlationId
+                let mutable directoryIndex = 0
+
+                while directoryIndex < directoryVersionDtos.Length do
+                    let directoryVersion =
+                        directoryVersionDtos[directoryIndex]
+                            .DirectoryVersion
+
+                    if (not includeOnlyReferenceRoots
+                        || isReferenceRootDirectoryVersion directoryVersion)
+                       && directoryVersionMatchesHashQuery sha256Hash blake3Hash directoryVersion then
+                        matchesByDirectoryVersionId[directoryVersion.DirectoryVersionId] <- directoryVersion
+
+                    directoryIndex <- directoryIndex + 1
+
+                referenceIndex <- referenceIndex + 1
+
+            let matches = matchesByDirectoryVersionId.Values.ToArray()
+
+            match matches.Length with
+            | 0 -> return Services.NoMatches
+            | 1 -> return Services.UniqueMatch matches[0]
+            | _ -> return Services.AmbiguousMatches matches
+        }
+
     /// Finds an observable branch reference that owns a directory resolved by caller-supplied hash evidence.
     let private tryFindObservableDirectoryOwnerReference (context: HttpContext) (branchDto: BranchDto) (targetDirectoryVersionId: DirectoryVersionId) =
         task {
             let correlationId = getCorrelationId context
-            let! references = getVisibleReferences context branchDto visibleReferenceMaxScanLimit
+
+            let! branchReferences = getReferences branchDto.RepositoryId branchDto.BranchId Int32.MaxValue correlationId
+            let! references = filterVisibleReferenceWindowForBranch context branchDto -1 branchReferences
+
             let mutable index = 0
             let mutable ownerReference = Reference.ReferenceDto.Default
 
@@ -1152,21 +1236,16 @@ module Branch =
     let private tryResolveObservableDirectoryVersionByHash
         (context: HttpContext)
         (actorProxy: IBranchActor)
-        (repositoryId: RepositoryId)
         (sha256Hash: Sha256Hash)
         (blake3Hash: Blake3Hash)
-        (resolveByHash: RepositoryId
-                            -> Sha256Hash
-                            -> Blake3Hash
-                            -> CorrelationId
-                            -> Task<Services.VersionHashPrefixResolution<Grace.Types.Common.DirectoryVersion>>)
+        includeOnlyReferenceRoots
         =
         task {
             let correlationId = getCorrelationId context
+            let! branchDto = actorProxy.Get correlationId
 
-            match! resolveByHash repositoryId sha256Hash blake3Hash correlationId with
+            match! resolveObservableDirectoryVersionByHash context branchDto includeOnlyReferenceRoots sha256Hash blake3Hash with
             | Services.UniqueMatch directoryVersion ->
-                let! branchDto = actorProxy.Get correlationId
                 let! ownerReference = tryFindObservableDirectoryOwnerReference context branchDto directoryVersion.DirectoryVersionId
 
                 match ownerReference with
@@ -2869,10 +2948,9 @@ module Branch =
                                     tryResolveObservableDirectoryVersionByHash
                                         context
                                         actorProxy
-                                        graceIds.RepositoryId
                                         listContentsParameters.Sha256Hash
                                         listContentsParameters.Blake3Hash
-                                        Services.getDirectoryVersionResolutionByHashQuery
+                                        false
                                     with
                                 | Some directoryVersion ->
                                     let directoryActorProxy = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
@@ -2984,10 +3062,9 @@ module Branch =
                                     tryResolveObservableDirectoryVersionByHash
                                         context
                                         actorProxy
-                                        graceIds.RepositoryId
                                         listContentsParameters.Sha256Hash
                                         listContentsParameters.Blake3Hash
-                                        Services.getRootDirectoryVersionResolutionByHashQuery
+                                        true
                                     with
                                 | Some directoryVersion ->
                                     let directoryActorProxy = DirectoryVersion.CreateActorProxy directoryVersion.DirectoryVersionId repositoryId correlationId
@@ -3056,14 +3133,7 @@ module Branch =
                 not (String.IsNullOrEmpty(parameters.Sha256Hash))
                 || not (String.IsNullOrEmpty(parameters.Blake3Hash))
             then
-                return!
-                    tryResolveObservableDirectoryVersionByHash
-                        context
-                        actorProxy
-                        repositoryId
-                        parameters.Sha256Hash
-                        parameters.Blake3Hash
-                        Services.getRootDirectoryVersionResolutionByHashQuery
+                return! tryResolveObservableDirectoryVersionByHash context actorProxy parameters.Sha256Hash parameters.Blake3Hash true
             elif
                 not
                 <| String.IsNullOrEmpty(parameters.ReferenceId)


### PR DESCRIPTION
## Summary

- Applies branch/reference visibility filtering to branch read surfaces, direct reference lookup, reference buckets, latest-reference projection, diffs, `listContents`, `getRecursiveSize`, and `getVersion`.
- Stamps branch-inherited reference visibility metadata during reference creation, including the initial rebase path before the branch DTO has applied its `Created` event.
- Adds a focused server integration regression proving repository readers cannot observe private contributor branch references while branch-scoped `BranchAdmin` can.

## Related Issue

Related to #643.

## Why This Matters

The tracer proved one branch read path, but branch reference routes expose IDs, hashes, timestamps, latest values, and bucket membership. This slice closes those oracle surfaces by reusing the shared visibility helper from #642 and applying filtering before public reduction.

## Touched Paths

- `src/Grace.Actors/Branch.Actor.fs`
- `src/Grace.Server/Branch.Server.fs`
- `src/Grace.Server.Tests/Branch.Server.Tests.fs`

## Validation

- `dotnet tool run fantomas src\Grace.Server\Branch.Server.fs src\Grace.Actors\Branch.Actor.fs src\Grace.Server.Tests\Branch.Server.Tests.fs`: passed.
- `dotnet build --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~PrivateContributorBranchReferencesAreHiddenFromObserverAndVisibleToBranchAdmin"`: passed. The focused integration test logged Aspire cleanup cancellation messages during teardown, but NUnit reported the filtered test passed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.

## Review Status

- Current head: `9e954d49fde5af06891387aec74f002b4fe90f86`.
- Codex Code Review Bot state for current head: latest-head no-issues signal recorded with 👍🏻 on PR #663.
- GitHub Actions: `full` succeeded for current head in run `28904531856`, job `85748608267`.
- Merge state: clean against `epic/638-visibility-owned-branches`.
- Manual trigger decision: not attempted.
- Manual trigger lock: no manual trigger may be used while bot state is pending, acknowledged with eyes, completed with no-issues, or ambiguous. Use `pwsh ./scripts/guard-codex-review-trigger.ps1 -PullRequest 663` only if the documented missed-ack exception is reached.
- Prior fresh findings from head `789503e9250138f35ef7fff45f555d1569caacce`:
  - `PRRT_kwDOILVrb86Oy7V4`: fixed in `40fcbbe9`; replied and resolved.
  - `PRRT_kwDOILVrb86Oy7V9`: fixed in `40fcbbe9`; replied and resolved.
- Stabilization findings from head `40fcbbe9525c8a39ce46f4eaabf6da0896eba82b`:
  - `PRRT_kwDOILVrb86OzMRy`: fixed in `69d29896`; stabilization status map posted; replied and resolved.
  - `PRRT_kwDOILVrb86OzMR4`: fixed in `69d29896`; stabilization status map posted; replied and resolved.
  - `PRRT_kwDOILVrb86OzMR9`: fixed in `69d29896`; stabilization status map posted; replied and resolved.
  - `PRRT_kwDOILVrb86OzMR_`: fixed in `69d29896`; stabilization status map posted; replied and resolved.
  - `PRRT_kwDOILVrb86OzMSC`: fixed in `69d29896`; stabilization status map posted; replied and resolved.
- Validation failure from head `40fcbbe9525c8a39ce46f4eaabf6da0896eba82b`: fixed in `961827cb` by isolating full-profile hash tests from shared repository/default-branch state.
- Validation failure from head `69d298960c2bce09b4b67afa9d3238c7dc763843`: fixed in `9e954d49` by updating the visible-prefix ambiguity test to create more than one observable reference-owned root before expecting ambiguity. This was test-only and the stabilization status map remains accurate.
- Prior-head comments from `69d298960c2bce09b4b67afa9d3238c7dc763843` not repeated on the latest reviewed head:
  - `PRRT_kwDOILVrb86PEg8n`: resolved as stale/non-current-head review history; no code change was made for this thread.
  - `PRRT_kwDOILVrb86PEg8q`: resolved as stale/non-current-head review history; no code change was made for this thread.
  - `PRRT_kwDOILVrb86PEg8u`: resolved as stale/non-current-head review history; no code change was made for this thread.
  - `PRRT_kwDOILVrb86PEg8w`: resolved as stale/non-current-head review history; no code change was made for this thread.
- Substantive review cycle count: 2. Stabilization ledger posted and status map completed in `69d29896`; current-head no-issues gate is satisfied.
- Fix commits: `40fcbbe9525c8a39ce46f4eaabf6da0896eba82b`, `961827cba952eee8013ddebbc851b85920574b36`, `69d298960c2bce09b4b67afa9d3238c7dc763843`, `9e954d49fde5af06891387aec74f002b4fe90f86`.
- Final review-thread state: zero unresolved review threads.

## Docs Impact

No public docs changed. This slice changes server/actor visibility behavior without changing public DTO, CLI, SDK, OpenAPI, or generated-client shapes. Broader contract propagation remains owned by later #638 child issues.

## Residual Risk

`ReferenceDto` still has no visibility fields by contract, so this slice enforces reference visibility as inherited branch visibility and records inherited visibility facts in reference event metadata. Independent reference reveal/private-reference contracts remain future-scope.

`GetLatestReferencesByReferenceTypes` is protected in `Branch.Server.fs`, but the worker found no registered public route for that handler in the current endpoint/startup surface. Route registration was not added because that would expand beyond this issue-owned path set; future route-propagation work should revisit this if it becomes a public surface.
