### PR TITLE
A3.2: Implement archive replay and scoped rehydration

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -84,6 +84,38 @@ type RawUsageFactArchiveCandidate =
 /// Carries the Blob authority that must match before Operations clears a hot SQL payload.
 type RawUsageFactArchivePointer = { UsageFactId: UsageFactId; BlobName: string; ChecksumSha256Hex: string; ByteLength: int64 }
 
+/// Limits archive replay or support rehydration to an explicit Grace repository scope.
+type RawUsageFactArchiveScope = { OwnerId: OwnerId option; OrganizationId: OrganizationId option; RepositoryId: RepositoryId option }
+
+/// Describes an archived raw usage fact whose compact SQL index can authorize Blob replay.
+type RawUsageFactArchiveReplayItem =
+    {
+        UsageFactId: UsageFactId
+        CorrelationId: CorrelationId
+        FactKind: UsageFactKind
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        StoragePoolId: StoragePoolId
+        Quantity: int64
+        ObservedAt: Instant
+        Pointer: RawUsageFactArchivePointer
+    }
+
+/// Records the local support-audit evidence for one temporarily rehydrated archived payload.
+type RawUsageFactRehydrationAuditEntry =
+    {
+        UsageFactId: UsageFactId
+        Scope: RawUsageFactArchiveScope
+        Pointer: RawUsageFactArchivePointer
+        RequestedBy: string
+        Reason: string
+        RehydratedAt: Instant
+        ExpiresAt: Instant
+        RestoredByteLength: int
+        ChangedSqlState: bool
+    }
+
 /// Lists and transitions raw usage facts through the hot/cold archive boundary.
 type IOperationsUsageArchiveStore =
 
@@ -96,6 +128,16 @@ type IOperationsUsageArchiveStore =
 
     /// Clears the hot SQL payload only when the verified SQL pointer still matches the supplied Blob authority.
     abstract CompleteArchiveAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<bool>
+
+    /// Returns archived rows whose compact SQL pointer is the authority for replay or support rehydration.
+    abstract ListArchivedUsageFactsAsync:
+        scope: RawUsageFactArchiveScope option * batchSize: int * cancellationToken: CancellationToken -> Task<RawUsageFactArchiveReplayItem list>
+
+    /// Temporarily restores archived payload bytes only when the SQL pointer still matches Blob authority.
+    abstract RehydrateArchivedPayloadAsync: pointer: RawUsageFactArchivePointer * rawPayload: byte array * cancellationToken: CancellationToken -> Task<bool>
+
+    /// Clears a temporary support rehydration only when the SQL pointer still matches Blob authority.
+    abstract CleanupRehydratedPayloadAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<bool>
 
 /// Chooses whether schema initialization may connect to `master` to create the operations database.
 type OperationsUsageSchemaBootstrapMode =
@@ -206,6 +248,10 @@ type IOperationsUsageTransaction =
     /// Attempts to insert the raw fact, returning `false` when `UsageFactId` already exists.
     abstract TryInsertRawUsageFactAsync: rawFact: RawUsageFact * cancellationToken: CancellationToken -> Task<bool>
 
+    /// Attempts to insert an archived replay fact without restoring hot SQL payload bytes.
+    abstract TryInsertReplayedArchivedUsageFactAsync:
+        rawFact: RawUsageFact * pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<bool>
+
     /// Adds the accepted raw fact quantity to the derived minute aggregate.
     abstract AddToUsageAggregateMinuteAsync: aggregate: UsageAggregateMinute * cancellationToken: CancellationToken -> Task
 
@@ -257,6 +303,16 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
         addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
 
+    /// Adds archive pointer parameters for replay inserts that keep hot payload bytes out of SQL.
+    let addReplayedArchivePointerParameters (command: SqlCommand) (pointer: RawUsageFactArchivePointer) =
+        addStringParameter command "@ArchiveBlobName" OperationsUsageSql.ArchiveBlobNameMaxLength pointer.BlobName
+
+        let checksumParameter = command.Parameters.Add("@ArchiveChecksumSha256Hex", SqlDbType.Char, OperationsUsageSql.ArchiveChecksumSha256HexLength)
+
+        checksumParameter.Value <- pointer.ChecksumSha256Hex
+        addParameter command "@ArchiveByteLength" SqlDbType.BigInt pointer.ByteLength
+        addParameter command "@ArchiveStateArchived" SqlDbType.Int (int RawUsageFactArchiveState.Archived)
+
     /// Adds the aggregate parameters expected by `OperationsUsageSql.AddToUsageAggregateMinute`.
     let addUsageAggregateMinuteParameters (command: SqlCommand) (aggregate: UsageAggregateMinute) =
         addParameter command "@FactKind" SqlDbType.Int (int aggregate.Key.FactKind)
@@ -273,6 +329,15 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
             task {
                 use command = createCommand OperationsUsageSql.TryInsertRawUsageFact
                 addRawUsageFactParameters command rawFact
+                let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
+                return rowsAffected = 1
+            }
+
+        member _.TryInsertReplayedArchivedUsageFactAsync(rawFact, pointer, cancellationToken) =
+            task {
+                use command = createCommand OperationsUsageSql.TryInsertReplayedArchivedRawUsageFact
+                addRawUsageFactParameters command rawFact
+                addReplayedArchivePointerParameters command pointer
                 let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
                 return rowsAffected = 1
             }
@@ -374,6 +439,30 @@ type SqlOperationsUsageArchiveStore(connectionString: string) =
         checksumParameter.Value <- pointer.ChecksumSha256Hex
         addParameter command "@ArchiveByteLength" SqlDbType.BigInt pointer.ByteLength
 
