### PR TITLE
GC-07: Implement Direct materialization plan generation

### DIFF
--- a/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
@@ -4,8 +4,12 @@ open Grace.Actors.DirectoryVersion
 open Grace.Server
 open Grace.Shared
 open Grace.Shared.Parameters.Materialization
+open Grace.Types.Branch
 open Grace.Types.Common
+open Grace.Types.DirectoryVersion
 open Grace.Types.MaterializationPlan
+open Grace.Types.Reference
+open Grace.Types.Repository
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -19,6 +23,13 @@ type MaterializationPlanRouteTests() =
 
     let targetRootDirectoryVersionId = DirectoryVersionId.Parse "11111111-1111-1111-1111-111111111111"
     let repositoryId = RepositoryId.Parse "22222222-2222-2222-2222-222222222222"
+    let explicitBranchId = BranchId.Parse "33333333-3333-3333-3333-333333333333"
+    let defaultBranchId = BranchId.Parse "44444444-4444-4444-4444-444444444444"
+    let referenceId = ReferenceId.Parse "55555555-5555-5555-5555-555555555555"
+    let ownerId = OwnerId.Parse "66666666-6666-6666-6666-666666666666"
+    let organizationId = OrganizationId.Parse "77777777-7777-7777-7777-777777777777"
+    let defaultBranchName = BranchName Constants.InitialBranchName
+    let explicitBranchName = BranchName "feature"
     let correlationId = "corr-materialization-plan"
 
     /// Builds a Direct/Bypass request for a resolved immutable root.
@@ -66,14 +77,45 @@ type MaterializationPlanRouteTests() =
     let directoryVersion directoryVersionId directoryRepositoryId (relativePath: string) =
         Grace.Types.Common.DirectoryVersion.Create
             directoryVersionId
-            (OwnerId.Parse "44444444-4444-4444-4444-444444444444")
-            (OrganizationId.Parse "55555555-5555-5555-5555-555555555555")
+            ownerId
+            organizationId
             directoryRepositoryId
             (RelativePath relativePath)
             (Sha256Hash "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
             (List<DirectoryVersionId>())
             (List<FileVersion>())
             0L
+
+    /// Builds a DirectoryVersionDto around the supplied root directory contract.
+    let directoryVersionDto directoryVersionId directoryRepositoryId relativePath =
+        { DirectoryVersionDto.Default with DirectoryVersion = directoryVersion directoryVersionId directoryRepositoryId relativePath }
+
+    /// Builds a repository DTO with a current default branch name.
+    let repository defaultBranchName =
+        { RepositoryDto.Default with RepositoryId = repositoryId; OwnerId = ownerId; OrganizationId = organizationId; DefaultBranchName = defaultBranchName }
+
+    /// Builds a reference DTO that points at one root directory version.
+    let reference referenceId branchId directoryVersionId =
+        { ReferenceDto.Default with
+            ReferenceId = referenceId
+            OwnerId = ownerId
+            OrganizationId = organizationId
+            RepositoryId = repositoryId
+            BranchId = branchId
+            DirectoryId = directoryVersionId
+        }
+
+    /// Builds a branch DTO with its latest reference already recomputed by the actor.
+    let branch branchId branchName latestReference =
+        { BranchDto.Default with
+            BranchId = branchId
+            BranchName = branchName
+            OwnerId = ownerId
+            OrganizationId = organizationId
+            RepositoryId = repositoryId
+            LatestReference = latestReference
+            ShouldRecomputeLatestReferences = false
+        }
 
     /// Ensures projection evidence becomes the same descriptors consumed by the route planner.
     let ensureProjectionArtifacts zipSource metadataSource =
@@ -283,6 +325,158 @@ type MaterializationPlanRouteTests() =
             assertErrorContains Materialization.directoryVersionSelectorNotFoundMessage result
         }
 
+    /// Verifies missing repository state is rejected before selector resolution.
+    [<Test>]
+    member _.RepositorySelectorRejectsMissingRepositoryBeforeMovingSelectors() =
+        task {
+            let! result = Materialization.resolveRepositorySelectorWith repositoryId (fun () -> Task.FromResult RepositoryDto.Default) correlationId
+
+            assertErrorContains Materialization.repositorySelectorNotFoundMessage result
+        }
+
+    /// Verifies explicit ReferenceId selectors resolve server-side to one immutable root DirectoryVersionId.
+    [<Test>]
+    member _.ReferenceSelectorResolvesToImmutableDirectoryVersionRoot() =
+        task {
+            let! result =
+                Materialization.resolveReferenceSelectorWith
+                    repositoryId
+                    referenceId
+                    (fun () -> Task.FromResult(reference referenceId explicitBranchId targetRootDirectoryVersionId))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+        }
+
+    /// Verifies missing ReferenceId selectors use an intentional public selector error.
+    [<Test>]
+    member _.ReferenceSelectorRejectsMissingReference() =
+        task {
+            let! result =
+                Materialization.resolveReferenceSelectorWith
+                    repositoryId
+                    referenceId
+                    (fun () -> Task.FromResult ReferenceDto.Default)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.referenceSelectorNotFoundMessage result
+        }
+
+    /// Verifies explicit branch selectors resolve the current branch tip to one immutable root.
+    [<Test>]
+    member _.BranchNameSelectorResolvesLatestReferenceRoot() =
+        task {
+            let latestReference = reference referenceId explicitBranchId targetRootDirectoryVersionId
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+        }
+
+    /// Verifies default branch selectors use the repository's current default branch name and resolve its latest root.
+    [<Test>]
+    member _.DefaultBranchSelectorResolvesRepositoryDefaultBranchRoot() =
+        task {
+            let repositoryDto = repository defaultBranchName
+            let latestReference = reference referenceId defaultBranchId targetRootDirectoryVersionId
+
+            match Materialization.validateRepositorySelectorScope repositoryId repositoryDto correlationId with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok () -> ()
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    repositoryDto.DefaultBranchName
+                    (fun () -> Task.FromResult(Some defaultBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId repositoryDto.DefaultBranchName latestReference))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+        }
+
+    /// Verifies branch-name misses return an intentional selector error instead of falling back to cache or client resolution.
+    [<Test>]
+    member _.BranchNameSelectorRejectsMissingBranch() =
+        task {
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(None))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchNameSelectorNotFoundMessage result
+        }
+
+    /// Verifies stale branch-name index entries use the same public selector error as missing branch names.
+    [<Test>]
+    member _.BranchNameSelectorRejectsStaleBranchNameIndex() =
+        task {
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun _ -> raise (KeyNotFoundException("branch actor was not found")))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchNameSelectorNotFoundMessage result
+        }
+
+    /// Verifies branch-name index drift cannot materialize an unintended branch root.
+    [<Test>]
+    member _.BranchNameSelectorRejectsMismatchedBranchName() =
+        task {
+            let latestReference = reference referenceId explicitBranchId targetRootDirectoryVersionId
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId (BranchName "other") latestReference))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchNameSelectorNotFoundMessage result
+        }
+
+    /// Verifies a branch with no latest reference never produces a partial or cache-backed plan.
+    [<Test>]
+    member _.BranchNameSelectorRejectsMissingTipReference() =
+        task {
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchTipSelectorNotFoundMessage result
+        }
+
     /// Verifies actor, proxy, storage, or runtime selector failures are not collapsed into public 400s.
     [<Test>]
     member _.DirectoryVersionSelectorRuntimeFailureEscapesForRetryableServerStatus() =
