### PR TITLE
GV-11: Authorize content-block materialization read-through

### DIFF
--- a/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs
@@ -70,6 +70,7 @@ type ManifestDownloadSdkTests() =
             OrganizationName = "org"
             RepositoryId = "11111111-1111-1111-1111-111111111111"
             RepositoryName = "repo"
+            ReferenceId = Guid.Parse("44444444-4444-4444-4444-444444444444")
             FileVersion = fileVersion
             OutputStream = None
             CorrelationId = correlationId
@@ -156,7 +157,10 @@ type ManifestDownloadSdkTests() =
                     GetContentBlockDownloadUri =
                         fun parameters ->
                             requestedBlocks.Add(parameters.ContentBlockAddress)
+                            Assert.That(parameters.ReferenceId, Is.EqualTo(Guid.Parse("44444444-4444-4444-4444-444444444444")))
                             Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
+                            Assert.That(parameters.Sha256Hash, Is.EqualTo(fileVersion.Sha256Hash))
+                            Assert.That(parameters.Blake3Hash, Is.EqualTo(fileVersion.Blake3Hash))
                             Assert.That(parameters.ManifestAddress, Is.EqualTo(manifest.ManifestAddress))
                             Task.FromResult(Ok(GraceReturnValue.Create $"https://example.test/{parameters.ContentBlockAddress}" correlationId))
                     DownloadContentBlock =
@@ -213,6 +217,7 @@ type ManifestDownloadSdkTests() =
                             Assert.That(parameters.ManifestAddress, Is.EqualTo(manifest.ManifestAddress))
                             Assert.That(parameters.StoragePoolId, Is.EqualTo(manifest.StoragePoolId))
                             Assert.That(parameters.ContentBlockAddress, Is.Not.EqualTo(String.Empty))
+                            Assert.That(parameters.ReferenceId, Is.EqualTo(Guid.Parse("44444444-4444-4444-4444-444444444444")))
                             Assert.That(parameters.AuthorizedScope, Is.EqualTo(fileVersion.RelativePath))
                             let manifestProperty = parameters.GetType().GetProperty("Manifest")
                             Assert.That(manifestProperty, Is.Null)

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -1066,6 +1066,7 @@ module Services =
                                             OrganizationName = getDownloadUriParameters.OrganizationName
                                             RepositoryId = getDownloadUriParameters.RepositoryId
                                             RepositoryName = getDownloadUriParameters.RepositoryName
+                                            ReferenceId = getDownloadUriParameters.ReferenceId
                                             FileVersion = fileVersion
                                             OutputStream = Some outputStream
                                             CorrelationId = getDownloadUriParameters.CorrelationId

--- a/src/Grace.SDK/ManifestDownload.SDK.fs
+++ b/src/Grace.SDK/ManifestDownload.SDK.fs
@@ -21,6 +21,7 @@ module ManifestDownload =
             OrganizationName: OrganizationName
             RepositoryId: string
             RepositoryName: RepositoryName
+            ReferenceId: ReferenceId
             FileVersion: FileVersion
             OutputStream: Stream option
             CorrelationId: CorrelationId
@@ -66,7 +67,10 @@ module ManifestDownload =
     let private buildDownloadUriParameters request contentBlockAddress =
         let parameters = GetContentBlockDownloadUriParameters()
         setStorageParameters request parameters |> ignore
+        parameters.ReferenceId <- request.ReferenceId
         parameters.AuthorizedScope <- request.FileVersion.RelativePath
+        parameters.Sha256Hash <- request.FileVersion.Sha256Hash
+        parameters.Blake3Hash <- request.FileVersion.Blake3Hash
         parameters.ContentBlockAddress <- contentBlockAddress
 
         match request.FileVersion.ContentReference.Manifest with

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -605,6 +605,10 @@ type StorageContentBlockSasRoutes() =
     let createContentBlockDownloadParameters repositoryId =
         let parameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
         setContentBlockParameters parameters repositoryId
+        parameters.ReferenceId <- Guid.NewGuid()
+        parameters.Sha256Hash <- ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes $"sha-proof-{Guid.NewGuid():N}")
+        parameters.Blake3Hash <- ContentAddress.computeBlake3Hex (Encoding.UTF8.GetBytes $"blake-proof-{Guid.NewGuid():N}")
+        parameters.StoragePoolId <- $"pool-{Guid.NewGuid():N}"
         parameters.ContentBlockAddress <- ContentAddress.computeBlake3Hex (Guid.NewGuid().ToByteArray())
         parameters
 
@@ -1618,6 +1622,29 @@ type StorageManifestUploadSessionRoutes() =
         fileVersion.ContentReference <- FileContentReference.FileManifest manifest
         fileVersion
 
