### PR TITLE
A3.1: Implement hot/cold archive to Blob

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
     <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
     <Compile Include="Migrations\20260707120000_AddOperationsMonthlyPartitioning.fs" />
+    <Compile Include="Migrations\20260707130000_AddRawUsageFactArchiveState.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -12,6 +12,35 @@ schema is intentionally narrow:
 The ingestion hot path still uses reviewed raw SQL for the durable insert and aggregate update. That path preserves the
 `UsageFactId` idempotency lock and the aggregate `MERGE ... WITH (HOLDLOCK)` behavior that the worker depends on.
 
+## Hot/Cold Raw Payload Archive
+
+Raw payloads stay hot in SQL only for the configured Operations archive retention window. When archive Blob settings
+are supplied, the Operations archive worker writes one deterministic compressed JSONL Blob per `UsageFactId` after that
+window and records Blob authority before it clears `ops.RawUsageFact.RawPayload`. Existing ingestion-only local hosts
+that do not provide archive settings continue to start without registering the archive hosted service; partial archive
+settings still fail startup instead of silently running with missing Blob authority.
+
+Archive Blob names are deterministic and scope-qualified:
+
+```text
+usage-facts/v1/observedYear=<yyyy>/observedMonth=<MM>/ownerId=<owner-guid>/organizationId=<organization-guid>/repositoryId=<repository-guid>/usageFactId=<usage-fact-guid>.jsonl.gz
+```
+
+Each Blob contains one gzip-compressed JSONL record with archive schema version, usage fact identity, Grace scope,
+storage pool, quantity, observed UTC timestamp, and the exact accepted broker payload as base64. SQL stores:
+
+- `ArchiveState`, where `0` is hot, `1` is Blob-verified with hot payload retained, and `2` is archived with hot
+  payload cleared.
+- `ArchiveBlobName`, the deterministic Blob pointer.
+- `ArchiveChecksumSha256Hex`, the SHA-256 checksum of the compressed Blob bytes.
+- `ArchiveByteLength`, the exact compressed Blob byte length.
+- `ArchiveVerifiedAtUtc` and `ArchivedAtUtc`, the two ordering points for partial-success resume.
+
+The worker verifies Blob checksum and byte length from Blob storage before recording `ArchiveState = 1`, then verifies
+the same Blob pointer again before clearing `RawPayload` and setting `ArchiveState = 2`. If the Blob is missing,
+corrupt, or different from the SQL pointer, cleanup fails loudly and the hot payload is not cleared. A retry can resume
+from `ArchiveState = 1` without rewriting the Blob.
+
 ## Monthly Partitioning
 
 The current raw fact and minute aggregate tables are monthly partitioned by the UTC time columns used by range queries

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707130000_AddRawUsageFactArchiveState.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260707130000_AddRawUsageFactArchiveState.fs
@@ -1,0 +1,160 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore.Migrations
+
+/// Adds Blob archive authority columns for raw usage fact hot/cold retention.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260707130000_AddRawUsageFactArchiveState")>]
+type AddRawUsageFactArchiveState() =
+    inherit Migration()
+
+    /// Adds SQL archive state and makes the hot payload nullable only after verified Blob authority exists.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveState') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD ArchiveState int NOT NULL
+            CONSTRAINT DF_ops_RawUsageFact_ArchiveState DEFAULT (0) WITH VALUES;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveBlobName') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD ArchiveBlobName nvarchar(512) NULL;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveChecksumSha256Hex') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD ArchiveChecksumSha256Hex char(64) NULL;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveByteLength') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD ArchiveByteLength bigint NULL;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveVerifiedAtUtc') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD ArchiveVerifiedAtUtc datetime2(7) NULL;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchivedAtUtc') IS NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ADD ArchivedAtUtc datetime2(7) NULL;
+END;
+
+IF EXISTS
+(
+    SELECT 1
+    FROM sys.columns
+    WHERE object_id = OBJECT_ID(N'ops.RawUsageFact')
+    AND name = N'RawPayload'
+    AND is_nullable = 0
+)
+BEGIN
+    ALTER TABLE ops.RawUsageFact
+        ALTER COLUMN RawPayload varbinary(max) NULL;
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'ops.RawUsageFact')
+    AND name = N'IX_ops_RawUsageFact_ArchiveStateObservedAt'
+)
+BEGIN
+    IF EXISTS
+    (
+        SELECT 1
+        FROM sys.partition_schemes schemes
+        INNER JOIN sys.partition_functions functions
+            ON schemes.function_id = functions.function_id
+        WHERE schemes.name = N'PS_ops_OperationsUsageMonthUtc'
+        AND functions.name = N'PF_ops_OperationsUsageMonthUtc'
+    )
+    BEGIN
+        CREATE INDEX IX_ops_RawUsageFact_ArchiveStateObservedAt
+        ON ops.RawUsageFact (ArchiveState, ObservedAtUtc, UsageFactId)
+        ON PS_ops_OperationsUsageMonthUtc(ObservedAtUtc);
+    END
+    ELSE
+    BEGIN
+        CREATE INDEX IX_ops_RawUsageFact_ArchiveStateObservedAt
+        ON ops.RawUsageFact (ArchiveState, ObservedAtUtc, UsageFactId);
+    END;
+END;
+"""
+        )
+        |> ignore
+
+    /// Removes archive state columns for local rebuild and rollback scenarios.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+IF EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'ops.RawUsageFact')
+    AND name = N'IX_ops_RawUsageFact_ArchiveStateObservedAt'
+)
+BEGIN
+    DROP INDEX IX_ops_RawUsageFact_ArchiveStateObservedAt ON ops.RawUsageFact;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'RawPayload') IS NOT NULL
+BEGIN
+    UPDATE ops.RawUsageFact
+    SET RawPayload = 0x
+    WHERE RawPayload IS NULL;
+
+    ALTER TABLE ops.RawUsageFact
+        ALTER COLUMN RawPayload varbinary(max) NOT NULL;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchivedAtUtc') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact DROP COLUMN ArchivedAtUtc;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveVerifiedAtUtc') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact DROP COLUMN ArchiveVerifiedAtUtc;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveByteLength') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact DROP COLUMN ArchiveByteLength;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveChecksumSha256Hex') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact DROP COLUMN ArchiveChecksumSha256Hex;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveBlobName') IS NOT NULL
+BEGIN
+    ALTER TABLE ops.RawUsageFact DROP COLUMN ArchiveBlobName;
+END;
+
+IF COL_LENGTH(N'ops.RawUsageFact', N'ArchiveState') IS NOT NULL
+BEGIN
+    IF OBJECT_ID(N'ops.DF_ops_RawUsageFact_ArchiveState', N'D') IS NOT NULL
+    BEGIN
+        ALTER TABLE ops.RawUsageFact
+            DROP CONSTRAINT DF_ops_RawUsageFact_ArchiveState;
+    END;
+
+    ALTER TABLE ops.RawUsageFact DROP COLUMN ArchiveState;
+END;
+"""
+        )
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -36,7 +36,6 @@ type OperationsDbContextModelSnapshot() =
         rawFact
             .Property<byte array>("RawPayload")
             .HasColumnType("varbinary(max)")
-            .IsRequired()
         |> ignore
 
         rawFact
@@ -82,6 +81,36 @@ type OperationsDbContextModelSnapshot() =
             .IsRequired()
         |> ignore
 
+        rawFact.Property<int>("ArchiveState").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveBlobName")
+            .HasMaxLength(512)
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveChecksumSha256Hex")
+            .HasMaxLength(64)
+            .IsFixedLength()
+            .IsUnicode(false)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<int64>>("ArchiveByteLength")
+            .HasColumnType("bigint")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchivedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
         rawFact
             .Property<System.DateTime>("CreatedAtUtc")
             .HasColumnType("datetime2(7)")
@@ -100,6 +129,17 @@ type OperationsDbContextModelSnapshot() =
                 |]
             )
             .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "ArchiveState"
+                    "ObservedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ArchiveStateObservedAt")
         |> ignore
 
         let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -56,6 +56,47 @@ type UsageFactPersistenceStatus =
 /// Reports the outcome of transactionally storing a usage fact.
 type UsageFactPersistenceResult = { Status: UsageFactPersistenceStatus; UsageFactId: UsageFactId; Aggregate: UsageAggregateMinute option }
 
+/// Tracks whether a raw usage fact payload is still hot in SQL, verified in Blob, or fully archived.
+type RawUsageFactArchiveState =
+    | Hot = 0
+    | ArchiveVerified = 1
+    | Archived = 2
+
+/// Describes one raw usage fact that is ready for Blob archive processing or verified cleanup.
+type RawUsageFactArchiveCandidate =
+    {
+        UsageFactId: UsageFactId
+        RawPayload: byte array option
+        CorrelationId: CorrelationId
+        FactKind: UsageFactKind
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        StoragePoolId: StoragePoolId
+        Quantity: int64
+        ObservedAt: Instant
+        ArchiveState: RawUsageFactArchiveState
+        ArchiveBlobName: string option
+        ArchiveChecksumSha256Hex: string option
+        ArchiveByteLength: int64 option
+    }
+
+/// Carries the Blob authority that must match before Operations clears a hot SQL payload.
+type RawUsageFactArchivePointer = { UsageFactId: UsageFactId; BlobName: string; ChecksumSha256Hex: string; ByteLength: int64 }
+
+/// Lists and transitions raw usage facts through the hot/cold archive boundary.
+type IOperationsUsageArchiveStore =
+
+    /// Returns deterministic archive candidates older than the hot-retention cutoff.
+    abstract ListArchiveCandidatesAsync:
+        observedBefore: Instant * batchSize: int * cancellationToken: CancellationToken -> Task<RawUsageFactArchiveCandidate list>
+
+    /// Records verified Blob authority while the hot SQL payload is still present.
+    abstract MarkArchiveVerifiedAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<bool>
+
+    /// Clears the hot SQL payload only when the verified SQL pointer still matches the supplied Blob authority.
+    abstract CompleteArchiveAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<bool>
+
 /// Chooses whether schema initialization may connect to `master` to create the operations database.
 type OperationsUsageSchemaBootstrapMode =
 
