### PR TITLE
Add projection ensure helpers and manifest-backed zip proof (#612)

### DIFF
--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -1,5 +1,6 @@
 namespace Grace.Actors
 
+open Blake3
 open Azure.Storage.Blobs
 open Azure.Storage.Blobs.Models
 open Azure.Storage.Blobs.Specialized
@@ -99,6 +100,15 @@ module DirectoryVersion =
                 )
             | unsupported -> Error(GraceError.Create $"Projection helper does not support {unsupported} descriptors." correlationId)
 
+    /// Runs one projection helper and converts unexpected storage or actor failures into Grace errors.
+    let private ensureProjectionArtifactEvidence artifactKind ensureArtifact correlationId =
+        task {
+            try
+                return! ensureArtifact ()
+            with
+            | ex -> return Error(GraceError.CreateWithException ex $"{artifactKind} projection could not be ensured." correlationId)
+        }
+
     /// Ensures v1 target-root projection artifacts and returns canonical descriptors for the represented root.
     let ensureRequiredProjectionArtifactsWith
         targetRootDirectoryVersionId
@@ -107,14 +117,16 @@ module DirectoryVersion =
         correlationId
         =
         task {
-            match! ensureDirectoryVersionZip () with
+            match! ensureProjectionArtifactEvidence MaterializationArtifactKind.DirectoryVersionZip ensureDirectoryVersionZip correlationId with
             | Error error -> return Error error
             | Ok zipEvidence ->
                 match descriptorFromProjectionEvidence targetRootDirectoryVersionId MaterializationArtifactKind.DirectoryVersionZip correlationId zipEvidence
                     with
                 | Error error -> return Error error
                 | Ok zipDescriptor ->
-                    match! ensureRecursiveDirectoryMetadata () with
+                    match!
+                        ensureProjectionArtifactEvidence MaterializationArtifactKind.RecursiveDirectoryMetadata ensureRecursiveDirectoryMetadata correlationId
+                        with
                     | Error error -> return Error error
                     | Ok metadataEvidence ->
                         match
@@ -137,15 +149,12 @@ module DirectoryVersion =
         |> Convert.ToHexString
         |> fun value -> Sha256Hash(value.ToLowerInvariant())
 
-    /// GZip-compresses text file bytes to preserve existing directory zip entry storage semantics.
-    let private gzipBytes (bytes: byte array) =
-        use compressed = new MemoryStream()
-
-        do
-            use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
-            gzipStream.Write(bytes, 0, bytes.Length)
-
-        compressed.ToArray()
+    /// Computes the SHA-256 integrity value for a blob without retaining the blob payload in actor memory.
+    let private sha256HashForBlobStream (blobClient: BlockBlobClient) (blobName: string) =
+        task {
+            use! blobStream = blobClient.OpenReadAsync(position = 0L, bufferSize = (64 * 1024))
+            return! computeSha256ForFile blobStream (RelativePath blobName)
+        }
 
     /// Reads a blob payload and reports absence as a projection failure.
     let private readRequiredBlobPayload (blobClient: BlockBlobClient) missingMessage correlationId =
@@ -162,32 +171,48 @@ module DirectoryVersion =
     /// Describes a projection blob after the actor has ensured it exists.
     let private describeProjectionBlob (repositoryDto: RepositoryDto) blobName artifactKind source correlationId =
         task {
-            let! blobClient = getAzureBlobClient repositoryDto blobName correlationId
+            try
+                let! blobClient = getAzureBlobClient repositoryDto blobName correlationId
+                let missingMessage = $"Projection artifact '{blobName}' was not created."
+                let! exists = blobClient.ExistsAsync()
 
-            match! readRequiredBlobPayload blobClient $"Projection artifact '{blobName}' was not created." correlationId with
-            | Error error -> return Error error
-            | Ok bytes ->
-                return
-                    Ok
-                        {
-                            ArtifactKind = artifactKind
-                            SizeInBytes = int64 bytes.Length
-                            Sha256Hash = Some(sha256HashForBytes bytes)
-                            Blake3Hash = None
-                            Source = source
-                        }
+                if not exists.Value then
+                    return Error(GraceError.Create missingMessage correlationId)
+                else
+                    let! properties = blobClient.GetPropertiesAsync()
+                    let! sha256Hash = sha256HashForBlobStream blobClient blobName
+
+                    return
+                        Ok
+                            {
+                                ArtifactKind = artifactKind
+                                SizeInBytes = properties.Value.ContentLength
+                                Sha256Hash = Some sha256Hash
+                                Blake3Hash = None
+                                Source = source
+                            }
+            with
+            | ex -> return Error(GraceError.CreateWithException ex $"Projection artifact '{blobName}' could not be described." correlationId)
         }
 
-    /// Reads whole-file storage bytes using the existing zip entry storage convention.
-    let private readWholeFileZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId =
+    /// Copies whole-file storage bytes into a zip entry using the existing stored-payload convention.
+    let private writeWholeFileZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (zipEntryStream: Stream) correlationId =
         task {
             let! fileBlobClient = getReadableAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
 
-            return!
-                readRequiredBlobPayload
-                    fileBlobClient
-                    $"Whole-file content for '{fileVersion.RelativePath}' was missing while creating a DirectoryVersion zip projection."
-                    correlationId
+            let! exists = fileBlobClient.ExistsAsync()
+
+            if exists.Value then
+                use! blobStream = fileBlobClient.OpenReadAsync(position = 0L, bufferSize = (64 * 1024))
+                do! blobStream.CopyToAsync(zipEntryStream)
+                return Ok()
+            else
+                return
+                    Error(
+                        GraceError.Create
+                            $"Whole-file content for '{fileVersion.RelativePath}' was missing while creating a DirectoryVersion zip projection."
+                            correlationId
+                    )
         }
 
     /// Resolves finalized content-block metadata for a manifest-backed zip entry.
@@ -232,38 +257,181 @@ module DirectoryVersion =
                 | Ok payload -> return Ok payload
         }
 
