### PR TITLE
Define projection artifact descriptor identity rules (#611)

### DIFF
--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -29,6 +29,21 @@ module MaterializationPlanTestData =
     /// Provides a deterministic cache entry key that does not imply a direct source URL.
     let cacheKey = "cache/materialization/11111111/root.zip"
 
+    /// Provides the canonical identity used by existing directory-version zip storage.
+    let directoryVersionZipIdentity = "Grace-ZipFiles/11111111-1111-1111-1111-111111111111.zip"
+
+    /// Provides the canonical identity used by existing recursive directory metadata storage.
+    let recursiveDirectoryMetadataIdentity = "11111111-1111-1111-1111-111111111111.msgpack"
+
+    /// Provides a deterministic byte length for projection artifact descriptor validation.
+    let projectionArtifactSize = 4096L
+
+    /// Provides a canonical lowercase SHA-256 hash value for root projection descriptor validation.
+    let projectionArtifactSha256Hash = Sha256Hash "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    /// Provides a canonical lowercase BLAKE3 hash value for root projection descriptor validation.
+    let projectionArtifactBlake3Hash = Blake3Hash "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
     /// Provides a canonical lowercase BLAKE3 manifest address for descriptor validation.
     let manifestAddress = ManifestAddress "5dd11fdb1534c0f1c4fecca3c07498f9b59a7dff26d69fe78e43f7ce50d90895"
 
@@ -41,21 +56,38 @@ module MaterializationPlanTestData =
     /// Provides a canonical lowercase BLAKE3 hash value for whole-file descriptor validation.
     let blake3Hash = Blake3Hash "89abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
 
+    /// Builds a root zip descriptor with explicit identity, represented root, size, and integrity.
+    let directoryVersionZip targetRoot source =
+        MaterializationArtifactDescriptor.DirectoryVersionZip(
+            targetRoot,
+            projectionArtifactSize,
+            Some projectionArtifactSha256Hash,
+            Some projectionArtifactBlake3Hash,
+            source
+        )
+
+    /// Builds a recursive metadata descriptor with explicit identity, represented root, size, and integrity.
+    let recursiveDirectoryMetadata targetRoot source =
+        MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+            targetRoot,
+            projectionArtifactSize,
+            Some projectionArtifactSha256Hash,
+            Some projectionArtifactBlake3Hash,
+            source
+        )
+
     /// Builds the V1 required target-root artifact descriptors for the supplied root.
     let rootArtifacts targetRoot =
         [
-            MaterializationArtifactDescriptor.DirectoryVersionZip(targetRoot, Some(MaterializationArtifactSource.CacheOnly cacheKey))
-            MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some(MaterializationArtifactSource.CacheOnly $"{cacheKey}/metadata"))
+            directoryVersionZip targetRoot (Some(MaterializationArtifactSource.CacheOnly cacheKey))
+            recursiveDirectoryMetadata targetRoot (Some(MaterializationArtifactSource.CacheOnly $"{cacheKey}/metadata"))
         ]
 
     /// Builds V1 target-root artifact descriptors that are compatible with direct materialization.
     let directRootArtifacts targetRoot =
         [
-            MaterializationArtifactDescriptor.DirectoryVersionZip(
-                targetRoot,
-                Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
-            )
-            MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(targetRoot, Some MaterializationArtifactSource.Deferred)
+            directoryVersionZip targetRoot (Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip"))
+            recursiveDirectoryMetadata targetRoot (Some MaterializationArtifactSource.Deferred)
         ]
 
     /// Builds a valid Materialization Plan with all current artifact descriptor kinds represented.
@@ -202,14 +234,12 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.CacheRequired,
                 MaterializationCacheSelection.Required,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
-                    )
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
-                    )
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip"))
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey))
                 ]
             )
 
@@ -224,14 +254,12 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.CacheRequired,
                 MaterializationCacheSelection.Bypass,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
-                    )
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some MaterializationArtifactSource.Deferred
-                    )
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip"))
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some MaterializationArtifactSource.Deferred)
                 ]
             )
 