+    /// Adds optional scope parameters that constrain replay and support rehydration scans.
+    let addArchiveScopeParameters (command: SqlCommand) (scope: RawUsageFactArchiveScope option) =
+        let addOptionalGuidParameter name value =
+            let parameter = command.Parameters.Add(name, SqlDbType.UniqueIdentifier)
+
+            parameter.Value <-
+                match value with
+                | Some id -> box id
+                | None -> DBNull.Value
+
+        let ownerId = scope |> Option.bind (fun value -> value.OwnerId)
+
+        let organizationId =
+            scope
+            |> Option.bind (fun value -> value.OrganizationId)
+
+        let repositoryId =
+            scope
+            |> Option.bind (fun value -> value.RepositoryId)
+
+        addOptionalGuidParameter "@OwnerId" ownerId
+        addOptionalGuidParameter "@OrganizationId" organizationId
+        addOptionalGuidParameter "@RepositoryId" repositoryId
+
     /// Executes an archive transition command and returns whether this call changed SQL state.
     let executeArchiveTransitionAsync commandText pointer cancellationToken =
         task {
@@ -383,6 +472,32 @@ type SqlOperationsUsageArchiveStore(connectionString: string) =
             command.CommandText <- commandText
             addArchiveStateParameters command
             addArchivePointerParameters command pointer
+
+            let! scalar = command.ExecuteScalarAsync cancellationToken
+
+            return
+                match scalar with
+                | :? int as value -> value = 1
+                | :? int64 as value -> value = 1L
+                | :? decimal as value -> value = 1M
+                | _ -> false
+        }
+
+    /// Executes a single-row archive payload update guarded by the exact Blob pointer.
+    let executeArchivePayloadTransitionAsync commandText pointer rawPayload cancellationToken =
+        task {
+            use! connection = openConnectionAsync cancellationToken
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+            command.CommandText <- commandText
+            addArchiveStateParameters command
+            addArchivePointerParameters command pointer
+
+            match rawPayload with
+            | Some payload ->
+                let parameter = command.Parameters.Add("@RawPayload", SqlDbType.VarBinary, -1)
+                parameter.Value <- Array.copy payload
+            | None -> ()
 
             let! scalar = command.ExecuteScalarAsync cancellationToken
 
@@ -479,6 +594,78 @@ type SqlOperationsUsageArchiveStore(connectionString: string) =
         member _.CompleteArchiveAsync(pointer, cancellationToken) =
             executeArchiveTransitionAsync OperationsUsageSql.CompleteRawUsageFactArchive pointer cancellationToken
 
+        member _.ListArchivedUsageFactsAsync(scope, batchSize, cancellationToken) =
+            task {
+                if batchSize <= 0 then
+                    invalidArg (nameof batchSize) "Archive replay batch size must be greater than zero."
+
+                use! connection = openConnectionAsync cancellationToken
+                use command = connection.CreateCommand()
+                command.CommandType <- CommandType.Text
+                command.CommandText <- OperationsUsageSql.SelectArchivedRawUsageFactsForReplay
+                addParameter command "@BatchSize" SqlDbType.Int batchSize
+                addArchiveStateParameters command
+                addArchiveScopeParameters command scope
+
+                use! reader = command.ExecuteReaderAsync cancellationToken
+                let items = ResizeArray<RawUsageFactArchiveReplayItem>()
+
+                let usageFactIdOrdinal = reader.GetOrdinal("UsageFactId")
+                let correlationIdOrdinal = reader.GetOrdinal("CorrelationId")
+                let factKindOrdinal = reader.GetOrdinal("FactKind")
+                let ownerIdOrdinal = reader.GetOrdinal("OwnerId")
+                let organizationIdOrdinal = reader.GetOrdinal("OrganizationId")
+                let repositoryIdOrdinal = reader.GetOrdinal("RepositoryId")
+                let storagePoolIdOrdinal = reader.GetOrdinal("StoragePoolId")
+                let quantityOrdinal = reader.GetOrdinal("Quantity")
+                let observedAtOrdinal = reader.GetOrdinal("ObservedAtUtc")
+                let archiveBlobNameOrdinal = reader.GetOrdinal("ArchiveBlobName")
+                let archiveChecksumOrdinal = reader.GetOrdinal("ArchiveChecksumSha256Hex")
+                let archiveByteLengthOrdinal = reader.GetOrdinal("ArchiveByteLength")
+                let mutable reading = true
+
+                while reading do
+                    let! hasRow = reader.ReadAsync cancellationToken
+
+                    if hasRow then
+                        let usageFactId = reader.GetGuid usageFactIdOrdinal
+
+                        let pointer =
+                            {
+                                UsageFactId = usageFactId
+                                BlobName = reader.GetString archiveBlobNameOrdinal
+                                ChecksumSha256Hex = reader.GetString archiveChecksumOrdinal
+                                ByteLength = reader.GetInt64 archiveByteLengthOrdinal
+                            }
+
+                        items.Add
+                            {
+                                UsageFactId = usageFactId
+                                CorrelationId = CorrelationId(reader.GetString correlationIdOrdinal)
+                                FactKind = enum<UsageFactKind> (reader.GetInt32 factKindOrdinal)
+                                OwnerId = reader.GetGuid ownerIdOrdinal
+                                OrganizationId = reader.GetGuid organizationIdOrdinal
+                                RepositoryId = reader.GetGuid repositoryIdOrdinal
+                                StoragePoolId = StoragePoolId(reader.GetString storagePoolIdOrdinal)
+                                Quantity = reader.GetInt64 quantityOrdinal
+                                ObservedAt = toInstant (reader.GetDateTime observedAtOrdinal)
+                                Pointer = pointer
+                            }
+                    else
+                        reading <- false
+
+                return items |> Seq.toList
+            }
+
+        member _.RehydrateArchivedPayloadAsync(pointer, rawPayload, cancellationToken) =
+            if isNull rawPayload || rawPayload.Length = 0 then
+                invalidArg (nameof rawPayload) "Rehydrated raw payload bytes are required."
+
+            executeArchivePayloadTransitionAsync OperationsUsageSql.RehydrateArchivedRawUsageFactPayload pointer (Some rawPayload) cancellationToken
+
+        member _.CleanupRehydratedPayloadAsync(pointer, cancellationToken) =
+            executeArchivePayloadTransitionAsync OperationsUsageSql.CleanupRehydratedRawUsageFactPayload pointer None cancellationToken
+
 /// Ensures the operations usage SQL schema exists before ingestion starts consuming durable messages.
 type OperationsUsageSchema(connectionString: string, ?bootstrapMode: OperationsUsageSchemaBootstrapMode) =
 
@@ -556,4 +743,29 @@ type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
 
                 let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
                 return Ok result
+        }
+
+    /// Replays an archived usage fact into raw index and aggregate state without restoring hot SQL payload bytes.
+    member _.ReplayArchivedUsageFactAsync(fact: UsageFact, rawPayload: byte array, pointer: RawUsageFactArchivePointer, cancellationToken: CancellationToken) =
+        task {
+            if pointer.UsageFactId <> fact.UsageFactId then
+                return Error [ $"Replay pointer UsageFactId '{pointer.UsageFactId}' does not match payload UsageFactId '{fact.UsageFactId}'." ]
+            else
+                match UsageFactPersistencePlan.tryCreate fact rawPayload with
+                | Error errors -> return Error errors
+                | Ok plan ->
+                    let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
+                        task {
+                            let! accepted = transaction.TryInsertReplayedArchivedUsageFactAsync(plan.RawFact, pointer, operationCancellationToken)
+
+                            if accepted then
+                                do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
+
+                                return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
+                            else
+                                return { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = plan.RawFact.UsageFactId; Aggregate = None }
+                        }
+
+                    let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
+                    return Ok result
         }

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -87,6 +87,9 @@ type RawUsageFactArchivePointer = { UsageFactId: UsageFactId; BlobName: string; 
 /// Limits archive replay or support rehydration to an explicit Grace repository scope.
 type RawUsageFactArchiveScope = { OwnerId: OwnerId option; OrganizationId: OrganizationId option; RepositoryId: RepositoryId option }
 
+/// Carries the last archived row seen so replay pages advance through stable SQL ordering.
+type RawUsageFactArchiveReplayCursor = { ObservedAt: Instant; UsageFactId: UsageFactId }
+
 /// Describes an archived raw usage fact whose compact SQL index can authorize Blob replay.
 type RawUsageFactArchiveReplayItem =
     {
@@ -131,7 +134,8 @@ type IOperationsUsageArchiveStore =
 
     /// Returns archived rows whose compact SQL pointer is the authority for replay or support rehydration.
     abstract ListArchivedUsageFactsAsync:
-        scope: RawUsageFactArchiveScope option * batchSize: int * cancellationToken: CancellationToken -> Task<RawUsageFactArchiveReplayItem list>
+        scope: RawUsageFactArchiveScope option * after: RawUsageFactArchiveReplayCursor option * batchSize: int * cancellationToken: CancellationToken ->
+            Task<RawUsageFactArchiveReplayItem list>
 
     /// Temporarily restores archived payload bytes only when the SQL pointer still matches Blob authority.
     abstract RehydrateArchivedPayloadAsync: pointer: RawUsageFactArchivePointer * rawPayload: byte array * cancellationToken: CancellationToken -> Task<bool>
@@ -303,6 +307,18 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
         addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
 
+    /// Adds raw fact parameters for archive replay inserts that intentionally omit hot payload bytes.
+    let addReplayedRawUsageFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
+        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+        addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
+        addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
+        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength rawFact.StoragePoolId
+        addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
+        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
+
     /// Adds archive pointer parameters for replay inserts that keep hot payload bytes out of SQL.
     let addReplayedArchivePointerParameters (command: SqlCommand) (pointer: RawUsageFactArchivePointer) =
         addStringParameter command "@ArchiveBlobName" OperationsUsageSql.ArchiveBlobNameMaxLength pointer.BlobName
@@ -336,7 +352,7 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         member _.TryInsertReplayedArchivedUsageFactAsync(rawFact, pointer, cancellationToken) =
             task {
                 use command = createCommand OperationsUsageSql.TryInsertReplayedArchivedRawUsageFact
-                addRawUsageFactParameters command rawFact
+                addReplayedRawUsageFactParameters command rawFact
                 addReplayedArchivePointerParameters command pointer
                 let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
                 return rowsAffected = 1
@@ -594,7 +610,7 @@ type SqlOperationsUsageArchiveStore(connectionString: string) =
         member _.CompleteArchiveAsync(pointer, cancellationToken) =
             executeArchiveTransitionAsync OperationsUsageSql.CompleteRawUsageFactArchive pointer cancellationToken
 
-        member _.ListArchivedUsageFactsAsync(scope, batchSize, cancellationToken) =
+        member _.ListArchivedUsageFactsAsync(scope, after, batchSize, cancellationToken) =
             task {
                 if batchSize <= 0 then
                     invalidArg (nameof batchSize) "Archive replay batch size must be greater than zero."
@@ -606,6 +622,14 @@ type SqlOperationsUsageArchiveStore(connectionString: string) =
                 addParameter command "@BatchSize" SqlDbType.Int batchSize
                 addArchiveStateParameters command
                 addArchiveScopeParameters command scope
+
+                match after with
+                | Some cursor ->
+                    addParameter command "@AfterObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime cursor.ObservedAt)
+                    addParameter command "@AfterUsageFactId" SqlDbType.UniqueIdentifier cursor.UsageFactId
+                | None ->
+                    addParameter command "@AfterObservedAtUtc" SqlDbType.DateTime2 DBNull.Value
+                    addParameter command "@AfterUsageFactId" SqlDbType.UniqueIdentifier DBNull.Value
 
                 use! reader = command.ExecuteReaderAsync cancellationToken
                 let items = ResizeArray<RawUsageFactArchiveReplayItem>()

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -152,7 +152,7 @@ SELECT TOP (@BatchSize)
     ArchiveBlobName,
     ArchiveChecksumSha256Hex,
     ArchiveByteLength
-FROM ops.RawUsageFact WITH (READPAST, READCOMMITTEDLOCK)
+FROM ops.RawUsageFact WITH (READCOMMITTEDLOCK)
 WHERE ArchiveState = @ArchiveStateArchived
 AND ArchiveBlobName IS NOT NULL
 AND ArchiveChecksumSha256Hex IS NOT NULL

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -134,6 +134,115 @@ AND
 ORDER BY ObservedAtUtc ASC, UsageFactId ASC;
 """
 
+    /// Selects archived usage fact rows whose compact SQL index can authorize Blob replay.
+    [<Literal>]
+    let SelectArchivedRawUsageFactsForReplay =
+        """
+SELECT TOP (@BatchSize)
+    UsageFactId,
+    CorrelationId,
+    FactKind,
+    OwnerId,
+    OrganizationId,
+    RepositoryId,
+    StoragePoolId,
+    Quantity,
+    ObservedAtUtc,
+    ArchiveState,
+    ArchiveBlobName,
+    ArchiveChecksumSha256Hex,
+    ArchiveByteLength
+FROM ops.RawUsageFact WITH (READPAST, READCOMMITTEDLOCK)
+WHERE ArchiveState = @ArchiveStateArchived
+AND ArchiveBlobName IS NOT NULL
+AND ArchiveChecksumSha256Hex IS NOT NULL
+AND ArchiveByteLength IS NOT NULL
+AND (@OwnerId IS NULL OR OwnerId = @OwnerId)
+AND (@OrganizationId IS NULL OR OrganizationId = @OrganizationId)
+AND (@RepositoryId IS NULL OR RepositoryId = @RepositoryId)
+ORDER BY ObservedAtUtc ASC, UsageFactId ASC;
+"""
+
+    /// Inserts an archived replay row without repopulating the hot SQL payload, preserving replay idempotency by UsageFactId.
+    [<Literal>]
+    let TryInsertReplayedArchivedRawUsageFact =
+        """
+INSERT INTO ops.RawUsageFact
+(
+    UsageFactId,
+    RawPayload,
+    CorrelationId,
+    FactKind,
+    OwnerId,
+    OrganizationId,
+    RepositoryId,
+    StoragePoolId,
+    Quantity,
+    ObservedAtUtc,
+    ArchiveState,
+    ArchiveBlobName,
+    ArchiveChecksumSha256Hex,
+    ArchiveByteLength,
+    ArchiveVerifiedAtUtc,
+    ArchivedAtUtc
+)
+SELECT
+    @UsageFactId,
+    NULL,
+    @CorrelationId,
+    @FactKind,
+    @OwnerId,
+    @OrganizationId,
+    @RepositoryId,
+    @StoragePoolId,
+    @Quantity,
+    @ObservedAtUtc,
+    @ArchiveStateArchived,
+    @ArchiveBlobName,
+    @ArchiveChecksumSha256Hex,
+    @ArchiveByteLength,
+    SYSUTCDATETIME(),
+    SYSUTCDATETIME()
+WHERE NOT EXISTS
+(
+    SELECT 1
+    FROM ops.RawUsageFact WITH (UPDLOCK, HOLDLOCK)
+    WHERE UsageFactId = @UsageFactId
+);
+"""
+
+    /// Restores archived raw payload bytes only for an exact SQL Blob pointer match during scoped support rehydration.
+    [<Literal>]
+    let RehydrateArchivedRawUsageFactPayload =
+        """
+UPDATE ops.RawUsageFact
+SET RawPayload = @RawPayload
+WHERE UsageFactId = @UsageFactId
+AND ArchiveState = @ArchiveStateArchived
+AND RawPayload IS NULL
+AND ArchiveBlobName = @ArchiveBlobName
+AND ArchiveChecksumSha256Hex = @ArchiveChecksumSha256Hex
+AND ArchiveByteLength = @ArchiveByteLength;
+
+SELECT @@ROWCOUNT;
+"""
+
+    /// Clears temporarily rehydrated raw payload bytes only when the archived Blob pointer still matches.
+    [<Literal>]
+    let CleanupRehydratedRawUsageFactPayload =
+        """
+UPDATE ops.RawUsageFact
+SET RawPayload = NULL
+WHERE UsageFactId = @UsageFactId
+AND ArchiveState = @ArchiveStateArchived
+AND RawPayload IS NOT NULL
+AND ArchiveBlobName = @ArchiveBlobName
+AND ArchiveChecksumSha256Hex = @ArchiveChecksumSha256Hex
+AND ArchiveByteLength = @ArchiveByteLength;
+
+SELECT @@ROWCOUNT;
+"""
+
     /// Records verified Blob authority while retaining the hot payload for an idempotent cleanup retry.
     [<Literal>]
     let MarkRawUsageFactArchiveVerified =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -160,6 +160,12 @@ AND ArchiveByteLength IS NOT NULL
 AND (@OwnerId IS NULL OR OwnerId = @OwnerId)
 AND (@OrganizationId IS NULL OR OrganizationId = @OrganizationId)
 AND (@RepositoryId IS NULL OR RepositoryId = @RepositoryId)
+AND
+(
+    @AfterObservedAtUtc IS NULL
+    OR ObservedAtUtc > @AfterObservedAtUtc
+    OR (ObservedAtUtc = @AfterObservedAtUtc AND UsageFactId > @AfterUsageFactId)
+)
 ORDER BY ObservedAtUtc ASC, UsageFactId ASC;
 """
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
@@ -83,11 +83,19 @@ module OperationsUsageArchiveTestData =
         }
 
 /// Records archive store interactions without requiring SQL Server.
-type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list, events: List<string>) =
+type private RecordingArchiveStore
+    (
+        candidates: RawUsageFactArchiveCandidate list,
+        events: List<string>,
+        ?rehydrateResults: Result<bool, exn> list,
+        ?afterRehydrate: RawUsageFactArchivePointer -> bool -> unit
+    ) =
     let markedPointers = ResizeArray<RawUsageFactArchivePointer>()
     let completedPointers = ResizeArray<RawUsageFactArchivePointer>()
     let rehydratedPointers = ResizeArray<RawUsageFactArchivePointer>()
     let cleanedPointers = ResizeArray<RawUsageFactArchivePointer>()
+    let rehydrateResults = Queue<Result<bool, exn>>(defaultArg rehydrateResults [])
+    let afterRehydrate = defaultArg afterRehydrate (fun _ _ -> ())
 
     /// Returns Blob pointers recorded as verified in SQL.
     member _.MarkedPointers = markedPointers |> Seq.toList
@@ -117,7 +125,7 @@ type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list
             completedPointers.Add pointer
             Task.FromResult true
 
-        member _.ListArchivedUsageFactsAsync(scope, batchSize, _cancellationToken) =
+        member _.ListArchivedUsageFactsAsync(scope, after, batchSize, _cancellationToken) =
             events.Add("list-archived")
 
             let matchesScope (candidate: RawUsageFactArchiveCandidate) =
@@ -131,9 +139,19 @@ type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list
                     && (scope.RepositoryId
                         |> Option.forall ((=) candidate.RepositoryId))
 
+            let isAfterCursor (candidate: RawUsageFactArchiveCandidate) =
+                match after with
+                | None -> true
+                | Some cursor ->
+                    candidate.ObservedAt > cursor.ObservedAt
+                    || (candidate.ObservedAt = cursor.ObservedAt
+                        && candidate.UsageFactId > cursor.UsageFactId)
+
             let replayItems =
                 candidates
                 |> List.filter matchesScope
+                |> List.filter isAfterCursor
+                |> List.sortBy (fun candidate -> candidate.ObservedAt, candidate.UsageFactId)
                 |> List.truncate batchSize
                 |> List.map (fun candidate ->
                     match candidate.ArchiveBlobName, candidate.ArchiveChecksumSha256Hex, candidate.ArchiveByteLength with
@@ -159,8 +177,16 @@ type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list
         member _.RehydrateArchivedPayloadAsync(pointer, rawPayload, _cancellationToken) =
             events.Add("rehydrate")
             Assert.That(rawPayload, Is.Not.Empty)
-            rehydratedPointers.Add pointer
-            Task.FromResult true
+
+            let result = if rehydrateResults.Count > 0 then rehydrateResults.Dequeue() else Ok true
+
+            match result with
+            | Ok changed ->
+                if changed then rehydratedPointers.Add pointer
+
+                afterRehydrate pointer changed
+                Task.FromResult changed
+            | Error ex -> Task.FromException<bool> ex
 
         member _.CleanupRehydratedPayloadAsync(pointer, _cancellationToken) =
             events.Add("cleanup-rehydrated")
@@ -517,6 +543,58 @@ type OperationsUsageArchiveTests() =
             )
         }
 
+    /// Verifies archive replay advances its SQL cursor instead of rereading the same first page.
+    [<Test>]
+    member _.ArchiveReplayPagesPastFirstSqlBatch() =
+        task {
+            let events = List<string>()
+
+            let usageFactIds =
+                [
+                    Guid.Parse("45454545-4545-4545-8545-454545454546")
+                    Guid.Parse("45454545-4545-4545-8545-454545454547")
+                    Guid.Parse("45454545-4545-4545-8545-454545454548")
+                ]
+
+            let createReplayCandidate usageFactId =
+                let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+                let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+                let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+                let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Archived None (Some archiveBlob.Pointer), archiveBlob
+
+            let replayCandidates, archiveBlobs =
+                usageFactIds
+                |> List.map createReplayCandidate
+                |> List.unzip
+
+            let archiveStore = RecordingArchiveStore(replayCandidates, events)
+            let blobStore = RecordingArchiveBlobStore(events)
+
+            archiveBlobs
+            |> List.iter (fun archiveBlob -> blobStore.Put(archiveBlob.Pointer.BlobName, archiveBlob.Content))
+
+            let replayStore = RecordingArchiveReplayStore(events)
+            let processor = createReplayProcessor archiveStore blobStore replayStore
+
+            let! result = processor.ReplayBatchAsync(None, 1, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(result.Examined, Is.EqualTo(3))
+                    Assert.That(result.Accepted, Is.EqualTo(3))
+                    Assert.That(result.AlreadyProcessed, Is.EqualTo(0))
+                    Assert.That(replayStore.AcceptedCount, Is.EqualTo(3))
+
+                    Assert.That(
+                        events
+                        |> Seq.filter ((=) "list-archived")
+                        |> Seq.length,
+                        Is.EqualTo(4)
+                    ))
+            )
+        }
+
     /// Verifies replay fails loudly when Blob checksum, byte length, or UsageFactId authority disagrees.
     [<Test>]
     member _.ArchiveReplayRejectsCorruptArchiveAuthority() =
