### PR TITLE
GV-05: Reference visibility and reveal transition

### DIFF
--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -18,6 +18,7 @@ open Grace.Types.Reference
 open Grace.Types.Reminder
 open Grace.Types.RepositoryContentCounter
 open Grace.Types.Common
+open Grace.Types.Visibility
 open Microsoft.Extensions.Logging
 open NodaTime
 open Orleans
@@ -361,6 +362,24 @@ module Reference =
             && referenceDto.ReferenceText = referenceText
             && (referenceDto.Links |> Seq.toArray) = (links |> Seq.toArray)
         | _ -> false
+
+    /// Finds the durable reveal event for the supplied operation id so reveal retries do not depend on correlation ids.
+    let internal tryFindRevealEventByOperationId operationId (events: seq<ReferenceEvent>) =
+        events
+        |> Seq.tryPick (fun referenceEvent ->
+            match referenceEvent.Event with
+            | Revealed (eventOperationId, revealedBy, reason, fromVisibility, toVisibility) when eventOperationId = operationId ->
+                Some(referenceEvent.Metadata, revealedBy, reason, fromVisibility, toVisibility)
+            | _ -> None)
+
+    /// Checks whether an already-persisted reveal event represents the same semantic reveal command.
+    let internal revealEventMatchesCommand operationId reason revealedBy toVisibility (events: seq<ReferenceEvent>) =
+        match tryFindRevealEventByOperationId operationId events with
+        | Some (_, eventRevealedBy, eventReason, _, eventToVisibility) ->
+            String.Equals(eventReason, reason, StringComparison.Ordinal)
+            && String.Equals(eventRevealedBy, revealedBy, StringComparison.Ordinal)
+            && eventToVisibility = toVisibility
+        | None -> false
 
     /// Attempts to create manifest contribution start and returns no value when the required invariant is not met.
     let tryCreateManifestContributionStart plan intent =
@@ -804,7 +823,12 @@ module Reference =
                             if createCommandMatchesReference referenceDto command then
                                 return Ok command
                             else
-                                return Error(GraceError.Create (getErrorMessage ReferenceError.DuplicateCorrelationId) metadata.CorrelationId)
+                                match command with
+                                | Reveal (operationId, reason) when
+                                    revealEventMatchesCommand operationId reason metadata.Principal ResourceVisibility.Public state.State
+                                    ->
+                                    return Ok command
+                                | _ -> return Error(GraceError.Create (getErrorMessage ReferenceError.DuplicateCorrelationId) metadata.CorrelationId)
                         else
                             match command with
                             | Create (referenceId,
@@ -928,6 +952,11 @@ module Reference =
                             match! applyReferenceManifestBoundary referenceId repositoryId directoryId referenceType with
                             | Ok () -> return Ok(existingReferenceReturnValue ())
                             | Error graceError -> return Error graceError
+                        | Reveal (operationId, reason) when
+                            referenceDto.Visibility = ResourceVisibility.Public
+                            && revealEventMatchesCommand operationId reason metadata.Principal ResourceVisibility.Public state.State
+                            ->
+                            return Ok(existingReferenceReturnValue ())
                         | _ ->
                             let! (referenceEventTypeResult: Result<ReferenceEventType, GraceError>) =
                                 task {
@@ -1026,6 +1055,27 @@ module Reference =
                                             this.DeactivateOnIdle()
                                             return Ok PhysicalDeleted
                                         | Error graceError -> return Error graceError
+                                    | Reveal (operationId, reason) ->
+                                        if String.IsNullOrWhiteSpace operationId then
+                                            return Error(GraceError.Create "Reference reveal operationId is required." metadata.CorrelationId)
+                                        elif referenceDto.DeletedAt.IsSome then
+                                            return Error(GraceError.Create "Deleted references cannot be revealed." metadata.CorrelationId)
+                                        elif referenceDto.Visibility = ResourceVisibility.Public then
+                                            if revealEventMatchesCommand operationId reason metadata.Principal ResourceVisibility.Public state.State then
+                                                return Error(GraceError.Create "Reference reveal operation was already applied." metadata.CorrelationId)
+                                            else
+                                                return Error(GraceError.Create "Reference is already public." metadata.CorrelationId)
+                                        else
+                                            match tryFindRevealEventByOperationId operationId state.State with
+                                            | Some _ ->
+                                                return
+                                                    Error(
+                                                        GraceError.Create
+                                                            "Reference reveal operationId was already used for a different reveal."
+                                                            metadata.CorrelationId
+                                                    )
+                                            | None ->
+                                                return Ok(Revealed(operationId, metadata.Principal, reason, referenceDto.Visibility, ResourceVisibility.Public))
                                     | Undelete -> return Ok Undeleted
                                 }
 

--- a/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
+++ b/src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs
@@ -414,6 +414,7 @@ type EndpointAuthorizationManifestTests() =
             "POST", "/branch/commit"
             "POST", "/branch/createExternal"
             "POST", "/branch/promote"
+            "POST", "/branch/revealReference"
             "POST", "/branch/save"
             "POST", "/branch/tag"
         ]

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -5,6 +5,7 @@ open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.Reference
+open Grace.Types.Visibility
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -453,3 +454,46 @@ type ReferenceActorHashValidationTests() =
         assertBoundaryForcesRegeneration
             "let applyReferenceManifestExpiryBoundary referenceId repositoryId directoryId referenceType ="
             "let existingReferenceReturnValue () ="
