### PR TITLE
GV-07: DirectoryVersion reachability gating

### DIFF
--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -119,6 +119,91 @@ module DirectoryVersionServerTestHelpers =
 
         parameters
 
+    /// Builds get by directory ids parameters for route calls.
+    let getByDirectoryIdsParameters (repositoryId: string) (directoryVersionIds: DirectoryVersionId seq) =
+        let parameters = Parameters.DirectoryVersion.GetByDirectoryIdsParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.CorrelationId <- generateCorrelationId ()
+
+        for directoryVersionId in directoryVersionIds do
+            parameters.DirectoryIds.Add(directoryVersionId)
+
+        parameters
+
+    /// Builds get zip file parameters for route calls.
+    let getZipFileParameters (repositoryId: string) (directoryVersionId: DirectoryVersionId) =
+        let parameters = Parameters.DirectoryVersion.GetZipFileParameters()
+        parameters.OwnerId <- ownerId
+        parameters.OrganizationId <- organizationId
+        parameters.RepositoryId <- repositoryId
+        parameters.DirectoryVersionId <- $"{directoryVersionId}"
+        parameters.CorrelationId <- generateCorrelationId ()
+        parameters
+
+    /// Creates an isolated public repository and returns an observable branch that can publish saves.
+    let createPublicRepositoryBranchAsync repositoryNamePrefix =
+        task {
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync repositoryNamePrefix
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            let! branches = BranchServerTestHelpers.getRepositoryBranchesAsync repositoryId
+            let parentBranch = branches |> Array.exactlyOne
+
+            let! branchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    Client
+                    repositoryId
+                    parentBranch
+                    $"{repositoryNamePrefix}{Guid.NewGuid():N}"
+                    "Public"
+                    "RepositoryOwned"
+
+            let! branchResponse = BranchServerTestHelpers.getBranchResponseAsync Client repositoryId branchId
+            do! BranchServerTestHelpers.assertOk branchResponse
+            let! branchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> branchResponse
+            return repositoryId, branchReturnValue.ReturnValue
+        }
+
+    /// Saves directory versions and publishes the supplied root through an observable reference.
+    let saveDirectoryVersionsAndReferenceAsync
+        (repositoryId: string)
+        (branch: Branch.BranchDto)
+        (root: DirectoryVersionModel)
+        (directoryVersions: DirectoryVersionModel seq)
+        =
+        task {
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId directoryVersions
+
+            let! referenceResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch root.DirectoryVersionId root.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk referenceResponse
+        }
+
+    /// Posts a directory get route through the supplied authenticated client.
+    let getDirectoryVersionResponseAsync (client: HttpClient) repositoryId directoryVersionId =
+        client.PostAsync("/directory/get", createJsonContent (getParameters repositoryId directoryVersionId))
+
+    /// Posts a recursive directory get route through the supplied authenticated client.
+    let getDirectoryVersionsRecursiveResponseAsync (client: HttpClient) repositoryId directoryVersionId =
+        client.PostAsync("/directory/getDirectoryVersionsRecursive", createJsonContent (getParameters repositoryId directoryVersionId))
+
+    /// Posts a SHA-256 directory hash lookup through the supplied authenticated client.
+    let getBySha256HashResponseAsync (client: HttpClient) repositoryId directoryVersionId sha256Hash =
+        client.PostAsync("/directory/getBySha256Hash", createJsonContent (getBySha256HashParameters repositoryId directoryVersionId sha256Hash))
+
+    /// Posts a BLAKE3 directory hash lookup through the supplied authenticated client.
+    let getByBlake3HashResponseAsync (client: HttpClient) repositoryId blake3Hash =
+        client.PostAsync("/directory/getByBlake3Hash", createJsonContent (getByBlake3HashParameters repositoryId blake3Hash))
+
+    /// Posts a batch directory id lookup through the supplied authenticated client.
+    let getByDirectoryIdsResponseAsync (client: HttpClient) repositoryId directoryVersionIds =
+        client.PostAsync("/directory/getByDirectoryIds", createJsonContent (getByDirectoryIdsParameters repositoryId directoryVersionIds))
+
+    /// Posts a directory zip route through the supplied authenticated client.
+    let getZipFileResponseAsync (client: HttpClient) repositoryId directoryVersionId =
+        client.PostAsync("/directory/getZipFile", createJsonContent (getZipFileParameters repositoryId directoryVersionId))
+
     /// Builds a deterministic same SHA256 prefix directory pair for integration setup fixture for the server integration directory Version assertions.
     let createSameSha256PrefixDirectoryPair repositoryId pathPrefix =
         let candidates =
