### PR TITLE
WS7.4.1: Enforce current-branch notification latest authority

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13578,6 +13578,124 @@ module WatchTests =
             Watch.currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests { payload with BranchId = Guid.NewGuid() }
             |> should equal false)
 
+    let private referenceDtoForCurrentBranchNotification (payload: CurrentBranchReferenceNotification) =
+        { ReferenceDto.Default with
+            ReferenceId = payload.ReferenceId
+            OwnerId = payload.OwnerId
+            OrganizationId = payload.OrganizationId
+            RepositoryId = payload.RepositoryId
+            BranchId = payload.BranchId
+            DirectoryId = payload.DirectoryId
+            Sha256Hash = payload.Sha256Hash
+            Blake3Hash = payload.Blake3Hash
+            ReferenceType = payload.ReferenceType
+            ReferenceText = payload.ReferenceText
+        }
+
+    let private branchDtoWithLatestCurrentBranchReference (payload: CurrentBranchReferenceNotification) =
+        let referenceDto = referenceDtoForCurrentBranchNotification payload
+        let branchDto = { Grace.Types.Branch.BranchDto.Default with RepositoryId = payload.RepositoryId; BranchId = payload.BranchId }
+
+        match payload.ReferenceType with
+        | ReferenceType.Save -> { branchDto with LatestSave = referenceDto; LatestReference = referenceDto }
+        | ReferenceType.Checkpoint -> { branchDto with LatestCheckpoint = referenceDto; LatestReference = referenceDto }
+        | ReferenceType.Commit -> { branchDto with LatestCommit = referenceDto; LatestReference = referenceDto }
+        | _ -> branchDto
+
+    let private validCurrentBranchReferenceNotification repositoryId branchId referenceType rootDirectoryId rootSha256Hash rootBlake3Hash =
+        { CurrentBranchReferenceNotification.Default with
+            RepositoryId = repositoryId
+            BranchId = branchId
+            BranchName = BranchName "current-branch"
+            ReferenceId = Guid.NewGuid()
+            DirectoryId = rootDirectoryId
+            Sha256Hash = rootSha256Hash
+            Blake3Hash = rootBlake3Hash
+            ReferenceType = referenceType
+        }
+
+    /// Verifies that protocol-invalid current-branch notifications are rejected before BranchDto latest authority.
+    [<Test>]
+    let ``current branch reference decision rejects missing root identity and empty reference id`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let validPayload =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let branchDto = branchDtoWithLatestCurrentBranchReference validPayload
+
+            let assertRejected expectedReason payload =
+                let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto payload
+
+                decision.NeedsMaterialization
+                |> should equal false
+
+                decision.Reason |> should equal expectedReason
+
+            assertRejected
+                Services.LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable
+                { validPayload with DirectoryId = DirectoryVersionId.Empty }
+
+            assertRejected
+                Services.LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable
+                { validPayload with Sha256Hash = Sha256Hash String.Empty }
+
+            assertRejected
+                Services.LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable
+                { validPayload with Blake3Hash = Blake3Hash String.Empty }
+
+            assertRejected Services.LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable { validPayload with ReferenceId = ReferenceId.Empty })
+
+    /// Verifies that current-branch notification handling reads BranchDto before local status for concrete payloads.
+    [<Test>]
+    let ``current branch reference handler fetches BranchDto before local status for valid notifications`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let payload =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let calls = ResizeArray<string>()
+            let branchDto = branchDtoWithLatestCurrentBranchReference payload
+
+            let getBranch () =
+                task {
+                    calls.Add("branch")
+                    return Ok(GraceReturnValue.Create branchDto "branch-fetch-before-status")
+                }
+
+            let readLocalStatus () =
+                task {
+                    calls.Add("status")
+                    return Some status
+                }
+
+            let decision =
+                (Watch.handleCurrentBranchReferenceNotificationWithClientsForWatchTests getBranch readLocalStatus payload)
+                    .Result
+
+            decision
+            |> Option.map (fun result -> result.Reason)
+            |> should equal (Some Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired)
+
+            calls.ToArray()
+            |> should equal [| "branch"; "status" |])
+
     /// Verifies that same-root same-branch References do not schedule remote materialization.
     [<Test>]
     let ``latest current branch decision no-ops when remote root matches local status`` () =