+
+    /// Verifies that reference reveal idempotency uses durable operation id instead of correlation id.
+    [<Test>]
+    member _.RevealIdempotencyUsesOperationId() =
+        let metadata =
+            {
+                Timestamp = getCurrentInstant ()
+                CorrelationId = "reveal-correlation-1"
+                Principal = "reviewer@example.test"
+                ClientType = None
+                Properties = Dictionary<string, string>()
+            }
+
+        let revealEvent =
+            {
+                Event =
+                    ReferenceEventType.Revealed(
+                        "reveal-operation-1",
+                        "reviewer@example.test",
+                        "accepted work",
+                        ResourceVisibility.Private,
+                        ResourceVisibility.Public
+                    )
+                Metadata = metadata
+            }
+
+        let events = [ revealEvent ]
+
+        Assert.That(revealEventMatchesCommand "reveal-operation-1" "accepted work" "reviewer@example.test" ResourceVisibility.Public events, Is.True)
+
+        Assert.That(revealEventMatchesCommand "reveal-operation-1" "different reason" "reviewer@example.test" ResourceVisibility.Public events, Is.False)
+
+        Assert.That(
+            tryFindRevealEventByOperationId "reveal-operation-1" events
+            |> Option.isSome,
+            Is.True
+        )
+
+        Assert.That(
+            tryFindRevealEventByOperationId "other-operation" events
+            |> Option.isNone,
+            Is.True
+        )

--- a/src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/VisibilityAuthorization.Unit.Tests.fs
@@ -56,14 +56,15 @@ type VisibilityAuthorizationUnitTests() =
         Assert.That(canObserveBranch VisibilityCallerAudience.Anonymous noResourceAudience hiddenBranch, Is.False)
         Assert.That(canObserveBranch (caller (userId "other-user")) noResourceAudience hiddenBranch, Is.False)
 
-    /// Verifies that branch administration authority does not authorize non-branch hidden resources.
+    /// Verifies that branch administration authority is limited to branch-owned reference read surfaces.
     [<Test>]
-    member _.``canObserveReference and canObservePromotionSet ignore branch administration authority``() =
+    member _.``canObserveBranchReference allows branch administration while generic helpers ignore it``() =
         let hiddenResource = resource "reference-1" ResourceVisibility.Private ResourceOwnership.ContributorOwned (Some(userId "creator"))
         let branchAdminAudience _ = { VisibilityResourceAudience.None with HasBranchAdministration = true }
 
         let branchAdminCaller = caller (userId "branch-admin")
 
+        Assert.That(canObserveBranchReference branchAdminCaller branchAdminAudience hiddenResource, Is.True)
         Assert.That(canObserveReference branchAdminCaller branchAdminAudience hiddenResource, Is.False)
         Assert.That(canObservePromotionSet branchAdminCaller branchAdminAudience hiddenResource, Is.False)
 

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -207,9 +207,87 @@ module Branch =
             return VisibilityAuthorization.canObserveBranch caller (fun _ -> branchAudience) resource
         }
 
