### PR TITLE
GC-08: Move grace connect Direct execution to Materialization Plan

### DIFF
--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -9,6 +9,7 @@ open Grace.Types.Branch
 open Grace.Types.MaterializationPlan
 open Grace.Types.Common
 open Grace.Types.DirectoryVersion
+open Grace.Types.Reference
 open MessagePack
 open NUnit.Framework
 open Spectre.Console
@@ -103,8 +104,13 @@ module ConnectTests =
     let private repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
     let private rootId = Guid.Parse("44444444-4444-4444-4444-444444444444")
     let private alternateRootId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+    let private unpromotedTipRootId = Guid.Parse("77777777-7777-7777-7777-777777777777")
+    let private basedOnRootId = Guid.Parse("88888888-8888-8888-8888-888888888888")
     let private sha256Hash = Sha256Hash(String.replicate 64 "a")
     let private blake3Hash = Blake3Hash(String.replicate 64 "b")
+
+    /// Builds a branch reference carrying the directory version id used by connect target selection tests.
+    let private referenceDto referenceType directoryId = { ReferenceDto.Default with ReferenceType = referenceType; DirectoryId = directoryId }
 
     /// Computes the SHA-256 descriptor hash for artifact validation tests.
     let private computeSha256Hash (bytes: byte array) = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
@@ -145,6 +151,10 @@ module ConnectTests =
             source
         )
 
+    /// Builds a Direct plan descriptor whose only integrity field is the supplied payload's BLAKE3 hash.
+    let private zipArtifactForBlake3OnlyBytes source (bytes: byte array) =
+        MaterializationArtifactDescriptor.DirectoryVersionZip(rootId, int64 bytes.LongLength, None, Some(computeBlake3Hash bytes), source)
+
     /// Builds a recursive metadata descriptor whose integrity fields match the supplied payload.
     let private metadataArtifactForBytes source (bytes: byte array) =
         MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
@@ -175,20 +185,49 @@ module ConnectTests =
         request.TargetSelector.DirectoryVersionId
         |> should equal None
 
-    /// Verifies that Direct plan requests preserve default branch selection as a moving branch selector.
+    /// Verifies that implicit default connect keeps promoted target semantics even when the branch tip has moved.
     [<Test>]
-    let ``connect direct plan request preserves default branch selector intent`` () =
+    let ``connect default resolver chooses latest promotion before unpromoted tip`` () =
+        let branchDto =
+            { BranchDto.Default with
+                BranchName = BranchName "trunk"
+                BasedOn = referenceDto ReferenceType.Commit basedOnRootId
+                LatestReference = referenceDto ReferenceType.Commit unpromotedTipRootId
+                LatestPromotion = referenceDto ReferenceType.Promotion rootId
+                LatestCommit = referenceDto ReferenceType.Commit unpromotedTipRootId
+            }
+
+        Connect.resolveDefaultDirectoryVersionId branchDto
+        |> should equal (Some rootId)
+
+    /// Verifies that implicit default connect falls back to the branch base when no promotion exists.
+    [<Test>]
+    let ``connect default resolver falls back to based on when promotion is missing`` () =
+        let branchDto =
+            { BranchDto.Default with
+                BranchName = BranchName "trunk"
+                BasedOn = referenceDto ReferenceType.Commit basedOnRootId
+                LatestReference = referenceDto ReferenceType.Commit unpromotedTipRootId
+                LatestCommit = referenceDto ReferenceType.Commit unpromotedTipRootId
+            }
+
+        Connect.resolveDefaultDirectoryVersionId branchDto
+        |> should equal (Some basedOnRootId)
+
+    /// Verifies that Direct plan requests send the already-resolved implicit default target as an immutable selector.
+    [<Test>]
+    let ``connect direct plan request sends resolved default target as directory version selector`` () =
         let branchDto = { BranchDto.Default with BranchName = BranchName "trunk" }
 
         let request = Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector Connect.UseDefault branchDto rootId)
 
         request.TargetSelector.SelectorKind
-        |> should equal MaterializationTargetSelectorKind.BranchName
-
-        request.TargetSelector.BranchName
-        |> should equal (Some(BranchName "trunk"))
+        |> should equal MaterializationTargetSelectorKind.DirectoryVersionId
 
         request.TargetSelector.DirectoryVersionId
+        |> should equal (Some rootId)
+
+        request.TargetSelector.BranchName
         |> should equal None
 
     /// Verifies that Direct plan execution preparation preserves recursive metadata file versions and planned zip source.
@@ -305,6 +344,76 @@ module ConnectTests =
         match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact downloadedBytes with
         | Ok _ -> Assert.Fail("Expected artifact hash mismatch to fail before extraction.")
         | Error error -> error.Error |> should contain "SHA-256 mismatch"
+
+    /// Verifies that planned artifact validation accepts descriptors that carry matching BLAKE3-only integrity evidence.
+    [<Test>]
+    let ``connect direct plan artifact validation accepts blake3 only descriptor`` () =
+        let bytes = [| 1uy; 2uy; 3uy |]
+        let artifact = zipArtifactForBlake3OnlyBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) bytes
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact bytes with
+        | Error error -> Assert.Fail($"Unexpected BLAKE3-only artifact validation error: {error.Error}")
+        | Ok () -> ()
+
+    /// Verifies that planned artifact validation rejects descriptors whose BLAKE3-only integrity evidence does not match.
+    [<Test>]
+    let ``connect direct plan artifact validation rejects blake3 only mismatch`` () =
+        let plannedBytes = [| 1uy; 2uy; 3uy |]
+        let downloadedBytes = [| 1uy; 2uy; 4uy |]
+        let artifact = zipArtifactForBlake3OnlyBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) plannedBytes
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact downloadedBytes with
+        | Ok _ -> Assert.Fail("Expected BLAKE3-only artifact hash mismatch to fail before extraction.")
+        | Error error -> error.Error |> should contain "BLAKE3 mismatch"
+
+    /// Verifies that streamed DirectUri artifact validation accepts BLAKE3-only descriptors before extraction.
+    [<Test>]
+    let ``connect direct plan artifact stream validation accepts blake3 only descriptor`` () =
+        let bytes = [| 1uy; 2uy; 3uy |]
+        let artifact = zipArtifactForBlake3OnlyBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) bytes
+
+        use stream = new MemoryStream(bytes)
+
+        match Connect.validatePlannedArtifactStream "correlation-id" "DirectoryVersionZip" artifact stream
+              |> fun task -> task.GetAwaiter().GetResult()
+            with
+        | Error error -> Assert.Fail($"Unexpected streamed BLAKE3-only artifact validation error: {error.Error}")
+        | Ok () -> stream.Position |> should equal 0L
+
+    /// Verifies that streamed DirectUri artifact validation rejects mismatched BLAKE3-only descriptors before extraction.
+    [<Test>]
+    let ``connect direct plan artifact stream validation rejects blake3 only mismatch`` () =
+        let plannedBytes = [| 1uy; 2uy; 3uy |]
+        let downloadedBytes = [| 1uy; 2uy; 4uy |]
+        let artifact = zipArtifactForBlake3OnlyBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) plannedBytes
+
+        use stream = new MemoryStream(downloadedBytes)
+
+        match Connect.validatePlannedArtifactStream "correlation-id" "DirectoryVersionZip" artifact stream
+              |> fun task -> task.GetAwaiter().GetResult()
+            with
+        | Ok _ -> Assert.Fail("Expected streamed BLAKE3-only artifact hash mismatch to fail before extraction.")
+        | Error error -> error.Error |> should contain "BLAKE3 mismatch"
+
+    /// Verifies that planned artifact validation still rejects descriptors with no supported integrity evidence.
+    [<Test>]
+    let ``connect direct plan artifact validation rejects missing integrity evidence`` () =
+        let bytes = [| 1uy; 2uy; 3uy |]
+
+        let artifact =
+            MaterializationArtifactDescriptor.DirectoryVersionZip(
+                rootId,
+                int64 bytes.LongLength,
+                None,
+                None,
+                Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))
+            )
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact bytes with
+        | Ok _ -> Assert.Fail("Expected artifact validation to reject descriptors with no supported integrity evidence.")
+        | Error error ->
+            error.Error
+            |> should contain "SHA-256 or BLAKE3 integrity evidence"
 
     /// Verifies that connect executes recursive metadata from the planned artifact payload.
     [<Test>]

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -215,6 +215,23 @@ module ConnectTests =
 
         output.ToArray()
 
+    /// Builds a zip payload with multiple Grace text entries stored as gzip-compressed bytes.
+    let private zipBytesForTextEntries (entries: (string * byte array) seq) =
+        use output = new MemoryStream()
+
+        do
+            use zip = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen = true)
+
+            entries
+            |> Seq.iter (fun (relativePath, payload) ->
+                let entry = zip.CreateEntry(relativePath)
+
+                use entryStream = entry.Open()
+                let compressedPayload = gzipBytes payload
+                entryStream.Write(compressedPayload, 0, compressedPayload.Length))
+
+        output.ToArray()
+
     /// Builds the relative-path lookup required by Direct zip extraction.
     let private fileVersionLookup (fileVersions: FileVersion seq) =
         let lookup = Dictionary<RelativePath, FileVersion>()
@@ -776,6 +793,81 @@ module ConnectTests =
 
                         File.ReadAllText(filePath)
                         |> should equal sentinel)
+                ))
+
+    /// Verifies that staged Direct zip validation extracts files skipped only for final worktree writes.
+    [<Test>]
+    let ``connect staged direct zip validation extracts final skip-set files`` () =
+        withTempDir (fun root ->
+            Grace.Shared.Client.Configuration.resetConfiguration ()
+            let configuration = Grace.Shared.Client.Configuration.Current()
+
+            let unchangedPayload = Encoding.UTF8.GetBytes("already materialized text")
+            let updatedPayload = Encoding.UTF8.GetBytes("new materialized text")
+            let unchangedRelativePath = RelativePath "src/unchanged.fs"
+            let updatedRelativePath = RelativePath "src/updated.fs"
+            let unchangedFilePath = Path.Combine(root, string unchangedRelativePath)
+            let updatedFilePath = Path.Combine(root, string updatedRelativePath)
+
+            Directory.CreateDirectory(Path.GetDirectoryName(unchangedFilePath))
+            |> ignore
+
+            File.WriteAllBytes(unchangedFilePath, unchangedPayload)
+
+            let unchangedFileVersion =
+                FileVersion.CreateWithHashes
+                    unchangedRelativePath
+                    (computeSha256Hash unchangedPayload)
+                    (computeBlake3Hash unchangedPayload)
+                    String.Empty
+                    false
+                    (int64 unchangedPayload.Length)
+
+            let updatedFileVersion =
+                FileVersion.CreateWithHashes
+                    updatedRelativePath
+                    (computeSha256Hash updatedPayload)
+                    (computeBlake3Hash updatedPayload)
+                    String.Empty
+                    false
+                    (int64 updatedPayload.Length)
+
+            let filesToSkip = HashSet<RelativePath>()
+
+            filesToSkip.Add(unchangedRelativePath) |> ignore
+
+            use zipStream =
+                new MemoryStream(
+                    zipBytesForTextEntries [ string unchangedRelativePath, unchangedPayload
+                                             string updatedRelativePath, updatedPayload ]
+                )
+
+            let fileVersions =
+                [|
+                    unchangedFileVersion
+                    updatedFileVersion
+                |]
+
+            let parseResult = GraceCommand.rootCommand.Parse([| "connect" |])
+
+            let result =
+                Connect.extractValidatedZipEntries parseResult "correlation-id" (fileVersionLookup fileVersions) filesToSkip fileVersions zipStream
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match result with
+            | Error error -> Assert.Fail($"Unexpected staged Direct zip validation error: {error.Error}")
+            | Ok () ->
+                let objectFiles = Directory.GetFiles(string configuration.ObjectDirectory, "*", SearchOption.AllDirectories)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        File.ReadAllBytes(unchangedFilePath)
+                        |> should equal unchangedPayload
+
+                        File.ReadAllBytes(updatedFilePath)
+                        |> should equal updatedPayload
+
+                        objectFiles |> should haveLength 2)
                 ))
 
     /// Verifies that staged Direct zip validation still writes final files and object-cache bytes on success.

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -4,14 +4,18 @@ open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
 open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.Branch
 open Grace.Types.MaterializationPlan
 open Grace.Types.Common
 open Grace.Types.DirectoryVersion
+open MessagePack
 open NUnit.Framework
 open Spectre.Console
 open System
 open System.Collections.Generic
 open System.IO
+open System.Security.Cryptography
 
 /// Groups connect coverage for the CLI test project.
 [<NonParallelizable>]
@@ -102,6 +106,12 @@ module ConnectTests =
     let private sha256Hash = Sha256Hash(String.replicate 64 "a")
     let private blake3Hash = Blake3Hash(String.replicate 64 "b")
 
+    /// Computes the SHA-256 descriptor hash for artifact validation tests.
+    let private computeSha256Hash (bytes: byte array) = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
+
+    /// Computes the BLAKE3 descriptor hash for artifact validation tests.
+    let private computeBlake3Hash (bytes: byte array) = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+
     /// Builds a root DirectoryVersionDto for Direct plan execution tests.
     let private rootDirectoryDto (files: FileVersion array) =
         { DirectoryVersionDto.Default with
@@ -125,8 +135,61 @@ module ConnectTests =
     /// Builds a Direct plan descriptor for the target-root recursive metadata artifact.
     let private metadataArtifact source = MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(rootId, 64L, Some sha256Hash, Some blake3Hash, source)
 
+    /// Builds a Direct plan descriptor whose integrity fields match the supplied payload.
+    let private zipArtifactForBytes source (bytes: byte array) =
+        MaterializationArtifactDescriptor.DirectoryVersionZip(
+            rootId,
+            int64 bytes.LongLength,
+            Some(computeSha256Hash bytes),
+            Some(computeBlake3Hash bytes),
+            source
+        )
+
+    /// Builds a recursive metadata descriptor whose integrity fields match the supplied payload.
+    let private metadataArtifactForBytes source (bytes: byte array) =
+        MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(
+            rootId,
+            int64 bytes.LongLength,
+            Some(computeSha256Hash bytes),
+            Some(computeBlake3Hash bytes),
+            source
+        )
+
     /// Builds a Direct Materialization Plan for connect execution tests.
     let private directPlan artifacts = MaterializationPlan.Create(rootId, MaterializationExecutionMode.Direct, MaterializationCacheSelection.Bypass, artifacts)
+
+    /// Verifies that Direct plan requests preserve a moving reference selector for final server resolution.
+    [<Test>]
+    let ``connect direct plan request preserves reference selector intent`` () =
+        let referenceId = Guid.Parse("66666666-6666-6666-6666-666666666666")
+        let branchDto = { BranchDto.Default with BranchName = BranchName "main" }
+
+        let request = Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector (Connect.UseReferenceId referenceId) branchDto rootId)
+
+        request.TargetSelector.SelectorKind
+        |> should equal MaterializationTargetSelectorKind.ReferenceId
+
+        request.TargetSelector.ReferenceId
+        |> should equal (Some referenceId)
+
+        request.TargetSelector.DirectoryVersionId
+        |> should equal None
+
+    /// Verifies that Direct plan requests preserve default branch selection as a moving branch selector.
+    [<Test>]
+    let ``connect direct plan request preserves default branch selector intent`` () =
+        let branchDto = { BranchDto.Default with BranchName = BranchName "trunk" }
+
+        let request = Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector Connect.UseDefault branchDto rootId)
+
+        request.TargetSelector.SelectorKind
+        |> should equal MaterializationTargetSelectorKind.BranchName
+
+        request.TargetSelector.BranchName
+        |> should equal (Some(BranchName "trunk"))
+
+        request.TargetSelector.DirectoryVersionId
+        |> should equal None
 
     /// Verifies that Direct plan execution preparation preserves recursive metadata file versions and planned zip source.
     [<Test>]
@@ -148,6 +211,9 @@ module ConnectTests =
 
             artifacts.ZipUri
             |> should equal "https://example.test/root.zip"
+
+            artifacts.ZipArtifact.ArtifactKind
+            |> should equal MaterializationArtifactKind.DirectoryVersionZip
 
             artifacts.DirectoryVersionDtos
             |> should haveLength 1
@@ -214,3 +280,50 @@ module ConnectTests =
         match Connect.prepareDirectPlanExecutionArtifacts "correlation-id" plan directoryVersions with
         | Ok _ -> Assert.Fail("Expected missing recursive metadata artifact source to fail before extraction.")
         | Error error -> error.Error |> should contain "missing a source"
+
+    /// Verifies that planned artifact validation rejects stale or truncated bytes before extraction.
+    [<Test>]
+    let ``connect direct plan artifact validation rejects size mismatch`` () =
+        let bytes = [| 1uy; 2uy; 3uy |]
+
+        let artifact =
+            { zipArtifactForBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) bytes with
+                SizeInBytes = Some(int64 bytes.Length + 1L)
+            }
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact bytes with
+        | Ok _ -> Assert.Fail("Expected artifact size mismatch to fail before extraction.")
+        | Error error -> error.Error |> should contain "size mismatch"
+
+    /// Verifies that planned artifact validation rejects bytes whose SHA-256 evidence no longer matches the plan.
+    [<Test>]
+    let ``connect direct plan artifact validation rejects sha mismatch`` () =
+        let plannedBytes = [| 1uy; 2uy; 3uy |]
+        let downloadedBytes = [| 1uy; 2uy; 4uy |]
+        let artifact = zipArtifactForBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) plannedBytes
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact downloadedBytes with
+        | Ok _ -> Assert.Fail("Expected artifact hash mismatch to fail before extraction.")
+        | Error error -> error.Error |> should contain "SHA-256 mismatch"
+
+    /// Verifies that connect executes recursive metadata from the planned artifact payload.
+    [<Test>]
+    let ``connect direct plan decodes planned recursive metadata artifact`` () =
+        let directoryVersions =
+            [|
+                rootDirectoryDto Array.empty<FileVersion>
+            |]
+
+        let bytes = MessagePackSerializer.Serialize(directoryVersions, Constants.messagePackSerializerOptions)
+        let artifact = metadataArtifactForBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.msgpack"))) bytes
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "RecursiveDirectoryMetadata" artifact bytes with
+        | Error error -> Assert.Fail($"Unexpected metadata integrity error: {error.Error}")
+        | Ok () ->
+            match Connect.decodeRecursiveMetadataArtifact "correlation-id" bytes with
+            | Error error -> Assert.Fail($"Unexpected metadata decode error: {error.Error}")
+            | Ok decoded ->
+                decoded |> should haveLength 1
+
+                decoded[0].DirectoryVersion.DirectoryVersionId
+                |> should equal rootId

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -3,10 +3,14 @@ namespace Grace.CLI.Tests
 open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
+open Grace.Shared
+open Grace.Types.MaterializationPlan
 open Grace.Types.Common
+open Grace.Types.DirectoryVersion
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Generic
 open System.IO
 
 /// Groups connect coverage for the CLI test project.
@@ -89,3 +93,124 @@ module ConnectTests =
 
         Connect.existingFileMatchesRemoteVersion (Sha256Hash "legacy-sha") (Blake3Hash "different-local-blake3") remoteFile
         |> should equal true
