### PR TITLE
Add Operations monthly partitioning

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -13,10 +13,12 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="OperationsUsageSql.fs" />
+    <Compile Include="OperationsUsagePartitioningSql.fs" />
     <Compile Include="OperationsEntities.fs" />
     <Compile Include="OperationsDbContext.fs" />
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
     <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
+    <Compile Include="Migrations\20260707120000_AddOperationsMonthlyPartitioning.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -12,6 +12,30 @@ schema is intentionally narrow:
 The ingestion hot path still uses reviewed raw SQL for the durable insert and aggregate update. That path preserves the
 `UsageFactId` idempotency lock and the aggregate `MERGE ... WITH (HOLDLOCK)` behavior that the worker depends on.
 
+## Monthly Partitioning
+
+The current raw fact and minute aggregate tables are monthly partitioned by the UTC time columns used by range queries
+and future retention windows:
+
+- `ops.RawUsageFact` uses the shared `PF_ops_OperationsUsageMonthUtc` partition function through
+  `PS_ops_OperationsUsageMonthUtc`, with a clustered index on `(ObservedAtUtc, UsageFactId)`.
+- `ops.RawUsageFact` keeps `PK_ops_RawUsageFact` as a nonclustered primary key on `UsageFactId` so duplicate delivery
+  is still rejected by the durable usage-fact identity instead of by the partition month.
+- `ops.UsageAggregateMinute` keeps its logical primary key and places the clustered key on the partition scheme by
+  `BucketStartUtc`, which is already part of the aggregate key.
+- Scope-and-kind range indexes are rebuilt on the same partition scheme using `ObservedAtUtc` or `BucketStartUtc`.
+
+The initial partition function uses reviewed month-start UTC boundaries from January 2026 through January 2029 with
+`RANGE RIGHT`. The scheme maps all partitions to `[PRIMARY]`. That is the Azure SQL-compatible and local SQL Server
+test equivalent for this slice: it proves partition functions, partition schemes, and aligned index placement without
+requiring Azure-only filegroup behavior.
+
+Future retention or archive migrations must split the partition function before a new retention window needs an
+additional month. Do not add partition maintenance to worker startup or request-time bootstrap code.
+
+Rollback drops the partition-aligned indexes, restores the baseline unpartitioned keys and range indexes on `[PRIMARY]`,
+then removes the partition scheme and function after no indexes reference them.
+
 ## Raw SQL Escape Hatch
 
 Use EF migration builder APIs for ordinary tables, columns, keys, and indexes. Raw SQL is allowed only inside migration

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707120000_AddOperationsMonthlyPartitioning.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707120000_AddOperationsMonthlyPartitioning.fs
@@ -1,0 +1,20 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore.Migrations
+
+/// Adds SQL Server monthly partitioning for append-heavy Operations usage tables.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260707120000_AddOperationsMonthlyPartitioning")>]
+type AddOperationsMonthlyPartitioning() =
+    inherit Migration()
+
+    /// Applies reviewed physical partitioning without changing logical ingest or aggregate contracts.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(OperationsUsagePartitioningSql.ApplyMonthlyPartitioning)
+        |> ignore
+
+    /// Restores the unpartitioned baseline table layout for local rebuild and rollback scenarios.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(OperationsUsagePartitioningSql.RevertMonthlyPartitioning)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsagePartitioningSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsagePartitioningSql.fs
@@ -1,6 +1,7 @@
 namespace Grace.Operations.Data
 
 open System
+open System.Globalization
 
 /// Provides reviewed SQL Server partitioning text for append-heavy Operations usage tables.
 [<RequireQualifiedAccess>]
@@ -61,7 +62,7 @@ module OperationsUsagePartitioningSql =
         |]
 
     /// Formats a UTC month boundary as a SQL Server `datetime2(7)` literal.