@@ -273,7 +301,10 @@ type MaterializationPlanContractTests() =
             {
                 Class = nameof MaterializationArtifactDescriptor
                 ArtifactKind = MaterializationArtifactKind.WholeFileContent
+                CanonicalArtifactIdentity = None
+                RepresentedRootDirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
                 TargetRootDirectoryVersionId = MaterializationPlanTestData.targetRootDirectoryVersionId
+                SizeInBytes = None
                 RelativePath = None
                 Sha256Hash = None
                 Blake3Hash = None
@@ -287,6 +318,165 @@ type MaterializationPlanContractTests() =
 
         assertInvalid "Artifact RelativePath is required for WholeFileContent descriptors." result
         assertInvalid "Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors." result
+
+    /// Verifies that root projection artifacts use deterministic identities instead of retrieval locations.
+    [<Test>]
+    member _.ProjectionArtifactsBuildCanonicalIdentityForRepresentedRoot() =
+        let zip =
+            MaterializationPlanTestData.directoryVersionZip
+                MaterializationPlanTestData.targetRootDirectoryVersionId
+                (Some(MaterializationArtifactSource.Direct "https://cache.example.test/transient/downloads/root.zip?token=abc"))
+
+        let metadata =
+            MaterializationPlanTestData.recursiveDirectoryMetadata
+                MaterializationPlanTestData.targetRootDirectoryVersionId
+                (Some(MaterializationArtifactSource.CacheOnly "cache/temporary/metadata-entry"))
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(zip.CanonicalArtifactIdentity, Is.EqualTo(Some MaterializationPlanTestData.directoryVersionZipIdentity))
+                Assert.That(metadata.CanonicalArtifactIdentity, Is.EqualTo(Some MaterializationPlanTestData.recursiveDirectoryMetadataIdentity))
+                Assert.That(zip.RepresentedRootDirectoryVersionId, Is.EqualTo(Some MaterializationPlanTestData.targetRootDirectoryVersionId))
+                Assert.That(metadata.RepresentedRootDirectoryVersionId, Is.EqualTo(Some MaterializationPlanTestData.targetRootDirectoryVersionId))
+                Assert.That(zip.SizeInBytes, Is.EqualTo(Some MaterializationPlanTestData.projectionArtifactSize))
+                Assert.That(metadata.SizeInBytes, Is.EqualTo(Some MaterializationPlanTestData.projectionArtifactSize))
+                Assert.That(zip.CanonicalArtifactIdentity, Is.Not.EqualTo(zip.Source.Value.DirectUri))
+                Assert.That(metadata.CanonicalArtifactIdentity, Is.Not.EqualTo(metadata.Source.Value.CacheKey))
+                assertValid (Validation.validateArtifactDescriptor zip)
+                assertValid (Validation.validateArtifactDescriptor metadata))
+        )
+
+    /// Verifies that projection artifact identity must match the represented root and existing storage naming.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip,
+               "https://cache.example.test/transient/downloads/root.zip",
+               "Artifact CanonicalArtifactIdentity must be Grace-ZipFiles/11111111-1111-1111-1111-111111111111.zip for DirectoryVersionZip descriptors.")>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata,
+               "Grace-ZipFiles/22222222-2222-2222-2222-222222222222.zip",
+               "Artifact CanonicalArtifactIdentity must be 11111111-1111-1111-1111-111111111111.msgpack for RecursiveDirectoryMetadata descriptors.")>]
+    member _.ProjectionArtifactsRejectMismatchedCanonicalIdentity(kind: MaterializationArtifactKind, artifactIdentity: string, expected: string) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                { MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    CanonicalArtifactIdentity = Some artifactIdentity
+                }
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                { MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    CanonicalArtifactIdentity = Some artifactIdentity
+                }
+            | _ -> failwith "Unsupported projection artifact kind."
+
+        assertInvalid expected (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that projection artifacts cannot omit represented root, byte length, or integrity.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip)>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata)>]
+    member _.ProjectionArtifactsRejectMissingRepresentedRootSizeAndIntegrity(kind: MaterializationArtifactKind) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                { MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    RepresentedRootDirectoryVersionId = None
+                    SizeInBytes = None
+                    Sha256Hash = None
+                    Blake3Hash = None
+                }
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                { MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    RepresentedRootDirectoryVersionId = None
+                    SizeInBytes = None
+                    Sha256Hash = None
+                    Blake3Hash = None
+                }
+            | _ -> failwith "Unsupported projection artifact kind."
+
+        let result = Validation.validateArtifactDescriptor descriptor
+
+        assertInvalid $"Artifact RepresentedRootDirectoryVersionId is required for {string kind} descriptors." result
+        assertInvalid $"Artifact SizeInBytes is required for {string kind} descriptors." result
+        assertInvalid $"Artifact Sha256Hash or Blake3Hash is required for {string kind} descriptors." result
+
+    /// Verifies that projection artifacts cannot rely on byte length without integrity evidence.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip)>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata)>]
+    member _.ProjectionArtifactsRejectSizeOnlyIntegrity(kind: MaterializationArtifactKind) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                { MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    Sha256Hash = None
+                    Blake3Hash = None
+                }
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                { MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    Sha256Hash = None
+                    Blake3Hash = None
+                }
+            | _ -> failwith "Unsupported projection artifact kind."
+
+        assertInvalid $"Artifact Sha256Hash or Blake3Hash is required for {string kind} descriptors." (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that projection artifacts reject metadata that names a different represented root.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip)>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata)>]
+    member _.ProjectionArtifactsRejectRepresentedRootMismatch(kind: MaterializationArtifactKind) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                { MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    RepresentedRootDirectoryVersionId = Some MaterializationPlanTestData.otherDirectoryVersionId
+                }
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                { MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    RepresentedRootDirectoryVersionId = Some MaterializationPlanTestData.otherDirectoryVersionId
+                }
+            | _ -> failwith "Unsupported projection artifact kind."
+
+        assertInvalid "Artifact RepresentedRootDirectoryVersionId must match TargetRootDirectoryVersionId." (Validation.validateArtifactDescriptor descriptor)
+
+    /// Verifies that projection artifact integrity uses the same canonical lowercase digest rules as file content.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip, true, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")>]
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip, false, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbg")>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata, true, "")>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata, false, "bbbbbbbbbbbbbbbb")>]
+    member _.ProjectionArtifactsRejectMalformedIntegrity(kind: MaterializationArtifactKind, evaluateSha256: bool, malformedHash: string) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None
+            | _ -> failwith "Unsupported projection artifact kind."
+
+        let malformedDescriptor =
+            if evaluateSha256 then
+                { descriptor with Sha256Hash = Some(Sha256Hash malformedHash) }
+            else
+                { descriptor with Blake3Hash = Some(Blake3Hash malformedHash) }
+
+        let expected =
+            if evaluateSha256 then
+                $"Artifact Sha256Hash must be a canonical lowercase 64-character hexadecimal value for {string kind} descriptors."
+            else
+                $"Artifact Blake3Hash must be a canonical lowercase 64-character hexadecimal value for {string kind} descriptors."
+
+        assertInvalid expected (Validation.validateArtifactDescriptor malformedDescriptor)
+
+    /// Verifies that projection artifact size must be a concrete non-negative byte length.
+    [<TestCase(MaterializationArtifactKind.DirectoryVersionZip)>]
+    [<TestCase(MaterializationArtifactKind.RecursiveDirectoryMetadata)>]
+    member _.ProjectionArtifactsRejectNegativeSize(kind: MaterializationArtifactKind) =
+        let descriptor =
+            match kind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                { MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None with SizeInBytes = Some -1L }
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                { MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None with
+                    SizeInBytes = Some -1L
+                }
+            | _ -> failwith "Unsupported projection artifact kind."
+
+        assertInvalid $"Artifact SizeInBytes must be non-negative for {string kind} descriptors." (Validation.validateArtifactDescriptor descriptor)
 
     /// Verifies that CAS artifact descriptors require StoragePoolId.
     [<TestCase(MaterializationArtifactKind.FileManifest)>]