+    /// Saves a visible reference that reaches the manifest-backed FileVersion used for ContentBlock read-through.
+    let createReachableReferenceForManifestFile repositoryId (fileVersion: FileVersion) =
+        task {
+            let root = BranchServerTestHelpers.createRootDirectoryVersion repositoryId fileVersion
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ root ]
+
+            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId repositoryDefaultBranchIds[0]
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"StorageManifestDownload{Guid.NewGuid():N}"
+            let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch root.DirectoryVersionId root.Sha256Hash
+            let! saveBody = saveResponse.Content.ReadAsStringAsync()
+            Assert.That(saveResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), saveBody)
+            let! savedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
+            return savedBranch.LatestSave.ReferenceId
+        }
+
+    /// Applies the visible-reference proof tuple required before ContentBlock read-through can use finalized cache metadata.
+    let applyContentBlockDownloadProof (parameters: Parameters.Storage.GetContentBlockDownloadUriParameters) referenceId (fileVersion: FileVersion) =
+        parameters.ReferenceId <- referenceId
+        parameters.AuthorizedScope <- fileVersion.RelativePath
+        parameters.Sha256Hash <- fileVersion.Sha256Hash
+        parameters.Blake3Hash <- fileVersion.Blake3Hash
+
     /// Saves directory versions response through the branch test routes.
     let saveDirectoryVersionsResponse repositoryId (directoryVersions: Grace.Types.Common.DirectoryVersion seq) =
         task {
@@ -1779,9 +1806,12 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(finalizeResult.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
             Assert.That(finalizeResult.ReturnValue.Session.LifecycleState, Is.EqualTo(UploadSessionLifecycleState.RetentionPending))
 
+            let fileVersion = manifestBackedFileVersion (exactUploadScope sessionId) payload manifest
+            let! referenceId = createReachableReferenceForManifestFile repositoryId fileVersion
+
             let downloadUriParameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters downloadUriParameters repositoryId correlationId
-            downloadUriParameters.AuthorizedScope <- exactUploadScope sessionId
+            applyContentBlockDownloadProof downloadUriParameters referenceId fileVersion
             downloadUriParameters.ContentBlockAddress <- block.Address
             downloadUriParameters.StoragePoolId <- manifest.StoragePoolId
             downloadUriParameters.ManifestAddress <- manifest.ManifestAddress
@@ -1858,9 +1888,12 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(finalizeResult.ReturnValue.Session.StoragePoolId, Is.EqualTo(recordedPoolId))
             Assert.That(finalizeResult.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
 
+            let fileVersion = manifestBackedFileVersion authorizedScope payload manifest
+            let! referenceId = createReachableReferenceForManifestFile repositoryId fileVersion
+
             let wrongPoolDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters wrongPoolDownload repositoryId correlationId
-            wrongPoolDownload.AuthorizedScope <- authorizedScope
+            applyContentBlockDownloadProof wrongPoolDownload referenceId fileVersion
             wrongPoolDownload.ContentBlockAddress <- block.Address
             wrongPoolDownload.StoragePoolId <- StoragePoolRouting.repositoryDedupeStoragePoolId (Guid.Parse repositoryId)
             wrongPoolDownload.ManifestAddress <- manifest.ManifestAddress
@@ -1868,11 +1901,11 @@ type StorageManifestUploadSessionRoutes() =
             let! wrongPoolDownloadResponse = Client.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent wrongPoolDownload)
             let! wrongPoolDownloadBody = wrongPoolDownloadResponse.Content.ReadAsStringAsync()
             Assert.That(wrongPoolDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), wrongPoolDownloadBody)
-            Assert.That(wrongPoolDownloadBody, Does.Contain("storage pool"))
+            Assert.That(wrongPoolDownloadBody, Does.Contain("observable reference-root manifest plan"))
 
             let crossRepositoryDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters crossRepositoryDownload otherRepositoryId correlationId
-            crossRepositoryDownload.AuthorizedScope <- authorizedScope
+            applyContentBlockDownloadProof crossRepositoryDownload referenceId fileVersion
             crossRepositoryDownload.ContentBlockAddress <- block.Address
             crossRepositoryDownload.StoragePoolId <- recordedPoolId
             crossRepositoryDownload.ManifestAddress <- manifest.ManifestAddress
@@ -1880,11 +1913,11 @@ type StorageManifestUploadSessionRoutes() =
             let! crossRepositoryDownloadResponse = Client.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent crossRepositoryDownload)
             let! crossRepositoryDownloadBody = crossRepositoryDownloadResponse.Content.ReadAsStringAsync()
             Assert.That(crossRepositoryDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), crossRepositoryDownloadBody)
-            Assert.That(crossRepositoryDownloadBody, Does.Contain("repository, storage pool, and authorized scope"))
+            Assert.That(crossRepositoryDownloadBody, Does.Contain("not found in an observable reference"))
 
             let correctDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters correctDownload repositoryId correlationId
-            correctDownload.AuthorizedScope <- authorizedScope
+            applyContentBlockDownloadProof correctDownload referenceId fileVersion
             correctDownload.ContentBlockAddress <- block.Address
             correctDownload.StoragePoolId <- recordedPoolId
             correctDownload.ManifestAddress <- manifest.ManifestAddress
@@ -1967,6 +2000,9 @@ type StorageManifestUploadSessionRoutes() =
 
             Assert.That(firstFinalize.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some firstManifest.ManifestAddress))
             Assert.That(firstFinalize.ReturnValue.Session.StoragePoolId, Is.EqualTo(sharedStoragePoolId))
+
+            let firstFileVersion = manifestBackedFileVersion firstScope payload firstManifest
+            let! firstReferenceId = createReachableReferenceForManifestFile firstRepositoryId firstFileVersion
 
             let! discovery = discoverContentBlocks secondRepositoryId block
             let candidates = discovery.ReturnValue.CandidateContentBlocks
@@ -2072,12 +2108,15 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(secondFinalize.ReturnValue.Session.ConfirmedBlockUploads, Is.Empty)
             Assert.That(secondFinalize.ReturnValue.Session.ClaimedReuseRanges, Has.Length.EqualTo(1))
 
+            let secondFileVersion = manifestBackedFileVersion secondScope payload secondManifest
+            let! secondReferenceId = createReachableReferenceForManifestFile secondRepositoryId secondFileVersion
+
             /// Downloads block through storage test infrastructure.