@@ -565,6 +643,11 @@ type OperationsUsageArchiveTests() =
                     Assert.That(usageFactIdMessage, Does.Contain("UsageFactId mismatch")))
             )
         }
+
+    /// Verifies replay SQL never receives raw payload bytes for an insert that stores the archived pointer only.
+    [<Test>]
+    member _.ReplayInsertSqlDoesNotReferenceRawPayloadParameter() =
+        Assert.That(OperationsUsageSql.TryInsertReplayedArchivedRawUsageFact, Does.Not.Contain("@RawPayload"))
 
     /// Verifies support rehydration requires scope, quota, local audit proof, and exact-pointer cleanup.
     [<Test>]
@@ -627,6 +710,194 @@ type OperationsUsageArchiveTests() =
                     Assert.That(archiveStore.RehydratedPointers |> List.length, Is.EqualTo(1))
                     Assert.That(cleaned, Is.EqualTo(1))
                     Assert.That(archiveStore.CleanedPointers |> List.length, Is.EqualTo(1)))
+            )
+        }
+
+    /// Verifies support rehydration cleans rows restored by this request when a later row fails.
+    [<Test>]
+    member _.RehydrationCleansChangedRowsOnPartialFailure() =
+        task {
+            let events = List<string>()
+            let firstUsageFactId = Guid.Parse("48484848-4848-4848-8848-484848484849")
+            let secondUsageFactId = Guid.Parse("49494949-4949-4949-8949-494949494950")
+
+            let createReplayCandidate usageFactId =
+                let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+                let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+                let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+                let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Archived None (Some archiveBlob.Pointer), archiveBlob
+
+            let firstCandidate, firstBlob = createReplayCandidate firstUsageFactId
+            let secondCandidate, secondBlob = createReplayCandidate secondUsageFactId
+
+            let archiveStore =
+                RecordingArchiveStore(
+                    [ firstCandidate; secondCandidate ],
+                    events,
+                    [
+                        Ok true
+                        Error(InvalidOperationException("second rehydration failed"))
+                    ]
+                )
+
+            let blobStore = RecordingArchiveBlobStore(events)
+            blobStore.Put(firstBlob.Pointer.BlobName, firstBlob.Content)
+            blobStore.Put(secondBlob.Pointer.BlobName, secondBlob.Content)
+
+            let now = Instant.FromUtc(2026, 7, 7, 10, 0, 0)
+            let processor = createRehydrationProcessor archiveStore blobStore (FixedClock now)
+
+            let request: OperationsUsageRehydrationRequest =
+                {
+                    Scope =
+                        {
+                            OwnerId = Some OperationsUsageArchiveTestData.ownerId
+                            OrganizationId = Some OperationsUsageArchiveTestData.organizationId
+                            RepositoryId = Some OperationsUsageArchiveTestData.repositoryId
+                        }
+                    MaxFacts = 2
+                    RequestedBy = "support@example.test"
+                    Reason = "Investigate archived customer support case"
+                    ExpiresAt = now + Duration.FromHours 1.0
+                }
+
+            let mutable message = None
+
+            try
+                let! _ = processor.RehydrateAsync(request, CancellationToken.None)
+                Assert.Fail("Partial rehydration failure should be surfaced.")
+            with
+            | :? InvalidOperationException as ex -> message <- Some ex.Message
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(message.Value, Is.EqualTo("second rehydration failed"))
+                    Assert.That(archiveStore.RehydratedPointers |> List.length, Is.EqualTo(1))
+                    Assert.That(archiveStore.RehydratedPointers[0], Is.EqualTo(firstBlob.Pointer))
+                    Assert.That(archiveStore.CleanedPointers |> List.length, Is.EqualTo(1))
+                    Assert.That(archiveStore.CleanedPointers[0], Is.EqualTo(firstBlob.Pointer)))
+            )
+        }
+
+    /// Verifies partial rehydration cleanup still runs when caller cancellation arrives after a restore.
+    [<Test>]
+    member _.RehydrationCleansChangedRowsWhenCancellationArrivesAfterPartialRestore() =
+        task {
+            let events = List<string>()
+            let firstUsageFactId = Guid.Parse("48484848-4848-4848-8848-484848484852")
+            let secondUsageFactId = Guid.Parse("49494949-4949-4949-8949-494949494953")
+
+            let createReplayCandidate usageFactId =
+                let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+                let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+                let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+                let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Archived None (Some archiveBlob.Pointer), archiveBlob
+
+            let firstCandidate, firstBlob = createReplayCandidate firstUsageFactId
+            let secondCandidate, secondBlob = createReplayCandidate secondUsageFactId
+            use cancellationSource = new CancellationTokenSource()
+
+            let archiveStore =
+                RecordingArchiveStore([ firstCandidate; secondCandidate ], events, [ Ok true ], (fun _ changed -> if changed then cancellationSource.Cancel()))
+
+            let blobStore = RecordingArchiveBlobStore(events)
+            blobStore.Put(firstBlob.Pointer.BlobName, firstBlob.Content)
+            blobStore.Put(secondBlob.Pointer.BlobName, secondBlob.Content)
+
+            let now = Instant.FromUtc(2026, 7, 7, 10, 0, 0)
+            let processor = createRehydrationProcessor archiveStore blobStore (FixedClock now)
+
+            let request: OperationsUsageRehydrationRequest =
+                {
+                    Scope =
+                        {
+                            OwnerId = Some OperationsUsageArchiveTestData.ownerId
+                            OrganizationId = Some OperationsUsageArchiveTestData.organizationId
+                            RepositoryId = Some OperationsUsageArchiveTestData.repositoryId
+                        }
+                    MaxFacts = 2
+                    RequestedBy = "support@example.test"
+                    Reason = "Investigate archived customer support case"
+                    ExpiresAt = now + Duration.FromHours 1.0
+                }
+
+            try
+                let! _ = processor.RehydrateAsync(request, cancellationSource.Token)
+                Assert.Fail("Cancellation after partial rehydration should be surfaced.")
+            with
+            | :? OperationCanceledException -> ()
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(archiveStore.RehydratedPointers |> List.length, Is.EqualTo(1))
+                    Assert.That(archiveStore.RehydratedPointers[0], Is.EqualTo(firstBlob.Pointer))
+                    Assert.That(archiveStore.CleanedPointers |> List.length, Is.EqualTo(1))
+                    Assert.That(archiveStore.CleanedPointers[0], Is.EqualTo(firstBlob.Pointer)))
+            )
+        }
+
+    /// Verifies cleanup does not clear payloads for audit entries where this request did not change SQL.
+    [<Test>]
+    member _.RehydrationCleanupSkipsRowsThisRequestDidNotRestore() =
+        task {
+            let events = List<string>()
+            let firstUsageFactId = Guid.Parse("48484848-4848-4848-8848-484848484850")
+            let secondUsageFactId = Guid.Parse("49494949-4949-4949-8949-494949494951")
+
+            let createReplayCandidate usageFactId =
+                let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+                let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+                let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+                let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Archived None (Some archiveBlob.Pointer), archiveBlob
+
+            let firstCandidate, firstBlob = createReplayCandidate firstUsageFactId
+            let secondCandidate, secondBlob = createReplayCandidate secondUsageFactId
+            let archiveStore = RecordingArchiveStore([ firstCandidate; secondCandidate ], events, [ Ok false; Ok true ])
+            let blobStore = RecordingArchiveBlobStore(events)
+            blobStore.Put(firstBlob.Pointer.BlobName, firstBlob.Content)
+            blobStore.Put(secondBlob.Pointer.BlobName, secondBlob.Content)
+
+            let now = Instant.FromUtc(2026, 7, 7, 10, 0, 0)
+            let processor = createRehydrationProcessor archiveStore blobStore (FixedClock now)
+
+            let request: OperationsUsageRehydrationRequest =
+                {
+                    Scope =
+                        {
+                            OwnerId = Some OperationsUsageArchiveTestData.ownerId
+                            OrganizationId = Some OperationsUsageArchiveTestData.organizationId
+                            RepositoryId = Some OperationsUsageArchiveTestData.repositoryId
+                        }
+                    MaxFacts = 2
+                    RequestedBy = "support@example.test"
+                    Reason = "Investigate archived customer support case"
+                    ExpiresAt = now + Duration.FromHours 1.0
+                }
+
+            let! rehydrated = processor.RehydrateAsync(request, CancellationToken.None)
+
+            let result =
+                match rehydrated with
+                | Ok value -> value
+                | Error errors -> failwith (String.Join("; ", errors))
+
+            let! cleaned = processor.CleanupAsync(result.AuditEntries, CancellationToken.None)
+
+            let changedStates =
+                result.AuditEntries
+                |> List.map (fun entry -> entry.ChangedSqlState)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(changedStates |> List.length, Is.EqualTo(2))
+                    Assert.That(changedStates[0], Is.False)
+                    Assert.That(changedStates[1], Is.True)
+                    Assert.That(cleaned, Is.EqualTo(1))
+                    Assert.That(archiveStore.CleanedPointers |> List.length, Is.EqualTo(1))
+                    Assert.That(archiveStore.CleanedPointers[0], Is.EqualTo(secondBlob.Pointer)))
             )
         }
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
@@ -3,6 +3,7 @@ namespace Grace.Operations.Tests
 open Grace.Operations.Data
 open Grace.Operations.Data.Migrations
 open Grace.Operations.Worker