+
+    let private ownerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+    let private organizationId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+    let private repositoryId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+    let private rootId = Guid.Parse("44444444-4444-4444-4444-444444444444")
+    let private alternateRootId = Guid.Parse("55555555-5555-5555-5555-555555555555")
+    let private sha256Hash = Sha256Hash(String.replicate 64 "a")
+    let private blake3Hash = Blake3Hash(String.replicate 64 "b")
+
+    /// Builds a root DirectoryVersionDto for Direct plan execution tests.
+    let private rootDirectoryDto (files: FileVersion array) =
+        { DirectoryVersionDto.Default with
+            DirectoryVersion =
+                Grace.Types.Common.DirectoryVersion.CreateWithHashes
+                    rootId
+                    ownerId
+                    organizationId
+                    repositoryId
+                    Constants.RootDirectoryPath
+                    sha256Hash
+                    blake3Hash
+                    (List<DirectoryVersionId>())
+                    (List<FileVersion>(files :> seq<FileVersion>))
+                    1L
+        }
+
+    /// Builds a Direct plan descriptor for the target-root zip artifact.
+    let private zipArtifact source = MaterializationArtifactDescriptor.DirectoryVersionZip(rootId, 128L, Some sha256Hash, Some blake3Hash, source)
+
+    /// Builds a Direct plan descriptor for the target-root recursive metadata artifact.
+    let private metadataArtifact source = MaterializationArtifactDescriptor.RecursiveDirectoryMetadata(rootId, 64L, Some sha256Hash, Some blake3Hash, source)
+
+    /// Builds a Direct Materialization Plan for connect execution tests.
+    let private directPlan artifacts = MaterializationPlan.Create(rootId, MaterializationExecutionMode.Direct, MaterializationCacheSelection.Bypass, artifacts)
+
+    /// Verifies that Direct plan execution preparation preserves recursive metadata file versions and planned zip source.
+    [<Test>]
+    let ``connect direct plan preparation returns metadata file versions and zip source`` () =
+        let source = Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))
+
+        let fileVersion = FileVersion.CreateWithHashes (RelativePath "src/app.fs") sha256Hash blake3Hash String.Empty false 12L
+
+        let plan =
+            directPlan [ zipArtifact source
+                         metadataArtifact source ]
+
+        let directoryVersions = [| rootDirectoryDto [| fileVersion |] |]
+
+        match Connect.prepareDirectPlanExecutionArtifacts "correlation-id" plan directoryVersions with
+        | Ok artifacts ->
+            artifacts.TargetRootDirectoryVersionId
+            |> should equal rootId
+
+            artifacts.ZipUri
+            |> should equal "https://example.test/root.zip"
+
+            artifacts.DirectoryVersionDtos
+            |> should haveLength 1
+
+            artifacts.FileVersions |> should haveLength 1
+
+            artifacts.FileVersions[0].RelativePath
+            |> should equal (RelativePath "src/app.fs")
+        | Error error -> Assert.Fail($"Unexpected Direct plan preparation error: {error.Error}")
+
+    /// Verifies that Direct plan execution rejects mismatched root artifact descriptors before local writes.
+    [<Test>]
+    let ``connect direct plan preparation rejects mismatched artifact root`` () =
+        let source = Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))
+        let mismatchedZip = { zipArtifact source with RepresentedRootDirectoryVersionId = Some alternateRootId }
+
+        let plan =
+            directPlan [ mismatchedZip
+                         metadataArtifact source ]
+
+        let directoryVersions =
+            [|
+                rootDirectoryDto Array.empty<FileVersion>
+            |]
+
+        match Connect.prepareDirectPlanExecutionArtifacts "correlation-id" plan directoryVersions with
+        | Ok _ -> Assert.Fail("Expected mismatched Direct plan roots to fail before extraction.")
+        | Error error ->
+            error.Error
+            |> should contain "Materialization Plan"
+
+    /// Verifies that Direct plan execution rejects missing artifact sources before status or object-cache updates.
+    [<Test>]
+    let ``connect direct plan preparation rejects missing zip source`` () =
+        let source = Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))
+
+        let plan =
+            directPlan [ zipArtifact None
+                         metadataArtifact source ]
+
+        let directoryVersions =
+            [|
+                rootDirectoryDto Array.empty<FileVersion>
+            |]
+
+        match Connect.prepareDirectPlanExecutionArtifacts "correlation-id" plan directoryVersions with
+        | Ok _ -> Assert.Fail("Expected missing zip artifact source to fail before extraction.")
+        | Error error -> error.Error |> should contain "missing a source"
+
+    /// Verifies that Direct plan execution rejects missing recursive metadata sources before status or object-cache updates.
+    [<Test>]
+    let ``connect direct plan preparation rejects missing recursive metadata source`` () =
+        let source = Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))
+
+        let plan =
+            directPlan [ zipArtifact source
+                         metadataArtifact None ]
+
+        let directoryVersions =
+            [|
+                rootDirectoryDto Array.empty<FileVersion>
+            |]
+
+        match Connect.prepareDirectPlanExecutionArtifacts "correlation-id" plan directoryVersions with
+        | Ok _ -> Assert.Fail("Expected missing recursive metadata artifact source to fail before extraction.")
+        | Error error -> error.Error |> should contain "missing a source"

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -16,7 +16,10 @@ open Spectre.Console
 open System
 open System.Collections.Generic
 open System.IO
+open System.IO.Compression
 open System.Security.Cryptography
+open System.Text
+open System.Threading.Tasks
 
 /// Groups connect coverage for the CLI test project.
 [<NonParallelizable>]
@@ -52,6 +55,7 @@ module ConnectTests =
             action tempDir
         finally
             Environment.CurrentDirectory <- originalDir
+            Grace.Shared.Client.Configuration.resetConfiguration ()
 
             if Directory.Exists(tempDir) then
                 try
@@ -135,6 +139,23 @@ module ConnectTests =
                     1L
         }
 
+    /// Builds a DirectoryVersionDto for Direct plan execution tests.
+    let private directoryDto directoryVersionId (relativePath: string) (files: FileVersion array) =
+        { DirectoryVersionDto.Default with
+            DirectoryVersion =
+                Grace.Types.Common.DirectoryVersion.CreateWithHashes
+                    directoryVersionId
+                    ownerId
+                    organizationId
+                    repositoryId
+                    (RelativePath relativePath)
+                    sha256Hash
+                    blake3Hash
+                    (List<DirectoryVersionId>())
+                    (List<FileVersion>(files :> seq<FileVersion>))
+                    1L
+        }
+
     /// Builds a Direct plan descriptor for the target-root zip artifact.
     let private zipArtifact source = MaterializationArtifactDescriptor.DirectoryVersionZip(rootId, 128L, Some sha256Hash, Some blake3Hash, source)
 
@@ -168,6 +189,22 @@ module ConnectTests =
     /// Builds a Direct Materialization Plan for connect execution tests.
     let private directPlan artifacts = MaterializationPlan.Create(rootId, MaterializationExecutionMode.Direct, MaterializationCacheSelection.Bypass, artifacts)
 
+    /// Compresses test payload bytes with gzip for descriptor-versus-file integrity tests.
+    let private gzipBytes (bytes: byte array) =
+        use output = new MemoryStream()
+
+        do
+            use gzip = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen = true)
+            gzip.Write(bytes, 0, bytes.Length)
+
+        output.ToArray()
+
+    /// Keeps test streams inspectable after production code disposes the response stream wrapper.
+    type private NonDisposingMemoryStream(bytes: byte array) =
+        inherit MemoryStream(bytes)
+
+        override _.Dispose(disposing: bool) = ()
+
     /// Verifies that Direct plan requests preserve a moving reference selector for final server resolution.
     [<Test>]
     let ``connect direct plan request preserves reference selector intent`` () =
@@ -181,6 +218,26 @@ module ConnectTests =
 
         request.TargetSelector.ReferenceId
         |> should equal (Some referenceId)
+
+        request.TargetSelector.DirectoryVersionId
+        |> should equal None
+
+    /// Verifies that Direct plan requests preserve reference type selector intent for server-side latest-reference resolution.
+    [<Test>]
+    let ``connect direct plan request preserves reference type selector intent`` () =
+        let branchDto = { BranchDto.Default with BranchName = BranchName "main" }
+
+        let request =
+            Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector (Connect.UseReferenceType ReferenceType.Promotion) branchDto rootId)
+
+        request.TargetSelector.SelectorKind
+        |> should equal MaterializationTargetSelectorKind.ReferenceType
+
+        request.TargetSelector.BranchName
+        |> should equal (Some(BranchName "main"))
+
+        request.TargetSelector.ReferenceType
+        |> should equal (Some ReferenceType.Promotion)
 
         request.TargetSelector.DirectoryVersionId
         |> should equal None
@@ -230,6 +287,21 @@ module ConnectTests =
         request.TargetSelector.BranchName
         |> should equal None
 
+    /// Verifies that explicit DirectoryVersionId connects remain immutable selectors and can represent scoped directories.
+    [<Test>]
+    let ``connect direct plan request preserves explicit directory version selector`` () =
+        let scopedDirectoryVersionId = Guid.Parse("99999999-9999-9999-9999-999999999999")
+        let branchDto = { BranchDto.Default with BranchName = BranchName "trunk" }
+
+        let request =
+            Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector (Connect.UseDirectoryVersionId scopedDirectoryVersionId) branchDto rootId)
+
+        request.TargetSelector.SelectorKind
+        |> should equal MaterializationTargetSelectorKind.DirectoryVersionId
+
+        request.TargetSelector.DirectoryVersionId
+        |> should equal (Some scopedDirectoryVersionId)
+
     /// Verifies that Direct plan execution preparation preserves recursive metadata file versions and planned zip source.
     [<Test>]
     let ``connect direct plan preparation returns metadata file versions and zip source`` () =
@@ -262,6 +334,29 @@ module ConnectTests =
             artifacts.FileVersions[0].RelativePath
             |> should equal (RelativePath "src/app.fs")
         | Error error -> Assert.Fail($"Unexpected Direct plan preparation error: {error.Error}")
+
+    /// Verifies that Direct plan execution preparation accepts non-root target directory versions.
+    [<Test>]
+    let ``connect direct plan preparation accepts non-root target directory metadata`` () =
+        let source = Some(MaterializationArtifactSource.Direct("https://example.test/src.zip"))
+        let fileVersion = FileVersion.CreateWithHashes (RelativePath "src/app.fs") sha256Hash blake3Hash String.Empty false 12L
+
+        let plan =
+            directPlan [ zipArtifact source
+                         metadataArtifact source ]
+
+        let directoryVersions =
+            [|
+                directoryDto rootId "src" [| fileVersion |]
+            |]
+
+        match Connect.prepareDirectPlanExecutionArtifacts "correlation-id" plan directoryVersions with
+        | Ok artifacts ->
+            artifacts.TargetRootDirectoryVersionId
+            |> should equal rootId
+
+            artifacts.FileVersions |> should haveLength 1
+        | Error error -> Assert.Fail($"Unexpected non-root Direct plan preparation error: {error.Error}")
 
     /// Verifies that Direct plan execution rejects mismatched root artifact descriptors before local writes.
     [<Test>]
@@ -414,6 +509,83 @@ module ConnectTests =
         | Error error ->
             error.Error
             |> should contain "SHA-256 or BLAKE3 integrity evidence"
+
+    /// Verifies that DirectUri transfer rejects oversized Content-Length without opening the response body.
+    [<Test>]
+    let ``connect direct uri copy rejects oversized content length before transfer`` () =
+        let mutable opened = false
+
+        let result =
+            Connect.copyDirectUriArtifactToTempStream "correlation-id" "DirectoryVersionZip" (Some 3L) (Some 4L) (fun () ->
+                opened <- true
+                Task.FromResult<Stream>(new MemoryStream([| 1uy; 2uy; 3uy; 4uy |])))
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match result with
+        | Ok stream ->
+            stream.Dispose()
+            Assert.Fail("Expected oversized Content-Length to fail before transfer.")
+        | Error error ->
+            opened |> should equal false
+
+            error.Error
+            |> should contain "Content-Length exceeds planned size"
+
+    /// Verifies that DirectUri transfer stops after observing one byte beyond the planned delivered artifact size.
+    [<Test>]
+    let ``connect direct uri copy stops at planned size plus one when length is absent`` () =
+        let payload = [| 0uy .. 9uy |]
+        let source = new NonDisposingMemoryStream(payload)
+
+        let result =
+            Connect.copyDirectUriArtifactToTempStream "correlation-id" "DirectoryVersionZip" (Some 3L) None (fun () -> Task.FromResult<Stream>(source))
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match result with
+        | Ok stream ->
+            stream.Dispose()
+            Assert.Fail("Expected over-limit DirectUri body to fail during transfer.")
+        | Error error ->
+            source.Position |> should equal 4L
+            error.Error |> should contain "size mismatch"
+
+    /// Verifies that descriptor integrity is evaluated against delivered compressed artifact bytes.
+    [<Test>]
+    let ``connect direct plan artifact validation hashes delivered compressed bytes`` () =
+        let uncompressedBytes = Encoding.UTF8.GetBytes("uncompressed file content")
+        let compressedBytes = gzipBytes uncompressedBytes
+        let artifact = zipArtifactForBytes (Some(MaterializationArtifactSource.Direct("https://example.test/root.zip"))) compressedBytes
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact compressedBytes with
+        | Error error -> Assert.Fail($"Unexpected compressed artifact validation error: {error.Error}")
+        | Ok () -> ()
+
+        match Connect.validatePlannedArtifactBytes "correlation-id" "DirectoryVersionZip" artifact uncompressedBytes with
+        | Ok () -> Assert.Fail("Expected descriptor validation to reject uncompressed bytes when descriptor hashes compressed delivery bytes.")
+        | Error error -> error.Error |> should contain "size mismatch"
+
+    /// Verifies that final materialized file validation uses uncompressed working-tree file bytes.
+    [<Test>]
+    let ``connect materialized file validation hashes uncompressed file bytes`` () =
+        withTempDir (fun root ->
+            Grace.Shared.Client.Configuration.resetConfiguration ()
+            let payload = Encoding.UTF8.GetBytes("materialized text")
+            let relativePath = RelativePath "src/app.fs"
+            let filePath = Path.Combine(root, string relativePath)
+
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath))
+            |> ignore
+
+            File.WriteAllBytes(filePath, payload)
+
+            let fileVersion =
+                FileVersion.CreateWithHashes relativePath (computeSha256Hash payload) (computeBlake3Hash payload) String.Empty false (int64 payload.Length)
+
+            match Connect.validateMaterializedFiles "correlation-id" [| fileVersion |]
+                  |> fun task -> task.GetAwaiter().GetResult()
+                with
+            | Error error -> Assert.Fail($"Unexpected materialized file validation error: {error.Error}")
+            | Ok () -> ())
 
     /// Verifies that connect executes recursive metadata from the planned artifact payload.
     [<Test>]

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -201,6 +201,29 @@ module ConnectTests =
 
         output.ToArray()
 
+    /// Builds a zip payload with one Grace text entry stored as gzip-compressed bytes.
+    let private zipBytesForTextEntry relativePath (payload: byte array) =
+        use output = new MemoryStream()
+
+        do
+            use zip = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen = true)
+            let entry = zip.CreateEntry(relativePath)
+
+            use entryStream = entry.Open()
+            let compressedPayload = gzipBytes payload
+            entryStream.Write(compressedPayload, 0, compressedPayload.Length)
+
+        output.ToArray()
+
+    /// Builds the relative-path lookup required by Direct zip extraction.
+    let private fileVersionLookup (fileVersions: FileVersion seq) =
+        let lookup = Dictionary<RelativePath, FileVersion>()
+
+        fileVersions
+        |> Seq.iter (fun fileVersion -> lookup.Add(fileVersion.RelativePath, fileVersion))
+
+        lookup
+
     /// Keeps test streams inspectable after production code disposes the response stream wrapper.
     type private NonDisposingMemoryStream(bytes: byte array) =
         inherit MemoryStream(bytes)
@@ -701,6 +724,102 @@ module ConnectTests =
                 with
             | Error error -> Assert.Fail($"Unexpected materialized file validation error: {error.Error}")
             | Ok () -> ())
+
+    /// Verifies that staged Direct zip validation fails before replacing an existing working-tree file.
+    [<Test>]
+    let ``connect staged direct zip validation preserves existing worktree file on mismatch`` () =
+        withTempDir (fun root ->
+            Grace.Shared.Client.Configuration.resetConfiguration ()
+
+            Grace.Shared.Client.Configuration.Current()
+            |> ignore
+
+            let expectedPayload = Encoding.UTF8.GetBytes("expected materialized text")
+            let stalePayload = Encoding.UTF8.GetBytes("stale materialized text")
+            let sentinel = "existing local sentinel"
+            let relativePath = RelativePath "src/app.fs"
+            let filePath = Path.Combine(root, string relativePath)
+
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath))
+            |> ignore
+
+            File.WriteAllText(filePath, sentinel)
+
+            let fileVersion =
+                FileVersion.CreateWithHashes
+                    relativePath
+                    (computeSha256Hash expectedPayload)
+                    (computeBlake3Hash expectedPayload)
+                    String.Empty
+                    false
+                    (int64 expectedPayload.Length)
+
+            use zipStream = new MemoryStream(zipBytesForTextEntry (string relativePath) stalePayload)
+            let parseResult = GraceCommand.rootCommand.Parse([| "connect" |])
+
+            let result =
+                Connect.extractValidatedZipEntries
+                    parseResult
+                    "correlation-id"
+                    (fileVersionLookup [| fileVersion |])
+                    (HashSet<RelativePath>())
+                    [| fileVersion |]
+                    zipStream
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match result with
+            | Ok () -> Assert.Fail("Expected staged Direct zip validation to reject stale decompressed file bytes.")
+            | Error error ->
+                Assert.Multiple(
+                    Action (fun () ->
+                        error.Error |> should contain "mismatch"
+
+                        File.ReadAllText(filePath)
+                        |> should equal sentinel)
+                ))
+
+    /// Verifies that staged Direct zip validation still writes final files and object-cache bytes on success.
+    [<Test>]
+    let ``connect staged direct zip validation writes final worktree and object cache on success`` () =
+        withTempDir (fun root ->
+            Grace.Shared.Client.Configuration.resetConfiguration ()
+            let configuration = Grace.Shared.Client.Configuration.Current()
+
+            let payload = Encoding.UTF8.GetBytes("expected materialized text")
+            let relativePath = RelativePath "src/app.fs"
+            let filePath = Path.Combine(root, string relativePath)
+
+            let fileVersion =
+                FileVersion.CreateWithHashes relativePath (computeSha256Hash payload) (computeBlake3Hash payload) String.Empty false (int64 payload.Length)
+
+            use zipStream = new MemoryStream(zipBytesForTextEntry (string relativePath) payload)
+            let parseResult = GraceCommand.rootCommand.Parse([| "connect" |])
+
+            let result =
+                Connect.extractValidatedZipEntries
+                    parseResult
+                    "correlation-id"
+                    (fileVersionLookup [| fileVersion |])
+                    (HashSet<RelativePath>())
+                    [| fileVersion |]
+                    zipStream
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match result with
+            | Error error -> Assert.Fail($"Unexpected staged Direct zip validation error: {error.Error}")
+            | Ok () ->
+                let objectFiles = Directory.GetFiles(string configuration.ObjectDirectory, "*", SearchOption.AllDirectories)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        File.ReadAllBytes(filePath)
+                        |> should equal payload
+
+                        objectFiles |> should haveLength 1
+
+                        File.ReadAllBytes(objectFiles[0])
+                        |> should equal payload)
+                ))
 
     /// Verifies that connect executes recursive metadata from the planned artifact payload.
     [<Test>]

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -2,7 +2,9 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.CLI.Common
 open Grace.CLI.Command
+open Grace.CLI.Text
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Branch
@@ -211,7 +213,10 @@ module ConnectTests =
         let referenceId = Guid.Parse("66666666-6666-6666-6666-666666666666")
         let branchDto = { BranchDto.Default with BranchName = BranchName "main" }
 
-        let request = Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector (Connect.UseReferenceId referenceId) branchDto rootId)
+        let request =
+            Connect.createDirectPlanRequest (
+                Connect.createDirectPlanTargetSelector (Connect.UseReferenceId referenceId) (Connect.UsePlanBranchName branchDto.BranchName) rootId
+            )
 
         request.TargetSelector.SelectorKind
         |> should equal MaterializationTargetSelectorKind.ReferenceId
@@ -228,7 +233,12 @@ module ConnectTests =
         let branchDto = { BranchDto.Default with BranchName = BranchName "main" }
 
         let request =
-            Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector (Connect.UseReferenceType ReferenceType.Promotion) branchDto rootId)
+            Connect.createDirectPlanRequest (
+                Connect.createDirectPlanTargetSelector
+                    (Connect.UseReferenceType ReferenceType.Promotion)
+                    (Connect.UsePlanBranchName branchDto.BranchName)
+                    rootId
+            )
 
         request.TargetSelector.SelectorKind
         |> should equal MaterializationTargetSelectorKind.ReferenceType
@@ -236,11 +246,110 @@ module ConnectTests =
         request.TargetSelector.BranchName
         |> should equal (Some(BranchName "main"))
 
+        request.TargetSelector.BranchId
+        |> should equal None
+
         request.TargetSelector.ReferenceType
         |> should equal (Some ReferenceType.Promotion)
 
         request.TargetSelector.DirectoryVersionId
         |> should equal None
+
+    /// Verifies that Direct plan requests preserve explicit branch id selector intent for server-side resolution.
+    [<Test>]
+    let ``connect direct plan request preserves branch id reference type selector intent`` () =
+        let branchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        let branchDto = { BranchDto.Default with BranchId = branchId; BranchName = BranchName "renamed" }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "connect"
+                    OptionName.BranchId
+                    $"{branchId}"
+                    OptionName.ReferenceType
+                    $"{ReferenceType.Promotion}"
+                |]
+            )
+
+        let request =
+            Connect.createDirectPlanRequest (
+                Connect.createDirectPlanTargetSelector
+                    (Connect.UseReferenceType ReferenceType.Promotion)
+                    (Connect.getDirectPlanBranchIdentity parseResult branchDto)
+                    rootId
+            )
+
+        request.TargetSelector.SelectorKind
+        |> should equal MaterializationTargetSelectorKind.ReferenceType
+
+        request.TargetSelector.BranchId
+        |> should equal (Some branchId)
+
+        request.TargetSelector.BranchName
+        |> should equal None
+
+        request.TargetSelector.ReferenceType
+        |> should equal (Some ReferenceType.Promotion)
+
+    /// Verifies that Direct plan requests still use branch-name identity when the user selected a branch name.
+    [<Test>]
+    let ``connect direct plan request preserves branch name reference type selector intent`` () =
+        let branchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        let branchDto = { BranchDto.Default with BranchId = branchId; BranchName = BranchName "feature" }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "connect"
+                    OptionName.BranchName
+                    "feature"
+                    OptionName.ReferenceType
+                    $"{ReferenceType.Promotion}"
+                |]
+            )
+
+        let request =
+            Connect.createDirectPlanRequest (
+                Connect.createDirectPlanTargetSelector
+                    (Connect.UseReferenceType ReferenceType.Promotion)
+                    (Connect.getDirectPlanBranchIdentity parseResult branchDto)
+                    rootId
+            )
+
+        request.TargetSelector.BranchId
+        |> should equal None
+
+        request.TargetSelector.BranchName
+        |> should equal (Some(BranchName "feature"))
+
+    /// Verifies that Direct plan requests still use default branch-name identity when no branch id is explicit.
+    [<Test>]
+    let ``connect direct plan request preserves default branch name reference type selector intent`` () =
+        let branchDto = { BranchDto.Default with BranchId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"); BranchName = BranchName "main" }
+
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "connect"
+                    OptionName.ReferenceType
+                    $"{ReferenceType.Promotion}"
+                |]
+            )
+
+        let request =
+            Connect.createDirectPlanRequest (
+                Connect.createDirectPlanTargetSelector
+                    (Connect.UseReferenceType ReferenceType.Promotion)
+                    (Connect.getDirectPlanBranchIdentity parseResult branchDto)
+                    rootId
+            )
+
+        request.TargetSelector.BranchId
+        |> should equal None
+
+        request.TargetSelector.BranchName
+        |> should equal (Some(BranchName "main"))
 
     /// Verifies that implicit default connect keeps promoted target semantics even when the branch tip has moved.
     [<Test>]
