### PR TITLE
GC-10: Define cache service registration identity

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -746,6 +746,53 @@ export grace__auth__oidc__m2m_scopes="read:foo write:bar"
 
 ---
 
+### Grace Cache service registration identity
+
+Grace Cache registration uses the existing OIDC/JWT bearer authentication path. A cache service must authenticate with
+an OIDC machine-to-machine credential. Grace Server accepts it for cache registration only when the token is a JWT bearer
+token with `gty=client-credentials`, and the presented service principal ID is listed in server-side cache registration
+configuration. Grace PATs, interactive user credentials, local TestAuth headers, endpoint URLs, and cache-reported
+locations are not proof of cache service identity.
+
+Registration scope and capability approval is also server-owned. A cache service can request only scopes and
+capabilities that Grace Server configuration already approved; the cache service does not approve its own repositories,
+StoragePools, artifact grants, or read-through capabilities.
+
+Configure cache registration with these environment variables when the registration endpoint is implemented:
+
+* `grace__cache__registration__enabled`: `true` enables cache registration configuration validation. The default is
+  disabled.
+* `grace__cache__registration__service_principal_ids`: semicolon-delimited OIDC service principal IDs that may register
+  cache services.
+* `grace__cache__registration__allowed_scopes`: semicolon-delimited server-approved cache registration scopes. Use
+  stable server-defined scope keys such as repository or StoragePool scopes; do not use endpoint URLs as scopes.
+* `grace__cache__registration__allowed_capabilities`: semicolon-delimited server-approved cache registration
+  capabilities.
+
+PowerShell:
+
+```powershell
+$env:grace__cache__registration__enabled="true"
+$env:grace__cache__registration__service_principal_ids="cache-service-client"
+$env:grace__cache__registration__allowed_scopes="repository:owner/org/repo;storage-pool:pool-1"
+$env:grace__cache__registration__allowed_capabilities="Register;PublishHealth"
+```
+
+bash / zsh:
+
+```bash
+export grace__cache__registration__enabled="true"
+export grace__cache__registration__service_principal_ids="cache-service-client"
+export grace__cache__registration__allowed_scopes="repository:owner/org/repo;storage-pool:pool-1"
+export grace__cache__registration__allowed_capabilities="Register;PublishHealth"
+```
+
+Later Grace.Cache startup must validate this configuration before exposing its HTTP listener. Logs and status output
+must report only non-secret summaries, such as service principal count, approved scope count, and approved capability
+names; they must not print client secrets, bearer tokens, service principal IDs, or credential-bearing URLs.
+
+---
+
 ### Grace CLI PAT configuration
 
 * `GRACE_TOKEN` (optional)

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -156,16 +156,24 @@ docs-only classification with current evidence for the behavior they own.
 
 ### Cache Service Registration And Identity
 
-- Implementation seam: cache service registration, health or capability publication, configured
-  cache audience, and Cache Service Identity for prefetch subscriptions.
-- Proof seam: tests or static validation for unregistered cache rejection, wrong audience rejection,
-  duplicate registration handling, identity rotation, disabled-cache behavior, and rejection of
-  per-call artifact grant bypass attempts.
-- Status classification: `not applicable` to this docs-only scaffold.
-- Issue or PR evidence: #609 creates the audit slot; registration work must cite its owning issue or
-  PR and validation.
-- Residual risk or rationale: Cache Service Identity authorizes configured cache behavior only; it
-  must not become a global artifact reader or bypass per-call artifact grants.
+- Implementation seam: #617 defines the pre-registration identity boundary in
+  `Grace.Server.Security.CacheServiceIdentity`. Registration must use the existing OIDC/JWT bearer
+  scheme with a client-credentials service token and a configured service principal ID. Server
+  configuration owns the approved service principal IDs, registration scopes, and registration
+  capabilities.
+- Proof seam: `CacheServiceIdentityUnitTests` covers disabled configuration, fail-fast enabled
+  configuration, valid OIDC service-principal registration, PAT rejection, normal user rejection,
+  missing client-credentials marker rejection, unapproved scope and capability rejection, and
+  non-secret status summaries.
+- Status classification: `contract defined; registration actor/API not implemented`.
+- Issue or PR evidence: #617 owns the service credential, identity claim, allowed scheme, scope
+  model, configuration boundary, docs, and `pwsh ./scripts/validate.ps1 -Fast` validation for this
+  preflight.
+- Residual risk or rationale: #618 still owns duplicate registration handling, endpoint routing,
+  persistence, identity rotation behavior, and disabled-cache API behavior. #619 still owns
+  per-call artifact grants. #620 still owns cache-mode plan generation. Cache Service Identity
+  authorizes configured cache registration behavior only; it must not become a global artifact
+  reader or bypass per-call artifact grants.
 
 ### Read-Through Behavior
 