@@ -323,16 +513,14 @@ type MaterializationPlanContractTests() =
         let descriptor =
             match kind with
             | MaterializationArtifactKind.DirectoryVersionZip ->
-                MaterializationArtifactDescriptor.DirectoryVersionZip(MaterializationPlanTestData.targetRootDirectoryVersionId, None)
+                MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None
             | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
-                MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(MaterializationPlanTestData.targetRootDirectoryVersionId, None)
+                MaterializationPlanTestData.recursiveDirectoryMetadata MaterializationPlanTestData.targetRootDirectoryVersionId None
             | _ -> failwith "Unsupported test kind."
 
         let ambiguousDescriptor =
             { descriptor with
                 RelativePath = Some(RelativePath "src/app.fs")
-                Sha256Hash = Some(Sha256Hash "sha256-file")
-                Blake3Hash = Some(Blake3Hash "blake3-file")
                 ManifestAddress = Some(ManifestAddress "manifest-blake3-abc123")
                 ContentBlockAddress = Some(ContentBlockAddress "block-blake3-def456")
                 StoragePoolId = Some MaterializationPlanTestData.storagePoolId
@@ -341,8 +529,6 @@ type MaterializationPlanContractTests() =
         let result = Validation.validateArtifactDescriptor ambiguousDescriptor
 
         assertInvalid $"Artifact RelativePath must be empty for {string kind} descriptors." result
-        assertInvalid $"Artifact Sha256Hash must be empty for {string kind} descriptors." result
-        assertInvalid $"Artifact Blake3Hash must be empty for {string kind} descriptors." result
         assertInvalid $"Artifact ManifestAddress must be empty for {string kind} descriptors." result
         assertInvalid $"Artifact ContentBlockAddress must be empty for {string kind} descriptors." result
         assertInvalid $"Artifact StoragePoolId must be empty for {string kind} descriptors." result
@@ -444,10 +630,9 @@ type MaterializationPlanContractTests() =
     [<Test>]
     member _.InvalidArtifactKindValueFailsValidationClearly() =
         let descriptor =
-            MaterializationArtifactDescriptor.DirectoryVersionZip(
-                MaterializationPlanTestData.targetRootDirectoryVersionId,
-                Some MaterializationArtifactSource.Deferred
-            )
+            MaterializationPlanTestData.directoryVersionZip
+                MaterializationPlanTestData.targetRootDirectoryVersionId
+                (Some MaterializationArtifactSource.Deferred)
 
         let invalidDescriptor = { descriptor with ArtifactKind = enum<MaterializationArtifactKind> 999 }
 
@@ -512,10 +697,9 @@ type MaterializationPlanContractTests() =
     [<Test>]
     member _.UnknownArtifactKindStringFailsDeserializationClearly() =
         let descriptor =
-            MaterializationArtifactDescriptor.DirectoryVersionZip(
-                MaterializationPlanTestData.targetRootDirectoryVersionId,
-                Some MaterializationArtifactSource.Deferred
-            )
+            MaterializationPlanTestData.directoryVersionZip
+                MaterializationPlanTestData.targetRootDirectoryVersionId
+                (Some MaterializationArtifactSource.Deferred)
 
         let json =
             (serialize descriptor)
@@ -544,10 +728,9 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.Direct,
                 MaterializationCacheSelection.Bypass,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some MaterializationArtifactSource.Deferred
-                    )
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some MaterializationArtifactSource.Deferred)
                 ]
             )
 
