### PR TITLE
WS7.4.2: Add current-branch materialization coordinator gate

### DIFF
--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -372,6 +372,7 @@ module BranchCommandTests =
             let mutable inspected = false
             let mutable workflowRan = false
             let mutable leaseSeenByWorkflow = false
+            let mutable materializationLeaseHeldByWorkflow = false
             let mutable markerSeenByWorkflow = false
 
             let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
@@ -395,6 +396,15 @@ module BranchCommandTests =
                     task {
                         workflowRan <- true
                         leaseSeenByWorkflow <- File.Exists(switchLeaseFile)
+                        let materializationLeaseFile = WorkingDirectoryMaterialization.leaseFileName ()
+
+                        materializationLeaseHeldByWorkflow <-
+                            try
+                                use _probe = new FileStream(materializationLeaseFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+                                false
+                            with
+                            | :? IOException -> true
+
                         markerSeenByWorkflow <- File.Exists(updateMarkerFile)
                         return "computed"
                     }))
@@ -408,6 +418,10 @@ module BranchCommandTests =
             inspected |> should equal true
             workflowRan |> should equal true
             leaseSeenByWorkflow |> should equal true
+
+            materializationLeaseHeldByWorkflow
+            |> should equal true
+
             markerSeenByWorkflow |> should equal false
 
             File.Exists(switchLeaseFile) |> should equal false

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -369,7 +369,7 @@ module BranchCommandTests =
             let updateMarkerFile = Services.updateInProgressFileName ()
             let switchLeaseFile = Branch.branchSwitchWorkflowLeaseFileName updateMarkerFile
             let switchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
-            let mutable inspected = false
+            let mutable inspectionCount = 0
             let mutable workflowRan = false
             let mutable leaseSeenByWorkflow = false
             let mutable materializationLeaseHeldByWorkflow = false
@@ -380,7 +380,7 @@ module BranchCommandTests =
                     UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
                     InspectWatchStatus =
                         fun () ->
-                            inspected <- true
+                            inspectionCount <- inspectionCount + 1
 
                             File.Exists(updateMarkerFile)
                             |> should equal false
@@ -415,7 +415,7 @@ module BranchCommandTests =
             | Ok value -> value |> should equal "computed"
             | Error error -> Assert.Fail($"Expected branch switch lease to allow workflow, got: {error.Error}")
 
-            inspected |> should equal true
+            inspectionCount |> should equal 2
             workflowRan |> should equal true
             leaseSeenByWorkflow |> should equal true
 
@@ -423,6 +423,84 @@ module BranchCommandTests =
             |> should equal true
 
             markerSeenByWorkflow |> should equal false
+
+            File.Exists(switchLeaseFile) |> should equal false
+
+            File.Exists(updateMarkerFile)
+            |> should equal false)
+
+    /// Verifies that stale Watch-clean evidence cannot start switch work after the materialization lease wait.
+    [<Test>]
+    let ``branch switch workflow lease rechecks Watch preflight after materialization lease wait`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let switchLeaseFile = Branch.branchSwitchWorkflowLeaseFileName updateMarkerFile
+            let switchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
+            let dirtyStatus = { branchSwitchWatchStatus () with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+            let materializationLeaseFile = WorkingDirectoryMaterialization.leaseFileName ()
+            let mutable inspectionCount = 0
+            let mutable postLeasePreflightHeldMaterializationLease = false
+            let mutable workflowRan = false
+
+            Directory.CreateDirectory(Path.GetDirectoryName(materializationLeaseFile))
+            |> ignore
+
+            use blockingLease = new FileStream(materializationLeaseFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+            let operations: Branch.BranchSwitchWatchCleanPreflightOperations =
+                {
+                    UpdateMarkerExists = fun () -> File.Exists(updateMarkerFile)
+                    InspectWatchStatus =
+                        fun () ->
+                            inspectionCount <- inspectionCount + 1
+
+                            if inspectionCount = 2 then
+                                postLeasePreflightHeldMaterializationLease <-
+                                    try
+                                        use _probe = new FileStream(materializationLeaseFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+                                        false
+                                    with
+                                    | :? IOException -> true
+
+                                Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) dirtyStatus)
+                            else
+                                Task.FromResult(branchSwitchWatchInspection (Some GraceWatchRuntimeMode.HealthyIncremental) (branchSwitchWatchStatus ()))
+                    ReadPendingJournalSummary = fun () -> Task.FromResult(cleanPendingJournalSummary ())
+                }
+
+            let switchTask =
+                Task.Run (fun () ->
+                    (Branch.runBranchSwitchWorkflowWithLease operations correlationId switchLeaseFile switchLeaseText (fun () ->
+                        task {
+                            workflowRan <- true
+                            return "must-not-run"
+                        }))
+                        .GetAwaiter()
+                        .GetResult())
+
+            Task.Delay(150).Wait()
+
+            switchTask.IsCompleted |> should equal false
+
+            blockingLease.Dispose()
+
+            Task.WaitAll([| switchTask :> Task |], 5000)
+            |> should equal true
+
+            match switchTask.Result with
+            | Error error ->
+                error.Error
+                |> should contain "Branch switch refused before mutation"
+
+                error.Error |> should contain "dirty working tree"
+            | Ok _ -> Assert.Fail("Expected post-lease dirty Watch preflight to refuse branch switch.")
+
+            inspectionCount |> should equal 2
+
+            postLeasePreflightHeldMaterializationLease
+            |> should equal true
+
+            workflowRan |> should equal false
 
             File.Exists(switchLeaseFile) |> should equal false
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -14996,7 +14996,25 @@ module WatchTests =
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
 
             appliedReferences.ToArray()
-            |> should equal Array.empty<ReferenceId>)
+            |> should equal Array.empty<ReferenceId>
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal false
+
+            let inspection =
+                Services
+                    .inspectGraceWatchStatus()
+                    .GetAwaiter()
+                    .GetResult()
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal false
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal true
+            | None -> Assert.Fail("Expected stale materialization cleanup to publish clean Watch IPC."))
 
     /// Verifies that a failed apply cannot republish clean IPC from pre-apply status evidence.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -14396,6 +14396,66 @@ module WatchTests =
             outcome.Value.Reason
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied)
 
+    /// Verifies that a branch switch during dirty IPC publication is rechecked before the apply seam.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationApplyBoundary")>]
+    let ``current branch materialization coordinator drops branch switch after dirty ipc before apply`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let branchBId = Guid.NewGuid()
+            let status = liveWatchStatus (Guid.NewGuid())
+            let graceStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            writeWatchStatusJsonWithRuntimeSurface status
+            |> ignore
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "dirty-ipc-target-race-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let appliedReferences = ResizeArray<ReferenceId>()
+
+            let applyReference payload _ =
+                task {
+                    appliedReferences.Add(payload.ReferenceId)
+                    raise (InvalidOperationException("old-branch Reference must not apply after dirty IPC target race"))
+                }
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                let current = Current()
+                current.BranchId <- branchBId
+                current.BranchName <- "branch-b"
+
+                Task.FromResult(graceStatus))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+
+            appliedReferences.ToArray()
+            |> should equal Array.empty<ReferenceId>)
+
     /// Verifies that a failed apply cannot republish clean IPC from pre-apply status evidence.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator keeps ipc dirty when apply fails`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13618,6 +13618,24 @@ module WatchTests =
         | ReferenceType.Commit -> { branchDto with LatestCommit = perTypeReferenceDto }
         | _ -> branchDto
 
+    /// Wraps a Watch status snapshot in the inspected IPC shape consumed by the materialization coordinator.
+    let private watchStatusInspection (status: Services.GraceWatchStatus) : Services.GraceWatchStatusInspection =
+        { Exists = true; Status = Some status; PersistedMode = Some status.Mode; SafetyFlags = status.SafetyFlags; ReadError = None }
+
+    /// Represents missing Watch IPC authority for deterministic degraded coordinator tests.
+    let private missingWatchStatusInspection: Services.GraceWatchStatusInspection =
+        {
+            Exists = false
+            Status = None
+            PersistedMode = None
+            SafetyFlags =
+                [|
+                    "missingStatus"
+                    "requiresExplicitResync"
+                |]
+            ReadError = None
+        }
+
     /// Creates a concrete current-branch Reference notification with complete remote root identity.
     let private validCurrentBranchReferenceNotification repositoryId branchId referenceType rootDirectoryId rootSha256Hash rootBlake3Hash =
         { CurrentBranchReferenceNotification.Default with
@@ -13671,7 +13689,7 @@ module WatchTests =
 
             assertRejected Services.LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable { validPayload with ReferenceId = ReferenceId.Empty })
 
-    /// Verifies that current-branch notification handling reads BranchDto before local status for concrete payloads.
+    /// Verifies that current-branch notification handling reads BranchDto before local status and rechecks before apply.
     [<Test>]
     let ``current branch reference handler fetches BranchDto before local status for valid notifications`` () =
         withTempRepo (fun root ->
@@ -13711,7 +13729,7 @@ module WatchTests =
             |> should equal (Some Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired)
 
             calls.ToArray()
-            |> should equal [| "branch"; "status" |])
+            |> should equal [| "branch"; "status"; "status" |])
 
     /// Verifies that same-root same-branch References do not schedule remote materialization.
     [<Test>]
@@ -14020,6 +14038,457 @@ module WatchTests =
 
             decision.Reason
             |> should equal Services.LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync)
+
+    /// Verifies that the materialization coordinator processes one exact Reference at a time.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator blocks later reference until active reference completes`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let referenceA =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root-a")
+                    (Blake3Hash "remote-root-a-blake3")
+
+            let referenceB =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root-b")
+                    (Blake3Hash "remote-root-b-blake3")
+
+            let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
+
+            let branchFetches = ResizeArray<ReferenceId>()
+            let appliedReferences = ResizeArray<ReferenceId>()
+            use applyStarted = new ManualResetEventSlim(false)
+            use releaseApply = new ManualResetEventSlim(false)
+
+            let getBranch () =
+                task {
+                    let branchDto = branchDtos.Dequeue()
+                    branchFetches.Add(branchDto.LatestReference.ReferenceId)
+                    return Ok(GraceReturnValue.Create branchDto "serialized-materialization-test")
+                }
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+
+            let applyReference payload _ =
+                task {
+                    appliedReferences.Add(payload.ReferenceId)
+
+                    if payload.ReferenceId = referenceA.ReferenceId then
+                        applyStarted.Set() |> ignore
+                        releaseApply.Wait()
+                }
+
+            let taskA =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        referenceA)
+                        .GetAwaiter()
+                        .GetResult())
+
+            let mutable taskB: Task<Watch.CurrentBranchMaterializationCoordinatorOutcome option> = null
+
+            try
+                applyStarted.Wait(5000) |> should equal true
+
+                taskB <-
+                    Task.Run (fun () ->
+                        (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                            getBranch
+                            inspectStatus
+                            requestDegradedResync
+                            waitForSafePoint
+                            reestablishIpc
+                            applyReference
+                            referenceB)
+                            .GetAwaiter()
+                            .GetResult())
+
+                Task.Delay(150).Wait()
+
+                branchFetches.ToArray()
+                |> should equal [| referenceA.ReferenceId |]
+            finally
+                releaseApply.Set()
+
+            let tasksToWait = if isNull taskB then [| taskA :> Task |] else [| taskA :> Task; taskB :> Task |]
+
+            Task.WaitAll(tasksToWait, 5000)
+            |> should equal true
+
+            branchFetches.ToArray()
+            |> should
+                equal
+                [|
+                    referenceA.ReferenceId
+                    referenceB.ReferenceId
+                |]
+
+            appliedReferences.ToArray()
+            |> should
+                equal
+                [|
+                    referenceA.ReferenceId
+                    referenceB.ReferenceId
+                |])
+
+    /// Verifies that a queued Reference is checked against BranchDto latest only after it owns the serialized lane.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``queued current branch reference revalidates BranchDto latest when processed`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let referenceA =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root-a")
+                    (Blake3Hash "remote-root-a-blake3")
+
+            let referenceB =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root-b")
+                    (Blake3Hash "remote-root-b-blake3")
+
+            let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
+
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    let branchDto = branchDtos.Dequeue()
+                    branchFetches.Add(branchDto.LatestReference.ReferenceId)
+                    return Ok(GraceReturnValue.Create branchDto "queued-revalidation-test")
+                }
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromResult(())
+
+            let outcomeA =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    referenceA)
+                    .Result
+
+            let outcomeB =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    referenceB)
+                    .Result
+
+            outcomeA.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            outcomeB.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchFetches.ToArray()
+            |> should
+                equal
+                [|
+                    referenceA.ReferenceId
+                    referenceB.ReferenceId
+                |])
+
+    /// Verifies that dirty local Watch state blocks remote apply and leaves local files untouched.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator waits when local status is dirty`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let localFile = Path.Combine(root, "local-work.txt")
+            File.WriteAllText(localFile, "local edits must survive")
+
+            let dirtyStatus = { liveWatchStatus (Guid.NewGuid()) with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "dirty-gate-test"))
+            let inspectStatus () = Task.FromResult(watchStatusInspection dirtyStatus)
+            let requestDegradedResync _ = Assert.Fail("Dirty but readable IPC should wait, not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("dirty local state must not apply remote materialization"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+            File.ReadAllText(localFile)
+            |> should equal "local edits must survive")
+
+    /// Verifies that missing IPC enters degraded resync and keeps the exact Reference for revalidation.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator revalidates exact reference after degraded resync`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    branchFetches.Add(notification.ReferenceId)
+                    return Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "degraded-retry-test")
+                }
+
+            let mutable statusReestablished = false
+
+            let inspectStatus () =
+                Task.FromResult(
+                    if statusReestablished then
+                        watchStatusInspection status
+                    else
+                        missingWatchStatusInspection
+                )
+
+            let degradedRequests = ResizeArray<string>()
+            let requestDegradedResync reason = degradedRequests.Add(reason)
+
+            let reestablishIpc payload _ =
+                task {
+                    payload.ReferenceId
+                    |> should equal notification.ReferenceId
+
+                    statusReestablished <- true
+                }
+
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let appliedReferences = ResizeArray<ReferenceId>()
+
+            let applyReference payload _ = task { appliedReferences.Add(payload.ReferenceId) }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            degradedRequests.ToArray()
+            |> should
+                equal
+                [|
+                    "missing Watch IPC/status authority"
+                |]
+
+            branchFetches.ToArray()
+            |> should
+                equal
+                [|
+                    notification.ReferenceId
+                    notification.ReferenceId
+                |]
+
+            appliedReferences.ToArray()
+            |> should equal [| notification.ReferenceId |])
+
+    /// Verifies that degraded retry drops the preserved Reference when BranchDto latest changes before apply.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator drops stale reference after degraded resync revalidation`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let newerNotification =
+                { notification with
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "newer-remote-root"
+                    Blake3Hash = Blake3Hash "newer-remote-root-blake3"
+                }
+
+            let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference notification)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference newerNotification)
+
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    let branchDto = branchDtos.Dequeue()
+                    branchFetches.Add(branchDto.LatestReference.ReferenceId)
+                    return Ok(GraceReturnValue.Create branchDto "degraded-stale-drop-test")
+                }
+
+            let mutable statusReestablished = false
+
+            let inspectStatus () =
+                Task.FromResult(
+                    if statusReestablished then
+                        watchStatusInspection status
+                    else
+                        missingWatchStatusInspection
+                )
+
+            let requestDegradedResync _ = ()
+
+            let reestablishIpc payload _ =
+                task {
+                    payload.ReferenceId
+                    |> should equal notification.ReferenceId
+
+                    statusReestablished <- true
+                }
+
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("stale revalidated Reference must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+
+            outcome.Value.Decision.Value.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
+
+            branchFetches.ToArray()
+            |> should
+                equal
+                [|
+                    notification.ReferenceId
+                    newerNotification.ReferenceId
+                |])
+
+    /// Verifies that rootless notifications never enter a materialization apply or multi-reference optimization path.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator rejects rootless notification before branch fetch and apply`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let rootlessNotification =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = DirectoryVersionId.Empty
+                    Sha256Hash = Sha256Hash String.Empty
+                    Blake3Hash = Blake3Hash String.Empty
+                    ReferenceType = ReferenceType.Save
+                }
+
+            let getBranch () =
+                Task.FromException<Result<GraceReturnValue<Grace.Types.Branch.BranchDto>, GraceError>>(
+                    InvalidOperationException("rootless notification must not fetch BranchDto")
+                )
+
+            let inspectStatus () =
+                Task.FromException<Services.GraceWatchStatusInspection>(InvalidOperationException("rootless notification must not inspect IPC"))
+
+            let requestDegradedResync _ = Assert.Fail("Rootless notification must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("rootless notification must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    rootlessNotification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.ProtocolRejected
+
+            outcome.Value.Decision.Value.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable)
 
     /// Verifies that stale non-empty ids cannot be rescued by matching display names.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13700,6 +13700,11 @@ module WatchTests =
             let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
             let status = liveWatchStatus (Guid.NewGuid())
 
+            LocalStateDb
+                .ensureDbInitialized(Current().GraceStatusFile)
+                .GetAwaiter()
+                .GetResult()
+
             let payload =
                 validCurrentBranchReferenceNotification
                     currentRepositoryId

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -14387,6 +14387,71 @@ module WatchTests =
             outcome.Value.Reason
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied)
 
+    /// Verifies that a failed apply cannot republish clean IPC from pre-apply status evidence.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator keeps ipc dirty when apply fails`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            writeWatchStatusJsonWithRuntimeSurface status
+            |> ignore
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "dirty-ipc-after-apply-failure-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync before apply.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+
+            let applyReference _ _ =
+                task {
+                    File.WriteAllText(Path.Combine(root, "partially-materialized.txt"), "partial remote materialization")
+                    raise (InvalidOperationException("apply failed after mutating the working tree"))
+                }
+
+            let operation =
+                Func<Task> (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                    :> Task)
+
+            Assert.ThrowsAsync<InvalidOperationException>(operation)
+            |> ignore
+
+            let inspection =
+                Services
+                    .inspectGraceWatchStatus()
+                    .GetAwaiter()
+                    .GetResult()
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+
+                inspection.IsUsable |> should equal false
+            | None -> Assert.Fail("Expected failed materialization to preserve dirty Watch IPC."))
+
     /// Verifies that durable journal pending rows block materialization even when IPC status is otherwise clean.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator blocks clean ipc with durable journal pending rows`` () =
@@ -14621,6 +14686,61 @@ module WatchTests =
                     notification.ReferenceId
                     newerNotification.ReferenceId
                 |])