--- a/src/Grace.Server.Unit.Tests/CacheServiceIdentity.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/CacheServiceIdentity.Unit.Tests.fs
@@ -1,0 +1,217 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Security
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Microsoft.AspNetCore.Authentication.JwtBearer
+open Microsoft.Extensions.Configuration
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Security.Claims
+
+/// Covers Grace Cache service identity and registration configuration decisions.
+[<Parallelizable(ParallelScope.All)>]
+type CacheServiceIdentityUnitTests() =
+
+    /// Builds configuration test data for Cache service identity scenarios.
+    let configuration (values: (string * string) list) =
+        let pairs =
+            values
+            |> List.map (fun (key, value) -> KeyValuePair<string, string>(getConfigKey key, value))
+
+        ConfigurationBuilder()
+            .AddInMemoryCollection(pairs)
+            .Build()
+        :> IConfiguration
+
+    /// Builds the minimal enabled Cache registration config used by authorization assertions.
+    let enabledConfig: CacheServiceIdentity.CacheRegistrationConfig =
+        {
+            Enabled = true
+            ServicePrincipalIds = [ "cache-service-client" ]
+            AllowedScopes =
+                [
+                    "repository:owner/org/repo"
+                    "storage-pool:pool-1"
+                ]
+            AllowedCapabilities = [ "Register"; "PublishHealth" ]
+        }
+
+    /// Builds a claims principal with a specific authentication scheme and claims.
+    let principal (scheme: string) (claims: Claim list) = ClaimsPrincipal(ClaimsIdentity((claims :> Claim seq), scheme))
+
+    /// Builds an OIDC JWT bearer service principal fixture.
+    let servicePrincipal servicePrincipalId =
+        principal
+            JwtBearerDefaults.AuthenticationScheme
+            [
+                Claim("azp", servicePrincipalId)
+                Claim("gty", "client-credentials")
+            ]
+
+    /// Verifies that disabled registration does not require service policy configuration.
+    [<Test>]
+    member _.DisabledRegistrationDoesNotRequireServicePolicyConfiguration() =
+        let config = configuration []
+
+        match CacheServiceIdentity.tryGetRegistrationConfig config with
+        | Ok registration ->
+            Assert.That(registration.Enabled, Is.False)
+            Assert.That(registration.ServicePrincipalIds, Is.Empty)
+            Assert.That(registration.AllowedScopes, Is.Empty)
+            Assert.That(registration.AllowedCapabilities, Is.Empty)
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            Assert.Fail($"Expected disabled registration config, got {errorText}.")
+
+    /// Verifies that enabled Cache registration fails early when service policy configuration is incomplete.
+    [<Test>]
+    member _.EnabledRegistrationRequiresServicePrincipalsScopesAndCapabilities() =
+        let config = configuration [ EnvironmentVariables.GraceCacheRegistrationEnabled, "true" ]
+
+        match CacheServiceIdentity.tryGetRegistrationConfig config with
+        | Ok _ -> Assert.Fail("Expected Cache registration config errors.")
+        | Error errors ->
+            Assert.That(errors, Has.Some.Contains(EnvironmentVariables.GraceCacheRegistrationServicePrincipalIds))
+            Assert.That(errors, Has.Some.Contains(EnvironmentVariables.GraceCacheRegistrationAllowedScopes))
+            Assert.That(errors, Has.Some.Contains(EnvironmentVariables.GraceCacheRegistrationAllowedCapabilities))
+
+    /// Verifies that invalid enablement values fail before a Cache service exposes listeners.
+    [<Test>]
+    member _.InvalidRegistrationEnablementFailsConfigurationValidation() =
+        let config = configuration [ EnvironmentVariables.GraceCacheRegistrationEnabled, "sometimes" ]
+
+        match CacheServiceIdentity.tryGetRegistrationConfig config with
+        | Ok _ -> Assert.Fail("Expected invalid enablement to fail.")
+        | Error errors ->
+            Assert.That(
+                errors,
+                Is.EquivalentTo(
+                    [
+                        $"{EnvironmentVariables.GraceCacheRegistrationEnabled} must be true or false."
+                    ]
+                )
+            )
+
+    /// Verifies that configured Cache registration values are trimmed and deduplicated.
+    [<Test>]
+    member _.RegistrationConfigurationTrimsAndDeduplicatesValues() =
+        let config =
+            configuration [ EnvironmentVariables.GraceCacheRegistrationEnabled, "true"
+                            EnvironmentVariables.GraceCacheRegistrationServicePrincipalIds, " cache-service-client ; CACHE-SERVICE-CLIENT "
+                            EnvironmentVariables.GraceCacheRegistrationAllowedScopes, " repository:owner/org/repo ; storage-pool:pool-1 "
+                            EnvironmentVariables.GraceCacheRegistrationAllowedCapabilities, " Register ; register ; PublishHealth " ]
+
+        match CacheServiceIdentity.tryGetRegistrationConfig config with
+        | Error errors ->
+            let errorText = String.Join("; ", errors)
+            Assert.Fail($"Expected Cache registration config, got {errorText}.")
+        | Ok registration ->
+            Assert.That(registration.Enabled, Is.True)
+            Assert.That(registration.ServicePrincipalIds, Is.EquivalentTo([ "cache-service-client" ]))
+
+            Assert.That(
+                registration.AllowedScopes,
+                Is.EquivalentTo(
+                    [
+                        "repository:owner/org/repo"
+                        "storage-pool:pool-1"
+                    ]
+                )
+            )
+
+            Assert.That(registration.AllowedCapabilities, Is.EquivalentTo([ "Register"; "PublishHealth" ]))
+
+    /// Verifies that a configured OIDC service principal can register approved scopes and capabilities.
+    [<Test>]
+    member _.ConfiguredJwtServicePrincipalCanRegisterApprovedScopesAndCapabilities() =
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                (servicePrincipal "cache-service-client")
+                [ "repository:owner/org/repo" ]
+                [ "Register"; "PublishHealth" ]
+
+        Assert.That(decision, Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Allowed "cache-service-client"))
+
+    /// Verifies that Grace PAT identities cannot register Cache services even when the principal ID matches.
+    [<Test>]
+    member _.GracePatPrincipalCannotRegisterCacheService() =
+        let patPrincipal =
+            principal
+                PersonalAccessTokenAuth.SchemeName
+                [
+                    Claim(PrincipalMapper.GraceUserIdClaim, "cache-service-client")
+                ]
+
+        let decision = CacheServiceIdentity.decideRegistration enabledConfig patPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
+
+        Assert.That(decision, Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requires OIDC JWT bearer authentication."))
+
+    /// Verifies that normal user OIDC credentials cannot register Cache services without a configured service principal.
+    [<Test>]
+    member _.NormalJwtUserPrincipalCannotRegisterCacheService() =
+        let userPrincipal = principal JwtBearerDefaults.AuthenticationScheme [ Claim("sub", "auth0|developer-user") ]
+
+        let decision = CacheServiceIdentity.decideRegistration enabledConfig userPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
+
+        Assert.That(
+            decision,
+            Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requires an OIDC client-credentials service token.")
+        )
+
+    /// Verifies that a configured principal ID still needs an OIDC client-credentials service token.
+    [<Test>]
+    member _.ConfiguredPrincipalIdWithoutClientCredentialsGrantCannotRegisterCacheService() =
+        let userCompatibleConfig: CacheServiceIdentity.CacheRegistrationConfig = { enabledConfig with ServicePrincipalIds = [ "auth0|developer-user" ] }
+
+        let userPrincipal = principal JwtBearerDefaults.AuthenticationScheme [ Claim("sub", "auth0|developer-user") ]
+
+        let decision = CacheServiceIdentity.decideRegistration userCompatibleConfig userPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
+
+        Assert.That(
+            decision,
+            Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requires an OIDC client-credentials service token.")
+        )
+
+    /// Verifies that unapproved scopes and capabilities are rejected by server configuration.
+    [<Test>]
+    member _.UnapprovedScopesAndCapabilitiesAreRejectedByServerConfiguration() =
+        let scopeDecision =
+            CacheServiceIdentity.decideRegistration enabledConfig (servicePrincipal "cache-service-client") [ "repository:other/org/repo" ] [ "Register" ]
+
+        let capabilityDecision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                (servicePrincipal "cache-service-client")
+                [ "repository:owner/org/repo" ]
+                [ "ApproveOwnScope" ]
+
+        Assert.That(
+            scopeDecision,
+            Is.EqualTo(
+                CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requested a scope that is not approved by server configuration."
+            )
+        )
+
+        Assert.That(
+            capabilityDecision,
+            Is.EqualTo(
+                CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requested a capability that is not approved by server configuration."
+            )
+        )
+
+    /// Verifies that status summaries redact configured service principal and scope values.
+    [<Test>]
+    member _.ConfigurationSummaryDoesNotExposeServicePrincipalOrScopeValues() =
+        let summary = CacheServiceIdentity.summarizeConfig enabledConfig
+        let rendered = $"{summary}"
+
+        Assert.That(summary.Enabled, Is.True)
+        Assert.That(summary.ServicePrincipalCount, Is.EqualTo(1))
+        Assert.That(summary.AllowedScopeCount, Is.EqualTo(2))
+        Assert.That(summary.AllowedCapabilities, Is.EquivalentTo([ "Register"; "PublishHealth" ]))
+        Assert.That(rendered, Does.Not.Contain("cache-service-client"))
+        Assert.That(rendered, Does.Not.Contain("repository:owner/org/repo"))

--- a/src/Grace.Server.Unit.Tests/CacheServiceIdentity.Unit.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/CacheServiceIdentity.Unit.Tests.fs
@@ -42,6 +42,9 @@ type CacheServiceIdentityUnitTests() =
     /// Builds a claims principal with a specific authentication scheme and claims.
     let principal (scheme: string) (claims: Claim list) = ClaimsPrincipal(ClaimsIdentity((claims :> Claim seq), scheme))
 
+    /// Builds a claims principal authenticated by token validation without assuming the ASP.NET scheme name.
+    let tokenValidatedPrincipal (claims: Claim list) = principal "TokenValidation" claims
+
     /// Builds an OIDC JWT bearer service principal fixture.
     let servicePrincipal servicePrincipalId =
         principal
@@ -110,7 +113,16 @@ type CacheServiceIdentityUnitTests() =
             Assert.Fail($"Expected Cache registration config, got {errorText}.")
         | Ok registration ->
             Assert.That(registration.Enabled, Is.True)
-            Assert.That(registration.ServicePrincipalIds, Is.EquivalentTo([ "cache-service-client" ]))
+
+            Assert.That(
+                registration.ServicePrincipalIds,
+                Is.EquivalentTo(
+                    [
+                        "cache-service-client"
+                        "CACHE-SERVICE-CLIENT"
+                    ]
+                )
+            )
 
             Assert.That(
                 registration.AllowedScopes,
@@ -130,11 +142,42 @@ type CacheServiceIdentityUnitTests() =
         let decision =
             CacheServiceIdentity.decideRegistration
                 enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
                 (servicePrincipal "cache-service-client")
                 [ "repository:owner/org/repo" ]
                 [ "Register"; "PublishHealth" ]
 
         Assert.That(decision, Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Allowed "cache-service-client"))
+
+    /// Verifies that production JWT bearer authentication is keyed by the ASP.NET scheme, not identity metadata.
+    [<Test>]
+    member _.ProductionJwtBearerSchemeDoesNotDependOnIdentityAuthenticationType() =
+        let validatedPrincipal =
+            tokenValidatedPrincipal [ Claim("azp", "cache-service-client")
+                                      Claim("gty", "client-credentials") ]
+
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
+                validatedPrincipal
+                [ "repository:owner/org/repo" ]
+                [ "Register"; "PublishHealth" ]
+
+        Assert.That(decision, Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Allowed "cache-service-client"))
+
+    /// Verifies that valid-looking service claims cannot register through a non-bearer request scheme.
+    [<Test>]
+    member _.NonBearerAuthenticatedSchemeCannotRegisterCacheService() =
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                TestAuth.SchemeName
+                (servicePrincipal "cache-service-client")
+                [ "repository:owner/org/repo" ]
+                [ "Register" ]
+
+        Assert.That(decision, Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requires OIDC JWT bearer authentication."))
 
     /// Verifies that Grace PAT identities cannot register Cache services even when the principal ID matches.
     [<Test>]
@@ -146,7 +189,8 @@ type CacheServiceIdentityUnitTests() =
                     Claim(PrincipalMapper.GraceUserIdClaim, "cache-service-client")
                 ]
 