-    /// Reconstructs manifest-backed file bytes for a DirectoryVersion zip entry.
-    let private readManifestBackedZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (manifest: FileManifest) correlationId =
+    /// Validates manifest shape before writing any zip entry bytes.
+    let private validateManifestBackedZipEntryShape (manifest: FileManifest) correlationId =
+        if isNull (box manifest) then
+            Error(GraceError.Create "FileManifest content reference was null while creating a DirectoryVersion zip projection." correlationId)
+        elif manifest.Size <= 0L then
+            Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' must declare a positive size." correlationId)
+        elif isNull manifest.Blocks
+             || manifest.Blocks.Count = 0 then
+            Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' must include at least one ContentBlock." correlationId)
+        elif String.IsNullOrWhiteSpace(manifest.ChunkingSuiteId) then
+            Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' must include a chunking suite." correlationId)
+        elif manifest.ChunkingSuiteId
+             <> RabinChunking.SuiteName then
+            Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' uses unsupported chunking suite '{manifest.ChunkingSuiteId}'." correlationId)
+        elif not (ContentAddress.isValidAddress manifest.FileContentHash) then
+            Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' has an invalid file content hash." correlationId)
+        elif not (ContentAddress.isValidAddress manifest.ManifestAddress) then
+            Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' has an invalid manifest address." correlationId)
+        else
+            let expectedManifestAddress = ContentAddress.computeManifestAddressForManifest manifest
+
+            if manifest.ManifestAddress
+               <> expectedManifestAddress then
+                Error(
+                    GraceError.Create
+                        $"FileManifest '{manifest.ManifestAddress}' does not match its canonical manifest address '{expectedManifestAddress}'."
+                        correlationId
+                )
+            else
+                let mutable expectedOffset = 0L
+                let mutable error: GraceError option = None
+                let mutable index = 0
+
+                while index < manifest.Blocks.Count && error.IsNone do
+                    let block = manifest.Blocks[index]
+
+                    if isNull (box block) then
+                        error <- Some(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' has a null ContentBlock at index {index}." correlationId)
+                    elif not (ContentAddress.isValidAddress block.Address) then
+                        error <-
+                            Some(
+                                GraceError.Create
+                                    $"FileManifest '{manifest.ManifestAddress}' has an invalid ContentBlock address at index {index}."
+                                    correlationId
+                            )
+                    elif block.Size <= 0L then
+                        error <-
+                            Some(
+                                GraceError.Create
+                                    $"FileManifest '{manifest.ManifestAddress}' has a non-positive ContentBlock size at index {index}."
+                                    correlationId
+                            )
+                    elif block.Offset <> expectedOffset then
+                        error <-
+                            Some(
+                                GraceError.Create
+                                    $"FileManifest '{manifest.ManifestAddress}' has an out-of-order ContentBlock range at index {index}."
+                                    correlationId
+                            )
+                    else
+                        expectedOffset <- expectedOffset + block.Size
+
+                    index <- index + 1
+
+                match error with
+                | Some graceError -> Error graceError
+                | None when expectedOffset <> manifest.Size ->
+                    Error(
+                        GraceError.Create
+                            $"FileManifest '{manifest.ManifestAddress}' ranges cover {expectedOffset} bytes, expected {manifest.Size} bytes."
+                            correlationId
+                    )
+                | None -> Ok()
+
+    /// Decodes and validates one manifest content block before the zip writer streams it to the entry.
+    let private validateManifestContentBlockPayload (manifest: FileManifest) (blockIndex: int) (encodedPayload: byte array) correlationId =
+        let block = manifest.Blocks[blockIndex]
+
+        match ContentBlockFormat.decode encodedPayload with
+        | Error decodeError ->
+            Error(
+                GraceError.Create
+                    $"ContentBlock '{block.Address}' could not be decoded while creating a DirectoryVersion zip projection: {decodeError}."
+                    correlationId
+            )
+        | Ok decodedBlock ->
+            match ContentBlockFormat.validateAddress block.Address decodedBlock with
+            | Error addressError ->
+                Error(
+                    GraceError.Create
+                        $"ContentBlock '{block.Address}' did not match its address while creating a DirectoryVersion zip projection: {addressError}."
+                        correlationId
+                )
+            | Ok () ->
+                let decodedLength = decodedBlock.Payload.Length
+
+                if int64 decodedLength <> block.Size then
+                    Error(
+                        GraceError.Create
+                            $"ContentBlock '{block.Address}' decoded to {decodedLength} bytes while FileManifest '{manifest.ManifestAddress}' expected {block.Size} bytes."
+                            correlationId
+                    )
+                else
+                    Ok decodedBlock.Payload
+
+    /// Streams manifest-backed file bytes into a DirectoryVersion zip entry while validating final file hashes.
+    let private writeManifestBackedZipEntryPayload
+        (repositoryDto: RepositoryDto)
+        (fileVersion: FileVersion)
+        (manifest: FileManifest)
+        (zipEntryStream: Stream)
+        correlationId
+        =
         task {
-            let blockPayloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
-            let mutable blockIndex = 0
-            let mutable error: GraceError option = None
+            match validateManifestBackedZipEntryShape manifest correlationId with
+            | Error error -> return Error error
+            | Ok () ->
+                use targetStream =
+                    if fileVersion.IsBinary then
+                        zipEntryStream
+                    else
+                        new GZipStream(zipEntryStream, CompressionLevel.SmallestSize, leaveOpen = true) :> Stream
 
-            while blockIndex < manifest.Blocks.Count && error.IsNone do
-                let block = manifest.Blocks[blockIndex]
+                use sha256Hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256)
+                let mutable blake3Hasher = Hasher.New()
+                let mutable blockIndex = 0
+                let mutable writtenBytes = 0L
+                let mutable error: GraceError option = None
 
-                match! resolveManifestContentBlockMetadata repositoryDto.RepositoryId fileVersion manifest block.Address correlationId with
-                | Error graceError -> error <- Some graceError
-                | Ok metadata ->
-                    match! readManifestContentBlockPayload metadata block.Address correlationId with
+                while blockIndex < manifest.Blocks.Count && error.IsNone do
+                    let block = manifest.Blocks[blockIndex]
+
+                    match! resolveManifestContentBlockMetadata repositoryDto.RepositoryId fileVersion manifest block.Address correlationId with
                     | Error graceError -> error <- Some graceError
-                    | Ok payload -> blockPayloads.Add(ManifestValidation.createBlockPayload block.Address payload)
+                    | Ok metadata ->
+                        match! readManifestContentBlockPayload metadata block.Address correlationId with
+                        | Error graceError -> error <- Some graceError
+                        | Ok payload ->
+                            match validateManifestContentBlockPayload manifest blockIndex payload correlationId with
+                            | Error graceError -> error <- Some graceError
+                            | Ok decodedPayload ->
+                                let decodedLength = decodedPayload.Length
+                                sha256Hasher.AppendData(decodedPayload, 0, decodedLength)
+                                blake3Hasher.Update(decodedPayload.AsSpan(0, decodedLength))
+                                do! targetStream.WriteAsync(decodedPayload, 0, decodedLength)
+                                writtenBytes <- writtenBytes + int64 decodedLength
 
-                blockIndex <- blockIndex + 1
+                    blockIndex <- blockIndex + 1
 
-            match error with
-            | Some graceError -> return Error graceError
-            | None ->
-                match ManifestValidation.validate RabinChunking.SuiteName manifest blockPayloads with
-                | Error validationError ->
+                match error with
+                | Some graceError -> return Error graceError
+                | None when writtenBytes <> manifest.Size ->
                     return
                         Error(
                             GraceError.Create
-                                $"FileManifest '{manifest.ManifestAddress}' could not be validated while creating a DirectoryVersion zip projection: {validationError}."
+                                $"FileManifest '{manifest.ManifestAddress}' wrote {writtenBytes} bytes while {manifest.Size} bytes were required."
                                 correlationId
                         )
-                | Ok materializedBytes ->
-                    if not (String.Equals(string (sha256HashForBytes materializedBytes), string fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase)) then
+                | None ->
+                    targetStream.Flush()
+
+                    let sha256Hash =
+                        sha256Hasher.GetHashAndReset()
+                        |> Convert.ToHexString
+                        |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+                    let blake3Bytes = stackalloc<byte> Hash.Size
+                    blake3Hasher.Finalize(blake3Bytes)
+                    let blake3Hash = Blake3Hash(byteArrayToString blake3Bytes)
+                    let manifestFileContentHash = FileContentHash(string blake3Hash)
+
+                    if manifest.FileContentHash
+                       <> manifestFileContentHash then
+                        return Error(GraceError.Create $"FileManifest '{manifest.ManifestAddress}' bytes do not match its FileContentHash." correlationId)
+                    elif not (String.Equals(string sha256Hash, string fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase)) then
                         return
                             Error(
                                 GraceError.Create
@@ -272,9 +440,7 @@ module DirectoryVersion =
                             )
                     elif
                         not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
-                        && not (
-                            String.Equals(ContentAddress.computeBlake3Hex materializedBytes, string fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase)
-                        )
+                        && not (String.Equals(string blake3Hash, string fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase))
                     then
                         return
                             Error(
@@ -283,12 +449,11 @@ module DirectoryVersion =
                                     correlationId
                             )
                     else
-                        let zipPayload = if fileVersion.IsBinary then materializedBytes else gzipBytes materializedBytes
-                        return Ok zipPayload
+                        return Ok()
         }
 