-            let downloadBlock repositoryId correlationId authorizedScope manifest =
+            let downloadBlock repositoryId correlationId referenceId fileVersion manifest =
                 task {
                     let parameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
                     setStorageParameters parameters repositoryId correlationId
-                    parameters.AuthorizedScope <- authorizedScope
+                    applyContentBlockDownloadProof parameters referenceId fileVersion
                     parameters.ContentBlockAddress <- block.Address
                     parameters.StoragePoolId <- manifest.StoragePoolId
                     parameters.ManifestAddress <- manifest.ManifestAddress
@@ -2092,8 +2131,11 @@ type StorageManifestUploadSessionRoutes() =
                     return uri, downloaded
                 }
 
-            let! firstDownloadUri, firstDownloadedBlock = downloadBlock firstRepositoryId firstCorrelationId firstScope firstManifest
-            let! secondDownloadUri, secondDownloadedBlock = downloadBlock secondRepositoryId secondCorrelationId secondScope secondManifest
+            let! firstDownloadUri, firstDownloadedBlock = downloadBlock firstRepositoryId firstCorrelationId firstReferenceId firstFileVersion firstManifest
+
+            let! secondDownloadUri, secondDownloadedBlock =
+                downloadBlock secondRepositoryId secondCorrelationId secondReferenceId secondFileVersion secondManifest
+
             let firstDownloadPlacement = StoragePlacementTestHelpers.contentBlockPlacementFromUri firstDownloadUri None
             let secondDownloadPlacement = StoragePlacementTestHelpers.contentBlockPlacementFromUri secondDownloadUri None
 
@@ -2111,7 +2153,7 @@ type StorageManifestUploadSessionRoutes() =
 
             let wrongPoolDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters wrongPoolDownload secondRepositoryId secondCorrelationId
-            wrongPoolDownload.AuthorizedScope <- secondScope
+            applyContentBlockDownloadProof wrongPoolDownload secondReferenceId secondFileVersion
             wrongPoolDownload.ContentBlockAddress <- block.Address
             wrongPoolDownload.StoragePoolId <- oldRepositoryScopedPool
             wrongPoolDownload.ManifestAddress <- secondManifest.ManifestAddress
@@ -2120,7 +2162,7 @@ type StorageManifestUploadSessionRoutes() =
             let! wrongPoolBody = wrongPoolResponse.Content.ReadAsStringAsync()
 
             Assert.That(wrongPoolResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), wrongPoolBody)
-            Assert.That(wrongPoolBody, Does.Contain("storage pool"))
+            Assert.That(wrongPoolBody, Does.Contain("observable reference-root manifest plan"))
             Assert.That(wrongPoolBody, Does.Not.Contain(firstPlacement.ObjectKey))
         }
 
@@ -2254,7 +2296,7 @@ type StorageManifestUploadSessionRoutes() =
 
             let wrongPoolDownload = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters wrongPoolDownload repositoryId correlationId
-            wrongPoolDownload.AuthorizedScope <- authorizedScope
+            applyContentBlockDownloadProof wrongPoolDownload savedBranch.LatestSave.ReferenceId manifestFileVersion
             wrongPoolDownload.ContentBlockAddress <- firstBlock.Address
             wrongPoolDownload.StoragePoolId <- StoragePoolRouting.repositoryDedupeStoragePoolId (Guid.Parse repositoryId)
             wrongPoolDownload.ManifestAddress <- manifest.ManifestAddress
@@ -2262,7 +2304,7 @@ type StorageManifestUploadSessionRoutes() =
             let! wrongPoolDownloadResponse = Client.PostAsync("/storage/getContentBlockDownloadUri", createJsonContent wrongPoolDownload)
             let! wrongPoolDownloadBody = wrongPoolDownloadResponse.Content.ReadAsStringAsync()
             Assert.That(wrongPoolDownloadResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), wrongPoolDownloadBody)
-            Assert.That(wrongPoolDownloadBody, Does.Contain("storage pool"))
+            Assert.That(wrongPoolDownloadBody, Does.Contain("observable reference-root manifest plan"))
 
             let! downloadUri = getManifestFileDownloadUri repositoryId correlationId savedBranch.LatestSave.ReferenceId manifestFileVersion
             let! downloadedPayload = downloadFileWithSas downloadUri
@@ -3042,8 +3084,12 @@ type StorageManifestUploadSessionRoutes() =
             Assert.That(finalizeResult.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some manifest.ManifestAddress))
             Assert.That(finalizeResult.ReturnValue.Session.AuthorizedScope, Is.EqualTo(pathB))
 
+            let visibleFileVersion = manifestBackedFileVersion pathB payload manifest
+            let! visibleReferenceId = createReachableReferenceForManifestFile repositoryId visibleFileVersion
+
             let downloadUriParameters = Parameters.Storage.GetContentBlockDownloadUriParameters()
             setStorageParameters downloadUriParameters repositoryId correlationId
+            applyContentBlockDownloadProof downloadUriParameters visibleReferenceId visibleFileVersion
             downloadUriParameters.AuthorizedScope <- pathA
             downloadUriParameters.ContentBlockAddress <- block.Address
             downloadUriParameters.StoragePoolId <- manifest.StoragePoolId
@@ -3054,7 +3100,7 @@ type StorageManifestUploadSessionRoutes() =
             let! downloadUriBody = downloadUriResponse.Content.ReadAsStringAsync()
             Assert.That(downloadUriResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), downloadUriBody)
             assertJsonContent downloadUriResponse
-            Assert.That(downloadUriBody, Does.Contain("authorized scope"))
+            Assert.That(downloadUriBody, Does.Contain("observable reference"))
             Assert.That(downloadUriBody, Does.Not.Contain("cas/content/"))
         }
 