@@ -202,7 +287,7 @@ type DirectoryVersionServer() =
     [<Test>]
     member _.CreateGetGetByShaAndRecursiveRoutesPreserveDirectoryDtoShapeAndIdentity() =
         task {
-            let repositoryId = repositoryIds[0]
+            let! repositoryId, branch = DirectoryVersionServerTestHelpers.createPublicRepositoryBranchAsync "DirectoryPositiveReads"
             let childId = Guid.NewGuid()
             let rootId = Guid.NewGuid()
 
@@ -210,8 +295,7 @@ type DirectoryVersionServer() =
 
             let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" [ child ]
 
-            do! DirectoryVersionServerTestHelpers.createDirectoryVersionAsync child
-            do! DirectoryVersionServerTestHelpers.createDirectoryVersionAsync root
+            do! DirectoryVersionServerTestHelpers.saveDirectoryVersionsAndReferenceAsync repositoryId branch root [ child; root ]
 
             let! fetched = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
             DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetched
@@ -298,19 +382,14 @@ type DirectoryVersionServer() =
     [<Test>]
     member _.GetByShaRejectsAmbiguousPrefixInsteadOfReturningDefaultSentinel() =
         task {
-            let repositoryId = repositoryIds[0]
+            let! repositoryId, branch = DirectoryVersionServerTestHelpers.createPublicRepositoryBranchAsync "DirectoryAmbiguousSha"
 
             /// Defines first behavior for the surrounding tests used by the server integration directory Version scenario.
             let first, second, sharedPrefix =
                 DirectoryVersionServerTestHelpers.createSameSha256PrefixDirectoryPair repositoryId $"ambiguous-directory-sha/{Guid.NewGuid():N}"
 
-            let! saveResponse =
-                Client.PostAsync(
-                    "/directory/saveDirectoryVersions",
-                    createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ first; second ])
-                )
-
-            do! DirectoryVersionServerTestHelpers.assertOk saveResponse
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId "/" [ first; second ]
+            do! DirectoryVersionServerTestHelpers.saveDirectoryVersionsAndReferenceAsync repositoryId branch root [ first; second; root ]
 
             let getByShaParameters = DirectoryVersionServerTestHelpers.getBySha256HashParameters repositoryId first.DirectoryVersionId (Sha256Hash sharedPrefix)
 
@@ -325,7 +404,7 @@ type DirectoryVersionServer() =
     [<Test>]
     member _.SaveDirectoryVersionsCreatesMissingDirectoriesAndKeepsMissingGetAsGraceError() =
         task {
-            let repositoryId = repositoryIds[1]
+            let! repositoryId, branch = DirectoryVersionServerTestHelpers.createPublicRepositoryBranchAsync "DirectorySaveGet"
             let childId = Guid.NewGuid()
             let rootId = Guid.NewGuid()
 
@@ -333,15 +412,7 @@ type DirectoryVersionServer() =
 
             let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "/" [ child ]
 
-            let! saveResponse =
-                Client.PostAsync(
-                    "/directory/saveDirectoryVersions",
-                    createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ child; root ])
-                )
-
-            do! DirectoryVersionServerTestHelpers.assertOk saveResponse
-            let! saveReturnValue = deserializeContent<GraceReturnValue<string>> saveResponse
-            Assert.That(saveReturnValue.ReturnValue, Is.EqualTo("Uploaded new directory versions."))
+            do! DirectoryVersionServerTestHelpers.saveDirectoryVersionsAndReferenceAsync repositoryId branch root [ child; root ]
 
             let! fetchedRoot = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
             DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetchedRoot
@@ -366,23 +437,29 @@ type DirectoryVersionServer() =
     [<Test>]
     member _.SaveDirectoryVersionsOrdersDotRootAfterDirectChildrenWhenInputIsRootFirst() =
         task {
-            let repositoryId = repositoryIds[2]
+            let! repositoryId, branch = DirectoryVersionServerTestHelpers.createPublicRepositoryBranchAsync "DirectorySaveOrder"
             let childId = Guid.NewGuid()
             let rootId = Guid.NewGuid()
 
             let child = DirectoryVersionServerTestHelpers.createDirectoryVersion childId repositoryId "src" []
 
             let root = DirectoryVersionServerTestHelpers.createDirectoryVersion rootId repositoryId "." [ child ]
+            let referenceRoot = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId "/" [ root ]
 
             let! saveResponse =
                 Client.PostAsync(
                     "/directory/saveDirectoryVersions",
-                    createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ root; child ])
+                    createJsonContent (DirectoryVersionServerTestHelpers.saveParameters repositoryId [ root; child; referenceRoot ])
                 )
 
             do! DirectoryVersionServerTestHelpers.assertOk saveResponse
             let! saveReturnValue = deserializeContent<GraceReturnValue<string>> saveResponse
             Assert.That(saveReturnValue.ReturnValue, Is.EqualTo("Uploaded new directory versions."))
+
+            let! referenceResponse =
+                BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch referenceRoot.DirectoryVersionId referenceRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk referenceResponse
 
             let! fetchedRoot = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId rootId
             DirectoryVersionServerTestHelpers.assertDirectoryVersionDto root fetchedRoot
@@ -391,4 +468,200 @@ type DirectoryVersionServer() =
 
             let! fetchedChild = DirectoryVersionServerTestHelpers.getDirectoryVersionAsync repositoryId childId
             DirectoryVersionServerTestHelpers.assertDirectoryVersionDto child fetchedChild