-    /// Reads the bytes that should be written for one file entry in a DirectoryVersion zip projection.
-    let private readZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId =
+    /// Writes the bytes that should be stored for one file entry in a DirectoryVersion zip projection.
+    let private writeZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (zipEntryStream: Stream) correlationId =
         task {
             let contentReference =
                 if isNull (box fileVersion.ContentReference) then
@@ -297,10 +462,10 @@ module DirectoryVersion =
                     fileVersion.ContentReference
 
             match contentReference.ReferenceType with
-            | FileContentReferenceType.WholeFileContent -> return! readWholeFileZipEntryPayload repositoryDto fileVersion correlationId
+            | FileContentReferenceType.WholeFileContent -> return! writeWholeFileZipEntryPayload repositoryDto fileVersion zipEntryStream correlationId
             | FileContentReferenceType.FileManifest ->
                 match contentReference.Manifest with
-                | Some manifest -> return! readManifestBackedZipEntryPayload repositoryDto fileVersion manifest correlationId
+                | Some manifest -> return! writeManifestBackedZipEntryPayload repositoryDto fileVersion manifest zipEntryStream correlationId
                 | None ->
                     return
                         Error(
@@ -1813,14 +1978,13 @@ module DirectoryVersion =
 
                             // Step 4: Process the files in the current directory.
                             for fileVersion in fileVersions do
+                                let zipEntry = archive.CreateEntry(fileVersion.RelativePath, CompressionLevel.NoCompression)
+                                zipEntry.Comment <- fileVersion.GetObjectFileName
+                                use zipEntryStream = zipEntry.Open()
 
-                                match! readZipEntryPayload repositoryDto fileVersion correlationId with
+                                match! writeZipEntryPayload repositoryDto fileVersion zipEntryStream correlationId with
                                 | Error error -> raise (InvalidOperationException error.Error)
-                                | Ok zipEntryPayload ->
-                                    let zipEntry = archive.CreateEntry(fileVersion.RelativePath, CompressionLevel.NoCompression)
-                                    zipEntry.Comment <- fileVersion.GetObjectFileName
-                                    use zipEntryStream = zipEntry.Open()
-                                    do! zipEntryStream.WriteAsync(zipEntryPayload, 0, zipEntryPayload.Length)
+                                | Ok () -> ()
 
                             // Step 5: Upload the new ZIP to Azure Blob Storage
                             archive.Dispose() // Dispose the archive before uploading to ensure it's properly flushed to the disk.

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -21,6 +21,7 @@ open Grace.Types.Repository
 open Grace.Types.DirectoryVersion
 open Grace.Types.Common
 open Grace.Types.ContentBlockMetadata
+open Grace.Types.MaterializationPlan
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.ObjectPool
 open NodaTime
@@ -57,6 +58,264 @@ module DirectoryVersion =
             elapsedMs: float
         | MissingInStorage of fileVersion: FileVersion * elapsedMs: float
         | ValidationError of fileVersion: FileVersion * errorMessage: string * elapsedMs: float
+
+    /// Captures artifact evidence produced after a DirectoryVersion projection has been created or reused.
+    type ProjectionArtifactEvidence =
+        {
+            ArtifactKind: MaterializationArtifactKind
+            SizeInBytes: int64
+            Sha256Hash: Sha256Hash option
+            Blake3Hash: Blake3Hash option
+            Source: MaterializationArtifactSource option
+        }
+
+    /// Converts projection artifact evidence into the canonical descriptor used by Materialization Plans.
+    let private descriptorFromProjectionEvidence targetRootDirectoryVersionId expectedArtifactKind correlationId evidence =
+        if evidence.ArtifactKind <> expectedArtifactKind then
+            Error(GraceError.Create $"Projection helper returned {evidence.ArtifactKind} evidence while ensuring {expectedArtifactKind}." correlationId)
+        elif evidence.SizeInBytes < 0L then
+            Error(GraceError.Create $"Projection helper returned a negative size for {expectedArtifactKind}." correlationId)
+        else
+            match expectedArtifactKind with
+            | MaterializationArtifactKind.DirectoryVersionZip ->
+                Ok(
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        targetRootDirectoryVersionId,
+                        evidence.SizeInBytes,
+                        evidence.Sha256Hash,
+                        evidence.Blake3Hash,
+                        evidence.Source
+                    )
+                )
+            | MaterializationArtifactKind.RecursiveDirectoryMetadata ->
+                Ok(
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        targetRootDirectoryVersionId,
+                        evidence.SizeInBytes,
+                        evidence.Sha256Hash,
+                        evidence.Blake3Hash,
+                        evidence.Source
+                    )
+                )
+            | unsupported -> Error(GraceError.Create $"Projection helper does not support {unsupported} descriptors." correlationId)
+
+    /// Ensures v1 target-root projection artifacts and returns canonical descriptors for the represented root.
+    let ensureRequiredProjectionArtifactsWith
+        targetRootDirectoryVersionId
+        (ensureDirectoryVersionZip: unit -> Task<Result<ProjectionArtifactEvidence, GraceError>>)
+        (ensureRecursiveDirectoryMetadata: unit -> Task<Result<ProjectionArtifactEvidence, GraceError>>)
+        correlationId
+        =
+        task {
+            match! ensureDirectoryVersionZip () with
+            | Error error -> return Error error
+            | Ok zipEvidence ->
+                match descriptorFromProjectionEvidence targetRootDirectoryVersionId MaterializationArtifactKind.DirectoryVersionZip correlationId zipEvidence
+                    with
+                | Error error -> return Error error
+                | Ok zipDescriptor ->
+                    match! ensureRecursiveDirectoryMetadata () with
+                    | Error error -> return Error error
+                    | Ok metadataEvidence ->
+                        match
+                            descriptorFromProjectionEvidence
+                                targetRootDirectoryVersionId
+                                MaterializationArtifactKind.RecursiveDirectoryMetadata
+                                correlationId
+                                metadataEvidence
+                            with
+                        | Error error -> return Error error
+                        | Ok metadataDescriptor ->
+                            return
+                                Ok [| zipDescriptor
+                                      metadataDescriptor |]
+        }
+
+    /// Computes the SHA-256 integrity value for an artifact payload.
+    let private sha256HashForBytes (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+    /// GZip-compresses text file bytes to preserve existing directory zip entry storage semantics.
+    let private gzipBytes (bytes: byte array) =
+        use compressed = new MemoryStream()
+
+        do
+            use gzipStream = new GZipStream(compressed, CompressionLevel.SmallestSize, leaveOpen = true)
+            gzipStream.Write(bytes, 0, bytes.Length)
+
+        compressed.ToArray()
+
+    /// Reads a blob payload and reports absence as a projection failure.
+    let private readRequiredBlobPayload (blobClient: BlockBlobClient) missingMessage correlationId =
+        task {
+            let! exists = blobClient.ExistsAsync()
+
+            if exists.Value then
+                let! download = blobClient.DownloadContentAsync()
+                return Ok(download.Value.Content.ToArray())
+            else
+                return Error(GraceError.Create missingMessage correlationId)
+        }
+
+    /// Describes a projection blob after the actor has ensured it exists.
+    let private describeProjectionBlob (repositoryDto: RepositoryDto) blobName artifactKind source correlationId =
+        task {
+            let! blobClient = getAzureBlobClient repositoryDto blobName correlationId
+
+            match! readRequiredBlobPayload blobClient $"Projection artifact '{blobName}' was not created." correlationId with
+            | Error error -> return Error error
+            | Ok bytes ->
+                return
+                    Ok
+                        {
+                            ArtifactKind = artifactKind
+                            SizeInBytes = int64 bytes.Length
+                            Sha256Hash = Some(sha256HashForBytes bytes)
+                            Blake3Hash = None
+                            Source = source
+                        }
+        }
+
+    /// Reads whole-file storage bytes using the existing zip entry storage convention.
+    let private readWholeFileZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId =
+        task {
+            let! fileBlobClient = getReadableAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
+
+            return!
+                readRequiredBlobPayload
+                    fileBlobClient
+                    $"Whole-file content for '{fileVersion.RelativePath}' was missing while creating a DirectoryVersion zip projection."
+                    correlationId
+        }
+
+    /// Resolves finalized content-block metadata for a manifest-backed zip entry.
+    let private resolveManifestContentBlockMetadata repositoryId (fileVersion: FileVersion) (manifest: FileManifest) contentBlockAddress correlationId =
+        task {
+            let dedupeIndexActor = orleansClient.CreateActorProxyWithCorrelationId<IDedupeIndexActor>("dedupe-index:v1", correlationId)
+
+            let! metadata =
+                dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata(
+                    manifest.StoragePoolId,
+                    repositoryId,
+                    fileVersion.RelativePath,
+                    manifest.ManifestAddress,
+                    contentBlockAddress,
+                    correlationId
+                )
+
+            match metadata with
+            | Some metadata -> return Ok metadata
+            | None ->
+                return
+                    Error(
+                        GraceError.Create
+                            $"FileManifest '{manifest.ManifestAddress}' for '{fileVersion.RelativePath}' has no finalized placement evidence for ContentBlock '{contentBlockAddress}'."
+                            correlationId
+                    )
+        }
+
+    /// Reads one finalized encoded content block payload for manifest-backed zip materialization.
+    let private readManifestContentBlockPayload (metadata: ContentBlockMetadata) contentBlockAddress correlationId =
+        task {
+            match! getAzureContentBlockClientForPlacement metadata.StoragePlacement correlationId with
+            | Error error -> return Error error
+            | Ok blobClient ->
+                match!
+                    readRequiredBlobPayload
+                        blobClient
+                        $"ContentBlock '{contentBlockAddress}' was missing while creating a DirectoryVersion zip projection."
+                        correlationId
+                    with
+                | Error error -> return Error error
+                | Ok payload -> return Ok payload
+        }
+
+    /// Reconstructs manifest-backed file bytes for a DirectoryVersion zip entry.
+    let private readManifestBackedZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) (manifest: FileManifest) correlationId =
+        task {
+            let blockPayloads = ResizeArray<ManifestValidation.ManifestBlockPayload>()
+            let mutable blockIndex = 0
+            let mutable error: GraceError option = None
+
+            while blockIndex < manifest.Blocks.Count && error.IsNone do
+                let block = manifest.Blocks[blockIndex]
+
+                match! resolveManifestContentBlockMetadata repositoryDto.RepositoryId fileVersion manifest block.Address correlationId with
+                | Error graceError -> error <- Some graceError
+                | Ok metadata ->
+                    match! readManifestContentBlockPayload metadata block.Address correlationId with
+                    | Error graceError -> error <- Some graceError
+                    | Ok payload -> blockPayloads.Add(ManifestValidation.createBlockPayload block.Address payload)
+
+                blockIndex <- blockIndex + 1
+
+            match error with
+            | Some graceError -> return Error graceError
+            | None ->
+                match ManifestValidation.validate RabinChunking.SuiteName manifest blockPayloads with
+                | Error validationError ->
+                    return
+                        Error(
+                            GraceError.Create
+                                $"FileManifest '{manifest.ManifestAddress}' could not be validated while creating a DirectoryVersion zip projection: {validationError}."
+                                correlationId
+                        )
+                | Ok materializedBytes ->
+                    if not (String.Equals(string (sha256HashForBytes materializedBytes), string fileVersion.Sha256Hash, StringComparison.OrdinalIgnoreCase)) then
+                        return
+                            Error(
+                                GraceError.Create
+                                    $"FileManifest '{manifest.ManifestAddress}' bytes do not match FileVersion.Sha256Hash for '{fileVersion.RelativePath}'."
+                                    correlationId
+                            )
+                    elif
+                        not (String.IsNullOrWhiteSpace fileVersion.Blake3Hash)
+                        && not (
+                            String.Equals(ContentAddress.computeBlake3Hex materializedBytes, string fileVersion.Blake3Hash, StringComparison.OrdinalIgnoreCase)
+                        )
+                    then
+                        return
+                            Error(
+                                GraceError.Create
+                                    $"FileManifest '{manifest.ManifestAddress}' bytes do not match FileVersion.Blake3Hash for '{fileVersion.RelativePath}'."
+                                    correlationId
+                            )
+                    else
+                        let zipPayload = if fileVersion.IsBinary then materializedBytes else gzipBytes materializedBytes
+                        return Ok zipPayload
+        }
+
+    /// Reads the bytes that should be written for one file entry in a DirectoryVersion zip projection.
+    let private readZipEntryPayload (repositoryDto: RepositoryDto) (fileVersion: FileVersion) correlationId =
+        task {
+            let contentReference =
+                if isNull (box fileVersion.ContentReference) then
+                    FileContentReference.WholeFileContent
+                else
+                    fileVersion.ContentReference
+
+            match contentReference.ReferenceType with
+            | FileContentReferenceType.WholeFileContent -> return! readWholeFileZipEntryPayload repositoryDto fileVersion correlationId
+            | FileContentReferenceType.FileManifest ->
+                match contentReference.Manifest with
+                | Some manifest -> return! readManifestBackedZipEntryPayload repositoryDto fileVersion manifest correlationId
+                | None ->
+                    return
+                        Error(
+                            GraceError.Create
+                                $"FileManifest content reference for '{fileVersion.RelativePath}' was missing while creating a DirectoryVersion zip projection."
+                                correlationId
+                        )
+            | unsupported ->
+                return
+                    Error(
+                        GraceError.Create
+                            $"Unsupported content reference '{unsupported}' for '{fileVersion.RelativePath}' while creating a DirectoryVersion zip projection."
+                            correlationId
+                    )
+        }
 
     /// Validates recursive directory versions complete before the operation continues.
     let validateRecursiveDirectoryVersionsComplete rootDirectoryVersionId (directoryVersionDtos: DirectoryVersionDto seq) correlationId =