-    /// Checks inherited branch visibility for reference projections that have no independent visibility contract yet.
-    let private canObserveReferenceInBranch (context: HttpContext) (branchDto: BranchDto) (_referenceDto: Reference.ReferenceDto) =
-        canObserveBranch context branchDto
+    /// Projects reference durable visibility facts into the shared visibility helper resource shape.
+    let private referenceVisibilityResource (referenceDto: Reference.ReferenceDto) =
+        {
+            AuthorityKey = referenceDto.ReferenceId
+            Visibility = referenceDto.Visibility
+            Ownership = referenceDto.Ownership
+            CreatorUserId = referenceDto.CreatorUserId
+        }
+
+    /// Checks branch and reference visibility before a reference can reach public read, list, hash, or traversal surfaces.
+    let private canObserveReferenceInBranch (context: HttpContext) (branchDto: BranchDto) (referenceDto: Reference.ReferenceDto) =
+        task {
+            let! branchObservable = canObserveBranch context branchDto
+
+            if not branchObservable then
+                return false
+            else
+                let! caller = getVisibilityCallerAudience context branchDto
+                let resource = referenceVisibilityResource referenceDto
+                return VisibilityAuthorization.canObserveReference caller (fun _ -> VisibilityResourceAudience.None) resource
+        }
+
+    /// Validates that a reveal will not disclose hidden reference or promotion-review links.
+    let private validateRevealLinks repositoryId selectedReferenceId (referenceDto: Reference.ReferenceDto) correlationId =
+        task {
+            let linkArray = referenceDto.Links |> Seq.toArray
+            let mutable index = 0
+            let mutable error: GraceError option = None
+
+            while index < linkArray.Length && error.IsNone do
+                match linkArray[index] with
+                | ReferenceLinkType.BasedOn basedOnReferenceId when basedOnReferenceId <> selectedReferenceId ->
+                    let basedOnActorProxy = Reference.CreateActorProxy basedOnReferenceId repositoryId correlationId
+                    let! basedOnReference = basedOnActorProxy.Get correlationId
+
+                    if basedOnReference.ReferenceId = ReferenceId.Empty then
+                        error <-
+                            Some(
+                                (GraceError.Create "Reference reveal cannot follow a missing BasedOn reference." correlationId)
+                                    .enhance(nameof ReferenceId, selectedReferenceId)
+                                    .enhance ("BasedOnReferenceId", basedOnReferenceId)
+                            )
+                    elif basedOnReference.Visibility
+                         <> ResourceVisibility.Public then
+                        error <-
+                            Some(
+                                (GraceError.Create "Reference reveal cannot disclose a private BasedOn reference." correlationId)
+                                    .enhance(nameof ReferenceId, selectedReferenceId)
+                                    .enhance ("BasedOnReferenceId", basedOnReferenceId)
+                            )
+                | ReferenceLinkType.IncludedInPromotionSet promotionSetId
+                | ReferenceLinkType.PromotionSetTerminal promotionSetId ->
+                    error <-
+                        Some(
+                            (GraceError.Create "Reference reveal cannot disclose promotion review metadata in this slice." correlationId)
+                                .enhance(nameof ReferenceId, selectedReferenceId)
+                                .enhance (nameof PromotionSetId, promotionSetId)
+                        )
+                | _ -> ()
+
+                index <- index + 1
+
+            match error with
+            | Some error -> return Error error
+            | None -> return Ok()
+        }
+
+    /// Revalidates root graph completeness immediately before the durable reveal event is persisted.
+    let private validateRevealGraph repositoryId (referenceDto: Reference.ReferenceDto) correlationId =
+        task {
+            let directoryActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
+            let! directoryVersionDtos = directoryActorProxy.GetRecursiveDirectoryVersions true correlationId
+
+            return
+                Reference.validateRecursiveDirectoryVersionsComplete
+                    referenceDto.DirectoryId
+                    (directoryVersionDtos
+                     |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion))
+                    correlationId
+                |> Result.map (fun _ -> ())
+        }
 
     /// Creates the hidden-as-missing response used when a private contributor branch exists but is not observable.
     let internal hiddenBranchError context branchId =
@@ -2291,6 +2369,113 @@ module Branch =
                     return!
                         context
                         |> result500ServerError (GraceError.CreateWithException ex String.Empty (getCorrelationId context))