+open Grace.Shared
 open Grace.Types.Common
 open Grace.Types.Usage
 open Microsoft.EntityFrameworkCore
@@ -40,6 +41,22 @@ module OperationsUsageArchiveTestData =
     /// Creates the accepted raw payload bytes that later replay leaves will consume.
     let payload usageFactId = Encoding.UTF8.GetBytes($"{{\"usageFactId\":\"{usageFactId:D}\",\"payload\":\"exact broker bytes\"}}")
 
+    /// Creates a valid usage fact whose raw JSON payload can be validated during archive replay.
+    let usageFact usageFactId =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            CorrelationId $"corr-{usageFactId}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            storagePoolId,
+            4096L,
+            Instant.FromUtc(2026, 7, 4, 12, 34, 0)
+        )
+
+    /// Serializes a usage fact with the production JSON settings preserved in archive blobs.
+    let usageFactPayload fact = JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
+
     /// Creates a raw usage fact archive candidate with deterministic scope and observed time.
     let candidate usageFactId archiveState rawPayload pointer =
         {
@@ -69,12 +86,20 @@ module OperationsUsageArchiveTestData =
 type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list, events: List<string>) =
     let markedPointers = ResizeArray<RawUsageFactArchivePointer>()
     let completedPointers = ResizeArray<RawUsageFactArchivePointer>()
+    let rehydratedPointers = ResizeArray<RawUsageFactArchivePointer>()
+    let cleanedPointers = ResizeArray<RawUsageFactArchivePointer>()
 
     /// Returns Blob pointers recorded as verified in SQL.
     member _.MarkedPointers = markedPointers |> Seq.toList
 
     /// Returns Blob pointers completed by clearing the hot SQL payload.
     member _.CompletedPointers = completedPointers |> Seq.toList
+
+    /// Returns Blob pointers restored for temporary support rehydration.
+    member _.RehydratedPointers = rehydratedPointers |> Seq.toList
+
+    /// Returns Blob pointers cleaned after temporary support rehydration.
+    member _.CleanedPointers = cleanedPointers |> Seq.toList
 
     interface IOperationsUsageArchiveStore with
 
@@ -90,6 +115,56 @@ type private RecordingArchiveStore(candidates: RawUsageFactArchiveCandidate list
         member _.CompleteArchiveAsync(pointer, _cancellationToken) =
             events.Add("complete-archive")
             completedPointers.Add pointer
+            Task.FromResult true
+
+        member _.ListArchivedUsageFactsAsync(scope, batchSize, _cancellationToken) =
+            events.Add("list-archived")
+
+            let matchesScope (candidate: RawUsageFactArchiveCandidate) =
+                match scope with
+                | None -> true
+                | Some scope ->
+                    (scope.OwnerId
+                     |> Option.forall ((=) candidate.OwnerId))
+                    && (scope.OrganizationId
+                        |> Option.forall ((=) candidate.OrganizationId))
+                    && (scope.RepositoryId
+                        |> Option.forall ((=) candidate.RepositoryId))
+
+            let replayItems =
+                candidates
+                |> List.filter matchesScope
+                |> List.truncate batchSize
+                |> List.map (fun candidate ->
+                    match candidate.ArchiveBlobName, candidate.ArchiveChecksumSha256Hex, candidate.ArchiveByteLength with
+                    | Some blobName, Some checksum, Some byteLength ->
+                        let pointer = { UsageFactId = candidate.UsageFactId; BlobName = blobName; ChecksumSha256Hex = checksum; ByteLength = byteLength }
+
+                        {
+                            UsageFactId = candidate.UsageFactId
+                            CorrelationId = candidate.CorrelationId
+                            FactKind = candidate.FactKind
+                            OwnerId = candidate.OwnerId
+                            OrganizationId = candidate.OrganizationId
+                            RepositoryId = candidate.RepositoryId
+                            StoragePoolId = candidate.StoragePoolId
+                            Quantity = candidate.Quantity
+                            ObservedAt = candidate.ObservedAt
+                            Pointer = pointer
+                        }
+                    | _ -> failwith "Replay candidates require complete archive pointer authority.")
+
+            Task.FromResult replayItems
+
+        member _.RehydrateArchivedPayloadAsync(pointer, rawPayload, _cancellationToken) =
+            events.Add("rehydrate")
+            Assert.That(rawPayload, Is.Not.Empty)
+            rehydratedPointers.Add pointer
+            Task.FromResult true
+
+        member _.CleanupRehydratedPayloadAsync(pointer, _cancellationToken) =
+            events.Add("cleanup-rehydrated")
+            cleanedPointers.Add pointer
             Task.FromResult true
 
 /// Stores archive blobs in memory while preserving checksum and length verification semantics.
@@ -110,10 +185,14 @@ type private RecordingArchiveBlobStore(events: List<string>) =
         match blobs.TryGetValue pointer.BlobName with
         | false, _ -> invalidOp $"Archive Blob '{pointer.BlobName}' is missing."
         | true, content ->
-            Assert.That(int64 content.Length, Is.EqualTo(pointer.ByteLength))
+            if int64 content.Length <> pointer.ByteLength then
+                invalidOp
+                    $"Archive Blob '{pointer.BlobName}' length mismatch for UsageFactId '{pointer.UsageFactId}'. Expected {pointer.ByteLength}; actual {content.Length}."
 
             let checksum = OperationsUsageArchiveFormat.checksumSha256Hex content
-            Assert.That(checksum, Is.EqualTo(pointer.ChecksumSha256Hex))
+
+            if checksum <> pointer.ChecksumSha256Hex then
+                invalidOp $"Archive Blob '{pointer.BlobName}' checksum mismatch for UsageFactId '{pointer.UsageFactId}'."
 
     interface IOperationsUsageArchiveBlobStore with
 
@@ -140,6 +219,46 @@ type private RecordingArchiveBlobStore(events: List<string>) =
             with
             | ex -> Task.FromException ex
 
+        member this.DownloadVerifiedAsync(pointer, _cancellationToken) =
+            events.Add("download-verified")
+
+            try
+                this.VerifyPointer pointer
+                Task.FromResult(this.Content pointer.BlobName)
+            with
+            | ex -> Task.FromException<byte array> ex
+
+/// Records replay persistence calls and simulates UsageFactId idempotency.
+type private RecordingArchiveReplayStore(events: List<string>) =
+    let replayed = HashSet<UsageFactId>()
+
+    /// Returns the number of unique usage facts accepted by replay.
+    member _.AcceptedCount = replayed.Count
+
+    interface IOperationsUsageArchiveReplayStore with
+
+        member _.ReplayArchivedUsageFactAsync(fact, rawPayload, pointer, _cancellationToken) =
+            events.Add("replay-store")
+            Assert.That(rawPayload, Is.Not.Empty)
+            Assert.That(pointer.UsageFactId, Is.EqualTo(fact.UsageFactId))
+
+            let status =
+                if replayed.Add fact.UsageFactId then
+                    UsageFactPersistenceStatus.Accepted
+                else
+                    UsageFactPersistenceStatus.AlreadyProcessed
+
+            let result = { Status = status; UsageFactId = fact.UsageFactId; Aggregate = None }
+
+            Task.FromResult(Ok result)
+
+/// Provides deterministic time for rehydration expiry tests.
+type private FixedClock(now: Instant) =
+
+    interface IClock with
+
+        member _.GetCurrentInstant() = now
+
 /// Covers hot/cold archive layout, Blob verification, SQL state ordering, and migration shape.
 [<TestFixture>]
 type OperationsUsageArchiveTests() =
@@ -150,6 +269,26 @@ type OperationsUsageArchiveTests() =
             archiveStore,
             blobStore,
             NullLogger<OperationsUsageArchiveProcessor>
+                .Instance
+        )
+
+    /// Creates the replay processor with fake SQL, Blob, and replay dependencies.
+    let createReplayProcessor archiveStore blobStore replayStore =
+        OperationsUsageArchiveReplayProcessor(
+            archiveStore,
+            blobStore,
+            replayStore,
+            NullLogger<OperationsUsageArchiveReplayProcessor>
+                .Instance
+        )
+
+    /// Creates the scoped rehydration processor with deterministic time.
+    let createRehydrationProcessor archiveStore blobStore clock =
+        OperationsUsageRehydrationProcessor(
+            archiveStore,
+            blobStore,
+            clock,
+            NullLogger<OperationsUsageRehydrationProcessor>
                 .Instance
         )
 
