### PR TITLE
GC-09: Prove Direct materialization retry behavior

### DIFF
--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -84,15 +84,21 @@ docs-only classification with current evidence for the behavior they own.
 
 ### Direct Materialization
 
-- Implementation seam: client and server path that bypasses Grace Cache and reads from Grace Server
-  or storage through the existing authorized materialization flow.
-- Proof seam: focused tests or validation that show Direct mode does not require Grace Cache
-  registration, cache rows, or ContentAccessGrant validation.
-- Status classification: `not applicable` to this docs-only scaffold.
-- Issue or PR evidence: #609 creates the audit slot; the owning implementation issue or PR must add
-  the current proof before claiming Direct support.
-- Residual risk or rationale: Direct must remain a first-class non-cache path, not an accidental
-  fallback from failed CacheRequired behavior.
+- Implementation seam: `grace connect` requests `MaterializationExecutionMode.Direct` with
+  `MaterializationCacheSelection.Bypass`, downloads the planned DirectUri recursive metadata and
+  DirectoryVersion zip artifacts, validates descriptor/root/integrity evidence, stages extraction,
+  then writes the working tree, local status, and object-cache rows only after validation passes.
+- Proof seam: `Grace.CLI.Tests.ConnectTests` covers Direct plan shape, root consistency rejection,
+  delivered-artifact integrity, staged extraction before local state writes, retry-once behavior for
+  retryable artifact-source failures, no retry for permanent root mismatch, and byte equality for
+  manifest-backed plus whole-file materialization.
+- Status classification: `implemented and proven`.
+- Issue or PR evidence: #616 adds the Direct retry, negative consistency, manifest-backed byte
+  equivalence, object-cache regression, and `pwsh ./scripts/validate.ps1 -Fast` evidence for the
+  tracer branch.
+- Residual risk or rationale: OpenAPI/static contract propagation for the previous Runtime
+  `ReferenceType` decision is deferred to #687; this row only claims the Direct tracer behavior and
+  does not claim CachePreferred or CacheRequired support.
 
 ### CachePreferred Materialization
 

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -247,6 +247,39 @@ module ConnectTests =
 
         override _.Dispose(disposing: bool) = ()
 
+    /// Extracts the Grace error carried by DirectUri copy failure classifiers.
+    let private directUriCopyFailureError =
+        function
+        | Connect.DirectUriDeliveredSizeValidationFailure error
+        | Connect.DirectUriTransferFailure error -> error
+
+    /// Runs a DirectUri copy failure through the production retry-boundary classifiers.
+    let private executeDirectRetryAfterCopyFailure copyFailure =
+        let requestedPlans = ResizeArray<int>()
+
+        let requestPlan () =
+            task {
+                let planId = requestedPlans.Count + 1
+                requestedPlans.Add(planId)
+                return Ok planId
+            }
+
+        let executePlan _ =
+            task {
+                return
+                    Error(
+                        copyFailure
+                        |> Connect.directUriCopyFailureToFetchFailure
+                        |> Connect.directUriFetchFailureToExecutionError
+                    )
+            }
+
+        let result =
+            Connect.executeDirectPlanWithRetryOnce "correlation-id" requestPlan executePlan
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        result, requestedPlans
+
     /// Builds a manifest-backed FileVersion whose bytes are delivered through the Direct zip projection.
     let private manifestBackedFileVersion relativePath (payload: byte array) =
         let block = ContentBlock.Create(ContentBlockAddress(String.replicate 64 "c"), 0L, int64 payload.Length)
@@ -367,6 +400,64 @@ module ConnectTests =
                     error.Error |> should contain "target root"
                     requestedPlans |> should equal [ 1 ])
             )