@@ -13597,7 +13715,9 @@ module WatchTests =
                     ReferenceType = ReferenceType.Save
                 }
 
-            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) [| payload |]
+            let branchDto = branchDtoWithLatestCurrentBranchReference payload
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto payload
 
             decision.NeedsMaterialization
             |> should equal false
@@ -13609,60 +13729,106 @@ module WatchTests =
             |> Option.map (fun reference -> reference.ReferenceId)
             |> should equal (Some payload.ReferenceId))
 
-    /// Verifies that the helper chooses the latest applicable current-branch Reference without scans or remote lookups.
+    /// Verifies that BranchDto latest authority, not notification arrival order, selects the materializable Reference.
     [<Test>]
-    let ``latest current branch decision collapses notifications to latest applicable reference`` () =
+    let ``latest current branch decision drops older notification even when it arrives last`` () =
         withTempRepo (fun root ->
             let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
             let status = liveWatchStatus (Guid.NewGuid())
 
-            let olderApplicable =
-                { CurrentBranchReferenceNotification.Default with
-                    RepositoryId = currentRepositoryId
-                    BranchId = currentBranchId
-                    ReferenceId = Guid.NewGuid()
-                    DirectoryId = Guid.NewGuid()
-                    Sha256Hash = Sha256Hash "older-root"
-                    Blake3Hash = Blake3Hash "older-root-blake3"
-                    ReferenceType = ReferenceType.Save
-                }
-
-            let staleBranch =
-                { olderApplicable with
-                    ReferenceId = Guid.NewGuid()
-                    BranchId = Guid.NewGuid()
-                    DirectoryId = Guid.NewGuid()
-                    Sha256Hash = Sha256Hash "stale-branch-root"
-                    Blake3Hash = Blake3Hash "stale-branch-root-blake3"
-                }
-
-            let latestApplicable =
-                { olderApplicable with
-                    ReferenceId = Guid.NewGuid()
-                    DirectoryId = Guid.NewGuid()
-                    Sha256Hash = Sha256Hash "latest-root"
-                    Blake3Hash = Blake3Hash "latest-root-blake3"
-                }
-
-            let decision =
-                Services.decideLatestCurrentBranchReferenceMaterialization
+            let olderNotification =
+                validCurrentBranchReferenceNotification
                     currentRepositoryId
                     currentBranchId
-                    (Some status)
-                    [|
-                        olderApplicable
-                        staleBranch
-                        latestApplicable
-                    |]
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "older-root")
+                    (Blake3Hash "older-root-blake3")
 
-            decision.NeedsMaterialization |> should equal true
+            let newerNotification =
+                { olderNotification with
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "newer-root"
+                    Blake3Hash = Blake3Hash "newer-root-blake3"
+                }
+
+            let branchDto = branchDtoWithLatestCurrentBranchReference newerNotification
+
+            let decision =
+                Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto olderNotification
+
+            decision.NeedsMaterialization
+            |> should equal false
 
             decision.Reason
-            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
 
             decision.Reference
             |> Option.map (fun reference -> reference.ReferenceId)
-            |> should equal (Some latestApplicable.ReferenceId))
+            |> should equal (Some olderNotification.ReferenceId))
+
+    /// Verifies that a BranchDto latest mismatch drops the notification even when root values appear materializable.
+    [<Test>]
+    let ``latest current branch decision drops BranchDto latest mismatch as stale`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let branchDto = branchDtoWithLatestCurrentBranchReference { notification with ReferenceId = Guid.NewGuid() }
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto notification
+
+            decision.NeedsMaterialization
+            |> should equal false
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference)
+
+    /// Verifies that returning to an older root value is accepted only through the newer BranchDto latest Reference id.
+    [<Test>]
+    let ``latest current branch decision accepts newer reference that returns to older root value`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let olderRootId = Guid.NewGuid()
+            let olderRootSha256 = Sha256Hash "older-returned-root"
+            let olderRootBlake3 = Blake3Hash "older-returned-root-blake3"
+
+            let olderNotification =
+                validCurrentBranchReferenceNotification currentRepositoryId currentBranchId ReferenceType.Commit olderRootId olderRootSha256 olderRootBlake3
+
+            let newerNotification = { olderNotification with ReferenceId = Guid.NewGuid() }
+
+            let branchDto = branchDtoWithLatestCurrentBranchReference newerNotification
+
+            let staleDecision =
+                Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto olderNotification
+
+            staleDecision.NeedsMaterialization
+            |> should equal false
+
+            staleDecision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
+
+            let acceptedDecision =
+                Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto newerNotification
+
+            acceptedDecision.NeedsMaterialization
+            |> should equal true
+
+            acceptedDecision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired)
 
     /// Verifies that root-hash equality is enough to make a deterministic no-op decision.
     [<Test>]