@@ -342,6 +481,189 @@ type OperationsUsageArchiveTests() =
                     Assert.That(archiveStore.MarkedPointers, Is.Empty)
                     Assert.That(archiveStore.CompletedPointers, Is.Empty))
             )
+        }
+
+    /// Verifies archive replay validates Blob authority and remains idempotent by UsageFactId.
+    [<Test>]
+    member _.ArchiveReplayValidatesBlobAuthorityAndIsIdempotent() =
+        task {
+            let events = List<string>()
+            let usageFactId = Guid.Parse("45454545-4545-4545-8545-454545454545")
+            let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+            let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+            let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+            let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+
+            let replayCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Archived None (Some archiveBlob.Pointer)
+
+            let archiveStore = RecordingArchiveStore([ replayCandidate ], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            blobStore.Put(archiveBlob.Pointer.BlobName, archiveBlob.Content)
+            let replayStore = RecordingArchiveReplayStore(events)
+            let processor = createReplayProcessor archiveStore blobStore replayStore
+
+            let! first = processor.ReplayBatchAsync(None, 10, CancellationToken.None)
+            let! second = processor.ReplayBatchAsync(None, 10, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(first.Examined, Is.EqualTo(1))
+                    Assert.That(first.Accepted, Is.EqualTo(1))
+                    Assert.That(first.AlreadyProcessed, Is.EqualTo(0))
+                    Assert.That(second.Examined, Is.EqualTo(1))
+                    Assert.That(second.Accepted, Is.EqualTo(0))
+                    Assert.That(second.AlreadyProcessed, Is.EqualTo(1))
+                    Assert.That(replayStore.AcceptedCount, Is.EqualTo(1)))
+            )
+        }
+
+    /// Verifies replay fails loudly when Blob checksum, byte length, or UsageFactId authority disagrees.
+    [<Test>]
+    member _.ArchiveReplayRejectsCorruptArchiveAuthority() =
+        task {
+            let usageFactId = Guid.Parse("46464646-4646-4646-8646-464646464646")
+            let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+            let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+            let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+            let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+
+            let runReplayWithPointer (pointer: RawUsageFactArchivePointer) =
+                task {
+                    let events = List<string>()
+                    let replayCandidate = OperationsUsageArchiveTestData.candidate pointer.UsageFactId RawUsageFactArchiveState.Archived None (Some pointer)
+                    let archiveStore = RecordingArchiveStore([ replayCandidate ], events)
+                    let blobStore = RecordingArchiveBlobStore(events)
+                    blobStore.Put(pointer.BlobName, archiveBlob.Content)
+                    let replayStore = RecordingArchiveReplayStore(events)
+                    let processor = createReplayProcessor archiveStore blobStore replayStore
+                    let mutable message = None
+
+                    try
+                        let! _ = processor.ReplayBatchAsync(None, 10, CancellationToken.None)
+                        Assert.Fail("Corrupt archive authority should stop replay.")
+                    with
+                    | :? InvalidOperationException as ex -> message <- Some ex.Message
+
+                    return message.Value
+                }
+
+            let checksumPointer: RawUsageFactArchivePointer =
+                { archiveBlob.Pointer with ChecksumSha256Hex = String.replicate OperationsUsageSql.ArchiveChecksumSha256HexLength "0" }
+
+            let lengthPointer: RawUsageFactArchivePointer = { archiveBlob.Pointer with ByteLength = archiveBlob.Pointer.ByteLength + 1L }
+
+            let usageFactIdPointer: RawUsageFactArchivePointer = { archiveBlob.Pointer with UsageFactId = Guid.Parse("47474747-4747-4747-8747-474747474747") }
+
+            let! checksumMessage = runReplayWithPointer checksumPointer
+            let! lengthMessage = runReplayWithPointer lengthPointer
+            let! usageFactIdMessage = runReplayWithPointer usageFactIdPointer
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(checksumMessage, Does.Contain("checksum mismatch"))
+                    Assert.That(lengthMessage, Does.Contain("length mismatch"))
+                    Assert.That(usageFactIdMessage, Does.Contain("UsageFactId mismatch")))
+            )
+        }
+
+    /// Verifies support rehydration requires scope, quota, local audit proof, and exact-pointer cleanup.
+    [<Test>]
+    member _.RehydrationIsScopedQuotaLimitedAuditedAndCleanedUp() =
+        task {
+            let events = List<string>()
+            let firstUsageFactId = Guid.Parse("48484848-4848-4848-8848-484848484848")
+            let secondUsageFactId = Guid.Parse("49494949-4949-4949-8949-494949494949")
+
+            let createReplayCandidate usageFactId =
+                let fact = OperationsUsageArchiveTestData.usageFact usageFactId
+                let rawPayload = OperationsUsageArchiveTestData.usageFactPayload fact
+                let hotCandidate = OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Hot (Some rawPayload) None
+                let archiveBlob = OperationsUsageArchiveFormat.createArchiveBlob hotCandidate rawPayload
+                OperationsUsageArchiveTestData.candidate usageFactId RawUsageFactArchiveState.Archived None (Some archiveBlob.Pointer), archiveBlob
+
+            let firstCandidate, firstBlob = createReplayCandidate firstUsageFactId
+            let secondCandidate, secondBlob = createReplayCandidate secondUsageFactId
+            let archiveStore = RecordingArchiveStore([ firstCandidate; secondCandidate ], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            blobStore.Put(firstBlob.Pointer.BlobName, firstBlob.Content)
+            blobStore.Put(secondBlob.Pointer.BlobName, secondBlob.Content)
+
+            let now = Instant.FromUtc(2026, 7, 7, 10, 0, 0)
+            let processor = createRehydrationProcessor archiveStore blobStore (FixedClock now)
+
+            let scope: RawUsageFactArchiveScope =
+                {
+                    OwnerId = Some OperationsUsageArchiveTestData.ownerId
+                    OrganizationId = Some OperationsUsageArchiveTestData.organizationId
+                    RepositoryId = Some OperationsUsageArchiveTestData.repositoryId
+                }
+
+            let request: OperationsUsageRehydrationRequest =
+                {
+                    Scope = scope
+                    MaxFacts = 1
+                    RequestedBy = "support@example.test"
+                    Reason = "Investigate archived customer support case"
+                    ExpiresAt = now + Duration.FromHours 1.0
+                }
+
+            let! rehydrated = processor.RehydrateAsync(request, CancellationToken.None)
+
+            let result =
+                match rehydrated with
+                | Ok value -> value
+                | Error errors -> failwith (String.Join("; ", errors))
+
+            let! cleaned = processor.CleanupAsync(result.AuditEntries, CancellationToken.None)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(result.AuditEntries |> List.length, Is.EqualTo(1))
+                    Assert.That(result.AuditEntries[0].UsageFactId, Is.EqualTo(firstUsageFactId))
+                    Assert.That(result.AuditEntries[0].RequestedBy, Is.EqualTo(request.RequestedBy))
+                    Assert.That(result.AuditEntries[0].Reason, Is.EqualTo(request.Reason))
+                    Assert.That(result.AuditEntries[0].ExpiresAt, Is.EqualTo(request.ExpiresAt))
+                    Assert.That(result.AuditEntries[0].RestoredByteLength, Is.GreaterThan(0))
+                    Assert.That(archiveStore.RehydratedPointers |> List.length, Is.EqualTo(1))
+                    Assert.That(cleaned, Is.EqualTo(1))
+                    Assert.That(archiveStore.CleanedPointers |> List.length, Is.EqualTo(1)))
+            )
+        }
+
+    /// Verifies support rehydration rejects global or unbounded requests before reading Blob payloads.
+    [<Test>]
+    member _.RehydrationRejectsMissingScopeAndQuota() =
+        task {
+            let events = List<string>()
+            let archiveStore = RecordingArchiveStore([], events)
+            let blobStore = RecordingArchiveBlobStore(events)
+            let now = Instant.FromUtc(2026, 7, 7, 10, 0, 0)
+            let processor = createRehydrationProcessor archiveStore blobStore (FixedClock now)
+
+            let request: OperationsUsageRehydrationRequest =
+                {
+                    Scope = { OwnerId = None; OrganizationId = None; RepositoryId = None }
+                    MaxFacts = 0
+                    RequestedBy = ""
+                    Reason = ""
+                    ExpiresAt = now - Duration.FromMinutes 1.0
+                }
+
+            let! result = processor.RehydrateAsync(request, CancellationToken.None)
+
+            match result with
+            | Ok _ -> Assert.Fail("Global unbounded rehydration should be rejected.")
+            | Error errors ->
+                let errorText = String.Join("|", errors)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(errorText, Does.Contain("OwnerId scope"))
+                        Assert.That(errorText, Does.Contain("OrganizationId scope"))
+                        Assert.That(errorText, Does.Contain("RepositoryId scope"))
+                        Assert.That(errorText, Does.Contain("MaxFacts quota"))
+                        Assert.That(events, Is.Empty))
+                )
         }
 
     /// Verifies archive settings expose missing Blob dependencies as startup validation errors.

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageArchive.Tests.fs
@@ -94,6 +94,7 @@ type private RecordingArchiveStore
     let completedPointers = ResizeArray<RawUsageFactArchivePointer>()
     let rehydratedPointers = ResizeArray<RawUsageFactArchivePointer>()
     let cleanedPointers = ResizeArray<RawUsageFactArchivePointer>()