+
+    /// Verifies that an oversized DirectUri Content-Length is a permanent delivered-artifact failure, not a retry trigger.
+    [<Test>]
+    let ``connect direct plan retry does not re-request after oversized content length`` () =
+        let mutable opened = false
+
+        let copyResult =
+            Connect.copyDirectUriArtifactToTempStream "correlation-id" "DirectoryVersionZip" (Some 3L) (Some 4L) (fun () ->
+                opened <- true
+                Task.FromResult<Stream>(new MemoryStream([| 1uy; 2uy; 3uy; 4uy |])))
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match copyResult with
+        | Ok stream ->
+            stream.Dispose()
+            Assert.Fail("Expected oversized Content-Length to fail before success-looking local status could be recorded.")
+        | Error copyFailure ->
+            let result, requestedPlans = executeDirectRetryAfterCopyFailure copyFailure
+
+            match result with
+            | Ok value -> Assert.Fail($"Expected oversized Content-Length to fail permanently without retry, got {value}.")
+            | Error error ->
+                Assert.Multiple(
+                    Action (fun () ->
+                        opened |> should equal false
+
+                        error.Error
+                        |> should contain "Content-Length exceeds planned size"
+
+                        requestedPlans |> should equal [ 1 ])
+                )
+
+    /// Verifies that a DirectUri stream exceeding the planned size is permanent and cannot be masked by a fresh plan.
+    [<Test>]
+    let ``connect direct plan retry does not re-request after streamed artifact exceeds planned size`` () =
+        let payload = [| 0uy .. 9uy |]
+        let source = new NonDisposingMemoryStream(payload)
+
+        let copyResult =
+            Connect.copyDirectUriArtifactToTempStream "correlation-id" "DirectoryVersionZip" (Some 3L) None (fun () -> Task.FromResult<Stream>(source))
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match copyResult with
+        | Ok stream ->
+            stream.Dispose()
+            Assert.Fail("Expected over-limit DirectUri body to fail before success-looking local status could be recorded.")
+        | Error copyFailure ->
+            let result, requestedPlans = executeDirectRetryAfterCopyFailure copyFailure
+
+            match result with
+            | Ok value -> Assert.Fail($"Expected over-limit DirectUri body to fail permanently without retry, got {value}.")
+            | Error error ->
+                Assert.Multiple(
+                    Action (fun () ->
+                        source.Position |> should equal 4L
+                        error.Error |> should contain "size mismatch"
+                        requestedPlans |> should equal [ 1 ])
+                )
 
     /// Verifies that Direct plan requests preserve a moving reference selector for final server resolution.
     [<Test>]
@@ -801,7 +892,8 @@ module ConnectTests =
         | Ok stream ->
             stream.Dispose()
             Assert.Fail("Expected oversized Content-Length to fail before transfer.")
-        | Error error ->
+        | Error copyFailure ->
+            let error = directUriCopyFailureError copyFailure
             opened |> should equal false
 
             error.Error
@@ -821,7 +913,8 @@ module ConnectTests =
         | Ok stream ->
             stream.Dispose()
             Assert.Fail("Expected over-limit DirectUri body to fail during transfer.")
-        | Error error ->
+        | Error copyFailure ->
+            let error = directUriCopyFailureError copyFailure
             source.Position |> should equal 4L
             error.Error |> should contain "size mismatch"
 

--- a/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Connect.CLI.Tests.fs
@@ -247,6 +247,127 @@ module ConnectTests =
 
         override _.Dispose(disposing: bool) = ()
 