@@ -276,7 +385,8 @@ module ConnectTests =
     let ``connect direct plan request sends resolved default target as directory version selector`` () =
         let branchDto = { BranchDto.Default with BranchName = BranchName "trunk" }
 
-        let request = Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector Connect.UseDefault branchDto rootId)
+        let request =
+            Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector Connect.UseDefault (Connect.UsePlanBranchName branchDto.BranchName) rootId)
 
         request.TargetSelector.SelectorKind
         |> should equal MaterializationTargetSelectorKind.DirectoryVersionId
@@ -294,7 +404,12 @@ module ConnectTests =
         let branchDto = { BranchDto.Default with BranchName = BranchName "trunk" }
 
         let request =
-            Connect.createDirectPlanRequest (Connect.createDirectPlanTargetSelector (Connect.UseDirectoryVersionId scopedDirectoryVersionId) branchDto rootId)
+            Connect.createDirectPlanRequest (
+                Connect.createDirectPlanTargetSelector
+                    (Connect.UseDirectoryVersionId scopedDirectoryVersionId)
+                    (Connect.UsePlanBranchName branchDto.BranchName)
+                    rootId
+            )
 
         request.TargetSelector.SelectorKind
         |> should equal MaterializationTargetSelectorKind.DirectoryVersionId

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -1258,7 +1258,9 @@ module Connect =
                             Directory.CreateDirectory(stageRootDirectory)
                             |> ignore
 
-                            extractZipEntries parseResult stageRootDirectory stageObjectDirectory fileVersionsByRelativePath filesToSkip true false zipFile
+                            let stageFilesToSkip = HashSet<RelativePath>()
+
+                            extractZipEntries parseResult stageRootDirectory stageObjectDirectory fileVersionsByRelativePath stageFilesToSkip true false zipFile
 
                             return! validateMaterializedFilesInRoot correlationId stageRootDirectory fileVersions
                         with

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -181,6 +181,11 @@ module Connect =
         | UseReferenceType of ReferenceType
         | UseDefault
 
+    /// Identifies how Direct connect should preserve branch identity when it asks the server to resolve a moving selector.
+    type DirectPlanBranchIdentity =
+        | UsePlanBranchId of BranchId
+        | UsePlanBranchName of BranchName
+
     /// Carries the verified plan artifacts that Direct connect can execute without reusing legacy zip selection.
     type internal DirectPlanExecutionArtifacts =
         {
@@ -403,6 +408,16 @@ module Connect =
                         return Error(GraceError.Create $"No {referenceType} references were found for branch {branchDto.BranchName}." graceIds.CorrelationId)
                 | Error error -> return Error error
         }
+
+    /// Reads the branch identity shape the user selected so Direct ReferenceType planning preserves ID-or-name intent.
+    let internal getDirectPlanBranchIdentity (parseResult: ParseResult) (branchDto: BranchDto) =
+        let branchId =
+            tryGetExplicitValue parseResult Options.branchId
+            |> Option.filter (fun value -> value <> Guid.Empty)
+
+        match branchId with
+        | Some _ -> UsePlanBranchId branchDto.BranchId
+        | None -> UsePlanBranchName branchDto.BranchName
 
     /// Resolves target directory version id from command options, configuration, or local state.
     let private resolveTargetDirectoryVersionId
@@ -680,12 +695,15 @@ module Connect =
         }
 
     /// Builds the Materialization Plan target selector while preserving implicit default connect promotion semantics.
-    let internal createDirectPlanTargetSelector selection (branchDto: BranchDto) resolvedDirectoryVersionId =
+    let internal createDirectPlanTargetSelector selection branchIdentity resolvedDirectoryVersionId =
         match selection with
         | UseDirectoryVersionId directoryVersionId -> MaterializationTargetSelector.ForDirectoryVersion(directoryVersionId)
         | UseReferenceId referenceId -> MaterializationTargetSelector.ForReference(referenceId)
         | UseDefault -> MaterializationTargetSelector.ForDirectoryVersion(resolvedDirectoryVersionId)
-        | UseReferenceType referenceType -> MaterializationTargetSelector.ForReferenceType(branchDto.BranchName, referenceType)
+        | UseReferenceType referenceType ->
+            match branchIdentity with
+            | UsePlanBranchId branchId -> MaterializationTargetSelector.ForReferenceType(branchId, referenceType)
+            | UsePlanBranchName branchName -> MaterializationTargetSelector.ForReferenceType(branchName, referenceType)
 
     /// Builds the Direct Materialization Plan request for the target selected by connect.
     let internal createDirectPlanRequest targetSelector =
@@ -1217,17 +1235,18 @@ module Connect =
         =
         task {
             let directoryVersionSelection = getDirectoryVersionSelection parseResult
+            let branchIdentity = getDirectPlanBranchIdentity parseResult branchDto
 
             let! targetSelectorResult =
                 task {
                     match directoryVersionSelection with
                     | UseDefault ->
                         match! resolveTargetDirectoryVersionId parseResult graceIds ownerDto organizationDto repositoryDto branchDto with
-                        | Ok directoryVersionId -> return Ok(createDirectPlanTargetSelector directoryVersionSelection branchDto directoryVersionId)
+                        | Ok directoryVersionId -> return Ok(createDirectPlanTargetSelector directoryVersionSelection branchIdentity directoryVersionId)
                         | Error error -> return Error error
                     | UseDirectoryVersionId _
                     | UseReferenceId _
-                    | UseReferenceType _ -> return Ok(createDirectPlanTargetSelector directoryVersionSelection branchDto DirectoryVersionId.Empty)
+                    | UseReferenceType _ -> return Ok(createDirectPlanTargetSelector directoryVersionSelection branchIdentity DirectoryVersionId.Empty)
                 }
 
             match targetSelectorResult with

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -10,6 +10,7 @@ open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
 open Grace.Types.Owner
 open Grace.Types.Branch
+open Grace.Types.MaterializationPlan
 open Grace.Types.Organization
 open Grace.Types.Reference
 open Grace.Types.Repository
@@ -178,6 +179,15 @@ module Connect =
         | UseReferenceId of ReferenceId
         | UseReferenceType of ReferenceType
         | UseDefault
+
+    /// Carries the verified plan artifacts that Direct connect can execute without reusing legacy zip selection.
+    type internal DirectPlanExecutionArtifacts =
+        {
+            TargetRootDirectoryVersionId: DirectoryVersionId
+            ZipUri: string
+            DirectoryVersionDtos: Grace.Types.DirectoryVersion.DirectoryVersionDto array
+            FileVersions: FileVersion array
+        }
 
     /// Tries to map get explicit value and returns a GraceError instead of throwing on unsupported input.
     let private tryGetExplicitValue<'T> (parseResult: ParseResult) (option: Option<'T>) =
@@ -664,6 +674,126 @@ module Connect =
             RetrievedDefaultBranch = retrievedDefaultBranch
         }
 
+    /// Builds the Direct Materialization Plan request for the immutable root selected by connect.
+    let private createDirectPlanRequest directoryVersionId =
+        MaterializationPlanRequest.Create(
+            MaterializationTargetSelector.ForDirectoryVersion(directoryVersionId),
+            MaterializationExecutionMode.Direct,
+            MaterializationCacheSelection.Bypass,
+            [
+                MaterializationArtifactKind.DirectoryVersionZip
+                MaterializationArtifactKind.RecursiveDirectoryMetadata
+            ]
+        )
+
+    /// Requests the one-time Direct Materialization Plan used by connect to fetch root artifacts.
+    let private requestDirectMaterializationPlan
+        (graceIds: GraceIds)
+        (ownerDto: OwnerDto)
+        (organizationDto: OrganizationDto)
+        (repositoryDto: RepositoryDto)
+        directoryVersionId
+        =
+        let planParameters =
+            Parameters.Materialization.PlanParameters(
+                OwnerId = $"{ownerDto.OwnerId}",
+                OwnerName = ownerDto.OwnerName,
+                OrganizationId = $"{organizationDto.OrganizationId}",
+                OrganizationName = organizationDto.OrganizationName,
+                RepositoryId = $"{repositoryDto.RepositoryId}",
+                RepositoryName = repositoryDto.RepositoryName,
+                Request = createDirectPlanRequest directoryVersionId,
+                CorrelationId = graceIds.CorrelationId
+            )
+
+        Materialization.Plan(planParameters)
+
+    /// Returns the required root artifact descriptor from a Direct Materialization Plan.
+    let private tryFindRequiredRootArtifact artifactKind (plan: MaterializationPlan) =
+        plan.RequiredArtifacts
+        |> Seq.filter (fun artifact ->
+            artifact.ArtifactKind = artifactKind
+            && artifact.TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId)
+        |> Seq.tryExactlyOne
+
+    /// Reads the DirectUri source required to execute one planned root artifact.
+    let private tryGetDirectArtifactSourceUri artifactName correlationId (artifact: MaterializationArtifactDescriptor) =
+        match artifact.Source with
+        | Some source when
+            not (isNull (box source))
+            && source.SourceKind = MaterializationArtifactSourceKind.DirectUri
+            ->
+            match source.DirectUri with
+            | Some uri when not (String.IsNullOrWhiteSpace(uri)) -> Ok uri
+            | _ -> Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing a DirectUri source." correlationId)
+        | Some source when not (isNull (box source)) ->
+            Error(GraceError.Create $"Materialization Plan {artifactName} artifact source must be DirectUri for Direct connect." correlationId)
+        | _ -> Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing a source." correlationId)
+
+    /// Verifies the plan and recursive metadata describe the same target root before Direct connect writes local state.
+    let internal prepareDirectPlanExecutionArtifacts
+        correlationId
+        (plan: MaterializationPlan)
+        (directoryVersionDtos: Grace.Types.DirectoryVersion.DirectoryVersionDto array)
+        =
+        match Validation.validatePlan plan with
+        | Error errors ->
+            let errorMessage = String.Join("; ", errors)
+            Error(GraceError.Create $"Materialization Plan is invalid: {errorMessage}" correlationId)
+        | Ok () ->
+            if plan.ExecutionMode
+               <> MaterializationExecutionMode.Direct then
+                Error(GraceError.Create "Materialization Plan execution mode must be Direct for grace connect Direct execution." correlationId)
+            elif plan.CacheSelection.SelectionKind
+                 <> MaterializationCacheSelectionKind.BypassCache then
+                Error(GraceError.Create "Materialization Plan cache selection must bypass cache for grace connect Direct execution." correlationId)
+            else
+                match tryFindRequiredRootArtifact MaterializationArtifactKind.DirectoryVersionZip plan,
+                      tryFindRequiredRootArtifact MaterializationArtifactKind.RecursiveDirectoryMetadata plan
+                    with
+                | None, _ -> Error(GraceError.Create "Materialization Plan is missing the target root DirectoryVersionZip artifact." correlationId)
+                | _, None -> Error(GraceError.Create "Materialization Plan is missing the target root RecursiveDirectoryMetadata artifact." correlationId)
+                | Some zipArtifact, Some metadataArtifact ->
+                    match zipArtifact.RepresentedRootDirectoryVersionId, metadataArtifact.RepresentedRootDirectoryVersionId with
+                    | Some zipRoot, Some metadataRoot when
+                        zipRoot = plan.TargetRootDirectoryVersionId
+                        && metadataRoot = plan.TargetRootDirectoryVersionId
+                        ->
+                        let recursiveMetadataRootMatches =
+                            directoryVersionDtos
+                            |> Seq.exists (fun dto ->
+                                dto.DirectoryVersion.DirectoryVersionId = plan.TargetRootDirectoryVersionId
+                                && dto.DirectoryVersion.RelativePath = Constants.RootDirectoryPath)
+
+                        if not recursiveMetadataRootMatches then
+                            Error(GraceError.Create "Recursive DirectoryVersion metadata did not include the Materialization Plan target root." correlationId)
+                        else
+                            match tryGetDirectArtifactSourceUri "DirectoryVersionZip" correlationId zipArtifact with
+                            | Error error -> Error error
+                            | Ok zipUri ->
+                                match tryGetDirectArtifactSourceUri "RecursiveDirectoryMetadata" correlationId metadataArtifact with
+                                | Error error -> Error error
+                                | Ok _ ->
+                                    let fileVersions =
+                                        directoryVersionDtos
+                                        |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion)
+                                        |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+                                        |> Seq.toArray
+
+                                    Ok
+                                        {
+                                            TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId
+                                            ZipUri = zipUri
+                                            DirectoryVersionDtos = directoryVersionDtos
+                                            FileVersions = fileVersions
+                                        }
+                    | _ ->
+                        Error(
+                            GraceError.Create
+                                "Materialization Plan target root, zip represented root, and recursive metadata represented root must match."
+                                correlationId
+                        )
+
     /// Coordinates extract zip entries behavior for this CLI command path.
     let private extractZipEntries
         (parseResult: ParseResult)
@@ -743,80 +873,71 @@ module Connect =
             match directoryVersionResult with
             | Error error -> return (Error error |> renderOutput parseResult)
             | Ok directoryVersionId ->
-                let getDirectoryContentsParameters =
-                    Parameters.DirectoryVersion.GetParameters(
-                        OwnerId = $"{ownerDto.OwnerId}",
-                        OrganizationId = $"{organizationDto.OrganizationId}",
-                        RepositoryId = $"{repositoryDto.RepositoryId}",
-                        DirectoryVersionId = $"{directoryVersionId}",
-                        CorrelationId = graceIds.CorrelationId
-                    )
+                writeHumanLine parseResult $"[{Colors.Important}]Requesting Direct Materialization Plan.[/]"
+                let! materializationPlanResult = requestDirectMaterializationPlan graceIds ownerDto organizationDto repositoryDto directoryVersionId
+                writeHumanLine parseResult $"[{Colors.Important}]Finished requesting Direct Materialization Plan.[/]"
 
-                writeHumanLine parseResult $"[{Colors.Important}]Retrieving all DirectoryVersions.[/]"
+                match materializationPlanResult with
+                | Error error -> return (Error error |> renderOutput parseResult)
+                | Ok materializationPlanReturnValue ->
+                    let getDirectoryContentsParameters =
+                        Parameters.DirectoryVersion.GetParameters(
+                            OwnerId = $"{ownerDto.OwnerId}",
+                            OrganizationId = $"{organizationDto.OrganizationId}",
+                            RepositoryId = $"{repositoryDto.RepositoryId}",
+                            DirectoryVersionId = $"{materializationPlanReturnValue.ReturnValue.TargetRootDirectoryVersionId}",
+                            CorrelationId = graceIds.CorrelationId
+                        )
 
-                let! directoryVersionsResult = DirectoryVersion.GetDirectoryVersionsRecursive(getDirectoryContentsParameters)
+                    writeHumanLine parseResult $"[{Colors.Important}]Retrieving planned recursive DirectoryVersions.[/]"
 
-                let getZipFileParameters =
-                    Parameters.DirectoryVersion.GetZipFileParameters(
-                        OwnerId = $"{ownerDto.OwnerId}",
-                        OrganizationId = $"{organizationDto.OrganizationId}",
-                        RepositoryId = $"{repositoryDto.RepositoryId}",
-                        DirectoryVersionId = $"{directoryVersionId}",
-                        CorrelationId = graceIds.CorrelationId
-                    )
+                    let! directoryVersionsResult = DirectoryVersion.GetDirectoryVersionsRecursive(getDirectoryContentsParameters)
 
-                writeHumanLine parseResult $"[{Colors.Important}]Retrieving zip file download uri.[/]"
-                let! getZipFileResult = DirectoryVersion.GetZipFile(getZipFileParameters)
-                writeHumanLine parseResult $"[{Colors.Important}]Finished getting zip file download uri.[/]"
+                    match directoryVersionsResult with
+                    | Error error -> return (Error error |> renderOutput parseResult)
+                    | Ok directoryVerionsReturnValue ->
+                        writeHumanLine parseResult $"[{Colors.Important}]Retrieved planned recursive DirectoryVersions.[/]"
 
-                match (directoryVersionsResult, getZipFileResult) with
-                | (Ok directoryVerionsReturnValue, Ok getZipFileReturnValue) ->
-                    writeHumanLine parseResult $"[{Colors.Important}]Retrieved all DirectoryVersions.[/]"
+                        match
+                            prepareDirectPlanExecutionArtifacts
+                                graceIds.CorrelationId
+                                materializationPlanReturnValue.ReturnValue
+                                (directoryVerionsReturnValue.ReturnValue
+                                 |> Seq.toArray)
+                            with
+                        | Error error -> return (Error error |> renderOutput parseResult)
+                        | Ok executionArtifacts ->
+                            let force = parseResult.GetValue(Options.force)
 
-                    let directoryVersionDtos = directoryVerionsReturnValue.ReturnValue
+                            let! conflicts, filesToSkip = collectFileConflicts executionArtifacts.FileVersions force
 
-                    let fileVersions =
-                        directoryVersionDtos
-                        |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion)
-                        |> Seq.collect (fun dv -> dv.Files)
-                        |> Seq.toArray
+                            if conflicts.Count > 0 then
+                                writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
 
-                    let force = parseResult.GetValue(Options.force)
+                                if parseResult |> verbose then
+                                    conflicts
+                                    |> Seq.sort
+                                    |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
 
-                    let! conflicts, filesToSkip = collectFileConflicts fileVersions force
+                                return
+                                    (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
+                                     |> renderOutput parseResult)
+                            else
+                                let fileVersionsByRelativePath = buildFileVersionsByRelativePath executionArtifacts.FileVersions
 
-                    if conflicts.Count > 0 then
-                        writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
+                                let blobClient = BlobClient(Uri(executionArtifacts.ZipUri))
 
-                        if parseResult |> verbose then
-                            conflicts
-                            |> Seq.sort
-                            |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
+                                let! zipFile = blobClient.OpenReadAsync(bufferSize = 64 * 1024)
+                                extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
 
-                        return
-                            (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
-                             |> renderOutput parseResult)
-                    else
-                        let fileVersionsByRelativePath = buildFileVersionsByRelativePath fileVersions
+                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
+                                let! previousGraceStatus = readGraceStatusFile ()
+                                let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
+                                do! writeGraceStatusFile graceStatus
 
-                        let uriWithSharedAccessSignature = getZipFileReturnValue.ReturnValue
-
-                        // Download the .zip file to temp directory.
-                        let blobClient = BlobClient(uriWithSharedAccessSignature)
-
-                        let! zipFile = blobClient.OpenReadAsync(bufferSize = 64 * 1024)
-                        extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
-
-                        writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
-                        let! previousGraceStatus = readGraceStatusFile ()
-                        let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
-                        do! writeGraceStatusFile graceStatus
-
-                        writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
-                        do! upsertObjectCache graceStatus.Index.Values
-                        return 0
-                | (Error error, _) -> return (Error error |> renderOutput parseResult)
-                | (_, Error error) -> return (Error error |> renderOutput parseResult)
+                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
+                                do! upsertObjectCache graceStatus.Index.Values
+                                return 0
         }
 
     /// Routes the connect command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -680,12 +680,12 @@ module Connect =
         }
 
     /// Builds the Materialization Plan target selector while preserving implicit default connect promotion semantics.
-    let internal createDirectPlanTargetSelector selection (_branchDto: BranchDto) resolvedDirectoryVersionId =
+    let internal createDirectPlanTargetSelector selection (branchDto: BranchDto) resolvedDirectoryVersionId =
         match selection with
         | UseDirectoryVersionId directoryVersionId -> MaterializationTargetSelector.ForDirectoryVersion(directoryVersionId)
         | UseReferenceId referenceId -> MaterializationTargetSelector.ForReference(referenceId)
         | UseDefault -> MaterializationTargetSelector.ForDirectoryVersion(resolvedDirectoryVersionId)