+
+    /// Verifies that stale branch evidence is dropped before a mismatch safe-point wait can hold the lane.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator drops branch switch before mismatch safe point wait`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let branchBId = Guid.NewGuid()
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(
+                    Ok(
+                        GraceReturnValue.Create
+                            (branchDtoWithLatestCurrentBranchReference { notification with DirectoryId = Guid.NewGuid() })
+                            "stale-mismatch-safe-point-test"
+                    )
+                )
+
+            let dirtyStatus = { liveWatchStatus (Guid.NewGuid()) with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            let inspectStatus () =
+                let current = Current()
+                current.BranchId <- branchBId
+                current.BranchName <- "branch-b"
+
+                Task.FromResult(watchStatusInspection dirtyStatus)
+
+            let requestDegradedResync _ = Assert.Fail("Stale notification must be dropped before degraded resync.")
+
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("stale notification must not wait for a safe point"))
+
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("stale notification must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
 
     /// Verifies that rootless notifications never enter a materialization apply or multi-reference optimization path.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -11776,6 +11776,51 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should equal None)
 
+    /// Verifies that clean startup catch-up publication clears the manual pending marker.
+    [<Test; Category("StartupCatchUpPendingStatus")>]
+    let ``watch startup catch-up clean completion clears manual pending marker`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+            (Watch.publishStartupCatchUpPendingStatusForWatchTests status directoryIds Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            let readStatus () = Task.FromResult(status)
+            let processChangedFiles () = Task.FromResult(())
+
+            (Watch.completeStartupRecoveryIfPendingWorkDrainedForWatchTests readStatus Services.updateGraceWatchInterprocessFile processChangedFiles)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            let safetyFlags = readWatchStatusJsonSafetyFlags ()
+
+            safetyFlags
+            |> Set.contains "pendingWatchWork"
+            |> should equal false
+
+            Services.getGraceWatchStatus().Result
+            |> should not' (equal None))
+
     /// Verifies that processing pending Watch work publishes the dirty-to-clean IPC transition.
     [<Test>]
     let ``watch clean status transition is published after pending work drains`` () =
@@ -14194,6 +14239,128 @@ module WatchTests =
             |> should equal true
 
             operationEntered.IsSet |> should equal true)
+
+    /// Verifies that a Watch notification blocked on a local safe point does not own the repository file lease.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator releases file lease while waiting for safe point`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let dirtyStatus = { liveWatchStatus (Guid.NewGuid()) with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "safe-point-lease-test"))
+            let inspectStatus () = Task.FromResult(watchStatusInspection dirtyStatus)
+            let requestDegradedResync _ = Assert.Fail("Dirty IPC should wait for a safe point.")
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("dirty local status must not apply"))
+            use waitStarted = new ManualResetEventSlim(false)
+            use releaseWait = new ManualResetEventSlim(false)
+
+            let waitForSafePoint _ _ =
+                task {
+                    waitStarted.Set() |> ignore
+                    releaseWait.Wait()
+                }
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .GetAwaiter()
+                        .GetResult())
+
+            try
+                waitStarted.Wait(5000) |> should equal true
+
+                use _leaseProbe = new FileStream(WorkingDirectoryMaterialization.leaseFileName (), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+                Task.Delay(150).Wait()
+
+                materializationTask.IsCompleted
+                |> should equal false
+            finally
+                releaseWait.Set() |> ignore
+
+            Task.WaitAll([| materializationTask :> Task |], 5000)
+            |> should equal true
+
+            materializationTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint)
+
+    /// Verifies that a Watch notification blocked on degraded IPC retry does not own the repository file lease.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator releases file lease while retrying degraded ipc`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "degraded-lease-test"))
+
+            let inspectStatus () = Task.FromResult(missingWatchStatusInspection)
+            let requestDegradedResync _ = ()
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("missing IPC must not apply"))
+            use retryStarted = new ManualResetEventSlim(false)
+            use releaseRetry = new ManualResetEventSlim(false)
+
+            let reestablishIpc _ _ =
+                task {
+                    retryStarted.Set() |> ignore
+                    releaseRetry.Wait()
+                }
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .GetAwaiter()
+                        .GetResult())
+
+            try
+                retryStarted.Wait(5000) |> should equal true
+
+                use _leaseProbe = new FileStream(WorkingDirectoryMaterialization.leaseFileName (), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+                Task.Delay(150).Wait()
+
+                materializationTask.IsCompleted
+                |> should equal false
+            finally
+                releaseRetry.Set() |> ignore
+
+            Task.WaitAll([| materializationTask :> Task |], 5000)
+            |> should equal true
+
+            materializationTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync)
 
     /// Verifies that branch-switch working-tree materialization waits behind an active Reference materialization.
     [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -14276,6 +14276,185 @@ module WatchTests =
             File.ReadAllText(localFile)
             |> should equal "local edits must survive")
 
+    /// Verifies that branch identity is checked again after the final clean IPC inspection and before the apply seam.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator rejects branch switch before apply seam`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let branchBId = Guid.NewGuid()
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "branch-switch-gate-test"))
+            let mutable inspectionCount = 0
+
+            let inspectStatus () =
+                inspectionCount <- inspectionCount + 1
+
+                if inspectionCount = 1 then
+                    Task.FromResult(watchStatusInspection (liveWatchStatus (Guid.NewGuid())))
+                else
+                    let current = Current()
+                    current.BranchId <- branchBId
+                    current.BranchName <- "branch-b"
+
+                    Task.FromResult(watchStatusInspection (liveWatchStatus (Guid.NewGuid())))
+
+            let requestDegradedResync _ = Assert.Fail("Clean IPC for the new branch should not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("old-branch Reference must not reach apply after branch switch"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
+
+    /// Verifies that materialization-in-progress is published as dirty IPC before the apply seam can run.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator publishes dirty ipc before apply seam`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            writeWatchStatusJsonWithRuntimeSurface status
+            |> ignore
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "dirty-ipc-before-apply-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+
+            let applyReference _ _ =
+                task {
+                    let inspection =
+                        Services
+                            .inspectGraceWatchStatus()
+                            .GetAwaiter()
+                            .GetResult()
+
+                    match inspection.Status with
+                    | Some publishedStatus ->
+                        publishedStatus.HasPendingWatchWork
+                        |> should equal true
+
+                        publishedStatus.IsWorkingTreeClean
+                        |> should equal false
+
+                        inspection.IsUsable |> should equal false
+                    | None -> Assert.Fail("Expected materialization-in-progress to publish dirty Watch IPC before apply.")
+                }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied)
+
+    /// Verifies that durable journal pending rows block materialization even when IPC status is otherwise clean.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator blocks clean ipc with durable journal pending rows`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                let summary: LocalStateDb.WatchJournalPendingWorkSummary =
+                    { DbPath = Current().GraceStatusFile; AppliedThroughSequence = 0L; PendingRowCount = 1L }
+
+                Task.FromResult(summary))
+
+            try
+                let getBranch () =
+                    Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "durable-journal-gate-test"))
+
+                let inspectStatus () = Task.FromResult(watchStatusInspection status)
+                let requestDegradedResync _ = Assert.Fail("Durable journal pending rows should wait, not request degraded resync.")
+                let safePointWaits = ResizeArray<ReferenceId>()
+
+                let waitForSafePoint payload gate =
+                    task {
+                        safePointWaits.Add(payload.ReferenceId)
+
+                        match gate with
+                        | Watch.CurrentBranchMaterializationStatusGate.Blocked reason ->
+                            reason
+                            |> should equal "durable Watch journal has pending local observations"
+                        | _ -> Assert.Fail("Expected durable journal evidence to block the coordinator.")
+                    }
+
+                let reestablishIpc _ _ = Task.FromResult(())
+                let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("clean IPC with durable journal rows must not apply"))
+
+                let outcome =
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .Result
+
+                outcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+                safePointWaits.ToArray()
+                |> should
+                    equal
+                    [|
+                        notification.ReferenceId
+                        notification.ReferenceId
+                    |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that missing IPC enters degraded resync and keeps the exact Reference for revalidation.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator revalidates exact reference after degraded resync`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -185,6 +185,8 @@ module WatchTests =
         configuration.BranchName <- branchName
         configuration.RootDirectory <- rootDirectory
 
+        saveConfigFile (Path.Combine(rootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)) configuration
+
         repositoryId, branchId
 
     /// Writes a repository configuration file without relying on the process-local cached Current() value.
@@ -15430,6 +15432,66 @@ module WatchTests =
             degradedRequests.ToArray()
             |> should equal [| "missing local-state DB authority" |])
 
+    /// Verifies that suspended IPC requests degraded handling instead of waiting for ordinary queue drain.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator treats suspended ipc as degraded`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let suspendedInspection: Services.GraceWatchStatusInspection =
+                {
+                    Exists = true
+                    Status = Some status
+                    PersistedMode = Some Services.GraceWatchRuntimeMode.Suspended
+                    SafetyFlags = [| "suspended" |]
+                    ReadError = None
+                }
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "suspended-ipc-gate-test"))
+
+            let inspectStatus () = Task.FromResult(suspendedInspection)
+            let degradedRequests = ResizeArray<string>()
+            let requestDegradedResync reason = degradedRequests.Add(reason)
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("suspended IPC must not wait for a safe point"))
+            let reestablishedReferences = ResizeArray<ReferenceId>()
+            let reestablishIpc payload _ = task { reestablishedReferences.Add(payload.ReferenceId) }
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("suspended IPC must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+            degradedRequests.ToArray()
+            |> should equal [| "Watch is suspended" |]
+
+            reestablishedReferences.ToArray()
+            |> should
+                equal
+                [|
+                    notification.ReferenceId
+                    notification.ReferenceId
+                |])
+
     /// Verifies that degraded resync is not requested after the notification stops targeting Current().
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator rechecks branch before degraded resync request`` () =
@@ -15523,6 +15585,65 @@ module WatchTests =
             let current = Current()
             current.BranchId <- branchBId
             current.BranchName <- "branch-b"
+
+            blockingLease.Dispose()
+
+            Task.WaitAll([| materializationTask :> Task |], 5000)
+            |> should equal true
+
+            materializationTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
+
+    /// Verifies that a branch switch persisted during the repository lease wait is observed before apply.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator reloads persisted branch after lease wait`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let branchBId = Guid.NewGuid()
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "persisted-post-lease-branch-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Stale notification must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("stale persisted-branch notification must not apply"))
+            let leaseFileName = WorkingDirectoryMaterialization.leaseFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(leaseFileName))
+            |> ignore
+
+            use blockingLease = new FileStream(leaseFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .GetAwaiter()
+                        .GetResult())
+
+            Task.Delay(150).Wait()
+
+            writeRepositoryConfiguration root currentRepositoryId "current-repo" branchBId "branch-b"
+
+            Current().BranchId |> should equal currentBranchId
 
             blockingLease.Dispose()
 
@@ -15962,6 +16083,141 @@ module WatchTests =
 
             outcome.Value.Reason
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
+
+    /// Verifies that dirty status becoming clean re-runs the latest-reference decision before apply.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator retries after dirty status becomes clean`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let cleanStatus = liveWatchStatus (Guid.NewGuid())
+            let dirtyStatus = { cleanStatus with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    branchFetches.Add(notification.ReferenceId)
+                    return Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "dirty-clean-retry-test")
+                }
+
+            let mutable inspections = 0
+
+            let inspectStatus () =
+                inspections <- inspections + 1
+
+                if inspections = 1 then
+                    Task.FromResult(watchStatusInspection dirtyStatus)
+                else
+                    Task.FromResult(watchStatusInspection cleanStatus)
+
+            let requestDegradedResync _ = Assert.Fail("Clean recovered status must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("Clean recovered status must retry instead of waiting."))
+            let reestablishIpc _ _ = Task.FromException<unit>(InvalidOperationException("Clean recovered status must not reestablish IPC."))
+            let appliedReferences = ResizeArray<ReferenceId>()
+            let applyReference payload _ = task { appliedReferences.Add(payload.ReferenceId) }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchFetches.ToArray()
+            |> should
+                equal
+                [|
+                    notification.ReferenceId
+                    notification.ReferenceId
+                |]
+
+            inspections |> should equal 5
+
+            appliedReferences.ToArray()
+            |> should equal [| notification.ReferenceId |])
+
+    /// Verifies that unavailable status becoming clean re-runs the latest-reference decision before apply.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator retries after unavailable status becomes clean`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let cleanStatus = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    branchFetches.Add(notification.ReferenceId)
+                    return Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "unavailable-clean-retry-test")
+                }
+
+            let mutable inspections = 0
+
+            let inspectStatus () =
+                inspections <- inspections + 1
+
+                if inspections = 1 then
+                    Task.FromResult(missingWatchStatusInspection)
+                else
+                    Task.FromResult(watchStatusInspection cleanStatus)
+
+            let requestDegradedResync _ = Assert.Fail("Clean recovered status must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("Clean recovered status must retry instead of waiting."))
+            let reestablishIpc _ _ = Task.FromException<unit>(InvalidOperationException("Clean recovered status must not reestablish IPC."))
+            let appliedReferences = ResizeArray<ReferenceId>()
+            let applyReference payload _ = task { appliedReferences.Add(payload.ReferenceId) }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchFetches.ToArray()
+            |> should
+                equal
+                [|
+                    notification.ReferenceId
+                    notification.ReferenceId
+                |]
+
+            inspections |> should equal 5
+
+            appliedReferences.ToArray()
+            |> should equal [| notification.ReferenceId |])
 
     /// Verifies that a clean gate after a local status identity rejection terminates instead of spinning.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -14207,6 +14207,8 @@ module WatchTests =
 
             let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
 
             let branchFetches = ResizeArray<ReferenceId>()
@@ -14269,7 +14271,12 @@ module WatchTests =
                 Task.Delay(150).Wait()
 
                 branchFetches.ToArray()
-                |> should equal [| referenceA.ReferenceId |]
+                |> should
+                    equal
+                    [|
+                        referenceA.ReferenceId
+                        referenceA.ReferenceId
+                    |]
             finally
                 releaseApply.Set()
 
@@ -14283,6 +14290,8 @@ module WatchTests =
                 equal
                 [|
                     referenceA.ReferenceId
+                    referenceA.ReferenceId
+                    referenceB.ReferenceId
                     referenceB.ReferenceId
                 |]
 
@@ -14529,6 +14538,74 @@ module WatchTests =
 
             branchSwitchEntered.IsSet |> should equal true)
 
+    /// Verifies that clean status observed before the repository lease cannot reach apply after local work arrives.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator rechecks clean gate after lease wait`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let cleanStatus = liveWatchStatus (Guid.NewGuid())
+            let dirtyStatus = { cleanStatus with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "post-lease-gate-test"))
+            let mutable inspectionCount = 0
+
+            let inspectStatus () =
+                inspectionCount <- inspectionCount + 1
+
+                if inspectionCount < 4 then
+                    Task.FromResult(watchStatusInspection cleanStatus)
+                else
+                    Task.FromResult(watchStatusInspection dirtyStatus)
+
+            let requestDegradedResync _ = Assert.Fail("Dirty post-lease status should wait for a safe point.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("post-lease dirty status must not apply"))
+            let leaseFileName = WorkingDirectoryMaterialization.leaseFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(leaseFileName))
+            |> ignore
+
+            use blockingLease = new FileStream(leaseFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .GetAwaiter()
+                        .GetResult())
+
+            Task.Delay(150).Wait()
+
+            materializationTask.IsCompleted
+            |> should equal false
+
+            blockingLease.Dispose()
+
+            Task.WaitAll([| materializationTask :> Task |], 5000)
+            |> should equal true
+
+            materializationTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+            inspectionCount
+            |> should be (greaterThanOrEqualTo 4))
+
     /// Verifies that a queued Reference is checked against BranchDto latest only after it owns the serialized lane.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``queued current branch reference revalidates BranchDto latest when processed`` () =
@@ -14556,6 +14633,8 @@ module WatchTests =
 
             let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
 
             let branchFetches = ResizeArray<ReferenceId>()
@@ -14606,6 +14685,8 @@ module WatchTests =
                 equal
                 [|
                     referenceA.ReferenceId
+                    referenceA.ReferenceId
+                    referenceB.ReferenceId
                     referenceB.ReferenceId
                 |])
 
@@ -15229,6 +15310,63 @@ module WatchTests =
             outcome.Value.Reason
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
 
+    /// Verifies that a branch switch completed during the repository lease wait is observed before apply.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator rechecks branch after lease wait`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let branchBId = Guid.NewGuid()
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "post-lease-branch-test"))
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Stale notification must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("stale post-lease notification must not apply"))
+            let leaseFileName = WorkingDirectoryMaterialization.leaseFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(leaseFileName))
+            |> ignore
+
+            use blockingLease = new FileStream(leaseFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .GetAwaiter()
+                        .GetResult())
+
+            Task.Delay(150).Wait()
+
+            let current = Current()
+            current.BranchId <- branchBId
+            current.BranchName <- "branch-b"
+
+            blockingLease.Dispose()
+
+            Task.WaitAll([| materializationTask :> Task |], 5000)
+            |> should equal true
+
+            materializationTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
+
     /// Verifies that missing IPC enters degraded resync and keeps the exact Reference for revalidation.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator revalidates exact reference after degraded resync`` () =
@@ -15304,6 +15442,7 @@ module WatchTests =
             |> should
                 equal
                 [|
+                    notification.ReferenceId
                     notification.ReferenceId
                     notification.ReferenceId
                 |]
@@ -15450,6 +15589,65 @@ module WatchTests =
 
             outcome.Value.Reason
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
+
+    /// Verifies that a clean gate after a local status identity rejection terminates instead of spinning.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator terminates clean gate after status identity mismatch`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let legacyNameFallbackStatus = { liveWatchStatus (Guid.NewGuid()) with BranchId = BranchId.Empty; BranchName = BranchName "branch-a" }
+
+            let branchAStatus = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let mutable branchFetches = 0
+
+            let getBranch () =
+                branchFetches <- branchFetches + 1
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "identity-mismatch-clean-gate-test"))
+
+            let mutable inspections = 0
+
+            let inspectStatus () =
+                inspections <- inspections + 1
+
+                if inspections = 1 then
+                    Task.FromResult(watchStatusInspection legacyNameFallbackStatus)
+                else
+                    Task.FromResult(watchStatusInspection branchAStatus)
+
+            let requestDegradedResync _ = Assert.Fail("Clean status identity rejection must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("clean status identity rejection must not wait"))
+            let reestablishIpc _ _ = Task.FromException<unit>(InvalidOperationException("clean status identity rejection must not retry IPC"))
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("clean status identity rejection must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+
+            outcome.Value.Decision.Value.Reason
+            |> should equal Services.LatestCurrentBranchReferenceDecisionReason.LocalStatusIdentityMismatch
+
+            branchFetches |> should equal 1
+            inspections |> should equal 2)
 
     /// Verifies that rootless notifications never enter a materialization apply or multi-reference optimization path.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13825,17 +13825,12 @@ module WatchTests =
 
             assertRejected Services.LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable { validPayload with ReferenceId = ReferenceId.Empty })
 
-    /// Verifies that current-branch notification handling reads BranchDto before local status and rechecks before apply.
+    /// Verifies that current-branch notification handling reads BranchDto before initial local status and rechecks status before apply.
     [<Test>]
     let ``current branch reference handler fetches BranchDto before local status for valid notifications`` () =
         withTempRepo (fun root ->
             let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
             let status = liveWatchStatus (Guid.NewGuid())
-
-            LocalStateDb
-                .ensureDbInitialized(Current().GraceStatusFile)
-                .GetAwaiter()
-                .GetResult()
 
             let payload =
                 validCurrentBranchReferenceNotification
@@ -13855,22 +13850,48 @@ module WatchTests =
                     return Ok(GraceReturnValue.Create branchDto "branch-fetch-before-status")
                 }
 
-            let readLocalStatus () =
+            let inspectStatus () =
                 task {
                     calls.Add("status")
-                    return Some status
+                    return watchStatusInspection status
                 }
 
-            let decision =
-                (Watch.handleCurrentBranchReferenceNotificationWithClientsForWatchTests getBranch readLocalStatus payload)
+            let requestDegradedResync _ = Assert.Fail("Clean status must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+
+            let applyReference appliedPayload _ =
+                task {
+                    appliedPayload.ReferenceId
+                    |> should equal payload.ReferenceId
+
+                    calls.Add("apply")
+                }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    payload)
                     .Result
 
-            decision
-            |> Option.map (fun result -> result.Reason)
-            |> should equal (Some Services.LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired)
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
 
             calls.ToArray()
-            |> should equal [| "branch"; "status"; "status" |])
+            |> should
+                equal
+                [|
+                    "branch"
+                    "status"
+                    "status"
+                    "status"
+                    "apply"
+                |])
 
     /// Verifies that same-root same-branch References do not schedule remote materialization.
     [<Test>]
@@ -14207,8 +14228,6 @@ module WatchTests =
 
             let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
-            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
-            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
 
             let branchFetches = ResizeArray<ReferenceId>()
@@ -14271,12 +14290,7 @@ module WatchTests =
                 Task.Delay(150).Wait()
 
                 branchFetches.ToArray()