+        }
+
+    /// Verifies hidden directory ids are treated as absent for direct, batch, recursive, and zip directory routes.
+    [<Test>]
+    member _.HiddenDirectoryVersionIdReadsBehaveAsAbsentForRepositoryReader() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "DirectoryHiddenIdReads"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+
+            let! privateBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"DirectoryHiddenId{Guid.NewGuid():N}"
+                    "Private"
+                    "ContributorOwned"
+
+            let! privateBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk privateBranchResponse
+            let! privateBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> privateBranchResponse
+            let privateBranch = privateBranchReturnValue.ReturnValue
+
+            let hiddenChild = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId $"/hidden/{Guid.NewGuid():N}/" []
+
+            let hiddenRoot = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId "/" [ hiddenChild ]
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ hiddenChild; hiddenRoot ]
+
+            let! hiddenReference =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    privateBranch
+                    hiddenRoot.DirectoryVersionId
+                    hiddenRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk hiddenReference
+
+            let expectedMissing = DirectoryVersionError.getErrorMessage DirectoryVersionError.DirectoryDoesNotExist
+
+            let! getResponse = DirectoryVersionServerTestHelpers.getDirectoryVersionResponseAsync observerClient repositoryId hiddenRoot.DirectoryVersionId
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing getResponse
+
+            let! recursiveResponse =
+                DirectoryVersionServerTestHelpers.getDirectoryVersionsRecursiveResponseAsync observerClient repositoryId hiddenRoot.DirectoryVersionId
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing recursiveResponse
+
+            let! batchResponse = DirectoryVersionServerTestHelpers.getByDirectoryIdsResponseAsync observerClient repositoryId [ hiddenRoot.DirectoryVersionId ]
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing batchResponse
+
+            let! zipResponse = DirectoryVersionServerTestHelpers.getZipFileResponseAsync observerClient repositoryId hiddenRoot.DirectoryVersionId
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing zipResponse
+        }
+
+    /// Verifies hidden directory hashes are no-match-equivalent and hidden same-prefix roots do not create ambiguity.
+    [<Test>]
+    member _.DirectoryHashResolutionUsesVisibleCandidateSubsetOnly() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "DirectoryVisibleHashSubset"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+
+            let! visibleBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"DirectoryVisibleHash{Guid.NewGuid():N}"
+                    "Public"
+                    "RepositoryOwned"
+
+            let! hiddenBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"DirectoryHiddenHash{Guid.NewGuid():N}"
+                    "Private"
+                    "ContributorOwned"
+
+            let! visibleBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId visibleBranchId
+            do! BranchServerTestHelpers.assertOk visibleBranchResponse
+            let! visibleBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> visibleBranchResponse
+            let visibleBranch = visibleBranchReturnValue.ReturnValue
+
+            let! hiddenBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId hiddenBranchId
+            do! BranchServerTestHelpers.assertOk hiddenBranchResponse
+            let! hiddenBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> hiddenBranchResponse
+            let hiddenBranch = hiddenBranchReturnValue.ReturnValue
+
+            let visibleRoot, hiddenRoot, sharedShaPrefix =
+                DirectoryVersionServerTestHelpers.createSameSha256PrefixDirectoryPair repositoryId $"visible-hidden-sha/{Guid.NewGuid():N}"
+
+            let visibleReferenceRoot = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId "/" [ visibleRoot ]
+
+            let hiddenReferenceRoot = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId "/" [ hiddenRoot ]
+
+            let _visibleBlakeChild, _visibleBlakeRoot, hiddenBlakeChild, hiddenBlakeRoot, _hiddenBlakePrefix =
+                BranchServerTestHelpers.createSameBlake3PrefixRootPair repositoryId $"hidden-blake-only/{Guid.NewGuid():N}"
+
+            do!
+                BranchServerTestHelpers.saveDirectoryVersionsAsync
+                    repositoryId
+                    [
+                        visibleRoot
+                        hiddenRoot
+                        visibleReferenceRoot
+                        hiddenReferenceRoot
+                        hiddenBlakeChild
+                        hiddenBlakeRoot
+                    ]
+
+            let! visibleReference =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    visibleBranch
+                    visibleReferenceRoot.DirectoryVersionId
+                    visibleReferenceRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk visibleReference
+
+            let! hiddenReference =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    hiddenBranch
+                    hiddenReferenceRoot.DirectoryVersionId
+                    hiddenReferenceRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk hiddenReference
+
+            let! hiddenBlakeReference =
+                BranchServerTestHelpers.saveReferenceWithClientResponseAsync
+                    creatorClient
+                    repositoryId
+                    hiddenBranch
+                    hiddenBlakeRoot.DirectoryVersionId
+                    hiddenBlakeRoot.Sha256Hash
+
+            do! BranchServerTestHelpers.assertOk hiddenBlakeReference
+
+            let! hiddenOnlyShaResponse =
+                DirectoryVersionServerTestHelpers.getBySha256HashResponseAsync observerClient repositoryId hiddenRoot.DirectoryVersionId hiddenRoot.Sha256Hash
+
+            do! DirectoryVersionServerTestHelpers.assertOk hiddenOnlyShaResponse
+            let! hiddenOnlySha = deserializeContent<GraceReturnValue<DirectoryVersionServerTestHelpers.DirectoryVersionModel>> hiddenOnlyShaResponse
+            Assert.That(hiddenOnlySha.ReturnValue.DirectoryVersionId, Is.EqualTo(DirectoryVersion.Default.DirectoryVersionId))
+
+            let hiddenBlakeLookup = $"{hiddenBlakeRoot.Blake3Hash}"
+
+            let! hiddenOnlyBlakeResponse =
+                DirectoryVersionServerTestHelpers.getByBlake3HashResponseAsync observerClient repositoryId (Blake3Hash hiddenBlakeLookup)
+
+            do!
+                DirectoryVersionServerTestHelpers.assertBadRequestGraceError
+                    $"No DirectoryVersion matched the supplied BLAKE3 hash prefix '{hiddenBlakeLookup}' in repository scope."
+                    hiddenOnlyBlakeResponse
+
+            let! visibleSharedPrefixResponse =
+                DirectoryVersionServerTestHelpers.getBySha256HashResponseAsync
+                    observerClient
+                    repositoryId
+                    visibleRoot.DirectoryVersionId
+                    (Sha256Hash sharedShaPrefix)
+
+            do! DirectoryVersionServerTestHelpers.assertOk visibleSharedPrefixResponse
+            let! visibleSharedPrefix = deserializeContent<GraceReturnValue<DirectoryVersionServerTestHelpers.DirectoryVersionModel>> visibleSharedPrefixResponse
+
+            DirectoryVersionServerTestHelpers.assertDirectoryVersion visibleRoot visibleSharedPrefix.ReturnValue
         }

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -180,21 +180,20 @@ module DirectoryVersionServerTestHelpers =
             do! BranchServerTestHelpers.assertOk referenceResponse
         }
 