+            }
+
+    /// Reveals one private reference after revalidating graph completeness and hidden-link safety.
+    let RevealReference: HttpHandler =
+        fun (next: HttpFunc) (context: HttpContext) ->
+            task {
+                let startTime = getCurrentInstant ()
+                let graceIds = getGraceIds context
+                let repositoryId = graceIds.RepositoryId
+                let correlationId = getCorrelationId context
+
+                try
+                    let! parameters = context |> parse<RevealReferenceParameters>
+                    let parameterDictionary = getParametersAsDictionary parameters
+
+                    let badRequest message =
+                        (GraceError.Create message correlationId)
+                            .enhance(parameterDictionary)
+                            .enhance(nameof OwnerId, graceIds.OwnerId)
+                            .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                            .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                            .enhance(nameof BranchId, graceIds.BranchId)
+                            .enhance ("Path", context.Request.Path.Value)
+
+                    if parameters.ReferenceId = ReferenceId.Empty then
+                        return!
+                            context
+                            |> result400BadRequest (badRequest (ReferenceError.getErrorMessage ReferenceError.InvalidReferenceId))
+                    elif String.IsNullOrWhiteSpace parameters.OperationId then
+                        return!
+                            context
+                            |> result400BadRequest (badRequest "Reference reveal operationId is required.")
+                    else
+                        let referenceActorProxy = Reference.CreateActorProxy parameters.ReferenceId repositoryId correlationId
+                        let! referenceDto = referenceActorProxy.Get correlationId
+
+                        if referenceDto.ReferenceId = ReferenceId.Empty then
+                            return!
+                                context
+                                |> result400BadRequest (badRequest (ReferenceError.getErrorMessage ReferenceError.ReferenceIdDoesNotExist))
+                        elif referenceDto.RepositoryId <> repositoryId
+                             || referenceDto.BranchId <> graceIds.BranchId then
+                            return!
+                                context
+                                |> result400BadRequest (badRequest (ReferenceError.getErrorMessage ReferenceError.ReferenceIdDoesNotExist))
+                        else
+                            let revealPrincipal =
+                                PrincipalMapper.tryGetUserId context.User
+                                |> Option.defaultValue String.Empty
+
+                            let metadata = EventMetadata.New correlationId revealPrincipal
+                            metadata.Properties[ nameof RepositoryId ] <- $"{repositoryId}"
+                            metadata.Properties[ nameof BranchId ] <- $"{graceIds.BranchId}"
+                            metadata.Properties[ nameof ReferenceId ] <- $"{parameters.ReferenceId}"
+                            metadata.Properties[ "ReferenceRevealOperationId" ] <- parameters.OperationId
+
+                            /// Runs the durable actor transition after route-local reveal preconditions have passed or replay is detected.
+                            let executeReveal () =
+                                task {
+                                    match!
+                                        referenceActorProxy.Handle
+                                            (Grace.Types.Reference.ReferenceCommand.Reveal(parameters.OperationId, parameters.Reason))
+                                            metadata
+                                        with
+                                    | Ok revealReturnValue ->
+                                        let graceReturnValue =
+                                            (GraceReturnValue.Create revealReturnValue.ReturnValue correlationId)
+                                                .enhance(parameterDictionary)
+                                                .enhance(nameof OwnerId, graceIds.OwnerId)
+                                                .enhance(nameof OrganizationId, graceIds.OrganizationId)
+                                                .enhance(nameof RepositoryId, graceIds.RepositoryId)
+                                                .enhance(nameof BranchId, graceIds.BranchId)
+                                                .enhance(nameof ReferenceId, parameters.ReferenceId)
+                                                .enhance ("Path", context.Request.Path.Value)
+
+                                        return! context |> result200Ok graceReturnValue
+                                    | Error error -> return! context |> result400BadRequest error
+                                }
+
+                            if referenceDto.Visibility = ResourceVisibility.Public
+                               && referenceDto.LastRevealOperationId = Some parameters.OperationId then
+                                return! executeReveal ()
+                            else
+                                match! validateRevealGraph repositoryId referenceDto correlationId with
+                                | Error error -> return! context |> result400BadRequest error
+                                | Ok () ->
+                                    match! validateRevealLinks repositoryId parameters.ReferenceId referenceDto correlationId with
+                                    | Error error -> return! context |> result400BadRequest error
+                                    | Ok () -> return! executeReveal ()
+                with
+                | ex ->
+                    let duration_ms = getDurationRightAligned_ms startTime
+
+                    log.LogError(
+                        ex,
+                        "{CurrentInstant}: Node: {HostName}; Duration: {duration_ms}ms; CorrelationId: {correlationId}; Error in {path}; BranchId: {branchId}.",
+                        getCurrentInstantExtended (),
+                        getMachineName,
+                        duration_ms,
+                        correlationId,
+                        context.Request.Path,
+                        graceIds.BranchIdString
+                    )
+
+                    return!
+                        context
+                        |> result500ServerError (GraceError.CreateWithException ex String.Empty correlationId)
             }
 
     /// Annotates a server-known file from an existing reference in a branch.

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -219,14 +219,17 @@ module Branch =
     /// Checks branch and reference visibility before a reference can reach public read, list, hash, or traversal surfaces.
     let private canObserveReferenceInBranch (context: HttpContext) (branchDto: BranchDto) (referenceDto: Reference.ReferenceDto) =
         task {
-            let! branchObservable = canObserveBranch context branchDto
+            let! caller = getVisibilityCallerAudience context branchDto
+            let! branchAudience = getBranchResourceAudience context branchDto
+            let branchResource = branchVisibilityResource branchDto
+
+            let branchObservable = VisibilityAuthorization.canObserveBranch caller (fun _ -> branchAudience) branchResource
 
             if not branchObservable then
                 return false
             else
-                let! caller = getVisibilityCallerAudience context branchDto
                 let resource = referenceVisibilityResource referenceDto
-                return VisibilityAuthorization.canObserveReference caller (fun _ -> VisibilityResourceAudience.None) resource
+                return VisibilityAuthorization.canObserveBranchReference caller (fun _ -> branchAudience) resource
         }
 
     /// Validates that a reveal will not disclose hidden reference or promotion-review links.

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -274,6 +274,11 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/repository/setStatus" Authenticated
             endpoint "POST" "/repository/setVisibility" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/repository/undelete" Authenticated