-        | UseReferenceType _ -> MaterializationTargetSelector.ForDirectoryVersion(resolvedDirectoryVersionId)
+        | UseReferenceType referenceType -> MaterializationTargetSelector.ForReferenceType(branchDto.BranchName, referenceType)
 
     /// Builds the Direct Materialization Plan request for the target selected by connect.
     let internal createDirectPlanRequest targetSelector =
@@ -808,14 +808,12 @@ module Connect =
         match prepareDirectPlanArtifactSources correlationId plan with
         | Error error -> Error error
         | Ok sources ->
-            let recursiveMetadataRootMatches =
+            let recursiveMetadataTargetMatches =
                 directoryVersionDtos
-                |> Seq.exists (fun dto ->
-                    dto.DirectoryVersion.DirectoryVersionId = plan.TargetRootDirectoryVersionId
-                    && dto.DirectoryVersion.RelativePath = Constants.RootDirectoryPath)
+                |> Seq.exists (fun dto -> dto.DirectoryVersion.DirectoryVersionId = plan.TargetRootDirectoryVersionId)
 
-            if not recursiveMetadataRootMatches then
-                Error(GraceError.Create "Recursive DirectoryVersion metadata did not include the Materialization Plan target root." correlationId)
+            if not recursiveMetadataTargetMatches then
+                Error(GraceError.Create "Recursive DirectoryVersion metadata did not include the Materialization Plan target directory version." correlationId)
             else
                 let fileVersions =
                     directoryVersionDtos
@@ -953,8 +951,98 @@ module Connect =
         use stream = new MemoryStream(bytes, false)
         decodeRecursiveMetadataArtifactStream correlationId stream
 
+    /// Copies DirectUri artifact bytes into a temporary stream while enforcing the planned delivered-byte limit.
+    let internal copyDirectUriArtifactToTempStream correlationId artifactName expectedSize contentLength (openContentStream: unit -> Task<Stream>) =
+        task {
+            match expectedSize, contentLength with
+            | Some expectedSize, Some contentLength when contentLength > expectedSize ->
+                return
+                    Error(
+                        GraceError.Create
+                            $"Materialization Plan {artifactName} artifact Content-Length exceeds planned size. Expected at most {expectedSize} bytes, response declared {contentLength} bytes."
+                            correlationId
+                    )
+            | _ ->
+                let tempFilePath = Path.Combine(Path.GetTempPath(), $"grace-direct-artifact-{Guid.NewGuid():N}.tmp")
+
+                let tempFile =
+                    new FileStream(
+                        tempFilePath,
+                        FileMode.CreateNew,
+                        FileAccess.ReadWrite,
+                        FileShare.None,
+                        64 * 1024,
+                        FileOptions.Asynchronous
+                        ||| FileOptions.DeleteOnClose
+                    )
+
+                try
+                    use! sourceStream = openContentStream ()
+                    let buffer = Array.zeroCreate<byte> (64 * 1024)
+                    let mutable copiedBytes = 0L
+                    let mutable completed = false
+                    let mutable sizeError = None
+
+                    while not completed && sizeError.IsNone do
+                        let maxRead =
+                            match expectedSize with
+                            | Some expectedSize ->
+                                let remainingBeforeOversize = expectedSize - copiedBytes + 1L
+
+                                if remainingBeforeOversize <= 0L then
+                                    1
+                                else
+                                    min buffer.Length (int (min remainingBeforeOversize (int64 buffer.Length)))
+                            | None -> buffer.Length
+
+                        let! read =
+                            sourceStream
+                                .ReadAsync(buffer.AsMemory(0, maxRead))
+                                .AsTask()
+
+                        if read = 0 then
+                            completed <- true
+                        else
+                            let nextCopiedBytes = copiedBytes + int64 read
+
+                            match expectedSize with
+                            | Some expectedSize when nextCopiedBytes > expectedSize ->
+                                sizeError <-
+                                    Some(
+                                        GraceError.Create
+                                            $"Materialization Plan {artifactName} artifact size mismatch. Expected {expectedSize} bytes, received more than {expectedSize} bytes."
+                                            correlationId
+                                    )
+                            | _ ->
+                                do!
+                                    tempFile
+                                        .WriteAsync(buffer.AsMemory(0, read))
+                                        .AsTask()
+
+                                copiedBytes <- nextCopiedBytes
+
+                    match sizeError with
+                    | Some error ->
+                        tempFile.Dispose()
+                        return Error error
+                    | None ->
+                        tempFile.Position <- 0L
+                        return Ok(tempFile :> Stream)
+                with
+                | ex ->
+                    tempFile.Dispose()
+
+                    return
+                        Error(
+                            GraceError.CreateWithException
+                                ex
+                                $"Materialization Plan {artifactName} artifact download failed while writing the temporary artifact stream."
+                                correlationId
+                        )
+        }
+
     /// Fetches DirectUri artifact bytes to a temporary stream without assuming a backing blob provider.
-    let private fetchDirectUriArtifactStream correlationId artifactName uri =
+    let private fetchDirectUriArtifactStream correlationId artifactName uri (artifact: MaterializationArtifactDescriptor) =
         task {
             let mutable artifactUri = Unchecked.defaultof<Uri>
 
@@ -977,34 +1065,13 @@ module Connect =
                                     correlationId
                             )
                     else
-                        let tempFilePath = Path.Combine(Path.GetTempPath(), $"grace-direct-artifact-{Guid.NewGuid():N}.tmp")
+                        let contentLength =
+                            response.Content.Headers.ContentLength
+                            |> Option.ofNullable
 
-                        let tempFile =
-                            new FileStream(
-                                tempFilePath,
-                                FileMode.CreateNew,
-                                FileAccess.ReadWrite,
-                                FileShare.None,
-                                64 * 1024,
-                                FileOptions.Asynchronous
-                                ||| FileOptions.DeleteOnClose
-                            )
-
-                        try
-                            do! response.Content.CopyToAsync(tempFile)
-                            tempFile.Position <- 0L
-                            return Ok(tempFile :> Stream)
-                        with
-                        | ex ->
-                            tempFile.Dispose()
-
-                            return
-                                Error(
-                                    GraceError.CreateWithException
-                                        ex
-                                        $"Materialization Plan {artifactName} artifact download failed while writing the temporary artifact stream."
-                                        correlationId
-                                )
+                        return!
+                            copyDirectUriArtifactToTempStream correlationId artifactName artifact.SizeInBytes contentLength (fun () ->
+                                response.Content.ReadAsStreamAsync())
                 with
                 | ex -> return Error(GraceError.CreateWithException ex $"Materialization Plan {artifactName} artifact download failed." correlationId)
         }
@@ -1012,7 +1079,7 @@ module Connect =
     /// Downloads and verifies a planned DirectUri artifact before connect extracts or writes local state.
     let private downloadPlannedDirectUriArtifact correlationId artifactName uri artifact =
         task {
-            match! fetchDirectUriArtifactStream correlationId artifactName uri with
+            match! fetchDirectUriArtifactStream correlationId artifactName uri artifact with
             | Error error -> return Error error
             | Ok stream ->
                 match! validatePlannedArtifactStream correlationId artifactName artifact stream with
@@ -1022,15 +1089,67 @@ module Connect =
                 | Ok () -> return Ok stream
         }
 
+    /// Verifies materialized working-tree bytes against recursive metadata before local state records success.
+    let internal validateMaterializedFiles correlationId (fileVersions: FileVersion seq) =
+        task {
+            let fileVersionArray = fileVersions |> Seq.toArray
+            let mutable index = 0
+            let mutable validationError = None
+
+            while index < fileVersionArray.Length
+                  && validationError.IsNone do
+                let fileVersion = fileVersionArray[index]
+                let filePath = Path.Combine(Current().RootDirectory, fileVersion.RelativePath)
+                let fileInfo = FileInfo(filePath)
+
+                if not fileInfo.Exists then
+                    validationError <-
+                        Some(GraceError.Create $"Materialized file '{fileVersion.RelativePath}' is missing after Direct connect extraction." correlationId)
+                elif fileInfo.Length <> fileVersion.Size then
+                    validationError <-
+                        Some(
+                            GraceError.Create
+                                $"Materialized file '{fileVersion.RelativePath}' size mismatch. Expected {fileVersion.Size} bytes, received {fileInfo.Length} bytes."
+                                correlationId
+                        )
+                else
+                    use stream = new FileStream(fileInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.Read)
+                    let! localSha256Hash = Grace.Shared.Services.computeSha256ForFile stream fileVersion.RelativePath
+
+                    let! localBlake3Hash =
+                        if not (String.IsNullOrWhiteSpace(string fileVersion.Blake3Hash)) then
+                            stream.Position <- 0L
+
+                            task {
+                                let! localFileContentHash = Grace.Shared.Services.computeBlake3ForFile stream
+                                return Blake3Hash $"{localFileContentHash}"
+                            }
+                        else
+                            Task.FromResult(Blake3Hash String.Empty)
+
+                    if not (existingFileMatchesRemoteVersion localSha256Hash localBlake3Hash fileVersion) then
+                        validationError <-
+                            Some(
+                                GraceError.Create $"Materialized file '{fileVersion.RelativePath}' hash mismatch after Direct connect extraction." correlationId
+                            )
+
+                index <- index + 1
+
+            match validationError with
+            | Some error -> return Error error
+            | None -> return Ok()
+        }
+
     /// Coordinates extract zip entries behavior for this CLI command path.
     let private extractZipEntries
         (parseResult: ParseResult)
         (fileVersionsByRelativePath: Dictionary<RelativePath, FileVersion>)
         (filesToSkip: HashSet<RelativePath>)
+        writeWorkingFiles
+        writeObjectFiles
         (zipFile: Stream)
         =
-        use zipFile = zipFile
-        use zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Read)
+        use zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Read, leaveOpen = true)
 
         writeHumanLine parseResult $"[{Colors.Important}]Streaming contents from .zip file.[/]"
         writeHumanLine parseResult $"[{Colors.Important}]Starting to write files to disk.[/]"
@@ -1057,10 +1176,11 @@ module Connect =
                     |> ignore
 
                     let writeWorkingFile =
-                        not
-                        <| filesToSkip.Contains(fileVersion.RelativePath)
+                        writeWorkingFiles
+                        && not
+                           <| filesToSkip.Contains(fileVersion.RelativePath)
 
-                    let writeObjectFile = not objectFileInfo.Exists
+                    let writeObjectFile = writeObjectFiles && not objectFileInfo.Exists
 
                     if fileVersion.IsBinary then
                         if writeWorkingFile then entry.ExtractToFile(fileInfo.FullName, true)
@@ -1097,12 +1217,22 @@ module Connect =
         =
         task {
             let directoryVersionSelection = getDirectoryVersionSelection parseResult
-            let! directoryVersionResult = resolveTargetDirectoryVersionId parseResult graceIds ownerDto organizationDto repositoryDto branchDto
 
-            match directoryVersionResult with
+            let! targetSelectorResult =
+                task {
+                    match directoryVersionSelection with
+                    | UseDefault ->
+                        match! resolveTargetDirectoryVersionId parseResult graceIds ownerDto organizationDto repositoryDto branchDto with
+                        | Ok directoryVersionId -> return Ok(createDirectPlanTargetSelector directoryVersionSelection branchDto directoryVersionId)
+                        | Error error -> return Error error
+                    | UseDirectoryVersionId _
+                    | UseReferenceId _
+                    | UseReferenceType _ -> return Ok(createDirectPlanTargetSelector directoryVersionSelection branchDto DirectoryVersionId.Empty)
+                }
+
+            match targetSelectorResult with
             | Error error -> return (Error error |> renderOutput parseResult)
-            | Ok directoryVersionId ->
-                let targetSelector = createDirectPlanTargetSelector directoryVersionSelection branchDto directoryVersionId
+            | Ok targetSelector ->
                 writeHumanLine parseResult $"[{Colors.Important}]Requesting Direct Materialization Plan.[/]"
                 let! materializationPlanResult = requestDirectMaterializationPlan graceIds ownerDto organizationDto repositoryDto targetSelector
                 writeHumanLine parseResult $"[{Colors.Important}]Finished requesting Direct Materialization Plan.[/]"
@@ -1163,16 +1293,22 @@ module Connect =
                                         | Error error -> return (Error error |> renderOutput parseResult)
                                         | Ok zipFile ->
                                             use zipFile = zipFile
-                                            extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
+                                            extractZipEntries parseResult fileVersionsByRelativePath filesToSkip true false zipFile
 
-                                            writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
-                                            let! previousGraceStatus = readGraceStatusFile ()
-                                            let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
-                                            do! writeGraceStatusFile graceStatus
+                                            match! validateMaterializedFiles graceIds.CorrelationId executionArtifacts.FileVersions with
+                                            | Error error -> return (Error error |> renderOutput parseResult)
+                                            | Ok () ->
+                                                zipFile.Position <- 0L
+                                                extractZipEntries parseResult fileVersionsByRelativePath filesToSkip false true zipFile
 
-                                            writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
-                                            do! upsertObjectCache graceStatus.Index.Values
-                                            return 0
+                                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
+                                                let! previousGraceStatus = readGraceStatusFile ()
+                                                let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
+                                                do! writeGraceStatusFile graceStatus
+
+                                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
+                                                do! upsertObjectCache graceStatus.Index.Values
+                                                return 0
         }
 
     /// Routes the connect command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -1107,8 +1107,8 @@ module Connect =
                 | Ok () -> return Ok stream
         }
 
-    /// Verifies materialized working-tree bytes against recursive metadata before local state records success.
-    let internal validateMaterializedFiles correlationId (fileVersions: FileVersion seq) =
+    /// Verifies materialized bytes under a root directory against recursive metadata before local state records success.
+    let internal validateMaterializedFilesInRoot correlationId rootDirectory (fileVersions: FileVersion seq) =
         task {
             let fileVersionArray = fileVersions |> Seq.toArray
             let mutable index = 0
@@ -1117,7 +1117,7 @@ module Connect =
             while index < fileVersionArray.Length
                   && validationError.IsNone do
                 let fileVersion = fileVersionArray[index]
-                let filePath = Path.Combine(Current().RootDirectory, fileVersion.RelativePath)
+                let filePath = Path.Combine(rootDirectory, fileVersion.RelativePath)
                 let fileInfo = FileInfo(filePath)
 
                 if not fileInfo.Exists then
@@ -1158,9 +1158,15 @@ module Connect =
             | None -> return Ok()
         }
 
+    /// Verifies materialized working-tree bytes against recursive metadata before local state records success.
+    let internal validateMaterializedFiles correlationId (fileVersions: FileVersion seq) =
+        validateMaterializedFilesInRoot correlationId (Current().RootDirectory) fileVersions
+
     /// Coordinates extract zip entries behavior for this CLI command path.
     let private extractZipEntries
         (parseResult: ParseResult)
+        workingRootDirectory
+        objectRootDirectory
         (fileVersionsByRelativePath: Dictionary<RelativePath, FileVersion>)
         (filesToSkip: HashSet<RelativePath>)
         writeWorkingFiles
@@ -1183,9 +1189,9 @@ module Connect =
                 | true, fileVersion ->
                     let objectFileName = getLocalObjectCacheFileName fileVersion.RelativePath fileVersion.Sha256Hash fileVersion.Blake3Hash
 
-                    let fileInfo = FileInfo(Path.Combine(Current().RootDirectory, fileVersion.RelativePath))
+                    let fileInfo = FileInfo(Path.Combine(workingRootDirectory, fileVersion.RelativePath))
 
-                    let objectFileInfo = FileInfo(Path.Combine(Current().ObjectDirectory, fileVersion.RelativePath, objectFileName))
+                    let objectFileInfo = FileInfo(Path.Combine(objectRootDirectory, fileVersion.RelativePath, objectFileName))
 
                     Directory.CreateDirectory(fileInfo.DirectoryName)
                     |> ignore
@@ -1223,6 +1229,60 @@ module Connect =
             writeHumanLine parseResult $"[{Colors.Deemphasized}]Zip contained {additionalEntries.Count} additional entry(ies). Ignored.[/]"
 
         writeHumanLine parseResult $"[{Colors.Important}]Finished writing files to disk.[/]"
+
+    /// Stages Direct zip extraction, validates decompressed bytes, then writes final files and object-cache bytes.
+    let internal extractValidatedZipEntries
+        (parseResult: ParseResult)
+        correlationId
+        (fileVersionsByRelativePath: Dictionary<RelativePath, FileVersion>)
+        (filesToSkip: HashSet<RelativePath>)
+        (fileVersions: FileVersion seq)
+        (zipFile: Stream)
+        =
+        task {
+            let stageRootDirectory = Path.Combine(Path.GetTempPath(), $"grace-direct-materialization-{Guid.NewGuid():N}")
+            let stageObjectDirectory = Path.Combine(stageRootDirectory, Constants.GraceConfigDirectory, Constants.GraceObjectsDirectory)
+
+            /// Removes staged Direct materialization files after validation has either passed or failed.
+            let deleteStageRoot () =
+                if Directory.Exists(stageRootDirectory) then
+                    try
+                        Directory.Delete(stageRootDirectory, true)
+                    with
+                    | _ -> ()
+
+            try
+                let! stagingResult =
+                    task {
+                        try
+                            Directory.CreateDirectory(stageRootDirectory)
+                            |> ignore
+
+                            extractZipEntries parseResult stageRootDirectory stageObjectDirectory fileVersionsByRelativePath filesToSkip true false zipFile
+
+                            return! validateMaterializedFilesInRoot correlationId stageRootDirectory fileVersions
+                        with
+                        | ex ->
+                            return
+                                Error(
+                                    GraceError.CreateWithException
+                                        ex
+                                        "Direct Materialization Plan zip validation failed before local state could be recorded."
+                                        correlationId
+                                )
+                    }
+
+                match stagingResult with
+                | Error error -> return Error error
+                | Ok () ->
+                    zipFile.Position <- 0L
+
+                    extractZipEntries parseResult (Current().RootDirectory) (Current().ObjectDirectory) fileVersionsByRelativePath filesToSkip true true zipFile
+
+                    return Ok()
+            finally
+                deleteStageRoot ()
+        }
 
     /// Coordinates retrieve default branch and write behavior for this CLI command path.
     let private retrieveDefaultBranchAndWrite
@@ -1312,14 +1372,18 @@ module Connect =
                                         | Error error -> return (Error error |> renderOutput parseResult)
                                         | Ok zipFile ->
                                             use zipFile = zipFile
-                                            extractZipEntries parseResult fileVersionsByRelativePath filesToSkip true false zipFile
 
-                                            match! validateMaterializedFiles graceIds.CorrelationId executionArtifacts.FileVersions with
+                                            match!
+                                                extractValidatedZipEntries
+                                                    parseResult
+                                                    graceIds.CorrelationId
+                                                    fileVersionsByRelativePath
+                                                    filesToSkip
+                                                    executionArtifacts.FileVersions
+                                                    zipFile
+                                                with
                                             | Error error -> return (Error error |> renderOutput parseResult)
                                             | Ok () ->
-                                                zipFile.Position <- 0L
-                                                extractZipEntries parseResult fileVersionsByRelativePath filesToSkip false true zipFile
-
                                                 writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
                                                 let! previousGraceStatus = readGraceStatusFile ()
                                                 let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -25,9 +25,10 @@ open System.IO
 open System.Threading.Tasks
 open System.CommandLine
 open Spectre.Console
-open Azure.Storage.Blobs
-open Azure.Storage.Blobs.Models
 open System.IO.Compression
+open System.Net.Http
+open System.Security.Cryptography
+open MessagePack
 open Grace.CLI
 
 /// Groups the connect command parser, handlers, and output helpers.
@@ -185,9 +186,13 @@ module Connect =
         {
             TargetRootDirectoryVersionId: DirectoryVersionId
             ZipUri: string
+            ZipArtifact: MaterializationArtifactDescriptor
             DirectoryVersionDtos: Grace.Types.DirectoryVersion.DirectoryVersionDto array
             FileVersions: FileVersion array
         }
+
+    /// Owns HTTP artifact retrieval for Direct Materialization Plan execution.
+    let private directArtifactHttpClient = new HttpClient()
 
     /// Tries to map get explicit value and returns a GraceError instead of throwing on unsupported input.
     let private tryGetExplicitValue<'T> (parseResult: ParseResult) (option: Option<'T>) =
@@ -674,10 +679,18 @@ module Connect =
             RetrievedDefaultBranch = retrievedDefaultBranch
         }
 