+    /// Builds a manifest-backed FileVersion whose bytes are delivered through the Direct zip projection.
+    let private manifestBackedFileVersion relativePath (payload: byte array) =
+        let block = ContentBlock.Create(ContentBlockAddress(String.replicate 64 "c"), 0L, int64 payload.Length)
+
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress(String.replicate 64 "d"),
+                ChunkingSuiteId "grace-test-fixed",
+                FileContentHash(String.replicate 64 "e"),
+                int64 payload.Length,
+                [ block ]
+            )
+
+        let fileVersion =
+            FileVersion.CreateWithHashes relativePath (computeSha256Hash payload) (computeBlake3Hash payload) String.Empty false (int64 payload.Length)
+
+        fileVersion.ContentReference <- FileContentReference.FileManifest manifest
+        fileVersion
+
+    /// Verifies that a retryable artifact-source failure requests exactly one fresh Direct plan.
+    [<Test>]
+    let ``connect direct plan retry re-requests once after retryable artifact source failure`` () =
+        let requestedPlans = ResizeArray<int>()
+        let executedPlans = ResizeArray<int>()
+
+        let requestPlan () =
+            task {
+                let planId = requestedPlans.Count + 1
+                requestedPlans.Add(planId)
+                return Ok planId
+            }
+
+        let executePlan planId =
+            task {
+                executedPlans.Add(planId)
+
+                if planId = 1 then
+                    return Error(Connect.RetryableArtifactSourceFailure(GraceError.Create "temporary DirectUri source failure" "correlation-id"))
+                else
+                    return Ok "materialized"
+            }
+
+        let result =
+            Connect.executeDirectPlanWithRetryOnce "correlation-id" requestPlan executePlan
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match result with
+        | Error error -> Assert.Fail($"Expected second fresh Direct plan to succeed, got {error.Error}.")
+        | Ok value ->
+            Assert.Multiple(
+                Action (fun () ->
+                    value |> should equal "materialized"
+                    requestedPlans |> should equal [ 1; 2 ]
+                    executedPlans |> should equal [ 1; 2 ])
+            )
+
+    /// Verifies that a second retryable artifact-source failure returns an error without broad retry looping.
+    [<Test>]
+    let ``connect direct plan retry stops after second retryable artifact source failure`` () =
+        let requestedPlans = ResizeArray<int>()
+
+        let requestPlan () =
+            task {
+                let planId = requestedPlans.Count + 1
+                requestedPlans.Add(planId)
+                return Ok planId
+            }
+
+        let executePlan planId =
+            task { return Error(Connect.RetryableArtifactSourceFailure(GraceError.Create $"temporary DirectUri source failure {planId}" "correlation-id")) }
+
+        let result =
+            Connect.executeDirectPlanWithRetryOnce "correlation-id" requestPlan executePlan
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match result with
+        | Ok value -> Assert.Fail($"Expected retryable Direct plan failures to surface after one retry, got {value}.")
+        | Error error ->
+            Assert.Multiple(
+                Action (fun () ->
+                    error.Error |> should contain "failure 2"
+                    requestedPlans |> should equal [ 1; 2 ])
+            )
+
+    /// Verifies that permanent consistency failures do not request a replacement plan that could mask root mismatches.
+    [<Test>]
+    let ``connect direct plan retry does not mask permanent root mismatch`` () =
+        let requestedPlans = ResizeArray<int>()
+
+        let requestPlan () =
+            task {
+                let planId = requestedPlans.Count + 1
+                requestedPlans.Add(planId)
+                return Ok planId
+            }
+
+        let executePlan _ =
+            task {
+                return
+                    Error(
+                        Connect.PermanentPlanFailure(
+                            GraceError.Create
+                                "Materialization Plan target root, zip represented root, and recursive metadata represented root must match."
+                                "correlation-id"
+                        )
+                    )
+            }
+
+        let result =
+            Connect.executeDirectPlanWithRetryOnce "correlation-id" requestPlan executePlan
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        match result with
+        | Ok value -> Assert.Fail($"Expected permanent root mismatch to fail without retry, got {value}.")
+        | Error error ->
+            Assert.Multiple(
+                Action (fun () ->
+                    error.Error |> should contain "target root"
+                    requestedPlans |> should equal [ 1 ])
+            )
+
     /// Verifies that Direct plan requests preserve a moving reference selector for final server resolution.
     [<Test>]
     let ``connect direct plan request preserves reference selector intent`` () =
@@ -747,9 +868,7 @@ module ConnectTests =
     let ``connect staged direct zip validation preserves existing worktree file on mismatch`` () =
         withTempDir (fun root ->
             Grace.Shared.Client.Configuration.resetConfiguration ()
-
-            Grace.Shared.Client.Configuration.Current()
-            |> ignore
+            let configuration = Grace.Shared.Client.Configuration.Current()
 
             let expectedPayload = Encoding.UTF8.GetBytes("expected materialized text")
             let stalePayload = Encoding.UTF8.GetBytes("stale materialized text")
@@ -792,7 +911,10 @@ module ConnectTests =
                         error.Error |> should contain "mismatch"
 
                         File.ReadAllText(filePath)
-                        |> should equal sentinel)
+                        |> should equal sentinel
+
+                        File.Exists(configuration.GraceStatusFile)
+                        |> should equal false)
                 ))
 
     /// Verifies that staged Direct zip validation extracts files skipped only for final worktree writes.
@@ -911,6 +1033,82 @@ module ConnectTests =
 
                         File.ReadAllBytes(objectFiles[0])
                         |> should equal payload)