-                |> should
-                    equal
-                    [|
-                        referenceA.ReferenceId
-                        referenceA.ReferenceId
-                    |]
+                |> should equal [| referenceA.ReferenceId |]
             finally
                 releaseApply.Set()
 
@@ -14290,8 +14304,6 @@ module WatchTests =
                 equal
                 [|
                     referenceA.ReferenceId
-                    referenceA.ReferenceId
-                    referenceB.ReferenceId
                     referenceB.ReferenceId
                 |]
 
@@ -14561,7 +14573,7 @@ module WatchTests =
             let inspectStatus () =
                 inspectionCount <- inspectionCount + 1
 
-                if inspectionCount < 4 then
+                if inspectionCount < 3 then
                     Task.FromResult(watchStatusInspection cleanStatus)
                 else
                     Task.FromResult(watchStatusInspection dirtyStatus)
@@ -14604,7 +14616,93 @@ module WatchTests =
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
 
             inspectionCount
-            |> should be (greaterThanOrEqualTo 4))
+            |> should be (greaterThanOrEqualTo 3))
+
+    /// Verifies that an accepted Reference is not rejected solely because BranchDto advances during the lease wait.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator preserves accepted reference after latest advances during lease wait`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let acceptedReference =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "accepted-root")
+                    (Blake3Hash "accepted-root-blake3")
+
+            let newerReference =
+                { acceptedReference with
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "newer-root"
+                    Blake3Hash = Blake3Hash "newer-root-blake3"
+                }
+
+            let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference acceptedReference)
+            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference newerReference)
+
+            let branchFetches = ResizeArray<ReferenceId>()
+            use branchFetched = new ManualResetEventSlim(false)
+
+            let getBranch () =
+                task {
+                    let branchDto = branchDtos.Dequeue()
+                    branchFetches.Add(branchDto.LatestReference.ReferenceId)
+                    branchFetched.Set() |> ignore
+
+                    return Ok(GraceReturnValue.Create branchDto "post-lease-accepted-reference-test")
+                }
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let appliedReferences = ResizeArray<ReferenceId>()
+            let applyReference payload _ = task { appliedReferences.Add(payload.ReferenceId) }
+            let leaseFileName = WorkingDirectoryMaterialization.leaseFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(leaseFileName))
+            |> ignore
+
+            use blockingLease = new FileStream(leaseFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        acceptedReference)
+                        .GetAwaiter()
+                        .GetResult())
+
+            try
+                branchFetched.Wait(5000) |> should equal true
+
+                branchFetches.ToArray()
+                |> should equal [| acceptedReference.ReferenceId |]
+            finally
+                blockingLease.Dispose()
+
+            Task.WaitAll([| materializationTask :> Task |], 5000)
+            |> should equal true
+
+            materializationTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchFetches.ToArray()
+            |> should equal [| acceptedReference.ReferenceId |]
+
+            appliedReferences.ToArray()
+            |> should equal [| acceptedReference.ReferenceId |])
 
     /// Verifies that a queued Reference is checked against BranchDto latest only after it owns the serialized lane.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
@@ -14633,8 +14731,6 @@ module WatchTests =
 
             let branchDtos = Queue<Grace.Types.Branch.BranchDto>()
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
-            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceA)
-            branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
             branchDtos.Enqueue(branchDtoWithLatestCurrentBranchReference referenceB)
 
             let branchFetches = ResizeArray<ReferenceId>()
@@ -14685,8 +14781,6 @@ module WatchTests =
                 equal
                 [|
                     referenceA.ReferenceId
-                    referenceA.ReferenceId
-                    referenceB.ReferenceId
                     referenceB.ReferenceId
                 |])
 
@@ -15033,6 +15127,59 @@ module WatchTests =
                     [|
                         notification.ReferenceId
                         notification.ReferenceId
+                    |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that unreadable local-state journal authority requests degraded resync instead of holding the safe-point lane.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator treats unreadable journal authority as degraded`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                Task.FromException<LocalStateDb.WatchJournalPendingWorkSummary>(InvalidOperationException("local-state schema is incompatible")))
+
+            try
+                let getBranch () =
+                    Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "unreadable-journal-gate-test"))
+
+                let inspectStatus () = Task.FromResult(watchStatusInspection status)
+                let degradedRequests = ResizeArray<string>()
+                let requestDegradedResync reason = degradedRequests.Add(reason)
+                let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("unreadable journal authority must not wait for a safe point"))
+                let reestablishIpc _ _ = Task.FromResult(())
+                let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("unreadable journal authority must not apply"))
+
+                let outcome =
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .Result
+
+                outcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+                degradedRequests.ToArray()
+                |> should
+                    equal
+                    [|
+                        "unreadable durable Watch journal authority"
                     |]
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
@@ -15442,7 +15589,6 @@ module WatchTests =
             |> should
                 equal
                 [|
-                    notification.ReferenceId
                     notification.ReferenceId
                     notification.ReferenceId
                 |]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13102,6 +13102,93 @@ module WatchTests =
                 |> should equal true
             | None -> Assert.Fail("Expected transition IPC to publish from the local transition read."))
 
+    /// Verifies that materialization-only pending status keeps IPC dirty without entering timer work.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``manual pending status marker publishes dirty ipc without timer processing`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let status =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "manual-pending-root"
+                    RootDirectoryBlake3Hash = Blake3Hash "manual-pending-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.updateGraceStatusDirectoryIds status
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+
+            let processablePending, hasPendingEvidence = Watch.pendingWatchWorkEvidenceForWatchTests ()
+
+            processablePending |> should equal false
+            hasPendingEvidence |> should equal true
+
+            Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            /// Tracks accidental timer status reads while only materialization pending status exists.
+            let mutable readStatusCalls = 0
+            /// Tracks accidental timer uploads while only materialization pending status exists.
+            let mutable uploadCalls = 0
+            /// Tracks accidental scan-based status updates while only materialization pending status exists.
+            let mutable scanStatusCalls = 0
+            /// Tracks accidental event-derived status updates while only materialization pending status exists.
+            let mutable eventStatusCalls = 0
+            /// Tracks accidental incremental status updates while only materialization pending status exists.
+            let mutable incrementalCalls = 0
+
+            let readStatus () =
+                readStatusCalls <- readStatusCalls + 1
+                Task.FromResult(status)
+
+            let upload _ _ =
+                uploadCalls <- uploadCalls + 1
+                Task.FromResult(())
+
+            let updateGraceStatus currentStatus _ =
+                scanStatusCalls <- scanStatusCalls + 1
+                Task.FromResult(Some currentStatus)
+
+            let updateGraceStatusFromDifferences currentStatus _ _ =
+                eventStatusCalls <- eventStatusCalls + 1
+                Task.FromResult(Some currentStatus)
+
+            let applyIncremental _ _ _ =
+                incrementalCalls <- incrementalCalls + 1
+                Task.FromResult(())
+
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scannerHostileDifferenceDiscovery
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            readStatusCalls |> should equal 0
+            uploadCalls |> should equal 0
+            scanStatusCalls |> should equal 0
+            eventStatusCalls |> should equal 0
+            incrementalCalls |> should equal 0)
+
     /// Verifies that overflow during an in-flight upload cancels normal status application.
     [<Test>]
     let ``overflow during upload prevents stale observation commit`` () =
@@ -14927,6 +15014,126 @@ module WatchTests =
                 [|
                     "process-local Watch queues have pending local observations"
                     "process-local Watch queues have pending local observations"
+                |])
+
+    /// Verifies that the materialization gate waits while the existing Grace update marker is present.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator blocks clean ipc while update marker exists`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, "`grace rebase` is in progress.")
+
+            try
+                let notification =
+                    validCurrentBranchReferenceNotification
+                        currentRepositoryId
+                        currentBranchId
+                        ReferenceType.Save
+                        (Guid.NewGuid())
+                        (Sha256Hash "remote-root")
+                        (Blake3Hash "remote-root-blake3")
+
+                let getBranch () =
+                    Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "update-marker-gate-test"))
+
+                let inspectStatus () = Task.FromResult(watchStatusInspection status)
+                let requestDegradedResync _ = Assert.Fail("Existing update marker should wait, not request degraded resync.")
+                let safePointWaits = ResizeArray<string>()
+
+                let waitForSafePoint _ gate =
+                    task {
+                        match gate with
+                        | Watch.CurrentBranchMaterializationStatusGate.Blocked reason -> safePointWaits.Add(reason)
+                        | _ -> Assert.Fail("Expected existing update marker to block the coordinator.")
+                    }
+
+                let reestablishIpc _ _ = Task.FromResult(())
+                let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("update marker must block clean materialization"))
+
+                let outcome =
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .Result
+
+                outcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+                safePointWaits.ToArray()
+                |> should
+                    equal
+                    [|
+                        "Grace update marker is present"
+                        "Grace update marker is present"
+                    |]
+            finally
+                if File.Exists(updateMarkerFile) then File.Delete(updateMarkerFile))
+
+    /// Verifies that materialization pending status remains a clean-gate blocker even though it is not timer work.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator blocks clean ipc with manual pending status marker`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "manual-pending-gate-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Manual pending status should wait, not request degraded resync.")
+            let safePointWaits = ResizeArray<string>()
+
+            let waitForSafePoint _ gate =
+                task {
+                    match gate with
+                    | Watch.CurrentBranchMaterializationStatusGate.Blocked reason -> safePointWaits.Add(reason)
+                    | _ -> Assert.Fail("Expected manual pending status to block the coordinator.")
+                }
+
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("manual pending status must block clean materialization"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+            safePointWaits.ToArray()
+            |> should
+                equal
+                [|
+                    "materialization pending status has not reached IPC"
+                    "materialization pending status has not reached IPC"
                 |])
 
     /// Verifies that clean IPC does not let materialization proceed when the local-state database is missing.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -15532,6 +15532,215 @@ module WatchTests =
             materializationTask.Result.Value.Reason
             |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
 
+    /// Verifies that an accepted Reference survives a post-lease blocked retry when BranchDto latest advances meanwhile.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator keeps accepted reference after post lease blocked retry`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let cleanStatus = liveWatchStatus (Guid.NewGuid())
+            let blockedStatus = { cleanStatus with HasPendingWatchWork = true; IsWorkingTreeClean = false }
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let newerNotification =
+                { notification with
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "newer-remote-root"
+                    Blake3Hash = Blake3Hash "newer-remote-root-blake3"
+                }
+
+            let mutable latestBranchDto = branchDtoWithLatestCurrentBranchReference notification
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    branchFetches.Add(latestBranchDto.LatestReference.ReferenceId)
+                    return Ok(GraceReturnValue.Create latestBranchDto "post-lease-blocked-retry-test")
+                }
+
+            let mutable inspectionCount = 0
+            let inspections = ResizeArray<string>()
+
+            let inspectStatus () =
+                task {
+                    inspectionCount <- inspectionCount + 1
+
+                    if inspectionCount = 3 then
+                        inspections.Add("blocked")
+                        return watchStatusInspection blockedStatus
+                    else
+                        inspections.Add("clean")
+                        return watchStatusInspection cleanStatus
+                }
+
+            let requestDegradedResync _ = Assert.Fail("Blocked post-lease retry must wait for a safe point, not request degraded resync.")
+            let safePointWaits = ResizeArray<string>()
+
+            let waitForSafePoint payload gate =
+                task {
+                    payload.ReferenceId
+                    |> should equal notification.ReferenceId
+
+                    match gate with
+                    | Watch.CurrentBranchMaterializationStatusGate.Blocked reason -> safePointWaits.Add(reason)
+                    | _ -> Assert.Fail("Expected a blocked safe-point gate.")
+
+                    latestBranchDto <- branchDtoWithLatestCurrentBranchReference newerNotification
+                }
+
+            let reestablishIpc _ _ = Task.FromException<unit>(InvalidOperationException("blocked retry must not reestablish IPC"))
+            let appliedReferences = ResizeArray<ReferenceId>()
+            let applyReference payload _ = task { appliedReferences.Add(payload.ReferenceId) }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchFetches.ToArray()
+            |> should equal [| notification.ReferenceId |]
+
+            safePointWaits.ToArray()
+            |> should
+                equal
+                [|
+                    "local Watch status has dirty or pending work"
+                |]
+
+            inspections.ToArray()
+            |> should
+                equal
+                [|
+                    "clean"
+                    "clean"
+                    "blocked"
+                    "clean"
+                    "clean"
+                |]
+
+            appliedReferences.ToArray()
+            |> should equal [| notification.ReferenceId |])
+
+    /// Verifies that an accepted Reference survives a post-lease degraded retry when BranchDto latest advances meanwhile.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator keeps accepted reference after post lease degraded retry`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let cleanStatus = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Checkpoint
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let newerNotification =
+                { notification with
+                    ReferenceId = Guid.NewGuid()
+                    DirectoryId = Guid.NewGuid()
+                    Sha256Hash = Sha256Hash "newer-remote-root"
+                    Blake3Hash = Blake3Hash "newer-remote-root-blake3"
+                }
+
+            let mutable latestBranchDto = branchDtoWithLatestCurrentBranchReference notification
+            let branchFetches = ResizeArray<ReferenceId>()
+
+            let getBranch () =
+                task {
+                    branchFetches.Add(latestBranchDto.LatestReference.ReferenceId)
+                    return Ok(GraceReturnValue.Create latestBranchDto "post-lease-degraded-retry-test")
+                }
+
+            let mutable inspectionCount = 0
+            let inspections = ResizeArray<string>()
+
+            let inspectStatus () =
+                task {
+                    inspectionCount <- inspectionCount + 1
+
+                    if inspectionCount = 3 then
+                        inspections.Add("degraded")
+                        return missingWatchStatusInspection
+                    else
+                        inspections.Add("clean")
+                        return watchStatusInspection cleanStatus
+                }
+
+            let degradedRequests = ResizeArray<string>()
+            let requestDegradedResync reason = degradedRequests.Add(reason)
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("degraded retry must not wait for a safe point"))
+            let reestablishedReferences = ResizeArray<ReferenceId>()
+
+            let reestablishIpc payload _ =
+                task {
+                    reestablishedReferences.Add(payload.ReferenceId)
+                    latestBranchDto <- branchDtoWithLatestCurrentBranchReference newerNotification
+                }
+
+            let appliedReferences = ResizeArray<ReferenceId>()
+            let applyReference payload _ = task { appliedReferences.Add(payload.ReferenceId) }
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchFetches.ToArray()
+            |> should equal [| notification.ReferenceId |]
+
+            degradedRequests.ToArray()
+            |> should
+                equal
+                [|
+                    "missing Watch IPC/status authority"
+                |]
+
+            reestablishedReferences.ToArray()
+            |> should equal [| notification.ReferenceId |]
+
+            inspections.ToArray()
+            |> should
+                equal
+                [|
+                    "clean"
+                    "clean"
+                    "degraded"
+                    "clean"
+                    "clean"
+                |]
+
+            appliedReferences.ToArray()
+            |> should equal [| notification.ReferenceId |])
+
     /// Verifies that missing IPC enters degraded resync and keeps the exact Reference for revalidation.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator revalidates exact reference after degraded resync`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -14162,6 +14162,119 @@ module WatchTests =
                     referenceB.ReferenceId
                 |])
 
+    /// Verifies that the repository/worktree lease blocks materialization in another lane owner.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``working directory materialization lane waits for repository lease`` () =
+        withTempRepo (fun root ->
+            configureCurrentWatchIdentity root "current-repo" "current-branch"
+            |> ignore
+
+            let leaseFileName = WorkingDirectoryMaterialization.leaseFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(leaseFileName))
+            |> ignore
+
+            use blockingLease = new FileStream(leaseFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+            use operationEntered = new ManualResetEventSlim(false)
+
+            let materializationTask =
+                Task.Run (fun () ->
+                    (WorkingDirectoryMaterialization.runSerialized (fun () -> task { operationEntered.Set() |> ignore }))
+                        .GetAwaiter()
+                        .GetResult())
+
+            try
+                Task.Delay(150).Wait()
+
+                operationEntered.IsSet |> should equal false
+            finally
+                blockingLease.Dispose()
+
+            Task.WaitAll([| materializationTask |], 5000)
+            |> should equal true
+
+            operationEntered.IsSet |> should equal true)
+
+    /// Verifies that branch-switch working-tree materialization waits behind an active Reference materialization.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]
+    let ``current branch materialization coordinator blocks branch switch lane until active reference completes`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "branch-switch-lane-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Clean IPC must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            use applyStarted = new ManualResetEventSlim(false)
+            use releaseApply = new ManualResetEventSlim(false)
+            use branchSwitchEntered = new ManualResetEventSlim(false)
+
+            let applyReference _ _ =
+                task {
+                    applyStarted.Set() |> ignore
+
+                    releaseApply.Wait()
+                }
+
+            let referenceTask =
+                Task.Run (fun () ->
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .GetAwaiter()
+                        .GetResult())
+
+            let mutable branchSwitchTask: Task = null
+
+            try
+                applyStarted.Wait(5000) |> should equal true
+
+                branchSwitchTask <-
+                    Task.Run (fun () ->
+                        (WorkingDirectoryMaterialization.runSerialized (fun () -> task { branchSwitchEntered.Set() |> ignore }))
+                            .GetAwaiter()
+                            .GetResult())
+
+                Task.Delay(150).Wait()
+
+                branchSwitchEntered.IsSet |> should equal false
+            finally
+                releaseApply.Set() |> ignore
+
+            let tasksToWait =
+                if isNull branchSwitchTask then
+                    [| referenceTask :> Task |]
+                else
+                    [|
+                        referenceTask :> Task
+                        branchSwitchTask
+                    |]
+
+            Task.WaitAll(tasksToWait, 5000)
+            |> should equal true
+
+            referenceTask.Result.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            branchSwitchEntered.IsSet |> should equal true)
+
     /// Verifies that a queued Reference is checked against BranchDto latest only after it owns the serialized lane.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``queued current branch reference revalidates BranchDto latest when processed`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13620,6 +13620,10 @@ module WatchTests =
 
     /// Wraps a Watch status snapshot in the inspected IPC shape consumed by the materialization coordinator.
     let private watchStatusInspection (status: Services.GraceWatchStatus) : Services.GraceWatchStatusInspection =