-        let decision = CacheServiceIdentity.decideRegistration enabledConfig patPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
+        let decision =
+            CacheServiceIdentity.decideRegistration enabledConfig PersonalAccessTokenAuth.SchemeName patPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
 
         Assert.That(decision, Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requires OIDC JWT bearer authentication."))
 
@@ -155,7 +199,13 @@ type CacheServiceIdentityUnitTests() =
     member _.NormalJwtUserPrincipalCannotRegisterCacheService() =
         let userPrincipal = principal JwtBearerDefaults.AuthenticationScheme [ Claim("sub", "auth0|developer-user") ]
 
-        let decision = CacheServiceIdentity.decideRegistration enabledConfig userPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
+                userPrincipal
+                [ "repository:owner/org/repo" ]
+                [ "Register" ]
 
         Assert.That(
             decision,
@@ -169,22 +219,68 @@ type CacheServiceIdentityUnitTests() =
 
         let userPrincipal = principal JwtBearerDefaults.AuthenticationScheme [ Claim("sub", "auth0|developer-user") ]
 
-        let decision = CacheServiceIdentity.decideRegistration userCompatibleConfig userPrincipal [ "repository:owner/org/repo" ] [ "Register" ]
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                userCompatibleConfig
+                JwtBearerDefaults.AuthenticationScheme
+                userPrincipal
+                [ "repository:owner/org/repo" ]
+                [ "Register" ]
 
         Assert.That(
             decision,
             Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requires an OIDC client-credentials service token.")
         )
 
+    /// Verifies that configured service principal IDs use exact matching for opaque OIDC client identifiers.
+    [<Test>]
+    member _.ConfiguredServicePrincipalIdsCompareExactly() =
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
+                (servicePrincipal "CACHE-SERVICE-CLIENT")
+                [ "repository:owner/org/repo" ]
+                [ "Register" ]
+
+        Assert.That(
+            decision,
+            Is.EqualTo(CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration service principal is not approved by server configuration.")
+        )
+
+    /// Verifies that configured scopes use exact matching because they can contain storage-pool IDs.
+    [<Test>]
+    member _.ConfiguredScopesCompareExactly() =
+        let decision =
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
+                (servicePrincipal "cache-service-client")
+                [ "storage-pool:POOL-1" ]
+                [ "Register" ]
+
+        Assert.That(
+            decision,
+            Is.EqualTo(
+                CacheServiceIdentity.CacheRegistrationDecision.Denied "Cache registration requested a scope that is not approved by server configuration."
+            )
+        )
+
     /// Verifies that unapproved scopes and capabilities are rejected by server configuration.
     [<Test>]
     member _.UnapprovedScopesAndCapabilitiesAreRejectedByServerConfiguration() =
         let scopeDecision =
-            CacheServiceIdentity.decideRegistration enabledConfig (servicePrincipal "cache-service-client") [ "repository:other/org/repo" ] [ "Register" ]
+            CacheServiceIdentity.decideRegistration
+                enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
+                (servicePrincipal "cache-service-client")
+                [ "repository:other/org/repo" ]
+                [ "Register" ]
 
         let capabilityDecision =
             CacheServiceIdentity.decideRegistration
                 enabledConfig
+                JwtBearerDefaults.AuthenticationScheme
                 (servicePrincipal "cache-service-client")
                 [ "repository:owner/org/repo" ]
                 [ "ApproveOwnScope" ]

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="CreatorScopeAdminGrant.Unit.Tests.fs" />
     <Compile Include="ExternalAuthConfig.Unit.Tests.fs" />
+    <Compile Include="CacheServiceIdentity.Unit.Tests.fs" />
     <Compile Include="AuthSchemeSelection.Unit.Tests.fs" />
     <Compile Include="SecurityPrivacy.Unit.Tests.fs" />
     <Compile Include="OutboundUrlSafety.Unit.Tests.fs" />

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -56,6 +56,7 @@
 		<Compile Include="Security\PrincipalMapper.Server.fs" />
 		<Compile Include="Security\TelemetryEnrichment.Server.fs" />
 		<Compile Include="Security\ExternalAuthConfig.Server.fs" />
+		<Compile Include="Security\CacheServiceIdentity.Server.fs" />
                 <Compile Include="Security\ClaimMapping.Server.fs" />
                 <Compile Include="Security\ClaimsTransformation.Server.fs" />
                 <Compile Include="Security\TestAuth.Server.fs" />

--- a/src/Grace.Server/Security/CacheServiceIdentity.Server.fs
+++ b/src/Grace.Server/Security/CacheServiceIdentity.Server.fs
@@ -6,6 +6,7 @@ open Grace.Shared.Utilities
 open Microsoft.AspNetCore.Authentication.JwtBearer
 open Microsoft.Extensions.Configuration
 open System
+open System.Collections.Generic
 open System.Security.Claims
 
 /// Contains Grace Cache registration identity and server-approved configuration boundaries.
@@ -34,14 +35,16 @@ module CacheServiceIdentity =
             if String.IsNullOrWhiteSpace value then None else Some(value.Trim())
 
     /// Parses a semicolon-delimited configuration list while removing empty entries and duplicate values.
-    let private parseConfiguredList (value: string option) =
+    let private parseConfiguredList (comparer: StringComparer) (value: string option) =
         match value with
         | None -> []
         | Some configured ->
+            let seen = HashSet<string>(comparer)
+
             configured.Split(listSeparators, StringSplitOptions.RemoveEmptyEntries)
             |> Seq.map (fun item -> item.Trim())
             |> Seq.filter (fun item -> not (String.IsNullOrWhiteSpace item))
-            |> Seq.distinctBy (fun item -> item.ToUpperInvariant())
+            |> Seq.filter seen.Add
             |> Seq.toList
 
     /// Parses the cache registration enablement flag so invalid startup configuration fails early.
@@ -66,17 +69,17 @@ module CacheServiceIdentity =
             let servicePrincipalIds =
                 EnvironmentVariables.GraceCacheRegistrationServicePrincipalIds
                 |> tryGetConfigValue configuration
-                |> parseConfiguredList
+                |> parseConfiguredList StringComparer.Ordinal
 
             let allowedScopes =
                 EnvironmentVariables.GraceCacheRegistrationAllowedScopes
                 |> tryGetConfigValue configuration
-                |> parseConfiguredList
+                |> parseConfiguredList StringComparer.Ordinal
 
             let allowedCapabilities =
                 EnvironmentVariables.GraceCacheRegistrationAllowedCapabilities
                 |> tryGetConfigValue configuration
-                |> parseConfiguredList
+                |> parseConfiguredList StringComparer.OrdinalIgnoreCase
 
             let errors = ResizeArray<string>()
 
@@ -115,7 +118,7 @@ module CacheServiceIdentity =
     /// Determines whether a requested Cache registration scope was approved by server configuration.
     let isScopeAllowed (config: CacheRegistrationConfig) (scope: string) =
         config.AllowedScopes
-        |> List.exists (fun allowed -> String.Equals(allowed, scope, StringComparison.OrdinalIgnoreCase))
+        |> List.exists (fun allowed -> String.Equals(allowed, scope, StringComparison.Ordinal))
 
     /// Determines whether a requested Cache registration capability was approved by server configuration.
     let isCapabilityAllowed (config: CacheRegistrationConfig) (capability: string) =
@@ -140,15 +143,17 @@ module CacheServiceIdentity =
                 |> Option.map (fun claim -> claim.Value.Trim())
                 |> Option.filter (fun value -> not (String.IsNullOrWhiteSpace value)))
 
-    /// Determines whether the principal was authenticated by the JWT bearer scheme used for OIDC service credentials.
-    let isJwtBearerPrincipal (principal: ClaimsPrincipal) =
-        if isNull principal || isNull principal.Identity then
+    /// Determines whether the request was authenticated by the JWT bearer scheme used for OIDC service credentials.
+    let isJwtBearerPrincipal (authenticatedScheme: string) (principal: ClaimsPrincipal) =
+        if isNull principal
+           || isNull principal.Identity
+           || String.IsNullOrWhiteSpace authenticatedScheme then
             false
         else
             let identity = principal.Identity
 
             identity.IsAuthenticated
-            && String.Equals(identity.AuthenticationType, JwtBearerDefaults.AuthenticationScheme, StringComparison.Ordinal)
+            && String.Equals(authenticatedScheme, JwtBearerDefaults.AuthenticationScheme, StringComparison.Ordinal)
 
     /// Determines whether the JWT carries the Auth0 client-credentials marker required for Cache service registration.
     let hasClientCredentialsGrant (principal: ClaimsPrincipal) =
@@ -161,10 +166,16 @@ module CacheServiceIdentity =
                 && String.Equals(claim.Value, "client-credentials", StringComparison.OrdinalIgnoreCase))
 
     /// Authorizes a Cache registration request against the configured service identity, scopes, and capabilities.
-    let decideRegistration (config: CacheRegistrationConfig) (principal: ClaimsPrincipal) (requestedScopes: string list) (requestedCapabilities: string list) =
+    let decideRegistration
+        (config: CacheRegistrationConfig)
+        (authenticatedScheme: string)
+        (principal: ClaimsPrincipal)
+        (requestedScopes: string list)
+        (requestedCapabilities: string list)
+        =
         if not config.Enabled then
             Denied "Cache registration is disabled."
-        elif not (isJwtBearerPrincipal principal) then
+        elif not (isJwtBearerPrincipal authenticatedScheme principal) then
             Denied "Cache registration requires OIDC JWT bearer authentication."
         elif not (hasClientCredentialsGrant principal) then
             Denied "Cache registration requires an OIDC client-credentials service token."
@@ -175,7 +186,7 @@ module CacheServiceIdentity =
                 not
                     (
                         config.ServicePrincipalIds
-                        |> List.exists (fun configured -> String.Equals(configured, servicePrincipalId, StringComparison.OrdinalIgnoreCase))
+                        |> List.exists (fun configured -> String.Equals(configured, servicePrincipalId, StringComparison.Ordinal))
                     )
                 ->
                 Denied "Cache registration service principal is not approved by server configuration."

--- a/src/Grace.Server/Security/CacheServiceIdentity.Server.fs
+++ b/src/Grace.Server/Security/CacheServiceIdentity.Server.fs
@@ -1,0 +1,196 @@
+namespace Grace.Server.Security
+
+open Grace.Shared
+open Grace.Shared.Constants
+open Grace.Shared.Utilities
+open Microsoft.AspNetCore.Authentication.JwtBearer
+open Microsoft.Extensions.Configuration
+open System
+open System.Security.Claims
+
+/// Contains Grace Cache registration identity and server-approved configuration boundaries.
+module CacheServiceIdentity =
+
+    /// Represents the server configuration that gates Grace Cache service registration.
+    type CacheRegistrationConfig = { Enabled: bool; ServicePrincipalIds: string list; AllowedScopes: string list; AllowedCapabilities: string list }
+
+    /// Represents the non-secret Cache registration configuration summary suitable for status output.
+    type CacheRegistrationConfigSummary = { Enabled: bool; ServicePrincipalCount: int; AllowedScopeCount: int; AllowedCapabilities: string list }
+
+    /// Represents the authorization decision for a Grace Cache service registration attempt.
+    type CacheRegistrationDecision =
+        | Allowed of servicePrincipalId: string
+        | Denied of reason: string
+
+    let private listSeparators = [| ';' |]
+
+    /// Reads a non-empty configuration value using Grace's environment-compatible key normalization.
+    let private tryGetConfigValue (configuration: IConfiguration) (name: string) =
+        if isNull configuration then
+            None
+        else
+            let value = configuration[getConfigKey name]
+
+            if String.IsNullOrWhiteSpace value then None else Some(value.Trim())
+
+    /// Parses a semicolon-delimited configuration list while removing empty entries and duplicate values.
+    let private parseConfiguredList (value: string option) =
+        match value with
+        | None -> []
+        | Some configured ->
+            configured.Split(listSeparators, StringSplitOptions.RemoveEmptyEntries)
+            |> Seq.map (fun item -> item.Trim())
+            |> Seq.filter (fun item -> not (String.IsNullOrWhiteSpace item))
+            |> Seq.distinctBy (fun item -> item.ToUpperInvariant())
+            |> Seq.toList
+
+    /// Parses the cache registration enablement flag so invalid startup configuration fails early.
+    let private parseEnabled (value: string option) =
+        match value with
+        | None -> Ok false
+        | Some configured ->
+            match configured.Trim().ToLowerInvariant() with
+            | "1"
+            | "true"
+            | "yes" -> Ok true
+            | "0"
+            | "false"
+            | "no" -> Ok false
+            | _ -> Error $"{EnvironmentVariables.GraceCacheRegistrationEnabled} must be true or false."
+
+    /// Builds the Grace Cache registration configuration and reports missing server-side approval data.
+    let tryGetRegistrationConfig (configuration: IConfiguration) =
+        match parseEnabled (tryGetConfigValue configuration EnvironmentVariables.GraceCacheRegistrationEnabled) with
+        | Error error -> Error [ error ]
+        | Ok enabled ->
+            let servicePrincipalIds =
+                EnvironmentVariables.GraceCacheRegistrationServicePrincipalIds
+                |> tryGetConfigValue configuration
+                |> parseConfiguredList
+
+            let allowedScopes =
+                EnvironmentVariables.GraceCacheRegistrationAllowedScopes
+                |> tryGetConfigValue configuration
+                |> parseConfiguredList
+
+            let allowedCapabilities =
+                EnvironmentVariables.GraceCacheRegistrationAllowedCapabilities
+                |> tryGetConfigValue configuration
+                |> parseConfiguredList
+
+            let errors = ResizeArray<string>()
+
+            if enabled && servicePrincipalIds.IsEmpty then
+                errors.Add
+                    $"{EnvironmentVariables.GraceCacheRegistrationServicePrincipalIds} must contain at least one OIDC service principal when Cache registration is enabled."
+
+            if enabled && allowedScopes.IsEmpty then
+                errors.Add
+                    $"{EnvironmentVariables.GraceCacheRegistrationAllowedScopes} must contain at least one server-approved scope when Cache registration is enabled."
+
+            if enabled && allowedCapabilities.IsEmpty then
+                errors.Add
+                    $"{EnvironmentVariables.GraceCacheRegistrationAllowedCapabilities} must contain at least one server-approved capability when Cache registration is enabled."
+
+            if errors.Count > 0 then
+                Error(errors |> Seq.toList)
+            else
+                Ok { Enabled = enabled; ServicePrincipalIds = servicePrincipalIds; AllowedScopes = allowedScopes; AllowedCapabilities = allowedCapabilities }
+
+    /// Requires valid Cache registration configuration before a service exposes registration listeners.
+    let requireValidRegistrationConfig configuration =
+        match tryGetRegistrationConfig configuration with
+        | Ok config -> config
+        | Error errors -> invalidOp (String.Join(" ", errors))
+
+    /// Creates a non-secret Cache registration configuration summary for logs or status output.
+    let summarizeConfig (config: CacheRegistrationConfig) =
+        {
+            Enabled = config.Enabled
+            ServicePrincipalCount = config.ServicePrincipalIds.Length
+            AllowedScopeCount = config.AllowedScopes.Length
+            AllowedCapabilities = config.AllowedCapabilities
+        }
+
+    /// Determines whether a requested Cache registration scope was approved by server configuration.
+    let isScopeAllowed (config: CacheRegistrationConfig) (scope: string) =
+        config.AllowedScopes
+        |> List.exists (fun allowed -> String.Equals(allowed, scope, StringComparison.OrdinalIgnoreCase))
+
+    /// Determines whether a requested Cache registration capability was approved by server configuration.
+    let isCapabilityAllowed (config: CacheRegistrationConfig) (capability: string) =
+        config.AllowedCapabilities
+        |> List.exists (fun allowed -> String.Equals(allowed, capability, StringComparison.OrdinalIgnoreCase))
+
+    /// Gets the configured OIDC service principal ID from the claims presented by an authenticated Cache service.
+    let tryGetServicePrincipalId (principal: ClaimsPrincipal) =
+        if isNull principal then
+            None
+        else
+            [
+                "azp"
+                "client_id"
+                "appid"
+                "sub"
+                PrincipalMapper.GraceUserIdClaim
+            ]
+            |> Seq.tryPick (fun claimType ->
+                principal.Claims
+                |> Seq.tryFind (fun claim -> String.Equals(claim.Type, claimType, StringComparison.OrdinalIgnoreCase))
+                |> Option.map (fun claim -> claim.Value.Trim())
+                |> Option.filter (fun value -> not (String.IsNullOrWhiteSpace value)))
+
+    /// Determines whether the principal was authenticated by the JWT bearer scheme used for OIDC service credentials.
+    let isJwtBearerPrincipal (principal: ClaimsPrincipal) =
+        if isNull principal || isNull principal.Identity then
+            false
+        else
+            let identity = principal.Identity
+
+            identity.IsAuthenticated
+            && String.Equals(identity.AuthenticationType, JwtBearerDefaults.AuthenticationScheme, StringComparison.Ordinal)
+
+    /// Determines whether the JWT carries the Auth0 client-credentials marker required for Cache service registration.
+    let hasClientCredentialsGrant (principal: ClaimsPrincipal) =
+        if isNull principal then
+            false
+        else
+            principal.Claims
+            |> Seq.exists (fun claim ->
+                String.Equals(claim.Type, "gty", StringComparison.OrdinalIgnoreCase)
+                && String.Equals(claim.Value, "client-credentials", StringComparison.OrdinalIgnoreCase))
+
+    /// Authorizes a Cache registration request against the configured service identity, scopes, and capabilities.
+    let decideRegistration (config: CacheRegistrationConfig) (principal: ClaimsPrincipal) (requestedScopes: string list) (requestedCapabilities: string list) =
+        if not config.Enabled then
+            Denied "Cache registration is disabled."
+        elif not (isJwtBearerPrincipal principal) then
+            Denied "Cache registration requires OIDC JWT bearer authentication."
+        elif not (hasClientCredentialsGrant principal) then
+            Denied "Cache registration requires an OIDC client-credentials service token."
+        else
+            match tryGetServicePrincipalId principal with
+            | None -> Denied "Cache registration requires a service principal claim."
+            | Some servicePrincipalId when
+                not
+                    (
+                        config.ServicePrincipalIds
+                        |> List.exists (fun configured -> String.Equals(configured, servicePrincipalId, StringComparison.OrdinalIgnoreCase))
+                    )
+                ->
+                Denied "Cache registration service principal is not approved by server configuration."
+            | Some _ when requestedScopes.IsEmpty -> Denied "Cache registration requires at least one server-approved scope."
+            | Some _ when requestedCapabilities.IsEmpty -> Denied "Cache registration requires at least one server-approved capability."
+            | Some servicePrincipalId ->
+                let unapprovedScope =
+                    requestedScopes
+                    |> List.tryFind (isScopeAllowed config >> not)
+
+                let unapprovedCapability =
+                    requestedCapabilities
+                    |> List.tryFind (isCapabilityAllowed config >> not)
+
+                match unapprovedScope, unapprovedCapability with
+                | Some _, _ -> Denied "Cache registration requested a scope that is not approved by server configuration."
+                | _, Some _ -> Denied "Cache registration requested a capability that is not approved by server configuration."
+                | None, None -> Allowed servicePrincipalId

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -302,6 +302,22 @@ module Constants =
         [<Literal>]
         let GraceAuthOidcM2mScopes = "grace__auth__oidc__m2m_scopes"
 
+        /// Enables Grace Cache service registration endpoints when the server has approved service principals and scope policy.
+        [<Literal>]
+        let GraceCacheRegistrationEnabled = "grace__cache__registration__enabled"
+
+        /// Semicolon-delimited OIDC service principal IDs that may register Grace Cache services.
+        [<Literal>]
+        let GraceCacheRegistrationServicePrincipalIds = "grace__cache__registration__service_principal_ids"
+
+        /// Semicolon-delimited Grace Cache registration scopes approved by server configuration.
+        [<Literal>]
+        let GraceCacheRegistrationAllowedScopes = "grace__cache__registration__allowed_scopes"
+
+        /// Semicolon-delimited Grace Cache registration capabilities approved by server configuration.
+        [<Literal>]
+        let GraceCacheRegistrationAllowedCapabilities = "grace__cache__registration__allowed_capabilities"
+
         /// Deprecated: External authentication settings for Microsoft (MSA + Entra).
         [<Literal>]
         let GraceAuthMicrosoftClientId = "grace__auth__microsoft__client_id"

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -248,6 +248,16 @@ Messages are completed only after SQL processing succeeds or the durable usage f
 - `grace__auth__pat__max_lifetime_days`
 - `grace__auth__pat__allow_no_expiry`
 
+### Grace Cache Registration
+
+- `grace__cache__registration__enabled`: enables server-side cache registration configuration validation. Default:
+  disabled.
+- `grace__cache__registration__service_principal_ids`: semicolon-delimited OIDC service principal IDs that may register
+  cache services. Do not store client secrets here.
+- `grace__cache__registration__allowed_scopes`: semicolon-delimited server-approved cache registration scopes.
+- `grace__cache__registration__allowed_capabilities`: semicolon-delimited server-approved cache registration
+  capabilities.
+
 ### Authorization (Bootstrap)
 
 - `grace__authz__bootstrap__system_admin_users`: semicolon-delimited user IDs to seed SystemAdmin at system


### PR DESCRIPTION
## Summary

- Defines the cache service registration identity boundary before the CacheRegistration actor/API work.
- Adds a narrow server-side evaluator for OIDC client-credentials cache service principals, server-approved scopes, and server-approved capabilities.
- Documents the configuration boundary and records the #617 audit handoff for #618, #619, and #620.

## Issue Links

Related to #617.
Part of #600.
Part of #597.

## Validation

- `dotnet tool run fantomas -- C:\Source\Grace-617-cache-service-identity\src\Grace.Shared\Constants.Shared.fs C:\Source\Grace-617-cache-service-identity\src\Grace.Server\Security\CacheServiceIdentity.Server.fs C:\Source\Grace-617-cache-service-identity\src\Grace.Server.Unit.Tests\CacheServiceIdentity.Unit.Tests.fs`
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`
- `dotnet test --no-build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~CacheServiceIdentity"`
- `npx --yes markdownlint-cli2 "docs/Authentication.md" "docs/Grace Cache implementation audit.md" "src/docs/ENVIRONMENT.md"`
- `git diff --check`
- `pwsh ./scripts/validate.ps1 -Fast`

`pwsh ./scripts/validate.ps1 -Full` was skipped because this stayed in server auth/config preflight, docs, and unit-test surfaces and did not touch Aspire, emulator, storage, Service Bus, Cosmos, Redis, deployment, or cross-service runtime behavior.

## Review Status

- Head commit: `ce644d1ea509c8ce0ed3fe655f85dbf0548d5c51`.
- Worker self-review: completed over the actual diff before push.
- Awaiting automatic Codex Code Review Bot review; no manual review request was made.

## Contract Propagation

- Server-side preflight/evaluator: added.
- Configuration/environment docs: updated.
- Authentication docs: updated.
- Grace Cache audit scaffold: updated.
- CacheRegistration actor/API: intentionally deferred to #618.
- Artifact grants: intentionally deferred to #619.
- Cache-mode plan generation: intentionally deferred to #620.


- Codex Code Review Bot cycle 1 on `f31919aa54a0e244c2d555b38b85114b9a7cf0bc`: fresh P2 findings in `CacheServiceIdentity.Server.fs`:
  - production JWT bearer principals should not be detected through `ClaimsIdentity.AuthenticationType`;
  - registration scopes must compare exactly unless canonicalized at the same boundary used by resource resolution;
  - configured service principal IDs must compare exactly as opaque OIDC client identifiers.
- Fix routing: assigning one fresh serialized worker because the findings share the same evaluator/test surface.




- Fix commit: `ce644d1ea509c8ce0ed3fe655f85dbf0548d5c51` makes the evaluator use an explicit authenticated scheme instead of `ClaimsIdentity.AuthenticationType`, compares registration scopes exactly, and compares configured service principal IDs exactly.
- Worker validation for `ce644d1ea509c8ce0ed3fe655f85dbf0548d5c51`: targeted Fantomas passed; focused Release build passed; focused `CacheServiceIdentityUnitTests` passed with 14 tests; `git diff --check` passed; `pwsh ./scripts/validate.ps1 -Fast` passed.
- Prevention: tests now cover production-like JWT bearer principals without a `Bearer` identity authentication type, non-bearer request scheme rejection, exact scope matching, and exact opaque client ID matching.
- Awaiting automatic Codex Code Review Bot review for `ce644d1ea509c8ce0ed3fe655f85dbf0548d5c51`; no manual review request was made.




- Final review gate on `ce644d1ea509c8ce0ed3fe655f85dbf0548d5c51`: Codex Code Review Bot returned `👍`; all review threads are resolved.
- Final GitHub validation gate: `full` completed successfully on July 9, 2026.