@@ -13682,7 +13848,9 @@ module WatchTests =
                     ReferenceType = ReferenceType.Checkpoint
                 }
 
-            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) [| payload |]
+            let branchDto = branchDtoWithLatestCurrentBranchReference payload
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto payload
 
             decision.NeedsMaterialization
             |> should equal false
@@ -13712,7 +13880,9 @@ module WatchTests =
                     ReferenceType = ReferenceType.Commit
                 }
 
-            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) [| payload |]
+            let branchDto = branchDtoWithLatestCurrentBranchReference payload
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto payload
 
             decision.NeedsMaterialization
             |> should equal false

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13578,6 +13578,7 @@ module WatchTests =
             Watch.currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests { payload with BranchId = Guid.NewGuid() }
             |> should equal false)
 
+    /// Builds the ReferenceDto authority shape that BranchDto latest fields expose for Watch notification decisions.
     let private referenceDtoForCurrentBranchNotification (payload: CurrentBranchReferenceNotification) =
         { ReferenceDto.Default with
             ReferenceId = payload.ReferenceId
@@ -13592,6 +13593,7 @@ module WatchTests =
             ReferenceText = payload.ReferenceText
         }
 
+    /// Builds a BranchDto whose overall and per-type latest Reference authorities agree on the supplied notification.
     let private branchDtoWithLatestCurrentBranchReference (payload: CurrentBranchReferenceNotification) =
         let referenceDto = referenceDtoForCurrentBranchNotification payload
         let branchDto = { Grace.Types.Branch.BranchDto.Default with RepositoryId = payload.RepositoryId; BranchId = payload.BranchId }
@@ -13602,6 +13604,21 @@ module WatchTests =
         | ReferenceType.Commit -> { branchDto with LatestCommit = referenceDto; LatestReference = referenceDto }
         | _ -> branchDto
 
+    /// Builds a BranchDto where a delayed per-type notification is older than the branch's overall latest Reference.
+    let private branchDtoWithPerTypeLatestAndOverallLatest
+        (perTypePayload: CurrentBranchReferenceNotification)
+        (overallLatestPayload: CurrentBranchReferenceNotification)
+        =
+        let perTypeReferenceDto = referenceDtoForCurrentBranchNotification perTypePayload
+        let branchDto = branchDtoWithLatestCurrentBranchReference overallLatestPayload
+
+        match perTypePayload.ReferenceType with
+        | ReferenceType.Save -> { branchDto with LatestSave = perTypeReferenceDto }
+        | ReferenceType.Checkpoint -> { branchDto with LatestCheckpoint = perTypeReferenceDto }
+        | ReferenceType.Commit -> { branchDto with LatestCommit = perTypeReferenceDto }
+        | _ -> branchDto
+
+    /// Creates a concrete current-branch Reference notification with complete remote root identity.
     let private validCurrentBranchReferenceNotification repositoryId branchId referenceType rootDirectoryId rootSha256Hash rootBlake3Hash =
         { CurrentBranchReferenceNotification.Default with
             RepositoryId = repositoryId
@@ -13768,6 +13785,91 @@ module WatchTests =
             |> Option.map (fun reference -> reference.ReferenceId)
             |> should equal (Some olderNotification.ReferenceId))
 