+        (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+            .GetAwaiter()
+            .GetResult()
+
         { Exists = true; Status = Some status; PersistedMode = Some status.Mode; SafetyFlags = status.SafetyFlags; ReadError = None }
 
     /// Represents missing Watch IPC authority for deterministic degraded coordinator tests.
@@ -14519,6 +14523,159 @@ module WatchTests =
                     |]
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies that process-local Watch queues block materialization before IPC or journal snapshots can appear clean.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator blocks clean ipc with process local pending work`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let queuedFile = Path.Combine(root, "queued-before-ipc.txt")
+            File.WriteAllText(queuedFile, "queued local work")
+            Watch.OnChanged(changedEvent queuedFile)
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "process-local-work-gate-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("Process-local queues should wait, not request degraded resync.")
+            let safePointWaits = ResizeArray<string>()
+
+            let waitForSafePoint _ gate =
+                task {
+                    match gate with
+                    | Watch.CurrentBranchMaterializationStatusGate.Blocked reason -> safePointWaits.Add(reason)
+                    | _ -> Assert.Fail("Expected process-local Watch queues to block the coordinator.")
+                }
+
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("process-local Watch queues must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+            safePointWaits.ToArray()
+            |> should
+                equal
+                [|
+                    "process-local Watch queues have pending local observations"
+                    "process-local Watch queues have pending local observations"
+                |])
+
+    /// Verifies that clean IPC does not let materialization proceed when the local-state database is missing.
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator fails closed when local state database is missing`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+            deleteLocalStateDbFiles ()
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "missing-local-state-gate-test"))
+
+            let inspectStatus () =
+                Task.FromResult<Services.GraceWatchStatusInspection>(
+                    { Exists = true; Status = Some status; PersistedMode = Some status.Mode; SafetyFlags = status.SafetyFlags; ReadError = None }
+                )
+
+            let degradedRequests = ResizeArray<string>()
+            let requestDegradedResync reason = degradedRequests.Add(reason)
+            let reestablishIpc _ _ = Task.FromResult(())
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("missing local-state DB must not wait as clean work"))
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("missing local-state DB must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+            degradedRequests.ToArray()
+            |> should equal [| "missing local-state DB authority" |])
+
+    /// Verifies that degraded resync is not requested after the notification stops targeting Current().
+    [<Test; Category("CurrentBranchMaterializationCoordinator")>]
+    let ``current branch materialization coordinator rechecks branch before degraded resync request`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "branch-a"
+            let branchBId = Guid.NewGuid()
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "degraded-current-recheck-test"))
+
+            let inspectStatus () =
+                let current = Current()
+                current.BranchId <- branchBId
+                current.BranchName <- "branch-b"
+
+                Task.FromResult(missingWatchStatusInspection)
+
+            let requestDegradedResync _ = Assert.Fail("Stale notification must not request degraded resync.")
+            let reestablishIpc _ _ = Task.FromException<unit>(InvalidOperationException("stale notification must not reestablish IPC"))
+            let waitForSafePoint _ _ = Task.FromException<unit>(InvalidOperationException("stale notification must not wait for a safe point"))
+            let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("stale notification must not apply"))
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch)
 
     /// Verifies that missing IPC enters degraded resync and keeps the exact Reference for revalidation.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3802,37 +3802,38 @@ module Branch =
                                         }
 
                                     let! workingTreeUpdateResult =
-                                        runBranchSwitchWorkingTreeUpdateWithMarker
-                                            preflightOperations
-                                            (getCorrelationId parseResult)
-                                            workingTreeUpdateMarkerFileName
-                                            workingTreeUpdateMarkerText
-                                            (fun () ->
-                                                task {
-                                                    //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
+                                        WorkingDirectoryMaterialization.runSerialized (fun () ->
+                                            runBranchSwitchWorkingTreeUpdateWithMarker
+                                                preflightOperations
+                                                (getCorrelationId parseResult)
+                                                workingTreeUpdateMarkerFileName
+                                                workingTreeUpdateMarkerText
+                                                (fun () ->
+                                                    task {
+                                                        //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
 
-                                                    // Update working directory based on new GraceStatus.Index
-                                                    do!
-                                                        updateWorkingDirectory
-                                                            newGraceStatus
-                                                            graceStatusWithNewDirectoryVersionsFromServer
-                                                            newDirectoryVersionDtos
-                                                            (getCorrelationId parseResult)
-                                                    //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
+                                                        // Update working directory based on new GraceStatus.Index
+                                                        do!
+                                                            updateWorkingDirectory
+                                                                newGraceStatus
+                                                                graceStatusWithNewDirectoryVersionsFromServer
+                                                                newDirectoryVersionDtos
+                                                                (getCorrelationId parseResult)
+                                                        //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
 
-                                                    // Save the new Grace Status.
-                                                    do!
-                                                        applyBranchSwitchLocalState
-                                                            (fun () -> writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer)
-                                                            (fun () ->
-                                                                let configuration = Current()
-                                                                configuration.BranchId <- newBranch.BranchId
-                                                                configuration.BranchName <- newBranch.BranchName
-                                                                updateConfiguration configuration)
-                                                            (fun () -> upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values)
+                                                        // Save the new Grace Status.
+                                                        do!
+                                                            applyBranchSwitchLocalState
+                                                                (fun () -> writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer)
+                                                                (fun () ->
+                                                                    let configuration = Current()
+                                                                    configuration.BranchId <- newBranch.BranchId
+                                                                    configuration.BranchName <- newBranch.BranchName
+                                                                    updateConfiguration configuration)
+                                                                (fun () -> upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values)
 
-                                                    t |> setProgressTaskValue showOutput 100.0
-                                                })
+                                                        t |> setProgressTaskValue showOutput 100.0
+                                                    }))
 
                                     match workingTreeUpdateResult with
                                     | Error error -> return Error error

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3116,8 +3116,17 @@ module Branch =
                     match! runBranchSwitchWatchCleanPreflight operations correlationId with
                     | Error error -> return Error error
                     | Ok () ->
-                        let! result = WorkingDirectoryMaterialization.runWithLease workflow
-                        return Ok result
+                        let! result =
+                            WorkingDirectoryMaterialization.runWithLease (fun () ->
+                                task {
+                                    match! runBranchSwitchWatchCleanPreflight operations correlationId with
+                                    | Error error -> return Error error
+                                    | Ok () ->
+                                        let! workflowResult = workflow ()
+                                        return Ok workflowResult
+                                })
+
+                        return result
                 finally
                     if leaseCreatedByThisInvocation then
                         deleteBranchSwitchWorkflowLeaseIfOwned switchLeaseFileName leaseText

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3072,7 +3072,7 @@ module Branch =
     let internal deleteBranchSwitchWorkflowLeaseIfOwned (switchLeaseFileName: string) (leaseText: string) =
         deleteBranchSwitchUpdateMarkerIfOwned switchLeaseFileName leaseText
 
-    /// Runs a branch-switch workflow under a non-Watch-suppressing lease before state is computed.
+    /// Runs a branch-switch workflow under precompute and materialization leases before state is computed.
     let internal runBranchSwitchWorkflowWithLease
         (operations: BranchSwitchWatchCleanPreflightOperations)
         correlationId
@@ -3116,7 +3116,7 @@ module Branch =
                     match! runBranchSwitchWatchCleanPreflight operations correlationId with
                     | Error error -> return Error error
                     | Ok () ->
-                        let! result = workflow ()
+                        let! result = WorkingDirectoryMaterialization.runWithLease workflow
                         return Ok result
                 finally
                     if leaseCreatedByThisInvocation then
@@ -3802,38 +3802,37 @@ module Branch =
                                         }
 
                                     let! workingTreeUpdateResult =
-                                        WorkingDirectoryMaterialization.runSerialized (fun () ->
-                                            runBranchSwitchWorkingTreeUpdateWithMarker
-                                                preflightOperations
-                                                (getCorrelationId parseResult)
-                                                workingTreeUpdateMarkerFileName
-                                                workingTreeUpdateMarkerText
-                                                (fun () ->
-                                                    task {
-                                                        //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
+                                        runBranchSwitchWorkingTreeUpdateWithMarker
+                                            preflightOperations
+                                            (getCorrelationId parseResult)
+                                            workingTreeUpdateMarkerFileName
+                                            workingTreeUpdateMarkerText
+                                            (fun () ->
+                                                task {
+                                                    //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
 
-                                                        // Update working directory based on new GraceStatus.Index
-                                                        do!
-                                                            updateWorkingDirectory
-                                                                newGraceStatus
-                                                                graceStatusWithNewDirectoryVersionsFromServer
-                                                                newDirectoryVersionDtos
-                                                                (getCorrelationId parseResult)
-                                                        //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
+                                                    // Update working directory based on new GraceStatus.Index
+                                                    do!
+                                                        updateWorkingDirectory
+                                                            newGraceStatus
+                                                            graceStatusWithNewDirectoryVersionsFromServer
+                                                            newDirectoryVersionDtos
+                                                            (getCorrelationId parseResult)
+                                                    //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
 
-                                                        // Save the new Grace Status.
-                                                        do!
-                                                            applyBranchSwitchLocalState
-                                                                (fun () -> writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer)
-                                                                (fun () ->
-                                                                    let configuration = Current()
-                                                                    configuration.BranchId <- newBranch.BranchId
-                                                                    configuration.BranchName <- newBranch.BranchName
-                                                                    updateConfiguration configuration)
-                                                                (fun () -> upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values)
+                                                    // Save the new Grace Status.
+                                                    do!
+                                                        applyBranchSwitchLocalState
+                                                            (fun () -> writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer)
+                                                            (fun () ->
+                                                                let configuration = Current()
+                                                                configuration.BranchId <- newBranch.BranchId
+                                                                configuration.BranchName <- newBranch.BranchName
+                                                                updateConfiguration configuration)
+                                                            (fun () -> upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values)
 
-                                                        t |> setProgressTaskValue showOutput 100.0
-                                                    }))
+                                                    t |> setProgressTaskValue showOutput 100.0
+                                                })
 
                                     match workingTreeUpdateResult with
                                     | Error error -> return Error error

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3364,6 +3364,7 @@ module Watch =
             let mutable terminal = false
             let mutable attempts = 0
             let mutable degradedResyncRequestedForReason: string option = None
+            let mutable acceptedMaterializationDecision: LatestCurrentBranchReferenceDecision option = None
 
             let canRetry () =
                 clients.MaxAttempts
@@ -3372,7 +3373,12 @@ module Watch =
             while not terminal && canRetry () do
                 attempts <- attempts + 1
 
-                match! currentBranchMaterializationDecision clients current payload with
+                let! decisionResult =
+                    match acceptedMaterializationDecision with
+                    | Some decision -> Task.FromResult(Ok decision)
+                    | None -> currentBranchMaterializationDecision clients current payload
+
+                match decisionResult with
                 | Error _ ->
                     terminalOutcome <-
                         {
@@ -3399,6 +3405,7 @@ module Watch =
                             terminal <- true
                         | Clean _ ->
                             let acceptedDecision = decision
+                            acceptedMaterializationDecision <- Some acceptedDecision
                             let mutable postLeaseRetryGate: CurrentBranchMaterializationStatusGate option = None
 
                             let! cleanOutcome =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2130,18 +2130,21 @@ module Watch =
     type private PendingWatchWorkEvidence =
         {
             HasProcessablePendingWork: bool
+            HasManualPendingStatusEvidence: bool
             HasDurableWatchJournalEvidence: bool
         }
 
         /// Reports whether any Watch work or durable journal evidence must keep IPC dirty.
         member this.HasPendingWork =
             this.HasProcessablePendingWork
+            || this.HasManualPendingStatusEvidence
             || this.HasDurableWatchJournalEvidence
 
         /// Reports whether durable journal evidence is the only reason IPC must be dirty.
         member this.HasDurableOnlyPendingWork =
             this.HasDurableWatchJournalEvidence
             && not this.HasProcessablePendingWork
+            && not this.HasManualPendingStatusEvidence
 
     /// Reports whether Watch has queued process-local work other than a startup catch-up marker.
     let private hasProcessablePendingWatchWorkExceptManual () =
@@ -2160,20 +2163,29 @@ module Watch =
         || hasPendingDurableWatchJournalEvidence ()
 
     /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
-    let private hasProcessablePendingWatchWork () =
-        hasManualPendingWatchWorkStatusFlag ()
-        || hasProcessablePendingWatchWorkExceptManual ()
+    let private hasProcessablePendingWatchWork () = hasProcessablePendingWatchWorkExceptManual ()
 
     /// Evaluates has pending watch work against parsed options, process state, and durable journal evidence.
     let private hasPendingWatchWork () =
-        hasProcessablePendingWatchWork ()
+        hasManualPendingWatchWorkStatusFlag ()
+        || hasProcessablePendingWatchWork ()
         || hasPendingDurableWatchJournalEvidence ()
 
     /// Reads process-local and durable pending-work facts once for a single status publication decision.
     let private readPendingWatchWorkEvidence () =
         let hasProcessablePendingWork = hasProcessablePendingWatchWork ()
 
-        { HasProcessablePendingWork = hasProcessablePendingWork; HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence () }
+        {
+            HasProcessablePendingWork = hasProcessablePendingWork
+            HasManualPendingStatusEvidence = hasManualPendingWatchWorkStatusFlag ()
+            HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence ()
+        }
+
+    /// Exposes pending Watch work checks to tests without running the foreground timer loop.
+    let internal pendingWatchWorkEvidenceForWatchTests () =
+        let evidence = readPendingWatchWorkEvidence ()
+
+        evidence.HasProcessablePendingWork, evidence.HasPendingWork
 
     /// Reads the generation for Grace Status DB refresh events observed from the filesystem.
     let private currentGraceStatusRefreshGeneration () = Volatile.Read(&graceStatusRefreshGeneration)
@@ -2201,6 +2213,9 @@ module Watch =
             |> ignore
 
             setGraceWatchHasPendingWorkForStatus hasPendingWork)
+
+    /// Sets the materialization pending status marker for focused Watch tests.
+    let internal setGraceWatchPendingWorkStatusFlagForWatchTests hasPendingWork = setGraceWatchPendingWorkStatusFlag hasPendingWork
 
     /// Reports whether the last verified IPC pending-work publication is stale against fresh evidence.
     let private pendingWatchWorkTransitionNeedsPublication () =
@@ -3263,6 +3278,10 @@ module Watch =
     let private currentBranchMaterializationStatusGate payload (inspection: GraceWatchStatusInspection) =
         if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
             NotCurrentBranch
+        elif updateInProgress () then
+            Blocked "Grace update marker is present"
+        elif hasManualPendingWatchWorkStatusFlag () then
+            Blocked "materialization pending status has not reached IPC"
         elif hasProcessablePendingWatchWork () then
             Blocked "process-local Watch queues have pending local observations"
         elif inspection.IsUsable then

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3276,6 +3276,19 @@ module Watch =
         payload.RepositoryId = current.RepositoryId
         && payload.BranchId = current.BranchId
 
+    /// Reports whether a same-branch Reference notification still matches the repository identity persisted on disk.
+    let private currentBranchReferenceNotificationTargetsPersistedCurrentBranch (payload: CurrentBranchReferenceNotification) =
+        match tryInspectCurrentDirectoryConfiguration () with
+        | Ok inspection ->
+            payload.RepositoryId = inspection.Configuration.RepositoryId
+            && payload.BranchId = inspection.Configuration.BranchId
+        | Error _ -> false
+
+    /// Reports whether cached Watch identity and persisted repository identity both still match the notification.
+    let private currentBranchReferenceNotificationTargetsCurrentAndPersistedBranch (payload: CurrentBranchReferenceNotification) =
+        currentBranchReferenceNotificationTargetsCurrentBranch payload
+        && currentBranchReferenceNotificationTargetsPersistedCurrentBranch payload
+
     /// Reports whether the local-state database can be opened as durable Watch authority before materialization side effects.
     let private hasReadableLocalStateDbAuthority () =
         let inspection = Grace.CLI.LocalStateDb.inspectReadOnly (Current().GraceStatusFile)
@@ -3320,7 +3333,7 @@ module Watch =
                 Blocked "local Watch status has dirty or pending work"
             | _, Some GraceWatchRuntimeMode.StartingUp -> Blocked "Watch startup catch-up is still in progress"
             | _, Some GraceWatchRuntimeMode.Resynchronizing -> Blocked "Watch resync is still in progress"
-            | _, Some GraceWatchRuntimeMode.Suspended -> Blocked "Watch is suspended"
+            | _, Some GraceWatchRuntimeMode.Suspended -> Degraded "Watch is suspended"
             | _, Some GraceWatchRuntimeMode.Stopping -> Degraded "Watch IPC/status authority is stopping"
             | _ -> Degraded "ambiguous Watch IPC/status authority"
 
@@ -3365,6 +3378,7 @@ module Watch =
             let mutable attempts = 0
             let mutable degradedResyncRequestedForReason: string option = None
             let mutable acceptedMaterializationDecision: LatestCurrentBranchReferenceDecision option = None
+            let mutable retriedAfterRecoveredLocalStatus = false
 
             let canRetry () =
                 clients.MaxAttempts
@@ -3413,30 +3427,24 @@ module Watch =
                                     task {
                                         let! leaseInspection = clients.InspectLocalStatus()
 
-                                        match currentBranchMaterializationStatusGate payload leaseInspection with
-                                        | NotCurrentBranch ->
+                                        if not (currentBranchReferenceNotificationTargetsCurrentAndPersistedBranch payload) then
                                             return
                                                 {
                                                     ReferenceId = payload.ReferenceId
                                                     Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                                     Decision = Some acceptedDecision
                                                 }
-                                        | Clean leaseStatus ->
-                                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                        else
+                                            match currentBranchMaterializationStatusGate payload leaseInspection with
+                                            | NotCurrentBranch ->
                                                 return
                                                     {
                                                         ReferenceId = payload.ReferenceId
                                                         Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                                         Decision = Some acceptedDecision
                                                     }
-                                            else
-                                                setGraceWatchPendingWorkStatusFlag true
-                                                publishPendingWatchWorkTransitionIfNeeded ()
-
-                                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
-                                                    setGraceWatchPendingWorkStatusFlag false
-                                                    publishPendingWatchWorkTransitionIfNeeded ()
-
+                                            | Clean leaseStatus ->
+                                                if not (currentBranchReferenceNotificationTargetsCurrentAndPersistedBranch payload) then
                                                     return
                                                         {
                                                             ReferenceId = payload.ReferenceId
@@ -3444,54 +3452,68 @@ module Watch =
                                                             Decision = Some acceptedDecision
                                                         }
                                                 else
-                                                    try
-                                                        do! clients.ApplyReference payload leaseStatus
+                                                    setGraceWatchPendingWorkStatusFlag true
+                                                    publishPendingWatchWorkTransitionIfNeeded ()
 
+                                                    if not (currentBranchReferenceNotificationTargetsCurrentAndPersistedBranch payload) then
                                                         setGraceWatchPendingWorkStatusFlag false
                                                         publishPendingWatchWorkTransitionIfNeeded ()
 
                                                         return
                                                             {
                                                                 ReferenceId = payload.ReferenceId
-                                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                                                 Decision = Some acceptedDecision
                                                             }
-                                                    with
-                                                    | ex ->
-                                                        setGraceWatchPendingWorkStatusFlag true
-                                                        publishPendingWatchWorkTransitionIfNeeded ()
-                                                        return raise ex
-                                        | Blocked reason ->
-                                            logToAnsiConsole
-                                                Colors.Verbose
-                                                $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point after lease acquisition: {reason}."
+                                                    else
+                                                        try
+                                                            do! clients.ApplyReference payload leaseStatus
 
-                                            postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Blocked reason)
+                                                            setGraceWatchPendingWorkStatusFlag false
+                                                            publishPendingWatchWorkTransitionIfNeeded ()
 
-                                            return
-                                                {
-                                                    ReferenceId = payload.ReferenceId
-                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
-                                                    Decision = Some acceptedDecision
-                                                }
-                                        | Degraded reason ->
-                                            logToAnsiConsole
-                                                Colors.Important
-                                                $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync after lease acquisition: {reason}."
+                                                            return
+                                                                {
+                                                                    ReferenceId = payload.ReferenceId
+                                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                                    Decision = Some acceptedDecision
+                                                                }
+                                                        with
+                                                        | ex ->
+                                                            setGraceWatchPendingWorkStatusFlag true
+                                                            publishPendingWatchWorkTransitionIfNeeded ()
+                                                            return raise ex
+                                            | Blocked reason ->
+                                                logToAnsiConsole
+                                                    Colors.Verbose
+                                                    $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point after lease acquisition: {reason}."
 
-                                            postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Degraded reason)
+                                                postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Blocked reason)
 
-                                            return
-                                                {
-                                                    ReferenceId = payload.ReferenceId
-                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
-                                                    Decision = Some acceptedDecision
-                                                }
+                                                return
+                                                    {
+                                                        ReferenceId = payload.ReferenceId
+                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                                                        Decision = Some acceptedDecision
+                                                    }
+                                            | Degraded reason ->
+                                                logToAnsiConsole
+                                                    Colors.Important
+                                                    $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync after lease acquisition: {reason}."
+
+                                                postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Degraded reason)
+
+                                                return
+                                                    {
+                                                        ReferenceId = payload.ReferenceId
+                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                                        Decision = Some acceptedDecision
+                                                    }
                                     })
 
                             match postLeaseRetryGate with
                             | Some (CurrentBranchMaterializationStatusGate.Blocked reason as gate) ->
-                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                if not (currentBranchReferenceNotificationTargetsCurrentAndPersistedBranch payload) then
                                     terminalOutcome <-
                                         {
                                             ReferenceId = payload.ReferenceId
@@ -3506,7 +3528,7 @@ module Watch =
                                     terminalOutcome <- cleanOutcome
                                     terminal <- true
                             | Some (CurrentBranchMaterializationStatusGate.Degraded reason) ->
-                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                if not (currentBranchReferenceNotificationTargetsCurrentAndPersistedBranch payload) then
                                     terminalOutcome <-
                                         {
                                             ReferenceId = payload.ReferenceId
@@ -3617,6 +3639,13 @@ module Watch =
                                 }
 
                             terminal <- true
+                        | Clean _ when
+                            not retriedAfterRecoveredLocalStatus
+                            && decision.Reason
+                               <> LatestCurrentBranchReferenceDecisionReason.LocalStatusIdentityMismatch
+                            && canRetry ()
+                            ->
+                            retriedAfterRecoveredLocalStatus <- true
                         | Clean _ ->
                             terminalOutcome <-
                                 {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3219,6 +3219,7 @@ module Watch =
 
     /// Names the local status gate that decides whether a BranchDto-latest Reference may reach apply.
     type internal CurrentBranchMaterializationStatusGate =
+        | NotCurrentBranch
         | Clean of GraceWatchStatus
         | Blocked of string
         | Degraded of string
@@ -3235,10 +3236,32 @@ module Watch =
             MaxAttempts: int option
         }
 
-    /// Converts inspected Watch IPC into the private materialization gate used by the current-branch coordinator.
-    let private currentBranchMaterializationStatusGate (inspection: GraceWatchStatusInspection) =
-        if inspection.IsUsable then
-            if hasPendingDurableWatchJournalEvidence () then
+    /// Reports whether a same-branch Reference notification still matches the repository identity Watch has loaded.
+    let private currentBranchReferenceNotificationTargetsCurrentBranch (payload: CurrentBranchReferenceNotification) =
+        let current = Current()
+
+        payload.RepositoryId = current.RepositoryId
+        && payload.BranchId = current.BranchId
+
+    /// Reports whether the local-state database can be opened as durable Watch authority before materialization side effects.
+    let private hasReadableLocalStateDbAuthority () =
+        let inspection = Grace.CLI.LocalStateDb.inspectReadOnly (Current().GraceStatusFile)
+
+        inspection.ParentDirectoryExists
+        && inspection.DbFileExists
+        && not inspection.DbPathIsDirectory
+        && inspection.OpenedReadOnly
+
+    /// Converts current target, local queues, durable DB authority, and inspected IPC into the private materialization gate.
+    let private currentBranchMaterializationStatusGate payload (inspection: GraceWatchStatusInspection) =
+        if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+            NotCurrentBranch
+        elif hasProcessablePendingWatchWork () then
+            Blocked "process-local Watch queues have pending local observations"
+        elif inspection.IsUsable then
+            if not (hasReadableLocalStateDbAuthority ()) then
+                Degraded "missing local-state DB authority"
+            elif hasPendingDurableWatchJournalEvidence () then
                 Blocked "durable Watch journal has pending local observations"
             else
                 Clean inspection.Status.Value
@@ -3262,13 +3285,6 @@ module Watch =
             | _, Some GraceWatchRuntimeMode.Suspended -> Blocked "Watch is suspended"
             | _, Some GraceWatchRuntimeMode.Stopping -> Degraded "Watch IPC/status authority is stopping"
             | _ -> Degraded "ambiguous Watch IPC/status authority"
-
-    /// Reports whether a same-branch Reference notification still matches the repository identity Watch has loaded.
-    let private currentBranchReferenceNotificationTargetsCurrentBranch (payload: CurrentBranchReferenceNotification) =
-        let current = Current()
-
-        payload.RepositoryId = current.RepositoryId
-        && payload.BranchId = current.BranchId
 
     /// Runs #678 protocol and BranchDto latest checks before the coordinator consults the local IPC gate.
     let private currentBranchMaterializationDecision
@@ -3333,7 +3349,16 @@ module Watch =
                     | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
                         let! inspection = clients.InspectLocalStatus()
 
-                        match currentBranchMaterializationStatusGate inspection with
+                        match currentBranchMaterializationStatusGate payload inspection with
+                        | NotCurrentBranch ->
+                            terminalOutcome <-
+                                {
+                                    ReferenceId = payload.ReferenceId
+                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                    Decision = Some decision
+                                }
+
+                            terminal <- true
                         | Clean status ->
                             if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                 terminalOutcome <-
@@ -3391,25 +3416,35 @@ module Watch =
 
                                 terminal <- true
                         | Degraded reason ->
-                            if degradedResyncRequestedForReason <> Some reason then
-                                clients.RequestDegradedResync reason
-                                degradedResyncRequestedForReason <- Some reason
-
-                            logToAnsiConsole
-                                Colors.Important
-                                $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
-
-                            if canRetry () then
-                                do! clients.ReestablishIpc payload reason
-                            else
+                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                 terminalOutcome <-
                                     {
                                         ReferenceId = payload.ReferenceId
-                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                         Decision = Some decision
                                     }
 
                                 terminal <- true
+                            elif degradedResyncRequestedForReason <> Some reason then
+                                clients.RequestDegradedResync reason
+                                degradedResyncRequestedForReason <- Some reason
+
+                            if not terminal then
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
+
+                                if canRetry () then
+                                    do! clients.ReestablishIpc payload reason
+                                else
+                                    terminalOutcome <-
+                                        {
+                                            ReferenceId = payload.ReferenceId
+                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                            Decision = Some decision
+                                        }
+
+                                    terminal <- true
                     | LatestCurrentBranchReferenceDecisionReason.NoApplicableReference ->
                         terminalOutcome <-
                             {
@@ -3434,7 +3469,16 @@ module Watch =
                     | LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync ->
                         let! inspection = clients.InspectLocalStatus()
 
-                        match currentBranchMaterializationStatusGate inspection with
+                        match currentBranchMaterializationStatusGate payload inspection with
+                        | NotCurrentBranch ->
+                            terminalOutcome <-
+                                {
+                                    ReferenceId = payload.ReferenceId
+                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                    Decision = Some decision
+                                }
+
+                            terminal <- true
                         | Clean _ ->
                             if attempts >= 3 then
                                 terminalOutcome <-
@@ -3471,25 +3515,35 @@ module Watch =
 
                                 terminal <- true
                         | Degraded reason ->
-                            if degradedResyncRequestedForReason <> Some reason then
-                                clients.RequestDegradedResync reason
-                                degradedResyncRequestedForReason <- Some reason
-
-                            logToAnsiConsole
-                                Colors.Important
-                                $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
-
-                            if canRetry () then
-                                do! clients.ReestablishIpc payload reason
-                            else
+                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                 terminalOutcome <-
                                     {
                                         ReferenceId = payload.ReferenceId
-                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                         Decision = Some decision
                                     }
 
                                 terminal <- true
+                            elif degradedResyncRequestedForReason <> Some reason then
+                                clients.RequestDegradedResync reason
+                                degradedResyncRequestedForReason <- Some reason
+
+                            if not terminal then
+                                logToAnsiConsole
+                                    Colors.Important
+                                    $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
+
+                                if canRetry () then
+                                    do! clients.ReestablishIpc payload reason
+                                else
+                                    terminalOutcome <-
+                                        {
+                                            ReferenceId = payload.ReferenceId
+                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                            Decision = Some decision
+                                        }
+
+                                    terminal <- true
                     | _ ->
                         terminalOutcome <-
                             {

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2104,6 +2104,13 @@ module Watch =
     /// Clears a specific resync attempt without losing a newer confidence-loss request.
     let private tryClearGraceWatchResyncAttempt attempt = Interlocked.CompareExchange(&graceWatchResyncGeneration, 0L, attempt) = attempt
 
+    let mutable private manualPendingWatchWorkStatusFlag = 0
+
+    /// Reports whether a coordinator-owned side effect must keep Watch IPC dirty before normal queues can observe it.
+    let private hasManualPendingWatchWorkStatusFlag () =
+        Volatile.Read(&manualPendingWatchWorkStatusFlag)
+        <> 0
+
     /// Reports whether unresolved durable journal rows must keep Watch status dirty.
     let private hasPendingDurableWatchJournalEvidence () =
         try
@@ -2138,7 +2145,8 @@ module Watch =
 
     /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
     let private hasProcessablePendingWatchWork () =
-        isGraceWatchResyncPending ()
+        hasManualPendingWatchWorkStatusFlag ()
+        || isGraceWatchResyncPending ()
         || graceStatusHasChanged
         || not (
             filesToProcess.IsEmpty
@@ -2178,7 +2186,12 @@ module Watch =
             false
 
     /// Records the pending-work flag that the next Watch IPC snapshot should publish.
-    let private setGraceWatchPendingWorkStatusFlag hasPendingWork = lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
+    let private setGraceWatchPendingWorkStatusFlag hasPendingWork =
+        lock watchStatusPublishLock (fun () ->
+            Interlocked.Exchange(&manualPendingWatchWorkStatusFlag, (if hasPendingWork then 1 else 0))
+            |> ignore
+
+            setGraceWatchHasPendingWorkForStatus hasPendingWork)
 
     /// Reports whether the last verified IPC pending-work publication is stale against fresh evidence.
     let private pendingWatchWorkTransitionNeedsPublication () =
@@ -2741,6 +2754,7 @@ module Watch =
         uploadedFileVersions.Clear()
         lock processedFileRelativePathsPendingStatusLock (fun () -> processedFileRelativePathsPendingStatus.Clear())
         lock canceledFileUploadDeleteRelativePathsLock (fun () -> canceledFileUploadDeleteRelativePaths.Clear())
+        setGraceWatchPendingWorkStatusFlag false
         clearPendingStatusDifferencesForTests ()
         lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferenceReplaySequences.Clear())
         clearGraceWatchResyncPending ()
@@ -3224,7 +3238,10 @@ module Watch =
     /// Converts inspected Watch IPC into the private materialization gate used by the current-branch coordinator.
     let private currentBranchMaterializationStatusGate (inspection: GraceWatchStatusInspection) =
         if inspection.IsUsable then
-            Clean inspection.Status.Value
+            if hasPendingDurableWatchJournalEvidence () then
+                Blocked "durable Watch journal has pending local observations"
+            else
+                Clean inspection.Status.Value
         elif inspection.ReadError.IsSome then
             Degraded "unreadable Watch IPC/status authority"
         elif not inspection.Exists then
@@ -3245,6 +3262,13 @@ module Watch =
             | _, Some GraceWatchRuntimeMode.Suspended -> Blocked "Watch is suspended"
             | _, Some GraceWatchRuntimeMode.Stopping -> Degraded "Watch IPC/status authority is stopping"
             | _ -> Degraded "ambiguous Watch IPC/status authority"
+
+    /// Reports whether a same-branch Reference notification still matches the repository identity Watch has loaded.
+    let private currentBranchReferenceNotificationTargetsCurrentBranch (payload: CurrentBranchReferenceNotification) =
+        let current = Current()
+
+        payload.RepositoryId = current.RepositoryId
+        && payload.BranchId = current.BranchId
 
     /// Runs #678 protocol and BranchDto latest checks before the coordinator consults the local IPC gate.
     let private currentBranchMaterializationDecision
@@ -3311,21 +3335,29 @@ module Watch =
 
                         match currentBranchMaterializationStatusGate inspection with
                         | Clean status ->
-                            setGraceWatchPendingWorkStatusFlag true
-                            publishPendingWatchWorkTransitionIfNeeded ()
-
-                            try
-                                do! clients.ApplyReference payload status
-
+                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                 terminalOutcome <-
                                     {
                                         ReferenceId = payload.ReferenceId
-                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                         Decision = Some decision
                                     }
-                            finally
-                                setGraceWatchPendingWorkStatusFlag false
+                            else
+                                setGraceWatchPendingWorkStatusFlag true
                                 publishPendingWatchWorkTransitionIfNeeded ()
+
+                                try
+                                    do! clients.ApplyReference payload status
+
+                                    terminalOutcome <-
+                                        {
+                                            ReferenceId = payload.ReferenceId
+                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                            Decision = Some decision
+                                        }
+                                finally
+                                    setGraceWatchPendingWorkStatusFlag false
+                                    publishPendingWatchWorkTransitionIfNeeded ()
 
                             terminal <- true
                         | Blocked reason as gate ->
@@ -3462,13 +3494,6 @@ module Watch =
                 currentBranchMaterializationLane.Release()
                 |> ignore
         }
-
-    /// Reports whether a same-branch Reference notification still matches the repository identity Watch has loaded.
-    let private currentBranchReferenceNotificationTargetsCurrentBranch (payload: CurrentBranchReferenceNotification) =
-        let current = Current()
-
-        payload.RepositoryId = current.RepositoryId
-        && payload.BranchId = current.BranchId
 
     /// Reads the current BranchDto so same-branch notifications are checked against server latest-reference authority.
     let private getCurrentBranchForCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3385,51 +3385,159 @@ module Watch =
                                 }
 
                             terminal <- true
-                        | Clean status ->
+                        | Clean _ ->
+                            let mutable postLeaseRetryGate: CurrentBranchMaterializationStatusGate option = None
+
                             let! cleanOutcome =
                                 WorkingDirectoryMaterialization.runWithLease (fun () ->
                                     task {
-                                        if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                        match! currentBranchMaterializationDecision clients current payload with
+                                        | Error _ ->
                                             return
                                                 {
                                                     ReferenceId = payload.ReferenceId
-                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                                    Decision = Some decision
+                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                                    Decision = None
                                                 }
-                                        else
-                                            setGraceWatchPendingWorkStatusFlag true
-                                            publishPendingWatchWorkTransitionIfNeeded ()
+                                        | Ok leaseDecision ->
+                                            match leaseDecision.Reason with
+                                            | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
+                                                let! leaseInspection = clients.InspectLocalStatus()
 
-                                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
-                                                return
-                                                    {
-                                                        ReferenceId = payload.ReferenceId
-                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                                        Decision = Some decision
-                                                    }
-                                            else
-                                                try
-                                                    do! clients.ApplyReference payload status
+                                                match currentBranchMaterializationStatusGate payload leaseInspection with
+                                                | NotCurrentBranch ->
+                                                    return
+                                                        {
+                                                            ReferenceId = payload.ReferenceId
+                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                            Decision = Some leaseDecision
+                                                        }
+                                                | Clean leaseStatus ->
+                                                    if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                                        return
+                                                            {
+                                                                ReferenceId = payload.ReferenceId
+                                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                                Decision = Some leaseDecision
+                                                            }
+                                                    else
+                                                        setGraceWatchPendingWorkStatusFlag true
+                                                        publishPendingWatchWorkTransitionIfNeeded ()
 
-                                                    setGraceWatchPendingWorkStatusFlag false
-                                                    publishPendingWatchWorkTransitionIfNeeded ()
+                                                        if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                                            return
+                                                                {
+                                                                    ReferenceId = payload.ReferenceId
+                                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                                    Decision = Some leaseDecision
+                                                                }
+                                                        else
+                                                            try
+                                                                do! clients.ApplyReference payload leaseStatus
+
+                                                                setGraceWatchPendingWorkStatusFlag false
+                                                                publishPendingWatchWorkTransitionIfNeeded ()
+
+                                                                return
+                                                                    {
+                                                                        ReferenceId = payload.ReferenceId
+                                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                                        Decision = Some leaseDecision
+                                                                    }
+                                                            with
+                                                            | ex ->
+                                                                setGraceWatchPendingWorkStatusFlag true
+                                                                publishPendingWatchWorkTransitionIfNeeded ()
+                                                                return raise ex
+                                                | Blocked reason ->
+                                                    logToAnsiConsole
+                                                        Colors.Verbose
+                                                        $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point after lease acquisition: {reason}."
+
+                                                    postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Blocked reason)
 
                                                     return
                                                         {
                                                             ReferenceId = payload.ReferenceId
-                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
-                                                            Decision = Some decision
+                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                                                            Decision = Some leaseDecision
                                                         }
-                                                with
-                                                | ex ->
-                                                    setGraceWatchPendingWorkStatusFlag true
-                                                    publishPendingWatchWorkTransitionIfNeeded ()
-                                                    return raise ex
+                                                | Degraded reason ->
+                                                    logToAnsiConsole
+                                                        Colors.Important
+                                                        $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync after lease acquisition: {reason}."
+
+                                                    postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Degraded reason)
+
+                                                    return
+                                                        {
+                                                            ReferenceId = payload.ReferenceId
+                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                                            Decision = Some leaseDecision
+                                                        }
+                                            | LatestCurrentBranchReferenceDecisionReason.NoApplicableReference ->
+                                                return
+                                                    {
+                                                        ReferenceId = payload.ReferenceId
+                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                        Decision = Some leaseDecision
+                                                    }
+                                            | LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable
+                                            | LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable ->
+                                                return
+                                                    {
+                                                        ReferenceId = payload.ReferenceId
+                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.ProtocolRejected
+                                                        Decision = Some leaseDecision
+                                                    }
+                                            | _ ->
+                                                return
+                                                    {
+                                                        ReferenceId = payload.ReferenceId
+                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+                                                        Decision = Some leaseDecision
+                                                    }
                                     })
 
-                            terminalOutcome <- cleanOutcome
+                            match postLeaseRetryGate with
+                            | Some (CurrentBranchMaterializationStatusGate.Blocked reason as gate) ->
+                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                    terminalOutcome <-
+                                        {
+                                            ReferenceId = payload.ReferenceId
+                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                            Decision = cleanOutcome.Decision
+                                        }
 
-                            terminal <- true
+                                    terminal <- true
+                                elif canRetry () then
+                                    do! clients.WaitForSafePoint payload gate
+                                else
+                                    terminalOutcome <- cleanOutcome
+                                    terminal <- true
+                            | Some (CurrentBranchMaterializationStatusGate.Degraded reason) ->
+                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                    terminalOutcome <-
+                                        {
+                                            ReferenceId = payload.ReferenceId
+                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                            Decision = cleanOutcome.Decision
+                                        }
+
+                                    terminal <- true
+                                elif degradedResyncRequestedForReason <> Some reason then
+                                    clients.RequestDegradedResync reason
+                                    degradedResyncRequestedForReason <- Some reason
+
+                                if not terminal then
+                                    if canRetry () then
+                                        do! clients.ReestablishIpc payload reason
+                                    else
+                                        terminalOutcome <- cleanOutcome
+                                        terminal <- true
+                            | _ ->
+                                terminalOutcome <- cleanOutcome
+                                terminal <- true
                         | Blocked reason as gate ->
                             logToAnsiConsole
                                 Colors.Verbose
@@ -3520,15 +3628,14 @@ module Watch =
 
                             terminal <- true
                         | Clean _ ->
-                            if attempts >= 3 then
-                                terminalOutcome <-
-                                    {
-                                        ReferenceId = payload.ReferenceId
-                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
-                                        Decision = Some decision
-                                    }
+                            terminalOutcome <-
+                                {
+                                    ReferenceId = payload.ReferenceId
+                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+                                    Decision = Some decision
+                                }
 
-                                terminal <- true
+                            terminal <- true
                         | Blocked reason as gate ->
                             logToAnsiConsole
                                 Colors.Verbose

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3371,23 +3371,31 @@ module Watch =
                                 setGraceWatchPendingWorkStatusFlag true
                                 publishPendingWatchWorkTransitionIfNeeded ()
 
-                                try
-                                    do! clients.ApplyReference payload status
-
-                                    setGraceWatchPendingWorkStatusFlag false
-                                    publishPendingWatchWorkTransitionIfNeeded ()
-
+                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                     terminalOutcome <-
                                         {
                                             ReferenceId = payload.ReferenceId
-                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
                                             Decision = Some decision
                                         }
-                                with
-                                | ex ->
-                                    setGraceWatchPendingWorkStatusFlag true
-                                    publishPendingWatchWorkTransitionIfNeeded ()
-                                    raise ex
+                                else
+                                    try
+                                        do! clients.ApplyReference payload status
+
+                                        setGraceWatchPendingWorkStatusFlag false
+                                        publishPendingWatchWorkTransitionIfNeeded ()
+
+                                        terminalOutcome <-
+                                            {
+                                                ReferenceId = payload.ReferenceId
+                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                Decision = Some decision
+                                            }
+                                    with
+                                    | ex ->
+                                        setGraceWatchPendingWorkStatusFlag true
+                                        publishPendingWatchWorkTransitionIfNeeded ()
+                                        raise ex
 
                             terminal <- true
                         | Blocked reason as gate ->

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2143,10 +2143,9 @@ module Watch =
             this.HasDurableWatchJournalEvidence
             && not this.HasProcessablePendingWork
 
-    /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
-    let private hasProcessablePendingWatchWork () =
-        hasManualPendingWatchWorkStatusFlag ()
-        || isGraceWatchResyncPending ()
+    /// Reports whether Watch has queued process-local work other than a startup catch-up marker.
+    let private hasProcessablePendingWatchWorkExceptManual () =
+        isGraceWatchResyncPending ()
         || graceStatusHasChanged
         || not (
             filesToProcess.IsEmpty
@@ -2154,6 +2153,16 @@ module Watch =
             && statusUpdateTriggers.IsEmpty
             && not (hasPendingStatusDifferences ())
         )
+
+    /// Evaluates pending Watch work without counting the startup catch-up marker against its own clean publication.
+    let private hasPendingWatchWorkExceptManual () =
+        hasProcessablePendingWatchWorkExceptManual ()
+        || hasPendingDurableWatchJournalEvidence ()
+
+    /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
+    let private hasProcessablePendingWatchWork () =
+        hasManualPendingWatchWorkStatusFlag ()
+        || hasProcessablePendingWatchWorkExceptManual ()
 
     /// Evaluates has pending watch work against parsed options, process state, and durable journal evidence.
     let private hasPendingWatchWork () =
@@ -3358,42 +3367,48 @@ module Watch =
 
                             terminal <- true
                         | Clean status ->
-                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
-                                terminalOutcome <-
-                                    {
-                                        ReferenceId = payload.ReferenceId
-                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                        Decision = Some decision
-                                    }
-                            else
-                                setGraceWatchPendingWorkStatusFlag true
-                                publishPendingWatchWorkTransitionIfNeeded ()
+                            let! cleanOutcome =
+                                WorkingDirectoryMaterialization.runWithLease (fun () ->
+                                    task {
+                                        if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                            return
+                                                {
+                                                    ReferenceId = payload.ReferenceId
+                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                    Decision = Some decision
+                                                }
+                                        else
+                                            setGraceWatchPendingWorkStatusFlag true
+                                            publishPendingWatchWorkTransitionIfNeeded ()
 
-                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
-                                    terminalOutcome <-
-                                        {
-                                            ReferenceId = payload.ReferenceId
-                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                            Decision = Some decision
-                                        }
-                                else
-                                    try
-                                        do! clients.ApplyReference payload status
+                                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                                return
+                                                    {
+                                                        ReferenceId = payload.ReferenceId
+                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                        Decision = Some decision
+                                                    }
+                                            else
+                                                try
+                                                    do! clients.ApplyReference payload status
 
-                                        setGraceWatchPendingWorkStatusFlag false
-                                        publishPendingWatchWorkTransitionIfNeeded ()
+                                                    setGraceWatchPendingWorkStatusFlag false
+                                                    publishPendingWatchWorkTransitionIfNeeded ()
 
-                                        terminalOutcome <-
-                                            {
-                                                ReferenceId = payload.ReferenceId
-                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
-                                                Decision = Some decision
-                                            }
-                                    with
-                                    | ex ->
-                                        setGraceWatchPendingWorkStatusFlag true
-                                        publishPendingWatchWorkTransitionIfNeeded ()
-                                        raise ex
+                                                    return
+                                                        {
+                                                            ReferenceId = payload.ReferenceId
+                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                            Decision = Some decision
+                                                        }
+                                                with
+                                                | ex ->
+                                                    setGraceWatchPendingWorkStatusFlag true
+                                                    publishPendingWatchWorkTransitionIfNeeded ()
+                                                    return raise ex
+                                    })
+
+                            terminalOutcome <- cleanOutcome
 
                             terminal <- true
                         | Blocked reason as gate ->
@@ -3568,7 +3583,7 @@ module Watch =
         (clients: CurrentBranchMaterializationCoordinatorClients)
         (payload: CurrentBranchReferenceNotification)
         =
-        WorkingDirectoryMaterialization.runSerialized (fun () -> processCurrentBranchMaterializationNotification clients payload)
+        WorkingDirectoryMaterialization.runSerializedLane (fun () -> processCurrentBranchMaterializationNotification clients payload)
 
     /// Reads the current BranchDto so same-branch notifications are checked against server latest-reference authority.
     let private getCurrentBranchForCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
@@ -5315,7 +5330,7 @@ module Watch =
             let mutable attemptedStartupCompletion = false
 
             if
-                not (hasProcessablePendingWatchWork ())
+                not (hasProcessablePendingWatchWorkExceptManual ())
                 && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.StartingUp
             then
                 attemptedStartupCompletion <- true
@@ -5330,23 +5345,27 @@ module Watch =
 
             if
                 attemptedStartupCompletion
-                && not (hasPendingWatchWork ())
+                && not (hasPendingWatchWorkExceptManual ())
             then
                 promoteStartupModeIfRecoverySucceeded ()
 
             if
                 attemptedStartupCompletion
-                && not (hasPendingWatchWork ())
+                && not (hasPendingWatchWorkExceptManual ())
             then
                 let! startupCatchUpStatus = readGraceStatusFileClient ()
                 updateGraceStatusDirectoryIds startupCatchUpStatus
 
-                do!
-                    publishGraceWatchInterprocessFileForCurrentConfidence
+                setGraceWatchPendingWorkStatusFlag false
+
+                let! cleanStartupStatusPublished =
+                    tryPublishGraceWatchInterprocessFileForCurrentConfidence
                         startupCatchUpStatus
                         graceStatusDirectoryIds
                         updateGraceWatchInterprocessFileClient
                         "startup catch-up"
+
+                if not cleanStartupStatusPublished then setGraceWatchPendingWorkStatusFlag true
         }
 
     /// Exposes delayed startup replay completion to tests without starting the foreground watcher loop.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3349,15 +3349,20 @@ module Watch =
                                 try
                                     do! clients.ApplyReference payload status
 
+                                    setGraceWatchPendingWorkStatusFlag false
+                                    publishPendingWatchWorkTransitionIfNeeded ()
+
                                     terminalOutcome <-
                                         {
                                             ReferenceId = payload.ReferenceId
                                             Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
                                             Decision = Some decision
                                         }
-                                finally
-                                    setGraceWatchPendingWorkStatusFlag false
+                                with
+                                | ex ->
+                                    setGraceWatchPendingWorkStatusFlag true
                                     publishPendingWatchWorkTransitionIfNeeded ()
+                                    raise ex
 
                             terminal <- true
                         | Blocked reason as gate ->
@@ -3365,7 +3370,16 @@ module Watch =
                                 Colors.Verbose
                                 $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point: {reason}."
 
-                            if canRetry () then
+                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                            elif canRetry () then
                                 do! clients.WaitForSafePoint payload gate
                             else
                                 terminalOutcome <-
@@ -3436,7 +3450,16 @@ module Watch =
                                 Colors.Verbose
                                 $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point: {reason}."
 
-                            if canRetry () then
+                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                            elif canRetry () then
                                 do! clients.WaitForSafePoint payload gate
                             else
                                 terminalOutcome <-

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3192,8 +3192,6 @@ module Watch =
     let internal handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch envelope =
         handleSignalRAutomationEvent readStatus rebaseCurrentBranch envelope
 
-    let private currentBranchMaterializationLane = new SemaphoreSlim(1, 1)
-
     /// Names the coordinator result for one exact same-branch Reference notification.
     type internal CurrentBranchMaterializationCoordinatorOutcomeReason =
         /// The notification was ignored because it did not target the current Watch branch.
@@ -3570,15 +3568,7 @@ module Watch =
         (clients: CurrentBranchMaterializationCoordinatorClients)
         (payload: CurrentBranchReferenceNotification)
         =
-        task {
-            do! currentBranchMaterializationLane.WaitAsync()
-
-            try
-                return! processCurrentBranchMaterializationNotification clients payload
-            finally
-                currentBranchMaterializationLane.Release()
-                |> ignore
-        }
+        WorkingDirectoryMaterialization.runSerialized (fun () -> processCurrentBranchMaterializationNotification clients payload)
 
     /// Reads the current BranchDto so same-branch notifications are checked against server latest-reference authority.
     let private getCurrentBranchForCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3178,6 +3178,291 @@ module Watch =
     let internal handleSignalRAutomationEventForWatchTests readStatus rebaseCurrentBranch envelope =
         handleSignalRAutomationEvent readStatus rebaseCurrentBranch envelope
 
+    let private currentBranchMaterializationLane = new SemaphoreSlim(1, 1)
+
+    /// Names the coordinator result for one exact same-branch Reference notification.
+    type internal CurrentBranchMaterializationCoordinatorOutcomeReason =
+        /// The notification was ignored because it did not target the current Watch branch.
+        | NotCurrentBranch = 0
+        /// The notification failed the concrete Reference and root-identity protocol checks.
+        | ProtocolRejected = 1
+        /// BranchDto latest-reference authority made the notification stale or otherwise non-materializable.
+        | LatestAuthorityRejected = 2
+        /// Local Watch status is clean and trusted, so the apply seam completed for this exact Reference.
+        | Applied = 3
+        /// Local Watch status is trustworthy but currently blocks remote materialization until a later safe point.
+        | WaitingForSafePoint = 4
+        /// Watch could not trust local IPC/status authority even after degraded resync revalidation.
+        | WaitingForDegradedResync = 5
+
+    /// Carries the terminal coordinator result for one exact same-branch Reference notification.
+    type internal CurrentBranchMaterializationCoordinatorOutcome =
+        {
+            ReferenceId: ReferenceId
+            Reason: CurrentBranchMaterializationCoordinatorOutcomeReason
+            Decision: LatestCurrentBranchReferenceDecision option
+        }
+
+    /// Names the local status gate that decides whether a BranchDto-latest Reference may reach apply.
+    type internal CurrentBranchMaterializationStatusGate =
+        | Clean of GraceWatchStatus
+        | Blocked of string
+        | Degraded of string
+
+    /// Coordinates a same-branch Reference once clean IPC and BranchDto latest authority have both been proven.
+    type private CurrentBranchMaterializationCoordinatorClients =
+        {
+            GetCurrentBranch: unit -> Task<Result<GraceReturnValue<Grace.Types.Branch.BranchDto>, GraceError>>
+            InspectLocalStatus: unit -> Task<GraceWatchStatusInspection>
+            RequestDegradedResync: string -> unit
+            WaitForSafePoint: CurrentBranchReferenceNotification -> CurrentBranchMaterializationStatusGate -> Task<unit>
+            ReestablishIpc: CurrentBranchReferenceNotification -> string -> Task<unit>
+            ApplyReference: CurrentBranchReferenceNotification -> GraceWatchStatus -> Task<unit>
+            MaxAttempts: int option
+        }
+
+    /// Converts inspected Watch IPC into the private materialization gate used by the current-branch coordinator.
+    let private currentBranchMaterializationStatusGate (inspection: GraceWatchStatusInspection) =
+        if inspection.IsUsable then
+            Clean inspection.Status.Value
+        elif inspection.ReadError.IsSome then
+            Degraded "unreadable Watch IPC/status authority"
+        elif not inspection.Exists then
+            Degraded "missing Watch IPC/status authority"
+        elif not inspection.IsFresh then
+            Degraded "stale Watch IPC/status authority"
+        elif not inspection.HasCurrentRepositoryIdentity then
+            Degraded "ambiguous Watch IPC/status authority"
+        else
+            match inspection.Status, inspection.EffectiveMode with
+            | Some status, Some GraceWatchRuntimeMode.HealthyIncremental when
+                status.HasPendingWatchWork
+                || not status.IsWorkingTreeClean
+                ->
+                Blocked "local Watch status has dirty or pending work"
+            | _, Some GraceWatchRuntimeMode.StartingUp -> Blocked "Watch startup catch-up is still in progress"
+            | _, Some GraceWatchRuntimeMode.Resynchronizing -> Blocked "Watch resync is still in progress"
+            | _, Some GraceWatchRuntimeMode.Suspended -> Blocked "Watch is suspended"
+            | _, Some GraceWatchRuntimeMode.Stopping -> Degraded "Watch IPC/status authority is stopping"
+            | _ -> Degraded "ambiguous Watch IPC/status authority"
+
+    /// Runs #678 protocol and BranchDto latest checks before the coordinator consults the local IPC gate.
+    let private currentBranchMaterializationDecision
+        (clients: CurrentBranchMaterializationCoordinatorClients)
+        (current: Grace.Shared.Client.Configuration.GraceConfiguration)
+        (payload: CurrentBranchReferenceNotification)
+        =
+        task {
+            match currentBranchReferenceProtocolValidationDecision current.RepositoryId current.BranchId payload with
+            | Some decision -> return Ok decision
+            | None ->
+                match! clients.GetCurrentBranch() with
+                | Error error ->
+                    let errorText = Markup.Escape(error.ToString())
+
+                    logToAnsiConsole Colors.Error $"Failed to refresh BranchDto for current-branch reference notification {payload.ReferenceId}: {errorText}."
+
+                    return Error error
+                | Ok branchReturnValue ->
+                    let branchDto = branchReturnValue.ReturnValue
+                    let! inspection = clients.InspectLocalStatus()
+
+                    let localStatus =
+                        match inspection.Status with
+                        | Some status when inspection.HasCurrentRepositoryIdentity -> Some status
+                        | _ -> None
+
+                    return Ok(decideLatestCurrentBranchReferenceMaterialization current.RepositoryId current.BranchId localStatus branchDto payload)
+        }
+
+    /// Processes one exact same-branch Reference notification behind the serialized materialization lane.
+    let private processCurrentBranchMaterializationNotification
+        (clients: CurrentBranchMaterializationCoordinatorClients)
+        (payload: CurrentBranchReferenceNotification)
+        =
+        task {
+            let current = Current()
+            let mutable terminalOutcome = Unchecked.defaultof<CurrentBranchMaterializationCoordinatorOutcome>
+            let mutable terminal = false
+            let mutable attempts = 0
+            let mutable degradedResyncRequestedForReason: string option = None
+
+            let canRetry () =
+                clients.MaxAttempts
+                |> Option.forall (fun maxAttempts -> attempts < maxAttempts)
+
+            while not terminal && canRetry () do
+                attempts <- attempts + 1
+
+                match! currentBranchMaterializationDecision clients current payload with
+                | Error _ ->
+                    terminalOutcome <-
+                        {
+                            ReferenceId = payload.ReferenceId
+                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                            Decision = None
+                        }
+
+                    terminal <- true
+                | Ok decision ->
+                    match decision.Reason with
+                    | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
+                        let! inspection = clients.InspectLocalStatus()
+
+                        match currentBranchMaterializationStatusGate inspection with
+                        | Clean status ->
+                            setGraceWatchPendingWorkStatusFlag true
+                            publishPendingWatchWorkTransitionIfNeeded ()
+
+                            try
+                                do! clients.ApplyReference payload status
+
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                        Decision = Some decision
+                                    }
+                            finally
+                                setGraceWatchPendingWorkStatusFlag false
+                                publishPendingWatchWorkTransitionIfNeeded ()
+
+                            terminal <- true
+                        | Blocked reason as gate ->
+                            logToAnsiConsole
+                                Colors.Verbose
+                                $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point: {reason}."
+
+                            if canRetry () then
+                                do! clients.WaitForSafePoint payload gate
+                            else
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                        | Degraded reason ->
+                            if degradedResyncRequestedForReason <> Some reason then
+                                clients.RequestDegradedResync reason
+                                degradedResyncRequestedForReason <- Some reason
+
+                            logToAnsiConsole
+                                Colors.Important
+                                $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
+
+                            if canRetry () then
+                                do! clients.ReestablishIpc payload reason
+                            else
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                    | LatestCurrentBranchReferenceDecisionReason.NoApplicableReference ->
+                        terminalOutcome <-
+                            {
+                                ReferenceId = payload.ReferenceId
+                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                Decision = Some decision
+                            }
+
+                        terminal <- true
+                    | LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable
+                    | LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable ->
+                        terminalOutcome <-
+                            {
+                                ReferenceId = payload.ReferenceId
+                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.ProtocolRejected
+                                Decision = Some decision
+                            }
+
+                        terminal <- true
+                    | LatestCurrentBranchReferenceDecisionReason.LocalStatusUnavailable
+                    | LatestCurrentBranchReferenceDecisionReason.LocalStatusIdentityMismatch
+                    | LatestCurrentBranchReferenceDecisionReason.LocalStatusRequiresResync ->
+                        let! inspection = clients.InspectLocalStatus()
+
+                        match currentBranchMaterializationStatusGate inspection with
+                        | Clean _ ->
+                            if attempts >= 3 then
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                        | Blocked reason as gate ->
+                            logToAnsiConsole
+                                Colors.Verbose
+                                $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point: {reason}."
+
+                            if canRetry () then
+                                do! clients.WaitForSafePoint payload gate
+                            else
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                        | Degraded reason ->
+                            if degradedResyncRequestedForReason <> Some reason then
+                                clients.RequestDegradedResync reason
+                                degradedResyncRequestedForReason <- Some reason
+
+                            logToAnsiConsole
+                                Colors.Important
+                                $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
+
+                            if canRetry () then
+                                do! clients.ReestablishIpc payload reason
+                            else
+                                terminalOutcome <-
+                                    {
+                                        ReferenceId = payload.ReferenceId
+                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                        Decision = Some decision
+                                    }
+
+                                terminal <- true
+                    | _ ->
+                        terminalOutcome <-
+                            {
+                                ReferenceId = payload.ReferenceId
+                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+                                Decision = Some decision
+                            }
+
+                        terminal <- true
+
+            return terminalOutcome
+        }
+
+    /// Serializes current-branch materialization so queued References revalidate only when they own the lane.
+    let private runCurrentBranchMaterializationCoordinator
+        (clients: CurrentBranchMaterializationCoordinatorClients)
+        (payload: CurrentBranchReferenceNotification)
+        =
+        task {
+            do! currentBranchMaterializationLane.WaitAsync()
+
+            try
+                return! processCurrentBranchMaterializationNotification clients payload
+            finally
+                currentBranchMaterializationLane.Release()
+                |> ignore
+        }
+
     /// Reports whether a same-branch Reference notification still matches the repository identity Watch has loaded.
     let private currentBranchReferenceNotificationTargetsCurrentBranch (payload: CurrentBranchReferenceNotification) =
         let current = Current()
@@ -3204,8 +3489,8 @@ module Watch =
 
         Grace.SDK.Branch.Get parameters
 
-    /// Handles same-branch Reference notifications with injectable readers for focused Watch tests.
-    let private handleCurrentBranchReferenceNotificationWithClients getCurrentBranch readLocalStatus (payload: CurrentBranchReferenceNotification) =
+    /// Handles same-branch Reference notifications with injectable coordinator clients for focused Watch tests.
+    let private handleCurrentBranchReferenceNotificationWithCoordinatorClients clients (payload: CurrentBranchReferenceNotification) =
         task {
             try
                 if not
@@ -3216,59 +3501,82 @@ module Watch =
 
                     return None
                 else
-                    let current = Current()
+                    let! outcome = runCurrentBranchMaterializationCoordinator clients payload
 
-                    match currentBranchReferenceProtocolValidationDecision current.RepositoryId current.BranchId payload with
+                    match outcome.Decision with
                     | Some decision ->
-                        logToAnsiConsole
-                            Colors.Verbose
-                            $"Skipped current-branch reference notification {payload.ReferenceId} because protocol validation was {decision.Reason}."
+                        match decision.Reason with
+                        | LatestCurrentBranchReferenceDecisionReason.SameRoot ->
+                            logToAnsiConsole
+                                Colors.Verbose
+                                $"Skipped current-branch reference notification {payload.ReferenceId} because local Watch status already has root {payload.DirectoryId}."
+                        | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
+                            logToAnsiConsole
+                                Colors.Highlighted
+                                $"Current-branch reference notification {payload.ReferenceId} requires remote materialization for root {payload.DirectoryId}."
+                        | reason ->
+                            logToAnsiConsole
+                                Colors.Verbose
+                                $"Skipped current-branch reference notification {payload.ReferenceId} because latest-current-branch decision was {reason}."
 
                         return Some decision
-                    | None ->
-                        match! getCurrentBranch () with
-                        | Error error ->
-                            let errorText = Markup.Escape(error.ToString())
-
-                            logToAnsiConsole
-                                Colors.Error
-                                $"Failed to refresh BranchDto for current-branch reference notification {payload.ReferenceId}: {errorText}."
-
-                            return None
-                        | Ok branchReturnValue ->
-                            let branchDto = branchReturnValue.ReturnValue
-                            let! localStatus = readLocalStatus ()
-
-                            let decision = decideLatestCurrentBranchReferenceMaterialization current.RepositoryId current.BranchId localStatus branchDto payload
-
-                            match decision.Reason with
-                            | LatestCurrentBranchReferenceDecisionReason.SameRoot ->
-                                logToAnsiConsole
-                                    Colors.Verbose
-                                    $"Skipped current-branch reference notification {payload.ReferenceId} because local Watch status already has root {payload.DirectoryId}."
-                            | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
-                                logToAnsiConsole
-                                    Colors.Highlighted
-                                    $"Current-branch reference notification {payload.ReferenceId} requires remote materialization for root {payload.DirectoryId}."
-                            | reason ->
-                                logToAnsiConsole
-                                    Colors.Verbose
-                                    $"Skipped current-branch reference notification {payload.ReferenceId} because latest-current-branch decision was {reason}."
-
-                            return Some decision
+                    | None -> return None
             with
             | ex ->
                 logToAnsiConsole Colors.Error $"Failed to process current-branch reference notification {payload.ReferenceId}: {Markup.Escape(ex.Message)}."
                 return None
         }
 
+    /// Handles same-branch Reference notifications with injectable readers for focused Watch tests.
+    let private handleCurrentBranchReferenceNotificationWithClients getCurrentBranch readLocalStatus (payload: CurrentBranchReferenceNotification) =
+        let inspectLocalStatus () =
+            task {
+                let! status = readLocalStatus ()
+
+                return
+                    match status with
+                    | Some status ->
+                        { Exists = true; Status = Some status; PersistedMode = Some status.Mode; SafetyFlags = status.SafetyFlags; ReadError = None }
+                    | None ->
+                        {
+                            Exists = false
+                            Status = None
+                            PersistedMode = None
+                            SafetyFlags =
+                                [|
+                                    "missingStatus"
+                                    "requiresExplicitResync"
+                                |]
+                            ReadError = None
+                        }
+            }
+
+        handleCurrentBranchReferenceNotificationWithCoordinatorClients
+            {
+                GetCurrentBranch = getCurrentBranch
+                InspectLocalStatus = inspectLocalStatus
+                RequestDegradedResync = ignore
+                WaitForSafePoint = fun _ _ -> Task.FromResult(())
+                ReestablishIpc = fun _ _ -> Task.FromResult(())
+                ApplyReference = fun _ _ -> Task.FromResult(())
+                MaxAttempts = Some 3
+            }
+            payload
+
     /// Handles same-branch Reference notifications that later WS7 slices can use for remote materialization.
     let private handleCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
         task {
             let! _ =
-                handleCurrentBranchReferenceNotificationWithClients
-                    (fun () -> getCurrentBranchForCurrentBranchReferenceNotification payload)
-                    getGraceWatchStatus
+                handleCurrentBranchReferenceNotificationWithCoordinatorClients
+                    {
+                        GetCurrentBranch = (fun () -> getCurrentBranchForCurrentBranchReferenceNotification payload)
+                        InspectLocalStatus = inspectGraceWatchStatus
+                        RequestDegradedResync = requestGraceWatchExplicitResync
+                        WaitForSafePoint = fun _ _ -> task { do! Task.Delay(TimeSpan.FromSeconds(1.0)) }
+                        ReestablishIpc = fun _ _ -> task { do! Task.Delay(TimeSpan.FromSeconds(1.0)) }
+                        ApplyReference = fun _ _ -> Task.FromResult(())
+                        MaxAttempts = None
+                    }
                     payload
 
             return ()
@@ -3280,6 +3588,36 @@ module Watch =
     /// Exposes same-branch Reference notification handling to Watch tests without opening a HubConnection.
     let internal handleCurrentBranchReferenceNotificationWithClientsForWatchTests getCurrentBranch readLocalStatus payload =
         handleCurrentBranchReferenceNotificationWithClients getCurrentBranch readLocalStatus payload
+
+    /// Exposes serialized current-branch materialization coordination to Watch tests without opening a HubConnection.
+    let internal handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+        getCurrentBranch
+        inspectLocalStatus
+        requestDegradedResync
+        waitForSafePoint
+        reestablishIpc
+        applyReference
+        payload
+        =
+        task {
+            if currentBranchReferenceNotificationTargetsCurrentBranch payload then
+                let! outcome =
+                    runCurrentBranchMaterializationCoordinator
+                        {
+                            GetCurrentBranch = getCurrentBranch
+                            InspectLocalStatus = inspectLocalStatus
+                            RequestDegradedResync = requestDegradedResync
+                            WaitForSafePoint = waitForSafePoint
+                            ReestablishIpc = reestablishIpc
+                            ApplyReference = applyReference
+                            MaxAttempts = Some 3
+                        }
+                        payload
+
+                return Some outcome
+            else
+                return None
+        }
 
     /// Registers SignalR branch groups only after the local refresh still has authority for the active branch.
     let private registerCurrentSignalRParentBranchWithClients

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2225,6 +2225,9 @@ module Watch =
     /// Sets the materialization pending status marker for focused Watch tests.
     let internal setGraceWatchPendingWorkStatusFlagForWatchTests hasPendingWork = setGraceWatchPendingWorkStatusFlag hasPendingWork
 
+    /// Reports whether focused Watch tests still have the manual materialization pending marker set.
+    let internal hasManualPendingWatchWorkStatusFlagForWatchTests () = hasManualPendingWatchWorkStatusFlag ()
+
     /// Reports whether the last verified IPC pending-work publication is stale against fresh evidence.
     let private pendingWatchWorkTransitionNeedsPublication () =
         File.Exists(IpcFileName())
@@ -3424,6 +3427,9 @@ module Watch =
                                                 publishPendingWatchWorkTransitionIfNeeded ()
 
                                                 if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                                    setGraceWatchPendingWorkStatusFlag false
+                                                    publishPendingWatchWorkTransitionIfNeeded ()
+
                                                     return
                                                         {
                                                             ReferenceId = payload.ReferenceId

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2111,20 +2111,28 @@ module Watch =
         Volatile.Read(&manualPendingWatchWorkStatusFlag)
         <> 0
 
-    /// Reports whether unresolved durable journal rows must keep Watch status dirty.
-    let private hasPendingDurableWatchJournalEvidence () =
+    /// Reads whether unresolved durable journal rows still need local Watch processing.
+    let private inspectDurableWatchJournalPendingEvidence () =
         try
-            readWatchJournalPendingWorkSummaryForWatch()
-                .GetAwaiter()
-                .GetResult()
-                .HasPendingRows
+            let summary =
+                readWatchJournalPendingWorkSummaryForWatch()
+                    .GetAwaiter()
+                    .GetResult()
+
+            Ok summary.HasPendingRows
         with
         | ex ->
             logToAnsiConsole
                 Colors.Error
                 $"Grace Watch could not inspect durable journal pending work; treating status as dirty until local state can be read: {Markup.Escape(ex.Message)}."
 
-            true
+            Error ex.Message
+
+    /// Reports whether unresolved durable journal rows must keep Watch status dirty.
+    let private hasPendingDurableWatchJournalEvidence () =
+        match inspectDurableWatchJournalPendingEvidence () with
+        | Ok hasPendingRows -> hasPendingRows
+        | Error _ -> true
 
     /// Describes pending Watch work without merging process-local queues and durable journal evidence.
     type private PendingWatchWorkEvidence =
@@ -3287,10 +3295,11 @@ module Watch =
         elif inspection.IsUsable then
             if not (hasReadableLocalStateDbAuthority ()) then
                 Degraded "missing local-state DB authority"
-            elif hasPendingDurableWatchJournalEvidence () then
-                Blocked "durable Watch journal has pending local observations"
             else
-                Clean inspection.Status.Value
+                match inspectDurableWatchJournalPendingEvidence () with
+                | Error _ -> Degraded "unreadable durable Watch journal authority"
+                | Ok true -> Blocked "durable Watch journal has pending local observations"
+                | Ok false -> Clean inspection.Status.Value
         elif inspection.ReadError.IsSome then
             Degraded "unreadable Watch IPC/status authority"
         elif not inspection.Exists then
@@ -3386,117 +3395,85 @@ module Watch =
 
                             terminal <- true
                         | Clean _ ->
+                            let acceptedDecision = decision
                             let mutable postLeaseRetryGate: CurrentBranchMaterializationStatusGate option = None
 
                             let! cleanOutcome =
                                 WorkingDirectoryMaterialization.runWithLease (fun () ->
                                     task {
-                                        match! currentBranchMaterializationDecision clients current payload with
-                                        | Error _ ->
+                                        let! leaseInspection = clients.InspectLocalStatus()
+
+                                        match currentBranchMaterializationStatusGate payload leaseInspection with
+                                        | NotCurrentBranch ->
                                             return
                                                 {
                                                     ReferenceId = payload.ReferenceId
-                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
-                                                    Decision = None
+                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                    Decision = Some acceptedDecision
                                                 }
-                                        | Ok leaseDecision ->
-                                            match leaseDecision.Reason with
-                                            | LatestCurrentBranchReferenceDecisionReason.RemoteMaterializationRequired ->
-                                                let! leaseInspection = clients.InspectLocalStatus()
-
-                                                match currentBranchMaterializationStatusGate payload leaseInspection with
-                                                | NotCurrentBranch ->
-                                                    return
-                                                        {
-                                                            ReferenceId = payload.ReferenceId
-                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                                            Decision = Some leaseDecision
-                                                        }
-                                                | Clean leaseStatus ->
-                                                    if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
-                                                        return
-                                                            {
-                                                                ReferenceId = payload.ReferenceId
-                                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                                                Decision = Some leaseDecision
-                                                            }
-                                                    else
-                                                        setGraceWatchPendingWorkStatusFlag true
-                                                        publishPendingWatchWorkTransitionIfNeeded ()
-
-                                                        if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
-                                                            return
-                                                                {
-                                                                    ReferenceId = payload.ReferenceId
-                                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                                                    Decision = Some leaseDecision
-                                                                }
-                                                        else
-                                                            try
-                                                                do! clients.ApplyReference payload leaseStatus
-
-                                                                setGraceWatchPendingWorkStatusFlag false
-                                                                publishPendingWatchWorkTransitionIfNeeded ()
-
-                                                                return
-                                                                    {
-                                                                        ReferenceId = payload.ReferenceId
-                                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
-                                                                        Decision = Some leaseDecision
-                                                                    }
-                                                            with
-                                                            | ex ->
-                                                                setGraceWatchPendingWorkStatusFlag true
-                                                                publishPendingWatchWorkTransitionIfNeeded ()
-                                                                return raise ex
-                                                | Blocked reason ->
-                                                    logToAnsiConsole
-                                                        Colors.Verbose
-                                                        $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point after lease acquisition: {reason}."
-
-                                                    postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Blocked reason)
-
-                                                    return
-                                                        {
-                                                            ReferenceId = payload.ReferenceId
-                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
-                                                            Decision = Some leaseDecision
-                                                        }
-                                                | Degraded reason ->
-                                                    logToAnsiConsole
-                                                        Colors.Important
-                                                        $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync after lease acquisition: {reason}."
-
-                                                    postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Degraded reason)
-
-                                                    return
-                                                        {
-                                                            ReferenceId = payload.ReferenceId
-                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
-                                                            Decision = Some leaseDecision
-                                                        }
-                                            | LatestCurrentBranchReferenceDecisionReason.NoApplicableReference ->
+                                        | Clean leaseStatus ->
+                                            if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                                 return
                                                     {
                                                         ReferenceId = payload.ReferenceId
                                                         Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
-                                                        Decision = Some leaseDecision
+                                                        Decision = Some acceptedDecision
                                                     }
-                                            | LatestCurrentBranchReferenceDecisionReason.ReferenceIdUnavailable
-                                            | LatestCurrentBranchReferenceDecisionReason.ReferenceRootIdentityUnavailable ->
-                                                return
-                                                    {
-                                                        ReferenceId = payload.ReferenceId
-                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.ProtocolRejected
-                                                        Decision = Some leaseDecision
-                                                    }
-                                            | _ ->
-                                                return
-                                                    {
-                                                        ReferenceId = payload.ReferenceId
-                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
-                                                        Decision = Some leaseDecision
-                                                    }
+                                            else
+                                                setGraceWatchPendingWorkStatusFlag true
+                                                publishPendingWatchWorkTransitionIfNeeded ()
+
+                                                if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
+                                                    return
+                                                        {
+                                                            ReferenceId = payload.ReferenceId
+                                                            Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.NotCurrentBranch
+                                                            Decision = Some acceptedDecision
+                                                        }
+                                                else
+                                                    try
+                                                        do! clients.ApplyReference payload leaseStatus
+
+                                                        setGraceWatchPendingWorkStatusFlag false
+                                                        publishPendingWatchWorkTransitionIfNeeded ()
+
+                                                        return
+                                                            {
+                                                                ReferenceId = payload.ReferenceId
+                                                                Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                                Decision = Some acceptedDecision
+                                                            }
+                                                    with
+                                                    | ex ->
+                                                        setGraceWatchPendingWorkStatusFlag true
+                                                        publishPendingWatchWorkTransitionIfNeeded ()
+                                                        return raise ex
+                                        | Blocked reason ->
+                                            logToAnsiConsole
+                                                Colors.Verbose
+                                                $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point after lease acquisition: {reason}."
+
+                                            postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Blocked reason)
+
+                                            return
+                                                {
+                                                    ReferenceId = payload.ReferenceId
+                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                                                    Decision = Some acceptedDecision
+                                                }
+                                        | Degraded reason ->
+                                            logToAnsiConsole
+                                                Colors.Important
+                                                $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync after lease acquisition: {reason}."
+
+                                            postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Degraded reason)
+
+                                            return
+                                                {
+                                                    ReferenceId = payload.ReferenceId
+                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                                    Decision = Some acceptedDecision
+                                                }
                                     })
 
                             match postLeaseRetryGate with

--- a/src/Grace.CLI/Command/WorkingDirectoryMaterialization.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryMaterialization.CLI.fs
@@ -47,10 +47,9 @@ module internal WorkingDirectoryMaterialization =
             return leaseFile
         }
 
-    /// Runs a Grace-owned working-directory materialization action one at a time for the current repository/worktree.
-    let runSerialized (operation: unit -> Task<'T>) =
+    /// Runs an operation while this CLI process owns the repository/worktree-scoped file lease.
+    let internal runWithLease (operation: unit -> Task<'T>) =
         task {
-            do! lane.WaitAsync()
             let mutable leaseFile: FileStream = null
 
             try
@@ -59,6 +58,18 @@ module internal WorkingDirectoryMaterialization =
                 return! operation ()
             finally
                 if not (isNull leaseFile) then leaseFile.Dispose()
+        }
 
+    /// Runs a Grace-owned working-directory operation one at a time in the current CLI process.
+    let internal runSerializedLane (operation: unit -> Task<'T>) =
+        task {
+            do! lane.WaitAsync()
+
+            try
+                return! operation ()
+            finally
                 lane.Release() |> ignore
         }
+
+    /// Runs a Grace-owned working-directory materialization action one at a time for the current repository/worktree.
+    let runSerialized (operation: unit -> Task<'T>) = runSerializedLane (fun () -> runWithLease operation)

--- a/src/Grace.CLI/Command/WorkingDirectoryMaterialization.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryMaterialization.CLI.fs
@@ -1,0 +1,64 @@
+namespace Grace.CLI.Command
+
+open Grace.CLI.Services
+open System
+open System.IO
+open System.Threading
+open System.Threading.Tasks
+
+/// Coordinates Grace-owned working-directory materialization operations.
+module internal WorkingDirectoryMaterialization =
+    let private lane = new SemaphoreSlim(1, 1)
+
+    /// Gets the repository/worktree-scoped file lease that joins Watch and branch-switch materialization.
+    let internal leaseFileName () =
+        let markerDirectory = DirectoryInfo(Path.GetDirectoryName(updateInProgressFileName ()))
+
+        let repositoryScopeDirectory =
+            if isNull markerDirectory.Parent
+               || isNull markerDirectory.Parent.Parent then
+                markerDirectory
+            else
+                markerDirectory.Parent.Parent
+
+        Path.Combine(repositoryScopeDirectory.FullName, "working-directory-materialization.lease")
+
+    /// Opens the repository/worktree-scoped lease file when no other materialization operation owns it.
+    let private tryOpenLeaseFile (leaseFileName: string) =
+        Directory.CreateDirectory(Path.GetDirectoryName(leaseFileName))
+        |> ignore
+
+        try
+            Some(new FileStream(leaseFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+        with
+        | :? IOException -> None
+
+    /// Waits until this CLI process owns the repository/worktree-scoped materialization lease.
+    let private acquireLeaseFile () =
+        task {
+            let leaseFileName = leaseFileName ()
+            let mutable leaseFile: FileStream = null
+
+            while isNull leaseFile do
+                match tryOpenLeaseFile leaseFileName with
+                | Some openedLeaseFile -> leaseFile <- openedLeaseFile
+                | None -> do! Task.Delay(TimeSpan.FromMilliseconds(50.0))
+
+            return leaseFile
+        }
+
+    /// Runs a Grace-owned working-directory materialization action one at a time for the current repository/worktree.
+    let runSerialized (operation: unit -> Task<'T>) =
+        task {
+            do! lane.WaitAsync()
+            let mutable leaseFile: FileStream = null
+
+            try
+                let! acquiredLeaseFile = acquireLeaseFile ()
+                leaseFile <- acquiredLeaseFile
+                return! operation ()
+            finally
+                if not (isNull leaseFile) then leaseFile.Dispose()
+
+                lane.Release() |> ignore
+        }

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -36,6 +36,7 @@
 		<Compile Include="Command\Organization.CLI.fs" />
 		<Compile Include="Command\Repository.CLI.fs" />
 		<Compile Include="Command\Diff.CLI.fs" />
+		<Compile Include="Command\WorkingDirectoryMaterialization.CLI.fs" />
 		<Compile Include="Command\Branch.CLI.fs" />
 		<Compile Include="Command\Reference.CLI.fs" />
 		<Compile Include="Command\DirectoryVersion.CLI.fs" />


### PR DESCRIPTION
## Summary  Implements #679 as the second leaf of the #677 WS7.4 replacement mini-epic.  This PR adds the serialized current-branch materialization coordinator and internal IPC/status gate. It preserves #678 as the notification validity and BranchDto latest-reference check seam, then decides whether an exact Reference can proceed to the #679 no-op apply seam, must wait for a safe point, or must request degraded/resync behavior before revalidation.  Related to #679. Part of #677, #479, and #473. Builds on #678 and PR #683.  ## Scope  - Adds a semaphore-backed single lane for current-branch materialization work. - Revalidates queued/waiting References through #678 notification validity and BranchDto latest check before apply eligibility. - Distinguishes clean/trusted status, dirty/pending/in-progress/suspended/resync-required status, and missing/unreadable/stale/ambiguous IPC status. - Keeps real working-tree mutation out of scope; #680 owns file apply and object-cache preflight. - Avoids new public status fields, SignalR persistence, whole-repository scans, stale-root ledgers, anonymous/rootless credits, and multi-reference consumption boundaries.  ## Proof Map  - Reference A processing blocks Reference B until A reaches a terminal coordinator outcome. - Reference B is revalidated against BranchDto latest when it is eventually processed. - Dirty local state blocks apply and does not overwrite local work. - Ambiguous IPC/status data requests degraded/resync and preserves the exact Reference for revalidation. - After degraded/resync, a matching BranchDto latest Reference can proceed; a mismatch is dropped stale. - No stale-root, rootless, anonymous, or multi-reference optimization path is introduced.  ## Validation  - Passed: `dotnet tool run fantomas C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI\Command\WorkingDirectoryMaterialization.CLI.fs C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI\Command\Branch.CLI.fs C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI\Command\Watch.CLI.fs C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI.Tests\Watch.Tests.fs`. - Passed: `dotnet build --configuration Release C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`. - Passed: `dotnet test --configuration Release --no-build C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "TestCategory=BranchSwitchSerialization"`.   - Result: 2/2 passed. - Passed: `dotnet test --configuration Release --no-build C:\Source\Grace-679-materialization-coordinator-degraded-ipc-gate\src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "TestCategory=CurrentBranchMaterializationCoordinator"`.   - Result: 17/17 passed. - Passed: `git diff --check`. - Passed for session-6 lifecycle fix: `dotnet tool run fantomas -- src/Grace.CLI/Command/WorkingDirectoryMaterialization.CLI.fs src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI/Command/Branch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs src/Grace.CLI.Tests/Branch.CLI.Tests.fs`. - Passed for session-6 lifecycle fix: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`, final run with 0 warnings and 0 errors. - Passed for session-6 lifecycle fix: `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter "TestCategory=BranchSwitchSerialization|TestCategory=CurrentBranchMaterializationCoordinator|TestCategory=StartupCatchUpPendingStatus"`.   - Result: 20/20 passed. - Passed for session-6 lifecycle fix: `git diff --check`. - Passed before the latest fix: GitHub `full` on head `7e618c369b8823a5049feb9f96c69dac1c4e355c`.  ## Review Status  - Current head: `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd`. - GitHub `full`: passed on current head `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd`. - Codex Code Review Bot: passed on current head `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd` with 👍 and zero unresolved review threads. Previous head `786373c1cd28dec19a1c7166c540218796fbf774` reported fresh findings `3551011291`, `3551011299`, and `3551011305`; they were fixed in `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd`, replied to, and resolved. - Substantive review cycle count: 11 completed sessions, including the post-lease status/branch recheck review. - Review session count: 12 completed sessions. - Hard stop state: resolved. Structural fix worker pushed `334aace31d94d961c10ba8abac5add3e75f36f38`; follow-up worker pushed `00fda236b9812fcf5586a763003254babead2cc5`; dirty-latch cleanup worker pushed `3eb26088d54539a7c28dcf8134cc69d4284a510a`; accepted-reference retry worker pushed `786373c1cd28dec19a1c7166c540218796fbf774`; post-lease status/branch recheck worker pushed `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd`. GitHub `full` passed and Codex Code Review Bot passed with 👍 on the current head. - Session 1 findings `3543119751`, `3543119757`, and `3543119764` were fixed in `b586b0a9b890415046d7f97fd65312f4f4ce6bd3`, replied to, and resolved. - Session 2 findings `3543262719` and `3543262728` were fixed in `980e302e53776473b59b0c8e89f3d72d28fa66f6`, replied to, and resolved. - Session 3 finding `3543403949` was deferred to #680 by maintainer decision, replied to, and resolved. #680 records the exact finding, invariant, and proof obligation for positive pending-status publication acknowledgement before real file apply. - Session 3 #679-owned findings `3543403960`, `3543403963`, and `3543403969` were fixed in `1261cebdf1012cf319490d228e2a2dcb025757b0`, replied to, and resolved. - Session 4 finding `3547318236` was fixed in `7e618c369b8823a5049feb9f96c69dac1c4e355c`, replied to, and resolved. - Finding `3547482410` was resolved by maintainer product decision for same-branch mailbox semantics. - Finding `3547482406` was fixed in `8dc45305c8fa301262151ddacc997bba5708e5bd`, replied to, and resolved. Branch switching now shares the repository/worktree materialization lane with Reference notification materialization. - Finding `3547735944` was fixed in `c1e5967fa18987c72675c4f199914d9a05712a44`, replied to, and resolved. Startup catch-up now clears the manual pending marker when it publishes verified clean Watch status. - Finding `3547735950` was fixed in `c1e5967fa18987c72675c4f199914d9a05712a44`, replied to, and resolved. Watch Reference processing now holds the repository/worktree file lease only around pending-status publication through `ApplyReference`. - Finding `3547735951` was fixed in `c1e5967fa18987c72675c4f199914d9a05712a44`, replied to, and resolved. `grace switch` now acquires the repository/worktree file lease before local-change scan, upload, and pre-switch save creation. - Previous-head finding `3547391555` was reported on `5e0706ff26e013f3d8f6943e255d30cd9cd4c62f`. It remains open and is currently mapped onto the latest diff; do not route it as active fix work unless Codex repeats it on the current-head review or the maintainer directs stale/no-code-change disposition. - Suspected missing invariant family: repository/worktree materialization lane lifecycle. Latches must be scoped and cleared by their owning operation, the lease must cover branch-switch snapshot precompute, and the lease must not be held while Reference processing is only waiting rather than mutating. - Domain-decision stop rule: stop immediately if a future review finding appears to require a new domain construct, named data source, durable state, retry policy, stale/retirement rule, public contract, or materialization-domain concept not already named in #679/#677/#678/#680, the mailbox/branch-switch decision, or this lifecycle ledger. - Maintainer-approved lifecycle decisions already implemented in `c1e5967fa18987c72675c4f199914d9a05712a44`: keep one manual startup/materialization pending marker and clear it when startup catch-up publishes clean Watch status; hold the Watch Reference materialization file lease only around pending-status-publication-to-`ApplyReference`; release it before safe-point waits and degraded-IPC retry sleeps; acquire the `grace switch` materialization file lease before local-change scan, upload, and pre-switch save creation; preserve mailbox semantics and the #680 dirty-publication acknowledgement deferral; do not add a latest-only final apply gate. - Maintainer-approved session-7 decisions for the next worker: exclude the manual materialization pending marker from processable local-observation work when it is the only pending evidence while still counting it as pending IPC/status evidence; treat `3547910321` as #679 work by failing closed while an existing Grace update marker is present; do not expand shared repository/worktree materialization lease adoption to every command that uses the update marker in this PR; keep `3547910319` deferred to #680; preserve same-branch mailbox semantics; preserve the #680 positive pending-status acknowledgement deferral; do not add a latest-only final apply gate.
- Finding `3547910317` was fixed in `9820719826d0cc07051b624b6ebc8dbee5ba4fa1`, with manual materialization pending status split from processable Watch timer work while still contributing pending IPC/status evidence.
- Finding `3547910321` was fixed in `9820719826d0cc07051b624b6ebc8dbee5ba4fa1`, with the #679 clean materialization gate failing closed while an existing Grace update marker is present and without broadening shared lease adoption in this PR.
- Session-7 fix validation: targeted Fantomas passed; Release build of `Grace.CLI.Tests` passed with 0 warnings and 0 errors; focused tests passed 23/23 for `CurrentBranchMaterializationCoordinator|BranchSwitchSerialization|StartupCatchUpPendingStatus`; `git diff --check` passed. `validate -Fast` was skipped to avoid a duplicate broad gate after focused CLI coverage.  ## Review Stabilization Ledger  ### Timeline  - Session 1, head `1f0a769f4c294f99f77be183d58eca5dce81f333`: Codex reported final branch revalidation, dirty IPC publication before apply, and durable-journal fail-closed evidence gaps. - Session 1 fix, head `b586b0a9b890415046d7f97fd65312f4f4ce6bd3`: fixed in `b586b0a9b890415046d7f97fd65312f4f4ce6bd3`; old threads were replied to and resolved. - Session 2, head `b586b0a9b890415046d7f97fd65312f4f4ce6bd3`: Codex reported failed-apply cleanup (`3543262719`) and stale notification waits in the mismatch/resync path (`3543262728`). - Session 2 stabilization fix, head `980e302e53776473b59b0c8e89f3d72d28fa66f6`: failed apply now preserves dirty IPC evidence, and all safe-point wait paths revalidate target branch before waiting. - Session 3, head `980e302e53776473b59b0c8e89f3d72d28fa66f6`: Codex reported dirty publication acknowledgement (`3543403949`), process-local queue evidence (`3543403960`), missing local-state DB fail-closed behavior (`3543403963`), and branch recheck before degraded resync (`3543403969`). - Maintainer decision: defer `3543403949` to #680; implement #679-owned gate fixes for `3543403960`, `3543403963`, and `3543403969`. - Session 3 #679 fix, head `1261cebdf1012cf319490d228e2a2dcb025757b0`: process-local queues now block materialization, clean IPC requires a readable local-state database, and degraded/resync side effects revalidate the current target. - CI fix, head `5e0706ff26e013f3d8f6943e255d30cd9cd4c62f`: pre-existing ordering test now initializes the local-state database; production code unchanged. - Session 4 finding, reviewed head `1261cebdf1012cf319490d228e2a2dcb025757b0`: Codex reported final apply-boundary target revalidation after dirty IPC publication (`3547318236`). - Session 6 lifecycle fix, head `c1e5967fa18987c72675c4f199914d9a05712a44`: startup catch-up clears its manual pending marker after verified clean publication; Watch Reference processing releases the file lease before safe-point waits and degraded-IPC retry sleeps; `grace switch` acquires the file lease before local-change scan, upload, and pre-switch save creation.  ### Missing Invariant Family  The coordinator needs one named materialization safety gate that is the single decision point for #679 apply-or-side-effect boundaries. For #679, the gate proves current target, no process-local pending work, a readable durable Watch journal with no pending rows, a readable local-state database, and no bypassable branch-switch/degraded/resync/materialization-in-progress state. Positive dirty-publication acknowledgement before real apply is explicitly deferred to #680.  ### Current Gate  Implemented in `c1e5967fa18987c72675c4f199914d9a05712a44`. The session-6 lifecycle fix covers fresh current-head findings `3547735944`, `3547735950`, and `3547735951`:  1. Startup catch-up keeps the existing manual pending marker and explicitly clears it when startup catch-up publishes verified clean Watch status. 2. Watch Reference processing acquires the repository/worktree materialization lease only around the pending-status-publication-to-`ApplyReference` window, releasing it before safe-point waits and degraded-IPC retry sleeps. 3. `grace switch` acquires the repository/worktree materialization lease before local-change scan, upload, and pre-switch save creation, and holds it through branch identity update and working-tree materialization.  The fix preserves same-branch mailbox semantics, preserves the #680 deferral for positive pending-status publication acknowledgement before real file apply, and does not add a latest-only final apply gate. Merge remains blocked until the current CI failure is fixed, GitHub `full` passes, and Codex Code Review Bot completes current-head review with no unresolved findings or approved deferrals.  ## Out Of Scope  - Working-tree file apply beyond deterministic no-op/test seams. - Object-cache preflight. - Persisted SignalR notification payloads. - Broad scans or marker-window scans. - Public status/IPC DTO expansion for blocked remote sync. - Local Save creation. - Stale-root ledgers, anonymous stale-root credits, root-history credits, or multi-reference consumption boundaries.  ### Session 7 Current Gate