@@ -562,10 +745,9 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.Direct,
                 MaterializationCacheSelection.Bypass,
                 [
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some MaterializationArtifactSource.Deferred
-                    )
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some MaterializationArtifactSource.Deferred)
                 ]
             )
 
@@ -581,10 +763,9 @@ type MaterializationPlanContractTests() =
                 MaterializationCacheSelection.Bypass,
                 [
                     yield! MaterializationPlanTestData.rootArtifacts MaterializationPlanTestData.targetRootDirectoryVersionId
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.otherDirectoryVersionId,
-                        Some MaterializationArtifactSource.Deferred
-                    )
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.otherDirectoryVersionId
+                        (Some MaterializationArtifactSource.Deferred)
                 ]
             )
 
@@ -993,14 +1174,12 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.Direct,
                 MaterializationCacheSelection.Bypass,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
-                    )
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some MaterializationArtifactSource.Deferred
-                    )
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey))
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some MaterializationArtifactSource.Deferred)
                 ]
             )
 
@@ -1159,11 +1338,10 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.CacheRequired,
                 MaterializationCacheSelection.Required,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(MaterializationPlanTestData.targetRootDirectoryVersionId, None)
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
-                    )
+                    MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId None
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey))
                 ]
             )
 
@@ -1185,11 +1363,10 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.CacheRequired,
                 MaterializationCacheSelection.Required,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(MaterializationPlanTestData.targetRootDirectoryVersionId, Some source)
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey)
-                    )
+                    MaterializationPlanTestData.directoryVersionZip MaterializationPlanTestData.targetRootDirectoryVersionId (Some source)
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.CacheOnly MaterializationPlanTestData.cacheKey))
                 ]
             )
 
@@ -1342,22 +1519,18 @@ type MaterializationPlanContractTests() =
                 MaterializationExecutionMode.Direct,
                 MaterializationCacheSelection.Bypass,
                 [
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip")
-                    )
-                    MaterializationArtifactDescriptor.DirectoryVersionZip(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root-copy.zip")
-                    )
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some MaterializationArtifactSource.Deferred
-                    )
-                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
-                        MaterializationPlanTestData.targetRootDirectoryVersionId,
-                        Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/metadata.json")
-                    )
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root.zip"))
+                    MaterializationPlanTestData.directoryVersionZip
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/root-copy.zip"))
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some MaterializationArtifactSource.Deferred)
+                    MaterializationPlanTestData.recursiveDirectoryMetadata
+                        MaterializationPlanTestData.targetRootDirectoryVersionId
+                        (Some(MaterializationArtifactSource.Direct "https://cache.example.test/artifacts/metadata.json"))
                 ]
             )
 

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -43,6 +43,33 @@ module MaterializationPlan =
         | CacheEntry = 2
         | Deferred = 3
 
