### PR TITLE
GV-13: Add contributor-owned accounting proof

### DIFF
--- a/docs/Contributor-owned accounting design.md
+++ b/docs/Contributor-owned accounting design.md
@@ -1,0 +1,96 @@
+# Contributor-Owned Accounting Design
+
+Issue #652 records the accounting decision needed before GV-14 implements contributor-owned billing transfer. This note
+captures the current repository content accounting model, the ownership boundary cases, and the implementation concept
+that GV-14 should use instead of discovering those semantics during review.
+
+## Current Accounting Model
+
+Grace currently has two cooperating manifest-backed accounting actors:
+
+- `RepositoryContentCounter` is keyed by `(RepositoryId, StoragePoolId, ManifestAddress)`. It counts repository-local
+  active references to one manifest-backed file object. Its zero crossings emit repository contribution intents:
+  `0 -> 1` emits `IncrementManifestReferenceCount`, and `1 -> 0` emits `DecrementManifestReferenceCount`. Intermediate
+  `N -> N+1` and `N -> N-1` transitions stay local to the repository counter and do not fan out to block ranges.
+- `ManifestContributionWorkflow` is keyed by the same repository, storage-pool, and manifest address target. It owns
+  durable fan-out progress across `ContentBlockRange` entries and emits range active-count deltas only when a range
+  succeeds. It is workflow state for retention and recovery, not an owner-specific usage ledger.
+
+The currently counted object level is the manifest-backed file object, identified by `(StoragePoolId, ManifestAddress)`.
+Range-level counts exist for physical retention and compaction safety. They do not decide which contributor or repository
+owns active usage. `FileVersion`, `DirectoryVersion`, content hashes, and whole-file fallback object keys are not the
+right place to attach contributor billing ownership for this slice:
+
+- `FileVersion` and `DirectoryVersion` are immutable content/version records and must not be rewritten to transfer
+  ownership.
+- `ContentBlockRange` is too physical and may be shared by multiple manifests, so it cannot distinguish intended owner
+  scope for a file-level acceptance transfer.
+- Whole-file non-manifest content has no matching repository content counter or manifest contribution workflow today.
+  GV-14 should limit transfer to manifest-backed content unless a separate issue adds equivalent whole-file active usage
+  accounting.
+
+## Decision
+
+The existing actors cannot express owner-specific active counts. They intentionally collapse repeated repository-local
+manifest references into one repository contribution and have no `ResourceOwnership`, `CreatorUserId`, or billing-owner
+dimension in their command, event, DTO, or primary-key contracts.
+
+GV-14 should add a named ownership ledger concept rather than extending immutable content objects or overloading range
+retention state. The recommended implementation concept is `ContentOwnershipLedger`:
+
+- Key the ledger by `(StoragePoolId, ManifestAddress)` so all owner changes for one manifest-backed file serialize
+  through one durable stream.
+- Store owner-scope entries for active usage, where the owner scope is either repository-owned usage for a repository or
+  contributor-owned usage for a creator user in that repository.
+- Record accepted transfer operation identities and reject reuse of the same identity with a different payload.
+- Treat reapplying the same accepted transfer identity and payload as an idempotent replay.
+- Keep repository content counters and manifest contribution workflows responsible for repository reachability and range
+  retention. The ledger should consume their stable manifest target and accepted promotion transfer evidence; it should
+  not replace them.
+
+The stable transfer operation identity should be derived from the accepted promotion transfer, not from a transient
+request retry. It must include the accepted promotion set and the manifest-backed content target, for example:
+
+```text
+promotion-transfer:{PromotionSetId:N}:{StoragePoolId}:{ManifestAddress}
+```
+
+If GV-14 needs to transfer multiple independently accepted steps for the same promotion set and manifest, include the
+step id or terminal reference id in the identity. The same identity must always resolve to the same source owner, target
+owner, repository, storage pool, manifest address, and accepted promotion evidence.
+
+## Boundary Classification
+
+| Case | Required accounting result |
+| ---- | -------------------------- |
+| Abandoned or rejected private branch | No accepted transfer exists, so no repository-owned usage is created. Contributor-owned active usage remains only while the private branch/reference is active. Deletion or expiry decrements the contributor-owned active entry. |
+| Same content across contributors | The content identity is the same `(StoragePoolId, ManifestAddress)`, but owner scopes stay separate. Each contributor scope can have one active entry for its own private reachability; repository-owned usage is counted once when accepted into the repository scope. |
+| Accepted twice | Reusing the same transfer identity is an idempotent no-op. A distinct accepted transfer for content that is already repository-owned must not double-charge either the contributor or the repository; it should either no-op against the current owner state or record an audit-only replay result. |
+| Deletion or retention | Deleting a branch/reference changes active owner usage for the current owner scope only. Physical retention still depends on repository counters, manifest workflows, pending fan-out, and range metadata. Bytes must not be reclaimed while any owner-scope active entry or pending contribution workflow still exists. |
+| Reapplying the same transfer identity | Identical identity and payload returns the original decision without a second owner delta. Same identity with a different owner, repository, storage pool, manifest, or accepted-promotion payload is rejected. |
+
+## Contract Propagation For GV-14
+
+GV-14 should update these surfaces if it implements the ledger:
+
+- `Grace.Types`: ledger owner-scope, command, event, DTO, decision, and operation-id contracts.
+- `Grace.Actors`: `ContentOwnershipLedgerActor` plus transfer wiring from the accepted promotion apply path.
+- `Grace.Server.Unit.Tests`: pure idempotency, duplicate, current-owner, deletion, and replay proof.
+- Server integration tests if the accepted promotion transfer crosses hosted HTTP, storage, or background workflow
+  boundaries.
+- Documentation that describes contributor-owned active usage and deferred billing user docs for GV-15.
+
+The change does not require OpenAPI or CLI surface updates unless GV-14 exposes the ledger directly. Internal transfer
+from accepted promotion application can stay server/actor-only.
+
+## Proof Anchors
+
+The executable proof in `ContentOwnershipAccounting.Proof.Tests.fs` locks down the current assumptions:
+
+- repository counters have no owner dimension and collapse same-repository manifest references into one repository
+  contribution;
+- the same manifest in different repositories has distinct repository counter keys;
+- manifest workflows use stable operation identities for idempotent replay and reject mismatched payload reuse;
+- range active-count workflow state is retention progress, not owner-specific usage.
+
+These tests are intentionally proof tests for GV-13. They do not implement billing transfer.