-    let private boundaryLiteral (boundary: DateTime) = boundary.ToString("yyyy-MM-ddTHH:mm:ss.fffffff")
+    let internal boundaryLiteral (boundary: DateTime) = boundary.ToString("yyyy-MM-ddTHH:mm:ss.fffffff", CultureInfo.InvariantCulture)
 
     /// Joins the reviewed UTC month boundaries for the partition function definition.
     let private boundaryList () =
@@ -119,7 +120,14 @@ INSERT INTO @ExpectedPartitionBoundaries (BoundaryValue)
 VALUES
 {boundaryValidationRows ()};
 
-IF
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.partition_functions
+    WHERE name = N'{PartitionFunctionName}'
+      AND boundary_value_on_right = 1
+)
+OR
 (
     SELECT COUNT(*)
     FROM sys.partition_range_values AS boundaryValues
@@ -163,6 +171,19 @@ BEGIN
     CREATE PARTITION SCHEME {PartitionSchemeName}
     AS PARTITION {PartitionFunctionName}
     ALL TO ([PRIMARY]);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.partition_schemes AS schemes
+    INNER JOIN sys.partition_functions AS functions
+        ON schemes.function_id = functions.function_id
+    WHERE schemes.name = N'{PartitionSchemeName}'
+      AND functions.name = N'{PartitionFunctionName}'
+)
+BEGIN
+    THROW 57106, 'PS_ops_OperationsUsageMonthUtc must reference PF_ops_OperationsUsageMonthUtc.', 1;
 END;
 
 IF NOT EXISTS

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsagePartitioningSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsagePartitioningSql.fs
@@ -1,0 +1,383 @@
+namespace Grace.Operations.Data
+
+open System
+
+/// Provides reviewed SQL Server partitioning text for append-heavy Operations usage tables.
+[<RequireQualifiedAccess>]
+module OperationsUsagePartitioningSql =
+
+    /// Names the shared monthly UTC partition function for raw facts and minute aggregates.
+    [<Literal>]
+    let PartitionFunctionName = "PF_ops_OperationsUsageMonthUtc"
+
+    /// Names the shared monthly UTC partition scheme for raw facts and minute aggregates.
+    [<Literal>]
+    let PartitionSchemeName = "PS_ops_OperationsUsageMonthUtc"
+
+    /// Names the partition-aligned clustered index that orders raw facts by UTC observation month.
+    [<Literal>]
+    let RawUsageFactClusteredIndexName = "CX_ops_RawUsageFact_ObservedAtUtc_UsageFactId"
+
+    /// Provides the first reviewed monthly UTC partition boundaries for Operations usage tables.
+    let InitialMonthlyBoundariesUtc =
+        [|
+            DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 11, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2026, 12, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 3, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 5, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 8, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 10, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 11, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2027, 12, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 2, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 3, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 4, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 5, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 6, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 7, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 8, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 10, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 11, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2028, 12, 1, 0, 0, 0, DateTimeKind.Utc)
+            DateTime(2029, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        |]
+
+    /// Formats a UTC month boundary as a SQL Server `datetime2(7)` literal.
+    let private boundaryLiteral (boundary: DateTime) = boundary.ToString("yyyy-MM-ddTHH:mm:ss.fffffff")
+
+    /// Joins the reviewed UTC month boundaries for the partition function definition.
+    let private boundaryList () =
+        InitialMonthlyBoundariesUtc
+        |> Array.map (fun boundary -> $"'{boundaryLiteral boundary}'")
+        |> String.concat ", "
+
+    /// Joins the reviewed UTC month boundaries for the partition validation table.
+    let private boundaryValidationRows () =
+        InitialMonthlyBoundariesUtc
+        |> Array.map (fun boundary -> $"    (CONVERT(datetime2(7), N'{boundaryLiteral boundary}'))")
+        |> String.concat $",{Environment.NewLine}"
+
+    /// Applies monthly partitioning while preserving raw fact idempotency and aggregate query keys.
+    let ApplyMonthlyPartitioning =
+        $"""
+IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL
+BEGIN
+    THROW 57101, 'ops.RawUsageFact must exist before applying Operations monthly partitioning.', 1;
+END;
+
+IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL
+BEGIN
+    THROW 57102, 'ops.UsageAggregateMinute must exist before applying Operations monthly partitioning.', 1;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ObservedAtUtc') IS NULL
+OR COL_LENGTH(N'ops.RawUsageFact', N'UsageFactId') IS NULL
+BEGIN
+    THROW 57103, 'ops.RawUsageFact must expose ObservedAtUtc and UsageFactId before monthly partitioning.', 1;
+END;
+
+IF COL_LENGTH(N'ops.UsageAggregateMinute', N'BucketStartUtc') IS NULL
+BEGIN
+    THROW 57104, 'ops.UsageAggregateMinute must expose BucketStartUtc before monthly partitioning.', 1;
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.partition_functions
+    WHERE name = N'{PartitionFunctionName}'
+)
+BEGIN
+    CREATE PARTITION FUNCTION {PartitionFunctionName} (datetime2(7))
+    AS RANGE RIGHT FOR VALUES ({boundaryList ()});
+END;
+
+DECLARE @ExpectedPartitionBoundaries TABLE
+(
+    BoundaryValue datetime2(7) NOT NULL PRIMARY KEY
+);
+
+INSERT INTO @ExpectedPartitionBoundaries (BoundaryValue)
+VALUES
+{boundaryValidationRows ()};
+
+IF
+(
+    SELECT COUNT(*)
+    FROM sys.partition_range_values AS boundaryValues
+    INNER JOIN sys.partition_functions AS functions
+        ON boundaryValues.function_id = functions.function_id
+    WHERE functions.name = N'{PartitionFunctionName}'
+) <> (SELECT COUNT(*) FROM @ExpectedPartitionBoundaries)
+OR EXISTS
+(
+    SELECT expected.BoundaryValue
+    FROM @ExpectedPartitionBoundaries AS expected
+    EXCEPT
+    SELECT CONVERT(datetime2(7), boundaryValues.value) AS BoundaryValue
+    FROM sys.partition_range_values AS boundaryValues
+    INNER JOIN sys.partition_functions AS functions
+        ON boundaryValues.function_id = functions.function_id
+    WHERE functions.name = N'{PartitionFunctionName}'
+)
+OR EXISTS
+(
+    SELECT CONVERT(datetime2(7), boundaryValues.value) AS BoundaryValue
+    FROM sys.partition_range_values AS boundaryValues
+    INNER JOIN sys.partition_functions AS functions
+        ON boundaryValues.function_id = functions.function_id
+    WHERE functions.name = N'{PartitionFunctionName}'
+    EXCEPT
+    SELECT expected.BoundaryValue
+    FROM @ExpectedPartitionBoundaries AS expected
+)
+BEGIN
+    THROW 57105, 'PF_ops_OperationsUsageMonthUtc boundaries differ from the reviewed monthly UTC set.', 1;
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.partition_schemes
+    WHERE name = N'{PartitionSchemeName}'
+)
+BEGIN
+    CREATE PARTITION SCHEME {PartitionSchemeName}
+    AS PARTITION {PartitionFunctionName}
+    ALL TO ([PRIMARY]);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes AS indexes
+    INNER JOIN sys.data_spaces AS dataSpaces
+        ON indexes.data_space_id = dataSpaces.data_space_id
+    WHERE indexes.object_id = OBJECT_ID(N'ops.RawUsageFact')
+      AND indexes.name = N'{RawUsageFactClusteredIndexName}'
+      AND dataSpaces.name = N'{PartitionSchemeName}'
+)
+BEGIN
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.indexes
+        WHERE name = N'IX_ops_RawUsageFact_ScopeKindObservedAt'
+          AND object_id = OBJECT_ID(N'ops.RawUsageFact')
+    )
+    BEGIN
+        DROP INDEX IX_ops_RawUsageFact_ScopeKindObservedAt ON ops.RawUsageFact;
+    END;
+
+    IF OBJECT_ID(N'ops.PK_ops_RawUsageFact', N'PK') IS NOT NULL
+    BEGIN
+        ALTER TABLE ops.RawUsageFact
+            DROP CONSTRAINT PK_ops_RawUsageFact;
+    END;
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.indexes
+        WHERE name = N'{RawUsageFactClusteredIndexName}'
+          AND object_id = OBJECT_ID(N'ops.RawUsageFact')
+    )
+    BEGIN
+        DROP INDEX {RawUsageFactClusteredIndexName} ON ops.RawUsageFact;
+    END;
+
+    CREATE CLUSTERED INDEX {RawUsageFactClusteredIndexName}
+    ON ops.RawUsageFact (ObservedAtUtc, UsageFactId)
+    ON {PartitionSchemeName}(ObservedAtUtc);
+
+    ALTER TABLE ops.RawUsageFact
+        ADD CONSTRAINT PK_ops_RawUsageFact
+        PRIMARY KEY NONCLUSTERED (UsageFactId)
+        ON [PRIMARY];
+
+    CREATE INDEX IX_ops_RawUsageFact_ScopeKindObservedAt
+    ON ops.RawUsageFact (OwnerId, OrganizationId, RepositoryId, FactKind, ObservedAtUtc)
+    ON {PartitionSchemeName}(ObservedAtUtc);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes AS indexes
+    INNER JOIN sys.data_spaces AS dataSpaces
+        ON indexes.data_space_id = dataSpaces.data_space_id
+    WHERE indexes.object_id = OBJECT_ID(N'ops.UsageAggregateMinute')
+      AND indexes.name = N'PK_ops_UsageAggregateMinute'
+      AND dataSpaces.name = N'{PartitionSchemeName}'
+)
+BEGIN
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.indexes
+        WHERE name = N'IX_ops_UsageAggregateMinute_ScopeKindBucket'
+          AND object_id = OBJECT_ID(N'ops.UsageAggregateMinute')
+    )
+    BEGIN
+        DROP INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket ON ops.UsageAggregateMinute;
+    END;
+
+    IF OBJECT_ID(N'ops.PK_ops_UsageAggregateMinute', N'PK') IS NOT NULL
+    BEGIN
+        ALTER TABLE ops.UsageAggregateMinute
+            DROP CONSTRAINT PK_ops_UsageAggregateMinute;
+    END;
+
+    ALTER TABLE ops.UsageAggregateMinute
+        ADD CONSTRAINT PK_ops_UsageAggregateMinute
+        PRIMARY KEY CLUSTERED
+        (
+            FactKind,
+            OwnerId,
+            OrganizationId,
+            RepositoryId,
+            StoragePoolId,
+            BucketStartUtc
+        )
+        ON {PartitionSchemeName}(BucketStartUtc);
+
+    CREATE INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket
+    ON ops.UsageAggregateMinute (OwnerId, OrganizationId, RepositoryId, FactKind, BucketStartUtc)
+    ON {PartitionSchemeName}(BucketStartUtc);
+END;
+"""
+
+    /// Reverts monthly partitioning to the baseline unpartitioned Operations table layout.
+    let RevertMonthlyPartitioning =
+        $"""
+IF OBJECT_ID(N'ops.RawUsageFact', N'U') IS NOT NULL
+BEGIN
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.indexes
+        WHERE name = N'IX_ops_RawUsageFact_ScopeKindObservedAt'
+          AND object_id = OBJECT_ID(N'ops.RawUsageFact')
+    )
+    BEGIN
+        DROP INDEX IX_ops_RawUsageFact_ScopeKindObservedAt ON ops.RawUsageFact;
+    END;
+
+    IF OBJECT_ID(N'ops.PK_ops_RawUsageFact', N'PK') IS NOT NULL
+    BEGIN
+        ALTER TABLE ops.RawUsageFact
+            DROP CONSTRAINT PK_ops_RawUsageFact;
+    END;
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.indexes
+        WHERE name = N'{RawUsageFactClusteredIndexName}'
+          AND object_id = OBJECT_ID(N'ops.RawUsageFact')
+    )
+    BEGIN
+        DROP INDEX {RawUsageFactClusteredIndexName} ON ops.RawUsageFact;
+    END;
+
+    ALTER TABLE ops.RawUsageFact
+        ADD CONSTRAINT PK_ops_RawUsageFact
+        PRIMARY KEY CLUSTERED (UsageFactId)
+        ON [PRIMARY];
+
+    CREATE INDEX IX_ops_RawUsageFact_ScopeKindObservedAt
+    ON ops.RawUsageFact (OwnerId, OrganizationId, RepositoryId, FactKind, ObservedAtUtc)
+    ON [PRIMARY];
+END;
+
+IF OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NOT NULL
+BEGIN
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.indexes
+        WHERE name = N'IX_ops_UsageAggregateMinute_ScopeKindBucket'
+          AND object_id = OBJECT_ID(N'ops.UsageAggregateMinute')
+    )
+    BEGIN
+        DROP INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket ON ops.UsageAggregateMinute;
+    END;
+
+    IF OBJECT_ID(N'ops.PK_ops_UsageAggregateMinute', N'PK') IS NOT NULL
+    BEGIN
+        ALTER TABLE ops.UsageAggregateMinute
+            DROP CONSTRAINT PK_ops_UsageAggregateMinute;
+    END;
+
+    ALTER TABLE ops.UsageAggregateMinute
+        ADD CONSTRAINT PK_ops_UsageAggregateMinute
+        PRIMARY KEY CLUSTERED
+        (
+            FactKind,
+            OwnerId,
+            OrganizationId,
+            RepositoryId,
+            StoragePoolId,
+            BucketStartUtc
+        )
+        ON [PRIMARY];
+
+    CREATE INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket
+    ON ops.UsageAggregateMinute (OwnerId, OrganizationId, RepositoryId, FactKind, BucketStartUtc)
+    ON [PRIMARY];
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM sys.partition_schemes
+    WHERE name = N'{PartitionSchemeName}'
+)
+AND NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes AS indexes
+    INNER JOIN sys.data_spaces AS dataSpaces
+        ON indexes.data_space_id = dataSpaces.data_space_id
+    WHERE dataSpaces.name = N'{PartitionSchemeName}'
+)
+BEGIN
+    DROP PARTITION SCHEME {PartitionSchemeName};
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM sys.partition_functions
+    WHERE name = N'{PartitionFunctionName}'
+)
+AND NOT EXISTS
+(
+    SELECT 1
+    FROM sys.partition_schemes AS schemes
+    INNER JOIN sys.partition_functions AS functions
+        ON schemes.function_id = functions.function_id
+    WHERE functions.name = N'{PartitionFunctionName}'
+)
+BEGIN
+    DROP PARTITION FUNCTION {PartitionFunctionName};
+END;
+"""

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -175,6 +175,13 @@ type OperationsUsageStorageTests() =
         let migrator = context.GetService<IMigrator>()
         migrator.GenerateScript(options = MigrationsSqlGenerationOptions.Idempotent)
 