--- a/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs
@@ -1072,8 +1072,18 @@ type StorageContentBlockSdkContract() =
 
         Assert.That(storageServerSource, Does.Contain("StoragePoolId = storagePoolId"))
         Assert.That(storageServerSource, Does.Contain("parameters.StoragePoolId"))
-        Assert.That(storageServerSource, Does.Contain("validateManifestForContentBlockDownload repositoryId parameters"))
+        Assert.That(storageServerSource, Does.Contain("validateReachableContentBlockDownloadPlan context repositoryId parameters correlationId"))
+        Assert.That(storageServerSource, Does.Contain("tryResolveContentBlockDownloadStoragePlacement repositoryId parameters correlationId"))
         Assert.That(storageServerSource, Does.Contain("DedupeIndex.discover storagePoolId"))
+
+        let planValidation =
+            compactedSource.IndexOf("validateReachableContentBlockDownloadPlan context repositoryId parameters correlationId", StringComparison.Ordinal)
+
+        let placementLookup =
+            compactedSource.IndexOf("tryResolveContentBlockDownloadStoragePlacement repositoryId parameters correlationId", StringComparison.Ordinal)
+
+        Assert.That(planValidation, Is.GreaterThanOrEqualTo(0))
+        Assert.That(placementLookup, Is.GreaterThan(planValidation))
 
     /// Verifies that discover Content Blocks Validates Repository Before Resolving Shared Dedupe Pool.
     [<Test>]

--- a/src/Grace.Server/Storage.Server.fs
+++ b/src/Grace.Server/Storage.Server.fs
@@ -1491,39 +1491,46 @@ module Storage =
     let internal tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId authorizedScope manifestAddress contentBlockAddress state =
         DedupeIndex.tryFindFinalizedScopedContentBlockMetadata storagePoolId repositoryId authorizedScope manifestAddress contentBlockAddress state
 