+            endpoint
+                "POST"
+                "/branch/revealReference"
+                (AnyOf [ Authorized(BranchAdmin, Branch)
+                         Authorized(BranchWrite, Branch) ])
             endpoint "POST" "/review/checkpoint" Authenticated
             endpoint "POST" "/review/candidate/attestations" Authenticated
             endpoint "POST" "/review/candidate/cancel" Authenticated

--- a/src/Grace.Server/Security/VisibilityAuthorization.Server.fs
+++ b/src/Grace.Server/Security/VisibilityAuthorization.Server.fs
@@ -105,6 +105,13 @@ module VisibilityAuthorization =
         | _, ResourceOwnership.RepositoryOwned -> true
         | _, ResourceOwnership.ContributorOwned -> hasContributorAudience false caller resolveResourceAudience reference
 
+    /// Determines whether branch-scoped read surfaces may expose a reference owned by an observable branch.
+    let canObserveBranchReference (caller: VisibilityCallerAudience) resolveResourceAudience reference =
+        match reference.Visibility, reference.Ownership with
+        | ResourceVisibility.Public, _ -> true
+        | _, ResourceOwnership.RepositoryOwned -> true
+        | _, ResourceOwnership.ContributorOwned -> hasContributorAudience true caller resolveResourceAudience reference
+
     /// Determines whether a caller may observe a promotion set after the route has loaded its authoritative visibility facts.
     let canObservePromotionSet (caller: VisibilityCallerAudience) resolveResourceAudience promotionSet =
         match promotionSet.Visibility, promotionSet.Ownership with

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1289,6 +1289,9 @@ module Application =
                                route "/rebase" Branch.Rebase
                                |> addMetadata typeof<Branch.RebaseParameters>
 
+                               route "/revealReference" (composeHandlers requireBranchWriteOrAdmin Branch.RevealReference)
+                               |> addMetadata typeof<Branch.RevealReferenceParameters>
+
                                route "/save" (composeHandlers requireBranchWriteOrAdmin Branch.Save)
                                |> addMetadata typeof<Branch.CreateReferenceParameters>
 

--- a/src/Grace.Shared/Parameters/Branch.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Branch.Parameters.fs
@@ -96,6 +96,13 @@ module Branch =
     type GetReferenceParameters() =
         inherit BranchQueryParameters()
 
+    /// Parameters for the /branch/revealReference endpoint.
+    type RevealReferenceParameters() =
+        inherit BranchParameters()
+        member val public ReferenceId: ReferenceId = ReferenceId.Empty with get, set
+        member val public OperationId = String.Empty with get, set
+        member val public Reason = String.Empty with get, set
+
     /// Parameters for the /branch/getReferences and /branch/get[reference] endpoints.
     type GetReferencesParameters() =
         inherit BranchParameters()

--- a/src/Grace.Types.Tests/Reference.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Reference.Types.Tests.fs
@@ -4,6 +4,7 @@ open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.Reference
+open Grace.Types.Visibility
 open NodaTime
 open NUnit.Framework
 open System
@@ -118,3 +119,39 @@ type ReferenceDtoTests() =
         Assert.That(deleted.CreatedBy, Is.EqualTo(Some "alice@example.test"))
         Assert.That(linked.UpdatedAt, Is.EqualTo(Some(timestamp + Duration.FromMinutes(1.0))))
         Assert.That(deleted.UpdatedAt, Is.EqualTo(Some(timestamp + Duration.FromMinutes(2.0))))