+                ))
+
+    /// Verifies that Direct zip materialization writes manifest-backed and whole-file bytes exactly.
+    [<Test>]
+    let ``connect staged direct zip validation materializes manifest backed and whole file bytes`` () =
+        withTempDir (fun root ->
+            Grace.Shared.Client.Configuration.resetConfiguration ()
+            let configuration = Grace.Shared.Client.Configuration.Current()
+
+            let manifestPayload = Encoding.UTF8.GetBytes("manifest-backed materialized text")
+            let wholeFilePayload = Encoding.UTF8.GetBytes("whole-file materialized text")
+            let manifestRelativePath = RelativePath "src/manifest-backed.fs"
+            let wholeFileRelativePath = RelativePath "src/whole-file.fs"
+            let manifestPath = Path.Combine(root, string manifestRelativePath)
+            let wholeFilePath = Path.Combine(root, string wholeFileRelativePath)
+
+            let manifestFileVersion = manifestBackedFileVersion manifestRelativePath manifestPayload
+
+            let wholeFileVersion =
+                FileVersion.CreateWithHashes
+                    wholeFileRelativePath
+                    (computeSha256Hash wholeFilePayload)
+                    (computeBlake3Hash wholeFilePayload)
+                    String.Empty
+                    false
+                    (int64 wholeFilePayload.Length)
+
+            let fileVersions =
+                [|
+                    manifestFileVersion
+                    wholeFileVersion
+                |]
+
+            use zipStream =
+                new MemoryStream(
+                    zipBytesForTextEntries [ string manifestRelativePath, manifestPayload
+                                             string wholeFileRelativePath, wholeFilePayload ]
+                )
+
+            let parseResult = GraceCommand.rootCommand.Parse([| "connect" |])
+
+            let result =
+                Connect.extractValidatedZipEntries
+                    parseResult
+                    "correlation-id"
+                    (fileVersionLookup fileVersions)
+                    (HashSet<RelativePath>())
+                    fileVersions
+                    zipStream
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match result with
+            | Error error -> Assert.Fail($"Unexpected manifest-backed Direct zip materialization error: {error.Error}")
+            | Ok () ->
+                let objectFiles = Directory.GetFiles(string configuration.ObjectDirectory, "*", SearchOption.AllDirectories)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        manifestFileVersion.ContentReference.ReferenceType
+                        |> should equal FileContentReferenceType.FileManifest
+
+                        File.ReadAllBytes(manifestPath)
+                        |> should equal manifestPayload
+
+                        File.ReadAllBytes(wholeFilePath)
+                        |> should equal wholeFilePayload
+
+                        objectFiles |> should haveLength 2
+
+                        objectFiles
+                        |> Array.map File.ReadAllBytes
+                        |> should contain manifestPayload
+
+                        objectFiles
+                        |> Array.map File.ReadAllBytes
+                        |> should contain wholeFilePayload)
                 ))
 
     /// Verifies that connect executes recursive metadata from the planned artifact payload.

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -1286,6 +1286,126 @@ module Connect =
                 deleteStageRoot ()
         }
 