-    /// Marks a saved reference as logically deleted through the actor state used by repository reference queries.
-    let deleteReferenceAsync (repositoryId: string) (referenceId: ReferenceId) =
+    /// Deletes the published branch through the hosted route so its references are marked deleted by the test server.
+    let deleteBranchReferencesAsync (repositoryId: string) (branchId: BranchId) =
         task {
-            let correlationId = generateCorrelationId ()
+            let parameters = Parameters.Branch.DeleteBranchParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branchId}"
+            parameters.Force <- true
+            parameters.DeleteReason <- "Directory version reachability regression."
+            parameters.CorrelationId <- generateCorrelationId ()
 
-            let actorProxy = Grace.Actors.Extensions.ActorProxy.Reference.CreateActorProxy referenceId (Guid.Parse repositoryId) correlationId
-
-            let! result =
-                actorProxy.Handle
-                    (Grace.Types.Reference.ReferenceCommand.DeleteLogical(false, "Directory version reachability regression."))
-                    (EventMetadata.New correlationId "directory-version-server-tests")
-
-            match result with
-            | Ok returnValue -> Assert.That(returnValue.ReturnValue.DeletedAt.IsSome, Is.True)
-            | Error graceError -> Assert.Fail($"{graceError}")
+            let! response = Client.PostAsync("/branch/delete", createJsonContent parameters)
+            do! BranchServerTestHelpers.assertOk response
         }
 
     /// Posts a directory get route through the supplied authenticated client.
@@ -574,7 +573,8 @@ type DirectoryVersionServer() =
             do! DirectoryVersionServerTestHelpers.assertOk activeHashResponse
 
             let! branchAfterSave = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
-            do! DirectoryVersionServerTestHelpers.deleteReferenceAsync repositoryId branchAfterSave.LatestSave.ReferenceId
+            Assert.That(branchAfterSave.LatestSave.ReferenceId, Is.Not.EqualTo(ReferenceId.Empty))
+            do! DirectoryVersionServerTestHelpers.deleteBranchReferencesAsync repositoryId branchAfterSave.BranchId
 
             let expectedMissing = DirectoryVersionError.getErrorMessage DirectoryVersionError.DirectoryDoesNotExist
 

--- a/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
+++ b/src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs
@@ -180,6 +180,23 @@ module DirectoryVersionServerTestHelpers =
             do! BranchServerTestHelpers.assertOk referenceResponse
         }
 
+    /// Marks a saved reference as logically deleted through the actor state used by repository reference queries.
+    let deleteReferenceAsync (repositoryId: string) (referenceId: ReferenceId) =
+        task {
+            let correlationId = generateCorrelationId ()
+
+            let actorProxy = Grace.Actors.Extensions.ActorProxy.Reference.CreateActorProxy referenceId (Guid.Parse repositoryId) correlationId
+
+            let! result =
+                actorProxy.Handle
+                    (Grace.Types.Reference.ReferenceCommand.DeleteLogical(false, "Directory version reachability regression."))
+                    (EventMetadata.New correlationId "directory-version-server-tests")
+
+            match result with
+            | Ok returnValue -> Assert.That(returnValue.ReturnValue.DeletedAt.IsSome, Is.True)
+            | Error graceError -> Assert.Fail($"{graceError}")
+        }
+
     /// Posts a directory get route through the supplied authenticated client.
     let getDirectoryVersionResponseAsync (client: HttpClient) repositoryId directoryVersionId =
         client.PostAsync("/directory/get", createJsonContent (getParameters repositoryId directoryVersionId))
@@ -536,6 +553,61 @@ type DirectoryVersionServer() =
             let! zipResponse = DirectoryVersionServerTestHelpers.getZipFileResponseAsync observerClient repositoryId hiddenRoot.DirectoryVersionId
 
             do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing zipResponse
+        }
+
+    /// Verifies deleted references do not authorize directory id, hash, recursive, or zip reads.
+    [<Test>]
+    member _.DeletedReferenceDirectoryReadsBehaveAsAbsentForRepositoryReader() =
+        task {
+            let! repositoryId, branch = DirectoryVersionServerTestHelpers.createPublicRepositoryBranchAsync "DirectoryDeletedReferenceReads"
+            let child = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId $"/deleted/{Guid.NewGuid():N}/" []
+
+            let root = DirectoryVersionServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId "/" [ child ]
+
+            do! DirectoryVersionServerTestHelpers.saveDirectoryVersionsAndReferenceAsync repositoryId branch root [ child; root ]
+
+            let! activeGetResponse = DirectoryVersionServerTestHelpers.getDirectoryVersionResponseAsync Client repositoryId root.DirectoryVersionId
+            do! DirectoryVersionServerTestHelpers.assertOk activeGetResponse
+
+            let! activeHashResponse = DirectoryVersionServerTestHelpers.getBySha256HashResponseAsync Client repositoryId root.DirectoryVersionId root.Sha256Hash
+
+            do! DirectoryVersionServerTestHelpers.assertOk activeHashResponse
+
+            let! branchAfterSave = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
+            do! DirectoryVersionServerTestHelpers.deleteReferenceAsync repositoryId branchAfterSave.LatestSave.ReferenceId
+
+            let expectedMissing = DirectoryVersionError.getErrorMessage DirectoryVersionError.DirectoryDoesNotExist
+
+            let! getResponse = DirectoryVersionServerTestHelpers.getDirectoryVersionResponseAsync Client repositoryId root.DirectoryVersionId
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing getResponse
+
+            let! recursiveResponse = DirectoryVersionServerTestHelpers.getDirectoryVersionsRecursiveResponseAsync Client repositoryId root.DirectoryVersionId
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing recursiveResponse
+
+            let! batchResponse = DirectoryVersionServerTestHelpers.getByDirectoryIdsResponseAsync Client repositoryId [ root.DirectoryVersionId ]
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing batchResponse
+
+            let! zipResponse = DirectoryVersionServerTestHelpers.getZipFileResponseAsync Client repositoryId root.DirectoryVersionId
+
+            do! DirectoryVersionServerTestHelpers.assertBadRequestGraceError expectedMissing zipResponse
+
+            let! deletedShaResponse = DirectoryVersionServerTestHelpers.getBySha256HashResponseAsync Client repositoryId root.DirectoryVersionId root.Sha256Hash
+
+            do! DirectoryVersionServerTestHelpers.assertOk deletedShaResponse
+            let! deletedSha = deserializeContent<GraceReturnValue<DirectoryVersionServerTestHelpers.DirectoryVersionModel>> deletedShaResponse
+            Assert.That(deletedSha.ReturnValue.DirectoryVersionId, Is.EqualTo(DirectoryVersion.Default.DirectoryVersionId))
+
+            let deletedBlakeLookup = $"{root.Blake3Hash}"
+
+            let! deletedBlakeResponse = DirectoryVersionServerTestHelpers.getByBlake3HashResponseAsync Client repositoryId (Blake3Hash deletedBlakeLookup)
+
+            do!
+                DirectoryVersionServerTestHelpers.assertBadRequestGraceError
+                    $"No DirectoryVersion matched the supplied BLAKE3 hash prefix '{deletedBlakeLookup}' in repository scope."
+                    deletedBlakeResponse
         }
 
     /// Verifies hidden directory hashes are no-match-equivalent and hidden same-prefix roots do not create ambiguity.