-    /// Validates validate manifest for content block download inputs before server processing continues.
-    let private validateManifestForContentBlockDownload repositoryId (parameters: GetContentBlockDownloadUriParameters) correlationId =
-        task {
-            if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
-                return Error(GraceError.Create "AuthorizedScope is required for ContentBlock manifest download authorization." correlationId)
-            else
-                match validateManifestAddress correlationId parameters.ManifestAddress with
-                | Error error -> return Error error
-                | Ok () ->
-                    if String.IsNullOrWhiteSpace parameters.StoragePoolId then
-                        return Error(GraceError.Create "StoragePoolId is required for ContentBlock manifest download authorization." correlationId)
-                    else
-                        let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
+    /// Validates the public ContentBlock download proof tuple before reachability lookup or cache read-through.
+    let private validateContentBlockDownloadRequestShape (parameters: GetContentBlockDownloadUriParameters) correlationId =
+        if String.IsNullOrWhiteSpace parameters.AuthorizedScope then
+            Error(GraceError.Create "AuthorizedScope is required for ContentBlock manifest download authorization." correlationId)
+        elif parameters.ReferenceId = ReferenceId.Empty then
+            Error(GraceError.Create "ReferenceId is required for ContentBlock manifest download authorization." correlationId)
+        elif
+            String.IsNullOrWhiteSpace(string parameters.Sha256Hash)
+            && String.IsNullOrWhiteSpace(string parameters.Blake3Hash)
+        then
+            Error(GraceError.Create "Sha256Hash or Blake3Hash is required for ContentBlock manifest download authorization." correlationId)
+        elif String.IsNullOrWhiteSpace parameters.StoragePoolId then
+            Error(GraceError.Create "StoragePoolId is required for ContentBlock manifest download authorization." correlationId)
+        else
+            validateManifestAddress correlationId parameters.ManifestAddress
 
-                        match!
-                            dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata
-                                (
-                                    parameters.StoragePoolId,
-                                    repositoryId,
-                                    parameters.AuthorizedScope,
-                                    parameters.ManifestAddress,
-                                    parameters.ContentBlockAddress,
-                                    correlationId
-                                )
-                            with
-                        | Some metadata -> return Ok metadata.StoragePlacement
-                        | None ->
-                            return
-                                Error(
-                                    GraceError.Create
-                                        $"ContentBlockAddress {parameters.ContentBlockAddress} is not referenced by finalized metadata reachable from this repository, storage pool, and authorized scope."
-                                        correlationId
-                                )
+    /// Resolves finalized ContentBlock placement only after request shape and visible-root proof have passed.
+    let private tryResolveContentBlockDownloadStoragePlacement repositoryId (parameters: GetContentBlockDownloadUriParameters) correlationId =
+        task {
+            let dedupeIndexActor = DedupeIndexActor.CreateActorProxy correlationId
+
+            match!
+                dedupeIndexActor.TryGetFinalizedScopedContentBlockMetadata
+                    (
+                        parameters.StoragePoolId,
+                        repositoryId,
+                        parameters.AuthorizedScope,
+                        parameters.ManifestAddress,
+                        parameters.ContentBlockAddress,
+                        correlationId
+                    )
+                with
+            | Some metadata -> return Ok metadata.StoragePlacement
+            | None ->
+                return
+                    Error(
+                        GraceError.Create
+                            $"ContentBlockAddress {parameters.ContentBlockAddress} is not referenced by finalized metadata reachable from this repository, storage pool, and authorized scope."
+                            correlationId
+                    )
         }
 
     /// Identifies a rejected whole-file download request before reachability lookup.
@@ -1572,7 +1579,46 @@ module Storage =
             String.IsNullOrWhiteSpace requestedBlake3Hash
             || String.Equals(string fileVersion.Blake3Hash, requestedBlake3Hash, StringComparison.Ordinal)
 
-        pathMatches && shaMatches && blake3Matches
+        not (String.IsNullOrWhiteSpace requestedPath)
+        && pathMatches
+        && shaMatches
+        && blake3Matches
+
+    /// Checks whether a manifest-backed FileVersion carries the requested manifest and block membership.
+    let private fileVersionIncludesRequestedContentBlock (parameters: GetContentBlockDownloadUriParameters) (fileVersion: FileVersion) =
+        if
+            isNull (box fileVersion.ContentReference)
+            || fileVersion.ContentReference.ReferenceType
+               <> FileContentReferenceType.FileManifest
+        then
+            false
+        else
+            match fileVersion.ContentReference.Manifest with
+            | None -> false
+            | Some manifest ->
+                manifest.StoragePoolId = parameters.StoragePoolId
+                && manifest.ManifestAddress = parameters.ManifestAddress
+                && not (isNull manifest.Blocks)
+                && manifest.Blocks
+                   |> Seq.exists (fun block ->
+                       not (isNull (box block))
+                       && block.Address = parameters.ContentBlockAddress)
+
+    /// Resolves the FileVersion proof tuple used by ContentBlock read-through routes.
+    let private contentBlockDownloadProof (parameters: GetContentBlockDownloadUriParameters) =
+        let proof = GetDownloadUriParameters()
+        proof.OwnerId <- parameters.OwnerId
+        proof.OwnerName <- parameters.OwnerName
+        proof.OrganizationId <- parameters.OrganizationId
+        proof.OrganizationName <- parameters.OrganizationName
+        proof.RepositoryId <- parameters.RepositoryId
+        proof.RepositoryName <- parameters.RepositoryName
+        proof.ReferenceId <- parameters.ReferenceId
+        proof.RelativePath <- parameters.AuthorizedScope
+        proof.Sha256Hash <- parameters.Sha256Hash
+        proof.Blake3Hash <- parameters.Blake3Hash
+        proof.CorrelationId <- parameters.CorrelationId
+        proof
 
     /// Resolves a FileVersion only when the requested reference is observable and its root tree reaches the file proof.
     let private tryResolveReachableFileVersionForDownload (context: HttpContext) repositoryId (parameters: GetDownloadUriParameters) correlationId =
@@ -1600,6 +1646,28 @@ module Storage =
                         recursiveDirectoryVersions
                         |> Seq.collect (fun directoryVersionDto -> directoryVersionDto.DirectoryVersion.Files)
                         |> Seq.tryFind (fileVersionMatchesDownloadProof parameters)
+        }
+
+    /// Revalidates the visible reference root before ContentBlock read-through can mint a SAS URI.
+    let private validateReachableContentBlockDownloadPlan context repositoryId (parameters: GetContentBlockDownloadUriParameters) correlationId =
+        task {
+            let proof = contentBlockDownloadProof parameters
+
+            match validateWholeFileDownloadRequest proof correlationId with
+            | Invalid error -> return Error error
+            | Valid ->
+                let! reachableFileVersion = tryResolveReachableFileVersionForDownload context repositoryId proof correlationId
+
+                match reachableFileVersion with
+                | None -> return Error(GraceError.Create "ContentBlock manifest download target was not found in an observable reference." correlationId)
+                | Some fileVersion when fileVersionIncludesRequestedContentBlock parameters fileVersion -> return Ok()
+                | Some _ ->
+                    return
+                        Error(
+                            GraceError.Create
+                                "ContentBlock manifest download target is not a member of the observable reference-root manifest plan."
+                                correlationId
+                        )
         }
 
     /// Gets a download URI for a reachable file proof that can be used by a Grace client.
@@ -1725,14 +1793,20 @@ module Storage =
                         parameters.ContentBlockAddress <- normalizedContentBlockAddress
                         let _, repositoryId = resolveStorageIds graceIds parameters
 
-                        match! validateManifestForContentBlockDownload repositoryId parameters correlationId with
+                        match validateContentBlockDownloadRequestShape parameters correlationId with
                         | Error error -> return! context |> result400BadRequest error
-                        | Ok storagePlacement ->
-                            match! createAzureContentBlockSasUriForPlacement storagePlacement azureBlobReadPermissions correlationId with
+                        | Ok () ->
+                            match! validateReachableContentBlockDownloadPlan context repositoryId parameters correlationId with
                             | Error error -> return! context |> result400BadRequest error
-                            | Ok downloadUri ->
-                                context.SetStatusCode StatusCodes.Status200OK
-                                return! context.WriteStringAsync downloadUri.AbsoluteUri
+                            | Ok () ->
+                                match! tryResolveContentBlockDownloadStoragePlacement repositoryId parameters correlationId with
+                                | Error error -> return! context |> result400BadRequest error
+                                | Ok storagePlacement ->
+                                    match! createAzureContentBlockSasUriForPlacement storagePlacement azureBlobReadPermissions correlationId with
+                                    | Error error -> return! context |> result400BadRequest error
+                                    | Ok downloadUri ->
+                                        context.SetStatusCode StatusCodes.Status200OK
+                                        return! context.WriteStringAsync downloadUri.AbsoluteUri
                 with
                 | ex ->
                     context.SetStatusCode StatusCodes.Status500InternalServerError

--- a/src/Grace.Shared/Parameters/Storage.Parameters.fs
+++ b/src/Grace.Shared/Parameters/Storage.Parameters.fs
@@ -75,7 +75,10 @@ module Storage =
     /// Represents get content block download uri parameters.
     type GetContentBlockDownloadUriParameters() =
         inherit StorageParameters()