@@ -1555,15 +1814,13 @@ module DirectoryVersion =
                             // Step 4: Process the files in the current directory.
                             for fileVersion in fileVersions do
 
-                                let! fileBlobClient = getReadableAzureBlobClientForFileVersion repositoryDto fileVersion correlationId
-                                let! existsResult = fileBlobClient.ExistsAsync()
-
-                                if existsResult.Value = true then
-                                    use! fileStream = fileBlobClient.OpenReadAsync()
+                                match! readZipEntryPayload repositoryDto fileVersion correlationId with
+                                | Error error -> raise (InvalidOperationException error.Error)
+                                | Ok zipEntryPayload ->
                                     let zipEntry = archive.CreateEntry(fileVersion.RelativePath, CompressionLevel.NoCompression)
                                     zipEntry.Comment <- fileVersion.GetObjectFileName
                                     use zipEntryStream = zipEntry.Open()
-                                    do! fileStream.CopyToAsync(zipEntryStream)
+                                    do! zipEntryStream.WriteAsync(zipEntryPayload, 0, zipEntryPayload.Length)
 
                             // Step 5: Upload the new ZIP to Azure Blob Storage
                             archive.Dispose() // Dispose the archive before uploading to ensure it's properly flushed to the disk.
@@ -1620,4 +1877,53 @@ module DirectoryVersion =
 
                         let! uriWithSas = getUriWithReadSharedAccessSignature repositoryDto blobName correlationId
                         return uriWithSas
+                }
+
+            /// Ensures the target-root zip and recursive metadata projection artifacts exist and returns descriptors for both.
+            member this.EnsureRequiredProjectionArtifacts correlationId =
+                this.correlationId <- correlationId
+
+                task {
+                    let directoryVersion = directoryVersionDto.DirectoryVersion
+                    let repositoryActorProxy = Repository.CreateActorProxy directoryVersion.OrganizationId directoryVersion.RepositoryId correlationId
+                    let! repositoryDto = repositoryActorProxy.Get correlationId
+
+                    /// Ensures and describes the target-root zip projection.
+                    let ensureZip () =
+                        task {
+                            try
+                                let! zipUri =
+                                    (this :> IDirectoryVersionActor)
+                                        .GetZipFileUri correlationId
+
+                                let blobName = getZipFileBlobName directoryVersion.DirectoryVersionId
+                                let source = Some(MaterializationArtifactSource.Direct(zipUri.AbsoluteUri))
+
+                                return! describeProjectionBlob repositoryDto blobName MaterializationArtifactKind.DirectoryVersionZip source correlationId
+                            with
+                            | ex -> return Error(GraceError.CreateWithException ex "DirectoryVersion zip projection could not be ensured." correlationId)
+                        }
+
+                    /// Ensures and describes the recursive metadata projection.
+                    let ensureRecursiveMetadata () =
+                        task {
+                            let! recursiveDirectoryVersions =
+                                (this :> IDirectoryVersionActor)
+                                    .GetRecursiveDirectoryVersions
+                                    false
+                                    correlationId
+
+                            match validateRecursiveDirectoryVersionsComplete directoryVersion.DirectoryVersionId recursiveDirectoryVersions correlationId with
+                            | Error error -> return Error error
+                            | Ok _ ->
+                                let blobName = getRecursiveDirectoryVersionsCacheFileName directoryVersion.DirectoryVersionId
+                                let source = Some(MaterializationArtifactSource.CacheOnly blobName)
+
+                                return!
+                                    describeProjectionBlob repositoryDto blobName MaterializationArtifactKind.RecursiveDirectoryMetadata source correlationId
+                        }
+
+                    match! ensureRequiredProjectionArtifactsWith directoryVersion.DirectoryVersionId ensureZip ensureRecursiveMetadata correlationId with
+                    | Error error -> return Error error
+                    | Ok descriptors -> return Ok(GraceReturnValue.Create descriptors correlationId)
                 }

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -24,6 +24,7 @@ open Grace.Types.Artifact
 open Grace.Types.UploadSession
 open Grace.Types.Webhooks
 open Grace.Types.WorkItem
+open Grace.Types.MaterializationPlan
 open Grace.Types.Common
 open Grace.Shared.Utilities
 open NodaTime
@@ -215,6 +216,9 @@ module Interfaces =
 
         /// Returns the Uri, with a shared access signature, to download the .zip file containing the contents of this directory and all subdirectories. If the .zip file doesn't exist, it will be created.
         abstract member GetZipFileUri: correlationId: CorrelationId -> Task<UriWithSharedAccessSignature>
+
+        /// Ensures the target-root projection artifacts required by v1 materialization planning exist and describes them.
+        abstract member EnsureRequiredProjectionArtifacts: correlationId: CorrelationId -> Task<GraceResult<MaterializationArtifactDescriptor array>>
 
         /// Delete the DirectoryVersion and all subdirectories and files.
         abstract member Delete: correlationId: CorrelationId -> Task<GraceResult<string>>

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -235,8 +235,22 @@ module DirectoryVersionServerTestHelpers =
             Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
 
     /// Builds a finalized FileManifest for a storage pool returned by the upload session.
-    let manifestForStoragePool (storagePoolId: StoragePoolId) (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
-        let contentBlock = ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+    let manifestForStoragePool (storagePoolId: StoragePoolId) (bytes: byte array) (blocks: ContentBlockFormat.EncodedContentBlock array) =
+        let mutable offset = 0L
+
+        let contentBlocks =
+            blocks
+            |> Array.map (fun block ->
+                let decodedLength =
+                    match ContentBlockFormat.decode block.Payload with
+                    | Ok decoded -> decoded.Payload.Length
+                    | Error error ->
+                        Assert.Fail($"Expected test ContentBlock to decode, got {error}.")
+                        0
+
+                let contentBlock = ContentBlock.Create(block.Address, offset, int64 decodedLength)
+                offset <- offset + int64 decodedLength
+                contentBlock)
 
         let manifest =
             FileManifest.Create(
@@ -245,7 +259,7 @@ module DirectoryVersionServerTestHelpers =
                 FileContentHash(computeBlake3Hash bytes),
                 int64 bytes.Length,
                 storagePoolId,
-                [ contentBlock ]
+                contentBlocks |> Array.toList
             )
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
@@ -301,12 +315,13 @@ module DirectoryVersionServerTestHelpers =
             return deserialize<GraceReturnValue<UploadSessionDecision>> body
         }
 