--- a/src/Grace.Server/DirectoryVersion.Server.fs
+++ b/src/Grace.Server/DirectoryVersion.Server.fs
@@ -6,18 +6,25 @@ open Grace.Actors.DirectoryVersion
 open Grace.Actors.Extensions.ActorProxy
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
+open Grace.Server.Security
 open Grace.Server.Services
 open Grace.Server.Validations
 open Grace.Shared
 open Grace.Shared.Parameters.DirectoryVersion
 open Grace.Shared.Resources.Text
+open Grace.Types
 open Grace.Types.DirectoryVersion
 open Grace.Types.Common
+open Grace.Types.Authorization
+open Grace.Types.Branch
+open Grace.Types.Reference
+open Grace.Types.Visibility
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Common
 open Grace.Shared.Validation.Errors
 open Grace.Shared.Validation.Utilities
 open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
 open System
 open System.Collections.Concurrent
 open System.Collections.Generic
@@ -36,6 +43,244 @@ module DirectoryVersion =
     //type QueryResult<'T, 'U when 'T :> DirectoryParameters> = 'T -> int -> IDirectoryVersionActor ->Task<'U>
 
     let activitySource = new ActivitySource("Branch")
+
+    /// Checks whether a version hash matches a caller-supplied prefix.
+    let private hashMatchesPrefix (hashPrefix: string) (candidateHash: string) =
+        not (String.IsNullOrWhiteSpace candidateHash)
+        && candidateHash.StartsWith(hashPrefix.Trim(), StringComparison.OrdinalIgnoreCase)
+
+    /// Resolves a hash prefix over an already-authorized candidate set.
+    let private resolveVisibleHashPrefix<'T> (hashPrefix: string) (getHash: 'T -> string) (matches: seq<'T>) : VersionHashPrefixResolution<'T> =
+        let boundedMatches =
+            matches
+            |> Seq.filter (fun candidate -> hashMatchesPrefix hashPrefix (getHash candidate))
+            |> Seq.truncate 2
+            |> Seq.toArray
+
+        match boundedMatches.Length with
+        | 0 -> NoMatches
+        | 1 -> UniqueMatch boundedMatches[0]
+        | _ -> AmbiguousMatches boundedMatches
+
+    /// Checks whether RBAC grants the requested operation over an authoritative Grace resource.
+    let private canPerformOperation (context: HttpContext) operation resource =
+        task {
+            let principals = PrincipalMapper.getPrincipals context.User
+            let claims = PrincipalMapper.getEffectiveClaims context.User
+            let evaluator = context.RequestServices.GetRequiredService<IGracePermissionEvaluator>()
+
+            match! evaluator.CheckAsync(principals, claims, operation, resource) with
+            | Allowed _ -> return true
+            | Denied _ -> return false
+        }
+
+    /// Checks whether RBAC already grants the caller elevated authority over the branch.
+    let private canAdministerBranch (context: HttpContext) (branchDto: BranchDto) =
+        let resource = Resource.Branch(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId, branchDto.BranchId)
+        canPerformOperation context Operation.BranchAdmin resource
+
+    /// Converts the authenticated HTTP principal into the reusable visibility audience facts.
+    let private getVisibilityCallerAudience (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let callerUserId =
+                PrincipalMapper.tryGetUserId context.User
+                |> Option.map UserId
+
+            let resource = Resource.Repository(branchDto.OwnerId, branchDto.OrganizationId, branchDto.RepositoryId)
+            let! hasRepositoryAdministration = canPerformOperation context Operation.RepositoryAdmin resource
+
+            return { VisibilityCallerAudience.Anonymous with UserId = callerUserId; HasRepositoryAdministration = hasRepositoryAdministration }
+        }
+
+    /// Projects branch durable visibility facts into the shared visibility helper resource shape.
+    let private branchVisibilityResource (branchDto: BranchDto) =
+        let creatorUserId = if branchDto.UserId = UserId String.Empty then None else Some branchDto.UserId
+
+        { AuthorityKey = branchDto.BranchId; Visibility = branchDto.Visibility; Ownership = branchDto.Ownership; CreatorUserId = creatorUserId }
+
+    /// Builds branch-scoped authority only after checking the exact branch resource being considered.
+    let private getBranchResourceAudience (context: HttpContext) (branchDto: BranchDto) =
+        task {
+            let! hasBranchAdministration = canAdministerBranch context branchDto
+
+            return { VisibilityResourceAudience.None with HasBranchAdministration = hasBranchAdministration }
+        }
+
+    /// Projects reference durable visibility facts into the shared visibility helper resource shape.
+    let private referenceVisibilityResource (referenceDto: ReferenceDto) =
+        {
+            AuthorityKey = referenceDto.ReferenceId
+            Visibility = referenceDto.Visibility
+            Ownership = referenceDto.Ownership
+            CreatorUserId = referenceDto.CreatorUserId
+        }
+
+    /// Checks branch and reference visibility before a reference can reach directory read, hash, recursive, or zip surfaces.
+    let private canObserveReferenceInBranch (context: HttpContext) (branchDto: BranchDto) (referenceDto: ReferenceDto) =
+        task {
+            let! caller = getVisibilityCallerAudience context branchDto
+            let! branchAudience = getBranchResourceAudience context branchDto
+            let branchResource = branchVisibilityResource branchDto
+
+            let branchObservable = VisibilityAuthorization.canObserveBranch caller (fun _ -> branchAudience) branchResource
+
+            if not branchObservable then
+                return false
+            else
+                let resource = referenceVisibilityResource referenceDto
+                return VisibilityAuthorization.canObserveBranchReference caller (fun _ -> branchAudience) resource
+        }
+
+    /// Gets references in the repository that the caller can observe at response time.
+    let private getObservableReferences
+        (context: HttpContext)
+        (ownerId: OwnerId)
+        (organizationId: OrganizationId)
+        (repositoryId: RepositoryId)
+        (correlationId: CorrelationId)
+        =
+        task {
+            let! branches = getBranches ownerId organizationId repositoryId Int32.MaxValue false correlationId
+            let visibleReferences = List<ReferenceDto>()
+
+            for branchDto in branches do
+                let! branchReferences = getReferences repositoryId branchDto.BranchId Int32.MaxValue correlationId
+
+                for referenceDto in branchReferences do
+                    let! canObserve = canObserveReferenceInBranch context branchDto referenceDto
+
+                    if canObserve then visibleReferences.Add(referenceDto)
+
+            return visibleReferences :> seq<ReferenceDto>
+        }
+
+    /// Loads the unique directory versions reachable from the caller-observable reference roots.
+    let private getObservableDirectoryVersions
+        (context: HttpContext)
+        (ownerId: OwnerId)
+        (organizationId: OrganizationId)
+        (repositoryId: RepositoryId)
+        (correlationId: CorrelationId)
+        =
+        task {
+            let! references = getObservableReferences context ownerId organizationId repositoryId correlationId
+            let directoryVersions = Dictionary<DirectoryVersionId, DirectoryVersion>()
+
+            for referenceDto in references do
+                let directoryVersionActorProxy = DirectoryVersion.CreateActorProxy referenceDto.DirectoryId repositoryId correlationId
+                let! recursiveDirectories = directoryVersionActorProxy.GetRecursiveDirectoryVersions false correlationId
+
+                for directoryVersionDto in recursiveDirectories do
+                    let directoryVersion = directoryVersionDto.DirectoryVersion
+                    directoryVersions[directoryVersion.DirectoryVersionId] <- directoryVersion
+
+            return directoryVersions.Values :> seq<DirectoryVersion>
+        }
+
+    /// Checks whether a directory version id is reachable from at least one caller-observable reference root.
+    let private canObserveDirectoryVersion
+        (context: HttpContext)
+        (ownerId: OwnerId)
+        (organizationId: OrganizationId)
+        (repositoryId: RepositoryId)
+        (directoryVersionId: DirectoryVersionId)
+        (correlationId: CorrelationId)
+        =
+        task {
+            let! directoryVersions = getObservableDirectoryVersions context ownerId organizationId repositoryId correlationId
+
+            return
+                directoryVersions
+                |> Seq.exists (fun directoryVersion -> directoryVersion.DirectoryVersionId = directoryVersionId)
+        }
+
+    /// Implements directory-version reachability as an absent-candidate validation result.
+    let private directoryIdIsObservable
+        (context: HttpContext)
+        (ownerId: OwnerId)
+        (organizationId: OrganizationId)
+        (repositoryIdText: string)
+        (directoryVersionIdText: string)
+        (correlationId: CorrelationId)
+        =
+        ValueTask<Result<unit, DirectoryVersionError>>(
+            task {
+                match Guid.TryParse repositoryIdText, Guid.TryParse directoryVersionIdText with
+                | (true, repositoryId), (true, directoryVersionId) ->
+                    let! isObservable = canObserveDirectoryVersion context ownerId organizationId repositoryId directoryVersionId correlationId
+
+                    return if isObservable then Ok() else Error DirectoryVersionError.DirectoryDoesNotExist
+                | _, (false, _) -> return Error DirectoryVersionError.InvalidDirectoryVersionId
+                | (false, _), _ -> return Error DirectoryVersionError.InvalidRepositoryId
+            }
+        )
+
+    /// Implements batch directory-version reachability as an absent-candidate validation result.
+    let private directoryIdsAreObservable
+        (context: HttpContext)
+        (ownerId: OwnerId)
+        (organizationId: OrganizationId)
+        (repositoryIdText: string)
+        (directoryVersionIds: IEnumerable<DirectoryVersionId>)
+        (correlationId: CorrelationId)
+        =
+        ValueTask<Result<unit, DirectoryVersionError>>(
+            task {
+                match Guid.TryParse repositoryIdText with
+                | false, _ -> return Error DirectoryVersionError.InvalidRepositoryId
+                | true, repositoryId ->
+                    let! directoryVersions = getObservableDirectoryVersions context ownerId organizationId repositoryId correlationId
+
+                    let observableDirectoryIds =
+                        directoryVersions
+                        |> Seq.map (fun directoryVersion -> directoryVersion.DirectoryVersionId)
+                        |> Set.ofSeq
+
+                    let allObservable =
+                        directoryVersionIds
+                        |> Seq.forall observableDirectoryIds.Contains
+
+                    return
+                        if allObservable then
+                            Ok()
+                        else
+                            Error DirectoryVersionError.DirectoryDoesNotExist
+            }
+        )
+
+    /// Resolves a SHA-256 prefix only against directory versions reachable from caller-observable reference roots.
+    let private resolveObservableDirectoryVersionBySha256Hash
+        (context: HttpContext)
+        ownerId
+        organizationId
+        repositoryId
+        (sha256Hash: Sha256Hash)
+        correlationId
+        =
+        task {
+            let! directoryVersions = getObservableDirectoryVersions context ownerId organizationId repositoryId correlationId
+
+            return
+                directoryVersions
+                |> resolveVisibleHashPrefix $"{sha256Hash}" (fun directoryVersion -> $"{directoryVersion.Sha256Hash}")
+        }
+
+    /// Resolves a BLAKE3 prefix only against directory versions reachable from caller-observable reference roots.
+    let private resolveObservableDirectoryVersionByBlake3Hash
+        (context: HttpContext)
+        ownerId
+        organizationId
+        repositoryId
+        (blake3Hash: Blake3Hash)
+        correlationId
+        =
+        task {
+            let! directoryVersions = getObservableDirectoryVersions context ownerId organizationId repositoryId correlationId
+
+            return
+                directoryVersions
+                |> resolveVisibleHashPrefix $"{blake3Hash}" (fun directoryVersion -> $"{directoryVersion.Blake3Hash}")
+        }
 
     /// Implements directory save depth for the server request pipeline.
     let private directorySaveDepth (relativePath: RelativePath) =
@@ -193,6 +438,13 @@ module DirectoryVersion =
                             repositoryId
                             parameters.CorrelationId
                             DirectoryVersionError.DirectoryDoesNotExist
+                        directoryIdIsObservable
+                            context
+                            graceIds.OwnerId
+                            graceIds.OrganizationId
+                            $"{parameters.RepositoryId}"
+                            $"{parameters.DirectoryVersionId}"
+                            parameters.CorrelationId
                     |]
 
                 /// Implements query for the server request pipeline.