@@ -372,6 +566,40 @@ type MaterializationPlanRouteTests() =
                     correlationId
 
             assertErrorContains "projection failed" result
+        }
+
+    /// Verifies a projection descriptor for another root is rejected before a Direct plan is returned.
+    [<Test>]
+    member _.ProjectionRootMismatchRejectsPlanBeforeResponse() =
+        task {
+            let otherRootDirectoryVersionId = DirectoryVersionId.Parse "88888888-8888-8888-8888-888888888888"
+
+            let mismatchedArtifacts =
+                [|
+                    MaterializationArtifactDescriptor.DirectoryVersionZip(
+                        otherRootDirectoryVersionId,
+                        123L,
+                        Some(Sha256Hash "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                        Some(Blake3Hash "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                        Some(MaterializationArtifactSource.Direct "https://example.invalid/other.zip")
+                    )
+                    MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+                        targetRootDirectoryVersionId,
+                        456L,
+                        Some(Sha256Hash "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+                        Some(Blake3Hash "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+                        Some(MaterializationArtifactSource.Direct "https://example.invalid/root.msgpack")
+                    )
+                |]
+
+            let! result =
+                Materialization.createDirectPlanForResolvedRoot
+                    (directRootRequest ())
+                    targetRootDirectoryVersionId
+                    (fun _ -> Task.FromResult(Ok mismatchedArtifacts))
+                    correlationId
+
+            assertErrorContains "Artifact TargetRootDirectoryVersionId must match the plan TargetRootDirectoryVersionId." result
         }
 
     /// Verifies valid Direct/Bypass requests with failed server-side projection map to the route's retryable 5xx path.

--- a/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
@@ -329,7 +329,30 @@ type MaterializationPlanRouteTests() =
     [<Test>]
     member _.RepositorySelectorRejectsMissingRepositoryBeforeMovingSelectors() =
         task {
-            let! result = Materialization.resolveRepositorySelectorWith repositoryId (fun () -> Task.FromResult RepositoryDto.Default) correlationId
+            let! result =
+                Materialization.resolveRepositorySelectorWith
+                    ownerId
+                    organizationId
+                    repositoryId
+                    (fun () -> Task.FromResult RepositoryDto.Default)
+                    correlationId
+
+            assertErrorContains Materialization.repositorySelectorNotFoundMessage result
+        }
+
+    /// Verifies repository selectors must match the authorized owner and organization, not only the requested repository id.
+    [<Test>]
+    member _.RepositorySelectorRejectsCrossOwnerRepositoryBeforeMovingSelectors() =
+        task {
+            let foreignOwnerRepository = { repository defaultBranchName with OwnerId = OwnerId.Parse "88888888-8888-8888-8888-888888888888" }
+
+            let! result =
+                Materialization.resolveRepositorySelectorWith
+                    ownerId
+                    organizationId
+                    repositoryId
+                    (fun () -> Task.FromResult foreignOwnerRepository)
+                    correlationId
 
             assertErrorContains Materialization.repositorySelectorNotFoundMessage result
         }
@@ -378,6 +401,7 @@ type MaterializationPlanRouteTests() =
                     explicitBranchName
                     (fun () -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
+                    (fun _ -> Task.FromResult latestReference)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -393,7 +417,7 @@ type MaterializationPlanRouteTests() =
             let repositoryDto = repository defaultBranchName
             let latestReference = reference referenceId defaultBranchId targetRootDirectoryVersionId
 
-            match Materialization.validateRepositorySelectorScope repositoryId repositoryDto correlationId with
+            match Materialization.validateRepositorySelectorScope ownerId organizationId repositoryId repositoryDto correlationId with
             | Error error -> Assert.Fail(error.Error)
             | Ok () -> ()
 
@@ -403,6 +427,7 @@ type MaterializationPlanRouteTests() =
                     repositoryDto.DefaultBranchName
                     (fun () -> Task.FromResult(Some defaultBranchId))
                     (fun branchId -> Task.FromResult(branch branchId repositoryDto.DefaultBranchName latestReference))
+                    (fun _ -> Task.FromResult latestReference)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -421,10 +446,37 @@ type MaterializationPlanRouteTests() =
                     explicitBranchName
                     (fun () -> Task.FromResult(None))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
+                    (fun _ -> Task.FromResult ReferenceDto.Default)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
             assertErrorContains Materialization.branchNameSelectorNotFoundMessage result
+        }
+
+    /// Verifies branch-name selectors use the durable resolver seam before loading branch state.
+    [<Test>]
+    member _.BranchNameSelectorUsesResolverCallbackOnColdBranchNameCache() =
+        task {
+            let latestReference = reference referenceId explicitBranchId targetRootDirectoryVersionId
+            let mutable resolverCalled = false
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () ->
+                        resolverCalled <- true
+                        Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
+                    (fun _ -> Task.FromResult latestReference)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+
+            Assert.That(resolverCalled, Is.True)
         }
 
     /// Verifies stale branch-name index entries use the same public selector error as missing branch names.
@@ -437,6 +489,7 @@ type MaterializationPlanRouteTests() =
                     explicitBranchName
                     (fun () -> Task.FromResult(Some explicitBranchId))
                     (fun _ -> raise (KeyNotFoundException("branch actor was not found")))
+                    (fun _ -> Task.FromResult ReferenceDto.Default)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -455,6 +508,7 @@ type MaterializationPlanRouteTests() =
                     explicitBranchName
                     (fun () -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId (BranchName "other") latestReference))