+    /// Generates an Operations migration script between two named migration points without opening SQL Server.
+    let migrationScriptFromTo fromMigration toMigration =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsMigrationScript;Integrated Security=true;"
+
+        let migrator = context.GetService<IMigrator>()
+        migrator.GenerateScript(fromMigration, toMigration, MigrationsSqlGenerationOptions.Idempotent)
+
     /// Reads the EF entity metadata that future migrations use for raw fact schema drift.
     let rawFactEntityType () : IEntityType =
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsMigrationModel;Integrated Security=true;"
@@ -356,6 +363,96 @@ type OperationsUsageStorageTests() =
                 Assert.That(script, Does.Contain("CREATE INDEX IX_ops_RawUsageFact_ScopeKindObservedAt"))
                 Assert.That(script, Does.Contain("CREATE INDEX IX_ops_UsageAggregateMinute_ScopeKindBucket"))
                 Assert.That(script, Does.Contain("[ops].[__EFMigrationsHistory]")))
+        )
+
+    /// Verifies reviewed partition boundaries are exact UTC month starts for range and retention alignment.
+    [<Test>]
+    member _.MonthlyPartitionBoundariesUseUtcMonthStarts() =
+        let boundaries = OperationsUsagePartitioningSql.InitialMonthlyBoundariesUtc
+
+        let allBoundariesAreMonthStarts =
+            boundaries
+            |> Array.forall (fun boundary ->
+                boundary.Kind = DateTimeKind.Utc
+                && boundary.Day = 1
+                && boundary.Hour = 0
+                && boundary.Minute = 0
+                && boundary.Second = 0
+                && boundary.Millisecond = 0)
+
+        let allBoundariesAreContiguousMonths =
+            boundaries
+            |> Seq.pairwise
+            |> Seq.forall (fun (previous, current) -> current = previous.AddMonths(1))
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(boundaries, Has.Length.EqualTo(37))
+                Assert.That(boundaries[0], Is.EqualTo(DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)))
+                Assert.That(boundaries[boundaries.Length - 1], Is.EqualTo(DateTime(2029, 1, 1, 0, 0, 0, DateTimeKind.Utc)))
+                Assert.That(allBoundariesAreMonthStarts, Is.True)
+                Assert.That(allBoundariesAreContiguousMonths, Is.True))
+        )
+
+    /// Verifies the monthly partitioning migration aligns table and index storage with UTC time columns.
+    [<Test>]
+    member _.MonthlyPartitioningMigrationScriptAlignsTablesAndIndexes() =
+        let script = migrationScript ()
+        let partitionFunctionIndex = script.IndexOf("CREATE PARTITION FUNCTION PF_ops_OperationsUsageMonthUtc", StringComparison.Ordinal)
+        let rawClusteredIndex = script.IndexOf("CREATE CLUSTERED INDEX CX_ops_RawUsageFact_ObservedAtUtc_UsageFactId", StringComparison.Ordinal)
+        let aggregatePartitionPlacement = script.IndexOf("ON PS_ops_OperationsUsageMonthUtc(BucketStartUtc)", StringComparison.Ordinal)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(partitionFunctionIndex, Is.GreaterThanOrEqualTo(0))
+                Assert.That(script, Does.Contain("AS RANGE RIGHT FOR VALUES"))
+                Assert.That(script, Does.Contain("'2026-07-01T00:00:00.0000000'"))
+                Assert.That(script, Does.Contain("'2029-01-01T00:00:00.0000000'"))
+                Assert.That(script, Does.Contain("THROW 57105"))
+                Assert.That(script, Does.Contain("@ExpectedPartitionBoundaries"))
+                Assert.That(script, Does.Contain("CREATE PARTITION SCHEME PS_ops_OperationsUsageMonthUtc"))
+                Assert.That(script, Does.Contain("ALL TO ([PRIMARY])"))
+                Assert.That(rawClusteredIndex, Is.GreaterThan(partitionFunctionIndex))
+                Assert.That(script, Does.Contain("ON ops.RawUsageFact (ObservedAtUtc, UsageFactId)"))
+                Assert.That(script, Does.Contain("ON PS_ops_OperationsUsageMonthUtc(ObservedAtUtc)"))
+                Assert.That(script, Does.Contain("PRIMARY KEY NONCLUSTERED (UsageFactId)"))
+                Assert.That(aggregatePartitionPlacement, Is.GreaterThan(partitionFunctionIndex))
+                Assert.That(script, Does.Contain("ON ops.RawUsageFact (OwnerId, OrganizationId, RepositoryId, FactKind, ObservedAtUtc)"))
+                Assert.That(script, Does.Contain("ON ops.UsageAggregateMinute (OwnerId, OrganizationId, RepositoryId, FactKind, BucketStartUtc)")))
+        )
+
+    /// Verifies partitioning is limited to current Operations tables and keeps local SQL Server testability.
+    [<Test>]
+    member _.MonthlyPartitioningMigrationStaysInsideCurrentUsageTables() =
+        let script = migrationScript ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(script, Does.Contain("OBJECT_ID(N'ops.RawUsageFact', N'U')"))
+                Assert.That(script, Does.Contain("OBJECT_ID(N'ops.UsageAggregateMinute', N'U')"))
+                Assert.That(script, Does.Contain("THROW 57101"))
+                Assert.That(script, Does.Contain("THROW 57102"))
+                Assert.That(script, Does.Contain("THROW 57103"))
+                Assert.That(script, Does.Contain("THROW 57104"))
+                Assert.That(script, Does.Not.Contain("ProviderLog"))
+                Assert.That(script, Does.Not.Contain("ChargeLedger"))
+                Assert.That(script, Does.Not.Contain("BillingPeriod"))
+                Assert.That(script, Does.Not.Contain("CREATE DATABASE"))
+                Assert.That(script, Does.Not.Contain("ONLINE = ON")))
+        )
+
+    /// Verifies rollback returns to the baseline unpartitioned keys and removes unused partition structures.
+    [<Test>]
+    member _.MonthlyPartitioningRollbackScriptRestoresBaselineLayout() =
+        let script = migrationScriptFromTo "20260707120000_AddOperationsMonthlyPartitioning" "20260707000000_AddRawUsageFactPayload"
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(script, Does.Contain("PRIMARY KEY CLUSTERED (UsageFactId)"))
+                Assert.That(script, Does.Contain("ON ops.RawUsageFact (OwnerId, OrganizationId, RepositoryId, FactKind, ObservedAtUtc)"))
+                Assert.That(script, Does.Contain("ON [PRIMARY]"))
+                Assert.That(script, Does.Contain("DROP PARTITION SCHEME PS_ops_OperationsUsageMonthUtc"))
+                Assert.That(script, Does.Contain("DROP PARTITION FUNCTION PF_ops_OperationsUsageMonthUtc")))
         )
 
     /// Verifies the initial migration records the target model used by future migration diffs.

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -14,6 +14,7 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Globalization
 open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