+        member val public ReferenceId: ReferenceId = ReferenceId.Empty with get, set
         member val public AuthorizedScope: RelativePath = String.Empty with get, set
+        member val public Sha256Hash: Sha256Hash = String.Empty with get, set
+        member val public Blake3Hash: Blake3Hash = String.Empty with get, set
         member val public StoragePoolId: StoragePoolId = String.Empty with get, set
         member val public ContentBlockAddress: ContentBlockAddress = String.Empty with get, set
         member val public ManifestAddress: ManifestAddress = String.Empty with get, set

--- a/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.3.1.2.yaml
@@ -4421,19 +4421,41 @@ components:
         AuthorizedScope:
           $ref: '#/components/schemas/RelativePath'
     GetContentBlockDownloadUriParameters:
-      description: Parameters for /storage/getContentBlockDownloadUri. The request carries the server-accepted StoragePoolId, ManifestAddress, and one ContentBlockAddress for an authorized manifest-backed reconstruction path. It must not embed the full FileManifest for every block request.
+      description: Parameters for /storage/getContentBlockDownloadUri. The request identifies an observable reference, authorized file path, file hash proof, server-accepted StoragePoolId and ManifestAddress, and one ContentBlockAddress for an authorized manifest-backed reconstruction path. It must not embed the full FileManifest for every block request, and raw content block or manifest addresses are not accepted as authorization by themselves. At least one of Sha256Hash or Blake3Hash is required; the server enforces that proof requirement as request validation.
       allOf:
         - $ref: '#/components/schemas/StorageParameters'
       type: object
+      if:
+        not:
+          required:
+            - Sha256Hash
+      then:
+        required:
+          - Blake3Hash
+      x-grace-required-one-of:
+        - Sha256Hash
+        - Blake3Hash
       properties:
+        ReferenceId:
+          $ref: '#/components/schemas/ReferenceId'
         AuthorizedScope:
           $ref: '#/components/schemas/RelativePath'
+        Sha256Hash:
+          $ref: '#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: '#/components/schemas/Blake3Hash'
         StoragePoolId:
           $ref: '#/components/schemas/StoragePoolId'
         ContentBlockAddress:
           $ref: '#/components/schemas/ContentBlockAddress'
         ManifestAddress:
           $ref: '#/components/schemas/ManifestAddress'
+      required:
+        - ReferenceId
+        - AuthorizedScope
+        - StoragePoolId
+        - ContentBlockAddress
+        - ManifestAddress
     DiscoverContentBlocksParameters:
       description: Parameters for /storage/discoverContentBlocks. Discovery is bounded and non-authoritative; empty results do not prove that chunks or future ContentBlocks are absent.
       allOf:
@@ -4589,7 +4611,7 @@ components:
         - WasIdempotentReplay
         - Message
     FileManifest:
-      description: Server-accepted reconstruction contract for one manifest-backed file. StoragePoolId is placement evidence selected by Grace Server, not authority for a client to choose physical storage shards.
+      description: Server-accepted reconstruction contract for one manifest-backed file. StoragePoolId is placement evidence selected by Grace Server, not a publication right for a client to choose physical storage shards.
       type: object
       properties:
         Class:
@@ -4657,7 +4679,7 @@ components:
       type: string
       pattern: ^[a-f0-9]{64}$
     StoragePoolId:
-      description: StoragePool-wide CAS scope identifier. Public clients treat this as server-provided placement evidence and must not use it to select storage accounts, containers, buckets, prefixes, or write authority directly.
+      description: StoragePool-wide CAS scope identifier. Public clients treat this as server-provided placement evidence and must not use it to select storage accounts, containers, buckets, prefixes, or write authorization directly.
       type: string
     ChunkingSuiteId:
       description: Versioned chunking suite identifier.

--- a/src/OpenAPI/Grace.OpenAPI.yaml
+++ b/src/OpenAPI/Grace.OpenAPI.yaml
@@ -4421,19 +4421,41 @@ components:
         AuthorizedScope:
           $ref: '#/components/schemas/RelativePath'
     GetContentBlockDownloadUriParameters:
-      description: Parameters for /storage/getContentBlockDownloadUri. The request carries the server-accepted StoragePoolId, ManifestAddress, and one ContentBlockAddress for an authorized manifest-backed reconstruction path. It must not embed the full FileManifest for every block request.
+      description: Parameters for /storage/getContentBlockDownloadUri. The request identifies an observable reference, authorized file path, file hash proof, server-accepted StoragePoolId and ManifestAddress, and one ContentBlockAddress for an authorized manifest-backed reconstruction path. It must not embed the full FileManifest for every block request, and raw content block or manifest addresses are not accepted as authorization by themselves. At least one of Sha256Hash or Blake3Hash is required; the server enforces that proof requirement as request validation.
       allOf:
         - $ref: '#/components/schemas/StorageParameters'
       type: object
+      if:
+        not:
+          required:
+            - Sha256Hash
+      then:
+        required:
+          - Blake3Hash
+      x-grace-required-one-of:
+        - Sha256Hash
+        - Blake3Hash
       properties:
+        ReferenceId:
+          $ref: '#/components/schemas/ReferenceId'
         AuthorizedScope:
           $ref: '#/components/schemas/RelativePath'