+                    (fun _ -> Task.FromResult latestReference)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -471,6 +525,28 @@ type MaterializationPlanRouteTests() =
                     explicitBranchName
                     (fun () -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
+                    (fun _ -> Task.FromResult ReferenceDto.Default)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchTipSelectorNotFoundMessage result
+        }
+
+    /// Verifies branch-name selectors re-read the live reference before trusting a branch snapshot's root directory.
+    [<Test>]
+    member _.BranchNameSelectorRejectsDeletedLiveTipReference() =
+        task {
+            let snapshotReference = reference referenceId explicitBranchId targetRootDirectoryVersionId
+
+            let deletedLiveReference = { snapshotReference with DeletedAt = Some(NodaTime.Instant.FromUnixTimeSeconds 1L) }
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName snapshotReference))
+                    (fun _ -> Task.FromResult deletedLiveReference)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 

--- a/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
@@ -410,6 +410,28 @@ type MaterializationPlanRouteTests() =
             | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
         }
 
+    /// Verifies durable branch-name resolver casing variants survive BranchDto revalidation.
+    [<Test>]
+    member _.BranchNameSelectorAcceptsResolverCasingVariant() =
+        task {
+            let requestedBranchName = BranchName "Feature"
+            let latestReference = reference referenceId explicitBranchId targetRootDirectoryVersionId
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    requestedBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
+                    (fun _ -> Task.FromResult latestReference)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+        }
+
     /// Verifies default branch selectors use the repository's current default branch name and resolve its latest root.
     [<Test>]
     member _.DefaultBranchSelectorResolvesRepositoryDefaultBranchRoot() =
@@ -496,6 +518,25 @@ type MaterializationPlanRouteTests() =
             assertErrorContains Materialization.branchNameSelectorNotFoundMessage result
         }
 
+    /// Verifies branch-name index drift cannot trust branch state that reports another durable branch id.
+    [<Test>]
+    member _.BranchNameSelectorRejectsBranchDtoIdMismatch() =
+        task {
+            let latestReference = reference referenceId defaultBranchId targetRootDirectoryVersionId
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun _ -> Task.FromResult(branch defaultBranchId explicitBranchName latestReference))
+                    (fun _ -> Task.FromResult latestReference)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchNameSelectorNotFoundMessage result
+        }
+
     /// Verifies branch-name index drift cannot materialize an unintended branch root.
     [<Test>]
     member _.BranchNameSelectorRejectsMismatchedBranchName() =
@@ -547,6 +588,26 @@ type MaterializationPlanRouteTests() =
                     (fun () -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName snapshotReference))
                     (fun _ -> Task.FromResult deletedLiveReference)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.branchTipSelectorNotFoundMessage result
+        }
+
+    /// Verifies a stale branch latest-reference snapshot cannot borrow another branch's live tip.
+    [<Test>]
+    member _.BranchNameSelectorRejectsLiveTipReferenceFromAnotherBranch() =
+        task {
+            let snapshotReference = reference referenceId explicitBranchId targetRootDirectoryVersionId
+            let otherBranchLiveReference = reference referenceId defaultBranchId targetRootDirectoryVersionId
+
+            let! result =
+                Materialization.resolveBranchNameSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName snapshotReference))
+                    (fun _ -> Task.FromResult otherBranchLiveReference)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 

--- a/src/Grace.Server/Materialization.Server.fs
+++ b/src/Grace.Server/Materialization.Server.fs
@@ -3,6 +3,7 @@ namespace Grace.Server
 open Giraffe
 open Grace.Actors.DirectoryVersion
 open Grace.Actors.Extensions
+open Grace.Actors.Services
 open Grace.Server.Services
 open Grace.Shared
 open Grace.Shared.Parameters.Materialization
@@ -217,10 +218,14 @@ module Materialization =
         }
 
     /// Validates that repository authority exists before moving selectors can resolve to repository state.
-    let validateRepositorySelectorScope repositoryId (repositoryDto: RepositoryDto) correlationId =
+    let validateRepositorySelectorScope ownerId organizationId repositoryId (repositoryDto: RepositoryDto) correlationId =
         if repositoryDto.RepositoryId = RepositoryId.Empty then
             Error(planError correlationId repositorySelectorNotFoundMessage)
         elif repositoryDto.RepositoryId <> repositoryId then
+            Error(planError correlationId repositorySelectorNotFoundMessage)
+        elif repositoryDto.OwnerId <> ownerId then
+            Error(planError correlationId repositorySelectorNotFoundMessage)
+        elif repositoryDto.OrganizationId <> organizationId then
             Error(planError correlationId repositorySelectorNotFoundMessage)
         elif repositoryDto.DeletedAt.IsSome then
             Error(planError correlationId repositorySelectorNotFoundMessage)
@@ -229,6 +234,8 @@ module Materialization =
 
     /// Resolves repository authority to current repository state for selector lookups.
     let internal resolveRepositorySelectorWith
+        ownerId
+        organizationId
         repositoryId
         (getRepository: unit -> Task<RepositoryDto>)
         correlationId
@@ -238,7 +245,7 @@ module Materialization =
             try
                 let! repositoryDto = getRepository ()
 
-                match validateRepositorySelectorScope repositoryId repositoryDto correlationId with
+                match validateRepositorySelectorScope ownerId organizationId repositoryId repositoryDto correlationId with
                 | Error error -> return Error error
                 | Ok () -> return Ok repositoryDto
             with