-    /// Builds the Direct Materialization Plan request for the immutable root selected by connect.
-    let private createDirectPlanRequest directoryVersionId =
+    /// Builds the Materialization Plan target selector that preserves the user's moving selector when the plan supports it.
+    let internal createDirectPlanTargetSelector selection (branchDto: BranchDto) resolvedDirectoryVersionId =
+        match selection with
+        | UseDirectoryVersionId directoryVersionId -> MaterializationTargetSelector.ForDirectoryVersion(directoryVersionId)
+        | UseReferenceId referenceId -> MaterializationTargetSelector.ForReference(referenceId)
+        | UseDefault -> MaterializationTargetSelector.ForBranch(branchDto.BranchName)
+        | UseReferenceType _ -> MaterializationTargetSelector.ForDirectoryVersion(resolvedDirectoryVersionId)
+
+    /// Builds the Direct Materialization Plan request for the target selected by connect.
+    let internal createDirectPlanRequest targetSelector =
         MaterializationPlanRequest.Create(
-            MaterializationTargetSelector.ForDirectoryVersion(directoryVersionId),
+            targetSelector,
             MaterializationExecutionMode.Direct,
             MaterializationCacheSelection.Bypass,
             [
@@ -692,7 +705,7 @@ module Connect =
         (ownerDto: OwnerDto)
         (organizationDto: OrganizationDto)
         (repositoryDto: RepositoryDto)
-        directoryVersionId
+        targetSelector
         =
         let planParameters =
             Parameters.Materialization.PlanParameters(
@@ -702,7 +715,7 @@ module Connect =
                 OrganizationName = organizationDto.OrganizationName,
                 RepositoryId = $"{repositoryDto.RepositoryId}",
                 RepositoryName = repositoryDto.RepositoryName,
-                Request = createDirectPlanRequest directoryVersionId,
+                Request = createDirectPlanRequest targetSelector,
                 CorrelationId = graceIds.CorrelationId
             )
 
@@ -717,7 +730,7 @@ module Connect =
         |> Seq.tryExactlyOne
 
     /// Reads the DirectUri source required to execute one planned root artifact.
-    let private tryGetDirectArtifactSourceUri artifactName correlationId (artifact: MaterializationArtifactDescriptor) =
+    let internal tryGetDirectArtifactSourceUri artifactName correlationId (artifact: MaterializationArtifactDescriptor) =
         match artifact.Source with
         | Some source when
             not (isNull (box source))
@@ -730,12 +743,18 @@ module Connect =
             Error(GraceError.Create $"Materialization Plan {artifactName} artifact source must be DirectUri for Direct connect." correlationId)
         | _ -> Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing a source." correlationId)
 
-    /// Verifies the plan and recursive metadata describe the same target root before Direct connect writes local state.
-    let internal prepareDirectPlanExecutionArtifacts
-        correlationId
-        (plan: MaterializationPlan)
-        (directoryVersionDtos: Grace.Types.DirectoryVersion.DirectoryVersionDto array)
-        =
+    /// Carries the source descriptors that passed the Direct plan shape validation gate.
+    type internal DirectPlanArtifactSources =
+        {
+            TargetRootDirectoryVersionId: DirectoryVersionId
+            ZipUri: string
+            MetadataUri: string
+            ZipArtifact: MaterializationArtifactDescriptor
+            MetadataArtifact: MaterializationArtifactDescriptor
+        }
+
+    /// Verifies that a Direct Materialization Plan can be executed without falling back to legacy artifact selection.
+    let internal prepareDirectPlanArtifactSources correlationId (plan: MaterializationPlan) =
         match Validation.validatePlan plan with
         | Error errors ->
             let errorMessage = String.Join("; ", errors)
@@ -759,40 +778,216 @@ module Connect =
                         zipRoot = plan.TargetRootDirectoryVersionId
                         && metadataRoot = plan.TargetRootDirectoryVersionId
                         ->
-                        let recursiveMetadataRootMatches =
-                            directoryVersionDtos
-                            |> Seq.exists (fun dto ->
-                                dto.DirectoryVersion.DirectoryVersionId = plan.TargetRootDirectoryVersionId
-                                && dto.DirectoryVersion.RelativePath = Constants.RootDirectoryPath)
-
-                        if not recursiveMetadataRootMatches then
-                            Error(GraceError.Create "Recursive DirectoryVersion metadata did not include the Materialization Plan target root." correlationId)
-                        else
-                            match tryGetDirectArtifactSourceUri "DirectoryVersionZip" correlationId zipArtifact with
+                        match tryGetDirectArtifactSourceUri "DirectoryVersionZip" correlationId zipArtifact with
+                        | Error error -> Error error
+                        | Ok zipUri ->
+                            match tryGetDirectArtifactSourceUri "RecursiveDirectoryMetadata" correlationId metadataArtifact with
                             | Error error -> Error error
-                            | Ok zipUri ->
-                                match tryGetDirectArtifactSourceUri "RecursiveDirectoryMetadata" correlationId metadataArtifact with
-                                | Error error -> Error error
-                                | Ok _ ->
-                                    let fileVersions =
-                                        directoryVersionDtos
-                                        |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion)
-                                        |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
-                                        |> Seq.toArray
-
-                                    Ok
-                                        {
-                                            TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId
-                                            ZipUri = zipUri
-                                            DirectoryVersionDtos = directoryVersionDtos
-                                            FileVersions = fileVersions
-                                        }
+                            | Ok metadataUri ->
+                                Ok
+                                    {
+                                        TargetRootDirectoryVersionId = plan.TargetRootDirectoryVersionId
+                                        ZipUri = zipUri
+                                        MetadataUri = metadataUri
+                                        ZipArtifact = zipArtifact
+                                        MetadataArtifact = metadataArtifact
+                                    }
                     | _ ->
                         Error(
                             GraceError.Create
                                 "Materialization Plan target root, zip represented root, and recursive metadata represented root must match."
                                 correlationId
                         )
+
+    /// Verifies the plan and recursive metadata describe the same target root before Direct connect writes local state.
+    let internal prepareDirectPlanExecutionArtifacts
+        correlationId
+        (plan: MaterializationPlan)
+        (directoryVersionDtos: Grace.Types.DirectoryVersion.DirectoryVersionDto array)
+        =
+        match prepareDirectPlanArtifactSources correlationId plan with
+        | Error error -> Error error
+        | Ok sources ->
+            let recursiveMetadataRootMatches =
+                directoryVersionDtos
+                |> Seq.exists (fun dto ->
+                    dto.DirectoryVersion.DirectoryVersionId = plan.TargetRootDirectoryVersionId
+                    && dto.DirectoryVersion.RelativePath = Constants.RootDirectoryPath)
+
+            if not recursiveMetadataRootMatches then
+                Error(GraceError.Create "Recursive DirectoryVersion metadata did not include the Materialization Plan target root." correlationId)
+            else
+                let fileVersions =
+                    directoryVersionDtos
+                    |> Seq.map (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion)
+                    |> Seq.collect (fun directoryVersion -> directoryVersion.Files)
+                    |> Seq.toArray
+
+                Ok
+                    {
+                        TargetRootDirectoryVersionId = sources.TargetRootDirectoryVersionId
+                        ZipUri = sources.ZipUri
+                        ZipArtifact = sources.ZipArtifact
+                        DirectoryVersionDtos = directoryVersionDtos
+                        FileVersions = fileVersions
+                    }
+
+    /// Validates downloaded artifact bytes against the size and hash evidence carried by the Materialization Plan.
+    let internal validatePlannedArtifactBytes correlationId (artifactName: string) (artifact: MaterializationArtifactDescriptor) (bytes: byte array) =
+        match artifact.SizeInBytes with
+        | Some expectedSize when int64 bytes.LongLength <> expectedSize ->
+            Error(
+                GraceError.Create
+                    $"Materialization Plan {artifactName} artifact size mismatch. Expected {expectedSize} bytes, received {bytes.LongLength} bytes."
+                    correlationId
+            )
+        | _ ->
+            match artifact.Sha256Hash with
+            | Some expectedSha256Hash ->
+                let actualSha256Hash = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
+
+                if not (String.Equals(string actualSha256Hash, string expectedSha256Hash, StringComparison.OrdinalIgnoreCase)) then
+                    Error(GraceError.Create $"Materialization Plan {artifactName} artifact SHA-256 mismatch." correlationId)
+                else
+                    match artifact.Blake3Hash with
+                    | Some expectedBlake3Hash when not (String.IsNullOrWhiteSpace(string expectedBlake3Hash)) ->
+                        let actualBlake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+
+                        if not (String.Equals(string actualBlake3Hash, string expectedBlake3Hash, StringComparison.OrdinalIgnoreCase)) then
+                            Error(GraceError.Create $"Materialization Plan {artifactName} artifact BLAKE3 mismatch." correlationId)
+                        else
+                            Ok()
+                    | _ -> Ok()
+            | None -> Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing SHA-256 integrity evidence." correlationId)
+
+    /// Validates a downloaded artifact stream against the size and hash evidence carried by the Materialization Plan.
+    let internal validatePlannedArtifactStream correlationId (artifactName: string) (artifact: MaterializationArtifactDescriptor) (stream: Stream) =
+        task {
+            if not stream.CanSeek then
+                return Error(GraceError.Create $"Materialization Plan {artifactName} artifact validation requires a seekable temporary stream." correlationId)
+            else
+                match artifact.SizeInBytes with
+                | Some expectedSize when stream.Length <> expectedSize ->
+                    return
+                        Error(
+                            GraceError.Create
+                                $"Materialization Plan {artifactName} artifact size mismatch. Expected {expectedSize} bytes, received {stream.Length} bytes."
+                                correlationId
+                        )
+                | _ ->
+                    match artifact.Sha256Hash with
+                    | None ->
+                        return Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing SHA-256 integrity evidence." correlationId)
+                    | Some expectedSha256Hash ->
+                        stream.Position <- 0L
+                        let! actualSha256Hash = Grace.Shared.Services.computeSha256ForFile stream (RelativePath artifactName)
+
+                        if not (String.Equals(string actualSha256Hash, string expectedSha256Hash, StringComparison.OrdinalIgnoreCase)) then
+                            return Error(GraceError.Create $"Materialization Plan {artifactName} artifact SHA-256 mismatch." correlationId)
+                        else
+                            match artifact.Blake3Hash with
+                            | Some expectedBlake3Hash when not (String.IsNullOrWhiteSpace(string expectedBlake3Hash)) ->
+                                stream.Position <- 0L
+                                let! actualBlake3Hash = Grace.Shared.Services.computeBlake3ForFile stream
+
+                                if not (String.Equals(string actualBlake3Hash, string expectedBlake3Hash, StringComparison.OrdinalIgnoreCase)) then
+                                    return Error(GraceError.Create $"Materialization Plan {artifactName} artifact BLAKE3 mismatch." correlationId)
+                                else
+                                    stream.Position <- 0L
+                                    return Ok()
+                            | _ ->
+                                stream.Position <- 0L
+                                return Ok()
+        }
+
+    /// Decodes the planned recursive metadata artifact stream after descriptor integrity validation.
+    let internal decodeRecursiveMetadataArtifactStream correlationId (stream: Stream) =
+        try
+            if stream.CanSeek then stream.Position <- 0L
+
+            let directoryVersions =
+                MessagePackSerializer.Deserialize<Grace.Types.DirectoryVersion.DirectoryVersionDto array>(stream, Constants.messagePackSerializerOptions)
+
+            if isNull directoryVersions then
+                Error(GraceError.Create "Materialization Plan RecursiveDirectoryMetadata artifact decoded to an empty payload." correlationId)
+            else
+                Ok directoryVersions
+        with
+        | ex -> Error(GraceError.CreateWithException ex "Materialization Plan RecursiveDirectoryMetadata artifact could not be decoded." correlationId)
+
+    /// Decodes the planned recursive metadata artifact after its bytes pass descriptor integrity validation.
+    let internal decodeRecursiveMetadataArtifact correlationId (bytes: byte array) =
+        use stream = new MemoryStream(bytes, false)
+        decodeRecursiveMetadataArtifactStream correlationId stream
+
+    /// Fetches DirectUri artifact bytes to a temporary stream without assuming a backing blob provider.
+    let private fetchDirectUriArtifactStream correlationId artifactName uri =
+        task {
+            let mutable artifactUri = Unchecked.defaultof<Uri>
+
+            if not (Uri.TryCreate(uri, UriKind.Absolute, &artifactUri)) then
+                return Error(GraceError.Create $"Materialization Plan {artifactName} artifact DirectUri is not an absolute URI." correlationId)
+            elif artifactUri.Scheme <> Uri.UriSchemeHttps
+                 && artifactUri.Scheme <> Uri.UriSchemeHttp then
+                return Error(GraceError.Create $"Materialization Plan {artifactName} artifact DirectUri must use HTTP or HTTPS." correlationId)
+            else
+                try
+                    use request = new HttpRequestMessage(HttpMethod.Get, artifactUri)
+
+                    use! response = directArtifactHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+
+                    if not response.IsSuccessStatusCode then
+                        return
+                            Error(
+                                GraceError.Create
+                                    $"Materialization Plan {artifactName} artifact download failed with HTTP status {(int response.StatusCode)}."
+                                    correlationId
+                            )
+                    else
+                        let tempFilePath = Path.Combine(Path.GetTempPath(), $"grace-direct-artifact-{Guid.NewGuid():N}.tmp")
+
+                        let tempFile =
+                            new FileStream(
+                                tempFilePath,
+                                FileMode.CreateNew,
+                                FileAccess.ReadWrite,
+                                FileShare.None,
+                                64 * 1024,
+                                FileOptions.Asynchronous
+                                ||| FileOptions.DeleteOnClose
+                            )
+
+                        try
+                            do! response.Content.CopyToAsync(tempFile)
+                            tempFile.Position <- 0L
+                            return Ok(tempFile :> Stream)
+                        with
+                        | ex ->
+                            tempFile.Dispose()
+
+                            return
+                                Error(
+                                    GraceError.CreateWithException
+                                        ex
+                                        $"Materialization Plan {artifactName} artifact download failed while writing the temporary artifact stream."
+                                        correlationId
+                                )
+                with
+                | ex -> return Error(GraceError.CreateWithException ex $"Materialization Plan {artifactName} artifact download failed." correlationId)
+        }
+
+    /// Downloads and verifies a planned DirectUri artifact before connect extracts or writes local state.
+    let private downloadPlannedDirectUriArtifact correlationId artifactName uri artifact =
+        task {
+            match! fetchDirectUriArtifactStream correlationId artifactName uri with
+            | Error error -> return Error error
+            | Ok stream ->
+                match! validatePlannedArtifactStream correlationId artifactName artifact stream with
+                | Error error ->
+                    stream.Dispose()
+                    return Error error
+                | Ok () -> return Ok stream
+        }
 
     /// Coordinates extract zip entries behavior for this CLI command path.
     let private extractZipEntries
@@ -868,76 +1063,83 @@ module Connect =
         (branchDto: BranchDto)
         =
         task {
+            let directoryVersionSelection = getDirectoryVersionSelection parseResult
             let! directoryVersionResult = resolveTargetDirectoryVersionId parseResult graceIds ownerDto organizationDto repositoryDto branchDto
 
             match directoryVersionResult with
             | Error error -> return (Error error |> renderOutput parseResult)
             | Ok directoryVersionId ->
+                let targetSelector = createDirectPlanTargetSelector directoryVersionSelection branchDto directoryVersionId
                 writeHumanLine parseResult $"[{Colors.Important}]Requesting Direct Materialization Plan.[/]"
-                let! materializationPlanResult = requestDirectMaterializationPlan graceIds ownerDto organizationDto repositoryDto directoryVersionId
+                let! materializationPlanResult = requestDirectMaterializationPlan graceIds ownerDto organizationDto repositoryDto targetSelector
                 writeHumanLine parseResult $"[{Colors.Important}]Finished requesting Direct Materialization Plan.[/]"
 
                 match materializationPlanResult with
                 | Error error -> return (Error error |> renderOutput parseResult)
                 | Ok materializationPlanReturnValue ->
-                    let getDirectoryContentsParameters =
-                        Parameters.DirectoryVersion.GetParameters(
-                            OwnerId = $"{ownerDto.OwnerId}",
-                            OrganizationId = $"{organizationDto.OrganizationId}",
-                            RepositoryId = $"{repositoryDto.RepositoryId}",
-                            DirectoryVersionId = $"{materializationPlanReturnValue.ReturnValue.TargetRootDirectoryVersionId}",
-                            CorrelationId = graceIds.CorrelationId
-                        )
-
-                    writeHumanLine parseResult $"[{Colors.Important}]Retrieving planned recursive DirectoryVersions.[/]"
-
-                    let! directoryVersionsResult = DirectoryVersion.GetDirectoryVersionsRecursive(getDirectoryContentsParameters)
-
-                    match directoryVersionsResult with
+                    match prepareDirectPlanArtifactSources graceIds.CorrelationId materializationPlanReturnValue.ReturnValue with
                     | Error error -> return (Error error |> renderOutput parseResult)
-                    | Ok directoryVerionsReturnValue ->
-                        writeHumanLine parseResult $"[{Colors.Important}]Retrieved planned recursive DirectoryVersions.[/]"
+                    | Ok artifactSources ->
+                        writeHumanLine parseResult $"[{Colors.Important}]Retrieving planned recursive DirectoryVersions.[/]"
 
-                        match
-                            prepareDirectPlanExecutionArtifacts
+                        match!
+                            downloadPlannedDirectUriArtifact
                                 graceIds.CorrelationId
-                                materializationPlanReturnValue.ReturnValue
-                                (directoryVerionsReturnValue.ReturnValue
-                                 |> Seq.toArray)
+                                "RecursiveDirectoryMetadata"
+                                artifactSources.MetadataUri
+                                artifactSources.MetadataArtifact
                             with
                         | Error error -> return (Error error |> renderOutput parseResult)
-                        | Ok executionArtifacts ->
-                            let force = parseResult.GetValue(Options.force)
+                        | Ok metadataStream ->
+                            use metadataStream = metadataStream
 
-                            let! conflicts, filesToSkip = collectFileConflicts executionArtifacts.FileVersions force
+                            match decodeRecursiveMetadataArtifactStream graceIds.CorrelationId metadataStream with
+                            | Error error -> return (Error error |> renderOutput parseResult)
+                            | Ok directoryVersionDtos ->
+                                writeHumanLine parseResult $"[{Colors.Important}]Retrieved planned recursive DirectoryVersions.[/]"
 
-                            if conflicts.Count > 0 then
-                                writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
+                                match prepareDirectPlanExecutionArtifacts graceIds.CorrelationId materializationPlanReturnValue.ReturnValue directoryVersionDtos
+                                    with
+                                | Error error -> return (Error error |> renderOutput parseResult)
+                                | Ok executionArtifacts ->
+                                    let force = parseResult.GetValue(Options.force)
 
-                                if parseResult |> verbose then
-                                    conflicts
-                                    |> Seq.sort
-                                    |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
+                                    let! conflicts, filesToSkip = collectFileConflicts executionArtifacts.FileVersions force
 
-                                return
-                                    (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
-                                     |> renderOutput parseResult)
-                            else
-                                let fileVersionsByRelativePath = buildFileVersionsByRelativePath executionArtifacts.FileVersions
+                                    if conflicts.Count > 0 then
+                                        writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
 
-                                let blobClient = BlobClient(Uri(executionArtifacts.ZipUri))
+                                        if parseResult |> verbose then
+                                            conflicts
+                                            |> Seq.sort
+                                            |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
 
-                                let! zipFile = blobClient.OpenReadAsync(bufferSize = 64 * 1024)
-                                extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
+                                        return
+                                            (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
+                                             |> renderOutput parseResult)
+                                    else
+                                        let fileVersionsByRelativePath = buildFileVersionsByRelativePath executionArtifacts.FileVersions
 
-                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
-                                let! previousGraceStatus = readGraceStatusFile ()
-                                let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
-                                do! writeGraceStatusFile graceStatus
+                                        match!
+                                            downloadPlannedDirectUriArtifact
+                                                graceIds.CorrelationId
+                                                "DirectoryVersionZip"
+                                                executionArtifacts.ZipUri
+                                                executionArtifacts.ZipArtifact
+                                            with
+                                        | Error error -> return (Error error |> renderOutput parseResult)
+                                        | Ok zipFile ->
+                                            use zipFile = zipFile
+                                            extractZipEntries parseResult fileVersionsByRelativePath filesToSkip zipFile
 
-                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
-                                do! upsertObjectCache graceStatus.Index.Values
-                                return 0
+                                            writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
+                                            let! previousGraceStatus = readGraceStatusFile ()
+                                            let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
+                                            do! writeGraceStatusFile graceStatus
+
+                                            writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
+                                            do! upsertObjectCache graceStatus.Index.Values
+                                            return 0
         }
 
     /// Routes the connect command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -679,12 +679,12 @@ module Connect =
             RetrievedDefaultBranch = retrievedDefaultBranch
         }
 
-    /// Builds the Materialization Plan target selector that preserves the user's moving selector when the plan supports it.
-    let internal createDirectPlanTargetSelector selection (branchDto: BranchDto) resolvedDirectoryVersionId =
+    /// Builds the Materialization Plan target selector while preserving implicit default connect promotion semantics.
+    let internal createDirectPlanTargetSelector selection (_branchDto: BranchDto) resolvedDirectoryVersionId =
         match selection with
         | UseDirectoryVersionId directoryVersionId -> MaterializationTargetSelector.ForDirectoryVersion(directoryVersionId)
         | UseReferenceId referenceId -> MaterializationTargetSelector.ForReference(referenceId)