+    /// Classifies one Direct Materialization Plan execution failure so connect only replans retryable artifact-source faults.
+    type internal DirectPlanExecutionError =
+        | RetryableArtifactSourceFailure of GraceError
+        | PermanentPlanFailure of GraceError
+
+    /// Requests one fresh Direct plan after a retryable artifact-source failure without retrying permanent consistency failures.
+    let internal executeDirectPlanWithRetryOnce
+        correlationId
+        (requestPlan: unit -> Task<Result<'Plan, GraceError>>)
+        (executePlan: 'Plan -> Task<Result<'Result, DirectPlanExecutionError>>)
+        =
+        task {
+            let! firstPlanResult = requestPlan ()
+
+            match firstPlanResult with
+            | Error error -> return Error error
+            | Ok firstPlan ->
+                match! executePlan firstPlan with
+                | Ok result -> return Ok result
+                | Error (PermanentPlanFailure error) -> return Error error
+                | Error (RetryableArtifactSourceFailure _) ->
+                    let! retryPlanResult = requestPlan ()
+
+                    match retryPlanResult with
+                    | Error error -> return Error error
+                    | Ok retryPlan ->
+                        match! executePlan retryPlan with
+                        | Ok result -> return Ok result
+                        | Error (PermanentPlanFailure error) -> return Error error
+                        | Error (RetryableArtifactSourceFailure error) ->
+                            return Error(GraceError.Create $"Direct Materialization Plan artifact source failed after one retry: {error.Error}" correlationId)
+        }
+
+    /// Executes one planned Direct materialization without requesting replacement plans for permanent validation failures.
+    let private executeDirectMaterializationPlan parseResult (graceIds: GraceIds) (materializationPlanReturnValue: GraceReturnValue<MaterializationPlan>) =
+        task {
+            match prepareDirectPlanArtifactSources graceIds.CorrelationId materializationPlanReturnValue.ReturnValue with
+            | Error error -> return Error(PermanentPlanFailure error)
+            | Ok artifactSources ->
+                writeHumanLine parseResult $"[{Colors.Important}]Retrieving planned recursive DirectoryVersions.[/]"
+
+                match!
+                    fetchDirectUriArtifactStream
+                        graceIds.CorrelationId
+                        "RecursiveDirectoryMetadata"
+                        artifactSources.MetadataUri
+                        artifactSources.MetadataArtifact
+                    with
+                | Error error -> return Error(RetryableArtifactSourceFailure error)
+                | Ok metadataStream ->
+                    use metadataStream = metadataStream
+
+                    match! validatePlannedArtifactStream graceIds.CorrelationId "RecursiveDirectoryMetadata" artifactSources.MetadataArtifact metadataStream
+                        with
+                    | Error error -> return Error(PermanentPlanFailure error)
+                    | Ok () ->
+                        match decodeRecursiveMetadataArtifactStream graceIds.CorrelationId metadataStream with
+                        | Error error -> return Error(PermanentPlanFailure error)
+                        | Ok directoryVersionDtos ->
+                            writeHumanLine parseResult $"[{Colors.Important}]Retrieved planned recursive DirectoryVersions.[/]"
+
+                            match prepareDirectPlanExecutionArtifacts graceIds.CorrelationId materializationPlanReturnValue.ReturnValue directoryVersionDtos
+                                with
+                            | Error error -> return Error(PermanentPlanFailure error)
+                            | Ok executionArtifacts ->
+                                let force = parseResult.GetValue(Options.force)
+
+                                let! conflicts, filesToSkip = collectFileConflicts executionArtifacts.FileVersions force
+
+                                if conflicts.Count > 0 then
+                                    writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
+
+                                    if parseResult |> verbose then
+                                        conflicts
+                                        |> Seq.sort
+                                        |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
+
+                                    return
+                                        Error(
+                                            PermanentPlanFailure(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
+                                        )
+                                else
+                                    let fileVersionsByRelativePath = buildFileVersionsByRelativePath executionArtifacts.FileVersions
+
+                                    match!
+                                        fetchDirectUriArtifactStream
+                                            graceIds.CorrelationId
+                                            "DirectoryVersionZip"
+                                            executionArtifacts.ZipUri
+                                            executionArtifacts.ZipArtifact
+                                        with
+                                    | Error error -> return Error(RetryableArtifactSourceFailure error)
+                                    | Ok zipFile ->
+                                        use zipFile = zipFile
+
+                                        match! validatePlannedArtifactStream graceIds.CorrelationId "DirectoryVersionZip" executionArtifacts.ZipArtifact zipFile
+                                            with
+                                        | Error error -> return Error(PermanentPlanFailure error)
+                                        | Ok () ->
+                                            match!
+                                                extractValidatedZipEntries
+                                                    parseResult
+                                                    graceIds.CorrelationId
+                                                    fileVersionsByRelativePath
+                                                    filesToSkip
+                                                    executionArtifacts.FileVersions
+                                                    zipFile
+                                                with
+                                            | Error error -> return Error(PermanentPlanFailure error)
+                                            | Ok () ->
+                                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
+                                                let! previousGraceStatus = readGraceStatusFile ()
+                                                let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
+                                                do! writeGraceStatusFile graceStatus
+
+                                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
+                                                do! upsertObjectCache graceStatus.Index.Values
+                                                return Ok 0
+        }
+
     /// Coordinates retrieve default branch and write behavior for this CLI command path.
     let private retrieveDefaultBranchAndWrite
         (parseResult: ParseResult)
@@ -1315,85 +1435,17 @@ module Connect =
             | Error error -> return (Error error |> renderOutput parseResult)
             | Ok targetSelector ->
                 writeHumanLine parseResult $"[{Colors.Important}]Requesting Direct Materialization Plan.[/]"
-                let! materializationPlanResult = requestDirectMaterializationPlan graceIds ownerDto organizationDto repositoryDto targetSelector
-                writeHumanLine parseResult $"[{Colors.Important}]Finished requesting Direct Materialization Plan.[/]"
 
-                match materializationPlanResult with
+                let requestPlan () =
+                    task {
+                        let! result = requestDirectMaterializationPlan graceIds ownerDto organizationDto repositoryDto targetSelector
+                        writeHumanLine parseResult $"[{Colors.Important}]Finished requesting Direct Materialization Plan.[/]"
+                        return result
+                    }
+
+                match! executeDirectPlanWithRetryOnce graceIds.CorrelationId requestPlan (executeDirectMaterializationPlan parseResult graceIds) with
                 | Error error -> return (Error error |> renderOutput parseResult)
-                | Ok materializationPlanReturnValue ->
-                    match prepareDirectPlanArtifactSources graceIds.CorrelationId materializationPlanReturnValue.ReturnValue with
-                    | Error error -> return (Error error |> renderOutput parseResult)
-                    | Ok artifactSources ->
-                        writeHumanLine parseResult $"[{Colors.Important}]Retrieving planned recursive DirectoryVersions.[/]"
-
-                        match!
-                            downloadPlannedDirectUriArtifact
-                                graceIds.CorrelationId
-                                "RecursiveDirectoryMetadata"
-                                artifactSources.MetadataUri
-                                artifactSources.MetadataArtifact
-                            with
-                        | Error error -> return (Error error |> renderOutput parseResult)
-                        | Ok metadataStream ->
-                            use metadataStream = metadataStream
-
-                            match decodeRecursiveMetadataArtifactStream graceIds.CorrelationId metadataStream with
-                            | Error error -> return (Error error |> renderOutput parseResult)
-                            | Ok directoryVersionDtos ->
-                                writeHumanLine parseResult $"[{Colors.Important}]Retrieved planned recursive DirectoryVersions.[/]"
-
-                                match prepareDirectPlanExecutionArtifacts graceIds.CorrelationId materializationPlanReturnValue.ReturnValue directoryVersionDtos
-                                    with
-                                | Error error -> return (Error error |> renderOutput parseResult)
-                                | Ok executionArtifacts ->
-                                    let force = parseResult.GetValue(Options.force)
-
-                                    let! conflicts, filesToSkip = collectFileConflicts executionArtifacts.FileVersions force
-
-                                    if conflicts.Count > 0 then
-                                        writeHumanLine parseResult $"[{Colors.Error}]Found {conflicts.Count} conflicting file(s). Use --force to overwrite.[/]"
-
-                                        if parseResult |> verbose then
-                                            conflicts
-                                            |> Seq.sort
-                                            |> Seq.iter (fun conflict -> writeHumanLine parseResult $"[{Colors.Error}]{conflict}[/]")
-
-                                        return
-                                            (Error(GraceError.Create "Conflicting files exist in the working directory." graceIds.CorrelationId)
-                                             |> renderOutput parseResult)
-                                    else
-                                        let fileVersionsByRelativePath = buildFileVersionsByRelativePath executionArtifacts.FileVersions
-
-                                        match!
-                                            downloadPlannedDirectUriArtifact
-                                                graceIds.CorrelationId
-                                                "DirectoryVersionZip"
-                                                executionArtifacts.ZipUri
-                                                executionArtifacts.ZipArtifact
-                                            with
-                                        | Error error -> return (Error error |> renderOutput parseResult)
-                                        | Ok zipFile ->
-                                            use zipFile = zipFile
-
-                                            match!
-                                                extractValidatedZipEntries
-                                                    parseResult
-                                                    graceIds.CorrelationId
-                                                    fileVersionsByRelativePath
-                                                    filesToSkip
-                                                    executionArtifacts.FileVersions
-                                                    zipFile
-                                                with
-                                            | Error error -> return (Error error |> renderOutput parseResult)
-                                            | Ok () ->
-                                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Index file.[/]"
-                                                let! previousGraceStatus = readGraceStatusFile ()
-                                                let! graceStatus = createNewGraceStatusFile previousGraceStatus parseResult
-                                                do! writeGraceStatusFile graceStatus
-
-                                                writeHumanLine parseResult $"[{Colors.Important}]Creating Grace Object Cache Index file.[/]"
-                                                do! upsertObjectCache graceStatus.Index.Values
-                                                return 0
+                | Ok exitCode -> return exitCode
         }
 
     /// Routes the connect command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Connect.CLI.fs
+++ b/src/Grace.CLI/Command/Connect.CLI.fs
@@ -969,17 +969,33 @@ module Connect =
         use stream = new MemoryStream(bytes, false)
         decodeRecursiveMetadataArtifactStream correlationId stream
 
+    /// Classifies DirectUri copy failures before the plan retry gate decides whether to request a replacement plan.
+    type internal DirectUriArtifactCopyFailure =
+        | DirectUriDeliveredSizeValidationFailure of GraceError
+        | DirectUriTransferFailure of GraceError
+
+    /// Classifies DirectUri fetch failures as retryable source failures or permanent delivered-artifact validation failures.
+    type internal DirectUriArtifactFetchFailure =
+        | RetryableDirectUriArtifactSourceFailure of GraceError
+        | PermanentDirectUriDeliveredArtifactFailure of GraceError
+
+    /// Preserves delivered-size validation failures as permanent after a DirectUri response begins producing bytes.
+    let internal directUriCopyFailureToFetchFailure =
+        function
+        | DirectUriDeliveredSizeValidationFailure error -> PermanentDirectUriDeliveredArtifactFailure error
+        | DirectUriTransferFailure error -> RetryableDirectUriArtifactSourceFailure error
+
     /// Copies DirectUri artifact bytes into a temporary stream while enforcing the planned delivered-byte limit.
     let internal copyDirectUriArtifactToTempStream correlationId artifactName expectedSize contentLength (openContentStream: unit -> Task<Stream>) =
         task {
             match expectedSize, contentLength with
             | Some expectedSize, Some contentLength when contentLength > expectedSize ->
                 return
-                    Error(
-                        GraceError.Create
-                            $"Materialization Plan {artifactName} artifact Content-Length exceeds planned size. Expected at most {expectedSize} bytes, response declared {contentLength} bytes."
-                            correlationId
-                    )
+                    GraceError.Create
+                        $"Materialization Plan {artifactName} artifact Content-Length exceeds planned size. Expected at most {expectedSize} bytes, response declared {contentLength} bytes."
+                        correlationId
+                    |> DirectUriDeliveredSizeValidationFailure
+                    |> Error
             | _ ->
                 let tempFilePath = Path.Combine(Path.GetTempPath(), $"grace-direct-artifact-{Guid.NewGuid():N}.tmp")
 
@@ -1030,6 +1046,7 @@ module Connect =
                                         GraceError.Create
                                             $"Materialization Plan {artifactName} artifact size mismatch. Expected {expectedSize} bytes, received more than {expectedSize} bytes."
                                             correlationId
+                                        |> DirectUriDeliveredSizeValidationFailure
                                     )
                             | _ ->
                                 do!
@@ -1051,12 +1068,12 @@ module Connect =
                     tempFile.Dispose()
 
                     return
-                        Error(
-                            GraceError.CreateWithException
-                                ex
-                                $"Materialization Plan {artifactName} artifact download failed while writing the temporary artifact stream."
-                                correlationId
-                        )
+                        GraceError.CreateWithException
+                            ex
+                            $"Materialization Plan {artifactName} artifact download failed while writing the temporary artifact stream."
+                            correlationId
+                        |> DirectUriTransferFailure
+                        |> Error
         }
 
     /// Fetches DirectUri artifact bytes to a temporary stream without assuming a backing blob provider.