@@ -246,11 +253,11 @@ module Materialization =
         }
 
     /// Resolves repository authority from actors before selector materialization starts.
-    let private resolveRepositorySelector organizationId repositoryId correlationId =
+    let private resolveRepositorySelector ownerId organizationId repositoryId correlationId =
         task {
             let repositoryActorProxy = ActorProxy.Repository.CreateActorProxy organizationId repositoryId correlationId
 
-            return! resolveRepositorySelectorWith repositoryId (fun () -> repositoryActorProxy.Get correlationId) correlationId
+            return! resolveRepositorySelectorWith ownerId organizationId repositoryId (fun () -> repositoryActorProxy.Get correlationId) correlationId
         }
 
     /// Validates that a reference belongs to the authorized repository and carries one immutable root directory.
@@ -325,8 +332,10 @@ module Materialization =
             Ok()
 
     /// Validates that a branch snapshot exposes one immutable latest reference for Direct planning.
-    let validateBranchTipReference repositoryId (referenceDto: ReferenceDto) correlationId =
+    let validateBranchTipReference repositoryId referenceId (referenceDto: ReferenceDto) correlationId =
         if referenceDto.ReferenceId = ReferenceId.Empty then
+            Error(planError correlationId branchTipSelectorNotFoundMessage)
+        elif referenceDto.ReferenceId <> referenceId then
             Error(planError correlationId branchTipSelectorNotFoundMessage)
         elif referenceDto.RepositoryId <> repositoryId then
             Error(planError correlationId branchTipSelectorNotFoundMessage)
@@ -341,8 +350,9 @@ module Materialization =
     let internal resolveBranchNameSelectorWith
         repositoryId
         (branchName: BranchName)
-        (getBranchId: unit -> Task<BranchId option>)
+        (resolveBranchIdByName: unit -> Task<BranchId option>)
         (getBranch: BranchId -> Task<BranchDto>)
+        (getReference: ReferenceId -> Task<ReferenceDto>)
         (getDirectoryVersion: DirectoryVersionId -> Task<DirectoryVersionDto>)
         correlationId
         : Task<Result<DirectoryVersionId, GraceError>>
@@ -352,7 +362,7 @@ module Materialization =
                 return Error(planError correlationId "BranchName selector is required.")
             else
                 try
-                    let! branchId = getBranchId ()
+                    let! branchId = resolveBranchIdByName ()
 
                     match branchId with
                     | None -> return Error(planError correlationId branchNameSelectorNotFoundMessage)
@@ -363,32 +373,50 @@ module Materialization =
                         match validateBranchNameSelectorScope repositoryId branchName branchDto correlationId with
                         | Error error -> return Error error
                         | Ok () ->
-                            match validateBranchTipReference repositoryId branchDto.LatestReference correlationId with
-                            | Error error -> return Error error
-                            | Ok () ->
-                                return!
-                                    resolveDirectoryVersionSelectorWith
-                                        repositoryId
-                                        branchDto.LatestReference.DirectoryId
-                                        (fun () -> getDirectoryVersion branchDto.LatestReference.DirectoryId)
-                                        correlationId
+                            let snapshotReferenceId = branchDto.LatestReference.ReferenceId
+
+                            if snapshotReferenceId = ReferenceId.Empty then
+                                return Error(planError correlationId branchTipSelectorNotFoundMessage)
+                            else
+                                let! latestReferenceResult =
+                                    task {
+                                        try
+                                            let! latestReference = getReference snapshotReferenceId
+                                            return Ok latestReference
+                                        with
+                                        | :? KeyNotFoundException -> return Error(planError correlationId branchTipSelectorNotFoundMessage)
+                                    }
+
+                                match latestReferenceResult with
+                                | Error error -> return Error error
+                                | Ok latestReference ->
+                                    match validateBranchTipReference repositoryId snapshotReferenceId latestReference correlationId with
+                                    | Error error -> return Error error
+                                    | Ok () ->
+                                        return!
+                                            resolveDirectoryVersionSelectorWith
+                                                repositoryId
+                                                latestReference.DirectoryId
+                                                (fun () -> getDirectoryVersion latestReference.DirectoryId)
+                                                correlationId
                 with
                 | :? KeyNotFoundException -> return Error(planError correlationId branchNameSelectorNotFoundMessage)
         }
 
     /// Resolves a BranchName selector to one target root from actor state.
-    let private resolveBranchNameSelector repositoryId branchName correlationId =
+    let private resolveBranchNameSelector ownerId organizationId repositoryId branchName correlationId =
         task {
-            let branchNameActorProxy = ActorProxy.BranchName.CreateActorProxy repositoryId branchName correlationId
-
             return!
                 resolveBranchNameSelectorWith
                     repositoryId
                     branchName
-                    (fun () -> branchNameActorProxy.GetBranchId correlationId)
+                    (fun () -> resolveBranchId ownerId organizationId repositoryId String.Empty branchName correlationId)
                     (fun branchId ->
                         let branchActorProxy = ActorProxy.Branch.CreateActorProxy branchId repositoryId correlationId
                         branchActorProxy.Get correlationId)
+                    (fun referenceId ->
+                        let referenceActorProxy = ActorProxy.Reference.CreateActorProxy referenceId repositoryId correlationId
+                        referenceActorProxy.Get correlationId)
                     (fun directoryVersionId ->
                         let directoryActorProxy = ActorProxy.DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
                         directoryActorProxy.Get correlationId)
@@ -396,9 +424,9 @@ module Materialization =
         }
 
     /// Resolves supported target selectors before artifact planning starts.