+    /// Verifies that an older Save is stale when the branch head has advanced to a newer Checkpoint.
+    [<Test>]
+    let ``latest current branch decision drops older save after newer checkpoint overall latest`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let olderSaveNotification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "older-save-root")
+                    (Blake3Hash "older-save-root-blake3")
+
+            let newerCheckpointNotification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "newer-checkpoint-root")
+                    (Blake3Hash "newer-checkpoint-root-blake3")
+
+            let branchDto = branchDtoWithPerTypeLatestAndOverallLatest olderSaveNotification newerCheckpointNotification
+
+            let decision =
+                Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto olderSaveNotification
+
+            decision.NeedsMaterialization
+            |> should equal false
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
+
+            decision.Reference
+            |> Option.map (fun reference -> reference.ReferenceId)
+            |> should equal (Some olderSaveNotification.ReferenceId))
+
+    /// Verifies that an older Checkpoint is stale when the branch head has advanced to a newer Commit.
+    [<Test>]
+    let ``latest current branch decision drops older checkpoint after newer commit overall latest`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let olderCheckpointNotification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "older-checkpoint-root")
+                    (Blake3Hash "older-checkpoint-root-blake3")
+
+            let newerCommitNotification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "newer-commit-root")
+                    (Blake3Hash "newer-commit-root-blake3")
+
+            let branchDto = branchDtoWithPerTypeLatestAndOverallLatest olderCheckpointNotification newerCommitNotification
+
+            let decision =
+                Services.decideLatestCurrentBranchReferenceMaterialization
+                    currentRepositoryId
+                    currentBranchId
+                    (Some status)
+                    branchDto
+                    olderCheckpointNotification
+
+            decision.NeedsMaterialization
+            |> should equal false
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
+
+            decision.Reference
+            |> Option.map (fun reference -> reference.ReferenceId)
+            |> should equal (Some olderCheckpointNotification.ReferenceId))
+
     /// Verifies that a BranchDto latest mismatch drops the notification even when root values appear materializable.
     [<Test>]
     let ``latest current branch decision drops BranchDto latest mismatch as stale`` () =
@@ -13793,6 +13895,35 @@ module WatchTests =
 
             decision.Reason
             |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference)