Implemented in `9820719826d0cc07051b624b6ebc8dbee5ba4fa1`:

1. The manual materialization pending marker is excluded from processable local-observation work when it is the only pending evidence; it still counts as pending IPC/status evidence.
2. Existing Grace update markers block the #679 clean materialization gate. While an existing Grace update marker is present, the clean gate fails closed.
3. Shared repository/worktree materialization lease adoption was not expanded to every command that uses the existing update marker in this PR.
4. `3547910319` remains deferred to #680.
5. Same-branch mailbox semantics, the #680 positive pending-status acknowledgement deferral, and the no-latest-only-final-apply rule are preserved.

Validation for the session-7 fix passed targeted Fantomas, Release build of `Grace.CLI.Tests`, focused tests 23/23 for `CurrentBranchMaterializationCoordinator|BranchSwitchSerialization|StartupCatchUpPendingStatus`, and `git diff --check`. Merge remains blocked: Codex reported current-head post-lease revalidation findings `3550243131`, `3550243139`, and `3550243145`; previous thread `3547391555` remains unresolved and mapped onto the current diff; GitHub `full` rerun passed.






### Session 8 Current Gate

Maintainer approved continuing past the session-8 hard stop:

1. Treat pre-lease safety decisions as stale. Watch must rerun the #679 materialization gate after acquiring the materialization lock and immediately before dirty-status publication and `ApplyReference`.
2. `grace switch` must rerun Watch clean/durable preflight after acquiring the materialization lock and before local-change scan, upload, pre-switch save creation, branch identity update, or working-tree materialization.
3. After acquiring the materialization lock, Watch must refresh current branch/worktree state before the final target check and apply decision. If the notification no longer matches the refreshed current branch, it must drop or retry through existing safe paths.
4. Active threads `3547391555`, `3550243131`, `3550243139`, and `3550243145` are one #679 post-lease revalidation structural fix.
5. Preserve same-branch mailbox semantics, keep `3547910319` deferred to #680, preserve the #680 positive pending-status acknowledgement deferral, do not add a latest-only final apply gate, and do not broaden shared lease adoption beyond approved #679 scope.