@@ -394,6 +395,24 @@ type OperationsUsageStorageTests() =
                 Assert.That(allBoundariesAreContiguousMonths, Is.True))
         )
 
+    /// Verifies SQL date literals stay Gregorian even when the ambient thread culture uses another calendar.
+    [<Test>]
+    member _.MonthlyPartitionBoundaryLiteralUsesInvariantCulture() =
+        let originalCulture = Thread.CurrentThread.CurrentCulture
+        let originalUiCulture = Thread.CurrentThread.CurrentUICulture
+
+        try
+            let thaiCulture = CultureInfo.GetCultureInfo("th-TH")
+            Thread.CurrentThread.CurrentCulture <- thaiCulture
+            Thread.CurrentThread.CurrentUICulture <- thaiCulture
+
+            let literal = OperationsUsagePartitioningSql.boundaryLiteral (DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc))
+
+            Assert.That(literal, Is.EqualTo("2026-07-01T00:00:00.0000000"))
+        finally
+            Thread.CurrentThread.CurrentCulture <- originalCulture
+            Thread.CurrentThread.CurrentUICulture <- originalUiCulture
+
     /// Verifies the monthly partitioning migration aligns table and index storage with UTC time columns.
     [<Test>]
     member _.MonthlyPartitioningMigrationScriptAlignsTablesAndIndexes() =