+    /// Builds the canonical artifact identity for the zip projection of a represented directory root.
+    let canonicalDirectoryVersionZipIdentity (representedRootDirectoryVersionId: DirectoryVersionId) =
+        $"{Constants.GraceZipFilesFolderName}/{representedRootDirectoryVersionId}.zip"
+
+    /// Builds the canonical artifact identity for the recursive metadata projection of a represented directory root.
+    let canonicalRecursiveDirectoryMetadataIdentity (representedRootDirectoryVersionId: DirectoryVersionId) = $"{representedRootDirectoryVersionId}.msgpack"
+
+    /// Builds the canonical descriptor identity for whole-file bytes under one represented root.
+    let canonicalWholeFileContentIdentity (representedRootDirectoryVersionId: DirectoryVersionId) (relativePath: RelativePath) =
+        $"whole-file/{representedRootDirectoryVersionId}/{relativePath}"
+
+    /// Builds the canonical descriptor identity for a manifest-backed artifact under one represented root.
+    let canonicalFileManifestIdentity
+        (representedRootDirectoryVersionId: DirectoryVersionId)
+        (storagePoolId: StoragePoolId)
+        (manifestAddress: ManifestAddress)
+        =
+        $"file-manifest/{representedRootDirectoryVersionId}/{storagePoolId}/{manifestAddress}"
+
+    /// Builds the canonical descriptor identity for a content block artifact under one represented root.
+    let canonicalContentBlockIdentity
+        (representedRootDirectoryVersionId: DirectoryVersionId)
+        (storagePoolId: StoragePoolId)
+        (contentBlockAddress: ContentBlockAddress)
+        =
+        $"content-block/{representedRootDirectoryVersionId}/{storagePoolId}/{contentBlockAddress}"
+
     /// Selects a target before server-side resolution to one immutable root DirectoryVersionId.
     [<CLIMutable; GenerateSerializer>]
     type MaterializationTargetSelector =
@@ -148,7 +175,10 @@ module MaterializationPlan =
         {
             Class: string
             ArtifactKind: MaterializationArtifactKind
+            CanonicalArtifactIdentity: string option
+            RepresentedRootDirectoryVersionId: DirectoryVersionId option
             TargetRootDirectoryVersionId: DirectoryVersionId
+            SizeInBytes: int64 option
             RelativePath: RelativePath option
             Sha256Hash: Sha256Hash option
             Blake3Hash: Blake3Hash option
@@ -159,14 +189,24 @@ module MaterializationPlan =
         }
 
         /// Describes the target-root zip artifact for a resolved immutable directory root.
-        static member DirectoryVersionZip(targetRootDirectoryVersionId: DirectoryVersionId, source: MaterializationArtifactSource option) =
+        static member DirectoryVersionZip
+            (
+                targetRootDirectoryVersionId: DirectoryVersionId,
+                sizeInBytes: int64,
+                sha256Hash: Sha256Hash option,
+                blake3Hash: Blake3Hash option,
+                source: MaterializationArtifactSource option
+            ) =
             {
                 Class = nameof MaterializationArtifactDescriptor
                 ArtifactKind = MaterializationArtifactKind.DirectoryVersionZip
+                CanonicalArtifactIdentity = Some(canonicalDirectoryVersionZipIdentity targetRootDirectoryVersionId)
+                RepresentedRootDirectoryVersionId = Some targetRootDirectoryVersionId
                 TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                SizeInBytes = Some sizeInBytes
                 RelativePath = None
-                Sha256Hash = None
-                Blake3Hash = None
+                Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
                 ManifestAddress = None
                 ContentBlockAddress = None
                 StoragePoolId = None
@@ -174,14 +214,24 @@ module MaterializationPlan =
             }
 
         /// Describes recursive metadata for the same immutable target root as the plan response.