@@ -228,6 +480,13 @@ module DirectoryVersion =
                             repositoryId
                             parameters.CorrelationId
                             DirectoryVersionError.DirectoryDoesNotExist
+                        directoryIdIsObservable
+                            context
+                            graceIds.OwnerId
+                            graceIds.OrganizationId
+                            $"{parameters.RepositoryId}"
+                            $"{parameters.DirectoryVersionId}"
+                            parameters.CorrelationId
                     |]
 
                 /// Implements query for the server request pipeline.
@@ -263,6 +522,13 @@ module DirectoryVersion =
                             repositoryId
                             parameters.CorrelationId
                             DirectoryVersionError.DirectoryDoesNotExist
+                        directoryIdsAreObservable
+                            context
+                            graceIds.OwnerId
+                            graceIds.OrganizationId
+                            $"{parameters.RepositoryId}"
+                            parameters.DirectoryIds
+                            parameters.CorrelationId
                     |]
 
                 /// Implements query for the server request pipeline.
@@ -313,7 +579,13 @@ module DirectoryVersion =
 
                     if validationsPassed then
                         let! resolution =
-                            getDirectoryVersionResolutionBySha256Hash (Guid.Parse(parameters.RepositoryId)) (Sha256Hash parameters.Sha256Hash) correlationId
+                            resolveObservableDirectoryVersionBySha256Hash
+                                context
+                                graceIds.OwnerId
+                                graceIds.OrganizationId
+                                (Guid.Parse(parameters.RepositoryId))
+                                (Sha256Hash parameters.Sha256Hash)
+                                correlationId
 
                         match resolution with
                         | NoMatches ->