-    let private resolveTargetRoot organizationId repositoryId (selector: MaterializationTargetSelector) correlationId =
+    let private resolveTargetRoot ownerId organizationId repositoryId (selector: MaterializationTargetSelector) correlationId =
         task {
-            match! resolveRepositorySelector organizationId repositoryId correlationId with
+            match! resolveRepositorySelector ownerId organizationId repositoryId correlationId with
             | Error error -> return Error error
             | Ok repositoryDto ->
                 match selector.SelectorKind with
@@ -419,7 +447,7 @@ module Materialization =
                             else
                                 branchName
 
-                        return! resolveBranchNameSelector repositoryId resolvedBranchName correlationId
+                        return! resolveBranchNameSelector ownerId organizationId repositoryId resolvedBranchName correlationId
                     | None -> return Error(planError correlationId "BranchName selector is required.")
                 | _ -> return Error(planError correlationId $"Target selector kind '{int selector.SelectorKind}' is not supported.")
         }
@@ -440,7 +468,7 @@ module Materialization =
                         match validatePlanParameters repositoryId parameters correlationId with
                         | Error error -> return! context |> result400BadRequest error
                         | Ok request ->
-                            match! resolveTargetRoot graceIds.OrganizationId repositoryId request.TargetSelector correlationId with
+                            match! resolveTargetRoot graceIds.OwnerId graceIds.OrganizationId repositoryId request.TargetSelector correlationId with
                             | Error error -> return! context |> result400BadRequest error
                             | Ok targetRootDirectoryVersionId ->
                                 let actorProxy = ActorProxy.DirectoryVersion.CreateActorProxy targetRootDirectoryVersionId repositoryId correlationId

--- a/src/Grace.Server/Materialization.Server.fs
+++ b/src/Grace.Server/Materialization.Server.fs
@@ -6,9 +6,12 @@ open Grace.Actors.Extensions
 open Grace.Server.Services
 open Grace.Shared
 open Grace.Shared.Parameters.Materialization
+open Grace.Types.Branch
 open Grace.Types.Common
 open Grace.Types.DirectoryVersion
 open Grace.Types.MaterializationPlan
+open Grace.Types.Reference
+open Grace.Types.Repository
 open Microsoft.AspNetCore.Http
 open System
 open System.Collections.Generic
@@ -27,6 +30,18 @@ module Materialization =
 
     /// Public-safe selector error used when a DirectoryVersionId is missing or outside the authorized repository.
     let directoryVersionSelectorNotFoundMessage = "DirectoryVersionId selector did not match an authorized directory version."
+
+    /// Public-safe selector error used when a repository authority is missing, deleted, or outside the authorized scope.
+    let repositorySelectorNotFoundMessage = "Repository selector did not match an authorized repository."
+
+    /// Public-safe selector error used when a ReferenceId is missing, deleted, or outside the authorized repository.
+    let referenceSelectorNotFoundMessage = "ReferenceId selector did not match an authorized reference."
+
+    /// Public-safe selector error used when a BranchName is missing, deleted, or outside the authorized repository.
+    let branchNameSelectorNotFoundMessage = "BranchName selector did not match an authorized branch."
+
+    /// Public-safe selector error used when a branch resolves but has no immutable target root.
+    let branchTipSelectorNotFoundMessage = "BranchName selector did not match an authorized branch tip."
 
     /// Classifies Direct/Bypass plan creation failures after the route has parsed repository authority and target selector intent.
     type internal DirectPlanFailure =
@@ -198,22 +213,215 @@ module Materialization =
 
             match! resolveDirectoryVersionSelectorWith repositoryId directoryVersionId (fun () -> actorProxy.Get correlationId) correlationId with
             | Error error -> return Error error