+
+    /// Verifies that created event inherits durable visibility metadata.
+    [<Test>]
+    member _.CreatedEventInheritsVisibilityMetadata() =
+        let referenceEvent = createdEvent "alice@example.test"
+        referenceEvent.Metadata.Properties[ "InheritedVisibility" ] <- "Public"
+        referenceEvent.Metadata.Properties[ "InheritedOwnership" ] <- "ContributorOwned"
+        referenceEvent.Metadata.Properties[ "InheritedCreatorUserId" ] <- "creator-user-1"
+
+        let updated = ReferenceDto.UpdateDto referenceEvent ReferenceDto.Default
+
+        Assert.That(updated.Visibility, Is.EqualTo(ResourceVisibility.Public))
+        Assert.That(updated.Ownership, Is.EqualTo(ResourceOwnership.ContributorOwned))
+        Assert.That(updated.CreatorUserId, Is.EqualTo(Some(UserId "creator-user-1")))
+
+    /// Verifies that reveal events persist public visibility and operation id replay evidence.
+    [<Test>]
+    member _.RevealEventPersistsPublicVisibilityAndOperationEvidence() =
+        let created = ReferenceDto.UpdateDto (createdEvent "alice@example.test") ReferenceDto.Default
+
+        let revealTimestamp = timestamp + Duration.FromMinutes(5.0)
+
+        let revealEvent =
+            {
+                Event =
+                    ReferenceEventType.Revealed("reveal-op-1", "reviewer@example.test", "accepted work", ResourceVisibility.Private, ResourceVisibility.Public)
+                Metadata = createMetadata "reviewer@example.test" revealTimestamp
+            }
+
+        let revealed = ReferenceDto.UpdateDto revealEvent created
+
+        Assert.That(revealed.Visibility, Is.EqualTo(ResourceVisibility.Public))
+        Assert.That(revealed.LastRevealOperationId, Is.EqualTo(Some "reveal-op-1"))
+        Assert.That(revealed.RevealedBy, Is.EqualTo(Some "reviewer@example.test"))
+        Assert.That(revealed.RevealedAt, Is.EqualTo(Some revealTimestamp))
+        Assert.That(revealed.RevealReason, Is.EqualTo(Some "accepted work"))

--- a/src/Grace.Types.Tests/Visibility.Types.Tests.fs
+++ b/src/Grace.Types.Tests/Visibility.Types.Tests.fs
@@ -26,13 +26,13 @@ type private BranchCreateVisibilityParameters() =
 [<Parallelizable(ParallelScope.All)>]
 type VisibilityContractTests() =
 
-    /// Verifies that branch DTOs now expose implemented visibility fields while later surfaces still defer them.
+    /// Verifies that branch and reference DTOs expose implemented visibility fields while promotion-set surfaces still defer them.
     [<Test>]
-    member _.CurrentDtosExposeOnlyImplementedBranchVisibilityAndOwnershipFields() =
+    member _.CurrentDtosExposeImplementedBranchAndReferenceVisibilityAndOwnershipFields() =
         Assert.That(typeof<Grace.Types.Branch.BranchDto>.GetProperty ("Visibility"), Is.Not.Null)
         Assert.That(typeof<Grace.Types.Branch.BranchDto>.GetProperty ("Ownership"), Is.Not.Null)
-        Assert.That(typeof<Grace.Types.Reference.ReferenceDto>.GetProperty ("Visibility"), Is.Null)
-        Assert.That(typeof<Grace.Types.Reference.ReferenceDto>.GetProperty ("Ownership"), Is.Null)
+        Assert.That(typeof<Grace.Types.Reference.ReferenceDto>.GetProperty ("Visibility"), Is.Not.Null)
+        Assert.That(typeof<Grace.Types.Reference.ReferenceDto>.GetProperty ("Ownership"), Is.Not.Null)
         Assert.That(typeof<Grace.Types.PromotionSet.PromotionSetDto>.GetProperty ("Visibility"), Is.Null)
         Assert.That(typeof<Grace.Types.PromotionSet.PromotionSetDto>.GetProperty ("Ownership"), Is.Null)
 

--- a/src/Grace.Types/Reference.Types.fs
+++ b/src/Grace.Types/Reference.Types.fs
@@ -3,6 +3,7 @@ namespace Grace.Types
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Common
+open Grace.Types.Visibility
 open NodaTime
 open Orleans
 open System
@@ -43,6 +44,7 @@ module Reference =
         | RemoveLink of link: ReferenceLinkType
         | DeleteLogical of force: bool * DeleteReason: DeleteReason
         | DeletePhysical
+        | Reveal of operationId: string * reason: string
         | Undelete
 
         /// Returns known nested union types for serializers.
@@ -67,6 +69,7 @@ module Reference =
         | LinkRemoved of link: ReferenceLinkType
         | LogicalDeleted of force: bool * DeleteReason: DeleteReason
         | PhysicalDeleted
+        | Revealed of operationId: string * revealedBy: string * reason: string * fromVisibility: ResourceVisibility * toVisibility: ResourceVisibility
         | Undeleted
 
         /// Returns known nested union types for serializers.
@@ -96,6 +99,13 @@ module Reference =
             ReferenceType: ReferenceType
             ReferenceText: ReferenceText
             Links: ReferenceLinkType seq
+            Visibility: ResourceVisibility
+            Ownership: ResourceOwnership
+            CreatorUserId: UserId option
+            LastRevealOperationId: string option
+            RevealedBy: string option
+            RevealedAt: Instant option
+            RevealReason: string option
             CreatedBy: string option
             CreatedAt: Instant
             UpdatedAt: Instant option