-    /// Creates and finalizes one manifest-backed FileVersion through the storage routes.
-    let createManifestBackedFileVersionAsync (repositoryId: string) (relativePath: RelativePath) (payload: byte array) =
+    /// Creates and finalizes one manifest-backed FileVersion through the storage routes from caller-selected chunks.
+    let createManifestBackedFileVersionFromChunksAsync (repositoryId: string) (relativePath: RelativePath) (chunks: byte array array) =
         task {
             let correlationId = generateCorrelationId ()
             let uploadSessionId = Guid.NewGuid()
-            let block = encodeBlock payload
+            let payload = chunks |> Array.concat
+            let blocks = chunks |> Array.map encodeBlock
 
             let start = Parameters.Storage.StartManifestUploadSessionParameters()
             setStorageParameters start repositoryId correlationId
@@ -319,42 +334,58 @@ module DirectoryVersionServerTestHelpers =
             start.OperationId <- "start"
 
             let! startResult = postUploadSessionDecisionAsync "/storage/startManifestUploadSession" start
-            let manifest = manifestForStoragePool startResult.ReturnValue.Session.StoragePoolId payload block
+            let manifest = manifestForStoragePool startResult.ReturnValue.Session.StoragePoolId payload blocks
 
-            let register = Parameters.Storage.RegisterContentBlockUploadParameters()
-            setStorageParameters register repositoryId correlationId
-            register.UploadSessionId <- uploadSessionId
-            register.AuthorizedScope <- normalizedFilePath relativePath
-            register.OperationId <- "register-0"
-            register.ContentBlockAddress <- block.Address
-            register.LogicalOffset <- 0L
-            register.LogicalLength <- int64 payload.Length
-            register.ExpectedPayloadLength <- int64 block.Payload.Length
+            let mutable logicalOffset = 0L
+            let mutable blockIndex = 0
 
-            let! _ = postUploadSessionDecisionAsync "/storage/registerContentBlockUpload" register
+            while blockIndex < blocks.Length do
+                let block = blocks[blockIndex]
 
-            let uploadUriParameters = Parameters.Storage.GetContentBlockUploadUriParameters()
-            setStorageParameters uploadUriParameters repositoryId correlationId
-            uploadUriParameters.UploadSessionId <- uploadSessionId
-            uploadUriParameters.AuthorizedScope <- normalizedFilePath relativePath
-            uploadUriParameters.ContentBlockAddress <- block.Address
+                let decodedLength =
+                    match ContentBlockFormat.decode block.Payload with
+                    | Ok decoded -> decoded.Payload.Length
+                    | Error error ->
+                        Assert.Fail($"Expected test ContentBlock to decode, got {error}.")
+                        0
 
-            let! uploadUriResponse = Client.PostAsync("/storage/getContentBlockUploadUri", createJsonContent uploadUriParameters)
-            let! uploadUriBody = uploadUriResponse.Content.ReadAsStringAsync()
-            Assert.That(uploadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadUriBody)
-            let uploadUri = Uri uploadUriBody
-            let! uploadETag = uploadContentBlockWithSasAsync block.Payload uploadUri
+                let register = Parameters.Storage.RegisterContentBlockUploadParameters()
+                setStorageParameters register repositoryId correlationId
+                register.UploadSessionId <- uploadSessionId
+                register.AuthorizedScope <- normalizedFilePath relativePath
+                register.OperationId <- $"register-{blockIndex}"
+                register.ContentBlockAddress <- block.Address
+                register.LogicalOffset <- logicalOffset
+                register.LogicalLength <- int64 decodedLength
+                register.ExpectedPayloadLength <- int64 block.Payload.Length
 
-            let confirm = Parameters.Storage.ConfirmContentBlockUploadParameters()
-            setStorageParameters confirm repositoryId correlationId
-            confirm.UploadSessionId <- uploadSessionId
-            confirm.AuthorizedScope <- normalizedFilePath relativePath
-            confirm.OperationId <- "confirm-0"
-            confirm.ContentBlockAddress <- block.Address
-            confirm.Payload <- block.Payload
-            confirm.StoragePlacement <- contentBlockPlacementFromUri uploadUri (Some uploadETag)
+                let! _ = postUploadSessionDecisionAsync "/storage/registerContentBlockUpload" register
 
-            let! _ = postUploadSessionDecisionAsync "/storage/confirmContentBlockUpload" confirm
+                let uploadUriParameters = Parameters.Storage.GetContentBlockUploadUriParameters()
+                setStorageParameters uploadUriParameters repositoryId correlationId
+                uploadUriParameters.UploadSessionId <- uploadSessionId
+                uploadUriParameters.AuthorizedScope <- normalizedFilePath relativePath
+                uploadUriParameters.ContentBlockAddress <- block.Address
+
+                let! uploadUriResponse = Client.PostAsync("/storage/getContentBlockUploadUri", createJsonContent uploadUriParameters)
+                let! uploadUriBody = uploadUriResponse.Content.ReadAsStringAsync()
+                Assert.That(uploadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadUriBody)
+                let uploadUri = Uri uploadUriBody
+                let! uploadETag = uploadContentBlockWithSasAsync block.Payload uploadUri
+
+                let confirm = Parameters.Storage.ConfirmContentBlockUploadParameters()
+                setStorageParameters confirm repositoryId correlationId
+                confirm.UploadSessionId <- uploadSessionId
+                confirm.AuthorizedScope <- normalizedFilePath relativePath
+                confirm.OperationId <- $"confirm-{blockIndex}"
+                confirm.ContentBlockAddress <- block.Address
+                confirm.Payload <- block.Payload
+                confirm.StoragePlacement <- contentBlockPlacementFromUri uploadUri (Some uploadETag)
+
+                let! _ = postUploadSessionDecisionAsync "/storage/confirmContentBlockUpload" confirm
+
+                logicalOffset <- logicalOffset + int64 decodedLength
+                blockIndex <- blockIndex + 1
 
             let finalize = Parameters.Storage.FinalizeManifestUploadParameters()
             setStorageParameters finalize repositoryId correlationId
@@ -364,9 +395,8 @@ module DirectoryVersionServerTestHelpers =
             finalize.Manifest <- manifest
 
             finalize.BlockPayloads <-
-                [|
-                    { Address = block.Address; Payload = block.Payload }
-                |]
+                blocks
+                |> Array.map (fun block -> { Address = block.Address; Payload = block.Payload })
 
             let! finalizeResult = postUploadSessionDecisionAsync "/storage/finalizeManifestUpload" finalize
             Assert.That(finalizeResult.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
@@ -375,6 +405,10 @@ module DirectoryVersionServerTestHelpers =
             fileVersion.ContentReference <- FileContentReference.FileManifest manifest
             return fileVersion
         }
+
+    /// Creates and finalizes one manifest-backed FileVersion through the storage routes.
+    let createManifestBackedFileVersionAsync (repositoryId: string) (relativePath: RelativePath) (payload: byte array) =
+        createManifestBackedFileVersionFromChunksAsync repositoryId relativePath [| payload |]
 
     /// Gets the retained zip route artifact bytes.
     let getZipBytesAsync (repositoryId: string) (directoryVersionId: DirectoryVersionId) =
@@ -688,14 +722,22 @@ type DirectoryVersionServer() =
             let wholeFilePath = RelativePath $"/zip-proof/{Guid.NewGuid():N}/whole.bin"
             let manifestFilePath = RelativePath $"/zip-proof/{Guid.NewGuid():N}/manifest.bin"
             let wholeFilePayload = DirectoryVersionServerTestHelpers.deterministicBytes "whole-file-zip-proof" 8192
-            let manifestPayload = DirectoryVersionServerTestHelpers.deterministicBytes "manifest-backed-zip-proof" 220000
+
+            let manifestPayloadChunks =
+                [|
+                    DirectoryVersionServerTestHelpers.deterministicBytes "manifest-backed-zip-proof-a" 64000
+                    DirectoryVersionServerTestHelpers.deterministicBytes "manifest-backed-zip-proof-b" 96000
+                    DirectoryVersionServerTestHelpers.deterministicBytes "manifest-backed-zip-proof-c" 60000
+                |]
+
+            let manifestPayload = manifestPayloadChunks |> Array.concat
 
             let wholeFileVersion = DirectoryVersionServerTestHelpers.createWholeFileVersion wholeFilePath wholeFilePayload
 
             let! uploadedWholeFileVersion = DirectoryVersionServerTestHelpers.uploadWholeFileAsync repositoryId wholeFileVersion wholeFilePayload
 
             let! manifestBackedFileVersion =
-                DirectoryVersionServerTestHelpers.createManifestBackedFileVersionAsync repositoryId manifestFilePath manifestPayload
+                DirectoryVersionServerTestHelpers.createManifestBackedFileVersionFromChunksAsync repositoryId manifestFilePath manifestPayloadChunks
 
             let root =
                 DirectoryVersionServerTestHelpers.createDirectoryVersionWithFiles

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -1,23 +1,51 @@
 namespace Grace.Server.Tests
 
+open Azure
+open Azure.Storage.Blobs
+open Azure.Storage.Blobs.Models
+open Azure.Storage.Blobs.Specialized
 open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Shared.Services
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
+open Grace.Types.ContentBlockMetadata
+open Grace.Types.UploadSession
 open Grace.Types
 open Grace.Types.Common
 open Grace.Types.DirectoryVersion
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.IO
+open System.IO.Compression
 open System.Net
 open System.Net.Http
+open System.Security.Cryptography
+open System.Text
 
 /// Groups shared helpers for directory version server test helpers.
 module DirectoryVersionServerTestHelpers =
     /// Captures directory version model values used by the test suite.
     type DirectoryVersionModel = Grace.Types.Common.DirectoryVersion
+
+    /// Computes the canonical SHA-256 hash for bytes used by test FileVersions.
+    let computeSha256Hash (bytes: byte array) =
+        SHA256.HashData(bytes)
+        |> Convert.ToHexString
+        |> fun value -> value.ToLowerInvariant()
+
+    /// Computes the canonical BLAKE3 hash for bytes used by test FileVersions.
+    let computeBlake3Hash (bytes: byte array) = ContentAddress.computeBlake3Hex bytes
+
+    /// Builds deterministic byte payloads for directory projection storage tests.
+    let deterministicBytes (label: string) (length: int) =
+        let seed = Encoding.UTF8.GetBytes(label)
+
+        [|
+            for index in 0 .. length - 1 do
+                byte ((int seed[index % seed.Length] + index * 17) % 251)
+        |]
 
     /// Normalizes d directory size for hash for stable assertions.
     let normalizedDirectorySizeForHash (directoryVersion: DirectoryVersionModel) =
@@ -25,6 +53,19 @@ module DirectoryVersionServerTestHelpers =
             0L
         else
             directoryVersion.Size
+
+    /// Normalizes file paths for stable directory preimage assertions.
+    let normalizedFilePath (relativePath: RelativePath) = RelativePath(normalizeFilePath $"{relativePath}")
+
+    /// Builds a binary FileVersion with whole-file content reference.
+    let createWholeFileVersion (relativePath: RelativePath) (payload: byte array) =
+        FileVersion.CreateWithHashes
+            (normalizedFilePath relativePath)
+            (Sha256Hash(computeSha256Hash payload))
+            (Blake3Hash(computeBlake3Hash payload))
+            String.Empty
+            true
+            (int64 payload.Length)
 
     let createDirectoryVersion
         (directoryVersionId: DirectoryVersionId)
@@ -63,6 +104,37 @@ module DirectoryVersionServerTestHelpers =
             (List<DirectoryVersionId>(childDirectoryIds))
             (List<FileVersion>())
             Constants.InitialDirectorySize
+
+    let createDirectoryVersionWithFiles
+        (directoryVersionId: DirectoryVersionId)
+        (repositoryId: string)
+        (relativePath: RelativePath)
+        (files: FileVersion seq)
+        : DirectoryVersionModel
+        =
+        let fileVersions = files |> Seq.toArray
+
+        let entries =
+            fileVersions
+            |> Seq.map (fun fileVersion ->
+                DirectoryVersionPreimageEntry.File fileVersion.RelativePath fileVersion.Size fileVersion.Blake3Hash fileVersion.Sha256Hash)
+            |> Seq.toArray
+
+        let sha256Hash = computeSha256ForDirectoryEntries relativePath entries
+        let blake3Hash = computeBlake3ForDirectory relativePath entries
+
+        DirectoryVersionModel.CreateWithHashes
+            directoryVersionId
+            (Guid.Parse ownerId)
+            (Guid.Parse organizationId)
+            (Guid.Parse repositoryId)
+            relativePath
+            sha256Hash
+            blake3Hash
+            (List<DirectoryVersionId>())
+            (List<FileVersion>(fileVersions))
+            (fileVersions
+             |> Seq.sumBy (fun fileVersion -> fileVersion.Size))
 
     /// Builds create parameters for route calls.
     let createParameters (directoryVersion: DirectoryVersionModel) =
@@ -118,6 +190,220 @@ module DirectoryVersionServerTestHelpers =
             parameters.DirectoryVersions.Add(directoryVersion)
 
         parameters
+
+    /// Builds storage parameters for route calls used by manifest-backed DirectoryVersion tests.
+    let setStorageParameters (parameters: Parameters.Storage.StorageParameters) (repositoryId: string) correlationId =
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.CorrelationId <- correlationId
+
+    /// Asserts OK for helper route calls declared before the shared module assertOk helper.
+    let assertProjectionHelperOk (response: HttpResponseMessage) =
+        task {
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+        }
+
+    /// Uploads a binary whole-file object and returns the server-normalized FileVersion.
+    let uploadWholeFileAsync (repositoryId: string) (fileVersion: FileVersion) (payload: byte array) =
+        task {
+            let parameters = Parameters.Storage.GetUploadMetadataForFilesParameters()
+            setStorageParameters parameters repositoryId (generateCorrelationId ())
+            parameters.FileVersions <- [| fileVersion |]
+
+            let! uploadResponse = Client.PostAsync("/storage/getUploadMetadataForFiles", createJsonContent parameters)
+            do! assertProjectionHelperOk uploadResponse
+            let! uploadMetadata = deserializeContent<GraceReturnValue<List<Parameters.Storage.UploadMetadata>>> uploadResponse
+            let metadata = uploadMetadata.ReturnValue |> Seq.exactlyOne
+
+            use payloadStream = new MemoryStream(payload, writable = false)
+            let blockBlobClient = BlockBlobClient(metadata.BlobUriWithSasToken)
+            let! response = blockBlobClient.UploadAsync(payloadStream, BlobUploadOptions())
+            Assert.That(response.GetRawResponse().Status, Is.EqualTo(int HttpStatusCode.Created))
+
+            fileVersion.ContentReference <- metadata.ContentReference
+            return fileVersion
+        }
+
+    /// Encodes bytes as one content block for manifest upload tests.
+    let encodeBlock (bytes: byte array) =
+        match ContentBlockFormat.encode [ { PhysicalOffset = 0L; Bytes = bytes } ] with
+        | Ok block -> block
+        | Error error ->
+            Assert.Fail($"Expected test ContentBlock to encode, got {error}.")
+            Unchecked.defaultof<ContentBlockFormat.EncodedContentBlock>
+
+    /// Builds a finalized FileManifest for a storage pool returned by the upload session.
+    let manifestForStoragePool (storagePoolId: StoragePoolId) (bytes: byte array) (block: ContentBlockFormat.EncodedContentBlock) =
+        let contentBlock = ContentBlock.Create(block.Address, 0L, int64 bytes.Length)
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                ChunkingSuiteId RabinChunking.SuiteName,
+                FileContentHash(computeBlake3Hash bytes),
+                int64 bytes.Length,
+                storagePoolId,
+                [ contentBlock ]
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    /// Parses placement details from a content block SAS URI and upload ETag.
+    let contentBlockPlacementFromUri (blobUriWithSasToken: Uri) eTag =
+        let pathSegments =
+            blobUriWithSasToken
+                .AbsolutePath
+                .Trim('/')
+                .Split([| '/' |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.map Uri.UnescapeDataString
+
+        let isPathStyleAzurite =
+            blobUriWithSasToken.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            || IPAddress.TryParse(blobUriWithSasToken.Host)
+               |> fst
+
+        let accountName =
+            if isPathStyleAzurite && pathSegments.Length >= 3 then
+                pathSegments[0]
+            else
+                let host = blobUriWithSasToken.Host
+                let firstDot = host.IndexOf('.')
+                if firstDot > 0 then host.Substring(0, firstDot) else host
+
+        let containerIndex = if isPathStyleAzurite then 1 else 0
+
+        {
+            StorageAccountName = accountName
+            StorageContainerName = StorageContainerName pathSegments[containerIndex]
+            ObjectKey = String.Join("/", pathSegments |> Array.skip (containerIndex + 1))
+            ETag = eTag
+        }
+
+    /// Uploads content block bytes through a SAS URI.
+    let uploadContentBlockWithSasAsync (payload: byte array) (uploadUri: Uri) =
+        task {
+            let blockBlobClient = BlockBlobClient(uploadUri)
+            use payloadStream = new MemoryStream(payload, writable = false)
+            let options = BlobUploadOptions()
+            options.Conditions <- BlobRequestConditions(IfNoneMatch = ETag.All)
+            let! response = blockBlobClient.UploadAsync(payloadStream, options)
+            return response.Value.ETag.ToString()
+        }
+
+    /// Posts an upload session command and returns the decision payload.
+    let postUploadSessionDecisionAsync (route: string) parameters =
+        task {
+            let! response = Client.PostAsync(route, createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), body)
+            return deserialize<GraceReturnValue<UploadSessionDecision>> body
+        }
+
+    /// Creates and finalizes one manifest-backed FileVersion through the storage routes.
+    let createManifestBackedFileVersionAsync (repositoryId: string) (relativePath: RelativePath) (payload: byte array) =
+        task {
+            let correlationId = generateCorrelationId ()
+            let uploadSessionId = Guid.NewGuid()
+            let block = encodeBlock payload
+
+            let start = Parameters.Storage.StartManifestUploadSessionParameters()
+            setStorageParameters start repositoryId correlationId
+            start.UploadSessionId <- uploadSessionId
+            start.AuthorizedScope <- normalizedFilePath relativePath
+            start.FileContentHash <- FileContentHash(computeBlake3Hash payload)
+            start.ExpectedSize <- int64 payload.Length
+            start.ChunkingSuiteId <- RabinChunking.SuiteName
+            start.SamplingPolicySnapshot <- "directory-version-zip-test"
+            start.OperationId <- "start"
+
+            let! startResult = postUploadSessionDecisionAsync "/storage/startManifestUploadSession" start
+            let manifest = manifestForStoragePool startResult.ReturnValue.Session.StoragePoolId payload block
+
+            let register = Parameters.Storage.RegisterContentBlockUploadParameters()
+            setStorageParameters register repositoryId correlationId
+            register.UploadSessionId <- uploadSessionId
+            register.AuthorizedScope <- normalizedFilePath relativePath
+            register.OperationId <- "register-0"
+            register.ContentBlockAddress <- block.Address
+            register.LogicalOffset <- 0L
+            register.LogicalLength <- int64 payload.Length
+            register.ExpectedPayloadLength <- int64 block.Payload.Length
+
+            let! _ = postUploadSessionDecisionAsync "/storage/registerContentBlockUpload" register
+
+            let uploadUriParameters = Parameters.Storage.GetContentBlockUploadUriParameters()
+            setStorageParameters uploadUriParameters repositoryId correlationId
+            uploadUriParameters.UploadSessionId <- uploadSessionId
+            uploadUriParameters.AuthorizedScope <- normalizedFilePath relativePath
+            uploadUriParameters.ContentBlockAddress <- block.Address
+
+            let! uploadUriResponse = Client.PostAsync("/storage/getContentBlockUploadUri", createJsonContent uploadUriParameters)
+            let! uploadUriBody = uploadUriResponse.Content.ReadAsStringAsync()
+            Assert.That(uploadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), uploadUriBody)
+            let uploadUri = Uri uploadUriBody
+            let! uploadETag = uploadContentBlockWithSasAsync block.Payload uploadUri
+
+            let confirm = Parameters.Storage.ConfirmContentBlockUploadParameters()
+            setStorageParameters confirm repositoryId correlationId
+            confirm.UploadSessionId <- uploadSessionId
+            confirm.AuthorizedScope <- normalizedFilePath relativePath
+            confirm.OperationId <- "confirm-0"
+            confirm.ContentBlockAddress <- block.Address
+            confirm.Payload <- block.Payload
+            confirm.StoragePlacement <- contentBlockPlacementFromUri uploadUri (Some uploadETag)
+
+            let! _ = postUploadSessionDecisionAsync "/storage/confirmContentBlockUpload" confirm
+
+            let finalize = Parameters.Storage.FinalizeManifestUploadParameters()
+            setStorageParameters finalize repositoryId correlationId
+            finalize.UploadSessionId <- uploadSessionId
+            finalize.AuthorizedScope <- normalizedFilePath relativePath
+            finalize.OperationId <- "finalize"
+            finalize.Manifest <- manifest
+
+            finalize.BlockPayloads <-
+                [|
+                    { Address = block.Address; Payload = block.Payload }
+                |]
+
+            let! finalizeResult = postUploadSessionDecisionAsync "/storage/finalizeManifestUpload" finalize
+            Assert.That(finalizeResult.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
+
+            let fileVersion = createWholeFileVersion relativePath payload
+            fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+            return fileVersion
+        }
+
+    /// Gets the retained zip route artifact bytes.
+    let getZipBytesAsync (repositoryId: string) (directoryVersionId: DirectoryVersionId) =
+        task {
+            let parameters = Parameters.DirectoryVersion.GetZipFileParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.DirectoryVersionId <- $"{directoryVersionId}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/directory/getZipFile", createJsonContent parameters)
+            do! assertProjectionHelperOk response
+            let! returnValue = deserializeContent<GraceReturnValue<UriWithSharedAccessSignature>> response
+            let blobClient = BlobClient(returnValue.ReturnValue)
+            let! download = blobClient.DownloadContentAsync()
+            return download.Value.Content.ToArray()
+        }
+
+    /// Reads a zip entry into a byte array.
+    let readZipEntryBytes (zipBytes: byte array) (entryName: string) =
+        use stream = new MemoryStream(zipBytes, writable = false)
+        use archive = new ZipArchive(stream, ZipArchiveMode.Read)
+        let entry = archive.GetEntry(entryName)
+        Assert.That(entry, Is.Not.Null, $"Expected zip entry '{entryName}'.")
+        use entryStream = entry.Open()
+        use output = new MemoryStream()
+        entryStream.CopyTo(output)
+        output.ToArray()
 
     /// Builds a deterministic same SHA256 prefix directory pair for integration setup fixture for the server integration directory Version assertions.
     let createSameSha256PrefixDirectoryPair repositoryId pathPrefix =
@@ -391,4 +677,47 @@ type DirectoryVersionServer() =
 
             let! fetchedChild = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId childId
             DirectoryVersionServerTestHelpers.assertDirectoryVersionDto child fetchedChild
+        }
+
+    /// Verifies the retained zip route preserves bytes for mixed whole-file and FileManifest-backed files.
+    [<Test>]
+    member _.GetZipFilePreservesManifestBackedFileBytes() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let rootId = Guid.NewGuid()
+            let wholeFilePath = RelativePath $"/zip-proof/{Guid.NewGuid():N}/whole.bin"
+            let manifestFilePath = RelativePath $"/zip-proof/{Guid.NewGuid():N}/manifest.bin"
+            let wholeFilePayload = DirectoryVersionServerTestHelpers.deterministicBytes "whole-file-zip-proof" 8192
+            let manifestPayload = DirectoryVersionServerTestHelpers.deterministicBytes "manifest-backed-zip-proof" 220000
+
+            let wholeFileVersion = DirectoryVersionServerTestHelpers.createWholeFileVersion wholeFilePath wholeFilePayload
+
+            let! uploadedWholeFileVersion = DirectoryVersionServerTestHelpers.uploadWholeFileAsync repositoryId wholeFileVersion wholeFilePayload
+
+            let! manifestBackedFileVersion =
+                DirectoryVersionServerTestHelpers.createManifestBackedFileVersionAsync repositoryId manifestFilePath manifestPayload
+
+            let root =
+                DirectoryVersionServerTestHelpers.createDirectoryVersionWithFiles
+                    rootId
+                    repositoryId
+                    "/"
+                    [
+                        uploadedWholeFileVersion
+                        manifestBackedFileVersion
+                    ]
+
+            let! saveResponse =
+                Client.PostAsync("/directory/saveDirectoryVersions", createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ root ]))
+
+            do! DirectoryVersionServerTestHelpers.assertOk saveResponse
+
+            let! zipBytes = DirectoryVersionServerTestHelpers.getZipBytesAsync repositoryId rootId
+
+            let wholeFileEntry = DirectoryVersionServerTestHelpers.readZipEntryBytes zipBytes uploadedWholeFileVersion.RelativePath
+
+            let manifestEntry = DirectoryVersionServerTestHelpers.readZipEntryBytes zipBytes manifestBackedFileVersion.RelativePath
+
+            Assert.That(Convert.ToBase64String(wholeFileEntry), Is.EqualTo(Convert.ToBase64String(wholeFilePayload)))
+            Assert.That(Convert.ToBase64String(manifestEntry), Is.EqualTo(Convert.ToBase64String(manifestPayload)))
         }