+        Sha256Hash:
+          $ref: '#/components/schemas/Sha256Hash'
+        Blake3Hash:
+          $ref: '#/components/schemas/Blake3Hash'
         StoragePoolId:
           $ref: '#/components/schemas/StoragePoolId'
         ContentBlockAddress:
           $ref: '#/components/schemas/ContentBlockAddress'
         ManifestAddress:
           $ref: '#/components/schemas/ManifestAddress'
+      required:
+        - ReferenceId
+        - AuthorizedScope
+        - StoragePoolId
+        - ContentBlockAddress
+        - ManifestAddress
     DiscoverContentBlocksParameters:
       description: Parameters for /storage/discoverContentBlocks. Discovery is bounded and non-authoritative; empty results do not prove that chunks or future ContentBlocks are absent.
       allOf:
@@ -4589,7 +4611,7 @@ components:
         - WasIdempotentReplay
         - Message
     FileManifest:
-      description: Server-accepted reconstruction contract for one manifest-backed file. StoragePoolId is placement evidence selected by Grace Server, not authority for a client to choose physical storage shards.
+      description: Server-accepted reconstruction contract for one manifest-backed file. StoragePoolId is placement evidence selected by Grace Server, not a publication right for a client to choose physical storage shards.
       type: object
       properties:
         Class:
@@ -4657,7 +4679,7 @@ components:
       type: string
       pattern: ^[a-f0-9]{64}$
     StoragePoolId:
-      description: StoragePool-wide CAS scope identifier. Public clients treat this as server-provided placement evidence and must not use it to select storage accounts, containers, buckets, prefixes, or write authority directly.
+      description: StoragePool-wide CAS scope identifier. Public clients treat this as server-provided placement evidence and must not use it to select storage accounts, containers, buckets, prefixes, or write authorization directly.
       type: string
     ChunkingSuiteId:
       description: Versioned chunking suite identifier.

