### PR TITLE
Harden branch traversal visibility

### DIFF
--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -778,6 +778,20 @@ module BranchServerTestHelpers =
             return! client.PostAsync("/branch/getVersion", createJsonContent parameters)
         }
 
+    /// Gets version by ReferenceId through the supplied authenticated client.
+    let getVersionByReferenceIdWithClientResponseAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) referenceId =
+        task {
+            let parameters = Parameters.Branch.GetBranchVersionParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- $"{branch.BranchId}"
+            parameters.ReferenceId <- $"{referenceId}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            return! client.PostAsync("/branch/getVersion", createJsonContent parameters)
+        }
+
     /// Gets recursive size by SHA256 hash response from the running test server.
     let getRecursiveSizeBySha256HashResponseAsync repositoryId (branch: Branch.BranchDto) sha256Hash =
         task {
@@ -1077,6 +1091,30 @@ module BranchServerTestHelpers =
 
             let! savedBranch = getBranchAsync repositoryId $"{branch.BranchId}"
             return savedBranch, fileVersion, savedBranch.LatestSave.ReferenceId
+        }
+
+    /// Builds a deterministic annotatable reference through a supplied authenticated client.
+    let createAnnotatableReferenceWithContentForClientAsync (client: HttpClient) repositoryId (branch: Branch.BranchDto) relativePath (content: string) =
+        task {
+            let contentBytes = Encoding.UTF8.GetBytes(content)
+
+            let fileVersion =
+                FileVersion.CreateWithHashes relativePath (sha256Hex contentBytes) (blake3Hex contentBytes) String.Empty false (int64 contentBytes.Length)
+
+            do! uploadFileToObjectStorageAsync repositoryId contentBytes fileVersion
+
+            let directoryVersion = createRootDirectoryVersion repositoryId fileVersion
+
+            do! saveDirectoryVersionAsync repositoryId directoryVersion
+
+            let! saveResponse = saveReferenceWithClientResponseAsync client repositoryId branch directoryVersion.DirectoryVersionId directoryVersion.Sha256Hash
+
+            do! assertOk saveResponse
+
+            let! savedBranchResponse = getBranchResponseAsync client repositoryId $"{branch.BranchId}"
+            do! assertOk savedBranchResponse
+            let! savedBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> savedBranchResponse
+            return savedBranchReturnValue.ReturnValue, fileVersion, savedBranchReturnValue.ReturnValue.LatestSave.ReferenceId
         }
 
     /// Defines promote latest save behavior for the surrounding tests used by the server integration branch scenario.
@@ -1620,6 +1658,63 @@ type BranchServer() =
                     .ReturnValue
 
             Assert.That(branchAdminDirectoryIds, Does.Contain(privateRoot.DirectoryVersionId))
+        }
+
+    /// Verifies hidden ReferenceId version traversal does not rewrite the public response around the private branch.
+    [<Test>]
+    member _.GetVersionWithHiddenReferenceIdDoesNotExposePrivateBranchIdentity() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityHiddenReferenceVersion"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+
+            let! privateBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"HiddenVersionRef{Guid.NewGuid():N}"
+                    "Private"
+                    "ContributorOwned"
+
+            let! creatorBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk creatorBranchResponse
+            let! creatorBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> creatorBranchResponse
+            let creatorBranch = creatorBranchReturnValue.ReturnValue
+
+            let! privateSaveResponse = BranchServerTestHelpers.saveBranchWithClientAsync creatorClient repositoryId creatorBranch
+            Assert.That(privateSaveResponse.ReturnValue, Is.Not.Empty)
+
+            let! savedPrivateBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk savedPrivateBranchResponse
+            let! savedPrivateBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> savedPrivateBranchResponse
+            let privateReferenceId = savedPrivateBranchReturnValue.ReturnValue.LatestSave.ReferenceId
+
+            Assert.That(privateReferenceId, Is.Not.EqualTo(ReferenceId.Empty))
+
+            let! observerVersion =
+                BranchServerTestHelpers.getVersionByReferenceIdWithClientResponseAsync observerClient repositoryId parentBranch privateReferenceId
+
+            let! observerVersionBody = observerVersion.Content.ReadAsStringAsync()
+            Assert.That(observerVersion.StatusCode, Is.EqualTo(HttpStatusCode.OK), observerVersionBody)
+
+            let observerDirectoryIds =
+                (deserialize<GraceReturnValue<Guid array>> observerVersionBody)
+                    .ReturnValue
+
+            Assert.That(observerDirectoryIds, Is.Empty)
+            Assert.That(observerVersionBody, Does.Not.Contain(privateBranchId))
+            Assert.That(observerVersionBody, Does.Contain($"{parentBranch.BranchId}"))
         }
 
     /// Verifies public hash reads resolve after visibility filtering when a hidden root shares the requested prefix.