-            | Ok resolvedDirectoryVersionId -> return Ok(resolvedDirectoryVersionId, actorProxy)
+            | Ok resolvedDirectoryVersionId -> return Ok resolvedDirectoryVersionId
+        }
+
+    /// Validates that repository authority exists before moving selectors can resolve to repository state.
+    let validateRepositorySelectorScope repositoryId (repositoryDto: RepositoryDto) correlationId =
+        if repositoryDto.RepositoryId = RepositoryId.Empty then
+            Error(planError correlationId repositorySelectorNotFoundMessage)
+        elif repositoryDto.RepositoryId <> repositoryId then
+            Error(planError correlationId repositorySelectorNotFoundMessage)
+        elif repositoryDto.DeletedAt.IsSome then
+            Error(planError correlationId repositorySelectorNotFoundMessage)
+        else
+            Ok()
+
+    /// Resolves repository authority to current repository state for selector lookups.
+    let internal resolveRepositorySelectorWith
+        repositoryId
+        (getRepository: unit -> Task<RepositoryDto>)
+        correlationId
+        : Task<Result<RepositoryDto, GraceError>>
+        =
+        task {
+            try
+                let! repositoryDto = getRepository ()
+
+                match validateRepositorySelectorScope repositoryId repositoryDto correlationId with
+                | Error error -> return Error error
+                | Ok () -> return Ok repositoryDto
+            with
+            | :? KeyNotFoundException -> return Error(planError correlationId repositorySelectorNotFoundMessage)
+        }
+
+    /// Resolves repository authority from actors before selector materialization starts.
+    let private resolveRepositorySelector organizationId repositoryId correlationId =
+        task {
+            let repositoryActorProxy = ActorProxy.Repository.CreateActorProxy organizationId repositoryId correlationId
+
+            return! resolveRepositorySelectorWith repositoryId (fun () -> repositoryActorProxy.Get correlationId) correlationId
+        }
+
+    /// Validates that a reference belongs to the authorized repository and carries one immutable root directory.
+    let validateReferenceSelectorScope repositoryId (referenceDto: ReferenceDto) correlationId =
+        if referenceDto.ReferenceId = ReferenceId.Empty then
+            Error(planError correlationId referenceSelectorNotFoundMessage)
+        elif referenceDto.RepositoryId <> repositoryId then
+            Error(planError correlationId referenceSelectorNotFoundMessage)
+        elif referenceDto.DeletedAt.IsSome then
+            Error(planError correlationId referenceSelectorNotFoundMessage)
+        elif referenceDto.DirectoryId = DirectoryVersionId.Empty then
+            Error(planError correlationId referenceSelectorNotFoundMessage)
+        else
+            Ok()
+
+    /// Resolves a ReferenceId selector to the immutable root represented by the current stored reference.
+    let internal resolveReferenceSelectorWith
+        repositoryId
+        (referenceId: ReferenceId)
+        (getReference: unit -> Task<ReferenceDto>)
+        (getDirectoryVersion: DirectoryVersionId -> Task<DirectoryVersionDto>)
+        correlationId
+        : Task<Result<DirectoryVersionId, GraceError>>
+        =
+        task {
+            if referenceId = ReferenceId.Empty then
+                return Error(planError correlationId "ReferenceId selector is required.")
+            else
+                try
+                    let! referenceDto = getReference ()
+
+                    match validateReferenceSelectorScope repositoryId referenceDto correlationId with
+                    | Error error -> return Error error
+                    | Ok () ->
+                        return!
+                            resolveDirectoryVersionSelectorWith
+                                repositoryId
+                                referenceDto.DirectoryId
+                                (fun () -> getDirectoryVersion referenceDto.DirectoryId)
+                                correlationId
+                with
+                | :? KeyNotFoundException -> return Error(planError correlationId referenceSelectorNotFoundMessage)
+        }
+
+    /// Resolves a ReferenceId selector to one target root from actor state.
+    let private resolveReferenceSelector repositoryId referenceId correlationId =
+        task {
+            let referenceActorProxy = ActorProxy.Reference.CreateActorProxy referenceId repositoryId correlationId
+
+            return!
+                resolveReferenceSelectorWith
+                    repositoryId
+                    referenceId
+                    (fun () -> referenceActorProxy.Get correlationId)
+                    (fun directoryVersionId ->
+                        let directoryActorProxy = ActorProxy.DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
+                        directoryActorProxy.Get correlationId)
+                    correlationId
+        }
+
+    /// Validates that a branch-name lookup resolved to the requested live branch in the authorized repository.
+    let validateBranchNameSelectorScope repositoryId branchName (branchDto: BranchDto) correlationId =
+        if branchDto.BranchId = BranchId.Empty then
+            Error(planError correlationId branchNameSelectorNotFoundMessage)
+        elif branchDto.RepositoryId <> repositoryId then
+            Error(planError correlationId branchNameSelectorNotFoundMessage)
+        elif branchDto.DeletedAt.IsSome then
+            Error(planError correlationId branchNameSelectorNotFoundMessage)
+        elif branchDto.BranchName <> branchName then
+            Error(planError correlationId branchNameSelectorNotFoundMessage)
+        else
+            Ok()
+
+    /// Validates that a branch snapshot exposes one immutable latest reference for Direct planning.
+    let validateBranchTipReference repositoryId (referenceDto: ReferenceDto) correlationId =
+        if referenceDto.ReferenceId = ReferenceId.Empty then
+            Error(planError correlationId branchTipSelectorNotFoundMessage)
+        elif referenceDto.RepositoryId <> repositoryId then
+            Error(planError correlationId branchTipSelectorNotFoundMessage)
+        elif referenceDto.DeletedAt.IsSome then
+            Error(planError correlationId branchTipSelectorNotFoundMessage)
+        elif referenceDto.DirectoryId = DirectoryVersionId.Empty then
+            Error(planError correlationId branchTipSelectorNotFoundMessage)
+        else
+            Ok()
+
+    /// Resolves a BranchName selector to the branch's current immutable root at the branch Get revalidation point.
+    let internal resolveBranchNameSelectorWith
+        repositoryId
+        (branchName: BranchName)
+        (getBranchId: unit -> Task<BranchId option>)
+        (getBranch: BranchId -> Task<BranchDto>)
+        (getDirectoryVersion: DirectoryVersionId -> Task<DirectoryVersionDto>)
+        correlationId
+        : Task<Result<DirectoryVersionId, GraceError>>
+        =
+        task {
+            if String.IsNullOrWhiteSpace branchName then
+                return Error(planError correlationId "BranchName selector is required.")
+            else
+                try
+                    let! branchId = getBranchId ()
+
+                    match branchId with
+                    | None -> return Error(planError correlationId branchNameSelectorNotFoundMessage)
+                    | Some branchId when branchId = BranchId.Empty -> return Error(planError correlationId branchNameSelectorNotFoundMessage)
+                    | Some branchId ->
+                        let! branchDto = getBranch branchId
+
+                        match validateBranchNameSelectorScope repositoryId branchName branchDto correlationId with
+                        | Error error -> return Error error
+                        | Ok () ->
+                            match validateBranchTipReference repositoryId branchDto.LatestReference correlationId with
+                            | Error error -> return Error error
+                            | Ok () ->
+                                return!
+                                    resolveDirectoryVersionSelectorWith
+                                        repositoryId
+                                        branchDto.LatestReference.DirectoryId
+                                        (fun () -> getDirectoryVersion branchDto.LatestReference.DirectoryId)
+                                        correlationId
+                with
+                | :? KeyNotFoundException -> return Error(planError correlationId branchNameSelectorNotFoundMessage)
+        }
+
+    /// Resolves a BranchName selector to one target root from actor state.
+    let private resolveBranchNameSelector repositoryId branchName correlationId =
+        task {
+            let branchNameActorProxy = ActorProxy.BranchName.CreateActorProxy repositoryId branchName correlationId
+
+            return!
+                resolveBranchNameSelectorWith
+                    repositoryId
+                    branchName
+                    (fun () -> branchNameActorProxy.GetBranchId correlationId)
+                    (fun branchId ->
+                        let branchActorProxy = ActorProxy.Branch.CreateActorProxy branchId repositoryId correlationId
+                        branchActorProxy.Get correlationId)
+                    (fun directoryVersionId ->
+                        let directoryActorProxy = ActorProxy.DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
+                        directoryActorProxy.Get correlationId)
+                    correlationId
         }
 
     /// Resolves supported target selectors before artifact planning starts.