@@ -1065,10 +1082,16 @@ module Connect =
             let mutable artifactUri = Unchecked.defaultof<Uri>
 
             if not (Uri.TryCreate(uri, UriKind.Absolute, &artifactUri)) then
-                return Error(GraceError.Create $"Materialization Plan {artifactName} artifact DirectUri is not an absolute URI." correlationId)
+                return
+                    GraceError.Create $"Materialization Plan {artifactName} artifact DirectUri is not an absolute URI." correlationId
+                    |> RetryableDirectUriArtifactSourceFailure
+                    |> Error
             elif artifactUri.Scheme <> Uri.UriSchemeHttps
                  && artifactUri.Scheme <> Uri.UriSchemeHttp then
-                return Error(GraceError.Create $"Materialization Plan {artifactName} artifact DirectUri must use HTTP or HTTPS." correlationId)
+                return
+                    GraceError.Create $"Materialization Plan {artifactName} artifact DirectUri must use HTTP or HTTPS." correlationId
+                    |> RetryableDirectUriArtifactSourceFailure
+                    |> Error
             else
                 try
                     use request = new HttpRequestMessage(HttpMethod.Get, artifactUri)
@@ -1081,24 +1104,33 @@ module Connect =
                                 GraceError.Create
                                     $"Materialization Plan {artifactName} artifact download failed with HTTP status {(int response.StatusCode)}."
                                     correlationId