@@ -118,6 +128,13 @@ module Reference =
                 ReferenceType = Save
                 ReferenceText = ReferenceText String.Empty
                 Links = Seq.empty
+                Visibility = ResourceVisibility.Private
+                Ownership = ResourceOwnership.RepositoryOwned
+                CreatorUserId = None
+                LastRevealOperationId = None
+                RevealedBy = None
+                RevealedAt = None
+                RevealReason = None
                 CreatedBy = None
                 CreatedAt = Constants.DefaultTimestamp
                 UpdatedAt = None
@@ -185,6 +202,22 @@ module Reference =
                         ReferenceType = referenceType
                         ReferenceText = referenceText
                         Links = links
+                        Visibility =
+                            match referenceEvent.Metadata.Properties.TryGetValue("InheritedVisibility") with
+                            | true, value ->
+                                ResourceVisibility.TryParsePublicInput value
+                                |> Option.defaultValue ResourceVisibility.Private
+                            | _ -> ResourceVisibility.Private
+                        Ownership =
+                            match referenceEvent.Metadata.Properties.TryGetValue("InheritedOwnership") with
+                            | true, value ->
+                                ResourceOwnership.TryParsePublicInput value
+                                |> Option.defaultValue ResourceOwnership.RepositoryOwned
+                            | _ -> ResourceOwnership.RepositoryOwned
+                        CreatorUserId =
+                            match referenceEvent.Metadata.Properties.TryGetValue("InheritedCreatorUserId") with
+                            | true, value when not (String.IsNullOrWhiteSpace value) -> Some(UserId value)
+                            | _ -> None
                         CreatedBy =
                             if String.IsNullOrWhiteSpace referenceEvent.Metadata.Principal then
                                 None
@@ -207,6 +240,14 @@ module Reference =
                     }
                 | LogicalDeleted (force, deleteReason) -> { currentReferenceDto with DeletedAt = Some(getCurrentInstant ()); DeleteReason = deleteReason }
                 | PhysicalDeleted -> currentReferenceDto // Do nothing because it's about to be deleted anyway.
+                | Revealed (operationId, revealedBy, reason, _, toVisibility) ->
+                    { currentReferenceDto with
+                        Visibility = toVisibility
+                        LastRevealOperationId = Some operationId
+                        RevealedBy = if String.IsNullOrWhiteSpace revealedBy then None else Some revealedBy
+                        RevealedAt = Some referenceEvent.Metadata.Timestamp
+                        RevealReason = if String.IsNullOrWhiteSpace reason then None else Some reason
+                    }
                 | Undeleted -> { currentReferenceDto with DeletedAt = None; DeleteReason = String.Empty }
 
             { newReferenceDto with UpdatedAt = Some referenceEvent.Metadata.Timestamp }

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -104,6 +104,7 @@
         { "method": "POST", "path": "/branch/getRecursiveSize" },
         { "method": "POST", "path": "/branch/getVersion" },
         { "method": "POST", "path": "/branch/listContents" },
+        { "method": "POST", "path": "/branch/revealReference" },
         { "method": "POST", "path": "/branch/setPromotionMode" },
         { "method": "POST", "path": "/branch/updateParentBranch" },
         { "method": "POST", "path": "/repository/setAllowsLargeFiles" },


### PR DESCRIPTION
# GV-05: Reference visibility and reveal transition

## Summary

- Adds persisted Reference visibility/ownership metadata plus durable reveal command/event state.
- Adds branch-scoped `/branch/revealReference` with stable operation-id idempotency, graph preflight, route authorization metadata, and route classification.
- Updates branch reference reads to require both branch observability and Reference observability, with focused DTO, actor, manifest, and route-classification tests.

## Related Issue

Related to #644.

## Why This Matters

Reference reveal is the public disclosure point for accepted-private work. This slice makes that transition durable and idempotent so private contributor work can become public by revealing a selected Reference without leaking private branch or promotion-review metadata first.

## Touched Paths

- `src/Grace.Actors/Reference.Actor.fs`
- `src/Grace.Authorization.Tests/EndpointAuthorizationManifest.Tests.fs`
- `src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs`
- `src/Grace.Server/Branch.Server.fs`
- `src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs`
- `src/Grace.Server/Startup.Server.fs`
- `src/Grace.Shared/Parameters/Branch.Parameters.fs`
- `src/Grace.Types.Tests/Reference.Types.Tests.fs`
- `src/Grace.Types.Tests/Visibility.Types.Tests.fs`
- `src/Grace.Types/Reference.Types.fs`
- `src/OpenAPI/RouteClassification.json`

## Validation