@@ -282,6 +323,161 @@ type SqlOperationsUsageTransactionScope(connectionString: string) =
                     do! rollbackIgnoringFailuresAsync transaction
                     return raise ex
             }
+
+/// Lists and updates archive state through reviewed SQL commands that preserve Blob authority ordering.
+type SqlOperationsUsageArchiveStore(connectionString: string) =
+
+    /// Opens a SQL connection for archive queries and state transitions.
+    let openConnectionAsync cancellationToken =
+        task {
+            let connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            return connection
+        }
+
+    /// Converts a NodaTime instant to the UTC SQL timestamp shape used by operations usage tables.
+    let toUtcDateTime (instant: Instant) = instant.ToDateTimeUtc()
+
+    /// Converts a UTC SQL timestamp into the instant used by archive layout decisions.
+    let toInstant (dateTime: DateTime) =
+        let utc =
+            if dateTime.Kind = DateTimeKind.Utc then
+                dateTime
+            else
+                DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+
+        Instant.FromDateTimeUtc utc
+
+    /// Adds a SQL parameter and assigns either the supplied value or database null.
+    let addParameter (command: SqlCommand) name sqlDbType value =
+        let parameter = command.Parameters.Add(name, sqlDbType)
+        parameter.Value <- value
+
+    /// Adds a string SQL parameter with a fixed column length.
+    let addStringParameter (command: SqlCommand) name length (value: string) =
+        let parameter = command.Parameters.Add(name, SqlDbType.NVarChar, length)
+        parameter.Value <- value
+
+    /// Adds archive-state parameters shared by archive SQL commands.
+    let addArchiveStateParameters (command: SqlCommand) =
+        addParameter command "@ArchiveStateHot" SqlDbType.Int (int RawUsageFactArchiveState.Hot)
+        addParameter command "@ArchiveStateVerified" SqlDbType.Int (int RawUsageFactArchiveState.ArchiveVerified)
+        addParameter command "@ArchiveStateArchived" SqlDbType.Int (int RawUsageFactArchiveState.Archived)
+
+    /// Adds Blob pointer parameters that guard archive idempotency and hot-payload cleanup.
+    let addArchivePointerParameters (command: SqlCommand) (pointer: RawUsageFactArchivePointer) =
+        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier pointer.UsageFactId
+        addStringParameter command "@ArchiveBlobName" OperationsUsageSql.ArchiveBlobNameMaxLength pointer.BlobName
+
+        let checksumParameter = command.Parameters.Add("@ArchiveChecksumSha256Hex", SqlDbType.Char, OperationsUsageSql.ArchiveChecksumSha256HexLength)
+
+        checksumParameter.Value <- pointer.ChecksumSha256Hex
+        addParameter command "@ArchiveByteLength" SqlDbType.BigInt pointer.ByteLength
+
+    /// Executes an archive transition command and returns whether this call changed SQL state.
+    let executeArchiveTransitionAsync commandText pointer cancellationToken =
+        task {
+            use! connection = openConnectionAsync cancellationToken
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+            command.CommandText <- commandText
+            addArchiveStateParameters command
+            addArchivePointerParameters command pointer
+
+            let! scalar = command.ExecuteScalarAsync cancellationToken
+
+            return
+                match scalar with
+                | :? int as value -> value = 1
+                | :? int64 as value -> value = 1L
+                | :? decimal as value -> value = 1M
+                | _ -> false
+        }
+
+    interface IOperationsUsageArchiveStore with
+
+        member _.ListArchiveCandidatesAsync(observedBefore, batchSize, cancellationToken) =
+            task {
+                if batchSize <= 0 then
+                    invalidArg (nameof batchSize) "Archive batch size must be greater than zero."
+
+                use! connection = openConnectionAsync cancellationToken
+                use command = connection.CreateCommand()
+                command.CommandType <- CommandType.Text
+                command.CommandText <- OperationsUsageSql.SelectRawUsageFactsForArchive
+                addParameter command "@BatchSize" SqlDbType.Int batchSize
+                addParameter command "@ObservedBeforeUtc" SqlDbType.DateTime2 (toUtcDateTime observedBefore)
+                addArchiveStateParameters command
+
+                use! reader = command.ExecuteReaderAsync cancellationToken
+                let candidates = ResizeArray<RawUsageFactArchiveCandidate>()
+
+                let usageFactIdOrdinal = reader.GetOrdinal("UsageFactId")
+                let rawPayloadOrdinal = reader.GetOrdinal("RawPayload")
+                let correlationIdOrdinal = reader.GetOrdinal("CorrelationId")
+                let factKindOrdinal = reader.GetOrdinal("FactKind")
+                let ownerIdOrdinal = reader.GetOrdinal("OwnerId")
+                let organizationIdOrdinal = reader.GetOrdinal("OrganizationId")
+                let repositoryIdOrdinal = reader.GetOrdinal("RepositoryId")
+                let storagePoolIdOrdinal = reader.GetOrdinal("StoragePoolId")
+                let quantityOrdinal = reader.GetOrdinal("Quantity")
+                let observedAtOrdinal = reader.GetOrdinal("ObservedAtUtc")
+                let archiveStateOrdinal = reader.GetOrdinal("ArchiveState")
+                let archiveBlobNameOrdinal = reader.GetOrdinal("ArchiveBlobName")
+                let archiveChecksumOrdinal = reader.GetOrdinal("ArchiveChecksumSha256Hex")
+                let archiveByteLengthOrdinal = reader.GetOrdinal("ArchiveByteLength")
+
+                let mutable reading = true
+
+                while reading do
+                    let! hasRow = reader.ReadAsync cancellationToken
+
+                    if hasRow then
+                        let rawPayload =
+                            if reader.IsDBNull rawPayloadOrdinal then
+                                None
+                            else
+                                Some(
+                                    reader.GetFieldValue<byte array>(rawPayloadOrdinal)
+                                    |> Array.copy
+                                )
+
+                        let readOptionalString ordinal = if reader.IsDBNull ordinal then None else Some(reader.GetString ordinal)
+
+                        let archiveByteLength =
+                            if reader.IsDBNull archiveByteLengthOrdinal then
+                                None
+                            else
+                                Some(reader.GetInt64 archiveByteLengthOrdinal)
+
+                        candidates.Add
+                            {
+                                UsageFactId = reader.GetGuid usageFactIdOrdinal
+                                RawPayload = rawPayload
+                                CorrelationId = CorrelationId(reader.GetString correlationIdOrdinal)
+                                FactKind = enum<UsageFactKind> (reader.GetInt32 factKindOrdinal)
+                                OwnerId = reader.GetGuid ownerIdOrdinal
+                                OrganizationId = reader.GetGuid organizationIdOrdinal
+                                RepositoryId = reader.GetGuid repositoryIdOrdinal
+                                StoragePoolId = StoragePoolId(reader.GetString storagePoolIdOrdinal)
+                                Quantity = reader.GetInt64 quantityOrdinal
+                                ObservedAt = toInstant (reader.GetDateTime observedAtOrdinal)
+                                ArchiveState = enum<RawUsageFactArchiveState> (reader.GetInt32 archiveStateOrdinal)
+                                ArchiveBlobName = readOptionalString archiveBlobNameOrdinal
+                                ArchiveChecksumSha256Hex = readOptionalString archiveChecksumOrdinal
+                                ArchiveByteLength = archiveByteLength
+                            }
+                    else
+                        reading <- false
+
+                return candidates |> Seq.toList
+            }
+
+        member _.MarkArchiveVerifiedAsync(pointer, cancellationToken) =
+            executeArchiveTransitionAsync OperationsUsageSql.MarkRawUsageFactArchiveVerified pointer cancellationToken
+
+        member _.CompleteArchiveAsync(pointer, cancellationToken) =
+            executeArchiveTransitionAsync OperationsUsageSql.CompleteRawUsageFactArchive pointer cancellationToken
 
 /// Ensures the operations usage SQL schema exists before ingestion starts consuming durable messages.
 type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsUsageSchemaBootstrapMode) =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -35,7 +35,6 @@ module OperationsModel =
         rawFact
             .Property<byte array>("RawPayload")
             .HasColumnType("varbinary(max)")
-            .IsRequired()
         |> ignore
 
         rawFact
@@ -81,6 +80,36 @@ module OperationsModel =
             .IsRequired()
         |> ignore
 
+        rawFact.Property<int>("ArchiveState").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveBlobName")
+            .HasMaxLength(OperationsUsageSql.ArchiveBlobNameMaxLength)
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveChecksumSha256Hex")
+            .HasMaxLength(OperationsUsageSql.ArchiveChecksumSha256HexLength)
+            .IsFixedLength()
+            .IsUnicode(false)
+        |> ignore
+
+        rawFact
+            .Property<Nullable<int64>>("ArchiveByteLength")
+            .HasColumnType("bigint")
+        |> ignore
+
+        rawFact
+            .Property<Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<Nullable<System.DateTime>>("ArchivedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
         rawFact
             .Property<System.DateTime>("CreatedAtUtc")
             .HasColumnType("datetime2(7)")
@@ -99,6 +128,17 @@ module OperationsModel =
                 |]
             )
             .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "ArchiveState"
+                    "ObservedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ArchiveStateObservedAt")
         |> ignore
 
         let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -9,7 +9,7 @@ type RawUsageFactEntity() =
     /// Stores the durable idempotency key supplied by the UsageFact contract.
     member val UsageFactId = Guid.Empty with get, set
 
-    /// Stores the exact accepted broker payload for replay and audit of raw facts.
+    /// Stores the exact accepted broker payload while the fact remains inside the hot SQL window.
     member val RawPayload: byte array = Array.empty with get, set
 
     /// Stores the request or workflow correlation identifier associated with the fact.
@@ -35,6 +35,24 @@ type RawUsageFactEntity() =
 
     /// Stores the UTC minute timestamp associated with the fact.
     member val ObservedAtUtc = DateTime.MinValue with get, set