-        | UseDefault -> MaterializationTargetSelector.ForBranch(branchDto.BranchName)
+        | UseDefault -> MaterializationTargetSelector.ForDirectoryVersion(resolvedDirectoryVersionId)
         | UseReferenceType _ -> MaterializationTargetSelector.ForDirectoryVersion(resolvedDirectoryVersionId)
 
     /// Builds the Direct Materialization Plan request for the target selected by connect.
@@ -832,7 +832,19 @@ module Connect =
                         FileVersions = fileVersions
                     }
 
-    /// Validates downloaded artifact bytes against the size and hash evidence carried by the Materialization Plan.
+    /// Returns the planned SHA-256 digest only when it carries usable integrity evidence.
+    let private tryGetPlannedSha256Hash (artifact: MaterializationArtifactDescriptor) =
+        match artifact.Sha256Hash with
+        | Some sha256Hash when not (String.IsNullOrWhiteSpace(string sha256Hash)) -> Some sha256Hash
+        | _ -> None
+
+    /// Returns the planned BLAKE3 digest only when it carries usable integrity evidence.
+    let private tryGetPlannedBlake3Hash (artifact: MaterializationArtifactDescriptor) =
+        match artifact.Blake3Hash with
+        | Some blake3Hash when not (String.IsNullOrWhiteSpace(string blake3Hash)) -> Some blake3Hash
+        | _ -> None
+
+    /// Validates downloaded artifact bytes against each supported hash evidence carried by the Materialization Plan.
     let internal validatePlannedArtifactBytes correlationId (artifactName: string) (artifact: MaterializationArtifactDescriptor) (bytes: byte array) =
         match artifact.SizeInBytes with
         | Some expectedSize when int64 bytes.LongLength <> expectedSize ->
@@ -842,25 +854,31 @@ module Connect =
                     correlationId
             )
         | _ ->
-            match artifact.Sha256Hash with
-            | Some expectedSha256Hash ->
-                let actualSha256Hash = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
+            match tryGetPlannedSha256Hash artifact, tryGetPlannedBlake3Hash artifact with
+            | None, None ->
+                Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing SHA-256 or BLAKE3 integrity evidence." correlationId)
+            | expectedSha256Hash, expectedBlake3Hash ->
+                match expectedSha256Hash with
+                | Some expectedSha256Hash ->
+                    let actualSha256Hash = Sha256Hash(byteArrayToString (SHA256.HashData(bytes).AsSpan()))
 
-                if not (String.Equals(string actualSha256Hash, string expectedSha256Hash, StringComparison.OrdinalIgnoreCase)) then
-                    Error(GraceError.Create $"Materialization Plan {artifactName} artifact SHA-256 mismatch." correlationId)
-                else
-                    match artifact.Blake3Hash with
-                    | Some expectedBlake3Hash when not (String.IsNullOrWhiteSpace(string expectedBlake3Hash)) ->
+                    if not (String.Equals(string actualSha256Hash, string expectedSha256Hash, StringComparison.OrdinalIgnoreCase)) then
+                        Error(GraceError.Create $"Materialization Plan {artifactName} artifact SHA-256 mismatch." correlationId)
+                    else
+                        Ok()
+                | None -> Ok()
+                |> Result.bind (fun () ->
+                    match expectedBlake3Hash with
+                    | Some expectedBlake3Hash ->
                         let actualBlake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
 
                         if not (String.Equals(string actualBlake3Hash, string expectedBlake3Hash, StringComparison.OrdinalIgnoreCase)) then
                             Error(GraceError.Create $"Materialization Plan {artifactName} artifact BLAKE3 mismatch." correlationId)
                         else
                             Ok()
-                    | _ -> Ok()
-            | None -> Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing SHA-256 integrity evidence." correlationId)
+                    | None -> Ok())
 
-    /// Validates a downloaded artifact stream against the size and hash evidence carried by the Materialization Plan.
+    /// Validates a downloaded artifact stream against each supported hash evidence carried by the Materialization Plan.
     let internal validatePlannedArtifactStream correlationId (artifactName: string) (artifact: MaterializationArtifactDescriptor) (stream: Stream) =
         task {
             if not stream.CanSeek then
@@ -875,22 +893,27 @@ module Connect =
                                 correlationId
                         )
                 | _ ->
-                    match artifact.Sha256Hash with
-                    | None ->
-                        return Error(GraceError.Create $"Materialization Plan {artifactName} artifact is missing SHA-256 integrity evidence." correlationId)
-                    | Some expectedSha256Hash ->
+                    match tryGetPlannedSha256Hash artifact, tryGetPlannedBlake3Hash artifact with
+                    | None, None ->
+                        return
+                            Error(
+                                GraceError.Create $"Materialization Plan {artifactName} artifact is missing SHA-256 or BLAKE3 integrity evidence." correlationId
+                            )
+                    | Some expectedSha256Hash, expectedBlake3Hash ->
                         stream.Position <- 0L
                         let! actualSha256Hash = Grace.Shared.Services.computeSha256ForFile stream (RelativePath artifactName)
 
                         if not (String.Equals(string actualSha256Hash, string expectedSha256Hash, StringComparison.OrdinalIgnoreCase)) then
+                            stream.Position <- 0L
                             return Error(GraceError.Create $"Materialization Plan {artifactName} artifact SHA-256 mismatch." correlationId)
                         else
-                            match artifact.Blake3Hash with
-                            | Some expectedBlake3Hash when not (String.IsNullOrWhiteSpace(string expectedBlake3Hash)) ->
+                            match expectedBlake3Hash with
+                            | Some expectedBlake3Hash ->
                                 stream.Position <- 0L
                                 let! actualBlake3Hash = Grace.Shared.Services.computeBlake3ForFile stream
 
                                 if not (String.Equals(string actualBlake3Hash, string expectedBlake3Hash, StringComparison.OrdinalIgnoreCase)) then
+                                    stream.Position <- 0L
                                     return Error(GraceError.Create $"Materialization Plan {artifactName} artifact BLAKE3 mismatch." correlationId)
                                 else
                                     stream.Position <- 0L
@@ -898,6 +921,16 @@ module Connect =
                             | _ ->
                                 stream.Position <- 0L
                                 return Ok()
+                    | None, Some expectedBlake3Hash ->
+                        stream.Position <- 0L
+                        let! actualBlake3Hash = Grace.Shared.Services.computeBlake3ForFile stream
+
+                        if not (String.Equals(string actualBlake3Hash, string expectedBlake3Hash, StringComparison.OrdinalIgnoreCase)) then
+                            stream.Position <- 0L
+                            return Error(GraceError.Create $"Materialization Plan {artifactName} artifact BLAKE3 mismatch." correlationId)
+                        else
+                            stream.Position <- 0L
+                            return Ok()
         }
 
     /// Decodes the planned recursive metadata artifact stream after descriptor integrity validation.

--- a/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
@@ -302,14 +302,16 @@ type MaterializationPlanRouteTests() =
         | Error missingError, Error hiddenError -> Assert.That(hiddenError.Error, Is.EqualTo(missingError.Error))
         | _ -> Assert.Fail("Expected missing and hidden DirectoryVersion selectors to fail.")
 
-    /// Verifies authorized non-root DirectoryVersion selectors keep the path-scoped validation error.
+    /// Verifies authorized non-root DirectoryVersion selectors remain supported for scoped Direct plans.
     [<Test>]
-    member _.DirectoryVersionSelectorRejectsPathScopedVersionAfterRepositoryScope() =
+    member _.DirectoryVersionSelectorAcceptsPathScopedVersionAfterRepositoryScope() =
         let pathScopedDirectoryVersion = directoryVersion targetRootDirectoryVersionId repositoryId "src"
 
         let result = Materialization.validateDirectoryVersionSelectorScope repositoryId pathScopedDirectoryVersion correlationId
 
-        assertErrorContains "Path-scoped Materialization Plan selectors are not supported" result
+        match result with
+        | Error error -> Assert.Fail(error.Error)
+        | Ok () -> ()
 
     /// Verifies missing selector actor results keep the public-safe 400 message.
     [<Test>]
@@ -387,6 +389,61 @@ type MaterializationPlanRouteTests() =
                     correlationId
 
             assertErrorContains Materialization.referenceSelectorNotFoundMessage result
+        }
+
+    /// Verifies ReferenceType selectors resolve the latest matching branch reference at plan time.
+    [<Test>]
+    member _.ReferenceTypeSelectorResolvesLatestMatchingReferenceRoot() =
+        task {
+            let olderReference =
+                { reference
+                      (ReferenceId.Parse "88888888-8888-8888-8888-888888888888")
+                      explicitBranchId
+                      (DirectoryVersionId.Parse "99999999-9999-9999-9999-999999999999") with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 1, 12, 0)
+                }
+
+            let latestReference =
+                { reference referenceId explicitBranchId targetRootDirectoryVersionId with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 2, 12, 0)
+                }
+
+            let! result =
+                Materialization.resolveReferenceTypeSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    ReferenceType.Promotion
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
+                    (fun _ ->
+                        Task.FromResult [| olderReference
+                                           latestReference |])
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+        }
+
+    /// Verifies ReferenceType selectors fail before planning when the branch has no matching reference.
+    [<Test>]
+    member _.ReferenceTypeSelectorRejectsMissingMatchingReference() =
+        task {
+            let! result =
+                Materialization.resolveReferenceTypeSelectorWith
+                    repositoryId
+                    explicitBranchName
+                    ReferenceType.Promotion
+                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
+                    (fun _ -> Task.FromResult Array.empty<ReferenceDto>)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            assertErrorContains Materialization.referenceTypeSelectorNotFoundMessage result
         }
 
     /// Verifies explicit branch selectors resolve the current branch tip to one immutable root.

--- a/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
@@ -418,9 +418,7 @@ type MaterializationPlanRouteTests() =
                     ReferenceType.Promotion
                     (fun _ -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
-                    (fun _ ->
-                        Task.FromResult [| olderReference
-                                           latestReference |])
+                    (fun _ -> Task.FromResult(Some latestReference))
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -441,7 +439,7 @@ type MaterializationPlanRouteTests() =
                     ReferenceType.Promotion
                     (fun _ -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
-                    (fun _ -> Task.FromResult Array.empty<ReferenceDto>)
+                    (fun _ -> Task.FromResult None)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -470,7 +468,7 @@ type MaterializationPlanRouteTests() =
                         nameLookupWasUsed <- true
                         Task.FromResult(Some defaultBranchId))
                     (fun branchId -> Task.FromResult(branch branchId (BranchName "renamed-after-cli-lookup") selectedReference))
-                    (fun _ -> Task.FromResult [| selectedReference |])
+                    (fun _ -> Task.FromResult(Some selectedReference))
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
@@ -511,15 +509,77 @@ type MaterializationPlanRouteTests() =
                     ReferenceType.Promotion
                     (fun _ -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName liveOlder))
-                    (fun _ ->
-                        Task.FromResult [| deletedNewest
-                                           liveOlder |])
+                    (fun _ -> Task.FromResult(Some liveOlder))
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
             match result with
             | Error error -> Assert.Fail(error.Error)
             | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(liveRoot))
+        }
+
+    /// Verifies ReferenceType selectors rely on storage paging to skip more deleted references than one list window.
+    [<Test>]
+    member _.ReferenceTypeSelectorSkipsBeyondDeletedCandidateWindow() =
+        task {
+            let liveRoot = DirectoryVersionId.Parse "99999999-9999-9999-9999-999999999999"
+
+            let deletedCandidateCount = 51
+
+            let deletedCandidates =
+                Array.init deletedCandidateCount (fun index ->
+                    let referenceOrdinal = index + 1
+
+                    { reference
+                          (ReferenceId.Parse($"aaaaaaaa-aaaa-aaaa-aaaa-{referenceOrdinal.ToString().PadLeft(12, '0')}"))
+                          explicitBranchId
+                          targetRootDirectoryVersionId with
+                        ReferenceType = ReferenceType.Promotion
+                        CreatedAt =
+                            NodaTime
+                                .Instant
+                                .FromUtc(2026, 7, 3, 12, 0)
+                                .Minus(NodaTime.Duration.FromMinutes(int64 referenceOrdinal))
+                        DeletedAt = Some(NodaTime.Instant.FromUtc(2026, 7, 4, 12, 0))
+                    })
+
+            let liveOlder =
+                { reference (ReferenceId.Parse "88888888-8888-8888-8888-888888888888") explicitBranchId liveRoot with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 1, 12, 0)
+                }
+
+            let storageOrderedCandidates = Array.append deletedCandidates [| liveOlder |]
+            let mutable latestLiveLookupSawDeletedWindow = false
+
+            let! result =
+                Materialization.resolveReferenceTypeSelectorWith
+                    repositoryId
+                    None
+                    (Some explicitBranchName)
+                    ReferenceType.Promotion
+                    (fun _ -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName liveOlder))
+                    (fun _ ->
+                        latestLiveLookupSawDeletedWindow <-
+                            storageOrderedCandidates
+                            |> Array.take 50
+                            |> Array.forall (fun reference -> reference.DeletedAt.IsSome)
+
+                        storageOrderedCandidates
+                        |> Array.tryFind (fun reference -> reference.DeletedAt.IsNone)
+                        |> Task.FromResult)
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot ->
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(resolvedRoot, Is.EqualTo(liveRoot))
+                        Assert.That(latestLiveLookupSawDeletedWindow, Is.True))
+                )
         }
 
     /// Verifies ReferenceType selectors choose by creation order instead of mutable UpdatedAt churn.
@@ -549,9 +609,7 @@ type MaterializationPlanRouteTests() =
                     ReferenceType.Promotion
                     (fun _ -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName createdNewer))
-                    (fun _ ->
-                        Task.FromResult [| updatedOlder
-                                           createdNewer |])
+                    (fun _ -> Task.FromResult(Some createdNewer))
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 

--- a/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/MaterializationPlan.Server.Tests.fs
@@ -413,9 +413,10 @@ type MaterializationPlanRouteTests() =
             let! result =
                 Materialization.resolveReferenceTypeSelectorWith
                     repositoryId
-                    explicitBranchName
+                    None
+                    (Some explicitBranchName)
                     ReferenceType.Promotion
-                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun _ -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName latestReference))
                     (fun _ ->
                         Task.FromResult [| olderReference
@@ -435,15 +436,128 @@ type MaterializationPlanRouteTests() =
             let! result =
                 Materialization.resolveReferenceTypeSelectorWith
                     repositoryId
-                    explicitBranchName
+                    None
+                    (Some explicitBranchName)
                     ReferenceType.Promotion
-                    (fun () -> Task.FromResult(Some explicitBranchId))
+                    (fun _ -> Task.FromResult(Some explicitBranchId))
                     (fun branchId -> Task.FromResult(branch branchId explicitBranchName ReferenceDto.Default))
                     (fun _ -> Task.FromResult Array.empty<ReferenceDto>)
                     (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
                     correlationId
 
             assertErrorContains Materialization.referenceTypeSelectorNotFoundMessage result
+        }
+
+    /// Verifies ReferenceType selectors carrying BranchId do not resolve through a stale or reused branch name.
+    [<Test>]
+    member _.ReferenceTypeSelectorPreservesBranchIdIdentityWithoutNameLookup() =
+        task {
+            let selectedReference =
+                { reference referenceId explicitBranchId targetRootDirectoryVersionId with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 2, 12, 0)
+                }
+
+            let mutable nameLookupWasUsed = false
+
+            let! result =
+                Materialization.resolveReferenceTypeSelectorWith
+                    repositoryId
+                    (Some explicitBranchId)
+                    None
+                    ReferenceType.Promotion
+                    (fun _ ->
+                        nameLookupWasUsed <- true
+                        Task.FromResult(Some defaultBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId (BranchName "renamed-after-cli-lookup") selectedReference))
+                    (fun _ -> Task.FromResult [| selectedReference |])
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot ->
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
+                        Assert.That(nameLookupWasUsed, Is.False))
+                )
+        }
+
+    /// Verifies ReferenceType selectors skip deleted candidates before returning the newest live reference.
+    [<Test>]
+    member _.ReferenceTypeSelectorSkipsDeletedNewestReference() =
+        task {
+            let liveRoot = DirectoryVersionId.Parse "99999999-9999-9999-9999-999999999999"
+
+            let deletedNewest =
+                { reference referenceId explicitBranchId targetRootDirectoryVersionId with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 3, 12, 0)
+                    DeletedAt = Some(NodaTime.Instant.FromUtc(2026, 7, 4, 12, 0))
+                }
+
+            let liveOlder =
+                { reference (ReferenceId.Parse "88888888-8888-8888-8888-888888888888") explicitBranchId liveRoot with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 2, 12, 0)
+                }
+
+            let! result =
+                Materialization.resolveReferenceTypeSelectorWith
+                    repositoryId
+                    None
+                    (Some explicitBranchName)
+                    ReferenceType.Promotion
+                    (fun _ -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName liveOlder))
+                    (fun _ ->
+                        Task.FromResult [| deletedNewest
+                                           liveOlder |])
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(liveRoot))
+        }
+
+    /// Verifies ReferenceType selectors choose by creation order instead of mutable UpdatedAt churn.
+    [<Test>]
+    member _.ReferenceTypeSelectorUsesCreatedAtInsteadOfUpdatedAt() =
+        task {
+            let olderRoot = DirectoryVersionId.Parse "99999999-9999-9999-9999-999999999999"
+
+            let updatedOlder =
+                { reference (ReferenceId.Parse "88888888-8888-8888-8888-888888888888") explicitBranchId olderRoot with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 1, 12, 0)
+                    UpdatedAt = Some(NodaTime.Instant.FromUtc(2026, 7, 4, 12, 0))
+                }
+
+            let createdNewer =
+                { reference referenceId explicitBranchId targetRootDirectoryVersionId with
+                    ReferenceType = ReferenceType.Promotion
+                    CreatedAt = NodaTime.Instant.FromUtc(2026, 7, 2, 12, 0)
+                }
+
+            let! result =
+                Materialization.resolveReferenceTypeSelectorWith
+                    repositoryId
+                    None
+                    (Some explicitBranchName)
+                    ReferenceType.Promotion
+                    (fun _ -> Task.FromResult(Some explicitBranchId))
+                    (fun branchId -> Task.FromResult(branch branchId explicitBranchName createdNewer))
+                    (fun _ ->
+                        Task.FromResult [| updatedOlder
+                                           createdNewer |])
+                    (fun directoryVersionId -> Task.FromResult(directoryVersionDto directoryVersionId repositoryId Constants.RootDirectoryPath))
+                    correlationId
+
+            match result with
+            | Error error -> Assert.Fail(error.Error)
+            | Ok resolvedRoot -> Assert.That(resolvedRoot, Is.EqualTo(targetRootDirectoryVersionId))
         }
 
     /// Verifies explicit branch selectors resolve the current branch tip to one immutable root.

--- a/src/Grace.Server/Materialization.Server.fs
+++ b/src/Grace.Server/Materialization.Server.fs
@@ -426,20 +426,20 @@ module Materialization =
                     correlationId
         }
 
-    /// Selects the newest reference after authoritative ReferenceType lookup revalidates branch scope.
+    /// Selects the newest live reference after authoritative ReferenceType lookup revalidates branch scope.
     let private selectLatestReference (references: ReferenceDto seq) =
         references
-        |> Seq.sortByDescending (fun reference ->
-            reference.UpdatedAt
-            |> Option.defaultValue reference.CreatedAt)
+        |> Seq.filter (fun reference -> reference.DeletedAt.IsNone)
+        |> Seq.sortByDescending (fun reference -> reference.CreatedAt)
         |> Seq.tryHead
 
     /// Resolves a ReferenceType selector to the latest matching reference for the selected branch at plan time.
     let internal resolveReferenceTypeSelectorWith
         repositoryId
-        (branchName: BranchName)
+        (branchId: BranchId option)
+        (branchName: BranchName option)
         (referenceType: ReferenceType)
-        (resolveBranchIdByName: unit -> Task<BranchId option>)
+        (resolveBranchIdByName: BranchName -> Task<BranchId option>)
         (getBranch: BranchId -> Task<BranchDto>)
         (getReferences: BranchId -> Task<ReferenceDto array>)
         (getDirectoryVersion: DirectoryVersionId -> Task<DirectoryVersionDto>)