+    let rehydrateCancellationCanBeCanceled = ResizeArray<bool>()
     let rehydrateResults = Queue<Result<bool, exn>>(defaultArg rehydrateResults [])
     let afterRehydrate = defaultArg afterRehydrate (fun _ _ -> ())
 
@@ -108,6 +109,9 @@ type private RecordingArchiveStore
 
     /// Returns Blob pointers cleaned after temporary support rehydration.
     member _.CleanedPointers = cleanedPointers |> Seq.toList
+
+    /// Returns whether each rehydration SQL mutation received a cancelable caller token.
+    member _.RehydrateCancellationCanBeCanceled = rehydrateCancellationCanBeCanceled |> Seq.toList
 
     interface IOperationsUsageArchiveStore with
 
@@ -174,9 +178,10 @@ type private RecordingArchiveStore
 
             Task.FromResult replayItems
 
-        member _.RehydrateArchivedPayloadAsync(pointer, rawPayload, _cancellationToken) =
+        member _.RehydrateArchivedPayloadAsync(pointer, rawPayload, cancellationToken) =
             events.Add("rehydrate")
             Assert.That(rawPayload, Is.Not.Empty)
+            rehydrateCancellationCanBeCanceled.Add cancellationToken.CanBeCanceled
 
             let result = if rehydrateResults.Count > 0 then rehydrateResults.Dequeue() else Ok true
 
@@ -649,6 +654,15 @@ type OperationsUsageArchiveTests() =
     member _.ReplayInsertSqlDoesNotReferenceRawPayloadParameter() =
         Assert.That(OperationsUsageSql.TryInsertReplayedArchivedRawUsageFact, Does.Not.Contain("@RawPayload"))
 
+    /// Verifies replay scans block instead of advancing the cursor past a locked lower-key row.
+    [<Test>]
+    member _.ReplayScanSqlDoesNotUseReadPast() =
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(OperationsUsageSql.SelectArchivedRawUsageFactsForReplay, Does.Not.Contain("READPAST"))
+                Assert.That(OperationsUsageSql.SelectArchivedRawUsageFactsForReplay, Does.Contain("WITH (READCOMMITTEDLOCK)")))
+        )
+
     /// Verifies support rehydration requires scope, quota, local audit proof, and exact-pointer cleanup.
     [<Test>]
     member _.RehydrationIsScopedQuotaLimitedAuditedAndCleanedUp() =
@@ -833,6 +847,7 @@ type OperationsUsageArchiveTests() =
                 Action (fun () ->
                     Assert.That(archiveStore.RehydratedPointers |> List.length, Is.EqualTo(1))
                     Assert.That(archiveStore.RehydratedPointers[0], Is.EqualTo(firstBlob.Pointer))
+                    Assert.That(archiveStore.RehydrateCancellationCanBeCanceled[0], Is.False)
                     Assert.That(archiveStore.CleanedPointers |> List.length, Is.EqualTo(1))
                     Assert.That(archiveStore.CleanedPointers[0], Is.EqualTo(firstBlob.Pointer)))
             )

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -117,6 +117,15 @@ type private InMemoryOperationsUsageTransactionScope() =
                                 rawFacts.Add(rawFact.UsageFactId, rawFact)
                                 Task.FromResult true
 
+                        member _.TryInsertReplayedArchivedUsageFactAsync(rawFact, _pointer, insertCancellationToken) =
+                            insertCancellationToken.ThrowIfCancellationRequested()
+
+                            if rawFacts.ContainsKey rawFact.UsageFactId then
+                                Task.FromResult false
+                            else
+                                rawFacts.Add(rawFact.UsageFactId, { rawFact with RawPayload = Array.empty })
+                                Task.FromResult true
+
                         member _.AddToUsageAggregateMinuteAsync(aggregate, updateCancellationToken) =
                             updateCancellationToken.ThrowIfCancellationRequested()
 
@@ -699,6 +708,35 @@ type OperationsUsageStorageTests() =
                     Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
                     Assert.That(Convert.ToBase64String(rawFact.RawPayload), Is.EqualTo(Convert.ToBase64String(rawPayload)))
                     Assert.That(transactionScope.AggregateQuantity(firstStored.Aggregate.Value.Key), Is.EqualTo(2048L)))
+            )
+        }
+
+    /// Verifies archived replay inserts aggregate state without restoring authoritative hot payload bytes.
+    [<Test>]
+    member _.ReplayArchivedUsageFactDoesNotRepopulateHotPayloadAndStaysIdempotent() =
+        task {
+            let store, transactionScope = createStore ()
+            let usageFactId = Guid.Parse("bcbcbcbc-bcbc-bcbc-bcbc-bcbcbcbcbcbc")
+            let fact = OperationsUsageStorageTestData.fact usageFactId 3072L (Instant.FromUtc(2026, 7, 4, 12, 34, 0))
+            let rawPayload = OperationsUsageStorageTestData.payloadFor fact
+
+            let pointer =
+                { UsageFactId = usageFactId; BlobName = "usage-facts/v1/replay.jsonl.gz"; ChecksumSha256Hex = String.replicate 64 "a"; ByteLength = 123L }
+
+            let! firstResult = store.ReplayArchivedUsageFactAsync(fact, rawPayload, pointer, CancellationToken.None)
+            let firstStored = requireStored firstResult
+
+            let! secondResult = store.ReplayArchivedUsageFactAsync(fact, rawPayload, pointer, CancellationToken.None)
+            let secondStored = requireStored secondResult
+            let rawFact = transactionScope.RawFact usageFactId
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(firstStored.Status, Is.EqualTo(UsageFactPersistenceStatus.Accepted))
+                    Assert.That(secondStored.Status, Is.EqualTo(UsageFactPersistenceStatus.AlreadyProcessed))
+                    Assert.That(rawFact.RawPayload, Is.Empty)
+                    Assert.That(transactionScope.RawFactCount, Is.EqualTo(1))
+                    Assert.That(transactionScope.AggregateQuantity(firstStored.Aggregate.Value.Key), Is.EqualTo(3072L)))
             )
         }
 

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -101,6 +101,25 @@ type IOperationsUsageArchiveBlobStore =
     /// Verifies an already-recorded Blob pointer before SQL cleanup resumes.
     abstract VerifyAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task
 
+    /// Downloads archived Blob bytes after verifying checksum and byte length against SQL pointer authority.
+    abstract DownloadVerifiedAsync: pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<byte array>
+
+/// Replays archived usage facts without restoring hot SQL payload authority.
+type IOperationsUsageArchiveReplayStore =
+
+    /// Persists an archived fact idempotently while keeping `ops.RawUsageFact.RawPayload` empty.
+    abstract ReplayArchivedUsageFactAsync:
+        fact: UsageFact * rawPayload: byte array * pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken ->
+            Task<Result<UsageFactPersistenceResult, string list>>
+
+/// Adapts the concrete operations usage store to archive replay.
+type OperationsUsageArchiveReplayStoreAdapter(store: OperationsUsageStore) =
+
+    interface IOperationsUsageArchiveReplayStore with
+
+        member _.ReplayArchivedUsageFactAsync(fact, rawPayload, pointer, cancellationToken) =
+            store.ReplayArchivedUsageFactAsync(fact, rawPayload, pointer, cancellationToken)
+
 /// Builds deterministic archive names, JSONL payloads, compression, and checksums for raw usage facts.
 [<RequireQualifiedAccess>]
 module OperationsUsageArchiveFormat =
@@ -202,6 +221,101 @@ module OperationsUsageArchiveFormat =
 
         { Pointer = pointer; Content = content }
 
+    /// Decompresses archived gzip JSONL bytes for replay validation.
+    let gunzip (content: byte array) =
+        use input = new MemoryStream(content)
+        use gzipStream = new GZipStream(input, CompressionMode.Decompress)
+        use output = new MemoryStream()
+        gzipStream.CopyTo output
+        output.ToArray()
+
+    /// Reads a required string property from the archive JSON record.
+    let private readString (root: JsonElement) (name: string) = root.GetProperty(name).GetString()
+
+    /// Fails replay when the archive record and compact SQL index disagree.
+    let private requireMatch description expected actual =
+        if not (String.Equals(expected, actual, StringComparison.Ordinal)) then
+            invalidOp $"Archive replay {description} mismatch. Expected '{expected}'; actual '{actual}'."
+
+    /// Extracts and validates the raw UsageFact payload from an archived Blob against the compact SQL index.
+    let readValidatedUsageFact (item: RawUsageFactArchiveReplayItem) (content: byte array) =
+        let jsonl = gunzip content
+        use document = JsonDocument.Parse(ReadOnlyMemory<byte>(jsonl))
+        let root = document.RootElement
+
+        let archiveSchemaVersion =
+            root
+                .GetProperty("archiveSchemaVersion")
+                .GetInt32()
+
+        if archiveSchemaVersion <> ArchiveSchemaVersion then
+            invalidOp
+                $"Archive replay schema version mismatch for UsageFactId '{item.UsageFactId}'. Expected {ArchiveSchemaVersion}; actual {archiveSchemaVersion}."
+
+        requireMatch "UsageFactId" (string item.UsageFactId) (readString root "usageFactId")
+        requireMatch "CorrelationId" (string item.CorrelationId) (readString root "correlationId")
+        requireMatch "FactKind" (item.FactKind.ToString()) (readString root "factKind")
+        requireMatch "OwnerId" (string item.OwnerId) (readString root "ownerId")
+        requireMatch "OrganizationId" (string item.OrganizationId) (readString root "organizationId")
+        requireMatch "RepositoryId" (string item.RepositoryId) (readString root "repositoryId")
+        requireMatch "StoragePoolId" (string item.StoragePoolId) (readString root "storagePoolId")
+
+        requireMatch
+            "Quantity"
+            (item.Quantity.ToString(CultureInfo.InvariantCulture))
+            (root
+                .GetProperty("quantity")
+                .GetInt64()
+                .ToString(CultureInfo.InvariantCulture))
+
+        requireMatch
+            "ObservedAtUtc"
+            (item
+                .ObservedAt
+                .ToDateTimeUtc()
+                .ToString("O", CultureInfo.InvariantCulture))
+            (readString root "observedAtUtc")
+
+        let rawPayload =
+            root
+                .GetProperty("rawPayloadBase64")
+                .GetBytesFromBase64()
+
+        let usageFact =
+            use stream = new MemoryStream(rawPayload, writable = false)
+            JsonSerializer.Deserialize<UsageFact>(stream, Constants.JsonSerializerOptions)
+
+        if isNull (box usageFact) then
+            invalidOp $"Archive replay payload for UsageFactId '{item.UsageFactId}' did not contain a UsageFact."
+
+        match UsageFact.Validate usageFact with
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            invalidOp $"Archive replay payload for UsageFactId '{item.UsageFactId}' is invalid: {errorText}"
+        | Ok () -> ()
+
+        requireMatch "payload UsageFactId" (string item.UsageFactId) (string usageFact.UsageFactId)
+        requireMatch "payload CorrelationId" (string item.CorrelationId) (string usageFact.CorrelationId)
+        requireMatch "payload FactKind" (item.FactKind.ToString()) (usageFact.FactKind.ToString())
+        requireMatch "payload OwnerId" (string item.OwnerId) (string usageFact.Scope.OwnerId)
+        requireMatch "payload OrganizationId" (string item.OrganizationId) (string usageFact.Scope.OrganizationId)
+        requireMatch "payload RepositoryId" (string item.RepositoryId) (string usageFact.Scope.RepositoryId)
+        requireMatch "payload StoragePoolId" (string item.StoragePoolId) (string usageFact.Resource.StoragePoolId)
+        requireMatch "payload Quantity" (item.Quantity.ToString(CultureInfo.InvariantCulture)) (usageFact.Quantity.ToString(CultureInfo.InvariantCulture))
+
+        requireMatch
+            "payload ObservedAtUtc"
+            (item
+                .ObservedAt
+                .ToDateTimeUtc()
+                .ToString("O", CultureInfo.InvariantCulture))
+            (usageFact
+                .ObservedAt
+                .ToDateTimeUtc()
+                .ToString("O", CultureInfo.InvariantCulture))
+
+        usageFact, rawPayload
+
 /// Stores archive blobs in Azure Blob Storage and reads them back for authority verification.
 type AzureOperationsUsageArchiveBlobStore(containerClient: BlobContainerClient) =
 