@@ -2618,6 +2713,61 @@ type BranchServer() =
                 | Error error -> Assert.Fail($"Expected SDK Branch.Annotate success, got {error.Error}.")
             finally
                 Grace.SDK.Auth.clearTokenProvider ()
+        }
+
+    /// Verifies annotate treats hidden target references as missing before materializing private source content.
+    [<Test>]
+    member _.AnnotateWithHiddenTargetReferenceDoesNotExposePrivateHistory() =
+        task {
+            let creatorUserId = $"{Guid.NewGuid()}"
+            let observerUserId = $"{Guid.NewGuid()}"
+            let! repositoryId = BranchServerTestHelpers.createRepositoryAsync "VisibilityAnnotateTarget"
+
+            do! BranchServerTestHelpers.setRepositoryVisibilityAsync repositoryId "Public"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId creatorUserId "RepositoryContributor"
+            do! BranchServerTestHelpers.grantRepositoryRoleAsync repositoryId observerUserId "RepositoryReader"
+
+            use creatorClient = BranchServerTestHelpers.createClientWithUserId creatorUserId
+            use observerClient = BranchServerTestHelpers.createClientWithUserId observerUserId
+
+            let! observerBranches = BranchServerTestHelpers.getRepositoryBranchesWithClientAsync observerClient repositoryId
+            let parentBranch = observerBranches |> Array.exactlyOne
+
+            let! privateBranchId =
+                BranchServerTestHelpers.createBranchWithVisibilityAsync
+                    creatorClient
+                    repositoryId
+                    parentBranch
+                    $"HiddenAnnotateTarget{Guid.NewGuid():N}"
+                    "Private"
+                    "ContributorOwned"
+
+            let! creatorBranchResponse = BranchServerTestHelpers.getBranchResponseAsync creatorClient repositoryId privateBranchId
+            do! BranchServerTestHelpers.assertOk creatorBranchResponse
+            let! creatorBranchReturnValue = deserializeContent<GraceReturnValue<Branch.BranchDto>> creatorBranchResponse
+            let creatorBranch = creatorBranchReturnValue.ReturnValue
+            let hiddenMarker = $"hidden-{Guid.NewGuid():N}"
+            let hiddenContent = $"let privateValue = \"{hiddenMarker}\"{Environment.NewLine}"
+
+            let! _, hiddenFileVersion, hiddenReferenceId =
+                BranchServerTestHelpers.createAnnotatableReferenceWithContentForClientAsync
+                    creatorClient
+                    repositoryId
+                    creatorBranch
+                    $"annotate/{Guid.NewGuid():N}/hidden.fs"
+                    hiddenContent
+
+            let parameters = BranchServerTestHelpers.annotateParameters repositoryId parentBranch hiddenFileVersion
+            parameters.TargetReferenceId <- hiddenReferenceId
+
+            let! response = observerClient.PostAsync("/branch/annotate", createJsonContent parameters)
+            let! responseBody = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), responseBody)
+
+            let error = deserialize<GraceError> responseBody
+            Assert.That(error.Error, Is.EqualTo(BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
+            Assert.That(responseBody, Does.Not.Contain(privateBranchId))
+            Assert.That(responseBody, Does.Not.Contain(hiddenMarker))
         }
 
     /// Verifies the annotate route returns grace error for bad parameters scenario.

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -2715,7 +2715,7 @@ type BranchServer() =
                 Grace.SDK.Auth.clearTokenProvider ()
         }
 
