### PR TITLE
Implement Operations raw usage ingest aggregates

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="OperationsEntities.fs" />
     <Compile Include="OperationsDbContext.fs" />
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
+    <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -3,7 +3,8 @@
 `Grace.Operations.Data` owns the EF Core model and migrations for the Azure SQL operations store. The current baseline
 schema is intentionally narrow:
 
-- `ops.RawUsageFact` stores immutable `UsageFact` rows with `UsageFactId` as the duplicate-delivery boundary.
+- `ops.RawUsageFact` stores immutable `UsageFact` rows with `UsageFactId` as the duplicate-delivery boundary and keeps
+  the exact accepted broker payload in `RawPayload` for replay and audit.
 - `ops.UsageAggregateMinute` stores one aggregate row per fact kind, Grace scope, storage pool, and UTC minute.
 - The EF migrations history table lives in `ops.__EFMigrationsHistory` so operations schema state stays with the
   operations schema.

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707000000_AddRawUsageFactPayload.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707000000_AddRawUsageFactPayload.fs
@@ -17,7 +17,14 @@ type AddRawUsageFactPayload() =
 IF COL_LENGTH(N'ops.RawUsageFact', N'RawPayload') IS NULL
 BEGIN
     ALTER TABLE ops.RawUsageFact
-        ADD RawPayload varbinary(max) NOT NULL;
+        ADD RawPayload varbinary(max) NOT NULL
+            CONSTRAINT DF_ops_RawUsageFact_RawPayload DEFAULT (0x) WITH VALUES;
+END;
+
+IF OBJECT_ID(N'ops.DF_ops_RawUsageFact_RawPayload', N'D') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        DROP CONSTRAINT DF_ops_RawUsageFact_RawPayload;
 END;
 """
         )

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707000000_AddRawUsageFactPayload.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707000000_AddRawUsageFactPayload.fs
@@ -2,20 +2,45 @@ namespace Grace.Operations.Data.Migrations
 
 open Grace.Operations.Data
 open Microsoft.EntityFrameworkCore
-open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
 
-/// Captures the current Operations EF model so future migrations can detect reviewed schema drift.
-[<DbContextAttribute(typeof<OperationsDbContext>)>]
-type OperationsDbContextModelSnapshot() =
-    inherit ModelSnapshot()
+/// Adds exact raw payload retention to accepted Operations usage facts.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260707000000_AddRawUsageFactPayload")>]
+type AddRawUsageFactPayload() =
+    inherit Migration()
 
-    /// Rebuilds the Operations model represented by the latest migration.
-    override _.BuildModel(modelBuilder: ModelBuilder) =
+    /// Adds the immutable raw payload column without changing the durable duplicate key.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+IF COL_LENGTH(N'ops.RawUsageFact', N'RawPayload') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD RawPayload varbinary(max) NOT NULL;
+END;
+"""
+        )
+        |> ignore
+
+    /// Removes the raw payload column when rolling this reviewed schema change back.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+IF COL_LENGTH(N'ops.RawUsageFact', N'RawPayload') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        DROP COLUMN RawPayload;
+END;
+"""
+        )
+        |> ignore
+
+    /// Captures the model shape after raw fact payload retention is enabled.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
-        // Deliberately keep this snapshot frozen with literals so future runtime model edits
-        // cannot change the latest reviewed migration point before a new migration updates it.
         modelBuilder.HasDefaultSchema("ops") |> ignore
 
         let rawFact = modelBuilder.Entity<RawUsageFactEntity>()

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -20,6 +20,7 @@ type internal OperationsDataAssembly =
 type RawUsageFact =
     {
         UsageFactId: UsageFactId
+        RawPayload: byte array
         CorrelationId: CorrelationId
         FactKind: UsageFactKind
         OwnerId: OwnerId
@@ -108,11 +109,14 @@ module UsageFactPersistencePlan =
     let bucketObservedAt (observedAt: Instant) = UsageFact.NormalizeObservedAtToMinute observedAt
 
     /// Validates a usage fact and converts it into the transaction plan required by operations storage.
-    let tryCreate (fact: UsageFact) =
+    let tryCreate (fact: UsageFact) (rawPayload: byte array) =
         match UsageFact.Validate fact with
         | Error errors -> Error errors
         | Ok () ->
             let errors = ResizeArray<string>()
+
+            if isNull rawPayload || rawPayload.Length = 0 then
+                errors.Add("Raw UsageFact payload is required for operations SQL storage.")
 
             if fact.CorrelationId.Length > OperationsUsageSql.CorrelationIdMaxLength then
                 errors.Add($"CorrelationId must be {OperationsUsageSql.CorrelationIdMaxLength} characters or fewer for operations SQL storage.")
@@ -128,6 +132,7 @@ module UsageFactPersistencePlan =
                 let rawFact =
                     {
                         UsageFactId = fact.UsageFactId
+                        RawPayload = Array.copy rawPayload
                         CorrelationId = fact.CorrelationId
                         FactKind = fact.FactKind
                         OwnerId = fact.Scope.OwnerId
@@ -182,6 +187,11 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         let parameter = command.Parameters.Add(name, SqlDbType.NVarChar, length)
         parameter.Value <- value
 
+    /// Adds a SQL parameter for the exact broker payload bytes stored with a raw fact.
+    let addRawPayloadParameter (command: SqlCommand) (value: byte array) =
+        let parameter = command.Parameters.Add("@RawPayload", SqlDbType.VarBinary, -1)
+        parameter.Value <- Array.copy value
+
     /// Creates a command that participates in the current operations usage transaction.
     let createCommand commandText =
         let command = connection.CreateCommand()
@@ -196,6 +206,7 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
     /// Adds the raw usage fact parameters expected by `OperationsUsageSql.TryInsertRawUsageFact`.
     let addRawUsageFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
         addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+        addRawPayloadParameter command rawFact.RawPayload
         addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
         addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
         addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
@@ -330,9 +341,9 @@ type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsU
 type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
 
     /// Stores a usage fact exactly once by durable `UsageFactId` and projects aggregates only for newly accepted facts.
-    member _.StoreUsageFactAsync(fact: UsageFact, cancellationToken: CancellationToken) =
+    member _.StoreUsageFactAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
         task {
-            match UsageFactPersistencePlan.tryCreate fact with
+            match UsageFactPersistencePlan.tryCreate fact rawPayload with
             | Error errors -> return Error errors
             | Ok plan ->
                 let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -33,6 +33,12 @@ module OperationsModel =
         |> ignore
 
         rawFact
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+            .IsRequired()
+        |> ignore
+
+        rawFact
             .Property<string>("CorrelationId")
             .HasMaxLength(OperationsUsageSql.CorrelationIdMaxLength)
             .IsRequired()

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -9,6 +9,9 @@ type RawUsageFactEntity() =
     /// Stores the durable idempotency key supplied by the UsageFact contract.
     member val UsageFactId = Guid.Empty with get, set
 
+    /// Stores the exact accepted broker payload for replay and audit of raw facts.
+    member val RawPayload: byte array = Array.empty with get, set
+
     /// Stores the request or workflow correlation identifier associated with the fact.
     member val CorrelationId = String.Empty with get, set
 

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -64,6 +64,7 @@ END;
 INSERT INTO ops.RawUsageFact
 (
     UsageFactId,
+    RawPayload,
     CorrelationId,
     FactKind,
     OwnerId,
@@ -75,6 +76,7 @@ INSERT INTO ops.RawUsageFact
 )
 SELECT
     @UsageFactId,
+    @RawPayload,
     @CorrelationId,
     @FactKind,
     @OwnerId,

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -1,5 +1,6 @@
 namespace Grace.Operations.Tests
 
+open Grace.Shared
 open Grace.Operations.Data
 open Grace.Operations.Data.Migrations
 open Grace.Types.Common
@@ -13,6 +14,7 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
 
@@ -60,6 +62,9 @@ module OperationsUsageStorageTestData =
             observedAt
         )
 
+    /// Serializes the raw usage fact payload that Operations stores for later replay and audit.
+    let payloadFor fact = JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
+
 /// Stores transaction state for the operations usage test double.
 type private InMemoryOperationsUsageState = { RawFacts: Dictionary<UsageFactId, RawUsageFact>; Aggregates: Dictionary<UsageAggregateMinuteKey, int64> }
 
@@ -78,6 +83,9 @@ type private InMemoryOperationsUsageTransactionScope() =
 
     /// Returns the number of committed raw facts.
     member _.RawFactCount = state.RawFacts.Count
+
+    /// Returns one committed raw fact by durable usage-fact identity.
+    member _.RawFact usageFactId = state.RawFacts[usageFactId]
 
     /// Returns the committed quantity for an aggregate row.
     member _.AggregateQuantity(key: UsageAggregateMinuteKey) =
@@ -269,6 +277,8 @@ type OperationsUsageStorageTests() =
                     Is.EqualTo(Nullable OperationsUsageSql.CorrelationIdMaxLength)
                 )
 
+                Assert.That(rawFact.FindProperty("RawPayload").GetColumnType(), Is.EqualTo("varbinary(max)"))
+
                 Assert.That(
                     rawFact
                         .FindProperty("StoragePoolId")
@@ -334,6 +344,8 @@ type OperationsUsageStorageTests() =
                 Assert.That(script, Does.Contain("IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.RawUsageFact"))
                 Assert.That(script, Does.Contain("CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)"))
+                Assert.That(script, Does.Contain("ALTER TABLE ops.RawUsageFact"))
+                Assert.That(script, Does.Contain("ADD RawPayload varbinary(max) NOT NULL"))
                 Assert.That(script, Does.Contain("IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.UsageAggregateMinute"))
                 Assert.That(script, Does.Contain("CONSTRAINT PK_ops_UsageAggregateMinute PRIMARY KEY CLUSTERED"))
@@ -413,7 +425,7 @@ type OperationsUsageStorageTests() =
                 OperationsUsageStorageTestData.storagePoolId
                 1L
                 observedAt
-            |> UsageFactPersistencePlan.tryCreate
+            |> fun fact -> UsageFactPersistencePlan.tryCreate fact (OperationsUsageStorageTestData.payloadFor fact)
             |> requirePlan
 
         let mixedPoolPlan =
@@ -422,7 +434,7 @@ type OperationsUsageStorageTests() =
                 OperationsUsageStorageTestData.storagePoolIdWithDifferentCase
                 1L
                 observedAt
-            |> UsageFactPersistencePlan.tryCreate
+            |> fun fact -> UsageFactPersistencePlan.tryCreate fact (OperationsUsageStorageTestData.payloadFor fact)
             |> requirePlan
 
         Assert.Multiple(
@@ -450,7 +462,7 @@ type OperationsUsageStorageTests() =
                 Instant.FromUtc(2026, 7, 4, 12, 37, 0)
             )
 
-        match UsageFactPersistencePlan.tryCreate fact with
+        match UsageFactPersistencePlan.tryCreate fact (OperationsUsageStorageTestData.payloadFor fact) with
         | Ok _ -> Assert.Fail("Overlong SQL-bound fact fields should be rejected before persistence.")
         | Error errors ->
             let errorText = String.Join("|", errors)
@@ -461,6 +473,15 @@ type OperationsUsageStorageTests() =
 
                     Assert.That(errorText, Does.Contain($"Resource.StoragePoolId must be {OperationsUsageSql.StoragePoolIdMaxLength} characters or fewer")))
             )
+
+    /// Verifies raw payload retention is mandatory for facts accepted into Operations storage.
+    [<Test>]
+    member _.PersistencePlanRejectsEmptyRawPayload() =
+        let fact = OperationsUsageStorageTestData.fact (Guid.Parse("67676767-6767-6767-6767-676767676767")) 1L (Instant.FromUtc(2026, 7, 4, 12, 38, 0))
+
+        match UsageFactPersistencePlan.tryCreate fact Array.empty with
+        | Ok _ -> Assert.Fail("Empty raw payloads should be rejected before persistence.")
+        | Error errors -> Assert.That(String.Join("|", errors), Does.Contain("Raw UsageFact payload is required"))
 
     /// Verifies the production SQL transaction scope satisfies the store dependency.
     [<Test>]
@@ -512,14 +533,17 @@ type OperationsUsageStorageTests() =
             let store, transactionScope = createStore ()
             let usageFactId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
             let fact = OperationsUsageStorageTestData.fact usageFactId 4096L (Instant.FromUtc(2026, 7, 4, 12, 34, 56))
+            let rawPayload = OperationsUsageStorageTestData.payloadFor fact
 
-            let! result = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let! result = store.StoreUsageFactAsync(fact, rawPayload, CancellationToken.None)
             let stored = requireStored result
+            let rawFact = transactionScope.RawFact usageFactId
 
             Assert.Multiple(
                 Action (fun () ->
                     Assert.That(stored.Status, Is.EqualTo(UsageFactPersistenceStatus.Accepted))
                     Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
+                    Assert.That(Convert.ToBase64String(rawFact.RawPayload), Is.EqualTo(Convert.ToBase64String(rawPayload)))
                     Assert.That(stored.Aggregate.IsSome, Is.True)
                     Assert.That(transactionScope.AggregateQuantity(stored.Aggregate.Value.Key), Is.EqualTo(4096L)))
             )
@@ -532,12 +556,15 @@ type OperationsUsageStorageTests() =
             let store, transactionScope = createStore ()
             let usageFactId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
             let fact = OperationsUsageStorageTestData.fact usageFactId 2048L (Instant.FromUtc(2026, 7, 4, 12, 34, 0))
+            let rawPayload = OperationsUsageStorageTestData.payloadFor fact
+            let duplicatePayload = Array.append rawPayload [| byte 0x0A |]
 
-            let! firstResult = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let! firstResult = store.StoreUsageFactAsync(fact, rawPayload, CancellationToken.None)
             let firstStored = requireStored firstResult
 
-            let! duplicateResult = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let! duplicateResult = store.StoreUsageFactAsync(fact, duplicatePayload, CancellationToken.None)
             let duplicateStored = requireStored duplicateResult
+            let rawFact = transactionScope.RawFact usageFactId
 
             Assert.Multiple(
                 Action (fun () ->
@@ -545,6 +572,7 @@ type OperationsUsageStorageTests() =
                     Assert.That(duplicateStored.Status, Is.EqualTo(UsageFactPersistenceStatus.AlreadyProcessed))
                     Assert.That(duplicateStored.Aggregate, Is.EqualTo(None))
                     Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
+                    Assert.That(Convert.ToBase64String(rawFact.RawPayload), Is.EqualTo(Convert.ToBase64String(rawPayload)))
                     Assert.That(transactionScope.AggregateQuantity(firstStored.Aggregate.Value.Key), Is.EqualTo(2048L)))
             )
         }
@@ -556,12 +584,13 @@ type OperationsUsageStorageTests() =
             let store, transactionScope = createStore ()
             let usageFactId = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc")
             let fact = OperationsUsageStorageTestData.fact usageFactId 1024L (Instant.FromUtc(2026, 7, 4, 12, 35, 0))
+            let rawPayload = OperationsUsageStorageTestData.payloadFor fact
             transactionScope.FailNextAggregateUpdate()
 
             let mutable thrownMessage = None
 
             try
-                let! _ = store.StoreUsageFactAsync(fact, CancellationToken.None)
+                let! _ = store.StoreUsageFactAsync(fact, rawPayload, CancellationToken.None)
                 Assert.Fail("Aggregate failure should propagate instead of reporting successful storage.")
             with
             | :? InvalidOperationException as ex -> thrownMessage <- Some ex.Message
@@ -569,7 +598,7 @@ type OperationsUsageStorageTests() =
             Assert.That(thrownMessage, Is.EqualTo(Some "forced aggregate failure"))
             Assert.That(transactionScope.RawFactCount, Is.EqualTo(0))
 
-            let! retryResult = store.StoreUsageFactAsync(fact, CancellationToken.None)
+            let! retryResult = store.StoreUsageFactAsync(fact, rawPayload, CancellationToken.None)
             let retryStored = requireStored retryResult
 
             Assert.Multiple(
@@ -590,15 +619,15 @@ type OperationsUsageStorageTests() =
         let third = OperationsUsageStorageTestData.fact (Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")) 1L (Instant.FromUtc(2026, 7, 4, 12, 35, 0))
 
         let firstPlan =
-            UsageFactPersistencePlan.tryCreate first
+            UsageFactPersistencePlan.tryCreate first (OperationsUsageStorageTestData.payloadFor first)
             |> requirePlan
 
         let secondPlan =
-            UsageFactPersistencePlan.tryCreate second
+            UsageFactPersistencePlan.tryCreate second (OperationsUsageStorageTestData.payloadFor second)
             |> requirePlan
 
         let thirdPlan =
-            UsageFactPersistencePlan.tryCreate third
+            UsageFactPersistencePlan.tryCreate third (OperationsUsageStorageTestData.payloadFor third)
             |> requirePlan
 
         Assert.Multiple(

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -335,6 +335,8 @@ type OperationsUsageStorageTests() =
         let script = migrationScript ()
         let schemaPreambleIndex = script.IndexOf("IF SCHEMA_ID(N'ops') IS NULL", StringComparison.Ordinal)
         let historyTableIndex = script.IndexOf("[ops].[__EFMigrationsHistory]", StringComparison.Ordinal)
+        let rawPayloadDefaultIndex = script.IndexOf("CONSTRAINT DF_ops_RawUsageFact_RawPayload DEFAULT (0x) WITH VALUES", StringComparison.Ordinal)
+        let rawPayloadDefaultDropIndex = script.IndexOf("DROP CONSTRAINT DF_ops_RawUsageFact_RawPayload", StringComparison.Ordinal)
 
         Assert.Multiple(
             Action (fun () ->
@@ -346,6 +348,8 @@ type OperationsUsageStorageTests() =
                 Assert.That(script, Does.Contain("CONSTRAINT PK_ops_RawUsageFact PRIMARY KEY CLUSTERED (UsageFactId)"))
                 Assert.That(script, Does.Contain("ALTER TABLE ops.RawUsageFact"))
                 Assert.That(script, Does.Contain("ADD RawPayload varbinary(max) NOT NULL"))
+                Assert.That(rawPayloadDefaultIndex, Is.GreaterThanOrEqualTo(0))
+                Assert.That(rawPayloadDefaultDropIndex, Is.GreaterThan(rawPayloadDefaultIndex))
                 Assert.That(script, Does.Contain("IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.UsageAggregateMinute"))
                 Assert.That(script, Does.Contain("CONSTRAINT PK_ops_UsageAggregateMinute PRIMARY KEY CLUSTERED"))

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -87,7 +87,7 @@ module OperationsWorkerIngestionTestData =
 
     /// Builds the aggregate projected by the data layer for a valid fact.
     let aggregateFor fact =
-        match UsageFactPersistencePlan.tryCreate fact with
+        match UsageFactPersistencePlan.tryCreate fact (serializeFact fact) with
         | Ok plan -> plan.Aggregate
         | Error errors -> failwith (String.Join("; ", errors))
 
@@ -189,18 +189,27 @@ type private ThrowingSettlementMessageActions(events: List<string>, operationToT
                 Task.CompletedTask
 
 /// Fakes the operations data-layer boundary for deterministic processor tests.
-type private StubUsageFactStore(storeAsync: UsageFact -> CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>, events: List<string>) =
+type private StubUsageFactStore
+    (
+        storeAsync: UsageFact -> byte array -> CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>,
+        events: List<string>
+    ) =
     let storedFacts = ResizeArray<UsageFact>()
+    let storedPayloads = ResizeArray<byte array>()
 
     /// Returns the facts sent to the fake store.
     member _.StoredFacts = storedFacts |> Seq.toList
 
+    /// Returns the raw payloads sent to the fake store.
+    member _.StoredPayloads = storedPayloads |> Seq.map Array.copy |> Seq.toList
+
     interface IOperationsUsageFactStore with
 
-        member _.StoreUsageFactAsync(fact, cancellationToken) =
+        member _.StoreUsageFactAsync(fact, rawPayload, cancellationToken) =
             storedFacts.Add fact
+            storedPayloads.Add(Array.copy rawPayload)
             events.Add("store")
-            storeAsync fact cancellationToken
+            storeAsync fact rawPayload cancellationToken
 
 /// Records formatted log output from worker infrastructure tests.
 type private RecordingLogger<'T>() =
@@ -239,7 +248,7 @@ type OperationsWorkerIngestionTests() =
             .Build()
 
     /// Creates a processor with deterministic fake dependencies and an inspectable readiness state.
-    let createProcessorWithReadiness storeAsync =
+    let createProcessorWithReadinessRaw storeAsync =
         let events = List<string>()
         let store = StubUsageFactStore(storeAsync, events)
         let readiness = OperationsUsageReadinessState()
@@ -254,9 +263,17 @@ type OperationsWorkerIngestionTests() =
         events,
         readiness
 
+    /// Creates a processor with deterministic fake dependencies and a store callback that ignores raw payload bytes.
+    let createProcessorWithReadiness storeAsync = createProcessorWithReadinessRaw (fun fact _rawPayload cancellationToken -> storeAsync fact cancellationToken)
+
     /// Creates a processor with deterministic fake dependencies.
     let createProcessor storeAsync =
         let processor, store, actions, events, _readiness = createProcessorWithReadiness storeAsync
+        processor, store, actions, events
+
+    /// Creates a processor with deterministic fake dependencies and inspectable raw payload forwarding.
+    let createProcessorRaw storeAsync =
+        let processor, store, actions, events, _readiness = createProcessorWithReadinessRaw storeAsync
         processor, store, actions, events
 
     /// Creates a processor backed by the real data-layer validation path.
@@ -603,11 +620,12 @@ type OperationsWorkerIngestionTests() =
         task {
             let fact = OperationsWorkerIngestionTestData.usageFact (Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
 
-            let processor, store, actions, events = createProcessor (fun storedFact _ -> Task.FromResult(Ok(accepted storedFact)))
+            let processor, store, actions, events = createProcessorRaw (fun storedFact _rawPayload _ -> Task.FromResult(Ok(accepted storedFact)))
+
+            let messageBody = OperationsWorkerIngestionTestData.serializeFact fact
 
             let message =
-                fact
-                |> OperationsWorkerIngestionTestData.serializeFact
+                messageBody
                 |> OperationsWorkerIngestionTestData.message
 
             do! processor.ProcessMessageAsync(message, actions, CancellationToken.None)
@@ -616,6 +634,7 @@ type OperationsWorkerIngestionTests() =
                 Action (fun () ->
                     Assert.That(List.length store.StoredFacts, Is.EqualTo(1))
                     Assert.That(store.StoredFacts[0].UsageFactId, Is.EqualTo(fact.UsageFactId))
+                    Assert.That(Convert.ToBase64String(store.StoredPayloads[0]), Is.EqualTo(Convert.ToBase64String(messageBody)))
                     Assert.That(eventText events, Is.EqualTo("store|complete"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("complete")))
             )

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -73,14 +73,15 @@ type IOperationsUsageMessageActions =
 type IOperationsUsageFactStore =
 
     /// Persists the fact idempotently and returns the operations data-layer result.
-    abstract StoreUsageFactAsync: fact: UsageFact * cancellationToken: CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>
+    abstract StoreUsageFactAsync:
+        fact: UsageFact * rawPayload: byte array * cancellationToken: CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>
 
 /// Adapts the concrete operations data store to the worker's fakeable ingestion dependency.
 type OperationsUsageFactStoreAdapter(store: OperationsUsageStore) =
 
     interface IOperationsUsageFactStore with
 
-        member _.StoreUsageFactAsync(fact, cancellationToken) = store.StoreUsageFactAsync(fact, cancellationToken)
+        member _.StoreUsageFactAsync(fact, rawPayload, cancellationToken) = store.StoreUsageFactAsync(fact, rawPayload, cancellationToken)
 
 /// Reports whether the operations usage worker is ready to consume durable ingestion messages.
 type OperationsUsageReadinessStatus =
@@ -799,7 +800,7 @@ type OperationsUsageIngestionProcessor
                                 let! _ = deadLetterAsync readinessAttempt "InvalidUsageFact" (describeErrors errors) actions cancellationToken
                                 ()
                             | Ok () ->
-                                let! stored = store.StoreUsageFactAsync(usageFact, cancellationToken)
+                                let! stored = store.StoreUsageFactAsync(usageFact, message.Body, cancellationToken)
 
                                 match stored with
                                 | Error errors ->


### PR DESCRIPTION
# Summary

Related to #570.
Part of #558 and #554.

This implements EF-backed raw usage fact ingest and minute aggregate projection for the WS2 ingestion/hot projections mini-epic. Grace needs this slice so Operations can retain the exact accepted broker payload, keep duplicate delivery idempotent, and maintain trusted hot aggregates for later archive, billing, and reconciliation leaves.

## Changes

- Adds `RawPayload varbinary(max) NOT NULL` to the Operations raw fact EF model, snapshot, and checked-in migration.
- Handles existing-row migration by adding the raw payload column with a temporary `0x` default/backfill, then dropping that default so future inserts must provide explicit raw payload bytes.
- Persists the original Service Bus message body bytes alongside the extracted raw usage fact fields.
- Keeps accepted raw fact storage and minute aggregate projection in the same accepted-fact transaction path.
- Preserves duplicate `UsageFactId` behavior: duplicates are acknowledged as already processed, do not update aggregates, and do not replace the original raw payload.
- Updates ingestion tests, storage tests, migration tests, and Operations migration documentation for the new persisted shape.

## Branch Contract

- Source branch: `agent/570-operations-raw-ingest-aggregates`.
- Target branch: `epic/558-operations-ingestion-hot-projections`.
- This is a leaf PR into the WS2 mini-epic integration branch. It intentionally uses non-closing issue wording; the orchestrator will close #570 manually after merge to the mini-epic branch.

## Validation

- `dotnet tool run fantomas -- <touched tracked F# files>`: passed, unchanged.
- `dotnet tool run fantomas -- src/Grace.Operations/Grace.Operations.Data/Migrations/20260707000000_AddRawUsageFactPayload.fs`: passed, unchanged.
- `npx --yes markdownlint-cli2 --config .markdownlint.jsonc "src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md"`: passed, 0 errors.
- `dotnet build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`: passed, 0 warnings, 0 errors.
- `dotnet test --no-build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj --filter "FullyQualifiedName~OperationsUsageStorageTests|FullyQualifiedName~OperationsWorkerIngestionTests"`: passed, 62/62.
- `dotnet test --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj --filter "FullyQualifiedName~BaselineMigrationScriptContainsExpectedOperationsSchema"`: passed, 1/1.
- `dotnet test --no-build --configuration Release src/Grace.Operations/Grace.Operations.slnx`: passed, 70/70 before the review-fix commit.
- `pwsh ./scripts/validate.ps1 -Full`: passed after the review-fix commit, including `Grace.Types.Tests` 159/159, `Grace.Authorization.Tests` 53/53, `Grace.Server.Unit.Tests` 732/732, `Grace.CLI.Tests` 689/690 with 1 skipped, `Grace.Server.Tests` 243/243, and `Grace.Operations.Tests` 70/70.
- GitHub `full`: passed for `a7401792d0f697fc7be9d5ad3a87f77c788ec55c`.
- `git diff --check`: passed.
- `git diff --cached --check`: passed before the initial commit.

## Review Status

- Latest head: `a7401792d0f697fc7be9d5ad3a87f77c788ec55c`.
- Codex Code Review Bot: thumbs-up on the latest head at 2026-07-07T10:03:17Z; no unresolved review threads.
- CI: GitHub `full` passed for `a7401792`.
- Substantive Codex review cycles: 1.
- Prevention note: migration coverage now proves the temporary default/backfill and default removal so future non-null raw-payload schema changes cannot rely on empty tables.

## Grace.slnx Isolation

Confirmed during worker handoff and review-fix handoff: `src/Grace.slnx` does not reference `Grace.Operations` projects.