--- a/src/OpenAPI/OpenAPI.ProofManifest.json
+++ b/src/OpenAPI/OpenAPI.ProofManifest.json
@@ -85,7 +85,7 @@
     },
     {
       "path": "Storage.Components.OpenAPI.yaml",
-      "sha256": "1fe4bb440e36b518d31e28d82f9a50ba77f33955de4ce4e35bbf7f215eac9fc2"
+      "sha256": "d090f2db3e281dcd8b6392d80604717786f36ecf0a2d55a6c8549278646f12c8"
     },
     {
       "path": "Storage.Paths.OpenAPI.yaml",
@@ -108,26 +108,26 @@
     {
       "path": "Grace.OpenAPI.yaml",
       "kind": "canonical-bundle",
-      "sourceDigest": "0fff7906181bad98f7ded1d2fd7b3c0f6e7cd31e61a962d027ac6dcc571fe088",
+      "sourceDigest": "6e2959deb3d1b527ab839a29c5dca573ef2afb86c33bb086712da7ced2f7aeb2",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
-      "sha256": "fc22d85474448b3a07d28f58d0635bcf48f341a5a852981e83f2f7473e135360"
+      "sha256": "c66b1820aefcc50c7315bab8f26d5f906eb8701fd00989b250daa9c5b3947b62"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.yaml",
       "kind": "generator-projection",
-      "sourceDigest": "0fff7906181bad98f7ded1d2fd7b3c0f6e7cd31e61a962d027ac6dcc571fe088",
+      "sourceDigest": "6e2959deb3d1b527ab839a29c5dca573ef2afb86c33bb086712da7ced2f7aeb2",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",
       "lossReport": "Grace.OpenAPI.3.1.2.loss-report.json",
-      "sha256": "1b25d06030c3a98c166a784a4b05a6d0e79234d3a0b523695f7da2dda7c43199"
+      "sha256": "4f1344ae53132bb3cc6910ff408f7f5e73f9317f8612586dd73ee3eabc052cce"
     },
     {
       "path": "Grace.OpenAPI.3.1.2.loss-report.json",
       "kind": "projection-loss-report",
-      "sourceDigest": "0fff7906181bad98f7ded1d2fd7b3c0f6e7cd31e61a962d027ac6dcc571fe088",
+      "sourceDigest": "6e2959deb3d1b527ab839a29c5dca573ef2afb86c33bb086712da7ced2f7aeb2",
       "generator": "@redocly/cli",
       "generatorVersion": "2.31.6",
       "command": "pwsh ./src/OpenAPI/generate-openapi-projections.ps1",

--- a/src/OpenAPI/Storage.Components.OpenAPI.yaml
+++ b/src/OpenAPI/Storage.Components.OpenAPI.yaml
@@ -98,21 +98,45 @@ GetContentBlockUploadUriParameters:
 
 GetContentBlockDownloadUriParameters:
   description: >-
-    Parameters for /storage/getContentBlockDownloadUri. The request carries the server-accepted StoragePoolId,
-    ManifestAddress, and one ContentBlockAddress for an authorized manifest-backed reconstruction path. It must not
-    embed the full FileManifest for every block request.
+    Parameters for /storage/getContentBlockDownloadUri. The request identifies an observable reference, authorized file
+    path, file hash proof, server-accepted StoragePoolId and ManifestAddress, and one ContentBlockAddress for an
+    authorized manifest-backed reconstruction path. It must not embed the full FileManifest for every block request, and
+    raw content block or manifest addresses are not accepted as authorization by themselves. At least one of Sha256Hash or
+    Blake3Hash is required; the server enforces that proof requirement as request validation.
   allOf:
     - $ref: '#/StorageParameters'
   type: object
+  if:
+    not:
+      required:
+        - Sha256Hash
+  then:
+    required:
+      - Blake3Hash
+  x-grace-required-one-of:
+    - Sha256Hash
+    - Blake3Hash
   properties:
+    ReferenceId:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/ReferenceId'
     AuthorizedScope:
       $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/RelativePath'
+    Sha256Hash:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Sha256Hash'
+    Blake3Hash:
+      $ref: 'Shared.Components.OpenAPI.yaml#/components/schemas/Blake3Hash'
     StoragePoolId:
       $ref: '#/StoragePoolId'
     ContentBlockAddress:
       $ref: '#/ContentBlockAddress'
     ManifestAddress:
       $ref: '#/ManifestAddress'
+  required:
+    - ReferenceId
+    - AuthorizedScope
+    - StoragePoolId
+    - ContentBlockAddress
+    - ManifestAddress
 
 DiscoverContentBlocksParameters:
   description: >-
@@ -910,7 +934,7 @@ FinalizeManifestBlockPayload:
 FileManifest:
   description: >-
     Server-accepted reconstruction contract for one manifest-backed file. StoragePoolId is placement evidence selected
-    by Grace Server, not authority for a client to choose physical storage shards.
+    by Grace Server, not a publication right for a client to choose physical storage shards.
   type: object
   properties:
     Class:
@@ -986,7 +1010,7 @@ FileContentHash:
 StoragePoolId:
   description: >-
     StoragePool-wide CAS scope identifier. Public clients treat this as server-provided placement evidence and must not
-    use it to select storage accounts, containers, buckets, prefixes, or write authority directly.
+    use it to select storage accounts, containers, buckets, prefixes, or write authorization directly.
   type: string
 
 ChunkingSuiteId:


### PR DESCRIPTION
Related to #650.

## Why This Matters

Materialization and content-block read-through can mint storage download URIs from durable object addresses. This slice keeps those addresses from becoming standalone capabilities by requiring the request to prove a visible reference root and manifest-backed file path before the server looks up finalized storage placement or issues a SAS URL.

## Summary

- Added visible-root request proof to content-block download URI parameters: reference id, relative path, and manifest hash proof travel with the manifest block request.
- Updated `/storage/getContentBlockDownloadUri` so it validates request shape, re-reads reference visibility, confirms the requested file is reachable through the supplied reference/path/hash, validates manifest/block membership, and only then looks up finalized storage placement.
- Propagated the new request proof through SDK manifest download and CLI object-storage manifest download flows.
- Refreshed the OpenAPI storage component, projected OpenAPI bundles, and proof manifest for the changed public request shape.
- Recorded source-search waivers in the handoff for absent future `/cache`, materialization-plan, raw plan-item, and zip-projection routes.

## Owned Paths

- `src/Grace.Shared/Parameters/Storage.Parameters.fs`
- `src/Grace.Server/Storage.Server.fs`
- `src/Grace.SDK/ManifestDownload.SDK.fs`
- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.Server.Tests/Storage.Server.Tests.fs`
- `src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs`
- `src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs`
- `src/OpenAPI/Storage.Components.OpenAPI.yaml`
- `src/OpenAPI/Grace.OpenAPI.yaml`
- `src/OpenAPI/Grace.OpenAPI.3.1.2.yaml`
- `src/OpenAPI/OpenAPI.ProofManifest.json`

## Validation

- `dotnet tool run fantomas src/Grace.Shared/Parameters/Storage.Parameters.fs src/Grace.Server/Storage.Server.fs src/Grace.SDK/ManifestDownload.SDK.fs src/Grace.CLI/Command/Services.CLI.fs src/Grace.Server.Tests/Storage.Server.Tests.fs src/Grace.CLI.Tests/ManifestDownload.SDK.Tests.fs`: passed.
- `dotnet tool run fantomas src/Grace.Server.Unit.Tests/Storage.Server.Tests.fs`: passed.
- `dotnet build --configuration Release src/Grace.slnx`: passed, 0 warnings, 0 errors.
- `dotnet test --no-build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter FullyQualifiedName~ManifestDownload`: passed, 9 tests.
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter FullyQualifiedName~ContentBlockDownloadUri`: passed, 6 tests.
- `dotnet test --no-build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~UploadSessionBackedSasUsesRecordedSessionPoolRoute`: passed, 1 test.
- `pwsh ./src/OpenAPI/generate-openapi-projections.ps1`: passed.
- `pwsh ./src/OpenAPI/prove-openapi.ps1`: OpenAPI freshness passed after generation; the script still exits nonzero on existing pending quality gates, generated-client matrix evidence deferred to #651, SDK package proof, and protocol vector proof.
- `dotnet test --no-build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter FullyQualifiedName~DirectoryHashResolutionUsesVisibleCandidateSubsetOnly`: passed, 1 test after one unrelated broad-run hash-prefix collision.
- `pwsh ./scripts/validate.ps1 -Full`: passed cleanly after the proof-manifest update.
- `git diff --check`: passed.

## Docs And Deferred Work

- No user-facing docs changed; the public contract propagation is the OpenAPI request schema and projected bundles.
- Generated-client matrix refresh remains queued for #651 by issue boundary. This PR updates the standard OpenAPI contract and proof manifest but does not regenerate SDK clients.

## Review Status

- Head commit: `37f067a611f6ef1558d509ffeea35953df890d47`
- CI: `full` passed on GitHub Actions run `28980761420`, job `85998761768`.
- Codex Code Review Bot: 👍🏻 no-issues signal on the current head at `2026-07-08T22:47:41Z`; no bot review comments or review threads were created.
- Manual trigger: not attempted. The bot acknowledged the head with 👀 and then returned 👍🏻, so the manual trigger path remained locked out.
- Final no-issues bot result: satisfied for the current head.