--- a/src/Grace.Server.Unit.Tests/DirectoryVersion.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/DirectoryVersion.Actor.Tests.fs
@@ -6,6 +6,7 @@ open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.MaterializationPlan
 open NUnit.Framework
+open System
 open System.Threading.Tasks
 
 /// Covers deterministic DirectoryVersion projection helper behavior.
@@ -106,6 +107,27 @@ type DirectoryVersionProjectionEnsureTests() =
             match result with
             | Ok _ -> Assert.Fail("Expected recursive metadata failure to block descriptor success.")
             | Error error -> Assert.That(error.Error, Is.EqualTo("recursive metadata projection failed"))
+        }
+
+    /// Verifies unexpected recursive metadata exceptions are returned as Grace errors instead of escaping the grain call.
+    [<Test>]
+    member _.EnsureRequiredProjectionArtifactsWrapsRecursiveMetadataExceptionsAsGraceErrors() =
+        task {
+            let targetRootDirectoryVersionId = DirectoryVersionId.Parse "55555555-5555-5555-5555-555555555555"
+
+            let failingRecursiveMetadata () : Task<Result<ProjectionArtifactEvidence, GraceError>> =
+                raise (InvalidOperationException "recursive metadata storage fault")
+
+            let! result =
+                ensureRequiredProjectionArtifactsWith
+                    targetRootDirectoryVersionId
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.DirectoryVersionZip 123L None)))
+                    failingRecursiveMetadata
+                    "corr-recursive-throw"
+
+            match result with
+            | Ok _ -> Assert.Fail("Expected recursive metadata exception to be wrapped as a Grace error.")
+            | Error error -> Assert.That(error.Error, Does.Contain("RecursiveDirectoryMetadata projection could not be ensured."))
         }
 
     /// Verifies malformed projection evidence cannot produce a successful descriptor response.