-    /// Verifies annotate treats hidden target references as missing before materializing private source content.
+    /// Verifies annotate treats hidden-branch target references as missing before materializing private source content.
     [<Test>]
     member _.AnnotateWithHiddenTargetReferenceDoesNotExposePrivateHistory() =
         task {
@@ -2768,6 +2768,31 @@ type BranchServer() =
             Assert.That(error.Error, Is.EqualTo(BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
             Assert.That(responseBody, Does.Not.Contain(privateBranchId))
             Assert.That(responseBody, Does.Not.Contain(hiddenMarker))
+
+            let revealParameters = Parameters.Branch.RevealReferenceParameters()
+            revealParameters.OwnerId <- ownerId
+            revealParameters.OrganizationId <- organizationId
+            revealParameters.RepositoryId <- repositoryId
+            revealParameters.BranchId <- privateBranchId
+            revealParameters.ReferenceId <- hiddenReferenceId
+            revealParameters.OperationId <- $"reveal-{Guid.NewGuid():N}"
+            revealParameters.Reason <- "Reveal reference for annotate hidden-branch oracle regression."
+            revealParameters.CorrelationId <- generateCorrelationId ()
+
+            let! revealResponse = creatorClient.PostAsync("/branch/revealReference", createJsonContent revealParameters)
+            do! BranchServerTestHelpers.assertOk revealResponse
+
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! revealedResponse = observerClient.PostAsync("/branch/annotate", createJsonContent parameters)
+            let! revealedResponseBody = revealedResponse.Content.ReadAsStringAsync()
+            Assert.That(revealedResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), revealedResponseBody)
+
+            let revealedError = deserialize<GraceError> revealedResponseBody
+            Assert.That(revealedError.Error, Is.EqualTo(BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
+            Assert.That(revealedResponseBody, Does.Not.Contain("Annotation target Reference must belong to the requested repository and branch."))
+            Assert.That(revealedResponseBody, Does.Not.Contain(privateBranchId))
+            Assert.That(revealedResponseBody, Does.Not.Contain(hiddenMarker))
         }
 
     /// Verifies the annotate route returns grace error for bad parameters scenario.

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -736,65 +736,73 @@ module Branch =
                 else
                     let referenceActorProxy = Reference.CreateActorProxy parameters.TargetReferenceId graceIds.RepositoryId correlationId
                     let! targetReference = referenceActorProxy.Get correlationId
-                    let! targetReference = getObservableReferenceInBranchOrDefault context branchDto targetReference
 
-                    if targetReference.ReferenceId = ReferenceId.Empty then
+                    if targetReference.ReferenceId <> ReferenceId.Empty
+                       && (targetReference.RepositoryId
+                           <> graceIds.RepositoryId
+                           || targetReference.BranchId <> graceIds.BranchId) then
                         return Error(annotationError correlationId (BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
-                    elif targetReference.DeletedAt.IsSome then
-                        return Error(annotationError correlationId "Annotation target Reference has been deleted.")
-                    elif targetReference.RepositoryId
-                         <> graceIds.RepositoryId
-                         || targetReference.BranchId <> graceIds.BranchId then
-                        return Error(annotationError correlationId "Annotation target Reference must belong to the requested repository and branch.")
                     else
-                        let! targetContents = getReferenceContents repositoryDto.RepositoryId correlationId targetReference
+                        let! targetReference = getObservableReferenceInBranchOrDefault context branchDto targetReference
 
-                        match tryFindFileVersion normalizedPath targetContents with
-                        | None ->
-                            return Error(annotationError correlationId $"Annotation target path '{normalizedPath}' was not found in the target Reference.")
-                        | Some _ ->
-                            let! branchReferences = getReferences targetReference.RepositoryId targetReference.BranchId Int32.MaxValue correlationId
-                            let! visibleBranchReferences = filterVisibleReferenceWindowForBranch context branchDto -1 branchReferences
+                        if targetReference.ReferenceId = ReferenceId.Empty then
+                            return Error(annotationError correlationId (BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
+                        elif targetReference.DeletedAt.IsSome then
+                            return Error(annotationError correlationId "Annotation target Reference has been deleted.")
+                        elif targetReference.RepositoryId
+                             <> graceIds.RepositoryId
+                             || targetReference.BranchId <> graceIds.BranchId then
+                            return Error(annotationError correlationId (BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
+                        else
+                            let! targetContents = getReferenceContents repositoryDto.RepositoryId correlationId targetReference
 
-                            let localHistoryWindow =
-                                if visibleBranchReferences
-                                   |> Array.exists (fun referenceDto -> referenceDto.ReferenceId = targetReference.ReferenceId) then
-                                    visibleBranchReferences
-                                else
-                                    Array.append visibleBranchReferences [| targetReference |]
-                                |> orderedHistoryWindowWithSyntheticBoundaries targetReference.ReferenceId parameters.MaxReferences
+                            match tryFindFileVersion normalizedPath targetContents with
+                            | None ->
+                                return Error(annotationError correlationId $"Annotation target path '{normalizedPath}' was not found in the target Reference.")
+                            | Some _ ->
+                                let! branchReferences = getReferences targetReference.RepositoryId targetReference.BranchId Int32.MaxValue correlationId
+                                let! visibleBranchReferences = filterVisibleReferenceWindowForBranch context branchDto -1 branchReferences
 
-                            let! references =
-                                includeStoredBasedOnReferences
-                                    context
-                                    targetReference.RepositoryId
-                                    correlationId
-                                    parameters.MaxReferences
-                                    localHistoryWindow.SyntheticBasedOnByReferenceId
-                                    localHistoryWindow.References
+                                let localHistoryWindow =
+                                    if visibleBranchReferences
+                                       |> Array.exists (fun referenceDto -> referenceDto.ReferenceId = targetReference.ReferenceId) then
+                                        visibleBranchReferences
+                                    else
+                                        Array.append visibleBranchReferences [| targetReference |]
+                                    |> orderedHistoryWindowWithSyntheticBoundaries targetReference.ReferenceId parameters.MaxReferences
 
-                            match! buildEffectiveHistory context repositoryDto normalizedPath targetReference.ReferenceId references with
-                            | Error error -> return Error error
-                            | Ok history ->
-                                let traversal = AnnotationLineCore.traverseEffectiveBranchHistory targetReference.ReferenceId parameters.MaxReferences history
+                                let! references =
+                                    includeStoredBasedOnReferences
+                                        context
+                                        targetReference.RepositoryId
+                                        correlationId
+                                        parameters.MaxReferences
+                                        localHistoryWindow.SyntheticBasedOnByReferenceId
+                                        localHistoryWindow.References
 
-                                match
-                                    AnnotationLineCore.buildAnnotationFromEffectiveHistoryTraversal
-                                        (
-                                            parameters.LineRange,
-                                            targetReference.ReferenceId,
-                                            normalizedPath,
-                                            parameters.ReferenceTypes,
-                                            parameters.MaxReferences,
-                                            parameters.IncludeLineText,
-                                            traversal
-                                        )
-                                    with
-                                | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
-                                | Ok annotation ->
-                                    match Annotation.validate annotation with
-                                    | Ok () -> return Ok annotation
+                                match! buildEffectiveHistory context repositoryDto normalizedPath targetReference.ReferenceId references with
+                                | Error error -> return Error error
+                                | Ok history ->
+                                    let traversal =
+                                        AnnotationLineCore.traverseEffectiveBranchHistory targetReference.ReferenceId parameters.MaxReferences history
+
+                                    match
+                                        AnnotationLineCore.buildAnnotationFromEffectiveHistoryTraversal
+                                            (
+                                                parameters.LineRange,
+                                                targetReference.ReferenceId,
+                                                normalizedPath,
+                                                parameters.ReferenceTypes,
+                                                parameters.MaxReferences,
+                                                parameters.IncludeLineText,
+                                                traversal
+                                            )
+                                        with
                                     | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
+                                    | Ok annotation ->
+                                        match Annotation.validate annotation with
+                                        | Ok () -> return Ok annotation
+                                        | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
         }
 
     /// Coordinates process command with post success processing for Grace Server.

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -232,6 +232,56 @@ module Branch =
                 return VisibilityAuthorization.canObserveBranchReference caller (fun _ -> branchAudience) resource
         }
 
+    /// Orders non-deleted references newest-first so public windows can refill past deleted rows before applying MaxCount.
+    let internal activeReferencesLatestFirst (references: Reference.ReferenceDto seq) =
+        references
+            .Where(fun referenceDto -> referenceDto.DeletedAt.IsNone)
+            .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
+            .ToArray()
+
+    /// Applies hidden-as-missing behavior to a reference that must be observable from the already-selected branch.
+    let private getObservableReferenceInBranchOrDefault (context: HttpContext) (branchDto: BranchDto) (referenceDto: Reference.ReferenceDto) =
+        task {
+            if referenceDto.ReferenceId = ReferenceId.Empty then
+                return Reference.ReferenceDto.Default
+            else
+                let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
+                return if isObservable then referenceDto else Reference.ReferenceDto.Default
+        }
+
+    /// Filters references for one already-authorized branch without reloading branch authority for every returned row.
+    let internal filterVisibleReferenceWindowForBranch (context: HttpContext) (branchDto: BranchDto) maxCount (references: Reference.ReferenceDto seq) =
+        task {
+            if maxCount = 0 then
+                return Array.empty<Reference.ReferenceDto>
+            else
+                let visibleReferences = List<Reference.ReferenceDto>()
+                let latestFirst = activeReferencesLatestFirst references
+
+                let mutable index = 0
+
+                let mutable keepScanning =
+                    index < latestFirst.Length
+                    && (maxCount < 0 || visibleReferences.Count < maxCount)
+
+                while keepScanning do
+                    let referenceDto = latestFirst[index]
+                    let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
+
+                    if isObservable then visibleReferences.Add referenceDto
+
+                    index <- index + 1
+
+                    keepScanning <-
+                        index < latestFirst.Length
+                        && (maxCount < 0 || visibleReferences.Count < maxCount)
+
+                return
+                    visibleReferences
+                        .OrderBy(fun referenceDto -> referenceDto.CreatedAt)
+                        .ToArray()
+        }
+
     /// Validates that a reveal will not disclose hidden reference or promotion-review links.
     let private validateRevealLinks repositoryId selectedReferenceId (referenceDto: Reference.ReferenceDto) correlationId =
         task {
@@ -583,6 +633,7 @@ module Branch =
 
     /// Implements include stored based on references for the server request pipeline.
     let private includeStoredBasedOnReferences
+        (context: HttpContext)
         repositoryId
         correlationId
         maxReferences
@@ -615,31 +666,38 @@ module Branch =
                     if basedOnReference.ReferenceId <> ReferenceId.Empty
                        && basedOnReference.DeletedAt.IsNone
                        && basedOnReference.RepositoryId = repositoryId then
-                        let! branchReferences = getReferences basedOnReference.RepositoryId basedOnReference.BranchId Int32.MaxValue correlationId
+                        let basedOnBranchActorProxy = Branch.CreateActorProxy basedOnReference.BranchId basedOnReference.RepositoryId correlationId
+                        let! basedOnBranch = basedOnBranchActorProxy.Get correlationId
+                        let! observableBasedOnReference = getObservableReferenceInBranchOrDefault context basedOnBranch basedOnReference
 
-                        let basedOnHistoryWindow =
-                            if branchReferences
-                               |> Array.exists (fun branchReference -> branchReference.ReferenceId = basedOnReference.ReferenceId) then
-                                branchReferences
-                            else
-                                Array.append branchReferences [| basedOnReference |]
-                            |> orderedHistoryWindowWithSyntheticBoundaries basedOnReference.ReferenceId maxReferences
+                        if observableBasedOnReference.ReferenceId
+                           <> ReferenceId.Empty then
+                            let! branchReferences = getReferences basedOnReference.RepositoryId basedOnReference.BranchId Int32.MaxValue correlationId
+                            let! visibleBranchReferences = filterVisibleReferenceWindowForBranch context basedOnBranch -1 branchReferences
 
-                        for syntheticBasedOn in basedOnHistoryWindow.SyntheticBasedOnByReferenceId do
-                            syntheticBasedOnByReferenceId[syntheticBasedOn.Key] <- syntheticBasedOn.Value
+                            let basedOnHistoryWindow =
+                                if visibleBranchReferences
+                                   |> Array.exists (fun branchReference -> branchReference.ReferenceId = basedOnReference.ReferenceId) then
+                                    visibleBranchReferences
+                                else
+                                    Array.append visibleBranchReferences [| basedOnReference |]
+                                |> orderedHistoryWindowWithSyntheticBoundaries basedOnReference.ReferenceId maxReferences
 
-                        let mutable basedOnHistoryIndex = 0
+                            for syntheticBasedOn in basedOnHistoryWindow.SyntheticBasedOnByReferenceId do
+                                syntheticBasedOnByReferenceId[syntheticBasedOn.Key] <- syntheticBasedOn.Value
 
-                        while basedOnHistoryIndex < basedOnHistoryWindow.References.Length do
-                            let basedOnHistoryReference = basedOnHistoryWindow.References[basedOnHistoryIndex]
+                            let mutable basedOnHistoryIndex = 0
 
-                            if not (knownReferenceIds.Contains basedOnHistoryReference.ReferenceId) then
-                                knownReferenceIds.Add basedOnHistoryReference.ReferenceId
-                                |> ignore
+                            while basedOnHistoryIndex < basedOnHistoryWindow.References.Length do
+                                let basedOnHistoryReference = basedOnHistoryWindow.References[basedOnHistoryIndex]
 
-                                effectiveReferences.Add basedOnHistoryReference
+                                if not (knownReferenceIds.Contains basedOnHistoryReference.ReferenceId) then
+                                    knownReferenceIds.Add basedOnHistoryReference.ReferenceId
+                                    |> ignore
 
-                            basedOnHistoryIndex <- basedOnHistoryIndex + 1
+                                    effectiveReferences.Add basedOnHistoryReference
+
+                                basedOnHistoryIndex <- basedOnHistoryIndex + 1
                 | _ -> ()
 
                 index <- index + 1
@@ -669,63 +727,74 @@ module Branch =
 
                 let! repositoryDto = repositoryActorProxy.Get correlationId
 
-                let referenceActorProxy = Reference.CreateActorProxy parameters.TargetReferenceId graceIds.RepositoryId correlationId
-                let! targetReference = referenceActorProxy.Get correlationId
+                let branchActorProxy = Branch.CreateActorProxy graceIds.BranchId graceIds.RepositoryId correlationId
+                let! branchDto = branchActorProxy.Get correlationId
+                let! isBranchObservable = canObserveBranch context branchDto
 
-                if targetReference.ReferenceId = ReferenceId.Empty then
-                    return Error(annotationError correlationId (BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
-                elif targetReference.DeletedAt.IsSome then
-                    return Error(annotationError correlationId "Annotation target Reference has been deleted.")
-                elif targetReference.RepositoryId
-                     <> graceIds.RepositoryId
-                     || targetReference.BranchId <> graceIds.BranchId then
-                    return Error(annotationError correlationId "Annotation target Reference must belong to the requested repository and branch.")
+                if not isBranchObservable then
+                    return Error(hiddenBranchError context (callerSuppliedBranchId context parameters))
                 else
-                    let! targetContents = getReferenceContents repositoryDto.RepositoryId correlationId targetReference
+                    let referenceActorProxy = Reference.CreateActorProxy parameters.TargetReferenceId graceIds.RepositoryId correlationId
+                    let! targetReference = referenceActorProxy.Get correlationId
+                    let! targetReference = getObservableReferenceInBranchOrDefault context branchDto targetReference
 
-                    match tryFindFileVersion normalizedPath targetContents with
-                    | None -> return Error(annotationError correlationId $"Annotation target path '{normalizedPath}' was not found in the target Reference.")
-                    | Some _ ->
-                        let! branchReferences = getReferences targetReference.RepositoryId targetReference.BranchId Int32.MaxValue correlationId
+                    if targetReference.ReferenceId = ReferenceId.Empty then
+                        return Error(annotationError correlationId (BranchError.getErrorMessage BranchError.ReferenceIdDoesNotExist))
+                    elif targetReference.DeletedAt.IsSome then
+                        return Error(annotationError correlationId "Annotation target Reference has been deleted.")
+                    elif targetReference.RepositoryId
+                         <> graceIds.RepositoryId
+                         || targetReference.BranchId <> graceIds.BranchId then
+                        return Error(annotationError correlationId "Annotation target Reference must belong to the requested repository and branch.")
+                    else
+                        let! targetContents = getReferenceContents repositoryDto.RepositoryId correlationId targetReference
 
-                        let localHistoryWindow =
-                            if branchReferences
-                               |> Array.exists (fun referenceDto -> referenceDto.ReferenceId = targetReference.ReferenceId) then
-                                branchReferences
-                            else
-                                Array.append branchReferences [| targetReference |]
-                            |> orderedHistoryWindowWithSyntheticBoundaries targetReference.ReferenceId parameters.MaxReferences
+                        match tryFindFileVersion normalizedPath targetContents with
+                        | None ->
+                            return Error(annotationError correlationId $"Annotation target path '{normalizedPath}' was not found in the target Reference.")
+                        | Some _ ->
+                            let! branchReferences = getReferences targetReference.RepositoryId targetReference.BranchId Int32.MaxValue correlationId
+                            let! visibleBranchReferences = filterVisibleReferenceWindowForBranch context branchDto -1 branchReferences
 
-                        let! references =
-                            includeStoredBasedOnReferences
-                                targetReference.RepositoryId
-                                correlationId
-                                parameters.MaxReferences
-                                localHistoryWindow.SyntheticBasedOnByReferenceId
-                                localHistoryWindow.References
+                            let localHistoryWindow =
+                                if visibleBranchReferences
+                                   |> Array.exists (fun referenceDto -> referenceDto.ReferenceId = targetReference.ReferenceId) then
+                                    visibleBranchReferences
+                                else
+                                    Array.append visibleBranchReferences [| targetReference |]
+                                |> orderedHistoryWindowWithSyntheticBoundaries targetReference.ReferenceId parameters.MaxReferences
 
-                        match! buildEffectiveHistory context repositoryDto normalizedPath targetReference.ReferenceId references with
-                        | Error error -> return Error error
-                        | Ok history ->
-                            let traversal = AnnotationLineCore.traverseEffectiveBranchHistory targetReference.ReferenceId parameters.MaxReferences history
+                            let! references =
+                                includeStoredBasedOnReferences
+                                    context
+                                    targetReference.RepositoryId
+                                    correlationId
+                                    parameters.MaxReferences
+                                    localHistoryWindow.SyntheticBasedOnByReferenceId
+                                    localHistoryWindow.References
 
-                            match
-                                AnnotationLineCore.buildAnnotationFromEffectiveHistoryTraversal
-                                    (
-                                        parameters.LineRange,
-                                        targetReference.ReferenceId,
-                                        normalizedPath,
-                                        parameters.ReferenceTypes,
-                                        parameters.MaxReferences,
-                                        parameters.IncludeLineText,
-                                        traversal
-                                    )
-                                with
-                            | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
-                            | Ok annotation ->
-                                match Annotation.validate annotation with
-                                | Ok () -> return Ok annotation
+                            match! buildEffectiveHistory context repositoryDto normalizedPath targetReference.ReferenceId references with
+                            | Error error -> return Error error
+                            | Ok history ->
+                                let traversal = AnnotationLineCore.traverseEffectiveBranchHistory targetReference.ReferenceId parameters.MaxReferences history
+
+                                match
+                                    AnnotationLineCore.buildAnnotationFromEffectiveHistoryTraversal
+                                        (
+                                            parameters.LineRange,
+                                            targetReference.ReferenceId,
+                                            normalizedPath,
+                                            parameters.ReferenceTypes,
+                                            parameters.MaxReferences,
+                                            parameters.IncludeLineText,
+                                            traversal
+                                        )
+                                    with
                                 | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
+                                | Ok annotation ->
+                                    match Annotation.validate annotation with
+                                    | Ok () -> return Ok annotation
+                                    | Error errors -> return Error(annotationError correlationId (String.Join(" ", errors)))
         }
 
     /// Coordinates process command with post success processing for Grace Server.
@@ -1050,46 +1119,6 @@ module Branch =
         task {
             let branchActorProxy = Branch.CreateActorProxy referenceDto.BranchId referenceDto.RepositoryId correlationId
             return! branchActorProxy.Get correlationId
-        }
-
-    /// Orders non-deleted references newest-first so public windows can refill past deleted rows before applying MaxCount.
-    let internal activeReferencesLatestFirst (references: Reference.ReferenceDto seq) =
-        references
-            .Where(fun referenceDto -> referenceDto.DeletedAt.IsNone)
-            .OrderByDescending(fun referenceDto -> referenceDto.CreatedAt)
-            .ToArray()
-
-    /// Filters references for one already-authorized branch without reloading branch authority for every returned row.
-    let internal filterVisibleReferenceWindowForBranch (context: HttpContext) (branchDto: BranchDto) maxCount (references: Reference.ReferenceDto seq) =
-        task {
-            if maxCount = 0 then
-                return Array.empty<Reference.ReferenceDto>
-            else
-                let visibleReferences = List<Reference.ReferenceDto>()
-                let latestFirst = activeReferencesLatestFirst references
-
-                let mutable index = 0
-
-                let mutable keepScanning =
-                    index < latestFirst.Length
-                    && (maxCount < 0 || visibleReferences.Count < maxCount)
-
-                while keepScanning do
-                    let referenceDto = latestFirst[index]
-                    let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
-
-                    if isObservable then visibleReferences.Add referenceDto
-
-                    index <- index + 1
-
-                    keepScanning <-
-                        index < latestFirst.Length
-                        && (maxCount < 0 || visibleReferences.Count < maxCount)
-
-                return
-                    visibleReferences
-                        .OrderBy(fun referenceDto -> referenceDto.CreatedAt)
-                        .ToArray()
         }
 
     /// Chooses the maximum bounded reference-history scan size for a public reference window.
@@ -3386,44 +3415,34 @@ module Branch =
             | None -> () // This should never happen because it would get caught in validations.
         }
 
-    /// Implements update parameters from reference for the server request pipeline.
-    let private updateParametersFromReference
+    /// Updates getVersion branch routing from ReferenceId only when that reference is observable to the caller.
+    let private updateParametersFromObservableReference
         (context: HttpContext)
         (parameters: GetBranchVersionParameters)
         (repositoryIdResolved: Guid)
         (correlationId: CorrelationId)
         =
         task {
-            logToConsole $"In Branch.GetVersion: parameters.ReferenceId: {parameters.ReferenceId}"
-            let referenceGuid = Guid.Parse(parameters.ReferenceId)
-            let referenceActorProxy = Reference.CreateActorProxy referenceGuid repositoryIdResolved correlationId
+            let mutable referenceGuid = Guid.Empty
 
-            let! referenceDto = referenceActorProxy.Get(getCorrelationId context)
-            logToConsole $"referenceDto.ReferenceId: {referenceDto.ReferenceId}"
-            parameters.BranchId <- $"{referenceDto.BranchId}"
-        }
+            if
+                Guid.TryParse(parameters.ReferenceId, &referenceGuid)
+                && referenceGuid <> Guid.Empty
+            then
+                let referenceActorProxy = Reference.CreateActorProxy referenceGuid repositoryIdResolved correlationId
+                let! referenceDto = referenceActorProxy.Get correlationId
 
-    /// Implements update parameters from sha for the server request pipeline.
-    let private updateParametersFromSha (parameters: GetBranchVersionParameters) (repositoryIdFromRoute: Guid) (graceIds: GraceIds) =
-        task {
-            logToConsole $"In Branch.GetVersion: parameters.Sha256Hash: {parameters.Sha256Hash}"
+                if referenceDto.ReferenceId <> ReferenceId.Empty then
+                    let branchActorProxy = Branch.CreateActorProxy referenceDto.BranchId referenceDto.RepositoryId correlationId
+                    let! branchDto = branchActorProxy.Get correlationId
+                    let! isObservable = canObserveReferenceInBranch context branchDto referenceDto
 
-            let! referenceResult = getReferenceBySha256Hash repositoryIdFromRoute graceIds.BranchId parameters.Sha256Hash
-
-            match referenceResult with
-            | Some referenceDto ->
-                logToConsole $"referenceDto.ReferenceId: {referenceDto.ReferenceId}"
-                parameters.BranchId <- $"{referenceDto.BranchId}"
-            | None ->
-                // Reference Id was not found in the database.
-                ()
+                    if isObservable then parameters.BranchId <- $"{referenceDto.BranchId}"
         }
 
     /// Implements update parameters for repository id option for the server request pipeline.
     let private updateParametersForRepositoryIdOption
         (context: HttpContext)
-        (graceIds: GraceIds)
-        (repositoryIdFromRoute: Guid)
         (correlationId: CorrelationId)
         (parameters: GetBranchVersionParameters)
         (repositoryIdOption: Guid option)
@@ -3441,9 +3460,7 @@ module Branch =
                 not
                 <| String.IsNullOrEmpty(parameters.ReferenceId)
             then
-                updateParametersFromReference context parameters repositoryIdResolved correlationId
-            elif not <| String.IsNullOrEmpty(parameters.Sha256Hash) then
-                updateParametersFromSha parameters repositoryIdFromRoute graceIds
+                updateParametersFromObservableReference context parameters repositoryIdResolved correlationId
             else
                 Task.FromResult(())
 
@@ -3452,7 +3469,6 @@ module Branch =
         task {
             let graceIds = getGraceIds context
             let correlationId = getCorrelationId context
-            let repositoryIdFromRoute = graceIds.RepositoryId
 
             let! parameters = context |> parse<GetBranchVersionParameters>
             context.Items[ callerSuppliedBranchIdItemKey ] <- parameters.BranchId
@@ -3460,7 +3476,7 @@ module Branch =
             let! repositoryIdOption =
                 resolveRepositoryId graceIds.OwnerId graceIds.OrganizationId parameters.RepositoryId parameters.RepositoryName parameters.CorrelationId
 
-            do! updateParametersForRepositoryIdOption context graceIds repositoryIdFromRoute correlationId parameters repositoryIdOption
+            do! updateParametersForRepositoryIdOption context correlationId parameters repositoryIdOption
 
             // Now that we've populated BranchId for sure...
             context.Items.Add("GetVersionParameters", parameters)


### PR DESCRIPTION
## Why this matters

Part of #647.

Branch traversal routes can leak private file names, hashes, ancestry, and annotation context if they resolve raw references before applying visibility. This change keeps traversal-oriented branch responses aligned with the visible-reference graph so public callers cannot use known hidden refs or roots as an oracle.

## Changes

- Gates annotation target references through selected-branch visibility before loading file contents or history.
- Filters local annotation history and stored `BasedOn` refill history to visible references before materialization.
- Keeps `getVersion` reference-only branch routing for visible references while avoiding raw hidden reference or hash branch mutation.
- Adds BranchServer integration coverage for hidden `ReferenceId` `getVersion` traversal and hidden target annotation materialization.

## Touched paths

- `src/Grace.Server/Branch.Server.fs`
- `src/Grace.Server.Tests/Branch.Server.Tests.fs`

## Validation

- `dotnet tool run fantomas src/Grace.Server/Branch.Server.fs src/Grace.Server.Tests/Branch.Server.Tests.fs`
- `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj` - passed, 0 warnings, 0 errors
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter "FullyQualifiedName~BranchServer"` - passed, 38/38
- `pwsh ./scripts/validate.ps1 -Fast` - passed

## Review Status

- Current head: `72fc58dffd68cc73de4e8775a88b0412f6b091f7`.
- Prior head validation: `pwsh ./scripts/validate.ps1 -Fast` passed on `62f2d3f200e791d30a99056c945e6aad5f27e2bf` before PR open.
- Current-head review fix: `PRRT_kwDOILVrb86PGTzW` fixed by checking annotate target-reference repository/branch ownership before visibility evaluation, preserving hidden-as-missing behavior for cross-branch target references.
- Review thread disposition: replied with fix evidence and resolved after `72fc58df` was pushed.
- Current-head focused validation:
  - `dotnet tool run fantomas src/Grace.Server/Branch.Server.fs src/Grace.Server.Tests/Branch.Server.Tests.fs`: passed.
  - `git diff --check`: passed.
  - `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj`: passed.
  - `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter FullyQualifiedName~AnnotateWithHiddenTargetReferenceDoesNotExposePrivateHistory`: passed; teardown cleanup cancellation messages appeared after pass.
- Current-head GitHub Actions: `full` run `28913056045`, job `85774264418`, passed.
- Current-head Codex Code Review Bot: latest-head thumbs-up on `72fc58df`; no fresh review threads.
- Completion gate: merge state `CLEAN`; full validation passed; latest-head Codex result has no issues; unresolved review thread count is zero.
- Manual trigger decision: not attempted.
- Manual trigger lock: no manual trigger may be used while bot state is pending, acknowledged with eyes, completed with no-issues, or ambiguous. Use `pwsh ./scripts/guard-codex-review-trigger.ps1 -PullRequest 676` only if the documented missed-ack exception is reached.
- Substantive review cycle count: 1.
- Final no-issues state: satisfied for PR #676.

## Docs impact

No docs update. This hardens existing server route behavior without adding public parameters, changing CLI/SDK shape, or changing documented visible public traversal output.

## Residual risks

- The focused integration test run logged teardown cleanup cancellation messages after passing; the process exited successfully.
- Full Aspire integration profile was not run because the change is route-local visibility hardening and `validate -Fast` was the requested final gate.