--- a/src/Grace.Server.Unit.Tests/ContentOwnershipAccounting.Proof.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ContentOwnershipAccounting.Proof.Tests.fs
@@ -1,0 +1,203 @@
+namespace Grace.Server.Tests
+
+open Grace.Types.Common
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.RepositoryContentCounter
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Generic
+
+module ContentOwnershipCounterActor = Grace.Actors.RepositoryContentCounter
+module ContentOwnershipWorkflowActor = Grace.Actors.ManifestContributionWorkflow
+
+/// Proves the contributor-owned accounting design assumptions that GV-14 must build on without implementing transfer.
+[<Parallelizable(ParallelScope.All)>]
+type ContentOwnershipAccountingProofTests() =
+
+    let timestamp = Instant.FromUtc(2026, 7, 9, 9, 0)
+    let repositoryId = Guid.Parse("4fa17137-1a45-4a0f-9ccb-638ca926cff1")
+    let otherRepositoryId = Guid.Parse("3b870a65-3791-4d05-81b8-110fe13f74e3")
+    let promotionSetId = Guid.Parse("a49646da-9002-4599-a8d1-3d23be3127f9")
+    let storagePoolId = StoragePoolId "pool-main"
+    let manifestAddress = ManifestAddress "manifest:blake3:owner-proof"
+
+    let range = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress "block-owner-proof"; OrdinalStart = 0; OrdinalCount = 1 }
+
+    /// Creates deterministic metadata so proof failures identify the exact accounting operation under test.
+    let metadata correlationId =
+        {
+            Timestamp = timestamp
+            CorrelationId = correlationId
+            Principal = "proof-worker"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = Dictionary<string, string>()
+        }
+
+    /// Applies repository counter events to the DTO snapshot used by the next proof command.
+    let applyCounterEvents events dto =
+        events
+        |> List.fold (fun current event -> RepositoryContentCounterDto.UpdateDto event current) dto
+
+    /// Applies manifest workflow events to the DTO snapshot used by the next proof command.
+    let applyWorkflowEvents events dto =
+        events
+        |> List.fold (fun current event -> ManifestContributionWorkflowDto.UpdateDto event current) dto
+
+    /// Extracts successful repository counter decisions while keeping assertion failures readable.
+    let expectCounterOk result =
+        match result with
+        | Ok decision -> decision
+        | Error error ->
+            Assert.Fail($"Expected repository content counter command to succeed, got {error.Error}.")
+            Unchecked.defaultof<RepositoryContentCounterDecision>
+
+    /// Extracts successful manifest workflow decisions while keeping assertion failures readable.
+    let expectWorkflowOk result =
+        match result with
+        | Ok decision -> decision
+        | Error error ->
+            Assert.Fail($"Expected manifest contribution workflow command to succeed, got {error.Error}.")
+            Unchecked.defaultof<ManifestContributionWorkflowDecision>
+
+    /// Builds a repository counter add command for the manifest-backed content proof target.
+    let add operationId repositoryId = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, storagePoolId, manifestAddress)
+
+    /// Builds a manifest workflow start command for an accepted transfer proof target.
+    let startTransfer operationId direction =
+        ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, [| range |])
+
+    /// Proves repeated contributor saves in one repository cannot be separated by owner using the current counter.
+    [<Test>]
+    member _.RepositoryContentCounterHasNoOwnerDimensionForSameRepositoryManifest() =
+        Assert.That(typeof<RepositoryContentCounterDto>.GetProperty ("Ownership"), Is.Null)
+        Assert.That(typeof<RepositoryContentCounterDto>.GetProperty ("CreatorUserId"), Is.Null)
+
+        let first =
+            ContentOwnershipCounterActor.decideCommand
+                []
+                RepositoryContentCounterDto.Default
+                (add "private-save:contributor-a" repositoryId)
+                (metadata "corr-contributor-a")
+            |> expectCounterOk
+
+        Assert.That(first.Counter.ReferenceCount, Is.EqualTo(1L))
+        Assert.That(first.Intents, Has.Length.EqualTo(1))
+
+        let afterFirst = applyCounterEvents first.Events RepositoryContentCounterDto.Default
+
+        let second =
+            ContentOwnershipCounterActor.decideCommand first.Events afterFirst (add "private-save:contributor-b" repositoryId) (metadata "corr-contributor-b")
+            |> expectCounterOk
+
+        Assert.That(second.Counter.ReferenceCount, Is.EqualTo(2L))
+        Assert.That(second.Intents, Is.Empty)
+
+    /// Proves repository content counters distinguish repositories even when the manifest-backed content matches.
+    [<Test>]
+    member _.SameManifestAddressInDifferentRepositoriesUsesDistinctRepositoryCounters() =
+        let firstKey = ContentOwnershipCounterActor.primaryKey repositoryId storagePoolId manifestAddress
+        let secondKey = ContentOwnershipCounterActor.primaryKey otherRepositoryId storagePoolId manifestAddress
+
+        Assert.That(secondKey, Is.Not.EqualTo(firstKey))
+
+        let firstRepository =
+            ContentOwnershipCounterActor.decideCommandForKey
+                (Some firstKey)
+                []
+                RepositoryContentCounterDto.Default
+                (add "repository-a:first-reference" repositoryId)
+                (metadata "corr-repository-a")
+            |> expectCounterOk
+
+        let secondRepository =
+            ContentOwnershipCounterActor.decideCommandForKey
+                (Some secondKey)
+                []
+                RepositoryContentCounterDto.Default
+                (add "repository-b:first-reference" otherRepositoryId)
+                (metadata "corr-repository-b")
+            |> expectCounterOk
+
+        Assert.That(firstRepository.Intents, Has.Length.EqualTo(1))
+        Assert.That(secondRepository.Intents, Has.Length.EqualTo(1))
+
+    /// Proves a replayed accepted transfer operation identity does not emit a second workflow delta.
+    [<Test>]
+    member _.StableTransferOperationIdentityReplaysWithoutSecondWorkflowDelta() =
+        let operationId = ManifestContributionWorkflowOperationId $"promotion-transfer:{promotionSetId:N}:{storagePoolId}:{manifestAddress}"
+
+        let first =
+            ContentOwnershipWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (startTransfer operationId ManifestContributionDirection.Increment)
+                (metadata "corr-transfer-start")
+            |> expectWorkflowOk
+
+        let afterFirst = applyWorkflowEvents first.Events ManifestContributionWorkflowDto.Default
+
+        let replay =
+            ContentOwnershipWorkflowActor.decideCommand
+                first.Events
+                afterFirst
+                (startTransfer operationId ManifestContributionDirection.Increment)
+                (metadata "corr-transfer-replay")
+            |> expectWorkflowOk
+
+        Assert.That(replay.WasIdempotentReplay, Is.True)
+        Assert.That(replay.Events, Is.Empty)
+        Assert.That(replay.Intents, Is.Empty)
+
+    /// Proves the same accepted transfer identity cannot be reused for a different manifest workflow payload.
+    [<Test>]
+    member _.StableTransferOperationIdentityRejectsDifferentPayloadReuse() =
+        let operationId = ManifestContributionWorkflowOperationId $"promotion-transfer:{promotionSetId:N}:{storagePoolId}:{manifestAddress}"
+
+        let first =
+            ContentOwnershipWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (startTransfer operationId ManifestContributionDirection.Increment)
+                (metadata "corr-transfer-start")
+            |> expectWorkflowOk
+
+        let afterFirst = applyWorkflowEvents first.Events ManifestContributionWorkflowDto.Default
+
+        match
+            ContentOwnershipWorkflowActor.decideCommand
+                first.Events
+                afterFirst
+                (startTransfer operationId ManifestContributionDirection.Decrement)
+                (metadata "corr-transfer-mismatched")
+            with
+        | Ok _ -> Assert.Fail("Expected reused transfer operation identity with a different payload to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow operation id was already used with a different payload."))
+
+    /// Proves range active counts model retention progress and do not carry owner-specific usage fields.
+    [<Test>]
+    member _.RangeActiveCountWorkflowIsRetentionProgressNotOwnerSpecificUsage() =
+        Assert.That(typeof<ManifestContributionWorkflowDto>.GetProperty ("Ownership"), Is.Null)
+        Assert.That(typeof<ManifestContributionWorkflowDto>.GetProperty ("CreatorUserId"), Is.Null)
+
+        let started =
+            ContentOwnershipWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (startTransfer "retention-proof-start" ManifestContributionDirection.Increment)
+                (metadata "corr-retention-start")
+            |> expectWorkflowOk
+
+        let afterStart = applyWorkflowEvents started.Events ManifestContributionWorkflowDto.Default
+
+        let succeeded =
+            ContentOwnershipWorkflowActor.decideCommand
+                started.Events
+                afterStart
+                (ManifestContributionWorkflowCommand.RecordRangeSucceeded("retention-proof-range", repositoryId, storagePoolId, manifestAddress, range))
+                (metadata "corr-retention-range")
+            |> expectWorkflowOk
+
+        Assert.That(succeeded.Intents, Has.Length.EqualTo(1))
+        Assert.That(succeeded.Intents[0], Is.EqualTo(ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(range, 1)))
+        Assert.That(succeeded.Workflow.CompletedRanges.ContainsKey range, Is.True)

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
+    <Compile Include="ContentOwnershipAccounting.Proof.Tests.fs" />
     <Compile Include="Reference.Actor.Tests.fs" />
     <Compile Include="SaveBoundary.Actor.Tests.fs" />
     <Compile Include="Services.VersionHashPrefixResolution.Tests.fs" />