@@ -410,8 +429,13 @@ type OperationsUsageStorageTests() =
                 Assert.That(script, Does.Contain("'2029-01-01T00:00:00.0000000'"))
                 Assert.That(script, Does.Contain("THROW 57105"))
                 Assert.That(script, Does.Contain("@ExpectedPartitionBoundaries"))
+                Assert.That(script, Does.Contain("boundary_value_on_right = 1"))
                 Assert.That(script, Does.Contain("CREATE PARTITION SCHEME PS_ops_OperationsUsageMonthUtc"))
                 Assert.That(script, Does.Contain("ALL TO ([PRIMARY])"))
+                Assert.That(script, Does.Contain("schemes.function_id = functions.function_id"))
+                Assert.That(script, Does.Contain("WHERE schemes.name = N'PS_ops_OperationsUsageMonthUtc'"))
+                Assert.That(script, Does.Contain("AND functions.name = N'PF_ops_OperationsUsageMonthUtc'"))
+                Assert.That(script, Does.Contain("THROW 57106"))
                 Assert.That(rawClusteredIndex, Is.GreaterThan(partitionFunctionIndex))
                 Assert.That(script, Does.Contain("ON ops.RawUsageFact (ObservedAtUtc, UsageFactId)"))
                 Assert.That(script, Does.Contain("ON PS_ops_OperationsUsageMonthUtc(ObservedAtUtc)"))