@@ -447,22 +447,51 @@ module Materialization =
         : Task<Result<DirectoryVersionId, GraceError>>
         =
         task {
-            if String.IsNullOrWhiteSpace branchName then
-                return Error(planError correlationId "BranchName selector is required for ReferenceType selectors.")
+            let hasBranchId =
+                match branchId with
+                | Some branchId -> branchId <> BranchId.Empty
+                | None -> false
+
+            let hasBranchName =
+                match branchName with
+                | Some branchName -> not (String.IsNullOrWhiteSpace branchName)
+                | None -> false
+
+            if hasBranchId = hasBranchName then
+                return Error(planError correlationId "ReferenceType selector requires exactly one branch identity.")
             else
                 try
-                    let! branchId = resolveBranchIdByName ()
+                    let! resolvedBranchId =
+                        match branchId, branchName with
+                        | Some branchId, None -> Task.FromResult(Some branchId)
+                        | None, Some branchName -> resolveBranchIdByName branchName
+                        | _ -> Task.FromResult(None)
 
-                    match branchId with
+                    match resolvedBranchId with
                     | None -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
-                    | Some branchId when branchId = BranchId.Empty -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
-                    | Some branchId ->
-                        let! branchDto = getBranch branchId
+                    | Some resolvedBranchId when resolvedBranchId = BranchId.Empty -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                    | Some resolvedBranchId ->
+                        let! branchDto = getBranch resolvedBranchId
 
-                        match validateBranchNameSelectorScope repositoryId branchId branchName branchDto correlationId with
+                        let branchScopeResult =
+                            match branchName with
+                            | Some branchName -> validateBranchNameSelectorScope repositoryId resolvedBranchId branchName branchDto correlationId
+                            | None ->
+                                if branchDto.BranchId = BranchId.Empty then
+                                    Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                                elif branchDto.BranchId <> resolvedBranchId then
+                                    Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                                elif branchDto.RepositoryId <> repositoryId then
+                                    Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                                elif branchDto.DeletedAt.IsSome then
+                                    Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                                else
+                                    Ok()
+
+                        match branchScopeResult with
                         | Error _ -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
                         | Ok () ->
-                            let! references = getReferences branchId
+                            let! references = getReferences resolvedBranchId
 
                             match selectLatestReference references with
                             | None -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
@@ -481,14 +510,15 @@ module Materialization =
         }
 
     /// Resolves a ReferenceType selector to one target root from current branch reference state.
-    let private resolveReferenceTypeSelector ownerId organizationId repositoryId branchName referenceType correlationId =
+    let private resolveReferenceTypeSelector ownerId organizationId repositoryId branchId branchName referenceType correlationId =
         task {
             return!
                 resolveReferenceTypeSelectorWith
                     repositoryId
+                    branchId
                     branchName
                     referenceType
-                    (fun () -> resolveBranchId ownerId organizationId repositoryId String.Empty branchName correlationId)
+                    (fun branchName -> resolveBranchId ownerId organizationId repositoryId String.Empty branchName correlationId)
                     (fun branchId ->
                         let branchActorProxy = ActorProxy.Branch.CreateActorProxy branchId repositoryId correlationId
                         branchActorProxy.Get correlationId)
@@ -526,11 +556,14 @@ module Materialization =
                         return! resolveBranchNameSelector ownerId organizationId repositoryId resolvedBranchName correlationId
                     | None -> return Error(planError correlationId "BranchName selector is required.")
                 | MaterializationTargetSelectorKind.ReferenceType ->
-                    match selector.BranchName, selector.ReferenceType with
-                    | Some branchName, Some referenceType ->
-                        return! resolveReferenceTypeSelector ownerId organizationId repositoryId branchName referenceType correlationId
-                    | None, _ -> return Error(planError correlationId "BranchName selector is required for ReferenceType selectors.")
-                    | _, None -> return Error(planError correlationId "ReferenceType selector is required.")
+                    match selector.BranchId, selector.BranchName, selector.ReferenceType with
+                    | branchId, branchName, Some referenceType when
+                        ((branchId.IsSome && branchName.IsNone)
+                         || (branchId.IsNone && branchName.IsSome))
+                        ->
+                        return! resolveReferenceTypeSelector ownerId organizationId repositoryId branchId branchName referenceType correlationId
+                    | _, _, None -> return Error(planError correlationId "ReferenceType selector is required.")
+                    | _, _, _ -> return Error(planError correlationId "ReferenceType selector requires exactly one branch identity.")
                 | _ -> return Error(planError correlationId $"Target selector kind '{int selector.SelectorKind}' is not supported.")
         }
 

--- a/src/Grace.Server/Materialization.Server.fs
+++ b/src/Grace.Server/Materialization.Server.fs
@@ -426,13 +426,6 @@ module Materialization =
                     correlationId
         }
 
-    /// Selects the newest live reference after authoritative ReferenceType lookup revalidates branch scope.
-    let private selectLatestReference (references: ReferenceDto seq) =
-        references
-        |> Seq.filter (fun reference -> reference.DeletedAt.IsNone)
-        |> Seq.sortByDescending (fun reference -> reference.CreatedAt)
-        |> Seq.tryHead
-
     /// Resolves a ReferenceType selector to the latest matching reference for the selected branch at plan time.
     let internal resolveReferenceTypeSelectorWith
         repositoryId
@@ -441,7 +434,7 @@ module Materialization =
         (referenceType: ReferenceType)
         (resolveBranchIdByName: BranchName -> Task<BranchId option>)
         (getBranch: BranchId -> Task<BranchDto>)
-        (getReferences: BranchId -> Task<ReferenceDto array>)
+        (getLatestReference: BranchId -> Task<ReferenceDto option>)
         (getDirectoryVersion: DirectoryVersionId -> Task<DirectoryVersionDto>)
         correlationId
         : Task<Result<DirectoryVersionId, GraceError>>
@@ -491,9 +484,9 @@ module Materialization =
                         match branchScopeResult with
                         | Error _ -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
                         | Ok () ->
-                            let! references = getReferences resolvedBranchId
+                            let! latestReference = getLatestReference resolvedBranchId
 
-                            match selectLatestReference references with
+                            match latestReference with
                             | None -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
                             | Some referenceDto ->
                                 match validateBranchTipReference repositoryId branchDto.BranchId referenceDto.ReferenceId referenceDto correlationId with
@@ -522,7 +515,7 @@ module Materialization =
                     (fun branchId ->
                         let branchActorProxy = ActorProxy.Branch.CreateActorProxy branchId repositoryId correlationId
                         branchActorProxy.Get correlationId)
-                    (fun branchId -> getReferencesByType referenceType repositoryId branchId 50 correlationId)
+                    (fun branchId -> getLatestReferenceByType referenceType repositoryId branchId)
                     (fun directoryVersionId ->
                         let directoryActorProxy = ActorProxy.DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
                         directoryActorProxy.Get correlationId)

--- a/src/Grace.Server/Materialization.Server.fs
+++ b/src/Grace.Server/Materialization.Server.fs
@@ -44,6 +44,9 @@ module Materialization =
     /// Public-safe selector error used when a branch resolves but has no immutable target root.
     let branchTipSelectorNotFoundMessage = "BranchName selector did not match an authorized branch tip."
 
+    /// Public-safe selector error used when a ReferenceType selector cannot resolve to an authorized branch reference.
+    let referenceTypeSelectorNotFoundMessage = "ReferenceType selector did not match an authorized branch reference."
+
     /// Classifies Direct/Bypass plan creation failures after the route has parsed repository authority and target selector intent.
     type internal DirectPlanFailure =
         /// The request shape is invalid for the Direct root-only tracer contract and must remain a client error.
@@ -172,16 +175,12 @@ module Materialization =
             | Error (ServerProjectionFailure error) -> return Error error
         }
 
-    /// Validates that a resolved DirectoryVersion belongs to the authorized repository root without leaking cross-scope state.
+    /// Validates that a resolved DirectoryVersion belongs to the authorized repository without leaking cross-scope state.
     let validateDirectoryVersionSelectorScope repositoryId (directoryVersion: DirectoryVersion) correlationId =
         if directoryVersion.DirectoryVersionId = DirectoryVersionId.Empty then
             Error(planError correlationId directoryVersionSelectorNotFoundMessage)
         elif directoryVersion.RepositoryId <> repositoryId then
             Error(planError correlationId directoryVersionSelectorNotFoundMessage)
-        elif directoryVersion.RelativePath
-             <> Constants.RootDirectoryPath
-             && directoryVersion.RelativePath <> "/" then
-            Error(planError correlationId "Path-scoped Materialization Plan selectors are not supported by /materialization/plan yet.")
         else
             Ok()
 
@@ -427,6 +426,79 @@ module Materialization =
                     correlationId
         }
 
+    /// Selects the newest reference after authoritative ReferenceType lookup revalidates branch scope.
+    let private selectLatestReference (references: ReferenceDto seq) =
+        references
+        |> Seq.sortByDescending (fun reference ->
+            reference.UpdatedAt
+            |> Option.defaultValue reference.CreatedAt)
+        |> Seq.tryHead
+
+    /// Resolves a ReferenceType selector to the latest matching reference for the selected branch at plan time.
+    let internal resolveReferenceTypeSelectorWith
+        repositoryId
+        (branchName: BranchName)
+        (referenceType: ReferenceType)
+        (resolveBranchIdByName: unit -> Task<BranchId option>)
+        (getBranch: BranchId -> Task<BranchDto>)
+        (getReferences: BranchId -> Task<ReferenceDto array>)
+        (getDirectoryVersion: DirectoryVersionId -> Task<DirectoryVersionDto>)
+        correlationId
+        : Task<Result<DirectoryVersionId, GraceError>>
+        =
+        task {
+            if String.IsNullOrWhiteSpace branchName then
+                return Error(planError correlationId "BranchName selector is required for ReferenceType selectors.")
+            else
+                try
+                    let! branchId = resolveBranchIdByName ()
+
+                    match branchId with
+                    | None -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                    | Some branchId when branchId = BranchId.Empty -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                    | Some branchId ->
+                        let! branchDto = getBranch branchId
+
+                        match validateBranchNameSelectorScope repositoryId branchId branchName branchDto correlationId with
+                        | Error _ -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                        | Ok () ->
+                            let! references = getReferences branchId
+
+                            match selectLatestReference references with
+                            | None -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                            | Some referenceDto ->
+                                match validateBranchTipReference repositoryId branchDto.BranchId referenceDto.ReferenceId referenceDto correlationId with
+                                | Error _ -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+                                | Ok () ->
+                                    return!
+                                        resolveDirectoryVersionSelectorWith
+                                            repositoryId
+                                            referenceDto.DirectoryId
+                                            (fun () -> getDirectoryVersion referenceDto.DirectoryId)
+                                            correlationId
+                with
+                | :? KeyNotFoundException -> return Error(planError correlationId referenceTypeSelectorNotFoundMessage)
+        }
+
+    /// Resolves a ReferenceType selector to one target root from current branch reference state.
+    let private resolveReferenceTypeSelector ownerId organizationId repositoryId branchName referenceType correlationId =
+        task {
+            return!
+                resolveReferenceTypeSelectorWith
+                    repositoryId
+                    branchName
+                    referenceType
+                    (fun () -> resolveBranchId ownerId organizationId repositoryId String.Empty branchName correlationId)
+                    (fun branchId ->
+                        let branchActorProxy = ActorProxy.Branch.CreateActorProxy branchId repositoryId correlationId
+                        branchActorProxy.Get correlationId)
+                    (fun branchId -> getReferencesByType referenceType repositoryId branchId 50 correlationId)
+                    (fun directoryVersionId ->
+                        let directoryActorProxy = ActorProxy.DirectoryVersion.CreateActorProxy directoryVersionId repositoryId correlationId
+                        directoryActorProxy.Get correlationId)
+                    correlationId
+        }
+
     /// Resolves supported target selectors before artifact planning starts.
     let private resolveTargetRoot ownerId organizationId repositoryId (selector: MaterializationTargetSelector) correlationId =
         task {
@@ -453,6 +525,12 @@ module Materialization =
 
                         return! resolveBranchNameSelector ownerId organizationId repositoryId resolvedBranchName correlationId
                     | None -> return Error(planError correlationId "BranchName selector is required.")
+                | MaterializationTargetSelectorKind.ReferenceType ->
+                    match selector.BranchName, selector.ReferenceType with
+                    | Some branchName, Some referenceType ->
+                        return! resolveReferenceTypeSelector ownerId organizationId repositoryId branchName referenceType correlationId
+                    | None, _ -> return Error(planError correlationId "BranchName selector is required for ReferenceType selectors.")
+                    | _, None -> return Error(planError correlationId "ReferenceType selector is required.")
                 | _ -> return Error(planError correlationId $"Target selector kind '{int selector.SelectorKind}' is not supported.")
         }
 

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -3,6 +3,7 @@ namespace Grace.Types.Tests
 open Grace.Shared.Utilities
 open Grace.Types.Common
 open Grace.Types.MaterializationPlan
+open Grace.Types.Reference
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -22,6 +23,9 @@ module MaterializationPlanTestData =
 
     /// Provides a deterministic branch name for selector serialization coverage.
     let branchName = BranchName "feature-cache-plan"
+
+    /// Provides a deterministic reference type for selector serialization coverage.
+    let referenceType = ReferenceType.Promotion
 
     /// Provides a deterministic storage pool id for CAS descriptor coverage.
     let storagePoolId = StoragePoolId "storage-pool-main"
@@ -176,6 +180,7 @@ type MaterializationPlanContractTests() =
                 MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId
                 MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId
                 MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName
+                MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType)
             ]
 
         for selector in selectors do
@@ -1599,9 +1604,15 @@ type MaterializationPlanContractTests() =
                 DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
             }
 
+        let referenceTypeSelector =
+            { MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType) with
+                ReferenceId = Some MaterializationPlanTestData.referenceId
+            }
+
         assertInvalid "TargetSelector.ReferenceId must be empty for DirectoryVersionId selectors." (Validation.validateTargetSelector directorySelector)
         assertInvalid "TargetSelector.BranchName must be empty for ReferenceId selectors." (Validation.validateTargetSelector referenceSelector)
         assertInvalid "TargetSelector.DirectoryVersionId must be empty for BranchName selectors." (Validation.validateTargetSelector branchSelector)
+        assertInvalid "TargetSelector.ReferenceId must be empty for ReferenceType selectors." (Validation.validateTargetSelector referenceTypeSelector)
 
     /// Verifies that every selector kind rejects each identity field owned by the other selector kinds.
     [<Test>]
@@ -1632,6 +1643,18 @@ type MaterializationPlanContractTests() =
                     ReferenceId = Some MaterializationPlanTestData.referenceId
                 },
                 "TargetSelector.ReferenceId must be empty for BranchName selectors."
+                { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with
+                    ReferenceType = Some MaterializationPlanTestData.referenceType
+                },
+                "TargetSelector.ReferenceType must be empty for BranchName selectors."
+                { MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType) with
+                    DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
+                },
+                "TargetSelector.DirectoryVersionId must be empty for ReferenceType selectors."
+                { MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType) with
+                    ReferenceId = Some MaterializationPlanTestData.referenceId
+                },
+                "TargetSelector.ReferenceId must be empty for ReferenceType selectors."
             ]
 
         for selector, expected in cases do

--- a/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
+++ b/src/Grace.Types.Tests/MaterializationPlan.Types.Tests.fs
@@ -24,6 +24,9 @@ module MaterializationPlanTestData =
     /// Provides a deterministic branch name for selector serialization coverage.
     let branchName = BranchName "feature-cache-plan"
 
+    /// Provides a deterministic branch id for selector serialization coverage.
+    let branchId = BranchId.Parse("44444444-4444-4444-4444-444444444444")
+
     /// Provides a deterministic reference type for selector serialization coverage.
     let referenceType = ReferenceType.Promotion
 
@@ -181,6 +184,7 @@ type MaterializationPlanContractTests() =
                 MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId
                 MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName
                 MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType)
+                MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchId, MaterializationPlanTestData.referenceType)
             ]
 
         for selector in selectors do
@@ -1627,6 +1631,10 @@ type MaterializationPlanContractTests() =
                     BranchName = Some MaterializationPlanTestData.branchName
                 },
                 "TargetSelector.BranchName must be empty for DirectoryVersionId selectors."
+                { MaterializationTargetSelector.ForDirectoryVersion MaterializationPlanTestData.targetRootDirectoryVersionId with
+                    BranchId = Some MaterializationPlanTestData.branchId
+                },
+                "TargetSelector.BranchId must be empty for DirectoryVersionId selectors."
                 { MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId with
                     DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
                 },
@@ -1635,6 +1643,8 @@ type MaterializationPlanContractTests() =
                     BranchName = Some MaterializationPlanTestData.branchName
                 },
                 "TargetSelector.BranchName must be empty for ReferenceId selectors."
+                { MaterializationTargetSelector.ForReference MaterializationPlanTestData.referenceId with BranchId = Some MaterializationPlanTestData.branchId },
+                "TargetSelector.BranchId must be empty for ReferenceId selectors."
                 { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with
                     DirectoryVersionId = Some MaterializationPlanTestData.targetRootDirectoryVersionId
                 },
@@ -1643,6 +1653,8 @@ type MaterializationPlanContractTests() =
                     ReferenceId = Some MaterializationPlanTestData.referenceId
                 },
                 "TargetSelector.ReferenceId must be empty for BranchName selectors."
+                { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with BranchId = Some MaterializationPlanTestData.branchId },
+                "TargetSelector.BranchId must be empty for BranchName selectors."
                 { MaterializationTargetSelector.ForBranch MaterializationPlanTestData.branchName with
                     ReferenceType = Some MaterializationPlanTestData.referenceType
                 },
@@ -1659,3 +1671,29 @@ type MaterializationPlanContractTests() =
 
         for selector, expected in cases do
             assertInvalid expected (Validation.validateTargetSelector selector)
+
+    /// Verifies ReferenceType selectors reject missing or ambiguous branch identity.
+    [<Test>]
+    member _.ReferenceTypeSelectorsRequireExactlyOneBranchIdentity() =
+        let missingIdentity =
+            { MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType) with
+                BranchName = None
+            }
+
+        let ambiguousIdentity =
+            { MaterializationTargetSelector.ForReferenceType(MaterializationPlanTestData.branchName, MaterializationPlanTestData.referenceType) with
+                BranchId = Some MaterializationPlanTestData.branchId
+            }
+
+        let emptyBranchId =
+            { MaterializationTargetSelector.ForReferenceType(BranchId.Empty, MaterializationPlanTestData.referenceType) with BranchId = Some BranchId.Empty }
+
+        assertInvalid
+            "TargetSelector must include exactly one of BranchId or BranchName for ReferenceType selectors."
+            (Validation.validateTargetSelector missingIdentity)
+
+        assertInvalid
+            "TargetSelector must include exactly one of BranchId or BranchName for ReferenceType selectors."
+            (Validation.validateTargetSelector ambiguousIdentity)
+
+        assertInvalid "TargetSelector.BranchId is required when supplied for ReferenceType selectors." (Validation.validateTargetSelector emptyBranchId)

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -2,6 +2,7 @@ namespace Grace.Types
 
 open Grace.Shared
 open Grace.Types.Common
+open Grace.Types.Reference
 open Orleans
 open System
 open System.Collections.Generic
@@ -22,6 +23,7 @@ module MaterializationPlan =
         | DirectoryVersionId = 1
         | ReferenceId = 2
         | BranchName = 3
+        | ReferenceType = 4
 
     /// Identifies the cache behavior requested for artifact source selection.
     type MaterializationCacheSelectionKind =
@@ -79,6 +81,7 @@ module MaterializationPlan =
             DirectoryVersionId: DirectoryVersionId option
             ReferenceId: ReferenceId option
             BranchName: BranchName option
+            ReferenceType: ReferenceType option
         }
 
         /// Selects a known immutable directory version root directly.
@@ -89,6 +92,7 @@ module MaterializationPlan =
                 DirectoryVersionId = Some directoryVersionId
                 ReferenceId = None
                 BranchName = None
+                ReferenceType = None
             }
 
         /// Selects the directory version reached by a stored Grace reference.
@@ -99,6 +103,7 @@ module MaterializationPlan =
                 DirectoryVersionId = None
                 ReferenceId = Some referenceId
                 BranchName = None
+                ReferenceType = None
             }
 
         /// Selects the directory version reached by the current branch tip at resolution time.
@@ -109,6 +114,18 @@ module MaterializationPlan =
                 DirectoryVersionId = None
                 ReferenceId = None
                 BranchName = Some branchName
+                ReferenceType = None
+            }
+
+        /// Selects the latest reference of a given type for one branch at server resolution time.
+        static member ForReferenceType(branchName: BranchName, referenceType: ReferenceType) =
+            {
+                Class = nameof MaterializationTargetSelector
+                SelectorKind = MaterializationTargetSelectorKind.ReferenceType
+                DirectoryVersionId = None
+                ReferenceId = None
+                BranchName = Some branchName
+                ReferenceType = Some referenceType
             }
 
         /// Represents an empty selector used before caller input contributes target identity.
@@ -119,6 +136,7 @@ module MaterializationPlan =
                 DirectoryVersionId = None
                 ReferenceId = None
                 BranchName = None
+                ReferenceType = None
             }
 
     /// Records cache-selection intent separately from artifact source details.
@@ -464,6 +482,9 @@ module MaterializationPlan =
 
                         if selector.BranchName.IsSome then
                             errors.Add("TargetSelector.BranchName must be empty for DirectoryVersionId selectors.")
+
+                        if selector.ReferenceType.IsSome then
+                            errors.Add("TargetSelector.ReferenceType must be empty for DirectoryVersionId selectors.")
                     | MaterializationTargetSelectorKind.ReferenceId ->
                         match selector.ReferenceId with
                         | Some referenceId when referenceId <> ReferenceId.Empty -> ()
@@ -474,6 +495,9 @@ module MaterializationPlan =
 
                         if selector.BranchName.IsSome then
                             errors.Add("TargetSelector.BranchName must be empty for ReferenceId selectors.")