@@ -394,7 +666,13 @@ module DirectoryVersion =
 
                     if validationsPassed then
                         let! resolution =
-                            getDirectoryVersionResolutionByBlake3Hash (Guid.Parse(parameters.RepositoryId)) (Blake3Hash parameters.Blake3Hash) correlationId
+                            resolveObservableDirectoryVersionByBlake3Hash
+                                context
+                                graceIds.OwnerId
+                                graceIds.OrganizationId
+                                (Guid.Parse(parameters.RepositoryId))
+                                (Blake3Hash parameters.Blake3Hash)
+                                correlationId
 
                         match resolution with
                         | NoMatches ->
@@ -454,6 +732,13 @@ module DirectoryVersion =
                             repositoryId
                             parameters.CorrelationId
                             DirectoryVersionError.DirectoryDoesNotExist
+                        directoryIdIsObservable
+                            context
+                            graceIds.OwnerId
+                            graceIds.OrganizationId
+                            $"{parameters.RepositoryId}"
+                            $"{parameters.DirectoryVersionId}"
+                            parameters.CorrelationId
                     |]
 
                 /// Implements query for the server request pipeline.

--- a/src/Grace.Server/DirectoryVersion.Server.fs
+++ b/src/Grace.Server/DirectoryVersion.Server.fs
@@ -146,7 +146,9 @@ module DirectoryVersion =
             for branchDto in branches do
                 let! branchReferences = getReferences repositoryId branchDto.BranchId Int32.MaxValue correlationId
 