+
+    /// Stores the hot/cold archive state for the raw payload.
+    member val ArchiveState = 0 with get, set
+
+    /// Stores the deterministic Blob name that owns the archived raw payload bytes.
+    member val ArchiveBlobName: string = null with get, set
+
+    /// Stores the SHA-256 checksum for the compressed archive Blob bytes.
+    member val ArchiveChecksumSha256Hex: string = null with get, set
+
+    /// Stores the exact compressed archive Blob byte length verified before hot SQL cleanup.
+    member val ArchiveByteLength = Nullable<int64>() with get, set
+
+    /// Stores when Blob authority was verified and recorded in SQL.
+    member val ArchiveVerifiedAtUtc = Nullable<DateTime>() with get, set
+
+    /// Stores when the hot raw payload was cleared after Blob authority was verified.
+    member val ArchivedAtUtc = Nullable<DateTime>() with get, set
 
     /// Stores the SQL-created UTC timestamp for the raw fact row.
     member val CreatedAtUtc = DateTime.MinValue with get, set

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -120,7 +120,7 @@ SELECT TOP (@BatchSize)
     ArchiveBlobName,
     ArchiveChecksumSha256Hex,
     ArchiveByteLength
-FROM ops.RawUsageFact WITH (READPAST)
+FROM ops.RawUsageFact WITH (READPAST, READCOMMITTEDLOCK)
 WHERE ObservedAtUtc < @ObservedBeforeUtc
 AND
 (

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -36,6 +36,14 @@ module OperationsUsageSql =
     [<Literal>]
     let StoragePoolIdMaxLength = 256
 
+    /// Limits deterministic archive Blob names stored with raw facts.
+    [<Literal>]
+    let ArchiveBlobNameMaxLength = 512
+
+    /// Fixes the length of lowercase SHA-256 hexadecimal checksums stored with archive pointers.
+    [<Literal>]
+    let ArchiveChecksumSha256HexLength = 64
+
     /// Creates the configured operations database when SQL Server does not already contain it.
     [<Literal>]
     let CreateDatabaseIfMissing =
@@ -91,6 +99,117 @@ WHERE NOT EXISTS
     FROM ops.RawUsageFact WITH (UPDLOCK, HOLDLOCK)
     WHERE UsageFactId = @UsageFactId
 );