- `dotnet tool run fantomas -- <touched F# files>`: passed.
- `dotnet build --configuration Release C:\Source\Grace-gh-644\src\Grace.Types.Tests\Grace.Types.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release C:\Source\Grace-gh-644\src\Grace.Types.Tests\Grace.Types.Tests.fsproj --filter "FullyQualifiedName~ReferenceDtoTests|FullyQualifiedName~VisibilityContractTests"`: passed, 25 passed.
- `dotnet build --configuration Release C:\Source\Grace-gh-644\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release C:\Source\Grace-gh-644\src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~ReferenceActorHashValidationTests`: passed, 14 passed.
- `dotnet build --configuration Release C:\Source\Grace-gh-644\src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj`: passed.
- `dotnet test --no-build --configuration Release C:\Source\Grace-gh-644\src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --filter FullyQualifiedName~EndpointAuthorizationManifestTests`: passed, 17 passed.
- `dotnet test --no-build --configuration Release C:\Source\Grace-gh-644\src\Grace.Authorization.Tests\Grace.Authorization.Tests.fsproj --filter FullyQualifiedName~OpenApiRouteCoverageTests`: passed, 8 passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.
- `git diff --check`: passed.

## Review Status

- Current head: `f5ae43da0a8584e57926c949c8f32e571f157e1f`.
- Codex Code Review Bot state for current head: latest-head no-issues signal recorded with thumbs up on PR #672.
- GitHub Actions: `full` succeeded for current head in run `28907407529`, job `85757344322`.
- Merge state: clean against `epic/638-visibility-owned-branches`.
- Previous `full` run `28906289367` failed on two `Grace.Server.Tests` BranchAdmin visibility regressions; fixed in `f5ae43da`.
- Validation-fix evidence: Hooke reproduced the two CI failures, added branch-scoped reference observability via `canObserveBranchReference`, and preserved generic reference/promotion fail-closed behavior.
- Fix validation:
  - `dotnet test --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~VisibilityAuthorizationUnitTests"`: passed, 9/9.
  - `dotnet test --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter "FullyQualifiedName~HashOwnedPrivateBranchContentIsHiddenFromRepositoryReaderAndVisibleToBranchAdmin|FullyQualifiedName~PrivateContributorBranchReferencesAreHiddenFromObserverAndVisibleToBranchAdmin"` with `GRACE_TEST_CLEANUP=1`: passed, 2/2.
  - `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - `git diff --check`: passed.
- Prior-head Codex review comments from `237d2b95efb6d72bee76b3be330da5bb1f352e1c` were not repeated on the latest reviewed head and were resolved as stale/non-current-head review history in a PR comment.
- Manual trigger decision: not attempted.
- Manual trigger lock: no manual trigger may be used while bot state is pending, acknowledged with eyes, completed with no-issues, or ambiguous. Use `pwsh ./scripts/guard-codex-review-trigger.ps1 -PullRequest 672` only if the documented missed-ack exception is reached.
- Substantive review cycle count: 0.
- Final review-thread state: zero unresolved review threads.
- Final no-issues state: satisfied for current head.

## First-Pass Review Readiness

- Worker bot-prevention self-review completed over durable idempotency, correlation-id separation, visibility filtering, route authorization metadata, hidden-link handling, graph preflight ordering, DTO/event replay, deferred OpenAPI/CLI/SDK scope, and validation freshness.
- Worker fixed route replay preflight before handoff so duplicate successful reveal operations bypass graph/link validation and return through actor idempotency instead of depending on later mutable link state.
- Worker fixed the prior visibility contract test to include Reference DTO visibility.

## Contract And Scope Notes

- Reference DTO/command/event/persisted replay: updated with `Visibility`, `Ownership`, creator/reveal metadata, `Reveal`, and `Revealed`.
- Reveal route: added `/branch/revealReference` with BranchWrite/BranchAdmin route authorization, operation-id idempotency, graph completeness preflight, and hidden-link/promotion-link rejection.
- Events/webhooks: only the durable Reference event seam was added; no webhook/projection dispatch behavior beyond existing `ReferenceEvent` publication was implemented.
- CLI/SDK/OpenAPI: deferred to #651. `/branch/revealReference` is classified in `src/OpenAPI/RouteClassification.json` as implemented but excluded from current OpenAPI expansion.
- Accounting transfer: deferred to #652/#653; no accounting side effects were added.

## Docs Impact

No user-facing docs changed in this slice. Public CLI, SDK, generated OpenAPI, and docs propagation remain owned by #651 and #654.

## Residual Risk

No Full/Aspire integration gate was run because this slice did not touch Aspire/runtime/webhook/service delivery. The reveal route itself is covered by compile, authorization manifest, route classification, actor/DTO focused tests, and Fast validation; it does not yet have a full HTTP integration happy-path test.