### PR DESCRIPTION
# Summary

Related to #571.
Part of #558 and #554.

This adds reviewed SQL Server monthly partitioning migration support for the Operations raw usage fact and minute aggregate tables. Grace needs this physical design so the hot Operations store can scale beyond the tracer-bullet schema while preserving the logical ingest, idempotency, and aggregate contracts established by #569 and #570.

## Changes

- Adds a reviewed `OperationsUsagePartitioningSql` helper with monthly UTC partition function/scheme SQL, dependency guards, partition-aligned index rebuilds, and rollback SQL.
- Adds an EF migration that applies the partitioning SQL to append-heavy Operations usage tables.
- Keeps raw usage fact idempotency stable: `UsageFactId` remains the duplicate key while physical clustered order uses `(ObservedAtUtc, UsageFactId)`.
- Keeps aggregate semantics stable and partition-compatible by preserving the logical aggregate key with `BucketStartUtc` included.
- Rejects current-culture boundary literal generation, existing `RANGE LEFT` partition functions, and existing schemes mapped to the wrong function.
- Adds migration-script tests for monthly boundaries, table/index alignment, local-test equivalent behavior, future-leaf scope exclusions, missing-dependency guards, partition function/scheme reuse validation, and rollback.
- Documents the partition strategy, `[PRIMARY]` local/Azure SQL equivalent, future split expectations, and rollback behavior.