-                for referenceDto in branchReferences do
+                for referenceDto in
+                    branchReferences
+                    |> Seq.filter (fun referenceDto -> referenceDto.DeletedAt.IsNone) do
                     let! canObserve = canObserveReferenceInBranch context branchDto referenceDto
 
                     if canObserve then visibleReferences.Add(referenceDto)


### PR DESCRIPTION
# GV-07: DirectoryVersion reachability gating

## Summary

- Gates DirectoryVersion direct id, batch id, recursive, zip, SHA-256, and BLAKE3 read paths through caller-observable branch/reference reachability.
- Resolves hash no-match and ambiguity over the visible recursive directory candidate subset so hidden candidates behave as absent.
- Adds focused server tests for hidden direct ids, hidden-only hash prefixes, visible-plus-hidden hash classification, recursive reads, and zip gating.

## Related Issue

Related to #646.

## Why This Matters

DirectoryVersion ids and hashes are discovery surfaces. This slice prevents leaked ids, hidden hashes, batch ids, recursive metadata, and zip requests from acting as capabilities or public oracles over private contributor work.

## Touched Paths

- `src/Grace.Server/DirectoryVersion.Server.fs`
- `src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs`

## Validation

- `dotnet tool run fantomas src/Grace.Server/DirectoryVersion.Server.fs src/Grace.Server.Tests/DirectoryVersion.Server.Tests.fs`: passed.
- `dotnet build src/Grace.Server.Tests/Grace.Server.Tests.fsproj -c Release`: passed.
- `dotnet test src/Grace.Server.Tests/Grace.Server.Tests.fsproj -c Release --no-build --filter FullyQualifiedName~DirectoryVersionServer`: passed, 9 passed, 0 failed.
- `git diff --check`: passed.
- `pwsh ./scripts/validate.ps1 -Fast`: passed.

## Review Status

- Current head: `24679fa056d454800be1d41242cba615777a888d`.
- Codex Code Review Bot state for current head: latest-head thumbs-up; no fresh review threads on `24679fa0`.
- GitHub Actions: `full` run `28910922708`, job `85767928315`, passed in 7m06s.
- Review finding fixed: `PRRT_kwDOILVrb86PFo4H` in `69e0805e7efbbac512c9ab67d0aac17a89b484c4` by filtering deleted references before reachability contribution.
- Validation-fix evidence: `24679fa056d454800be1d41242cba615777a888d` replaces the failing direct actor proxy test helper with hosted `/branch/delete` route usage.
- Stale prior-head thread disposition: `PRRT_kwDOILVrb86PF1NU` belonged to prior head `69e0805e`, was not repeated on latest head `24679fa0`, and was resolved as stale after the latest-head thumbs-up and passing full run.
- Fix validation:
  - `dotnet tool run fantomas C:\Source\Grace-gh-646\src\Grace.Server.Tests\DirectoryVersion.Server.Tests.fs`: passed; file unchanged.
  - `dotnet build --configuration Release src\Grace.Server.Tests\Grace.Server.Tests.fsproj`: passed.
  - `dotnet test --configuration Release --no-build src\Grace.Server.Tests\Grace.Server.Tests.fsproj --filter FullyQualifiedName~DeletedReferenceDirectoryReadsBehaveAsAbsentForRepositoryReader`: passed, 1/1.
  - `pwsh ./scripts/validate.ps1 -Fast`: passed.
  - `git diff --check`: passed.
- Completion gate: merge state `CLEAN`; full validation passed; latest-head Codex result has no issues; unresolved review thread count is zero.
- Manual trigger decision: not attempted.
- Manual trigger lock: no manual trigger may be used while bot state is pending, acknowledged with eyes, completed with no-issues, or ambiguous. Use `pwsh ./scripts/guard-codex-review-trigger.ps1 -PullRequest 674` only if the documented missed-ack exception is reached.
- Substantive review cycle count: 1.
- Final no-issues state: satisfied for PR #674.

## First-Pass Review Readiness

- Worker bot-prevention self-review completed over stale-authority/revalidation, hidden-candidate no-oracle behavior, direct leaked-id denial, hash ambiguity ordering, route error shape preservation, scope boundaries, and random-prefix test flake risk.
- Worker fixed one BLAKE3 hidden-only test flake risk before handoff by using the hidden root's full BLAKE3 hash instead of a two-character collision prefix.

## Contract And Scope Notes

- Route behavior updated for `/directory/get`, `/directory/getByDirectoryIds`, `/directory/getBySha256Hash`, `/directory/getByBlake3Hash`, `/directory/getDirectoryVersionsRecursive`, and `/directory/getZipFile`.
- DTOs/request parameters/OpenAPI/CLI/SDK are unchanged. No new public reference/root context parameter was added.
- Hidden direct ids return the existing absent-candidate `DirectoryDoesNotExist` shape. Hidden SHA-256 returns the existing default sentinel no-match shape. Hidden BLAKE3 returns the existing no-match `GraceError` shape.
- Zip is gated before `GetZipFileUri`; no zip/blob materialization runtime path was exercised, so `-Full` was not run.
- Storage/materialization/cache-plan follow-up remains deferred to GV-09/GV-11.
- #645 PromotionSet lifecycle and terminal reference apply surfaces were not touched.

## Docs Impact

No user-facing docs changed in this slice. Broader docs, CLI, SDK, OpenAPI/generated-client, materialization, and storage authorization propagation remain owned by later #638 child issues.

## Residual Risk

The reachability helper scans observable repository branches/references and their recursive roots at request time. This preserves the current public contract and avoids hidden candidate oracles, but it is intentionally not a storage/materialization optimization slice.