+                                |> RetryableDirectUriArtifactSourceFailure
                             )
                     else
                         let contentLength =
                             response.Content.Headers.ContentLength
                             |> Option.ofNullable
 
-                        return!
+                        match!
                             copyDirectUriArtifactToTempStream correlationId artifactName artifact.SizeInBytes contentLength (fun () ->
                                 response.Content.ReadAsStreamAsync())
+                            with
+                        | Ok stream -> return Ok stream
+                        | Error error -> return Error(directUriCopyFailureToFetchFailure error)
                 with
-                | ex -> return Error(GraceError.CreateWithException ex $"Materialization Plan {artifactName} artifact download failed." correlationId)
+                | ex ->
+                    return
+                        GraceError.CreateWithException ex $"Materialization Plan {artifactName} artifact download failed." correlationId
+                        |> RetryableDirectUriArtifactSourceFailure
+                        |> Error
         }
 
     /// Downloads and verifies a planned DirectUri artifact before connect extracts or writes local state.
     let private downloadPlannedDirectUriArtifact correlationId artifactName uri artifact =
         task {
             match! fetchDirectUriArtifactStream correlationId artifactName uri artifact with
-            | Error error -> return Error error
+            | Error (RetryableDirectUriArtifactSourceFailure error)
+            | Error (PermanentDirectUriDeliveredArtifactFailure error) -> return Error error
             | Ok stream ->
                 match! validatePlannedArtifactStream correlationId artifactName artifact stream with
                 | Error error ->
@@ -1291,6 +1323,12 @@ module Connect =
         | RetryableArtifactSourceFailure of GraceError
         | PermanentPlanFailure of GraceError
 
+    /// Maps DirectUri fetch failures onto the plan execution retry boundary.
+    let internal directUriFetchFailureToExecutionError =
+        function
+        | RetryableDirectUriArtifactSourceFailure error -> RetryableArtifactSourceFailure error
+        | PermanentDirectUriDeliveredArtifactFailure error -> PermanentPlanFailure error
+
     /// Requests one fresh Direct plan after a retryable artifact-source failure without retrying permanent consistency failures.
     let internal executeDirectPlanWithRetryOnce
         correlationId
@@ -1334,7 +1372,7 @@ module Connect =
                         artifactSources.MetadataUri
                         artifactSources.MetadataArtifact
                     with
-                | Error error -> return Error(RetryableArtifactSourceFailure error)
+                | Error error -> return Error(directUriFetchFailureToExecutionError error)
                 | Ok metadataStream ->
                     use metadataStream = metadataStream
 
@@ -1377,7 +1415,7 @@ module Connect =
                                             executionArtifacts.ZipUri
                                             executionArtifacts.ZipArtifact
                                         with
-                                    | Error error -> return Error(RetryableArtifactSourceFailure error)
+                                    | Error error -> return Error(directUriFetchFailureToExecutionError error)
                                     | Ok zipFile ->
                                         use zipFile = zipFile
 


### PR DESCRIPTION
## Summary

- Adds Direct materialization retry-once behavior for retryable artifact-source failures.
- Proves permanent integrity/consistency failures do not trigger a fresh plan or leave success-looking local state.
- Adds manifest-backed and whole-file byte equality proof, plus audit evidence for the Direct tracer.

## Issue Links

Related to #616.
Part of #599.
Part of #597.

## Validation

- `dotnet tool run fantomas -- C:\Source\Grace-616-direct-retry-proof\src\Grace.CLI\Command\Connect.CLI.fs C:\Source\Grace-616-direct-retry-proof\src\Grace.CLI.Tests\Connect.CLI.Tests.fs`
- `dotnet build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj`
- `dotnet test --no-build --configuration Release src\Grace.CLI.Tests\Grace.CLI.Tests.fsproj --filter "FullyQualifiedName~ConnectTests"` passed, 36 tests
- `git diff --check`
- `pwsh ./scripts/validate.ps1 -Fast`
- `npx --yes markdownlint-cli2 "docs/Grace Cache implementation audit.md"`

`pwsh ./scripts/validate.ps1 -Full` was skipped because this stayed in CLI, test, and docs surfaces and did not expand into Aspire, emulator, Service Bus, Redis, storage-service integration, or runtime deployment behavior.

## Review Status

- Head commit: `70458094a559347a747d923d334ea598616e9b65`
- Worker self-review: completed over the actual diff before each push.
- Codex Code Review Bot cycle 1 on `c1e9ae063aaea30ad59c5884dbdab519eb7e6ce7`: fresh P2 finding on over-limit DirectUri artifacts being classified as retryable.
- Fix commit: `70458094a559347a747d923d334ea598616e9b65` separates source transport/open/HTTP/transfer failures from delivered artifact size validation failures.
- Prevention: DirectUri retry classification now separates source transport failures from delivered artifact size validation, so a fresh plan cannot mask an oversized or stale artifact.
- Codex Code Review Bot on `70458094a559347a747d923d334ea598616e9b65`: `THUMBS_UP`, no issues.
- GitHub `full` workflow on `70458094a559347a747d923d334ea598616e9b65`: succeeded.
## Contract Propagation

- CLI Direct materialization behavior: updated and tested.
- Local materialization state ordering: covered by focused tests before status/object-cache success state.
- OpenAPI/static generated contract propagation: N/A for #616; tracked by sibling #687.