@@ -253,6 +367,13 @@ type AzureOperationsUsageArchiveBlobStore(containerClient: BlobContainerClient) 
             task {
                 let! storedContent = downloadContentAsync pointer.BlobName cancellationToken
                 verifyContent pointer storedContent
+            }
+
+        member _.DownloadVerifiedAsync(pointer, cancellationToken) =
+            task {
+                let! storedContent = downloadContentAsync pointer.BlobName cancellationToken
+                verifyContent pointer storedContent
+                return storedContent
             }
 
 /// Archives old hot raw payloads after Blob authority is verified and persisted in SQL.
@@ -316,6 +437,179 @@ type OperationsUsageArchiveProcessor
                 index <- index + 1
 
             return archived
+        }
+
+/// Summarizes one archive replay batch.
+type OperationsUsageArchiveReplayBatchResult = { Examined: int; Accepted: int; AlreadyProcessed: int }
+
+/// Replays archived UsageFact payloads through SQL compact-index and Blob authority checks.
+type OperationsUsageArchiveReplayProcessor
+    (
+        archiveStore: IOperationsUsageArchiveStore,
+        blobStore: IOperationsUsageArchiveBlobStore,
+        replayStore: IOperationsUsageArchiveReplayStore,
+        logger: ILogger<OperationsUsageArchiveReplayProcessor>
+    ) =
+
+    /// Replays one archived item after Blob checksum, byte length, and payload/index validation.
+    let replayItemAsync (item: RawUsageFactArchiveReplayItem) cancellationToken =
+        task {
+            let! content = blobStore.DownloadVerifiedAsync(item.Pointer, cancellationToken)
+            let usageFact, rawPayload = OperationsUsageArchiveFormat.readValidatedUsageFact item content
+            let! replayed = replayStore.ReplayArchivedUsageFactAsync(usageFact, rawPayload, item.Pointer, cancellationToken)
+
+            match replayed with
+            | Error errors ->
+                let errorText = String.Join("; ", errors)
+                return invalidOp $"Archive replay rejected UsageFactId '{item.UsageFactId}': {errorText}"
+            | Ok result ->
+                logger.LogInformation(
+                    "Replayed archived operational UsageFact. UsageFactId: {UsageFactId}; BlobName: {BlobName}; Status: {Status}.",
+                    item.UsageFactId,
+                    item.Pointer.BlobName,
+                    result.Status
+                )
+
+                return result.Status
+        }
+
+    /// Replays at most one SQL-index batch, using UsageFactId idempotency to avoid duplicate aggregate projection.
+    member _.ReplayBatchAsync(scope: RawUsageFactArchiveScope option, batchSize: int, cancellationToken: CancellationToken) =
+        task {
+            let! items = archiveStore.ListArchivedUsageFactsAsync(scope, batchSize, cancellationToken)
+            let itemArray = items |> List.toArray
+            let mutable index = 0
+            let mutable accepted = 0
+            let mutable alreadyProcessed = 0
+
+            while index < itemArray.Length do
+                cancellationToken.ThrowIfCancellationRequested()
+                let! status = replayItemAsync itemArray[index] cancellationToken
+
+                match status with
+                | UsageFactPersistenceStatus.Accepted -> accepted <- accepted + 1
+                | UsageFactPersistenceStatus.AlreadyProcessed -> alreadyProcessed <- alreadyProcessed + 1
+                | _ -> invalidOp $"Archive replay returned unsupported persistence status '{status}'."
+
+                index <- index + 1
+
+            return { Examined = itemArray.Length; Accepted = accepted; AlreadyProcessed = alreadyProcessed }
+        }
+
+/// Requests temporary support access to archived payloads for one Grace repository scope.
+type OperationsUsageRehydrationRequest = { Scope: RawUsageFactArchiveScope; MaxFacts: int; RequestedBy: string; Reason: string; ExpiresAt: Instant }
+
+/// Reports temporary support rehydration audit evidence and cleanup targets.
+type OperationsUsageRehydrationResult = { AuditEntries: RawUsageFactRehydrationAuditEntry list }
+
+/// Restores archived payloads temporarily for scoped support workflows and provides cleanup.
+type OperationsUsageRehydrationProcessor
+    (
+        archiveStore: IOperationsUsageArchiveStore,
+        blobStore: IOperationsUsageArchiveBlobStore,
+        clock: IClock,
+        logger: ILogger<OperationsUsageRehydrationProcessor>
+    ) =
+
+    /// Rejects global or unbounded rehydration requests before any Blob reads occur.
+    let validateRequest (request: OperationsUsageRehydrationRequest) =
+        let errors = ResizeArray<string>()
+
+        if request.Scope.OwnerId.IsNone then
+            errors.Add("Rehydration requires OwnerId scope.")
+
+        if request.Scope.OrganizationId.IsNone then
+            errors.Add("Rehydration requires OrganizationId scope.")
+
+        if request.Scope.RepositoryId.IsNone then
+            errors.Add("Rehydration requires RepositoryId scope.")
+
+        if request.MaxFacts <= 0 then
+            errors.Add("Rehydration MaxFacts quota must be greater than zero.")
+
+        if String.IsNullOrWhiteSpace request.RequestedBy then
+            errors.Add("Rehydration RequestedBy audit value is required.")
+
+        if String.IsNullOrWhiteSpace request.Reason then
+            errors.Add("Rehydration Reason audit value is required.")
+
+        if request.ExpiresAt <= clock.GetCurrentInstant() then
+            errors.Add("Rehydration ExpiresAt must be in the future.")
+
+        if errors.Count > 0 then Error(List.ofSeq errors) else Ok()
+
+    /// Rehydrates one archived payload after replay-equivalent archive validation.
+    let rehydrateItemAsync request rehydratedAt (item: RawUsageFactArchiveReplayItem) cancellationToken =
+        task {
+            let! content = blobStore.DownloadVerifiedAsync(item.Pointer, cancellationToken)
+            let _, rawPayload = OperationsUsageArchiveFormat.readValidatedUsageFact item content
+            let! changed = archiveStore.RehydrateArchivedPayloadAsync(item.Pointer, rawPayload, cancellationToken)
+
+            logger.LogInformation(
+                "Temporarily rehydrated archived operational UsageFact. UsageFactId: {UsageFactId}; BlobName: {BlobName}; ChangedSqlState: {ChangedSqlState}; RequestedBy: {RequestedBy}.",
+                item.UsageFactId,
+                item.Pointer.BlobName,
+                changed,
+                request.RequestedBy
+            )
+
+            return
+                {
+                    UsageFactId = item.UsageFactId
+                    Scope = request.Scope
+                    Pointer = item.Pointer
+                    RequestedBy = request.RequestedBy
+                    Reason = request.Reason
+                    RehydratedAt = rehydratedAt
+                    ExpiresAt = request.ExpiresAt
+                    RestoredByteLength = rawPayload.Length
+                    ChangedSqlState = changed
+                }
+        }
+
+    /// Rehydrates up to the explicit quota for one scoped support request and returns local audit proof.
+    member _.RehydrateAsync(request: OperationsUsageRehydrationRequest, cancellationToken: CancellationToken) =
+        task {
+            match validateRequest request with
+            | Error errors -> return Error errors
+            | Ok () ->
+                let! items = archiveStore.ListArchivedUsageFactsAsync(Some request.Scope, request.MaxFacts, cancellationToken)
+                let itemArray = items |> List.toArray
+                let entries = ResizeArray<RawUsageFactRehydrationAuditEntry>()
+                let rehydratedAt = clock.GetCurrentInstant()
+                let mutable index = 0
+
+                while index < itemArray.Length do
+                    cancellationToken.ThrowIfCancellationRequested()
+                    let! entry = rehydrateItemAsync request rehydratedAt itemArray[index] cancellationToken
+                    entries.Add entry
+                    index <- index + 1
+
+                return Ok { AuditEntries = entries |> Seq.toList }
+        }
+
+    /// Clears every payload represented by the supplied support-audit entries.
+    member _.CleanupAsync(entries: RawUsageFactRehydrationAuditEntry list, cancellationToken: CancellationToken) =
+        task {
+            let entryArray = entries |> List.toArray
+            let mutable index = 0
+            let mutable cleaned = 0
+
+            while index < entryArray.Length do
+                cancellationToken.ThrowIfCancellationRequested()
+                let! changed = archiveStore.CleanupRehydratedPayloadAsync(entryArray[index].Pointer, cancellationToken)
+
+                if changed then cleaned <- cleaned + 1
+
+                index <- index + 1
+
+            logger.LogInformation(
+                "Cleaned up temporary operations UsageFact rehydration. Requested: {Requested}; Cleaned: {Cleaned}.",
+                entryArray.Length,
+                cleaned
+            )
+
+            return cleaned
         }
 
 /// Reads Blob archive settings required by the hot/cold usage fact archive worker.

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -20,6 +20,7 @@ open System.Collections.Generic
 open System.Globalization
 open System.IO
 open System.IO.Compression
+open System.Runtime.ExceptionServices
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
@@ -473,27 +474,40 @@ type OperationsUsageArchiveReplayProcessor
                 return result.Status
         }
 