Continuation: assign one fresh structural fix worker. The orchestrator should not stop again for routine implementation or test work that fits this approved rule; stop only when a fresh review finding requires a product decision not already covered by #679, #680, or this ledger.
### Session 8 Fix Evidence

Implemented in `334aace31d94d961c10ba8abac5add3e75f36f38`:

1. `LocalStatusIdentityMismatch` plus a later clean gate now reaches a terminal non-apply result instead of looping indefinitely while holding the coordinator lane.
2. Watch reruns the materialization decision and local clean gate after acquiring the materialization lease, before dirty-status publication and `ApplyReference`.
3. `grace switch` reruns Watch clean/durable preflight after acquiring the materialization lease and before scan, upload, save, branch-state, or materialization side effects.
4. Watch refreshes BranchDto and current local status after the lease wait before the final target/apply decision; branch changes during the wait drop through existing stale/not-current paths.
5. Validation passed: targeted Fantomas, Release build of `Grace.CLI.Tests` with 0 warnings and 0 errors, focused tests 26/26 for `CurrentBranchMaterializationCoordinator|BranchSwitchSerialization|StartupCatchUpPendingStatus`, and `git diff --check`.

Review threads `3547391555`, `3550243131`, `3550243139`, and `3550243145` were replied to and resolved with this evidence. Merge remains blocked until the current CI failure is fixed, GitHub `full` passes, and Codex Code Review Bot completes current-head review with no unresolved findings or approved deferrals.
### Session 9 Fix Evidence