-    let private resolveTargetRoot repositoryId (selector: MaterializationTargetSelector) correlationId =
+    let private resolveTargetRoot organizationId repositoryId (selector: MaterializationTargetSelector) correlationId =
         task {
-            match selector.SelectorKind with
-            | MaterializationTargetSelectorKind.DirectoryVersionId ->
-                match selector.DirectoryVersionId with
-                | Some directoryVersionId -> return! resolveDirectoryVersionSelector repositoryId directoryVersionId correlationId
-                | None -> return Error(planError correlationId "DirectoryVersionId selector is required.")
-            | MaterializationTargetSelectorKind.ReferenceId ->
-                return Error(planError correlationId "ReferenceId Materialization Plan selectors are not implemented by /materialization/plan yet.")
-            | MaterializationTargetSelectorKind.BranchName ->
-                return Error(planError correlationId "BranchName Materialization Plan selectors are not implemented by /materialization/plan yet.")
-            | _ -> return Error(planError correlationId $"Target selector kind '{int selector.SelectorKind}' is not supported.")
+            match! resolveRepositorySelector organizationId repositoryId correlationId with
+            | Error error -> return Error error
+            | Ok repositoryDto ->
+                match selector.SelectorKind with
+                | MaterializationTargetSelectorKind.DirectoryVersionId ->
+                    match selector.DirectoryVersionId with
+                    | Some directoryVersionId -> return! resolveDirectoryVersionSelector repositoryId directoryVersionId correlationId
+                    | None -> return Error(planError correlationId "DirectoryVersionId selector is required.")
+                | MaterializationTargetSelectorKind.ReferenceId ->
+                    match selector.ReferenceId with
+                    | Some referenceId -> return! resolveReferenceSelector repositoryId referenceId correlationId
+                    | None -> return Error(planError correlationId "ReferenceId selector is required.")
+                | MaterializationTargetSelectorKind.BranchName ->
+                    match selector.BranchName with
+                    | Some branchName ->
+                        let resolvedBranchName =
+                            if branchName = repositoryDto.DefaultBranchName then
+                                repositoryDto.DefaultBranchName
+                            else
+                                branchName
+
+                        return! resolveBranchNameSelector repositoryId resolvedBranchName correlationId
+                    | None -> return Error(planError correlationId "BranchName selector is required.")
+                | _ -> return Error(planError correlationId $"Target selector kind '{int selector.SelectorKind}' is not supported.")
         }
 
     /// Handles POST /materialization/plan.
@@ -232,9 +440,11 @@ module Materialization =
                         match validatePlanParameters repositoryId parameters correlationId with
                         | Error error -> return! context |> result400BadRequest error
                         | Ok request ->
-                            match! resolveTargetRoot repositoryId request.TargetSelector correlationId with
+                            match! resolveTargetRoot graceIds.OrganizationId repositoryId request.TargetSelector correlationId with
                             | Error error -> return! context |> result400BadRequest error
-                            | Ok (targetRootDirectoryVersionId, actorProxy) ->
+                            | Ok targetRootDirectoryVersionId ->
+                                let actorProxy = ActorProxy.DirectoryVersion.CreateActorProxy targetRootDirectoryVersionId repositoryId correlationId
+
                                 let! planResult =
                                     createDirectPlanForResolvedRootWithFailureKind
                                         request

--- a/src/Grace.Server/Materialization.Server.fs
+++ b/src/Grace.Server/Materialization.Server.fs
@@ -319,25 +319,29 @@ module Materialization =
         }
 
     /// Validates that a branch-name lookup resolved to the requested live branch in the authorized repository.
-    let validateBranchNameSelectorScope repositoryId branchName (branchDto: BranchDto) correlationId =
+    let validateBranchNameSelectorScope repositoryId branchId branchName (branchDto: BranchDto) correlationId =
         if branchDto.BranchId = BranchId.Empty then
+            Error(planError correlationId branchNameSelectorNotFoundMessage)
+        elif branchDto.BranchId <> branchId then
             Error(planError correlationId branchNameSelectorNotFoundMessage)
         elif branchDto.RepositoryId <> repositoryId then
             Error(planError correlationId branchNameSelectorNotFoundMessage)
         elif branchDto.DeletedAt.IsSome then
             Error(planError correlationId branchNameSelectorNotFoundMessage)
-        elif branchDto.BranchName <> branchName then
+        elif not (String.Equals(string branchDto.BranchName, string branchName, StringComparison.OrdinalIgnoreCase)) then
             Error(planError correlationId branchNameSelectorNotFoundMessage)
         else
             Ok()
 
     /// Validates that a branch snapshot exposes one immutable latest reference for Direct planning.
-    let validateBranchTipReference repositoryId referenceId (referenceDto: ReferenceDto) correlationId =
+    let validateBranchTipReference repositoryId branchId referenceId (referenceDto: ReferenceDto) correlationId =
         if referenceDto.ReferenceId = ReferenceId.Empty then
             Error(planError correlationId branchTipSelectorNotFoundMessage)
         elif referenceDto.ReferenceId <> referenceId then
             Error(planError correlationId branchTipSelectorNotFoundMessage)
         elif referenceDto.RepositoryId <> repositoryId then
+            Error(planError correlationId branchTipSelectorNotFoundMessage)
+        elif referenceDto.BranchId <> branchId then
             Error(planError correlationId branchTipSelectorNotFoundMessage)
         elif referenceDto.DeletedAt.IsSome then
             Error(planError correlationId branchTipSelectorNotFoundMessage)
@@ -370,7 +374,7 @@ module Materialization =
                     | Some branchId ->
                         let! branchDto = getBranch branchId
 
-                        match validateBranchNameSelectorScope repositoryId branchName branchDto correlationId with
+                        match validateBranchNameSelectorScope repositoryId branchId branchName branchDto correlationId with
                         | Error error -> return Error error
                         | Ok () ->
                             let snapshotReferenceId = branchDto.LatestReference.ReferenceId
@@ -390,7 +394,7 @@ module Materialization =
                                 match latestReferenceResult with
                                 | Error error -> return Error error
                                 | Ok latestReference ->
-                                    match validateBranchTipReference repositoryId snapshotReferenceId latestReference correlationId with
+                                    match validateBranchTipReference repositoryId branchDto.BranchId snapshotReferenceId latestReference correlationId with
                                     | Error error -> return Error error
                                     | Ok () ->
                                         return!


### PR DESCRIPTION
## Summary