--- a/src/Grace.Server.Unit.Tests/DirectoryVersion.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/DirectoryVersion.Actor.Tests.fs
@@ -1,0 +1,138 @@
+namespace Grace.Server.Unit.Tests
+
+open Grace.Actors.DirectoryVersion
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open Grace.Types.MaterializationPlan
+open NUnit.Framework
+open System.Threading.Tasks
+
+/// Covers deterministic DirectoryVersion projection helper behavior.
+[<TestFixture>]
+type DirectoryVersionProjectionEnsureTests() =
+
+    /// Builds projection evidence for the helper seam without requiring object storage.
+    let evidence artifactKind size source =
+        {
+            ArtifactKind = artifactKind
+            SizeInBytes = size
+            Sha256Hash = Some(Sha256Hash "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            Blake3Hash = Some(Blake3Hash "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+            Source = source
+        }
+
+    /// Verifies the projection ensure helper returns exactly the two V1 target-root descriptors.
+    [<Test>]
+    member _.EnsureRequiredProjectionArtifactsReturnsTargetRootZipAndRecursiveMetadataDescriptors() =
+        task {
+            let targetRootDirectoryVersionId = DirectoryVersionId.Parse "11111111-1111-1111-1111-111111111111"
+            let zipSource = Some(MaterializationArtifactSource.Direct "https://example.invalid/root.zip")
+            let metadataSource = Some(MaterializationArtifactSource.CacheOnly "recursive/root.msgpack")
+
+            let! result =
+                ensureRequiredProjectionArtifactsWith
+                    targetRootDirectoryVersionId
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.DirectoryVersionZip 123L zipSource)))
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.RecursiveDirectoryMetadata 456L metadataSource)))
+                    "corr-projection"
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok descriptors ->
+                Assert.That(descriptors, Has.Length.EqualTo(2))
+
+                let zip = descriptors[0]
+                let metadata = descriptors[1]
+
+                Assert.That(zip.ArtifactKind, Is.EqualTo(MaterializationArtifactKind.DirectoryVersionZip))
+                Assert.That(metadata.ArtifactKind, Is.EqualTo(MaterializationArtifactKind.RecursiveDirectoryMetadata))
+                Assert.That(zip.TargetRootDirectoryVersionId, Is.EqualTo(targetRootDirectoryVersionId))
+                Assert.That(metadata.TargetRootDirectoryVersionId, Is.EqualTo(targetRootDirectoryVersionId))
+                Assert.That(zip.RepresentedRootDirectoryVersionId, Is.EqualTo(Some targetRootDirectoryVersionId))
+                Assert.That(metadata.RepresentedRootDirectoryVersionId, Is.EqualTo(Some targetRootDirectoryVersionId))
+                Assert.That(zip.CanonicalArtifactIdentity, Is.EqualTo(Some(canonicalDirectoryVersionZipIdentity targetRootDirectoryVersionId)))
+                Assert.That(metadata.CanonicalArtifactIdentity, Is.EqualTo(Some(canonicalRecursiveDirectoryMetadataIdentity targetRootDirectoryVersionId)))
+                Assert.That(zip.SizeInBytes, Is.EqualTo(Some 123L))
+                Assert.That(metadata.SizeInBytes, Is.EqualTo(Some 456L))
+                Assert.That(zip.Source, Is.EqualTo(zipSource))
+                Assert.That(metadata.Source, Is.EqualTo(metadataSource))
+
+                match Validation.validateArtifactDescriptor zip with
+                | Ok () -> ()
+                | Error errors -> Assert.Fail(String.concat "; " errors)
+
+                match Validation.validateArtifactDescriptor metadata with
+                | Ok () -> ()
+                | Error errors -> Assert.Fail(String.concat "; " errors)
+        }
+
+    /// Verifies projection failures block descriptor success and later artifact work.
+    [<Test>]
+    member _.EnsureRequiredProjectionArtifactsStopsWhenZipProjectionFails() =
+        task {
+            let targetRootDirectoryVersionId = DirectoryVersionId.Parse "22222222-2222-2222-2222-222222222222"
+            let mutable recursiveMetadataCalled = false
+
+            let! result =
+                ensureRequiredProjectionArtifactsWith
+                    targetRootDirectoryVersionId
+                    (fun () -> Task.FromResult(Error(GraceError.Create "zip projection failed" "corr-zip-failure")))
+                    (fun () ->
+                        recursiveMetadataCalled <- true
+                        Task.FromResult(Ok(evidence MaterializationArtifactKind.RecursiveDirectoryMetadata 456L None)))
+                    "corr-zip-failure"
+
+            match result with
+            | Ok _ -> Assert.Fail("Expected zip projection failure to block descriptor success.")
+            | Error error ->
+                Assert.That(error.Error, Is.EqualTo("zip projection failed"))
+                Assert.That(recursiveMetadataCalled, Is.False)
+        }
+
+    /// Verifies recursive metadata failures block descriptor success after zip evidence is available.
+    [<Test>]
+    member _.EnsureRequiredProjectionArtifactsFailsWhenRecursiveMetadataProjectionFails() =
+        task {
+            let targetRootDirectoryVersionId = DirectoryVersionId.Parse "33333333-3333-3333-3333-333333333333"
+
+            let! result =
+                ensureRequiredProjectionArtifactsWith
+                    targetRootDirectoryVersionId
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.DirectoryVersionZip 123L None)))
+                    (fun () -> Task.FromResult(Error(GraceError.Create "recursive metadata projection failed" "corr-metadata-failure")))
+                    "corr-metadata-failure"
+
+            match result with
+            | Ok _ -> Assert.Fail("Expected recursive metadata failure to block descriptor success.")
+            | Error error -> Assert.That(error.Error, Is.EqualTo("recursive metadata projection failed"))
+        }
+
+    /// Verifies malformed projection evidence cannot produce a successful descriptor response.
+    [<Test>]
+    member _.EnsureRequiredProjectionArtifactsRejectsMalformedProjectionEvidence() =
+        task {
+            let targetRootDirectoryVersionId = DirectoryVersionId.Parse "44444444-4444-4444-4444-444444444444"
+
+            let! wrongKindResult =
+                ensureRequiredProjectionArtifactsWith
+                    targetRootDirectoryVersionId
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.RecursiveDirectoryMetadata 123L None)))
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.RecursiveDirectoryMetadata 456L None)))
+                    "corr-wrong-kind"
+
+            match wrongKindResult with
+            | Ok _ -> Assert.Fail("Expected wrong projection artifact kind to block descriptor success.")
+            | Error error -> Assert.That(error.Error, Does.Contain("while ensuring DirectoryVersionZip"))
+
+            let! negativeSizeResult =
+                ensureRequiredProjectionArtifactsWith
+                    targetRootDirectoryVersionId
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.DirectoryVersionZip -1L None)))
+                    (fun () -> Task.FromResult(Ok(evidence MaterializationArtifactKind.RecursiveDirectoryMetadata 456L None)))
+                    "corr-negative-size"
+
+            match negativeSizeResult with
+            | Ok _ -> Assert.Fail("Expected negative projection artifact size to block descriptor success.")
+            | Error error -> Assert.That(error.Error, Does.Contain("negative size"))
+        }

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
+    <Compile Include="DirectoryVersion.Actor.Tests.fs" />
     <Compile Include="Reference.Actor.Tests.fs" />
     <Compile Include="SaveBoundary.Actor.Tests.fs" />
     <Compile Include="Services.VersionHashPrefixResolution.Tests.fs" />