+
+                        if selector.ReferenceType.IsSome then
+                            errors.Add("TargetSelector.ReferenceType must be empty for ReferenceId selectors.")
                     | MaterializationTargetSelectorKind.BranchName ->
                         match selector.BranchName with
                         | Some branchName when
@@ -490,6 +514,29 @@ module MaterializationPlan =
 
                         if selector.ReferenceId.IsSome then
                             errors.Add("TargetSelector.ReferenceId must be empty for BranchName selectors.")
+
+                        if selector.ReferenceType.IsSome then
+                            errors.Add("TargetSelector.ReferenceType must be empty for BranchName selectors.")
+                    | MaterializationTargetSelectorKind.ReferenceType ->
+                        match selector.BranchName with
+                        | Some branchName when
+                            not (String.IsNullOrWhiteSpace branchName)
+                            && Constants.GraceNameRegex.IsMatch(branchName)
+                            ->
+                            ()
+                        | Some branchName when not (String.IsNullOrWhiteSpace branchName) ->
+                            errors.Add("TargetSelector.BranchName must be a valid Grace branch name.")
+                        | _ -> errors.Add("TargetSelector.BranchName is required for ReferenceType selectors.")
+
+                        match selector.ReferenceType with
+                        | Some _ -> ()
+                        | _ -> errors.Add("TargetSelector.ReferenceType is required.")
+
+                        if selector.DirectoryVersionId.IsSome then
+                            errors.Add("TargetSelector.DirectoryVersionId must be empty for ReferenceType selectors.")
+
+                        if selector.ReferenceId.IsSome then
+                            errors.Add("TargetSelector.ReferenceId must be empty for ReferenceType selectors.")
                     | _ -> errors.Add($"TargetSelector.SelectorKind '{int selector.SelectorKind}' is not supported.")
 
             if errors.Count = 0 then Ok() else Error(List.ofSeq errors)

--- a/src/Grace.Types/MaterializationPlan.Types.fs
+++ b/src/Grace.Types/MaterializationPlan.Types.fs
@@ -80,6 +80,7 @@ module MaterializationPlan =
             SelectorKind: MaterializationTargetSelectorKind
             DirectoryVersionId: DirectoryVersionId option
             ReferenceId: ReferenceId option
+            BranchId: BranchId option
             BranchName: BranchName option
             ReferenceType: ReferenceType option
         }
@@ -91,6 +92,7 @@ module MaterializationPlan =
                 SelectorKind = MaterializationTargetSelectorKind.DirectoryVersionId
                 DirectoryVersionId = Some directoryVersionId
                 ReferenceId = None
+                BranchId = None
                 BranchName = None
                 ReferenceType = None
             }
@@ -102,6 +104,7 @@ module MaterializationPlan =
                 SelectorKind = MaterializationTargetSelectorKind.ReferenceId
                 DirectoryVersionId = None
                 ReferenceId = Some referenceId
+                BranchId = None
                 BranchName = None
                 ReferenceType = None
             }
@@ -113,18 +116,32 @@ module MaterializationPlan =
                 SelectorKind = MaterializationTargetSelectorKind.BranchName
                 DirectoryVersionId = None
                 ReferenceId = None
+                BranchId = None
                 BranchName = Some branchName
                 ReferenceType = None
             }
 
-        /// Selects the latest reference of a given type for one branch at server resolution time.
+        /// Selects the latest reference of a given type for one branch name at server resolution time.
         static member ForReferenceType(branchName: BranchName, referenceType: ReferenceType) =
             {
                 Class = nameof MaterializationTargetSelector
                 SelectorKind = MaterializationTargetSelectorKind.ReferenceType
                 DirectoryVersionId = None
                 ReferenceId = None
+                BranchId = None
                 BranchName = Some branchName
+                ReferenceType = Some referenceType
+            }
+
+        /// Selects the latest reference of a given type for one branch id at server resolution time.
+        static member ForReferenceType(branchId: BranchId, referenceType: ReferenceType) =
+            {
+                Class = nameof MaterializationTargetSelector
+                SelectorKind = MaterializationTargetSelectorKind.ReferenceType
+                DirectoryVersionId = None
+                ReferenceId = None
+                BranchId = Some branchId
+                BranchName = None
                 ReferenceType = Some referenceType
             }
 
@@ -135,6 +152,7 @@ module MaterializationPlan =
                 SelectorKind = MaterializationTargetSelectorKind.DirectoryVersionId
                 DirectoryVersionId = None
                 ReferenceId = None
+                BranchId = None
                 BranchName = None
                 ReferenceType = None
             }
@@ -480,6 +498,9 @@ module MaterializationPlan =
                         if selector.ReferenceId.IsSome then
                             errors.Add("TargetSelector.ReferenceId must be empty for DirectoryVersionId selectors.")
 
+                        if selector.BranchId.IsSome then
+                            errors.Add("TargetSelector.BranchId must be empty for DirectoryVersionId selectors.")
+
                         if selector.BranchName.IsSome then
                             errors.Add("TargetSelector.BranchName must be empty for DirectoryVersionId selectors.")
 
@@ -492,6 +513,9 @@ module MaterializationPlan =
 
                         if selector.DirectoryVersionId.IsSome then
                             errors.Add("TargetSelector.DirectoryVersionId must be empty for ReferenceId selectors.")
+
+                        if selector.BranchId.IsSome then
+                            errors.Add("TargetSelector.BranchId must be empty for ReferenceId selectors.")
 
                         if selector.BranchName.IsSome then
                             errors.Add("TargetSelector.BranchName must be empty for ReferenceId selectors.")
@@ -515,18 +539,35 @@ module MaterializationPlan =
                         if selector.ReferenceId.IsSome then
                             errors.Add("TargetSelector.ReferenceId must be empty for BranchName selectors.")
 
+                        if selector.BranchId.IsSome then
+                            errors.Add("TargetSelector.BranchId must be empty for BranchName selectors.")
+
                         if selector.ReferenceType.IsSome then
                             errors.Add("TargetSelector.ReferenceType must be empty for BranchName selectors.")
                     | MaterializationTargetSelectorKind.ReferenceType ->
-                        match selector.BranchName with
-                        | Some branchName when
-                            not (String.IsNullOrWhiteSpace branchName)
-                            && Constants.GraceNameRegex.IsMatch(branchName)
-                            ->
-                            ()
-                        | Some branchName when not (String.IsNullOrWhiteSpace branchName) ->
-                            errors.Add("TargetSelector.BranchName must be a valid Grace branch name.")
-                        | _ -> errors.Add("TargetSelector.BranchName is required for ReferenceType selectors.")
+                        let hasBranchId =
+                            match selector.BranchId with
+                            | Some branchId when branchId <> BranchId.Empty -> true
+                            | Some _ ->
+                                errors.Add("TargetSelector.BranchId is required when supplied for ReferenceType selectors.")
+                                false
+                            | None -> false
+
+                        let hasBranchName =
+                            match selector.BranchName with
+                            | Some branchName when
+                                not (String.IsNullOrWhiteSpace branchName)
+                                && Constants.GraceNameRegex.IsMatch(branchName)
+                                ->
+                                true
+                            | Some branchName when not (String.IsNullOrWhiteSpace branchName) ->
+                                errors.Add("TargetSelector.BranchName must be a valid Grace branch name.")
+                                false
+                            | Some _ -> false
+                            | None -> false
+
+                        if hasBranchId = hasBranchName then
+                            errors.Add("TargetSelector must include exactly one of BranchId or BranchName for ReferenceType selectors.")
 
                         match selector.ReferenceType with
                         | Some _ -> ()


### PR DESCRIPTION
## Summary

- Moves `grace connect` Direct retrieval onto `Grace.SDK.Materialization.Plan`.
- Removes the old independent `DirectoryVersion.GetZipFile` Direct connect path.
- Makes the plan target root authoritative before recursive metadata fetch and extraction.
- Validates required Direct plan artifacts and root consistency before extraction, status writes, or object-cache updates.

## Why This Matters

This is the CLI tracer slice for the #599 Direct Materialization Plan path. The CLI now consumes the server-owned plan boundary, so moving selector intent resolves on the server and local connect side effects remain behind a plan/artifact consistency barrier.

## Related Issue

Related to #615. Part of #599 and #597.

## Validation

- Passed: `dotnet tool run fantomas src/Grace.CLI/Command/Connect.CLI.fs src/Grace.CLI.Tests/Connect.CLI.Tests.fs`.
- Passed: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`.
- Passed: `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` (`694` tests).
- Passed: `pwsh ./scripts/validate.ps1 -Fast`.
- Passed: `git diff --check`.
- Skipped: `pwsh ./scripts/validate.ps1 -Full`; this CLI path change uses the existing plan route/SDK surface and #615 requested Fast as the final broad gate.

## Contract Propagation

- CLI: `grace connect` Direct retrieval now requests a one-time Direct/Bypass Materialization Plan and executes the required plan artifacts.
- SDK/OpenAPI/shared DTOs: N/A; #613/#614 already supplied the plan SDK and route contract. No public shape changed in this leaf.
- CLI docs/help: N/A; no user-visible option text changed.
- Tests: CLI tests cover plan-path success, descriptor/root consistency failure before writes, selector behavior, and missing plan artifact source errors.

## Side-Effect Ordering

- Connect requests the plan before recursive metadata and uses `plan.TargetRootDirectoryVersionId` for the recursive metadata fetch.
- Connect validates plan contract, Direct execution mode, Bypass cache selection, required target-root zip artifact, required recursive metadata artifact, represented-root agreement, recursive metadata inclusion of target root, and DirectUri sources before extraction or status/cache writes.
- Existing conflict checks, zip extraction, `GraceStatus` write, and object-cache update remain after the validation barrier.
- `--retrieve-default-branch false` and selector parsing behavior are preserved.

## Review Status

- Implementation commit: `a2a03aa0023f435c4b2c21a11314c35fb5842527`.
- Worker validation passed: targeted Fantomas, focused Release CLI test build, focused CLI tests (`694`), final `pwsh ./scripts/validate.ps1 -Fast`, and `git diff --check`.
- GitHub Actions `full` passed on `a2a03aa0023f435c4b2c21a11314c35fb5842527`; PR is clean. Codex Code Review Bot has acknowledged the head with 👀 and review is still pending. No manual Codex review request was made.
- Codex Code Review Bot reviewed `a2a03aa0023f435c4b2c21a11314c35fb5842527` at `2026-07-08T10:37:39Z` and opened four fresh cycle-one findings: preserve original selector intent in plan requests, fetch DirectUri artifacts without assuming Azure Blob, verify planned ZIP integrity before extraction, and execute the planned recursive metadata artifact instead of re-querying the legacy endpoint.
- Substantive cycle count: 1. These findings are in #615 scope and do not require a new domain construct or maintainer decision before the first fix cycle.
- Fresh fix worker assigned for the four current-head findings only; no manual Codex review request was made.
- Review fixes for the four cycle-one findings were pushed in `329581ddbcb8839ed061757b64ad7f694c0986d0`.
- Worker validation for `329581ddbcb8839ed061757b64ad7f694c0986d0` passed: targeted Fantomas, focused Release CLI build, focused Connect tests (`19/19`), `git diff --check`, and final `pwsh ./scripts/validate.ps1 -Fast`.
- Cycle-one review replies were posted and resolved: [preserve selector intent](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3543328450), [generic DirectUri artifact fetch](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3543328632), [planned ZIP integrity before extraction](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3543328818), and [execute planned recursive metadata artifact](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3543329046).
- Prevention summary: stale-snapshot/interleaving, contract-propagation, validation/stale-evidence, and side-effect ordering gaps were covered by #615 focused CLI regressions; no sibling issue, template, or process-doc update is needed for these first-cycle findings.
- GitHub Actions `full` passed on `329581ddbcb8839ed061757b64ad7f694c0986d0`; all cycle-one threads are replied to and resolved. Codex Code Review Bot has acknowledged the head with 👀 and review is still pending. No manual Codex review request was made.
- Codex Code Review Bot reviewed `329581ddbcb8839ed061757b64ad7f694c0986d0` at `2026-07-08T10:59:57Z` and opened two fresh cycle-two findings: implicit default connect must preserve promoted-default semantics, and DirectUri artifact validation must accept BLAKE3-only descriptors.
- Substantive cycle count: 2. Stabilization ledger posted on #615 before the next fix worker: https://github.com/ScottArbeit/Grace/issues/615#issuecomment-4914109043.
- Repeated-theme prevention: selector-semantics/side-effect-ordering gap; #615 now explicitly requires preserving user-visible default target semantics plus accepting any supported planned integrity evidence before Direct extraction/status/cache writes.
- Review fixes for the two cycle-two findings were pushed in `66c764ffe97547e56e62bc88374e1f60826ee854`.
- Worker validation for `66c764ffe97547e56e62bc88374e1f60826ee854` passed: targeted Fantomas, focused Release CLI build, focused Connect tests (`19/19`), `git diff --check`, and final `pwsh ./scripts/validate.ps1 -Fast`.
- Cycle-two review replies were posted and resolved: [preserve promoted default connect target](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3543451626) and [BLAKE3-only artifact integrity](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3543451854).
- Prevention summary: selector-semantics/side-effect-ordering and validation/stale-evidence gaps were covered by the #615 stabilization ledger and focused CLI regressions; no sibling issue, template, or process-doc update is needed for these cycle-two findings.
- GitHub Actions `full` passed on `66c764ffe97547e56e62bc88374e1f60826ee854`; Codex Code Review Bot reviewed that head at `2026-07-08T11:25:02Z` and opened three fresh cycle-three findings: preserve reference-type selectors, preserve scoped directory-version connects, and bound DirectUri artifact downloads by planned size.
- Substantive cycle count: 3. Coding and routine fix-worker routing are stopped until the maintainer approves the revised stabilization ledger or explicitly directs continued patching.
- Third-cycle stabilization notice posted on #615: https://github.com/ScottArbeit/Grace/issues/615#issuecomment-4914290141.
- Suspected missing invariant family: selector authority matrix, materialization scope contract, and artifact transfer bound. No manual Codex review request was made.

- Maintainer-approved third-cycle direction recorded on #615: explicit moving selectors, including `--reference-type`, must stay moving through the plan request; non-root `--directory-version-id` connects remain supported through the plan path; DirectUri `SizeInBytes`/descriptor hashes apply to delivered artifact bytes; final materialized file bytes must be verified against recursive metadata `FileVersion` hashes after decompression as needed; no manual Codex review request should be made.
- Fresh cycle-three stabilization fix worker is now authorized by maintainer direction.
- Cycle-three stabilization fixes for the three latest-head findings were pushed in `c091b798d6105dd95bb7faf4b4c8db73874376da`.
- Worker validation for `c091b798d6105dd95bb7faf4b4c8db73874376da` passed: focused CLI/Types/Server.Unit Release builds; focused Connect tests (`33/33`); focused MaterializationPlan type tests (`125/125`); focused MaterializationPlan server tests (`36/36`); targeted Fantomas; `git diff --check`; and final `pwsh ./scripts/validate.ps1 -Fast`.
- Cycle-three review replies were posted and resolved: [reference-type moving selector intent](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547246343), [scoped directory-version connects](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547246468), and [bounded DirectUri artifact downloads](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547246638).
- Prevention summary: selector authority matrix, materialization scope contract, artifact transfer bounds, and delivered-artifact versus materialized-file integrity are now explicit in #615 and covered by focused CLI/type/server regressions. No sibling issue is needed for these approved #615 contract changes.
- GitHub Actions `full` passed on `c091b798d6105dd95bb7faf4b4c8db73874376da`; waiting for the automatic Codex Code Review Bot result. No manual Codex review request was made.
- Codex Code Review Bot reviewed `c091b798d6105dd95bb7faf4b4c8db73874376da` at `2026-07-08T21:13:46Z` and opened four fresh cycle-four findings: skip deleted references for ReferenceType selectors, publish the new selector in OpenAPI contracts, preserve branch-id scope for reference-type connects, and select reference-type targets by creation time.
- Substantive cycle count: 4. Coding and routine fix-worker routing are stopped until the maintainer approves the revised ReferenceType selector authority/public-contract ledger.
- Fourth-cycle stabilization notice posted on #615: https://github.com/ScottArbeit/Grace/issues/615#issuecomment-4919289958.
- Suspected missing invariant family: ReferenceType selector branch authority, live-reference retirement, creation-time recency, and OpenAPI/static contract propagation. No manual Codex review request was made.
- Maintainer-approved fourth-cycle direction recorded on #615: ReferenceType selectors must preserve the selected branch identity (`BranchId` for `--branch-id`, `BranchName`/default for name/default), skip deleted references, and choose the latest live reference by creation order/storage order rather than mutable `UpdatedAt`.
- The OpenAPI/static contract propagation finding is accepted but deferred to sibling issue #687: https://github.com/ScottArbeit/Grace/issues/687. PR #686 will keep runtime ReferenceType behavior in #615 and resolve the OpenAPI review thread by naming #687 as the follow-up proof issue.
- Fresh cycle-four runtime fix worker is now authorized by maintainer direction. No manual Codex review request was made.
- Cycle-four runtime fixes were pushed in `f2b70ba4ccf6d3badf27c13cb9e6479df02eccca`.
- Worker validation for `f2b70ba4ccf6d3badf27c13cb9e6479df02eccca` passed: targeted Fantomas; focused Types tests (`275`); focused CLI tests (`716`); focused Server.Unit tests (`775`); `git diff --check`; and final `pwsh ./scripts/validate.ps1 -Fast` on the committed code state.
- Cycle-four runtime review replies were posted and resolved: [skip deleted ReferenceType refs](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547716132), [preserve branch-id scope](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547716442), and [select latest by creation order](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547716572).
- The OpenAPI/static contract propagation finding was accepted and resolved as a sibling-issue deferral to #687: [PR reply](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547716301), [follow-up issue](https://github.com/ScottArbeit/Grace/issues/687).
- Prevention summary: ReferenceType selector branch identity, live-reference filtering, creation-order latest selection, and explicit OpenAPI follow-up tracking are now recorded in #615/#687 and covered by focused runtime regressions. GitHub Actions `full` passed on `f2b70ba4ccf6d3badf27c13cb9e6479df02eccca`; waiting for the automatic Codex Code Review Bot result. No manual Codex review request was made.
- Codex Code Review Bot reviewed `f2b70ba4ccf6d3badf27c13cb9e6479df02eccca` at `2026-07-08T22:59:12Z` and opened two fresh latest-head findings: page past deleted `ReferenceType` candidates, and validate ZIP entries before overwriting the worktree.
- Substantive cycle count: 5. These findings are covered by already-approved #615 invariants: live-reference selection must find the newest live reference, and final file-content validation must precede local working-tree mutation/status/cache side effects. No new product decision, sibling issue, or public-contract deferral is needed before assigning the next fix worker.
- Fresh fix worker assigned for the two current-head findings only. No manual Codex review request was made.
- Fixes for the `f2b70ba4` latest-head findings were pushed in `37ab0617c1c632adef3d2e8f452f21bd994f88c8`.
- Worker validation for `37ab0617c1c632adef3d2e8f452f21bd994f88c8` passed: targeted Fantomas; focused Server.Unit build/tests (`776/776`); focused CLI build/tests (`718/718`); `git diff --check`; and final `pwsh ./scripts/validate.ps1 -Fast`.
- Review replies were posted and resolved: [page past deleted ReferenceType candidates](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547800719) and [validate ZIP entries before overwriting the worktree](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547800804).
- Prevention summary: ReferenceType planning now uses the latest-live reference helper rather than a fixed deleted-candidate window, and Direct ZIP execution validates staged decompressed bytes before local working-tree/object-cache/status mutation. GitHub Actions `full` passed on `37ab0617c1c632adef3d2e8f452f21bd994f88c8`; waiting for the automatic Codex Code Review Bot result. No manual Codex review request was made.
- Codex Code Review Bot reviewed `37ab0617c1c632adef3d2e8f452f21bd994f88c8` at `2026-07-08T23:19:01Z` and opened one fresh latest-head finding: staging ZIP extraction should not reuse the final worktree skip set, because skipped already-matching files are missing from the empty staging root.
- This is an implementation bug within the already-approved staged-validation invariant; no new product decision or sibling issue is needed before assigning the next fix worker.
- Fresh fix worker assigned for the single current-head finding only. No manual Codex review request was made.
- The `37ab0617` staging skip-set finding was fixed in `4faae38f53f8618d5325d2dbc4fed2e75c3bf1fb`.
- Worker validation for `4faae38f53f8618d5325d2dbc4fed2e75c3bf1fb` passed: targeted Fantomas; focused CLI Release build; focused CLI tests (`719/719`); `git diff --check`; and final `pwsh ./scripts/validate.ps1 -Fast`.
- Review reply was posted and resolved: [extract skipped files into the validation stage](https://github.com/ScottArbeit/Grace/pull/686#discussion_r3547851745).
- Prevention summary: staged ZIP validation now uses a fresh empty skip set so it validates a complete decompressed copy, while final worktree extraction can still skip already-matching files. GitHub Actions `full` passed on `4faae38f53f8618d5325d2dbc4fed2e75c3bf1fb`; waiting for the automatic Codex Code Review Bot result. No manual Codex review request was made.