### PR DESCRIPTION
Related to #652.

## Summary

- Records the contributor-owned accounting model decision for GV-13.
- Adds executable proof tests for the current repository-manifest accounting shape, idempotent transfer identity behavior, and unsupported owner-specific usage cases.
- Leaves GV-14 with an explicit implementation path: add a `ContentOwnershipLedger` concept for manifest-backed accepted content transfer rather than extending immutable content objects or overloading retention workflow state.

## Validation

- `dotnet tool run fantomas Grace.Server.Unit.Tests/ContentOwnershipAccounting.Proof.Tests.fs` from `C:\Source\Grace-gh-652\src` passed.
- `npx --yes markdownlint-cli2 "docs/Contributor-owned accounting design.md"` passed with 0 errors.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj` passed with 0 warnings and 0 errors.
- `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter FullyQualifiedName~ContentOwnershipAccountingProofTests` passed: 5 passed, 0 failed.
- `pwsh ./scripts/validate.ps1 -Fast` passed.
- `git diff --check` passed.

## Review Status

- Current head: `1de7ceba`.
- Worker self-review: complete; no blockers reported.
- Residual scope note: GV-14 transfer is limited to manifest-backed content unless a separate issue adds equivalent whole-file active usage accounting, because whole-file non-manifest content has no matching repository content counter or manifest contribution workflow today.
- Codex Code Review Bot: 👍🏻 on the current head; no issues reported.
- PR-attached Validate: passed on run `29010489308`, job `86092602313`.