--- a/src/Grace.Server/DirectoryVersion.Server.fs
+++ b/src/Grace.Server/DirectoryVersion.Server.fs
@@ -13,6 +13,7 @@ open Grace.Shared.Parameters.DirectoryVersion
 open Grace.Shared.Resources.Text
 open Grace.Types.DirectoryVersion
 open Grace.Types.Common
+open Grace.Types.MaterializationPlan
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Common
 open Grace.Shared.Validation.Errors
@@ -51,6 +52,10 @@ module DirectoryVersion =
                     StringSplitOptions.RemoveEmptyEntries
                 )
                 .Length
+
+    /// Ensures projection artifacts required for target-root materialization planning through the DirectoryVersion actor.
+    let ensureTargetRootProjectionArtifacts (actorProxy: IDirectoryVersionActor) correlationId : Task<GraceResult<MaterializationArtifactDescriptor array>> =
+        actorProxy.EnsureRequiredProjectionArtifacts correlationId
 
     /// Coordinates process command processing for Grace Server.
     let processCommand<'T when 'T :> DirectoryVersionParameters>


### PR DESCRIPTION
## Summary

- Adds a reusable projection ensure seam for the two v1 target-root artifacts: `DirectoryVersionZip` and `RecursiveDirectoryMetadata`.
- Describes ensured artifacts using the canonical identity, represented root, size, source, and integrity contract from #611.
- Hardens zip generation so manifest-backed files are reconstructed through manifest validation instead of being skipped.
- Adds focused actor/server tests for success, projection failure, malformed projection evidence, retained route behavior, and manifest-backed zip byte equivalence.

## Why This Matters

Materialization Plan generation needs one reliable projection seam instead of duplicating zip and recursive metadata logic. This keeps the later plan endpoint from returning success before required artifacts exist, and proves the Direct tracer can preserve manifest-backed file bytes through existing zip projection behavior.

## Related Issue

Related to #612. Part of #599 and #597.

## Validation

- Passed: `dotnet tool run fantomas src\Grace.Actors\DirectoryVersion.Actor.fs src\Grace.Actors\Interfaces.Actor.fs src\Grace.Server\DirectoryVersion.Server.fs src\Grace.Server.Unit.Tests\DirectoryVersion.Actor.Tests.fs src\Grace.Server.Tests\DirectoryVersion.Server.Tests.fs`.
- Passed: `dotnet test --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~DirectoryVersionProjectionEnsureTests"` (`4/4`).
- Passed: `dotnet test --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~GetZipFilePreservesManifestBackedFileBytes"` (`1/1`).
- Passed: `git diff --check` and `git diff --cached --check`.
- Passed: `pwsh ./scripts/validate.ps1 -Full` on the final diff.
  - Build: 0 warnings, 0 errors.
  - `Grace.Operations.Tests`: 26 passed.
  - `Grace.Types.Tests`: 274 passed.
  - `Grace.Authorization.Tests`: 53 passed.
  - `Grace.Server.Unit.Tests`: 735 passed.
  - `Grace.CLI.Tests`: 689 passed, 1 skipped.
  - `Grace.Server.Tests`: 244 passed.
  - Elapsed: `00:03:56.2770329`.

## Contract Propagation

- `Grace.Actors` interfaces: added `IDirectoryVersionActor.EnsureRequiredProjectionArtifacts`.
- `Grace.Actors` behavior: added the projection ensure helper that creates or reuses zip and recursive metadata projections before describing them.
- `Grace.Server` helper seam: added `ensureTargetRootProjectionArtifacts` as the server-side forwarding seam for later Materialization Plan generation.
- `Grace.Types` DTOs/validators: unchanged; this PR consumes the #611 descriptor constructors and validation contract.
- Server routes/validation/auth/error envelopes: retained existing directory projection routes; no new public route added in #612.
- CLI parser/output/help/examples: N/A; `grace connect` behavior is unchanged in this leaf.
- SDK/generated clients/OpenAPI/static artifacts: N/A; no public endpoint or generated contract changed.
- Tests: updated focused actor/server projection coverage.

## Stale Authority

The ensure helper revalidates projection existence by reading stored projection bytes after create-or-reuse behavior and only then builds descriptors. Projection failure blocks successful descriptors, and recursive metadata is not attempted when zip projection fails. Runtime plan publication and status writes are still owned by later #599 leaves.

## Review Status

- Codex Code Review Bot reviewed `3294f5d9f370bdbf7773bd113eb02fb7e5f77579` and found three #612 projection ensure issues.
- Review fixes were pushed in `6d76d1caac968e42b8a118d0cd29eaff12805c90`.
- Fixes cover metadata projection exceptions returning `GraceResult` errors, streamed manifest-backed zip writes, and streamed descriptor hashing for ensured zip/metadata artifacts.
- Worker validation for `6d76d1caac968e42b8a118d0cd29eaff12805c90` passed: targeted Fantomas, `DirectoryVersionProjectionEnsureTests` (`5` tests), `GetZipFilePreservesManifestBackedFileBytes` (`1` test), `git diff --check`, and `pwsh ./scripts/validate.ps1 -Full`.
- GitHub Actions `full` passed on `6d76d1caac968e42b8a118d0cd29eaff12805c90` in run `28859440605`.
- Codex Code Review Bot completed review on `6d76d1caac968e42b8a118d0cd29eaff12805c90` and reported no major issues.
- The three prior review threads were replied to and resolved.
- Residual risk: there is no practical Azure SDK unit seam to assert `DownloadContentAsync` was not called for projection descriptors; proof is by implementation diff plus full integration validation.