Implemented in `00fda236b9812fcf5586a763003254babead2cc5`:

1. Accepted same-branch References preserve mailbox semantics after the materialization lock wait. The post-lock path rechecks local status and branch/worktree safety without rejecting an already-accepted R1 only because BranchDto advanced to R2.
2. Invalid or incompatible local-state Watch journal shape is routed to degraded/resync handling instead of an indefinite safe-point wait.
3. The stale CI expectation was corrected to prove both the initial BranchDto-before-status acceptance pass and the post-lock status-before-apply revalidation pass.
4. Regression coverage was added for accepted Reference preservation while BranchDto advances during the lease wait and degraded handling for unreadable/incompatible local-state journal shape.
5. Validation passed: targeted Fantomas, Release build of `Grace.CLI.Tests` with 0 warnings and 0 errors, focused tests 29/29 for `FullyQualifiedName~fetches|CurrentBranchMaterializationCoordinator|BranchSwitchSerialization|StartupCatchUpPendingStatus`, and `git diff --check`.

Review threads `3550583488` and `3550583494` were replied to and resolved with this evidence. Merge remains blocked until GitHub `full` passes on `00fda236b9812fcf5586a763003254babead2cc5` and Codex Code Review Bot completes current-head review with no unresolved findings or approved deferrals.
### Session 10 Fix Evidence