+
+    /// Verifies that BranchDto overall latest and per-type latest agreement allows a complete notification to proceed.
+    [<Test>]
+    let ``latest current branch decision proceeds when overall latest matches notification reference`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "matching-overall-root")
+                    (Blake3Hash "matching-overall-root-blake3")
+
+            let branchDto = branchDtoWithLatestCurrentBranchReference notification
+
+            let decision = Services.decideLatestCurrentBranchReferenceMaterialization currentRepositoryId currentBranchId (Some status) branchDto notification
+
+            decision.NeedsMaterialization |> should equal true
+
+            decision.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired
+
+            decision.Reference
+            |> Option.map (fun reference -> reference.ReferenceId)
+            |> should equal (Some notification.ReferenceId))
 
     /// Verifies that returning to an older root value is accepted only through the newer BranchDto latest Reference id.
     [<Test>]

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -520,7 +520,7 @@ module Services =
         | RemoteMaterializationRequired = 6
         /// The supplied Reference notification did not include a concrete Reference id.
         | ReferenceIdUnavailable = 7
-        /// The server BranchDto no longer names the notification Reference as latest for its Reference type.
+        /// The server BranchDto no longer names the notification Reference as both overall and per-type latest.
         | StaleLatestReference = 8
 
     /// Carries the Watch decision for the latest applicable current-branch Reference notification.
@@ -556,13 +556,19 @@ module Services =
         || (status.RootDirectorySha256Hash = payload.Sha256Hash
             && status.RootDirectoryBlake3Hash = payload.Blake3Hash)
 
-    /// Selects the BranchDto latest-reference authority that must match a current-branch notification.
-    let private latestReferenceForCurrentBranchNotification (branchDto: Grace.Types.Branch.BranchDto) referenceType =
+    /// Selects the BranchDto per-type latest-reference authority that must agree with a current-branch notification.
+    let private latestTypedReferenceForCurrentBranchNotification (branchDto: Grace.Types.Branch.BranchDto) referenceType =
         match referenceType with
         | ReferenceType.Save -> Some branchDto.LatestSave
         | ReferenceType.Checkpoint -> Some branchDto.LatestCheckpoint
         | ReferenceType.Commit -> Some branchDto.LatestCommit
         | _ -> None
+
+    /// Reports whether BranchDto latest-reference authority still names the notification as the branch head.
+    let private currentBranchNotificationMatchesLatestReferenceAuthority (branchDto: Grace.Types.Branch.BranchDto) payload =
+        branchDto.LatestReference.ReferenceId = payload.ReferenceId
+        && (latestTypedReferenceForCurrentBranchNotification branchDto payload.ReferenceType
+            |> Option.exists (fun latestTypedReference -> latestTypedReference.ReferenceId = payload.ReferenceId))
 
     /// Rejects current-branch notifications that cannot safely wake same-branch materialization.
     let currentBranchReferenceProtocolValidationDecision repositoryId branchId (payload: CurrentBranchReferenceNotification) =
@@ -586,13 +592,9 @@ module Services =
         match currentBranchReferenceProtocolValidationDecision repositoryId branchId payload with
         | Some decision -> decision
         | None ->
-            let latestReference = latestReferenceForCurrentBranchNotification branchDto payload.ReferenceType
-
-            match latestReference with
-            | None -> LatestCurrentBranchReferenceDecision.NoApplicableReference
-            | Some latestReference when latestReference.ReferenceId <> payload.ReferenceId ->
+            if not (currentBranchNotificationMatchesLatestReferenceAuthority branchDto payload) then
                 LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.StaleLatestReference, payload)
-            | Some _ ->
+            else
                 match localStatus with
                 | None -> LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.LocalStatusUnavailable, payload)
                 | Some status when

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -518,6 +518,10 @@ module Services =
         | SameRoot = 5
         /// The remote Reference is the latest applicable current-branch Reference and differs from the local root.
         | RemoteMaterializationRequired = 6
+        /// The supplied Reference notification did not include a concrete Reference id.
+        | ReferenceIdUnavailable = 7
+        /// The server BranchDto no longer names the notification Reference as latest for its Reference type.
+        | StaleLatestReference = 8
 
     /// Carries the Watch decision for the latest applicable current-branch Reference notification.
     type LatestCurrentBranchReferenceDecision =
@@ -530,6 +534,9 @@ module Services =
         /// Defines the deterministic no-reference decision used when all candidates are stale or unsupported.
         static member NoApplicableReference =
             { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.NoApplicableReference; Reference = None }
+
+        /// Defines a rejected notification decision with the rejected payload preserved for diagnostics.
+        static member Rejected(reason, payload) = { NeedsMaterialization = false; Reason = reason; Reference = Some payload }
 
     /// Reports whether a current-branch Reference notification has enough root identity for a deterministic decision.
     let private currentBranchReferenceHasRootIdentity (payload: CurrentBranchReferenceNotification) =
@@ -549,40 +556,60 @@ module Services =
         || (status.RootDirectorySha256Hash = payload.Sha256Hash
             && status.RootDirectoryBlake3Hash = payload.Blake3Hash)
 
-    /// Chooses whether the latest applicable current-branch Reference requires remote materialization.
+    /// Selects the BranchDto latest-reference authority that must match a current-branch notification.
+    let private latestReferenceForCurrentBranchNotification (branchDto: Grace.Types.Branch.BranchDto) referenceType =
+        match referenceType with
+        | ReferenceType.Save -> Some branchDto.LatestSave
+        | ReferenceType.Checkpoint -> Some branchDto.LatestCheckpoint
+        | ReferenceType.Commit -> Some branchDto.LatestCommit
+        | _ -> None
+
+    /// Rejects current-branch notifications that cannot safely wake same-branch materialization.
+    let currentBranchReferenceProtocolValidationDecision repositoryId branchId (payload: CurrentBranchReferenceNotification) =
+        if not (currentBranchReferenceAppliesToWatch repositoryId branchId payload) then
+            Some LatestCurrentBranchReferenceDecision.NoApplicableReference
+        elif payload.ReferenceId = ReferenceId.Empty then
+            Some(LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable, payload))
+        elif not (currentBranchReferenceHasRootIdentity payload) then
+            Some(LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable, payload))
+        else
+            None
+
+    /// Chooses whether a BranchDto-confirmed current-branch Reference requires remote materialization.
     let decideLatestCurrentBranchReferenceMaterialization
         repositoryId
         branchId
         (localStatus: GraceWatchStatus option)
-        (payloads: CurrentBranchReferenceNotification seq)
+        (branchDto: Grace.Types.Branch.BranchDto)
+        (payload: CurrentBranchReferenceNotification)
         =
-        let latestApplicable =
-            payloads
-            |> Seq.filter (currentBranchReferenceAppliesToWatch repositoryId branchId)
-            |> Seq.tryLast
+        match currentBranchReferenceProtocolValidationDecision repositoryId branchId payload with
+        | Some decision -> decision
+        | None ->
+            let latestReference = latestReferenceForCurrentBranchNotification branchDto payload.ReferenceType
 
-        match latestApplicable with
-        | None -> LatestCurrentBranchReferenceDecision.NoApplicableReference
-        | Some payload when not (currentBranchReferenceHasRootIdentity payload) ->
-            { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable; Reference = Some payload }
-        | Some payload ->
-            match localStatus with
-            | None -> { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.LocalStatusUnavailable; Reference = Some payload }
-            | Some status when
-                status.RepositoryId <> repositoryId
-                || status.BranchId <> branchId
-                ->
-                { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.LocalStatusIdentityMismatch; Reference = Some payload }
-            | Some status when
-                status.SafetyFlags
-                |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal))
-                |> not
-                ->
-                { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync; Reference = Some payload }
-            | Some status when currentBranchReferenceMatchesLocalRoot status payload ->
-                { NeedsMaterialization = false; Reason = LatestCurrentBranchReferenceDecisionReason.SameRoot; Reference = Some payload }
+            match latestReference with
+            | None -> LatestCurrentBranchReferenceDecision.NoApplicableReference
+            | Some latestReference when latestReference.ReferenceId <> payload.ReferenceId ->
+                LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.StaleLatestReference, payload)
             | Some _ ->
-                { NeedsMaterialization = true; Reason = LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired; Reference = Some payload }
+                match localStatus with
+                | None -> LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.LocalStatusUnavailable, payload)
+                | Some status when
+                    status.RepositoryId <> repositoryId
+                    || status.BranchId <> branchId
+                    ->
+                    LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.LocalStatusIdentityMismatch, payload)
+                | Some status when
+                    status.SafetyFlags
+                    |> Array.exists (fun safetyFlag -> String.Equals(safetyFlag, "incrementalSafe", StringComparison.Ordinal))
+                    |> not
+                    ->
+                    LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync, payload)
+                | Some status when currentBranchReferenceMatchesLocalRoot status payload ->
+                    LatestCurrentBranchReferenceDecision.Rejected(LatestCurrentBranchReferenceDecisionReason.SameRoot, payload)
+                | Some _ ->
+                    { NeedsMaterialization = true; Reason = LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired; Reference = Some payload }
 
     /// Converts the in-memory Watch status model to the IPC JSON contract written for commands and agents.
     let private toGraceWatchStatusContractWithPersistedMode persistedModeOverride (status: GraceWatchStatus) =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3185,8 +3185,27 @@ module Watch =
         payload.RepositoryId = current.RepositoryId
         && payload.BranchId = current.BranchId
 
-    /// Handles same-branch Reference notifications that later WS7 slices can use for remote materialization.
-    let private handleCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
+    /// Reads the current BranchDto so same-branch notifications are checked against server latest-reference authority.
+    let private getCurrentBranchForCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
+        let current = Current()
+
+        let parameters =
+            GetBranchParameters(
+                OwnerId = $"{current.OwnerId}",
+                OwnerName = current.OwnerName,
+                OrganizationId = $"{current.OrganizationId}",
+                OrganizationName = current.OrganizationName,
+                RepositoryId = $"{current.RepositoryId}",
+                RepositoryName = current.RepositoryName,
+                BranchId = $"{current.BranchId}",
+                BranchName = current.BranchName,
+                CorrelationId = payload.CorrelationId
+            )
+
+        Grace.SDK.Branch.Get parameters
+
+    /// Handles same-branch Reference notifications with injectable readers for focused Watch tests.
+    let private handleCurrentBranchReferenceNotificationWithClients getCurrentBranch readLocalStatus (payload: CurrentBranchReferenceNotification) =
         task {
             try
                 if not
@@ -3194,31 +3213,73 @@ module Watch =
                     logToAnsiConsole
                         Colors.Verbose
                         $"Skipped current-branch reference notification {payload.ReferenceId} because it targets repository {payload.RepositoryId}, branch {payload.BranchId}, not current branch {Current().BranchId}."
+
+                    return None
                 else
                     let current = Current()
-                    let! localStatus = getGraceWatchStatus ()
 
-                    let decision = decideLatestCurrentBranchReferenceMaterialization current.RepositoryId current.BranchId localStatus [| payload |]
-
-                    match decision.Reason with
-                    | LatestCurrentBranchReferenceDecisionReason.SameRoot ->
+                    match currentBranchReferenceProtocolValidationDecision current.RepositoryId current.BranchId payload with
+                    | Some decision ->
                         logToAnsiConsole
                             Colors.Verbose
-                            $"Skipped current-branch reference notification {payload.ReferenceId} because local Watch status already has root {payload.DirectoryId}."
-                    | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
-                        logToAnsiConsole
-                            Colors.Highlighted
-                            $"Current-branch reference notification {payload.ReferenceId} requires remote materialization for root {payload.DirectoryId}."
-                    | reason ->
-                        logToAnsiConsole
-                            Colors.Verbose
-                            $"Skipped current-branch reference notification {payload.ReferenceId} because latest-current-branch decision was {reason}."
+                            $"Skipped current-branch reference notification {payload.ReferenceId} because protocol validation was {decision.Reason}."
+
+                        return Some decision
+                    | None ->
+                        match! getCurrentBranch () with
+                        | Error error ->
+                            let errorText = Markup.Escape(error.ToString())
+
+                            logToAnsiConsole
+                                Colors.Error
+                                $"Failed to refresh BranchDto for current-branch reference notification {payload.ReferenceId}: {errorText}."
+
+                            return None
+                        | Ok branchReturnValue ->
+                            let branchDto = branchReturnValue.ReturnValue
+                            let! localStatus = readLocalStatus ()
+
+                            let decision = decideLatestCurrentBranchReferenceMaterialization current.RepositoryId current.BranchId localStatus branchDto payload
+
+                            match decision.Reason with
+                            | LatestCurrentBranchReferenceDecisionReason.SameRoot ->
+                                logToAnsiConsole
+                                    Colors.Verbose
+                                    $"Skipped current-branch reference notification {payload.ReferenceId} because local Watch status already has root {payload.DirectoryId}."
+                            | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
+                                logToAnsiConsole
+                                    Colors.Highlighted
+                                    $"Current-branch reference notification {payload.ReferenceId} requires remote materialization for root {payload.DirectoryId}."
+                            | reason ->
+                                logToAnsiConsole
+                                    Colors.Verbose
+                                    $"Skipped current-branch reference notification {payload.ReferenceId} because latest-current-branch decision was {reason}."
+
+                            return Some decision
             with
-            | ex -> logToAnsiConsole Colors.Error $"Failed to process current-branch reference notification {payload.ReferenceId}: {Markup.Escape(ex.Message)}."
+            | ex ->
+                logToAnsiConsole Colors.Error $"Failed to process current-branch reference notification {payload.ReferenceId}: {Markup.Escape(ex.Message)}."
+                return None
+        }
+
+    /// Handles same-branch Reference notifications that later WS7 slices can use for remote materialization.
+    let private handleCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
+        task {
+            let! _ =
+                handleCurrentBranchReferenceNotificationWithClients
+                    (fun () -> getCurrentBranchForCurrentBranchReferenceNotification payload)
+                    getGraceWatchStatus
+                    payload
+
+            return ()
         }
 
     /// Exposes same-branch Reference notification identity matching to Watch tests without opening a HubConnection.
     let internal currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests payload = currentBranchReferenceNotificationTargetsCurrentBranch payload
+
+    /// Exposes same-branch Reference notification handling to Watch tests without opening a HubConnection.
+    let internal handleCurrentBranchReferenceNotificationWithClientsForWatchTests getCurrentBranch readLocalStatus payload =
+        handleCurrentBranchReferenceNotificationWithClients getCurrentBranch readLocalStatus payload
 
     /// Registers SignalR branch groups only after the local refresh still has authority for the active branch.
     let private registerCurrentSignalRParentBranchWithClients


### PR DESCRIPTION
## Summary

Implements #678 as the first leaf of the #677 WS7.4 replacement mini-epic.

This PR makes same-branch current Reference materialization notifications strict triggers instead of latest authority. A notification can proceed only when it has a concrete `ReferenceId`, full root identity, and a freshly fetched BranchDto whose appropriate `Latest*` Reference id matches the notification Reference id.

Related to #678.
Part of #677, #479, and #473.

## Scope

- Rejects protocol-invalid notification inputs before the decision helper can proceed.
- Fetches current BranchDto before the local Watch status / next-step decision path.
- Compares notification Reference id to BranchDto `LatestSave`, `LatestCheckpoint`, or `LatestCommit` as appropriate.
- Drops BranchDto-latest mismatches as stale notifications.
- Leaves file materialization, publication, persistence, retry, and working-tree mutation to later #677 leaves.

## Proof Map

- Missing root DirectoryVersion id is rejected as `ReferenceRootIdentityUnavailable`.
- Missing SHA-256 root hash is rejected as `ReferenceRootIdentityUnavailable`.
- Missing Blake3 root hash is rejected as `ReferenceRootIdentityUnavailable`.
- `ReferenceId.Empty` is rejected as `ReferenceIdUnavailable`.
- Concrete full-root notifications fetch BranchDto before local status / next-step decision work.
- BranchDto latest match allows the existing state machine decision to proceed to `RemoteMaterializationRequired` or `SameRoot`.
- BranchDto latest mismatch drops as `StaleLatestReference` without retry or materialization.
- Older notification arrival order cannot override BranchDto latest authority.
- A newer valid Reference can return to an older root when BranchDto latest points to that Reference id.

## Validation

- Passed: `dotnet tool run fantomas -- 'src/Grace.CLI/Command/Services.CLI.fs' 'src/Grace.CLI/Command/Watch.CLI.fs' 'src/Grace.CLI.Tests/Watch.Tests.fs'`.
- Passed: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`.
- Passed: `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter 'FullyQualifiedName~WatchTests'`.
  - Result: 261/261 passed.