- Implements server-side Direct materialization selector resolution for `DirectoryVersionId`, `ReferenceId`, and `BranchName` selectors.
- Resolves moving selectors to one immutable `DirectoryVersionId` before artifact projection.
- Validates repository/reference/branch/branch-tip/root relationships before returning a Direct plan.
- Adds route/generator regression coverage for missing selectors, stale branch indexes, projection root mismatch, and Direct root-only artifact behavior.

## Why This Matters

This turns the `POST /materialization/plan` route from a Direct shell into the server-owned plan boundary for moving target intent. Clients can ask for a branch or reference, but the response names one immutable root and the required v1 Direct artifacts before later `grace connect` work consumes it.

## Related Issue

Related to #614. Part of #599 and #597.

## Validation

- Passed: `dotnet tool run fantomas src\Grace.Server\Materialization.Server.fs src\Grace.Server.Unit.Tests\MaterializationPlan.Server.Tests.fs`.
- Passed: `dotnet build --configuration Release src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj`.
- Passed: `dotnet test --configuration Release --no-build src\Grace.Server.Unit.Tests\Grace.Server.Unit.Tests.fsproj` (`764` tests).
- Passed: `git diff --check`.
- Passed final gate: `pwsh ./scripts/validate.ps1 -Fast`.

## Contract Propagation

- Server route/generator: updated Direct plan generation to resolve supported selectors server-side.
- Shared DTOs/OpenAPI/SDK/generated clients: N/A; no public contract shape change was required.
- CLI: N/A; `grace connect` still consumes the existing path until #615 moves it to the plan route.
- Tests: added focused server unit coverage for supported selector resolution and failure boundaries.

## Stale Authority

- Moving selectors are resolved to a single immutable directory version before projection.
- Branch-name index drift and projection root mismatch are rejected before response.
- Direct mode remains cache-free and root-only.
- Known missing selector cases return intentional Grace errors; projection/runtime failures keep retryable server classification.

## Review Status

- Implementation commit: `b398c40cae67bb3b82da05a074546f86b9e4717d`.
- Worker validation passed: targeted Fantomas, focused Release server unit build, focused server unit tests (`764`), `git diff --check`, and final `pwsh ./scripts/validate.ps1 -Fast`.
- GitHub Actions `full` passed on `b398c40cae67bb3b82da05a074546f86b9e4717d`; PR is clean. Codex Code Review Bot has acknowledged the head with 👀 and review is still pending. No manual Codex review request was made.
- Codex Code Review Bot reviewed `b398c40cae67bb3b82da05a074546f86b9e4717d` at `2026-07-08T09:32:31Z` and opened three fresh cycle-one P1 findings: repository owner/organization validation for repository-id authority, branch-name resolution through the durable resolver, and live latest-reference validation before planning.
- Substantive cycle count: 1. These findings are in #614 scope and do not require a new domain construct or maintainer decision before the first fix cycle.
- Fresh fix worker assigned for the three current-head findings only; no manual Codex review request was made.
- Review fixes for the three cycle-one findings were pushed in `a0ee77d3966324b33a6861a6f43bd3adab5a3775`.
- Worker validation for `a0ee77d3966324b33a6861a6f43bd3adab5a3775` passed: targeted Fantomas, focused Release server unit build, focused `MaterializationPlanRouteTests` (`31/31`), `git diff --check`, and final `pwsh ./scripts/validate.ps1 -Fast`.
- Cycle-one review replies were posted and resolved: [repository owner/organization validation](https://github.com/ScottArbeit/Grace/pull/684#discussion_r3542897867), [durable branch-name resolution](https://github.com/ScottArbeit/Grace/pull/684#discussion_r3542898187), and [live branch-tip reference validation](https://github.com/ScottArbeit/Grace/pull/684#discussion_r3542898398).
- Prevention summary: auth/materialization/traversal ordering gap, validation/stale-evidence gap, and stale-snapshot/interleaving gap were covered by #614 focused route regressions; no sibling issue, template, or process-doc update is needed for these first-cycle findings.
- GitHub Actions `full` passed on `a0ee77d3966324b33a6861a6f43bd3adab5a3775`; all three cycle-one threads are replied to and resolved. Codex Code Review Bot has acknowledged the head with 👀 and review is still pending. No manual Codex review request was made.
- Codex Code Review Bot reviewed `a0ee77d3966324b33a6861a6f43bd3adab5a3775` at `2026-07-08T09:54:43Z` and opened two fresh cycle-two findings: branch-name comparisons must use the durable resolver's case-insensitive semantics, and live branch-tip references must still belong to the resolved branch.
- Substantive cycle count: 2. Stabilization ledger posted on #614 before the next fix worker: https://github.com/ScottArbeit/Grace/issues/614#issuecomment-4913592798.
- Repeated-theme prevention: stale-snapshot/interleaving gap; #614 now explicitly requires branch-name resolver equality semantics plus live branch-tip branch-membership validation before Direct plan generation.
- Review fixes for the two cycle-two findings were pushed in `2620e345cb699fccc8e909ff4a535cd19398d61d`.
- Worker validation for `2620e345cb699fccc8e909ff4a535cd19398d61d` passed: targeted Fantomas, focused Release server unit build, focused `MaterializationPlanRouteTests` (`34/34`), `git diff --check`, and final `pwsh ./scripts/validate.ps1 -Fast`.
- Cycle-two review replies were posted and resolved: [case-insensitive branch-name revalidation](https://github.com/ScottArbeit/Grace/pull/684#discussion_r3543028384) and [branch-tip branch membership validation](https://github.com/ScottArbeit/Grace/pull/684#discussion_r3543028598).
- Prevention summary: stale-snapshot/interleaving gap was covered by the #614 stabilization ledger and focused branch-selector regressions; no sibling issue, template, or process-doc update is needed for these cycle-two findings.
- GitHub Actions `full` passed on `2620e345cb699fccc8e909ff4a535cd19398d61d`; all cycle-two threads are replied to and resolved. Codex Code Review Bot reacted with 👍 on the PR body for this current head, indicating no issues. No manual Codex review request was made.