-    /// Replays at most one SQL-index batch, using UsageFactId idempotency to avoid duplicate aggregate projection.
+    /// Advances the archive replay cursor from the last row processed in SQL's stable archive ordering.
+    let nextReplayCursor (item: RawUsageFactArchiveReplayItem) = { ObservedAt = item.ObservedAt; UsageFactId = item.UsageFactId }
+
+    /// Replays archived rows in SQL-index pages, using UsageFactId idempotency to avoid duplicate aggregate projection.
     member _.ReplayBatchAsync(scope: RawUsageFactArchiveScope option, batchSize: int, cancellationToken: CancellationToken) =
         task {
-            let! items = archiveStore.ListArchivedUsageFactsAsync(scope, batchSize, cancellationToken)
-            let itemArray = items |> List.toArray
-            let mutable index = 0
+            let mutable cursor = None
+            let mutable keepReading = true
+            let mutable examined = 0
             let mutable accepted = 0
             let mutable alreadyProcessed = 0
 
-            while index < itemArray.Length do
-                cancellationToken.ThrowIfCancellationRequested()
-                let! status = replayItemAsync itemArray[index] cancellationToken
+            while keepReading do
+                let! items = archiveStore.ListArchivedUsageFactsAsync(scope, cursor, batchSize, cancellationToken)
+                let itemArray = items |> List.toArray
+                let mutable index = 0
 
-                match status with
-                | UsageFactPersistenceStatus.Accepted -> accepted <- accepted + 1
-                | UsageFactPersistenceStatus.AlreadyProcessed -> alreadyProcessed <- alreadyProcessed + 1
-                | _ -> invalidOp $"Archive replay returned unsupported persistence status '{status}'."
+                while index < itemArray.Length do
+                    cancellationToken.ThrowIfCancellationRequested()
+                    let item = itemArray[index]
+                    let! status = replayItemAsync item cancellationToken
 
-                index <- index + 1
+                    match status with
+                    | UsageFactPersistenceStatus.Accepted -> accepted <- accepted + 1
+                    | UsageFactPersistenceStatus.AlreadyProcessed -> alreadyProcessed <- alreadyProcessed + 1
+                    | _ -> invalidOp $"Archive replay returned unsupported persistence status '{status}'."
 
-            return { Examined = itemArray.Length; Accepted = accepted; AlreadyProcessed = alreadyProcessed }
+                    examined <- examined + 1
+                    cursor <- Some(nextReplayCursor item)
+                    index <- index + 1
+
+                keepReading <- itemArray.Length = batchSize
+
+            return { Examined = examined; Accepted = accepted; AlreadyProcessed = alreadyProcessed }
         }
 
 /// Requests temporary support access to archived payloads for one Grace repository scope.
@@ -573,25 +587,44 @@ type OperationsUsageRehydrationProcessor
             match validateRequest request with
             | Error errors -> return Error errors
             | Ok () ->
-                let! items = archiveStore.ListArchivedUsageFactsAsync(Some request.Scope, request.MaxFacts, cancellationToken)
+                let! items = archiveStore.ListArchivedUsageFactsAsync(Some request.Scope, None, request.MaxFacts, cancellationToken)
                 let itemArray = items |> List.toArray
                 let entries = ResizeArray<RawUsageFactRehydrationAuditEntry>()
                 let rehydratedAt = clock.GetCurrentInstant()
                 let mutable index = 0
 
-                while index < itemArray.Length do
-                    cancellationToken.ThrowIfCancellationRequested()
-                    let! entry = rehydrateItemAsync request rehydratedAt itemArray[index] cancellationToken
-                    entries.Add entry
-                    index <- index + 1
+                try
+                    while index < itemArray.Length do
+                        cancellationToken.ThrowIfCancellationRequested()
+                        let! entry = rehydrateItemAsync request rehydratedAt itemArray[index] cancellationToken
+                        entries.Add entry
+                        index <- index + 1
+                with
+                | ex ->
+                    let changedEntries =
+                        entries
+                        |> Seq.filter (fun entry -> entry.ChangedSqlState)
+                        |> Seq.toArray
+
+                    let mutable cleanupIndex = 0
+
+                    while cleanupIndex < changedEntries.Length do
+                        let! _ = archiveStore.CleanupRehydratedPayloadAsync(changedEntries[cleanupIndex].Pointer, CancellationToken.None)
+                        cleanupIndex <- cleanupIndex + 1
+
+                    ExceptionDispatchInfo.Capture(ex).Throw()
 
                 return Ok { AuditEntries = entries |> Seq.toList }
         }
 
-    /// Clears every payload represented by the supplied support-audit entries.
+    /// Clears only payloads this support request actually restored.
     member _.CleanupAsync(entries: RawUsageFactRehydrationAuditEntry list, cancellationToken: CancellationToken) =
         task {
-            let entryArray = entries |> List.toArray
+            let entryArray =
+                entries
+                |> List.filter (fun entry -> entry.ChangedSqlState)
+                |> List.toArray
+
             let mutable index = 0
             let mutable cleaned = 0
 

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -557,7 +557,7 @@ type OperationsUsageRehydrationProcessor
         task {
             let! content = blobStore.DownloadVerifiedAsync(item.Pointer, cancellationToken)
             let _, rawPayload = OperationsUsageArchiveFormat.readValidatedUsageFact item content
-            let! changed = archiveStore.RehydrateArchivedPayloadAsync(item.Pointer, rawPayload, cancellationToken)
+            let! changed = archiveStore.RehydrateArchivedPayloadAsync(item.Pointer, rawPayload, CancellationToken.None)
 
             logger.LogInformation(
                 "Temporarily rehydrated archived operational UsageFact. UsageFactId: {UsageFactId}; BlobName: {BlobName}; ChangedSqlState: {ChangedSqlState}; RequestedBy: {RequestedBy}.",


### PR DESCRIPTION
# Summary

Related to #573.

Part of #559 and #554.

This implements the A3.2 archive replay and scoped rehydration slice. Archived usage facts can now be streamed from Blob through the compact SQL index, validated against the persisted archive authority, and replayed idempotently without repopulating authoritative hot payloads by default. Support rehydration is scoped, quota-limited, evidence-returning, and cleanup-safe.

## What Changed

- Added archived usage replay contracts and SQL paths that enumerate archived compact-index rows, verify Blob authority, and replay through `UsageFactId` idempotency.
- Added exact-pointer rehydration and cleanup SQL commands for temporary support workflows.
- Added worker processors for archive replay and scoped rehydration.
- Added archive parser validation for archive schema version, Blob checksum, byte length, `UsageFactId`, scope, quantity, observed timestamp, and raw `UsageFact` payload/index agreement.
- Added local rehydration audit evidence via `RawUsageFactRehydrationAuditEntry`, including requester, reason, scope, expiry, restored byte length, and changed-SQL-state proof.
- Added focused tests for replay idempotency, checksum mismatch, byte-length mismatch, `UsageFactId` mismatch, scoped quota-limited rehydration, audit return, cleanup, and no-hot-payload replay persistence.

## Branch Flow

- Source branch: `agent/573-operations-archive-replay-rehydration`
- Target branch: `epic/559-operations-archive-replay`
- WS3 later merges to: `epic/554-grace-operations`
- This PR intentionally uses non-closing issue wording because it targets an epic integration branch. The orchestrator will close #573 after merge to WS3.

## Validation

Initial implementation validation:

- Targeted Fantomas passed for touched F# files.
- Focused diagnostic test passed:
  - `dotnet test src\Grace.Operations\Grace.Operations.Tests\Grace.Operations.Tests.fsproj --configuration Release`
  - Result: 97 passed, 0 failed, 0 skipped.
- `git diff --check` passed.
- Final gate passed:
  - `pwsh ./scripts/validate.ps1 -Full`
  - Elapsed: `00:06:05.2883303`
  - `Grace.Types.Tests`: 159 passed
  - `Grace.Authorization.Tests`: 53 passed
  - `Grace.Server.Unit.Tests`: 732 passed
  - `Grace.CLI.Tests`: 689 passed, 1 skipped
  - `Grace.Server.Tests`: 243 passed
  - `Grace.Operations.Tests`: 97 passed

Review-fix validation for `a68e4759a85e2dbdcfad1c811224818d66e5cf48`:

- Targeted Fantomas passed for touched F# files.
- Focused Operations build passed:
  - `dotnet build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`
- Focused Operations tests passed:
  - `dotnet test --no-build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj`
  - Result: 102 passed, 0 failed, 0 skipped.
- `git diff --check` passed.
- `pwsh ./scripts/validate.ps1 -Full` passed once before the final cancellation-cleanup tightening. After that last refinement, the focused Operations build/tests passed again; the final `validate -Full` rerun hit an unrelated Aspire/server restart fixture failure in `DurableActorStateRehydratesAcrossGraceServerProjectRestart`, followed by cascading server integration timeouts.

Second-pass review-fix validation for `ca419900faa9856071116c2a8afa92193fb8e853`:

- Targeted Fantomas passed for touched F# files.
- Focused Operations solution build passed:
  - `dotnet build src/Grace.Operations/Grace.Operations.slnx --configuration Release`
- Focused Operations solution tests passed:
  - `dotnet test src/Grace.Operations/Grace.Operations.slnx --configuration Release --no-build`
  - Result: 103 passed, 0 failed, 0 skipped.
- `git diff --check` passed.
- Final gate passed after stale prior-validation process cleanup:
  - `pwsh ./scripts/validate.ps1 -Full`
  - `Grace.Types.Tests`: 159 passed
  - `Grace.Authorization.Tests`: 53 passed
  - `Grace.Server.Unit.Tests`: 732 passed
  - `Grace.CLI.Tests`: 689 passed, 1 skipped
  - `Grace.Server.Tests`: 243 passed
  - `Grace.Operations.Tests`: 103 passed

## Solution Isolation

- Confirmed `src/Grace.slnx` is unchanged in this PR.
- Confirmed this slice keeps Operations projects in `src/Grace.Operations/Grace.Operations.slnx` and does not add `Grace.Operations` references to the root solution.

## Bot-Prevention Self-Review

- Scoped diff is limited to the issue-owned Operations Data, Worker, and Tests paths.
- No unexpected deletions.
- Replay does not repopulate authoritative hot payload by default; replay insert stores `RawPayload = NULL`.
- Rehydration requires full repository scope, positive quota, requester, reason, and future expiry before Blob reads.
- Rehydration cleanup is exact-pointer guarded against the archived SQL authority.
- Review-fix self-review covered multi-page replay, replay parameter isolation, cleanup of only rows changed by the current request, and cancellation after partial restore.

## Review Status

- Current head: `ca419900faa9856071116c2a8afa92193fb8e853`
- Codex Code Review Bot: latest-head no-issues signal received with 👍.
- All review threads are replied to and resolved.
- `full` check passed on GitHub for the latest head.
- Fixed second-pass findings:
  - Archive replay scans no longer use `READPAST`, so the replay cursor cannot advance past a locked lower-key archived row.
  - Exact-pointer SQL rehydration runs with a non-cancelable token after Blob validation, so cancellation cannot leave restored SQL payloads without audit evidence.
- Previous first-pass findings were fixed in `a68e4759a85e2dbdcfad1c811224818d66e5cf48` and their threads were replied to and resolved.
- Substantive review cycles: 1; first-pass findings were fixed, then the latest-head bot pass produced a second substantive finding set.
- Prevention note: the second-pass fix added regression proof for no-`READPAST` replay scan SQL, retained `READCOMMITTEDLOCK`, non-cancelable post-validation restore mutation, cleanup after partial cancellation, root-solution isolation, and a clean full-validation rerun before re-review.

## Residual Risks

- Durable audit-event infrastructure remains out of scope for #573 and is still owned by #583. This implementation returns explicit local support-audit evidence and logs rehydration/cleanup events, but does not add a durable audit table or event stream.