- Passed: `git diff --check`.

## Review Status

- Current head: `22cd0fdb80f34987c37f39d6c14a84d41e169925`.
- Session 1 findings `3542526297` and `3542526306` were fixed in `22cd0fdb80f34987c37f39d6c14a84d41e169925`, replied to, and resolved.
- GitHub `full`: running on current head.
- Codex Code Review Bot: acknowledged current head with 👀; awaiting completed review on current head.
- Substantive review cycle count: 1.
- Review session count: 1.
- Maintainer decision: approved the cross-type authority rule. BranchDto overall latest Reference authority wins over per-type latest authority for same-branch materialization eligibility.
- Stabilization threshold: because this touches Watch state and current-branch authority, start a stabilization pass after two substantive cycles; after three substantive cycles, stop coding until maintainer approval of the revised issue/ledger.
- Domain-decision stop rule: stop immediately if a future review finding appears to require a new domain construct, authority source, durable state, retry policy, stale/retirement rule, public contract, or materialization-domain concept not already named in #678/#677.

## Out Of Scope

- File materialization.
- Persisted notification payloads.
- Broad scans or marker-window scans.
- Working-tree mutation or publication behavior.
- Local Save creation.
- `CurrentBranchMaterializationAuthority`, stale-root ledgers, anonymous stale-root credits, root-history credits, or any new materialization-domain construct.