Implemented in `3eb26088d54539a7c28dcf8134cc69d4284a510a`:

1. Watch clears the manual materialization pending marker when the post-dirty-publication final target check drops an accepted Reference as stale/not-current before `ApplyReference` runs.
2. Watch republishes the pending-work transition after clearing the marker so the next current branch is not blocked as though materialization is still pending.
3. The branch-switch-after-dirty-publication regression now proves `ApplyReference` is skipped, the manual marker is cleared, and clean IPC is republished.
4. Validation passed: targeted Fantomas, Release build of `Grace.CLI.Tests` with 0 warnings and 0 errors, `CurrentBranchMaterializationCoordinator` tests 27/27, direct changed regression 1/1 through `NUnit.Where`, and `git diff --check`.

Review thread `3550736991` was replied to and resolved with this evidence. Merge remains blocked until GitHub `full` passes on `3eb26088d54539a7c28dcf8134cc69d4284a510a` and Codex Code Review Bot completes current-head review with no unresolved findings or approved deferrals.
### Session 11 Fix Evidence

Implemented in `786373c1cd28dec19a1c7166c540218796fbf774`:

1. Watch preserves the accepted current-branch materialization decision after clean pre-lease admission, so post-lease blocked/degraded retries for the same payload do not rerun BranchDto latest-reference rejection against an already-accepted R1.
2. Retries still recheck local status, branch/worktree target, dirty/pending state, IPC, durable journal, and local DB gates before side effects.
3. Regression tests cover post-lease blocked and post-lease degraded retries where R1 is accepted, BranchDto advances to R2 during the wait/resync path, and R1 still applies after local safety returns clean.
4. Validation passed: targeted Fantomas, Release build of `Grace.CLI.Tests` with 0 warnings and 0 errors, `CurrentBranchMaterializationCoordinator` tests 29/29, and `git diff --check`.

Review thread `3550853958` was replied to and resolved with this evidence. Merge remains blocked until GitHub `full` passes on `786373c1cd28dec19a1c7166c540218796fbf774` and Codex Code Review Bot completes current-head review with no unresolved findings or approved deferrals.
### Session 12 Fix Evidence

Implemented in `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd`:

1. Watch revalidates persisted branch/worktree state at the post-lease boundary so a cached old branch cannot apply to a newly switched working tree.
2. If dirty or unavailable local status becomes clean before the second gate, Watch retries the materialization decision instead of terminating the accepted SignalR notification as stale.
3. Suspended Watch status is treated as degraded/resync work instead of waiting forever for processable observations that suspended Watch will not produce.
4. Regression tests cover suspended IPC, persisted branch switch after lease wait, dirty-to-clean retry, and unavailable-to-clean retry.
5. Validation passed: targeted Fantomas, Release build of `Grace.CLI.Tests` with 0 warnings and 0 errors, `CurrentBranchMaterializationCoordinator` tests 33/33, and `git diff --check`.

Review threads `3551011291`, `3551011299`, and `3551011305` were replied to and resolved with this evidence. Merge remains blocked until GitHub `full` passes on `ec0d5306351b590b8b7f4a5aec825dfcad78f5fd` and Codex Code Review Bot completes current-head review with no unresolved findings or approved deferrals.