-        static member RecursiveDirectoryMetadata(targetRootDirectoryVersionId: DirectoryVersionId, source: MaterializationArtifactSource option) =
+        static member RecursiveDirectoryMetadata
+            (
+                targetRootDirectoryVersionId: DirectoryVersionId,
+                sizeInBytes: int64,
+                sha256Hash: Sha256Hash option,
+                blake3Hash: Blake3Hash option,
+                source: MaterializationArtifactSource option
+            ) =
             {
                 Class = nameof MaterializationArtifactDescriptor
                 ArtifactKind = MaterializationArtifactKind.RecursiveDirectoryMetadata
+                CanonicalArtifactIdentity = Some(canonicalRecursiveDirectoryMetadataIdentity targetRootDirectoryVersionId)
+                RepresentedRootDirectoryVersionId = Some targetRootDirectoryVersionId
                 TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                SizeInBytes = Some sizeInBytes
                 RelativePath = None
-                Sha256Hash = None
-                Blake3Hash = None
+                Sha256Hash = sha256Hash
+                Blake3Hash = blake3Hash
                 ManifestAddress = None
                 ContentBlockAddress = None
                 StoragePoolId = None
@@ -200,7 +250,10 @@ module MaterializationPlan =
             {
                 Class = nameof MaterializationArtifactDescriptor
                 ArtifactKind = MaterializationArtifactKind.WholeFileContent
+                CanonicalArtifactIdentity = Some(canonicalWholeFileContentIdentity targetRootDirectoryVersionId relativePath)
+                RepresentedRootDirectoryVersionId = Some targetRootDirectoryVersionId
                 TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                SizeInBytes = None
                 RelativePath = Some relativePath
                 Sha256Hash = sha256Hash
                 Blake3Hash = blake3Hash
@@ -221,7 +274,10 @@ module MaterializationPlan =
             {
                 Class = nameof MaterializationArtifactDescriptor
                 ArtifactKind = MaterializationArtifactKind.FileManifest
+                CanonicalArtifactIdentity = Some(canonicalFileManifestIdentity targetRootDirectoryVersionId storagePoolId manifestAddress)
+                RepresentedRootDirectoryVersionId = Some targetRootDirectoryVersionId
                 TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                SizeInBytes = None
                 RelativePath = None
                 Sha256Hash = None
                 Blake3Hash = None
@@ -242,7 +298,10 @@ module MaterializationPlan =
             {
                 Class = nameof MaterializationArtifactDescriptor
                 ArtifactKind = MaterializationArtifactKind.ContentBlock
+                CanonicalArtifactIdentity = Some(canonicalContentBlockIdentity targetRootDirectoryVersionId storagePoolId contentBlockAddress)
+                RepresentedRootDirectoryVersionId = Some targetRootDirectoryVersionId
                 TargetRootDirectoryVersionId = targetRootDirectoryVersionId
+                SizeInBytes = None
                 RelativePath = None
                 Sha256Hash = None
                 Blake3Hash = None
@@ -503,22 +562,56 @@ module MaterializationPlan =
                 if descriptor.TargetRootDirectoryVersionId = DirectoryVersionId.Empty then
                     errors.Add("Artifact TargetRootDirectoryVersionId is required.")
 
+            let requireRepresentedRoot artifactKind =
+                match descriptor.RepresentedRootDirectoryVersionId with
+                | Some representedRootDirectoryVersionId when representedRootDirectoryVersionId = DirectoryVersionId.Empty ->
+                    errors.Add($"Artifact RepresentedRootDirectoryVersionId is required for {artifactKind} descriptors.")
+                | Some representedRootDirectoryVersionId when representedRootDirectoryVersionId = descriptor.TargetRootDirectoryVersionId -> ()
+                | Some _ -> errors.Add("Artifact RepresentedRootDirectoryVersionId must match TargetRootDirectoryVersionId.")
+                | None -> errors.Add($"Artifact RepresentedRootDirectoryVersionId is required for {artifactKind} descriptors.")
+
+            let requireCanonicalArtifactIdentity expected artifactKind =
+                match descriptor.CanonicalArtifactIdentity with
+                | Some artifactIdentity when String.Equals(artifactIdentity, expected, StringComparison.Ordinal) -> ()
+                | Some _ -> errors.Add($"Artifact CanonicalArtifactIdentity must be {expected} for {artifactKind} descriptors.")
+                | None -> errors.Add($"Artifact CanonicalArtifactIdentity is required for {artifactKind} descriptors.")
+
+            let validateOptionalSize artifactKind =
+                match descriptor.SizeInBytes with
+                | Some sizeInBytes when sizeInBytes >= 0L -> ()
+                | Some _ -> errors.Add($"Artifact SizeInBytes must be non-negative for {artifactKind} descriptors.")
+                | None -> ()
+
+            let requireSize artifactKind =
+                match descriptor.SizeInBytes with
+                | Some sizeInBytes when sizeInBytes >= 0L -> ()
+                | Some _ -> errors.Add($"Artifact SizeInBytes must be non-negative for {artifactKind} descriptors.")
+                | None -> errors.Add($"Artifact SizeInBytes is required for {artifactKind} descriptors.")
+
             let requireStoragePool () =
                 match descriptor.StoragePoolId with
                 | Some storagePoolId when not (String.IsNullOrWhiteSpace storagePoolId) -> ()
                 | _ -> errors.Add("Artifact StoragePoolId is required for CAS artifact descriptors.")
 
-            let requireCanonicalSha256Hash () =
+            let requireCanonicalSha256Hash artifactKind =
                 match descriptor.Sha256Hash with
                 | Some sha256Hash when isCanonicalLowercaseHexAddress sha256Hash -> ()
-                | Some _ -> errors.Add("Artifact Sha256Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors.")
+                | Some _ -> errors.Add($"Artifact Sha256Hash must be a canonical lowercase 64-character hexadecimal value for {artifactKind} descriptors.")
                 | None -> ()
 
-            let requireCanonicalBlake3Hash () =
+            let requireCanonicalBlake3Hash artifactKind =
                 match descriptor.Blake3Hash with
                 | Some blake3Hash when isCanonicalLowercaseHexAddress blake3Hash -> ()
-                | Some _ -> errors.Add("Artifact Blake3Hash must be a canonical lowercase 64-character hexadecimal value for WholeFileContent descriptors.")
+                | Some _ -> errors.Add($"Artifact Blake3Hash must be a canonical lowercase 64-character hexadecimal value for {artifactKind} descriptors.")
                 | None -> ()
+
+            let requireAnyIntegrity artifactKind =
+                requireCanonicalSha256Hash artifactKind
+                requireCanonicalBlake3Hash artifactKind
+
+                if descriptor.Sha256Hash.IsNone
+                   && descriptor.Blake3Hash.IsNone then
+                    errors.Add($"Artifact Sha256Hash or Blake3Hash is required for {artifactKind} descriptors.")
 
             let rejectRelativePath artifactKind =
                 if descriptor.RelativePath.IsSome then
@@ -545,7 +638,6 @@ module MaterializationPlan =
 
             let rejectNonRootDescriptorIdentity artifactKind =
                 rejectRelativePath artifactKind
-                rejectHashes artifactKind
                 rejectManifestAddress artifactKind
                 rejectContentBlockAddress artifactKind
                 rejectStoragePool artifactKind
@@ -560,47 +652,76 @@ module MaterializationPlan =
                 if not (isSupportedArtifactKind descriptor.ArtifactKind) then
                     errors.Add($"ArtifactKind '{int descriptor.ArtifactKind}' is not supported.")
                 else
+                    let artifactKind = string descriptor.ArtifactKind
+
+                    requireTargetRoot ()
+                    requireRepresentedRoot artifactKind
+
                     match descriptor.ArtifactKind with
-                    | MaterializationArtifactKind.DirectoryVersionZip
+                    | MaterializationArtifactKind.DirectoryVersionZip ->
+                        let expectedIdentity = canonicalDirectoryVersionZipIdentity descriptor.TargetRootDirectoryVersionId
+
+                        requireCanonicalArtifactIdentity expectedIdentity artifactKind
+                        requireSize artifactKind
+                        requireAnyIntegrity artifactKind
+                        rejectNonRootDescriptorIdentity artifactKind
                     | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
-                        requireTargetRoot ()
-                        rejectNonRootDescriptorIdentity (string descriptor.ArtifactKind)
+                        let expectedIdentity = canonicalRecursiveDirectoryMetadataIdentity descriptor.TargetRootDirectoryVersionId
+
+                        requireCanonicalArtifactIdentity expectedIdentity artifactKind
+                        requireSize artifactKind
+                        requireAnyIntegrity artifactKind
+                        rejectNonRootDescriptorIdentity artifactKind
                     | MaterializationArtifactKind.WholeFileContent ->
-                        requireTargetRoot ()
+                        validateOptionalSize artifactKind
+
+                        match descriptor.RelativePath with
+                        | Some relativePath ->
+                            requireCanonicalArtifactIdentity
+                                (canonicalWholeFileContentIdentity descriptor.TargetRootDirectoryVersionId relativePath)
+                                artifactKind
+                        | None -> ()
 
                         match descriptor.RelativePath with
                         | Some relativePath when isNormalizedRepositoryRelativePath relativePath -> ()
                         | Some _ -> errors.Add("Artifact RelativePath must be a normalized repository-relative path for WholeFileContent descriptors.")
                         | _ -> errors.Add("Artifact RelativePath is required for WholeFileContent descriptors.")
 
-                        requireCanonicalSha256Hash ()
-                        requireCanonicalBlake3Hash ()
+                        requireAnyIntegrity artifactKind
 
-                        if descriptor.Sha256Hash.IsNone
-                           && descriptor.Blake3Hash.IsNone then
-                            errors.Add("Artifact Sha256Hash or Blake3Hash is required for WholeFileContent descriptors.")
-
-                        rejectManifestAddress (string descriptor.ArtifactKind)
-                        rejectContentBlockAddress (string descriptor.ArtifactKind)
-                        rejectStoragePool (string descriptor.ArtifactKind)
+                        rejectManifestAddress artifactKind
+                        rejectContentBlockAddress artifactKind
+                        rejectStoragePool artifactKind
                     | MaterializationArtifactKind.FileManifest ->
-                        requireTargetRoot ()
+                        validateOptionalSize artifactKind
 
                         match descriptor.ManifestAddress with
-                        | Some manifestAddress when isCanonicalLowercaseHexAddress manifestAddress -> ()
+                        | Some manifestAddress when isCanonicalLowercaseHexAddress manifestAddress ->
+                            match descriptor.StoragePoolId with
+                            | Some storagePoolId when not (String.IsNullOrWhiteSpace storagePoolId) ->
+                                requireCanonicalArtifactIdentity
+                                    (canonicalFileManifestIdentity descriptor.TargetRootDirectoryVersionId storagePoolId manifestAddress)
+                                    artifactKind
+                            | _ -> ()
                         | Some _ ->
                             errors.Add("Artifact ManifestAddress must be a canonical lowercase 64-character hexadecimal value for FileManifest descriptors.")
                         | _ -> errors.Add("Artifact ManifestAddress is required for FileManifest descriptors.")
 
                         requireStoragePool ()
-                        rejectRelativePath (string descriptor.ArtifactKind)
-                        rejectHashes (string descriptor.ArtifactKind)
-                        rejectContentBlockAddress (string descriptor.ArtifactKind)
+                        rejectRelativePath artifactKind
+                        rejectHashes artifactKind
+                        rejectContentBlockAddress artifactKind
                     | MaterializationArtifactKind.ContentBlock ->
-                        requireTargetRoot ()
+                        validateOptionalSize artifactKind
 
                         match descriptor.ContentBlockAddress with
-                        | Some contentBlockAddress when isCanonicalLowercaseHexAddress contentBlockAddress -> ()
+                        | Some contentBlockAddress when isCanonicalLowercaseHexAddress contentBlockAddress ->
+                            match descriptor.StoragePoolId with
+                            | Some storagePoolId when not (String.IsNullOrWhiteSpace storagePoolId) ->
+                                requireCanonicalArtifactIdentity
+                                    (canonicalContentBlockIdentity descriptor.TargetRootDirectoryVersionId storagePoolId contentBlockAddress)
+                                    artifactKind
+                            | _ -> ()
                         | Some _ ->
                             errors.Add(
                                 "Artifact ContentBlockAddress must be a canonical lowercase 64-character hexadecimal value for ContentBlock descriptors."
@@ -608,9 +729,9 @@ module MaterializationPlan =
                         | _ -> errors.Add("Artifact ContentBlockAddress is required for ContentBlock descriptors.")
 
                         requireStoragePool ()
-                        rejectRelativePath (string descriptor.ArtifactKind)
-                        rejectHashes (string descriptor.ArtifactKind)
-                        rejectManifestAddress (string descriptor.ArtifactKind)
+                        rejectRelativePath artifactKind
+                        rejectHashes artifactKind
+                        rejectManifestAddress artifactKind
                     | _ -> errors.Add($"ArtifactKind '{int descriptor.ArtifactKind}' is not supported.")
 
                 match descriptor.Source with


### PR DESCRIPTION
## Summary

- Defines canonical projection artifact descriptor identity for `DirectoryVersionZip` and `RecursiveDirectoryMetadata` artifacts.
- Requires represented root, canonical identity, size, and integrity for projection descriptors at the shared contract seam.
- Adds focused contract tests for deterministic identities, mismatch rejection, missing fields, malformed integrity, and source-is-not-identity behavior.

## Why This Matters

Descriptor identity is the contract that later server, SDK, CLI, and cache slices will trust. Keeping retrieval locations separate from artifact identity prevents later agents from accepting a zip or metadata artifact for the wrong root just because it came from a plausible source.

## Related Issue

Related to #611. Part of #599 and #597.

## Validation

- Passed: `dotnet tool run fantomas src/Grace.Types/MaterializationPlan.Types.fs src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs`.
- Passed: `dotnet test --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj --filter FullyQualifiedName~MaterializationPlanContractTests` (`125/125`).
- Passed: `git diff --check`.
- Passed: `pwsh ./scripts/validate.ps1 -Fast`.

## Contract Propagation

- `Grace.Types` DTOs/validators: updated projection artifact descriptors with canonical identity, represented root, size, and integrity validation.
- `Grace.Shared` parameters/helpers: N/A; no shared helper surface was needed for this contract-only slice.
- Server routes/validation/auth/error envelopes: N/A; server route generation is owned by later #599 leaves.
- CLI parser/output/help/examples: N/A; `grace connect` behavior is unchanged in #611.
- SDK/generated clients: N/A; no route or generated client surface exists yet for these DTOs.
- OpenAPI/static generated artifacts: N/A; no endpoint/component generation was required by this leaf.
- Events/webhooks/SignalR/watch/search/projections: N/A; no runtime publication or durable event shape was added.
- Tests: updated in `Grace.Types.Tests`.

## Stale Authority

Runtime stale-authority handling is N/A for this contract-only slice because no materialization read, mutation, cache lookup, publication, or extraction behavior was added. The represented-root invariant is enforced by `MaterializationPlan.Validation.validatePlan` before later runtime slices consume descriptors.

## Review Status

- Codex Code Review Bot completed review on `f7fcd97044c53b94f34446d9ef8c792b9232b517` and reported no major issues.
- GitHub Actions `full` passed on `f7fcd97044c53b94f34446d9ef8c792b9232b517` in run `28851700962`.
- Worker validation passed on final head: targeted Fantomas, focused `MaterializationPlanContractTests` (`125/125`), `git diff --check`, and `pwsh ./scripts/validate.ps1 -Fast`.
- Worker bot-prevention self-review reported the diff is limited to `Grace.Types` contract and type-test files.
- Residual risk is explicitly deferred to later runtime leaves: server-side generation must supply real byte size and integrity from the storage/materialization seam.