## Branch Contract

- Source branch: `agent/571-operations-monthly-partitioning`.
- Target branch: `epic/558-operations-ingestion-hot-projections`.
- This is a leaf PR into the WS2 mini-epic integration branch. It intentionally uses non-closing issue wording; the orchestrator will close #571 manually after merge to the mini-epic branch.

## Validation

- `dotnet tool run fantomas -- <touched F# files>`: passed.
- `dotnet test src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj --configuration Release --filter FullyQualifiedName~OperationsUsageStorageTests`: passed, 24/24 before review fixes and 25/25 after review fixes.
- `dotnet test src/Grace.Operations/Grace.Operations.slnx --configuration Release`: passed, 74/74 before review fixes.
- `npx --yes markdownlint-cli2 src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md`: passed, 0 errors.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Full`: passed for the latest review-fix head; Operations solution tests passed 75/75. Earlier first run hit an unrelated Aspire Service Bus emulator readiness timeout, then retry passed end to end.
- GitHub `full`: passed for initial head `eae807e87964853eabb42fa652770487894e3bf6`; awaiting GitHub `full` for `f9ebda53263ccee9cde15b3e63f198f0e4579b5d`.

## Review Status

- Latest head: `f9ebda53263ccee9cde15b3e63f198f0e4579b5d`.
- Codex Code Review Bot: first latest-head review found three partitioning SQL invariants; all fixed in `f9ebda53` with review-thread replies and resolutions. Awaiting next review result for this PR head.
- CI: GitHub `full` passed for `eae807e8`; awaiting `full` for `f9ebda53`.
- Substantive Codex review cycles: 1.
- Prevention note: review-fix tests now cover invariant-culture boundary literals, `RANGE RIGHT` function reuse, and partition scheme/function identity matching so local/manual partial partition setup cannot silently violate the monthly partition contract.

## Grace.slnx Isolation

Confirmed during worker handoff and review-fix handoff: `src/Grace.slnx` does not reference `Grace.Operations` projects.