+"""
+
+    /// Selects hot facts and partially verified facts that need archive processing or cleanup.
+    [<Literal>]
+    let SelectRawUsageFactsForArchive =
+        """
+SELECT TOP (@BatchSize)
+    UsageFactId,
+    RawPayload,
+    CorrelationId,
+    FactKind,
+    OwnerId,
+    OrganizationId,
+    RepositoryId,
+    StoragePoolId,
+    Quantity,
+    ObservedAtUtc,
+    ArchiveState,
+    ArchiveBlobName,
+    ArchiveChecksumSha256Hex,
+    ArchiveByteLength
+FROM ops.RawUsageFact WITH (READPAST)
+WHERE ObservedAtUtc < @ObservedBeforeUtc
+AND
+(
+    (
+        ArchiveState = @ArchiveStateHot
+        AND RawPayload IS NOT NULL
+        AND DATALENGTH(RawPayload) > 0
+    )
+    OR ArchiveState = @ArchiveStateVerified
+)
+ORDER BY ObservedAtUtc ASC, UsageFactId ASC;
+"""
+
+    /// Records verified Blob authority while retaining the hot payload for an idempotent cleanup retry.
+    [<Literal>]
+    let MarkRawUsageFactArchiveVerified =
+        """
+UPDATE ops.RawUsageFact
+SET
+    ArchiveState = @ArchiveStateVerified,
+    ArchiveBlobName = @ArchiveBlobName,
+    ArchiveChecksumSha256Hex = @ArchiveChecksumSha256Hex,
+    ArchiveByteLength = @ArchiveByteLength,
+    ArchiveVerifiedAtUtc = SYSUTCDATETIME()
+WHERE UsageFactId = @UsageFactId
+AND ArchiveState = @ArchiveStateHot
+AND RawPayload IS NOT NULL
+AND DATALENGTH(RawPayload) > 0;
+
+IF @@ROWCOUNT = 1
+BEGIN
+    SELECT 1;
+END
+ELSE IF EXISTS
+(
+    SELECT 1
+    FROM ops.RawUsageFact
+    WHERE UsageFactId = @UsageFactId
+    AND ArchiveState IN (@ArchiveStateVerified, @ArchiveStateArchived)
+    AND ArchiveBlobName = @ArchiveBlobName
+    AND ArchiveChecksumSha256Hex = @ArchiveChecksumSha256Hex
+    AND ArchiveByteLength = @ArchiveByteLength
+)
+BEGIN
+    SELECT 0;
+END
+ELSE
+BEGIN
+    THROW 57201, 'Raw UsageFact archive verification could not be recorded because SQL archive state no longer matches the verified Blob pointer.', 1;
+END;
+"""
+
+    /// Clears the hot payload only after SQL already carries the exact verified Blob authority.
+    [<Literal>]
+    let CompleteRawUsageFactArchive =
+        """
+UPDATE ops.RawUsageFact
+SET
+    RawPayload = NULL,
+    ArchiveState = @ArchiveStateArchived,
+    ArchivedAtUtc = SYSUTCDATETIME()
+WHERE UsageFactId = @UsageFactId
+AND ArchiveState = @ArchiveStateVerified
+AND ArchiveBlobName = @ArchiveBlobName
+AND ArchiveChecksumSha256Hex = @ArchiveChecksumSha256Hex
+AND ArchiveByteLength = @ArchiveByteLength;
+
+IF @@ROWCOUNT = 1
+BEGIN
+    SELECT 1;
+END
+ELSE IF EXISTS
+(
+    SELECT 1
+    FROM ops.RawUsageFact
+    WHERE UsageFactId = @UsageFactId
+    AND ArchiveState = @ArchiveStateArchived
+    AND RawPayload IS NULL
+    AND ArchiveBlobName = @ArchiveBlobName
+    AND ArchiveChecksumSha256Hex = @ArchiveChecksumSha256Hex
+    AND ArchiveByteLength = @ArchiveByteLength
+)
+BEGIN
+    SELECT 0;
+END
+ELSE
+BEGIN
+    THROW 57202, 'Raw UsageFact hot payload could not be cleared because verified SQL archive authority is missing or different.', 1;
+END;
 """
 
     /// Adds a quantity to the minute aggregate row associated with a newly accepted raw fact.

--- a/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="OperationsSkeleton.Tests.fs" />
     <Compile Include="OperationsUsageStorage.Tests.fs" />
+    <Compile Include="OperationsUsageArchive.Tests.fs" />
     <Compile Include="OperationsWorkerIngestion.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
@@ -153,6 +153,12 @@ type OperationsUsageArchiveTests() =
                 .Instance
         )
 
+    /// Creates archive worker configuration from exact setting names so startup validation paths can be tested.
+    let archiveConfiguration (settings: KeyValuePair<string, string> seq) =
+        ConfigurationBuilder()
+            .AddInMemoryCollection(Dictionary<string, string>(settings))
+            .Build()
+
     /// Decompresses gzip JSONL bytes for deterministic archive content assertions.
     let decompressGzip (content: byte array) =
         use input = new MemoryStream(content)
@@ -371,6 +377,66 @@ type OperationsUsageArchiveTests() =
         | Error errors ->
             let errorText = String.Join("; ", errors)
             Assert.Fail($"No archive settings should not fail ingestion-only startup: {errorText}")
+
+    /// Verifies malformed archive tuning values fail startup instead of silently reverting to defaults.
+    [<Test>]
+    member _.ArchiveSettingsRejectMalformedTuningValuesWhenArchiveConfigurationIsPresent() =
+        let configuration =
+            archiveConfiguration [ KeyValuePair(OperationsUsageArchiveSettings.BlobConnectionStringEnvironmentVariable, "UseDevelopmentStorage=true")
+                                   KeyValuePair(OperationsUsageArchiveSettings.BlobContainerNameEnvironmentVariable, "usage-archives")
+                                   KeyValuePair(OperationsUsageArchiveSettings.HotRetentionDaysEnvironmentVariable, "7d")
+                                   KeyValuePair(OperationsUsageArchiveSettings.BatchSizeEnvironmentVariable, "abc")
+                                   KeyValuePair(OperationsUsageArchiveSettings.PollIntervalSecondsEnvironmentVariable, "0") ]
+
+        match OperationsUsageArchiveSettings.fromConfiguration configuration with
+        | Ok _ -> Assert.Fail("Archive settings should reject malformed or non-positive tuning values.")
+        | Error errors ->
+            let errorText = String.Join("|", errors)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(errorText, Does.Contain(OperationsUsageArchiveSettings.HotRetentionDaysEnvironmentVariable))
+                    Assert.That(errorText, Does.Contain(OperationsUsageArchiveSettings.BatchSizeEnvironmentVariable))
+                    Assert.That(errorText, Does.Contain(OperationsUsageArchiveSettings.PollIntervalSecondsEnvironmentVariable)))
+            )
+
+    /// Verifies archive Blob container names follow Azure's lowercase DNS-style naming rules.
+    [<TestCase("UsageArchives")>]
+    [<TestCase("archive--hot")>]
+    [<TestCase("-archive-hot")>]
+    [<TestCase("archive-hot-")>]
+    [<TestCase("ar")>]
+    [<TestCase("archive_hot")>]
+    member _.ArchiveSettingsRejectInvalidBlobContainerNames(containerName: string) =
+        let configuration =
+            archiveConfiguration [ KeyValuePair(OperationsUsageArchiveSettings.BlobConnectionStringEnvironmentVariable, "UseDevelopmentStorage=true")
+                                   KeyValuePair(OperationsUsageArchiveSettings.BlobContainerNameEnvironmentVariable, containerName) ]
+
+        match OperationsUsageArchiveSettings.fromConfiguration configuration with
+        | Ok _ -> Assert.Fail($"Archive settings should reject invalid Blob container name '{containerName}'.")
+        | Error errors ->
+            let errorText = String.Join("|", errors)
+            Assert.That(errorText, Does.Contain(OperationsUsageArchiveSettings.BlobContainerNameEnvironmentVariable))
+
+    /// Verifies a valid archive configuration still applies default worker tuning values.
+    [<Test>]
+    member _.ArchiveSettingsAcceptValidConfigurationWithDefaultTuning() =
+        let configuration =
+            archiveConfiguration [ KeyValuePair(OperationsUsageArchiveSettings.BlobConnectionStringEnvironmentVariable, "UseDevelopmentStorage=true")
+                                   KeyValuePair(OperationsUsageArchiveSettings.BlobContainerNameEnvironmentVariable, "usage-archives") ]
+
+        match OperationsUsageArchiveSettings.fromConfiguration configuration with
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            Assert.Fail($"Archive settings should accept valid Blob configuration: {errorText}")
+        | Ok settings ->
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(settings.BlobContainerName, Is.EqualTo("usage-archives"))
+                    Assert.That(settings.HotRetentionDays, Is.EqualTo(90))
+                    Assert.That(settings.BatchSize, Is.EqualTo(100))
+                    Assert.That(settings.PollInterval, Is.EqualTo(TimeSpan.FromSeconds 300.0)))
+            )
 
     /// Verifies EF model metadata includes the persisted archive authority surface.
     [<Test>]

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
@@ -1,0 +1,442 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Operations.Data.Migrations
+open Grace.Operations.Worker
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Logging.Abstractions
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+open System.IO.Compression
+open System.Text
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Provides deterministic raw fact archive candidates for hot/cold archive tests.
+module OperationsUsageArchiveTestData =
+
+    /// Provides the owner used by archive usage facts.
+    let ownerId = OwnerId.Parse("11111111-1111-1111-1111-111111111111")
+
+    /// Provides the organization used by archive usage facts.
+    let organizationId = OrganizationId.Parse("22222222-2222-2222-2222-222222222222")
+
+    /// Provides the repository used by archive usage facts.
+    let repositoryId = RepositoryId.Parse("33333333-3333-3333-3333-333333333333")
+
+    /// Provides the storage pool used by archive usage facts.
+    let storagePoolId = StoragePoolId "storage-pool-main"
+
+    /// Creates the accepted raw payload bytes that later replay leaves will consume.
+    let payload usageFactId = Encoding.UTF8.GetBytes($"{{\"usageFactId\":\"{usageFactId:D}\",\"payload\":\"exact broker bytes\"}}")
+
+    /// Creates a raw usage fact archive candidate with deterministic scope and observed time.
+    let candidate usageFactId archiveState rawPayload pointer =
+        {
+            UsageFactId = usageFactId
+            RawPayload = rawPayload
+            CorrelationId = CorrelationId $"corr-{usageFactId}"
+            FactKind = UsageFactKind.RepositoryStorageBytesMinute
+            OwnerId = ownerId
+            OrganizationId = organizationId
+            RepositoryId = repositoryId
+            StoragePoolId = storagePoolId
+            Quantity = 4096L
+            ObservedAt = Instant.FromUtc(2026, 7, 4, 12, 34, 0)
+            ArchiveState = archiveState
+            ArchiveBlobName =
+                pointer
+                |> Option.map (fun value -> value.BlobName)
+            ArchiveChecksumSha256Hex =
+                pointer
+                |> Option.map (fun value -> value.ChecksumSha256Hex)
+            ArchiveByteLength =
+                pointer
+                |> Option.map (fun value -> value.ByteLength)
+        }
+
+/// Records archive store interactions without requiring SQL Server.
+type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list, events: List<string>) =
+    let markedPointers = ResizeArray<RawUsageFactArchivePointer>()
+    let completedPointers = ResizeArray<RawUsageFactArchivePointer>()
+
+    /// Returns Blob pointers recorded as verified in SQL.
+    member _.MarkedPointers = markedPointers |> Seq.toList
+
+    /// Returns Blob pointers completed by clearing the hot SQL payload.
+    member _.CompletedPointers = completedPointers |> Seq.toList
+
+    interface IOperationsUsageArchiveStore with
+
+        member _.ListArchiveCandidatesAsync(_observedBefore, _batchSize, _cancellationToken) =
+            events.Add("list-candidates")
+            Task.FromResult candidates
+
+        member _.MarkArchiveVerifiedAsync(pointer, _cancellationToken) =
+            events.Add("mark-verified")
+            markedPointers.Add pointer
+            Task.FromResult true
+
+        member _.CompleteArchiveAsync(pointer, _cancellationToken) =
+            events.Add("complete-archive")
+            completedPointers.Add pointer
+            Task.FromResult true
+
+/// Stores archive blobs in memory while preserving checksum and length verification semantics.
+type private RecordingArchiveBlobStore(events: List<string>) =
+    let blobs = Dictionary<string, byte array>()
+
+    /// Inserts an existing blob for resume and corruption tests.
+    member _.Put(blobName, content: byte array) = blobs[blobName] <- Array.copy content
+
+    /// Returns whether a deterministic Blob name has been written.
+    member _.Contains(blobName) = blobs.ContainsKey blobName
+
+    /// Returns the stored bytes for a deterministic Blob name.
+    member _.Content(blobName) = blobs[blobName] |> Array.copy
+
+    /// Throws when stored bytes do not match a SQL archive pointer.
+    member _.VerifyPointer(pointer: RawUsageFactArchivePointer) =
+        match blobs.TryGetValue pointer.BlobName with
+        | false, _ -> invalidOp $"Archive Blob '{pointer.BlobName}' is missing."
+        | true, content ->
+            Assert.That(int64 content.Length, Is.EqualTo(pointer.ByteLength))
+
+            let checksum = OperationsUsageArchiveFormat.checksumSha256Hex content
+            Assert.That(checksum, Is.EqualTo(pointer.ChecksumSha256Hex))
+
+    interface IOperationsUsageArchiveBlobStore with
+
+        member this.WriteAndVerifyAsync(archiveBlob, _cancellationToken) =
+            events.Add("write-verify-blob")
+
+            match blobs.TryGetValue archiveBlob.Pointer.BlobName with
+            | true, existing when
+                Convert.ToBase64String(existing)
+                <> Convert.ToBase64String(archiveBlob.Content)
+                ->
+                Task.FromException(InvalidOperationException("Archive Blob already exists with different content."))
+            | _ ->
+                blobs[archiveBlob.Pointer.BlobName] <- Array.copy archiveBlob.Content
+                this.VerifyPointer archiveBlob.Pointer
+                Task.CompletedTask
+
+        member this.VerifyAsync(pointer, _cancellationToken) =
+            events.Add("verify-blob")
+
+            try
+                this.VerifyPointer pointer
+                Task.CompletedTask
+            with
+            | ex -> Task.FromException ex
+
+/// Covers hot/cold archive layout, Blob verification, SQL state ordering, and migration shape.
+[<TestFixture>]
+type OperationsUsageArchiveTests() =
+
+    /// Creates the archive processor with fake SQL and Blob dependencies.
+    let createProcessor archiveStore blobStore =
+        OperationsUsageArchiveProcessor(
+            archiveStore,
+            blobStore,
+            NullLogger<OperationsUsageArchiveProcessor>
+                .Instance
+        )
+
+    /// Decompresses gzip JSONL bytes for deterministic archive content assertions.
+    let decompressGzip (content: byte array) =
+        use input = new MemoryStream(content)
+        use gzip = new GZipStream(input, CompressionMode.Decompress)
+        use output = new MemoryStream()
+        gzip.CopyTo output
+        output.ToArray()
+
+    /// Generates the Operations migration script without connecting to SQL Server.
+    let migrationScript () =
+        use context =
+            OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsArchiveMigrationScript;Integrated Security=true;"
+
+        let migrator = context.GetService<IMigrator>()
+        migrator.GenerateScript(options = MigrationsSqlGenerationOptions.Idempotent)
+
+    /// Reads the EF entity metadata that future migrations use for raw fact archive schema drift.
+    let rawFactEntityType () : IEntityType =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsArchiveMigrationModel;Integrated Security=true;"
+
+        context.Model.FindEntityType(typeof<RawUsageFactEntity>)
+
+    /// Verifies deterministic gzip JSONL output and pointer authority for a hot raw usage fact.
+    [<Test>]
+    member _.ArchiveFormatIsDeterministicCompressedJsonlWithChecksumAuthority() =
+        let usageFactId = Guid.Parse("40404040-4040-4040-8040-404040404040")
+        let rawPayload = OperationsUsageArchiveTestData.payload usageFactId
+        let candidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+
+        let first = OperationsUsageArchiveFormat.createArchiveBlob candidate rawPayload
+        let second = OperationsUsageArchiveFormat.createArchiveBlob candidate rawPayload
+
+        let jsonl =
+            first.Content
+            |> decompressGzip
+            |> Encoding.UTF8.GetString
+
+        using (JsonDocument.Parse(jsonl)) (fun document ->
+            let root = document.RootElement
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(first.Pointer.BlobName, Is.EqualTo(second.Pointer.BlobName))
+                    Assert.That(Convert.ToBase64String(first.Content), Is.EqualTo(Convert.ToBase64String(second.Content)))
+                    Assert.That(first.Pointer.ChecksumSha256Hex, Is.EqualTo(second.Pointer.ChecksumSha256Hex))
+                    Assert.That(first.Pointer.ByteLength, Is.EqualTo(int64 first.Content.Length))
+                    Assert.That(first.Pointer.BlobName, Does.Contain("usage-facts/v1/observedYear=2026/observedMonth=07"))
+                    Assert.That(first.Pointer.BlobName, Does.Contain($"usageFactId={usageFactId:D}.jsonl.gz"))
+
+                    Assert.That(
+                        root
+                            .GetProperty("archiveSchemaVersion")
+                            .GetInt32(),
+                        Is.EqualTo(OperationsUsageArchiveFormat.ArchiveSchemaVersion)
+                    )
+
+                    Assert.That(root.GetProperty("usageFactId").GetString(), Is.EqualTo(string usageFactId))
+
+                    Assert.That(
+                        Convert.ToBase64String(
+                            root
+                                .GetProperty("rawPayloadBase64")
+                                .GetBytesFromBase64()
+                        ),
+                        Is.EqualTo(Convert.ToBase64String(rawPayload))
+                    ))
+            ))
+
+    /// Verifies hot payload cleanup happens after Blob write/verify and SQL pointer verification.
+    [<Test>]
+    member _.ArchiveBatchWritesBlobRecordsPointerThenClearsHotPayload() =
+        task {
+            let events = List<string>()
+            let usageFactId = Guid.Parse("41414141-4141-4141-8141-414141414141")
+            let rawPayload = OperationsUsageArchiveTestData.payload usageFactId
+            let candidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+            let archiveStore = RecordingArchiveStore([ candidate ], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            let processor = createProcessor archiveStore blobStore
+
+            let! archived = processor.ArchiveBatchAsync(Instant.FromUtc(2026, 8, 1, 0, 0), 10, CancellationToken.None)
+            let pointer = archiveStore.CompletedPointers[0]
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(archived, Is.EqualTo(1))
+
+                    Assert.That(String.Join("|", events), Is.EqualTo("list-candidates|write-verify-blob|mark-verified|verify-blob|complete-archive"))
+
+                    Assert.That(archiveStore.MarkedPointers[0], Is.EqualTo(pointer))
+                    Assert.That(blobStore.Contains(pointer.BlobName), Is.True))
+            )
+        }
+
+    /// Verifies a retry can resume after Blob authority was recorded but before hot SQL payload cleanup.
+    [<Test>]
+    member _.ArchiveBatchResumesVerifiedPointerWithoutRewritingBlob() =
+        task {
+            let events = List<string>()
+            let usageFactId = Guid.Parse("42424242-4242-4242-8242-424242424242")
+            let rawPayload = OperationsUsageArchiveTestData.payload usageFactId
+            let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+            let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+
+            let verifiedCandidate =
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.ArchiveVerified None (Some archiveBlob.Pointer)
+
+            let archiveStore = RecordingArchiveStore([ verifiedCandidate ], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            blobStore.Put(archiveBlob.Pointer.BlobName, archiveBlob.Content)
+            let processor = createProcessor archiveStore blobStore
+
+            let! archived = processor.ArchiveBatchAsync(Instant.FromUtc(2026, 8, 1, 0, 0), 10, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(archived, Is.EqualTo(1))
+
+                    Assert.That(String.Join("|", events), Is.EqualTo("list-candidates|verify-blob|complete-archive"))
+
+                    Assert.That(archiveStore.MarkedPointers, Is.Empty)
+                    Assert.That(archiveStore.CompletedPointers[0], Is.EqualTo(archiveBlob.Pointer)))
+            )
+        }
+
+    /// Verifies missing or corrupt verified blobs fail before SQL cleanup can clear hot payload authority.
+    [<Test>]
+    member _.ArchiveBatchFailsBeforeCleanupWhenVerifiedBlobIsMissingOrCorrupt() =
+        task {
+            let events = List<string>()
+            let usageFactId = Guid.Parse("43434343-4343-4343-8343-434343434343")
+            let rawPayload = OperationsUsageArchiveTestData.payload usageFactId
+            let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+            let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+
+            let verifiedCandidate =
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.ArchiveVerified None (Some archiveBlob.Pointer)
+
+            let archiveStore = RecordingArchiveStore([ verifiedCandidate ], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            let processor = createProcessor archiveStore blobStore
+
+            let mutable message = None
+
+            try
+                let! _ = processor.ArchiveBatchAsync(Instant.FromUtc(2026, 8, 1, 0, 0), 10, CancellationToken.None)
+                Assert.Fail("Missing verified archive Blob should fail before SQL cleanup.")
+            with
+            | :? InvalidOperationException as ex -> message <- Some ex.Message
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(message.Value, Does.Contain("is missing"))
+                    Assert.That(String.Join("|", events), Is.EqualTo("list-candidates|verify-blob"))
+                    Assert.That(archiveStore.CompletedPointers, Is.Empty))
+            )
+        }
+
+    /// Verifies a hot row without payload bytes fails loudly instead of recording fake Blob authority.
+    [<Test>]
+    member _.ArchiveBatchRejectsHotCandidateWithoutRawPayload() =
+        task {
+            let events = List<string>()
+            let usageFactId = Guid.Parse("44444444-4444-4444-8444-444444444444")
+            let candidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot None None
+            let archiveStore = RecordingArchiveStore([ candidate ], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            let processor = createProcessor archiveStore blobStore
+            let mutable message = None
+
+            try
+                let! _ = processor.ArchiveBatchAsync(Instant.FromUtc(2026, 8, 1, 0, 0), 10, CancellationToken.None)
+                Assert.Fail("Hot rows without raw payload bytes should fail before Blob writes.")
+            with
+            | :? InvalidOperationException as ex -> message <- Some ex.Message
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(message.Value, Does.Contain("has no raw payload"))
+                    Assert.That(String.Join("|", events), Is.EqualTo("list-candidates"))
+                    Assert.That(archiveStore.MarkedPointers, Is.Empty)
+                    Assert.That(archiveStore.CompletedPointers, Is.Empty))
+            )
+        }
+
+    /// Verifies archive settings expose missing Blob dependencies as startup validation errors.
+    [<Test>]
+    member _.ArchiveSettingsRequireBlobAuthorityConfiguration() =
+        let configuration =
+            ConfigurationBuilder()
+                .AddInMemoryCollection(Dictionary<string, string>())
+                .Build()
+
+        match OperationsUsageArchiveSettings.fromConfiguration configuration with
+        | Ok _ -> Assert.Fail("Archive settings should reject missing Blob dependencies.")
+        | Error errors ->
+            let errorText = String.Join("|", errors)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(errorText, Does.Contain(OperationsUsageArchiveSettings.BlobConnectionStringEnvironmentVariable))
+                    Assert.That(errorText, Does.Contain(OperationsUsageArchiveSettings.BlobContainerNameEnvironmentVariable)))
+            )
+
+    /// Verifies the worker can keep ingestion-only startup when no archive settings are supplied by the host.
+    [<Test>]
+    member _.ArchiveSettingsAreOptionalUntilArchiveConfigurationIsPresent() =
+        let configuration =
+            ConfigurationBuilder()
+                .AddInMemoryCollection(Dictionary<string, string>())
+                .Build()
+
+        match OperationsUsageArchiveSettings.tryFromConfiguration configuration with
+        | Ok None -> Assert.Pass()
+        | Ok (Some _) -> Assert.Fail("No archive settings should leave the archive worker unregistered.")
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            Assert.Fail($"No archive settings should not fail ingestion-only startup: {errorText}")
+
+    /// Verifies EF model metadata includes the persisted archive authority surface.
+    [<Test>]
+    member _.OperationsEfModelCarriesRawFactArchiveAuthorityColumns() =
+        let rawFact = rawFactEntityType ()
+
+        let hasArchiveIndex =
+            rawFact.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = "IX_ops_RawUsageFact_ArchiveStateObservedAt")
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(rawFact.FindProperty("RawPayload").IsNullable, Is.True)
+                Assert.That(rawFact.FindProperty("ArchiveState").IsNullable, Is.False)
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("ArchiveBlobName")
+                        .GetMaxLength(),
+                    Is.EqualTo(Nullable OperationsUsageSql.ArchiveBlobNameMaxLength)
+                )
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("ArchiveChecksumSha256Hex")
+                        .GetMaxLength(),
+                    Is.EqualTo(Nullable OperationsUsageSql.ArchiveChecksumSha256HexLength)
+                )
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("ArchiveByteLength")
+                        .GetColumnType(),
+                    Is.EqualTo("bigint")
+                )
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("ArchiveVerifiedAtUtc")
+                        .GetColumnType(),
+                    Is.EqualTo("datetime2(7)")
+                )
+
+                Assert.That(
+                    rawFact
+                        .FindProperty("ArchivedAtUtc")
+                        .GetColumnType(),
+                    Is.EqualTo("datetime2(7)")
+                )
+
+                Assert.That(hasArchiveIndex, Is.True))
+        )
+
+    /// Verifies the archive migration emits guarded SQL for authority columns, nullable payloads, and archive scan index.
+    [<Test>]
+    member _.ArchiveMigrationScriptContainsAuthorityAndCleanupGuards() =
+        let script = migrationScript ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(script, Does.Contain("ArchiveState int NOT NULL"))
+                Assert.That(script, Does.Contain("CONSTRAINT DF_ops_RawUsageFact_ArchiveState DEFAULT (0) WITH VALUES"))
+                Assert.That(script, Does.Contain("ArchiveBlobName nvarchar(512) NULL"))
+                Assert.That(script, Does.Contain("ArchiveChecksumSha256Hex char(64) NULL"))
+                Assert.That(script, Does.Contain("ArchiveByteLength bigint NULL"))
+                Assert.That(script, Does.Contain("ALTER COLUMN RawPayload varbinary(max) NULL"))
+                Assert.That(script, Does.Contain("CREATE INDEX IX_ops_RawUsageFact_ArchiveStateObservedAt"))
+                Assert.That(script, Does.Contain("ON PS_ops_OperationsUsageMonthUtc(ObservedAtUtc)")))
+        )

--- a/src/Grace.Operations/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -1,8 +1,10 @@
 namespace Grace.Operations.Worker
 
+open Azure
 open Azure.Core
 open Azure.Identity
 open Azure.Messaging.ServiceBus
+open Azure.Storage.Blobs
 open Grace.Operations.Data
 open Grace.Shared
 open Grace.Shared.Utilities
@@ -15,7 +17,11 @@ open Microsoft.Extensions.Logging
 open NodaTime
 open System
 open System.Collections.Generic
+open System.Globalization
 open System.IO
+open System.IO.Compression
+open System.Security.Cryptography
+open System.Text
 open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
@@ -82,6 +88,349 @@ type OperationsUsageFactStoreAdapter(store: OperationsUsageStore) =
     interface IOperationsUsageFactStore with
 
         member _.StoreUsageFactAsync(fact, rawPayload, cancellationToken) = store.StoreUsageFactAsync(fact, rawPayload, cancellationToken)
+
+/// Carries deterministic compressed JSONL bytes and the Blob authority they must verify against.
+type OperationsUsageArchiveBlob = { Pointer: RawUsageFactArchivePointer; Content: byte array }
+
+/// Writes and verifies archive Blob content before SQL clears hot payload bytes.
+type IOperationsUsageArchiveBlobStore =
+
+    /// Writes archive content if absent, then verifies checksum and byte length from Blob storage.
+    abstract WriteAndVerifyAsync: archiveBlob: OperationsUsageArchiveBlob * cancellationToken: CancellationToken -> Task
+
+    /// Verifies an already-recorded Blob pointer before SQL cleanup resumes.
+    abstract VerifyAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task
+
+/// Builds deterministic archive names, JSONL payloads, compression, and checksums for raw usage facts.
+[<RequireQualifiedAccess>]
+module OperationsUsageArchiveFormat =
+
+    /// Identifies the archive record schema written into compressed JSONL blobs.
+    [<Literal>]
+    let ArchiveSchemaVersion = 1
+
+    /// Converts binary data into lowercase hexadecimal for persisted SHA-256 checksums.
+    let private toLowerHex (bytes: byte array) =
+        let builder = StringBuilder(bytes.Length * 2)
+        let mutable index = 0
+
+        while index < bytes.Length do
+            builder.Append(
+                bytes[index]
+                    .ToString("x2", CultureInfo.InvariantCulture)
+            )
+            |> ignore
+
+            index <- index + 1
+
+        builder.ToString()
+
+    /// Computes the lowercase SHA-256 checksum used by SQL archive authority.
+    let checksumSha256Hex (content: byte array) = SHA256.HashData content |> toLowerHex
+
+    /// Builds the deterministic Blob name for one archived usage fact.
+    let blobName (candidate: RawUsageFactArchiveCandidate) =
+        let observedUtc = candidate.ObservedAt.ToDateTimeUtc()
+        let observedYear = observedUtc.Year.ToString("0000", CultureInfo.InvariantCulture)
+        let observedMonth = observedUtc.Month.ToString("00", CultureInfo.InvariantCulture)
+
+        String.Join(
+            "/",
+            [|
+                "usage-facts"
+                "v1"
+                $"observedYear={observedYear}"
+                $"observedMonth={observedMonth}"
+                $"ownerId={candidate.OwnerId:D}"
+                $"organizationId={candidate.OrganizationId:D}"
+                $"repositoryId={candidate.RepositoryId:D}"
+                $"usageFactId={candidate.UsageFactId:D}.jsonl.gz"
+            |]
+        )
+
+    /// Writes one JSONL record with a stable property order and the exact accepted raw payload bytes.
+    let jsonLineBytes (candidate: RawUsageFactArchiveCandidate) (rawPayload: byte array) =
+        use stream = new MemoryStream()
+        use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = false))
+
+        writer.WriteStartObject()
+        writer.WriteNumber("archiveSchemaVersion", ArchiveSchemaVersion)
+        writer.WriteString("usageFactId", string candidate.UsageFactId)
+        writer.WriteString("correlationId", string candidate.CorrelationId)
+        writer.WriteString("factKind", candidate.FactKind.ToString())
+        writer.WriteString("ownerId", string candidate.OwnerId)
+        writer.WriteString("organizationId", string candidate.OrganizationId)
+        writer.WriteString("repositoryId", string candidate.RepositoryId)
+        writer.WriteString("storagePoolId", string candidate.StoragePoolId)
+        writer.WriteNumber("quantity", candidate.Quantity)
+
+        writer.WriteString(
+            "observedAtUtc",
+            candidate
+                .ObservedAt
+                .ToDateTimeUtc()
+                .ToString("O", CultureInfo.InvariantCulture)
+        )
+
+        writer.WriteBase64String("rawPayloadBase64", ReadOnlySpan<byte>(rawPayload))
+        writer.WriteEndObject()
+        writer.Flush()
+        stream.WriteByte(byte '\n')
+        stream.ToArray()
+
+    /// Compresses JSONL bytes with gzip so archive content remains compact and byte-for-byte repeatable.
+    let gzip (jsonl: byte array) =
+        use output = new MemoryStream()
+
+        use gzipStream = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen = true)
+
+        gzipStream.Write(jsonl, 0, jsonl.Length)
+        gzipStream.Dispose()
+        output.ToArray()
+
+    /// Builds the compressed archive blob and SQL pointer for one hot raw usage fact.
+    let createArchiveBlob (candidate: RawUsageFactArchiveCandidate) (rawPayload: byte array) =
+        let content = rawPayload |> jsonLineBytes candidate |> gzip
+
+        let pointer =
+            {
+                UsageFactId = candidate.UsageFactId
+                BlobName = blobName candidate
+                ChecksumSha256Hex = checksumSha256Hex content
+                ByteLength = int64 content.Length
+            }
+
+        { Pointer = pointer; Content = content }
+
+/// Stores archive blobs in Azure Blob Storage and reads them back for authority verification.
+type AzureOperationsUsageArchiveBlobStore(containerClient: BlobContainerClient) =
+
+    /// Downloads Blob content so checksum and byte length are verified from durable storage, not local memory.
+    let downloadContentAsync blobName cancellationToken =
+        task {
+            let blobClient = containerClient.GetBlobClient blobName
+            let! response = blobClient.DownloadContentAsync cancellationToken
+            return response.Value.Content.ToArray()
+        }
+
+    /// Throws when durable Blob bytes do not match the SQL archive authority.
+    let verifyContent (pointer: RawUsageFactArchivePointer) (content: byte array) =
+        let actualByteLength = int64 content.Length
+
+        if actualByteLength <> pointer.ByteLength then
+            invalidOp
+                $"Archive Blob '{pointer.BlobName}' length mismatch for UsageFactId '{pointer.UsageFactId}'. Expected {pointer.ByteLength}; actual {actualByteLength}."
+
+        let actualChecksum = OperationsUsageArchiveFormat.checksumSha256Hex content
+
+        if not (String.Equals(actualChecksum, pointer.ChecksumSha256Hex, StringComparison.Ordinal)) then
+            invalidOp $"Archive Blob '{pointer.BlobName}' checksum mismatch for UsageFactId '{pointer.UsageFactId}'."
+
+    /// Uploads content only when the deterministic Blob does not already exist.
+    let uploadIfMissingAsync (archiveBlob: OperationsUsageArchiveBlob) cancellationToken =
+        task {
+            let blobClient = containerClient.GetBlobClient archiveBlob.Pointer.BlobName
+
+            try
+                use stream = new MemoryStream(archiveBlob.Content, writable = false)
+                let! _ = blobClient.UploadAsync(stream, overwrite = false, cancellationToken = cancellationToken)
+                return ()
+            with
+            | :? RequestFailedException as ex when String.Equals(ex.ErrorCode, "BlobAlreadyExists", StringComparison.OrdinalIgnoreCase) -> return ()
+        }
+
+    interface IOperationsUsageArchiveBlobStore with
+
+        member _.WriteAndVerifyAsync(archiveBlob, cancellationToken) =
+            task {
+                let! _ = containerClient.CreateIfNotExistsAsync(cancellationToken = cancellationToken)
+                do! uploadIfMissingAsync archiveBlob cancellationToken
+                let! storedContent = downloadContentAsync archiveBlob.Pointer.BlobName cancellationToken
+                verifyContent archiveBlob.Pointer storedContent
+            }
+
+        member _.VerifyAsync(pointer, cancellationToken) =
+            task {
+                let! storedContent = downloadContentAsync pointer.BlobName cancellationToken
+                verifyContent pointer storedContent
+            }
+
+/// Archives old hot raw payloads after Blob authority is verified and persisted in SQL.
+type OperationsUsageArchiveProcessor
+    (
+        archiveStore: IOperationsUsageArchiveStore,
+        blobStore: IOperationsUsageArchiveBlobStore,
+        logger: ILogger<OperationsUsageArchiveProcessor>
+    ) =
+
+    /// Rebuilds a verified SQL pointer from a partially archived row before retrying hot-payload cleanup.
+    let pointerFromVerifiedCandidate (candidate: RawUsageFactArchiveCandidate) =
+        match candidate.ArchiveBlobName, candidate.ArchiveChecksumSha256Hex, candidate.ArchiveByteLength with
+        | Some blobName, Some checksum, Some byteLength ->
+            { UsageFactId = candidate.UsageFactId; BlobName = blobName; ChecksumSha256Hex = checksum; ByteLength = byteLength }
+        | _ -> invalidOp $"UsageFactId '{candidate.UsageFactId}' is marked archive-verified without a complete Blob pointer."
+
+    /// Archives one hot candidate or resumes cleanup for an already verified candidate.
+    let archiveCandidateAsync (candidate: RawUsageFactArchiveCandidate) cancellationToken =
+        task {
+            let! pointer =
+                task {
+                    match candidate.ArchiveState with
+                    | RawUsageFactArchiveState.Hot ->
+                        match candidate.RawPayload with
+                        | Some rawPayload ->
+                            let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob candidate rawPayload
+                            do! blobStore.WriteAndVerifyAsync(archiveBlob, cancellationToken)
+                            let! _ = archiveStore.MarkArchiveVerifiedAsync(archiveBlob.Pointer, cancellationToken)
+                            return archiveBlob.Pointer
+                        | None -> return invalidOp $"Hot UsageFactId '{candidate.UsageFactId}' has no raw payload to archive."
+                    | RawUsageFactArchiveState.ArchiveVerified -> return pointerFromVerifiedCandidate candidate
+                    | RawUsageFactArchiveState.Archived -> return pointerFromVerifiedCandidate candidate
+                    | state -> return invalidOp $"UsageFactId '{candidate.UsageFactId}' has unsupported archive state '{state}'."
+                }
+
+            do! blobStore.VerifyAsync(pointer, cancellationToken)
+            let! completed = archiveStore.CompleteArchiveAsync(pointer, cancellationToken)
+
+            logger.LogInformation(
+                "Archived operational UsageFact hot payload. UsageFactId: {UsageFactId}; BlobName: {BlobName}; ByteLength: {ByteLength}; CompletedStateChange: {CompletedStateChange}.",
+                pointer.UsageFactId,
+                pointer.BlobName,
+                pointer.ByteLength,
+                completed
+            )
+        }
+
+    /// Archives at most one batch of candidates older than the supplied hot-retention cutoff.
+    member _.ArchiveBatchAsync(observedBefore: Instant, batchSize: int, cancellationToken: CancellationToken) =
+        task {
+            let! candidates = archiveStore.ListArchiveCandidatesAsync(observedBefore, batchSize, cancellationToken)
+            let mutable index = 0
+            let mutable archived = 0
+            let candidateArray = candidates |> List.toArray
+
+            while index < candidateArray.Length do
+                cancellationToken.ThrowIfCancellationRequested()
+                do! archiveCandidateAsync candidateArray[index] cancellationToken
+                archived <- archived + 1
+                index <- index + 1
+
+            return archived
+        }
+
+/// Reads Blob archive settings required by the hot/cold usage fact archive worker.
+type OperationsUsageArchiveSettings =
+    {
+        BlobConnectionString: string option
+        BlobServiceUri: string option
+        BlobContainerName: string
+        HotRetentionDays: int
+        BatchSize: int
+        PollInterval: TimeSpan
+    }
+
+/// Resolves hot/cold archive settings from host configuration and environment variables.
+[<RequireQualifiedAccess>]
+module OperationsUsageArchiveSettings =
+
+    /// The environment variable that contains an Azure Storage connection string for archive Blob writes.
+    [<Literal>]
+    let BlobConnectionStringEnvironmentVariable = "grace__operations__archive__blob_connectionstring"
+
+    /// The environment variable that contains a Blob service URI for managed-identity archive writes.
+    [<Literal>]
+    let BlobServiceUriEnvironmentVariable = "grace__operations__archive__blob_service_uri"
+
+    /// The environment variable that names the container used for compressed usage fact archives.
+    [<Literal>]
+    let BlobContainerNameEnvironmentVariable = "grace__operations__archive__blob_container"
+
+    /// The environment variable that controls how long raw payloads remain hot in SQL.
+    [<Literal>]
+    let HotRetentionDaysEnvironmentVariable = "grace__operations__archive__hot_retention_days"
+
+    /// The environment variable that controls the maximum number of raw facts archived per batch.
+    [<Literal>]
+    let BatchSizeEnvironmentVariable = "grace__operations__archive__batch_size"
+
+    /// The environment variable that controls the delay between archive worker batches.
+    [<Literal>]
+    let PollIntervalSecondsEnvironmentVariable = "grace__operations__archive__poll_interval_seconds"
+
+    /// Returns a trimmed setting value when configuration contains a non-empty entry.
+    let private optionalSetting (configuration: IConfiguration) name =
+        [
+            configuration[getConfigKey name]
+            configuration[name]
+            Environment.GetEnvironmentVariable name
+        ]
+        |> List.tryPick (fun value -> if String.IsNullOrWhiteSpace value then None else Some(value.Trim()))
+
+    /// Reads a positive integer setting or returns the supplied default.
+    let private positiveIntSetting configuration name defaultValue =
+        match optionalSetting configuration name with
+        | Some value ->
+            match Int32.TryParse value with
+            | true, parsed when parsed > 0 -> parsed
+            | _ -> defaultValue
+        | None -> defaultValue
+
+    /// Builds validated archive settings from configuration.
+    let fromConfiguration (configuration: IConfiguration) =
+        let blobConnectionString = optionalSetting configuration BlobConnectionStringEnvironmentVariable
+        let blobServiceUri = optionalSetting configuration BlobServiceUriEnvironmentVariable
+        let blobContainerName = optionalSetting configuration BlobContainerNameEnvironmentVariable
+        let hotRetentionDays = positiveIntSetting configuration HotRetentionDaysEnvironmentVariable 90
+        let batchSize = positiveIntSetting configuration BatchSizeEnvironmentVariable 100
+        let pollIntervalSeconds = positiveIntSetting configuration PollIntervalSecondsEnvironmentVariable 300
+        let errors = ResizeArray<string>()
+
+        if blobConnectionString.IsNone
+           && blobServiceUri.IsNone then
+            errors.Add($"{BlobConnectionStringEnvironmentVariable} or {BlobServiceUriEnvironmentVariable} is required.")
+
+        if blobContainerName.IsNone then
+            errors.Add($"{BlobContainerNameEnvironmentVariable} is required.")
+
+        match blobServiceUri with
+        | Some uri ->
+            match Uri.TryCreate(uri, UriKind.Absolute) with
+            | true, parsed when parsed.Scheme = Uri.UriSchemeHttps -> ()
+            | _ -> errors.Add($"{BlobServiceUriEnvironmentVariable} must be an absolute HTTPS URI.")
+        | None -> ()
+
+        if errors.Count > 0 then
+            Error(List.ofSeq errors)
+        else
+            Ok
+                {
+                    BlobConnectionString = blobConnectionString
+                    BlobServiceUri = blobServiceUri
+                    BlobContainerName = blobContainerName.Value
+                    HotRetentionDays = hotRetentionDays
+                    BatchSize = batchSize
+                    PollInterval = TimeSpan.FromSeconds(float pollIntervalSeconds)
+                }
+
+    /// Enables the archive worker only when archive storage settings are present, while rejecting partial configuration.
+    let tryFromConfiguration (configuration: IConfiguration) =
+        let hasArchiveSetting =
+            [
+                BlobConnectionStringEnvironmentVariable
+                BlobServiceUriEnvironmentVariable
+                BlobContainerNameEnvironmentVariable
+                HotRetentionDaysEnvironmentVariable
+                BatchSizeEnvironmentVariable
+                PollIntervalSecondsEnvironmentVariable
+            ]
+            |> List.exists (fun name ->
+                optionalSetting configuration name
+                |> Option.isSome)
+
+        if hasArchiveSetting then
+            fromConfiguration configuration |> Result.map Some
+        else
+            Ok None
 
 /// Reports whether the operations usage worker is ready to consume durable ingestion messages.
 type OperationsUsageReadinessStatus =
@@ -924,6 +1273,61 @@ module internal OperationsUsageServiceBusMessage =
             OperationsUsageReadinessTransitions.recordServiceBusReceiveSuccess readiness receiveAttempt
 
         processor.ProcessMessageAsync(fromReceivedMessage message, actions, cancellationToken)
+
+/// Runs hot/cold archive batches for raw usage fact payload retention.
+type OperationsUsageArchiveWorkerService
+    (
+        settings: OperationsUsageArchiveSettings,
+        processor: OperationsUsageArchiveProcessor,
+        logger: ILogger<OperationsUsageArchiveWorkerService>
+    ) =
+    inherit BackgroundService()
+
+    /// Computes the exclusive hot-retention cutoff for the next archive batch.
+    let observedBefore () =
+        SystemClock.Instance.GetCurrentInstant()
+        - Duration.FromDays(settings.HotRetentionDays)
+
+    /// Runs one archive pass and records redacted operational evidence.
+    let runBatchAsync cancellationToken =
+        task {
+            let cutoff = observedBefore ()
+            let! archived = processor.ArchiveBatchAsync(cutoff, settings.BatchSize, cancellationToken)
+
+            logger.LogInformation(
+                "Completed operations usage archive batch. ArchivedFacts: {ArchivedFacts}; HotRetentionDays: {HotRetentionDays}; CutoffUtc: {CutoffUtc}.",
+                archived,
+                settings.HotRetentionDays,
+                cutoff
+            )
+        }
+
+    /// Delays between archive passes while allowing prompt host shutdown.
+    let delayUntilNextBatchAsync (cancellationToken: CancellationToken) = Task.Delay(settings.PollInterval, cancellationToken)
+
+    /// Runs archive batches until the worker host shuts down.
+    override _.ExecuteAsync(stoppingToken: CancellationToken) =
+        task {
+            logger.LogInformation(
+                "Started operations usage archive worker for container {ContainerName}; HotRetentionDays: {HotRetentionDays}; BatchSize: {BatchSize}.",
+                settings.BlobContainerName,
+                settings.HotRetentionDays,
+                settings.BatchSize
+            )
+
+            let mutable running = true
+
+            while running
+                  && not stoppingToken.IsCancellationRequested do
+                try
+                    do! runBatchAsync stoppingToken
+                    do! delayUntilNextBatchAsync stoppingToken
+                with
+                | :? OperationCanceledException when stoppingToken.IsCancellationRequested -> running <- false
+                | ex ->
+                    logger.LogError(ex, "Operations usage archive batch failed; retrying after the configured poll interval.")
+                    do! delayUntilNextBatchAsync stoppingToken
+        }
 
 /// Runs the operational fact Service Bus processor for the Grace operations worker process.
 type OperationsUsageWorkerService

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -366,14 +366,42 @@ module OperationsUsageArchiveSettings =
         ]
         |> List.tryPick (fun value -> if String.IsNullOrWhiteSpace value then None else Some(value.Trim()))
 
-    /// Reads a positive integer setting or returns the supplied default.
+    /// Reads a positive integer setting, rejecting malformed values once archive configuration is present.
     let private positiveIntSetting configuration name defaultValue =
         match optionalSetting configuration name with
         | Some value ->
-            match Int32.TryParse value with
-            | true, parsed when parsed > 0 -> parsed
-            | _ -> defaultValue
-        | None -> defaultValue
+            match Int32.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture) with
+            | true, parsed when parsed > 0 -> Ok parsed
+            | _ -> Error $"{name} must be a positive integer."
+        | None -> Ok defaultValue
+
+    /// Validates the lowercase DNS-style Azure Blob container name used for usage fact archives.
+    let private validateContainerName (name: string) =
+        let isLowercaseLetterOrDigit (value: char) =
+            (value >= 'a' && value <= 'z')
+            || (value >= '0' && value <= '9')
+
+        let isValidCharacter (value: char) = isLowercaseLetterOrDigit value || value = '-'
+
+        let hasValidLength = name.Length >= 3 && name.Length <= 63
+
+        let hasValidBoundary =
+            hasValidLength
+            && isLowercaseLetterOrDigit name[0]
+            && isLowercaseLetterOrDigit name[name.Length - 1]
+
+        let hasValidCharacters = name |> Seq.forall isValidCharacter
+
+        if
+            hasValidLength
+            && hasValidBoundary
+            && hasValidCharacters
+            && not (name.Contains("--", StringComparison.Ordinal))
+        then
+            Ok()
+        else
+            Error
+                $"{BlobContainerNameEnvironmentVariable} must be 3-63 lowercase letters, numbers, or hyphens; start and end with a letter or number; and not contain consecutive hyphens."
 
     /// Builds validated archive settings from configuration.
     let fromConfiguration (configuration: IConfiguration) =
@@ -391,6 +419,22 @@ module OperationsUsageArchiveSettings =
 
         if blobContainerName.IsNone then
             errors.Add($"{BlobContainerNameEnvironmentVariable} is required.")
+        else
+            match validateContainerName blobContainerName.Value with
+            | Ok () -> ()
+            | Error error -> errors.Add error
+
+        match hotRetentionDays with
+        | Ok _ -> ()
+        | Error error -> errors.Add error
+
+        match batchSize with
+        | Ok _ -> ()
+        | Error error -> errors.Add error
+
+        match pollIntervalSeconds with
+        | Ok _ -> ()
+        | Error error -> errors.Add error
 
         match blobServiceUri with
         | Some uri ->
@@ -399,18 +443,18 @@ module OperationsUsageArchiveSettings =
             | _ -> errors.Add($"{BlobServiceUriEnvironmentVariable} must be an absolute HTTPS URI.")
         | None -> ()
 
-        if errors.Count > 0 then
-            Error(List.ofSeq errors)
-        else
+        match hotRetentionDays, batchSize, pollIntervalSeconds with
+        | Ok hotRetentionDaysValue, Ok batchSizeValue, Ok pollIntervalSecondsValue when errors.Count = 0 ->
             Ok
                 {
                     BlobConnectionString = blobConnectionString
                     BlobServiceUri = blobServiceUri
                     BlobContainerName = blobContainerName.Value
-                    HotRetentionDays = hotRetentionDays
-                    BatchSize = batchSize
-                    PollInterval = TimeSpan.FromSeconds(float pollIntervalSeconds)
+                    HotRetentionDays = hotRetentionDaysValue
+                    BatchSize = batchSizeValue
+                    PollInterval = TimeSpan.FromSeconds(float pollIntervalSecondsValue)
                 }
+        | _ -> Error(List.ofSeq errors)
 
     /// Enables the archive worker only when archive storage settings are present, while rejecting partial configuration.
     let tryFromConfiguration (configuration: IConfiguration) =

--- a/src/Grace.Operations/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/Program.fs
@@ -1,6 +1,9 @@
 namespace Grace.Operations.Worker
 
 open Grace.Operations.Data
+open Azure.Core
+open Azure.Identity
+open Azure.Storage.Blobs
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Diagnostics.HealthChecks
 open Microsoft.Extensions.Hosting
@@ -18,6 +21,11 @@ module Program =
                 .ConfigureServices(fun context services ->
                     let settings =
                         match OperationsWorkerSettings.fromConfiguration context.Configuration with
+                        | Ok value -> value
+                        | Error errors -> invalidOp (String.Join("; ", errors))
+
+                    let archiveSettings =
+                        match OperationsUsageArchiveSettings.tryFromConfiguration context.Configuration with
                         | Ok value -> value
                         | Error errors -> invalidOp (String.Join("; ", errors))
 
@@ -60,7 +68,34 @@ module Program =
                     |> ignore
 
                     services.AddHostedService<OperationsUsageWorkerService>()
-                    |> ignore)
+                    |> ignore
+
+                    match archiveSettings with
+                    | Some archiveSettings ->
+                        services.AddSingleton(archiveSettings) |> ignore
+
+                        services.AddSingleton<IOperationsUsageArchiveStore> (fun _ ->
+                            SqlOperationsUsageArchiveStore(settings.SqlConnectionString) :> IOperationsUsageArchiveStore)
+                        |> ignore
+
+                        services.AddSingleton<IOperationsUsageArchiveBlobStore> (fun _ ->
+                            let containerClient =
+                                match archiveSettings.BlobConnectionString, archiveSettings.BlobServiceUri with
+                                | Some connectionString, _ -> BlobContainerClient(connectionString, archiveSettings.BlobContainerName)
+                                | None, Some serviceUri ->
+                                    BlobServiceClient(Uri serviceUri, DefaultAzureCredential() :> TokenCredential)
+                                        .GetBlobContainerClient(archiveSettings.BlobContainerName)
+                                | None, None -> invalidOp "Operations archive Blob storage must be configured."
+
+                            AzureOperationsUsageArchiveBlobStore(containerClient) :> IOperationsUsageArchiveBlobStore)
+                        |> ignore
+
+                        services.AddSingleton<OperationsUsageArchiveProcessor>()
+                        |> ignore
+
+                        services.AddHostedService<OperationsUsageArchiveWorkerService>()
+                        |> ignore
+                    | None -> ())
                 .Build()
                 .Run()
 


### PR DESCRIPTION
# Summary

Related to #572.

Part of #559 and #554.

This implements the A3.1 hot/cold archive slice for Grace.Operations. Raw usage facts can now move from hot SQL payload storage to deterministic compressed JSONL Blob archives after the archive writer proves the Blob content by checksum and byte length. SQL cleanup is guarded by the verified Blob pointer, checksum, and length so the durable archive remains the authority before hot payload removal.

## What Changed

- Added SQL archive state and pointer fields for `ops.RawUsageFact`, including archive state, deterministic Blob pointer, checksum, byte length, verification timestamp, and archived timestamp.
- Added migration `20260707130000_AddRawUsageFactArchiveState` and updated the EF model snapshot.
- Made `RawPayload` nullable only for archived rows and guarded cleanup through exact verified pointer/checksum/length SQL transitions.
- Added deterministic compressed JSONL archive generation and SHA-256/byte-length authority in the Operations worker.
- Added Azure Blob write/read verification with fail-loud missing/corrupt Blob behavior.
- Added opt-in archive worker settings:
  - no archive config keeps ingestion-only local hosts working
  - partial or malformed archive config fails startup
- Added focused archive tests for deterministic layout, positive flow, partial-success resume, missing/corrupt Blob failure, missing hot payload failure, settings behavior, and migration/model shape.
- Updated `MIGRATIONS.md` with archive layout and retention assumptions.

## Branch Flow

- Source branch: `agent/572-operations-hot-cold-archive`
- Target branch: `epic/559-operations-archive-replay`
- WS3 later merges to: `epic/554-grace-operations`
- This PR intentionally uses non-closing issue wording because it targets an epic integration branch. The orchestrator will close #572 after merge to WS3.

## Validation

- `dotnet tool run fantomas ...` passed for touched F# files.
- `dotnet build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj` passed with 0 warnings/errors.
- `dotnet test --no-build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj` passed: 84 passed, 0 failed, 0 skipped.
- `npx --yes markdownlint-cli2 "src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md"` passed: 0 errors.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Full` passed:
  - Types: 159 passed
  - Authorization: 53 passed
  - Server.Unit: 732 passed
  - CLI: 689 passed, 1 skipped
  - Server integration: 243 passed
  - Operations: 84 passed
  - Elapsed: `00:03:53.2687957`

## Solution Isolation

- Confirmed `src/Grace.slnx` is unchanged in this PR.
- Confirmed this slice keeps Operations projects in `src/Grace.Operations/Grace.Operations.slnx` and does not add `Grace.Operations` references to the root solution.

## Bot-Prevention Self-Review

- Verified hot SQL payload cleanup is guarded by exact SQL pointer/checksum/byte-length authority.
- Verified Blob write is followed by durable readback verification before SQL pointer persistence.
- Verified partial resume from `ArchiveState = ArchiveVerified` verifies the Blob again before cleanup.
- Verified missing/corrupt Blob paths fail before `CompleteArchiveAsync`.
- Verified deterministic Blob naming does not depend on current time or random values.
- Verified startup does not break current ingestion-only AppHost runs when no archive settings are supplied.
- Verified changed paths stay inside the issue-owned Operations Data/Worker/Tests surface plus the required Operations migration doc.

## Review Status

- Current head: `6d5cb1e37c4becd6d421c4a06b8692f41fdd7436`
- Codex Code Review Bot: 👍🏻 no issues for the latest head.
- CI: `full` succeeded for the latest head on rerun job `85748251101`.
- Substantive review cycles: 1. Repeated-theme prevention note: archive runtime/config invariants now include Azure SQL locking legality, fail-fast archive tuning parsing, and Azure Blob container-name validation with focused tests.
- Detailed review/fix comments: [READPAST locking hint thread](https://github.com/ScottArbeit/Grace/pull/670#discussion_r3539997634), [archive tuning validation thread](https://github.com/ScottArbeit/Grace/pull/670#discussion_r3540076298), [archive container validation thread](https://github.com/ScottArbeit/Grace/pull/670#discussion_r3540076301)
- Prevention note: latest review-fix self-review confirmed invalid tuning values no longer silently default, invalid Azure container names are rejected, valid `usage-archives` config still succeeds, and root-solution isolation remains unchanged.
- Merge readiness: no unresolved review threads; `src/Grace.slnx` is unchanged in the PR diff; PR targets `epic/559-operations-archive-replay`.

## Residual Risks

- Live Azure Blob behavior is covered through the fakeable Blob abstraction and checksum/byte-length semantics, not through a live Azure Storage integration test in this slice.
- Archive worker hosted-service registration is opt-in until archive Blob settings are provided by deployment/AppHost configuration; partial archive config fails fast.
