### PR TITLE
GV-10: Gate public projections by current visibility

### DIFF
--- a/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
@@ -410,6 +410,36 @@ type AutomationEventingTests() =
         let envelope = EventingPublisher.tryCreateEnvelope (GraceEvent.PromotionSetEvent promotionSetEvent)
         Assert.That(envelope.IsNone, Is.True)
 
+    /// Verifies that current source visibility can suppress stale public event metadata before automation fanout.
+    [<Test>]
+    member _.CurrentHiddenPromotionSetSuppressesPublicAutomationProjection() =
+        let repositoryId = Guid.NewGuid()
+        let metadata = metadata "corr-current-hidden-apply" repositoryId
+        metadata.Properties[ "ActorId" ] <- $"{Guid.NewGuid()}"
+
+        let promotionSetEvent: PromotionSetEvent = { Event = PromotionSetEventType.Applied(Guid.NewGuid()); Metadata = metadata }
+
+        let envelope = EventingPublisher.tryCreateEnvelopeWithCurrentVisibility (Some false) (GraceEvent.PromotionSetEvent promotionSetEvent)
+
+        Assert.That(envelope.IsNone, Is.True)
+
+    /// Verifies that current public visibility never replays old private PromotionSet apply metadata.
+    [<Test>]
+    member _.CurrentPublicPromotionSetDoesNotReplayPrivateAutomationProjection() =
+        let repositoryId = Guid.NewGuid()
+
+        let promotionSetEvent: PromotionSetEvent =
+            {
+                Event = PromotionSetEventType.Applied(Guid.NewGuid())
+                Metadata =
+                    metadata "corr-current-public-private-apply" repositoryId
+                    |> markPrivateContributorOwned
+            }
+
+        let envelope = EventingPublisher.tryCreateEnvelopeWithCurrentVisibility (Some true) (GraceEvent.PromotionSetEvent promotionSetEvent)
+
+        Assert.That(envelope.IsNone, Is.True)
+
     /// Verifies that private validation results do not emit public automation events.
     [<Test>]
     member _.PrivateValidationResultDoesNotMapToAutomationEvent() =

--- a/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
@@ -209,6 +209,41 @@ type AutomationEventingTests() =
         let envelope = EventingPublisher.tryCreateEnvelope (GraceEvent.ReferenceEvent referenceEvent)
         Assert.That(envelope.IsNone, Is.True)
 
+    /// Verifies that current public visibility never replays old private terminal reference creation automation.
+    [<Test>]
+    member _.CurrentPublicTerminalReferenceDoesNotReplayPrivateCreatedAutomationProjection() =
+        let repositoryId = Guid.NewGuid()
+        let referenceId = Guid.NewGuid()
+        let promotionSetId = Guid.NewGuid()
+        let branchId = Guid.NewGuid()
+
+        let referenceEvent: ReferenceEvent =
+            {
+                Event =
+                    ReferenceEventType.Created(
+                        referenceId,
+                        Guid.NewGuid(),
+                        Guid.NewGuid(),
+                        repositoryId,
+                        branchId,
+                        Guid.NewGuid(),
+                        Sha256Hash String.Empty,
+                        Blake3Hash String.Empty,
+                        ReferenceType.Promotion,
+                        "promotion",
+                        [
+                            ReferenceLinkType.IncludedInPromotionSet promotionSetId
+                            ReferenceLinkType.PromotionSetTerminal promotionSetId
+                        ]
+                    )
+                Metadata =
+                    metadata "corr-current-public-private-terminal" repositoryId
+                    |> markPrivateInheritedReference
+            }
+
+        let envelope = EventingPublisher.tryCreateEnvelopeWithCurrentVisibility (Some true) (GraceEvent.ReferenceEvent referenceEvent)
+        Assert.That(envelope.IsNone, Is.True)
+
     /// Verifies that terminal reference reveal maps to public PromotionSet applied automation.
     [<Test>]
     member _.TerminalReferenceRevealMapsToPromotionSetApplied() =

--- a/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs
@@ -423,6 +423,20 @@ type AutomationEventingTests() =
 
         Assert.That(envelope.IsNone, Is.True)
 
+    /// Verifies that missing current PromotionSet snapshots fall back to durable public event metadata.
+    [<Test>]
+    member _.MissingCurrentPromotionSetSnapshotAllowsPublicPromotionSetAppliedMetadata() =
+        let repositoryId = Guid.NewGuid()
+        let metadata = metadata "corr-missing-current-public-apply" repositoryId
+        metadata.Properties[ "ActorId" ] <- $"{Guid.NewGuid()}"
+
+        let promotionSetEvent: PromotionSetEvent = { Event = PromotionSetEventType.Applied(Guid.NewGuid()); Metadata = metadata }
+
+        let envelope = EventingPublisher.tryCreateEnvelopeWithCurrentVisibility Option.None (GraceEvent.PromotionSetEvent promotionSetEvent)
+
+        Assert.That(envelope.IsSome, Is.True)
+        Assert.That(envelope.Value.EventType, Is.EqualTo(AutomationEventType.PromotionSetApplied))
+
     /// Verifies that current public visibility never replays old private PromotionSet apply metadata.
     [<Test>]
     member _.CurrentPublicPromotionSetDoesNotReplayPrivateAutomationProjection() =
@@ -509,6 +523,20 @@ type AutomationEventingTests() =
         Assert.That(envelope.IsSome, Is.True)
         Assert.That(envelope.Value.EventType, Is.EqualTo(AutomationEventType.AgentSummaryAdded))
         Assert.That(envelope.Value.RepositoryId, Is.EqualTo(repositoryId))
+
+    /// Verifies that add-summary artifact links can inherit current PromotionSet suppression.
+    [<Test>]
+    member _.WorkItemArtifactLinkedWithPromotionSetScopeCanBeSuppressedByCurrentHiddenProjection() =
+        let repositoryId = Guid.NewGuid()
+        let promotionSetId = Guid.NewGuid()
+        let eventMetadata = metadata "corr-work-item-summary-hidden-promotion-set" repositoryId
+        eventMetadata.Properties[ nameof PromotionSetId ] <- $"{promotionSetId}"
+
+        let workItemEvent: WorkItemEvent = { Event = WorkItemEventType.ArtifactLinked(Guid.NewGuid()); Metadata = eventMetadata }
+
+        let envelope = EventingPublisher.tryCreateEnvelopeWithCurrentVisibility (Some false) (GraceEvent.WorkItemEvent workItemEvent)
+
+        Assert.That(envelope.IsNone, Is.True)
 
     /// Verifies that private work-item PromotionSet link events do not emit public automation events.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -19,3 +19,11 @@ type NotificationServerTests() =
     member _.BranchNameGlobMatchingIsCaseInsensitiveAndSupportsWildcard(branchName: string, glob: string, expected: bool) =
         let actual = Subscriber.matchesBranchGlob (BranchName branchName) glob
         Assert.That(actual, Is.EqualTo(expected))
+
+    /// Verifies that SignalR reference notification fanout is suppressed for currently hidden references.
+    [<Test>]
+    member _.ReferenceNotificationProjectionSuppressesCurrentHiddenReference() = Assert.That(Subscriber.shouldNotifyReferenceProjection (Some false), Is.False)
+
+    /// Verifies that SignalR reference notification fanout remains enabled when no current source override is available.
+    [<Test>]
+    member _.ReferenceNotificationProjectionAllowsUnscopedLegacyReference() = Assert.That(Subscriber.shouldNotifyReferenceProjection None, Is.True)

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -1,15 +1,39 @@
 namespace Grace.Server.Tests
 
 open Grace.Server.Notification
+open Grace.Types
+open Grace.Types.Events
+open Grace.Types.Queue
 open Grace.Types.Common
 open Grace.Types.Reference
 open Grace.Types.Visibility
 open NodaTime
 open NUnit.Framework
+open System
+open System.Collections.Generic
 
 /// Covers notification Server behavior in no-Aspire server unit tests.
 [<Parallelizable(ParallelScope.All)>]
 type NotificationServerTests() =
+
+    /// Constructs metadata fixtures used by the notification projection assertions.
+    let metadata correlationId repositoryId =
+        let properties = Dictionary<string, string>()
+        properties[nameof RepositoryId] <- $"{repositoryId}"
+
+        {
+            Timestamp = Instant.FromUtc(2026, 7, 9, 10, 30)
+            CorrelationId = correlationId
+            Principal = "tester"
+            ClientType = Microsoft.FSharp.Core.Option.None
+            Properties = properties
+        }
+
+    /// Marks an event fixture as private at creation time.
+    let markPrivateContributorOwned (metadata: EventMetadata) =
+        metadata.Properties[ "Visibility" ] <- $"{ResourceVisibility.Private}"
+        metadata.Properties[ "Ownership" ] <- $"{ResourceOwnership.ContributorOwned}"
+        metadata
 
     /// Verifies that branch Name Glob Matching Is Case Insensitive And Supports Wildcard.
     [<TestCase("main", "main", true)>]
@@ -52,3 +76,81 @@ type NotificationServerTests() =
     /// Verifies that derived quick-scan fanout remains available when no current reference override is available.
     [<Test>]
     member _.DerivedReferenceProjectionAllowsUnscopedReference() = Assert.That(Subscriber.shouldRecordDerivedReferenceProjection None, Is.True)
+
+    /// Verifies that private reference creation metadata stays suppressed even after the current reference is public.
+    [<Test>]
+    member _.PrivateReferenceCreatedProjectionStaysSuppressedAfterReveal() =
+        let eventMetadata =
+            metadata "corr-private-created-after-reveal" (Guid.NewGuid())
+            |> markPrivateContributorOwned
+
+        Assert.That(Subscriber.shouldNotifyReferenceCreatedProjection eventMetadata (Some true), Is.False)
+        Assert.That(Subscriber.shouldRecordDerivedReferenceCreatedProjection eventMetadata (Some true), Is.False)
+
+    /// Verifies that public reference creation still publishes when the current reference is public.
+    [<Test>]
+    member _.PublicReferenceCreatedProjectionAllowsCurrentPublicReference() =
+        let eventMetadata = metadata "corr-public-created" (Guid.NewGuid())
+
+        Assert.That(Subscriber.shouldNotifyReferenceCreatedProjection eventMetadata (Some true), Is.True)
+        Assert.That(Subscriber.shouldRecordDerivedReferenceCreatedProjection eventMetadata (Some true), Is.True)
+
+    /// Verifies that PromotionSet created events carry their own source id for projection rechecks.
+    [<Test>]
+    member _.PromotionSetCreatedProjectionIdUsesCreatedEventSource() =
+        let repositoryId = Guid.NewGuid()
+        let promotionSetId = Guid.NewGuid()
+
+        let promotionSetEvent: PromotionSet.PromotionSetEvent =
+            {
+                Event =
+                    PromotionSet.PromotionSetEventType.Created(
+                        promotionSetId,
+                        Guid.NewGuid(),
+                        Guid.NewGuid(),
+                        repositoryId,
+                        Guid.NewGuid(),
+                        ResourceVisibility.Public,
+                        ResourceOwnership.RepositoryOwned,
+                        Some(UserId "creator@example.test")
+                    )
+                Metadata = metadata "corr-promotion-set-created" repositoryId
+            }
+
+        let projectionId = Subscriber.tryGetPromotionSetProjectionId (GraceEvent.PromotionSetEvent promotionSetEvent)
+        Assert.That(projectionId, Is.EqualTo(Some promotionSetId))
+
+    /// Verifies that non-create PromotionSet events derive source scope from actor identity metadata.
+    [<Test>]
+    member _.PromotionSetNonCreateProjectionIdUsesActorIdWhenScopeMetadataIsMissing() =
+        let repositoryId = Guid.NewGuid()
+        let promotionSetId = Guid.NewGuid()
+        let eventMetadata = metadata "corr-promotion-set-applied" repositoryId
+        eventMetadata.Properties[ "ActorId" ] <- $"{promotionSetId}"
+
+        let promotionSetEvent: PromotionSet.PromotionSetEvent = { Event = PromotionSet.PromotionSetEventType.Applied(Guid.NewGuid()); Metadata = eventMetadata }
+
+        let projectionId = Subscriber.tryGetPromotionSetProjectionId (GraceEvent.PromotionSetEvent promotionSetEvent)
+        Assert.That(projectionId, Is.EqualTo(Some promotionSetId))
+
+    /// Verifies that non-create PromotionSet events without source scope remain unscoped for suppression.
+    [<Test>]
+    member _.PromotionSetNonCreateProjectionIdIsMissingWithoutScopeMetadata() =
+        let repositoryId = Guid.NewGuid()
+        let eventMetadata = metadata "corr-promotion-set-missing-scope" repositoryId
+
+        let promotionSetEvent: PromotionSet.PromotionSetEvent = { Event = PromotionSet.PromotionSetEventType.ApplyStarted; Metadata = eventMetadata }
+
+        let projectionId = Subscriber.tryGetPromotionSetProjectionId (GraceEvent.PromotionSetEvent promotionSetEvent)
+        Assert.That(projectionId, Is.EqualTo(Option.None))
+
+    /// Verifies that retry-like queue events carry PromotionSet scope directly from the event payload.
+    [<Test>]
+    member _.PromotionQueueProjectionIdUsesEventPromotionSetId() =
+        let promotionSetId = Guid.NewGuid()
+
+        let queueEvent: PromotionQueueEvent =
+            { Event = PromotionQueueEventType.PromotionSetEnqueued promotionSetId; Metadata = metadata "corr-queue-scope" (Guid.NewGuid()) }
+
+        let projectionId = Subscriber.tryGetPromotionSetProjectionId (GraceEvent.QueueEvent queueEvent)
+        Assert.That(projectionId, Is.EqualTo(Some promotionSetId))

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -2,6 +2,9 @@ namespace Grace.Server.Tests
 
 open Grace.Server.Notification
 open Grace.Types.Common
+open Grace.Types.Reference
+open Grace.Types.Visibility
+open NodaTime
 open NUnit.Framework
 
 /// Covers notification Server behavior in no-Aspire server unit tests.
@@ -27,3 +30,25 @@ type NotificationServerTests() =
     /// Verifies that SignalR reference notification fanout remains enabled when no current source override is available.
     [<Test>]
     member _.ReferenceNotificationProjectionAllowsUnscopedLegacyReference() = Assert.That(Subscriber.shouldNotifyReferenceProjection None, Is.True)
+
+    /// Verifies that deleted references are treated as hidden for public projection fanout.
+    [<Test>]
+    member _.ReferenceProjectionSuppressesDeletedPublicReference() =
+        let referenceDto =
+            { ReferenceDto.Default with
+                ReferenceId = System.Guid.NewGuid()
+                Visibility = ResourceVisibility.Public
+                Ownership = ResourceOwnership.RepositoryOwned
+                DeletedAt = Some(Instant.FromUtc(2026, 7, 9, 10, 0))
+            }
+
+        Assert.That(Subscriber.referenceDtoAllowsPublicProjection referenceDto, Is.False)
+
+    /// Verifies that derived quick-scan fanout observes the current reference projection decision.
+    [<Test>]
+    member _.DerivedReferenceProjectionSuppressesCurrentHiddenReference() =
+        Assert.That(Subscriber.shouldRecordDerivedReferenceProjection (Some false), Is.False)
+
+    /// Verifies that derived quick-scan fanout remains available when no current reference override is available.
+    [<Test>]
+    member _.DerivedReferenceProjectionAllowsUnscopedReference() = Assert.That(Subscriber.shouldRecordDerivedReferenceProjection None, Is.True)

--- a/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
@@ -395,6 +395,36 @@ type WebhookDispatchUnitTests() =
             Assert.That(deliveries, Is.Empty)
         }
 
+    /// Verifies that missing current PromotionSet snapshots still allow public apply metadata to create webhook delivery.
+    [<Test>]
+    member _.MissingCurrentPromotionSetSnapshotAllowsPublicWebhookDelivery() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.Succeeded 202 ])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatchWithCurrentVisibility
+                    Option.None
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId)
+
+            Assert.That(result.DeliveryCount, Is.EqualTo(1))
+            Assert.That(result.DeliveredCount, Is.EqualTo(1))
+            Assert.That(transport.Requests, Has.Length.EqualTo(1))
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Has.Count.EqualTo(1))
+            Assert.That(deliveries[0].Status, Is.EqualTo(WebhookDeliveryStatus.Succeeded))
+        }
+
     /// Verifies that current public visibility does not replay a private apply event as a public webhook.
     [<Test>]
     member _.CurrentPublicPromotionSetDoesNotReplayPrivateWebhookDelivery() =

--- a/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs
@@ -243,6 +243,17 @@ module private WebhookDispatchTestHelpers =
     let dispatch transport graceEvent =
         WebhookDispatch.dispatchCommittedEventAsync logger configuration hostEnvironment transport graceEvent CancellationToken.None
 
+    /// Builds dispatch test data with a current source visibility decision for stale-projection assertions.
+    let dispatchWithCurrentVisibility currentSourceAllowsProjection transport graceEvent =
+        WebhookDispatch.dispatchCommittedEventAsyncWithCurrentVisibility
+            logger
+            configuration
+            hostEnvironment
+            transport
+            currentSourceAllowsProjection
+            graceEvent
+            CancellationToken.None
+
 /// Covers webhook Dispatch Unit behavior in no-Aspire server unit tests.
 [<NonParallelizable>]
 type WebhookDispatchUnitTests() =
@@ -344,6 +355,64 @@ type WebhookDispatchUnitTests() =
 
             let! result =
                 WebhookDispatchTestHelpers.dispatch
+                    transport
+                    (WebhookDispatchTestHelpers.privateAppliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId)
+
+            Assert.That(result.DeliveryCount, Is.EqualTo(0))
+            Assert.That(result.DeliveredCount, Is.EqualTo(0))
+            Assert.That(transport.Requests, Is.Empty)
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Is.Empty)
+        }
+
+    /// Verifies that stale public apply metadata cannot publish a webhook when the source is currently hidden.
+    [<Test>]
+    member _.CurrentHiddenPromotionSetAppliedDoesNotCreateWebhookDelivery() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.Succeeded 202 ])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatchWithCurrentVisibility
+                    (Some false)
+                    transport
+                    (WebhookDispatchTestHelpers.appliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId)
+
+            Assert.That(result.DeliveryCount, Is.EqualTo(0))
+            Assert.That(result.DeliveredCount, Is.EqualTo(0))
+            Assert.That(transport.Requests, Is.Empty)
+
+            let deliveries = WebhookStore.listDeliveries rule.Scope rule.WebhookRuleId true
+            Assert.That(deliveries, Is.Empty)
+        }
+
+    /// Verifies that current public visibility does not replay a private apply event as a public webhook.
+    [<Test>]
+    member _.CurrentPublicPromotionSetDoesNotReplayPrivateWebhookDelivery() =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let targetBranchId = Guid.NewGuid()
+            let promotionSetId = Guid.NewGuid()
+            let terminalReferenceId = Guid.NewGuid()
+            let rule = WebhookDispatchTestHelpers.rule (Guid.NewGuid()) ownerId organizationId repositoryId (Option.Some targetBranchId)
+            WebhookStore.upsertRule rule |> ignore
+
+            let transport = WebhookDispatchTestHelpers.RecordingTransport([ OutboundWebhookResult.Succeeded 202 ])
+
+            let! result =
+                WebhookDispatchTestHelpers.dispatchWithCurrentVisibility
+                    (Some true)
                     transport
                     (WebhookDispatchTestHelpers.privateAppliedEvent ownerId organizationId repositoryId targetBranchId promotionSetId terminalReferenceId)
 

--- a/src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs
@@ -318,6 +318,19 @@ type WorkItemServerUnitTests() =
 
         Assert.That(summaryArtifactId, Is.Not.EqualTo(promptArtifactId))
 
+    /// Verifies that add-summary artifact link metadata carries the PromotionSet scope for public projection gating.
+    [<Test>]
+    member _.AddSummaryArtifactLinkMetadataCarriesPromotionSetScope() =
+        let promotionSetId = Guid.NewGuid()
+        let originalMetadata = metadata (Instant.FromUtc(2026, 7, 9, 10, 15))
+        originalMetadata.Properties[ "Unrelated" ] <- "kept"
+
+        let scopedMetadata = WorkItem.withPromotionSetProjectionScope (Some promotionSetId) originalMetadata
+
+        Assert.That(scopedMetadata.Properties[nameof PromotionSetId], Is.EqualTo($"{promotionSetId}"))
+        Assert.That(scopedMetadata.Properties["Unrelated"], Is.EqualTo("kept"))
+        Assert.That(originalMetadata.Properties.ContainsKey(nameof PromotionSetId), Is.False)
+
     /// Verifies that deterministic Add Summary Artifact Id Differs By Repository Work Item And Correlation Segment.
     [<Test>]
     member _.DeterministicAddSummaryArtifactIdDiffersByRepositoryWorkItemAndCorrelationSegment() =

--- a/src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/WorkItem.Server.Tests.fs
@@ -331,6 +331,30 @@ type WorkItemServerUnitTests() =
         Assert.That(scopedMetadata.Properties["Unrelated"], Is.EqualTo("kept"))
         Assert.That(originalMetadata.Properties.ContainsKey(nameof PromotionSetId), Is.False)
 
+    /// Verifies that add-summary artifact creation, artifact link, and PromotionSet link metadata share projection scope.
+    [<Test>]
+    member _.AddSummaryProjectionMetadataCarriesPromotionSetScopeForAllFanoutSegments() =
+        let promotionSetId = Guid.NewGuid()
+        let originalMetadata = metadata (Instant.FromUtc(2026, 7, 9, 10, 25))
+        let baseCorrelationId = "corr-add-summary"
+
+        let segments =
+            [|
+                "summary-artifact"
+                "summary-link"
+                "prompt-artifact"
+                "prompt-link"
+                "promotion-set-link"
+            |]
+
+        for segment in segments do
+            let scopedMetadata = WorkItem.addSummaryProjectionMetadata originalMetadata baseCorrelationId segment (Some promotionSetId)
+
+            Assert.That(scopedMetadata.CorrelationId, Is.EqualTo($"{baseCorrelationId}:add-summary:{segment}"))
+            Assert.That(scopedMetadata.Properties[nameof PromotionSetId], Is.EqualTo($"{promotionSetId}"))
+
+        Assert.That(originalMetadata.Properties.ContainsKey(nameof PromotionSetId), Is.False)
+
     /// Verifies that deterministic Add Summary Artifact Id Differs By Repository Work Item And Correlation Segment.
     [<Test>]
     member _.DeterministicAddSummaryArtifactIdDiffersByRepositoryWorkItemAndCorrelationSegment() =

--- a/src/Grace.Server/Eventing.Server.fs
+++ b/src/Grace.Server/Eventing.Server.fs
@@ -80,6 +80,13 @@ module EventingPublisher =
         visibility = ResourceVisibility.Public
         || ownership = ResourceOwnership.RepositoryOwned
 
+    /// Combines persisted event metadata with the current source visibility read used just before public fanout.
+    let internal currentSourceAllowsPublicProjection currentSourceAllowsProjection =
+        match currentSourceAllowsProjection with
+        | Option.Some false -> false
+        | Option.Some true
+        | Option.None -> true
+
     /// Implements envelope for the server request pipeline.
     let private envelope
         (eventType: AutomationEventType)
@@ -142,180 +149,186 @@ module EventingPublisher =
         |> Some
 
     /// Converts Grace domain events that have automation mappings into serialized event envelopes for dispatch.
-    let tryCreateEnvelope (graceEvent: GraceEvent) =
-        match graceEvent with
-        | PromotionSetEvent promotionSetEvent ->
-            let eventType = mapPromotionSetEventType promotionSetEvent.Event
+    let tryCreateEnvelopeWithCurrentVisibility currentSourceAllowsProjection (graceEvent: GraceEvent) =
+        if not (currentSourceAllowsPublicProjection currentSourceAllowsProjection) then
+            Option.None
+        else
+            match graceEvent with
+            | PromotionSetEvent promotionSetEvent ->
+                let eventType = mapPromotionSetEventType promotionSetEvent.Event
 
-            if not (metadataAllowsPublicProjection promotionSetEvent.Metadata) then
-                Option.None
-            else
+                if not (metadataAllowsPublicProjection promotionSetEvent.Metadata) then
+                    Option.None
+                else
+                    envelope
+                        eventType
+                        promotionSetEvent.Metadata
+                        (tryGetOwnerId promotionSetEvent.Metadata
+                         |> Option.defaultValue OwnerId.Empty)
+                        (tryGetOrganizationId promotionSetEvent.Metadata
+                         |> Option.defaultValue OrganizationId.Empty)
+                        (tryGetRepositoryId promotionSetEvent.Metadata
+                         |> Option.defaultValue RepositoryId.Empty)
+                        (tryGetActorId promotionSetEvent.Metadata "PromotionSet")
+                        (serialize promotionSetEvent)
+                    |> Some
+            | ValidationSetEvent validationSetEvent ->
+                let eventType =
+                    match validationSetEvent.Event with
+                    | ValidationSetEventType.Created _ -> AutomationEventType.ValidationSetCreated
+                    | ValidationSetEventType.Updated _
+                    | ValidationSetEventType.LogicalDeleted _ -> AutomationEventType.ValidationSetUpdated
+
                 envelope
                     eventType
-                    promotionSetEvent.Metadata
-                    (tryGetOwnerId promotionSetEvent.Metadata
-                     |> Option.defaultValue OwnerId.Empty)
-                    (tryGetOrganizationId promotionSetEvent.Metadata
-                     |> Option.defaultValue OrganizationId.Empty)
-                    (tryGetRepositoryId promotionSetEvent.Metadata
-                     |> Option.defaultValue RepositoryId.Empty)
-                    (tryGetActorId promotionSetEvent.Metadata "PromotionSet")
-                    (serialize promotionSetEvent)
-                |> Some
-        | ValidationSetEvent validationSetEvent ->
-            let eventType =
-                match validationSetEvent.Event with
-                | ValidationSetEventType.Created _ -> AutomationEventType.ValidationSetCreated
-                | ValidationSetEventType.Updated _
-                | ValidationSetEventType.LogicalDeleted _ -> AutomationEventType.ValidationSetUpdated
-
-            envelope
-                eventType
-                validationSetEvent.Metadata
-                OwnerId.Empty
-                OrganizationId.Empty
-                (tryGetRepositoryId validationSetEvent.Metadata
-                 |> Option.defaultValue RepositoryId.Empty)
-                (tryGetActorId validationSetEvent.Metadata "ValidationSet")
-                (serialize validationSetEvent)
-            |> Some
-        | ValidationResultEvent validationResultEvent ->
-            if not (metadataAllowsPublicProjection validationResultEvent.Metadata) then
-                Option.None
-            else
-                envelope
-                    AutomationEventType.ValidationResultRecorded
-                    validationResultEvent.Metadata
+                    validationSetEvent.Metadata
                     OwnerId.Empty
                     OrganizationId.Empty
-                    (tryGetRepositoryId validationResultEvent.Metadata
+                    (tryGetRepositoryId validationSetEvent.Metadata
                      |> Option.defaultValue RepositoryId.Empty)
-                    (tryGetActorId validationResultEvent.Metadata "ValidationResult")
-                    (serialize validationResultEvent)
+                    (tryGetActorId validationSetEvent.Metadata "ValidationSet")
+                    (serialize validationSetEvent)
                 |> Some
-        | ArtifactEvent artifactEvent ->
-            if not (metadataAllowsPublicProjection artifactEvent.Metadata) then
-                Option.None
-            else
-                envelope
-                    AutomationEventType.ArtifactCreated
-                    artifactEvent.Metadata
-                    OwnerId.Empty
-                    OrganizationId.Empty
-                    (tryGetRepositoryId artifactEvent.Metadata
-                     |> Option.defaultValue RepositoryId.Empty)
-                    (tryGetActorId artifactEvent.Metadata "Artifact")
-                    (serialize artifactEvent)
-                |> Some
-        | QueueEvent queueEvent ->
-            let eventType =
-                match queueEvent.Event with
-                | PromotionQueueEventType.PromotionSetEnqueued _ -> Some AutomationEventType.PromotionSetEnqueued
-                | PromotionQueueEventType.PromotionSetDequeued _ -> Some AutomationEventType.PromotionSetDequeued
-                | _ -> Option.None
-
-            if not (metadataAllowsPublicProjection queueEvent.Metadata) then
-                Option.None
-            else
-                eventType
-                |> Option.map (fun mappedType ->
+            | ValidationResultEvent validationResultEvent ->
+                if not (metadataAllowsPublicProjection validationResultEvent.Metadata) then
+                    Option.None
+                else
                     envelope
-                        mappedType
-                        queueEvent.Metadata
+                        AutomationEventType.ValidationResultRecorded
+                        validationResultEvent.Metadata
                         OwnerId.Empty
                         OrganizationId.Empty
-                        (tryGetRepositoryId queueEvent.Metadata
+                        (tryGetRepositoryId validationResultEvent.Metadata
                          |> Option.defaultValue RepositoryId.Empty)
-                        (tryGetActorId queueEvent.Metadata "PromotionQueue")
-                        (serialize queueEvent))
-        | ReviewEvent reviewEvent ->
-            let ownerId, organizationId, repositoryId, eventType =
-                match reviewEvent.Event with
-                | ReviewEventType.NotesUpserted notes -> notes.OwnerId, notes.OrganizationId, notes.RepositoryId, AutomationEventType.ReviewNotesUpdated
-                | ReviewEventType.CheckpointAdded _ ->
-                    OwnerId.Empty,
-                    OrganizationId.Empty,
-                    (tryGetRepositoryId reviewEvent.Metadata
-                     |> Option.defaultValue RepositoryId.Empty),
-                    AutomationEventType.ReviewCheckpointRecorded
-                | ReviewEventType.FindingResolved _ ->
-                    OwnerId.Empty,
-                    OrganizationId.Empty,
-                    (tryGetRepositoryId reviewEvent.Metadata
-                     |> Option.defaultValue RepositoryId.Empty),
-                    AutomationEventType.ReviewNotesUpdated
-
-            if not (metadataAllowsPublicProjection reviewEvent.Metadata) then
-                Option.None
-            else
-                envelope
-                    eventType
-                    reviewEvent.Metadata
-                    ownerId
-                    organizationId
-                    repositoryId
-                    (tryGetActorId reviewEvent.Metadata "Review")
-                    (serialize reviewEvent)
-                |> Some
-        | ReferenceEvent referenceEvent ->
-            match referenceEvent.Event with
-            | ReferenceEventType.Created (referenceId, ownerId, organizationId, repositoryId, branchId, _, _, _, referenceType, _, links) ->
-                if referenceType = ReferenceType.Promotion
-                   && metadataAllowsPublicProjection referenceEvent.Metadata then
-                    match tryGetTerminalPromotionSetId links with
-                    | Some promotionSetId ->
-                        createPromotionSetAppliedEnvelope referenceEvent.Metadata ownerId organizationId repositoryId branchId promotionSetId referenceId
-                        |> Some
-                    | Option.None -> Option.None
-                else
+                        (tryGetActorId validationResultEvent.Metadata "ValidationResult")
+                        (serialize validationResultEvent)
+                    |> Some
+            | ArtifactEvent artifactEvent ->
+                if not (metadataAllowsPublicProjection artifactEvent.Metadata) then
                     Option.None
-            | ReferenceEventType.Revealed (_, _, _, previousVisibility, newVisibility) ->
-                if previousVisibility = ResourceVisibility.Private
-                   && newVisibility = ResourceVisibility.Public then
-                    match tryGetOwnerId referenceEvent.Metadata,
-                          tryGetOrganizationId referenceEvent.Metadata,
-                          tryGetRepositoryId referenceEvent.Metadata,
-                          tryGetBranchId referenceEvent.Metadata,
-                          tryGetPromotionSetId referenceEvent.Metadata,
-                          tryGetTerminalPromotionReferenceId referenceEvent.Metadata
-                        with
-                    | Some ownerId, Some organizationId, Some repositoryId, Some branchId, Some promotionSetId, Some terminalPromotionReferenceId ->
-                        createPromotionSetAppliedEnvelope
-                            referenceEvent.Metadata
-                            ownerId
-                            organizationId
-                            repositoryId
-                            branchId
-                            promotionSetId
-                            terminalPromotionReferenceId
-                        |> Some
+                else
+                    envelope
+                        AutomationEventType.ArtifactCreated
+                        artifactEvent.Metadata
+                        OwnerId.Empty
+                        OrganizationId.Empty
+                        (tryGetRepositoryId artifactEvent.Metadata
+                         |> Option.defaultValue RepositoryId.Empty)
+                        (tryGetActorId artifactEvent.Metadata "Artifact")
+                        (serialize artifactEvent)
+                    |> Some
+            | QueueEvent queueEvent ->
+                let eventType =
+                    match queueEvent.Event with
+                    | PromotionQueueEventType.PromotionSetEnqueued _ -> Some AutomationEventType.PromotionSetEnqueued
+                    | PromotionQueueEventType.PromotionSetDequeued _ -> Some AutomationEventType.PromotionSetDequeued
                     | _ -> Option.None
-                else
-                    Option.None
-            | _ -> Option.None
-        | WorkItemEvent workItemEvent ->
-            let eventType =
-                match workItemEvent.Event with
-                | WorkItemEventType.ArtifactLinked _ -> AutomationEventType.AgentSummaryAdded
-                | _ -> AutomationEventType.ReviewNotesUpdated
 
-            if not (metadataAllowsPublicProjection workItemEvent.Metadata) then
-                Option.None
-            else
-                envelope
+                if not (metadataAllowsPublicProjection queueEvent.Metadata) then
+                    Option.None
+                else
                     eventType
-                    workItemEvent.Metadata
-                    OwnerId.Empty
-                    OrganizationId.Empty
-                    (tryGetRepositoryId workItemEvent.Metadata
-                     |> Option.defaultValue RepositoryId.Empty)
-                    (tryGetActorId workItemEvent.Metadata "WorkItem")
-                    (serialize workItemEvent)
-                |> Some
-        | PolicyEvent _
-        | ApprovalRequestEvent _
-        | OwnerEvent _
-        | BranchEvent _
-        | DirectoryVersionEvent _
-        | OrganizationEvent _
-        | RepositoryEvent _ -> Option.None
+                    |> Option.map (fun mappedType ->
+                        envelope
+                            mappedType
+                            queueEvent.Metadata
+                            OwnerId.Empty
+                            OrganizationId.Empty
+                            (tryGetRepositoryId queueEvent.Metadata
+                             |> Option.defaultValue RepositoryId.Empty)
+                            (tryGetActorId queueEvent.Metadata "PromotionQueue")
+                            (serialize queueEvent))
+            | ReviewEvent reviewEvent ->
+                let ownerId, organizationId, repositoryId, eventType =
+                    match reviewEvent.Event with
+                    | ReviewEventType.NotesUpserted notes -> notes.OwnerId, notes.OrganizationId, notes.RepositoryId, AutomationEventType.ReviewNotesUpdated
+                    | ReviewEventType.CheckpointAdded _ ->
+                        OwnerId.Empty,
+                        OrganizationId.Empty,
+                        (tryGetRepositoryId reviewEvent.Metadata
+                         |> Option.defaultValue RepositoryId.Empty),
+                        AutomationEventType.ReviewCheckpointRecorded
+                    | ReviewEventType.FindingResolved _ ->
+                        OwnerId.Empty,
+                        OrganizationId.Empty,
+                        (tryGetRepositoryId reviewEvent.Metadata
+                         |> Option.defaultValue RepositoryId.Empty),
+                        AutomationEventType.ReviewNotesUpdated
+
+                if not (metadataAllowsPublicProjection reviewEvent.Metadata) then
+                    Option.None
+                else
+                    envelope
+                        eventType
+                        reviewEvent.Metadata
+                        ownerId
+                        organizationId
+                        repositoryId
+                        (tryGetActorId reviewEvent.Metadata "Review")
+                        (serialize reviewEvent)
+                    |> Some
+            | ReferenceEvent referenceEvent ->
+                match referenceEvent.Event with
+                | ReferenceEventType.Created (referenceId, ownerId, organizationId, repositoryId, branchId, _, _, _, referenceType, _, links) ->
+                    if referenceType = ReferenceType.Promotion
+                       && metadataAllowsPublicProjection referenceEvent.Metadata then
+                        match tryGetTerminalPromotionSetId links with
+                        | Some promotionSetId ->
+                            createPromotionSetAppliedEnvelope referenceEvent.Metadata ownerId organizationId repositoryId branchId promotionSetId referenceId
+                            |> Some
+                        | Option.None -> Option.None
+                    else
+                        Option.None
+                | ReferenceEventType.Revealed (_, _, _, previousVisibility, newVisibility) ->
+                    if previousVisibility = ResourceVisibility.Private
+                       && newVisibility = ResourceVisibility.Public then
+                        match tryGetOwnerId referenceEvent.Metadata,
+                              tryGetOrganizationId referenceEvent.Metadata,
+                              tryGetRepositoryId referenceEvent.Metadata,
+                              tryGetBranchId referenceEvent.Metadata,
+                              tryGetPromotionSetId referenceEvent.Metadata,
+                              tryGetTerminalPromotionReferenceId referenceEvent.Metadata
+                            with
+                        | Some ownerId, Some organizationId, Some repositoryId, Some branchId, Some promotionSetId, Some terminalPromotionReferenceId ->
+                            createPromotionSetAppliedEnvelope
+                                referenceEvent.Metadata
+                                ownerId
+                                organizationId
+                                repositoryId
+                                branchId
+                                promotionSetId
+                                terminalPromotionReferenceId
+                            |> Some
+                        | _ -> Option.None
+                    else
+                        Option.None
+                | _ -> Option.None
+            | WorkItemEvent workItemEvent ->
+                let eventType =
+                    match workItemEvent.Event with
+                    | WorkItemEventType.ArtifactLinked _ -> AutomationEventType.AgentSummaryAdded
+                    | _ -> AutomationEventType.ReviewNotesUpdated
+
+                if not (metadataAllowsPublicProjection workItemEvent.Metadata) then
+                    Option.None
+                else
+                    envelope
+                        eventType
+                        workItemEvent.Metadata
+                        OwnerId.Empty
+                        OrganizationId.Empty
+                        (tryGetRepositoryId workItemEvent.Metadata
+                         |> Option.defaultValue RepositoryId.Empty)
+                        (tryGetActorId workItemEvent.Metadata "WorkItem")
+                        (serialize workItemEvent)
+                    |> Some
+            | PolicyEvent _
+            | ApprovalRequestEvent _
+            | OwnerEvent _
+            | BranchEvent _
+            | DirectoryVersionEvent _
+            | OrganizationEvent _
+            | RepositoryEvent _ -> Option.None
+
+    /// Converts Grace domain events that have automation mappings into serialized event envelopes for dispatch.
+    let tryCreateEnvelope (graceEvent: GraceEvent) = tryCreateEnvelopeWithCurrentVisibility Option.None graceEvent

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -469,6 +469,11 @@ module Notification =
             visibility = ResourceVisibility.Public
             || ownership = ResourceOwnership.RepositoryOwned
 
+        /// Determines whether a persisted reference snapshot is still eligible for public projection fanout.
+        let internal referenceDtoAllowsPublicProjection (referenceDto: ReferenceDto) =
+            referenceDto.DeletedAt.IsNone
+            && allowsPublicProjection referenceDto.Visibility referenceDto.Ownership
+
         /// Re-reads a PromotionSet before public projection so stale event metadata cannot publish hidden work.
         let private currentPromotionSetAllowsPublicProjection repositoryId promotionSetId correlationId =
             task {
@@ -477,8 +482,6 @@ module Notification =
                 return
                     promotionSetContext
                     |> Option.map (fun (promotionSet, _) -> allowsPublicProjection promotionSet.Visibility promotionSet.Ownership)
-                    |> Option.defaultValue false
-                    |> Some
             }
 
         /// Re-reads a Reference before public projection so SignalR, automation, and webhook fanout use current visibility.
@@ -487,13 +490,17 @@ module Notification =
                 let! referenceDto = getReferenceDto referenceId repositoryId correlationId
 
                 if referenceDto.ReferenceId = ReferenceId.Empty then
-                    return Some false
+                    return None
                 else
-                    return Some(allowsPublicProjection referenceDto.Visibility referenceDto.Ownership)
+                    return Some(referenceDtoAllowsPublicProjection referenceDto)
             }
 
         /// Applies the current reference visibility decision before SignalR clients receive reference ids.
         let internal shouldNotifyReferenceProjection currentReferenceProjection =
+            EventingPublisher.currentSourceAllowsPublicProjection currentReferenceProjection
+
+        /// Determines whether reference-derived validation side effects may run for the current source snapshot.
+        let internal shouldRecordDerivedReferenceProjection currentReferenceProjection =
             EventingPublisher.currentSourceAllowsPublicProjection currentReferenceProjection
 
         /// Extracts the PromotionSet id that owns review, queue, validation, artifact, or work-item projection side effects.
@@ -819,8 +826,6 @@ module Notification =
                         correlationId
                     )
 
-                    do! DerivedComputation.handleReferenceEvent referenceEvent
-
                     match referenceEvent.Event with
                     | ReferenceEventType.Created (referenceId,
                                                   ownerId,
@@ -835,6 +840,9 @@ module Notification =
                                                   links) ->
                         let! currentReferenceProjection = currentReferenceAllowsPublicProjection repositoryId referenceId correlationId
                         let referenceAllowsPublicNotification = shouldNotifyReferenceProjection currentReferenceProjection
+
+                        if shouldRecordDerivedReferenceProjection currentReferenceProjection then
+                            do! DerivedComputation.handleReferenceEvent referenceEvent
 
                         match referenceType with
                         | ReferenceType.Promotion ->

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -469,6 +469,34 @@ module Notification =
             visibility = ResourceVisibility.Public
             || ownership = ResourceOwnership.RepositoryOwned
 
+        /// Determines whether event metadata was public when the event was recorded for replay-sensitive public fanout.
+        let private metadataAllowsPublicProjection (metadata: EventMetadata) =
+            let visibility =
+                match metadata.Properties.TryGetValue("Visibility") with
+                | true, value ->
+                    ResourceVisibility.TryParsePublicInput value
+                    |> Option.defaultValue ResourceVisibility.Private
+                | _ ->
+                    match metadata.Properties.TryGetValue("InheritedVisibility") with
+                    | true, value ->
+                        ResourceVisibility.TryParsePublicInput value
+                        |> Option.defaultValue ResourceVisibility.Private
+                    | _ -> ResourceVisibility.Public
+
+            let ownership =
+                match metadata.Properties.TryGetValue("Ownership") with
+                | true, value ->
+                    ResourceOwnership.TryParsePublicInput value
+                    |> Option.defaultValue ResourceOwnership.ContributorOwned
+                | _ ->
+                    match metadata.Properties.TryGetValue("InheritedOwnership") with
+                    | true, value ->
+                        ResourceOwnership.TryParsePublicInput value
+                        |> Option.defaultValue ResourceOwnership.ContributorOwned
+                    | _ -> ResourceOwnership.RepositoryOwned
+
+            allowsPublicProjection visibility ownership
+
         /// Determines whether a persisted reference snapshot is still eligible for public projection fanout.
         let internal referenceDtoAllowsPublicProjection (referenceDto: ReferenceDto) =
             referenceDto.DeletedAt.IsNone
@@ -499,19 +527,40 @@ module Notification =
         let internal shouldNotifyReferenceProjection currentReferenceProjection =
             EventingPublisher.currentSourceAllowsPublicProjection currentReferenceProjection
 
+        /// Applies creation-time and current reference visibility before replay-sensitive public reference side effects.
+        let internal shouldNotifyReferenceCreatedProjection metadata currentReferenceProjection =
+            metadataAllowsPublicProjection metadata
+            && shouldNotifyReferenceProjection currentReferenceProjection
+
         /// Determines whether reference-derived validation side effects may run for the current source snapshot.
         let internal shouldRecordDerivedReferenceProjection currentReferenceProjection =
             EventingPublisher.currentSourceAllowsPublicProjection currentReferenceProjection
 
+        /// Determines whether reference-derived validation side effects may run for creation replay.
+        let internal shouldRecordDerivedReferenceCreatedProjection metadata currentReferenceProjection =
+            metadataAllowsPublicProjection metadata
+            && shouldRecordDerivedReferenceProjection currentReferenceProjection
+
+        /// Reads a GUID metadata property used by projection source revalidation.
+        let private tryGetMetadataGuid propertyName (metadata: EventMetadata) =
+            match metadata.Properties.TryGetValue propertyName with
+            | true, rawValue -> parseGuid rawValue
+            | _ -> None
+
         /// Extracts the PromotionSet id that owns review, queue, validation, artifact, or work-item projection side effects.
-        let private tryGetPromotionSetProjectionId graceEvent =
+        let internal tryGetPromotionSetProjectionId graceEvent =
             match graceEvent with
             | QueueEvent queueEvent ->
                 match queueEvent.Event with
                 | PromotionQueueEventType.PromotionSetEnqueued promotionSetId
                 | PromotionQueueEventType.PromotionSetDequeued promotionSetId -> Some promotionSetId
                 | _ -> None
-            | PromotionSetEvent promotionSetEvent -> tryGetPromotionSetIdFromMetadata promotionSetEvent.Metadata
+            | PromotionSetEvent promotionSetEvent ->
+                match promotionSetEvent.Event with
+                | PromotionSet.PromotionSetEventType.Created (promotionSetId, _, _, _, _, _, _, _) -> Some promotionSetId
+                | _ ->
+                    tryGetPromotionSetIdFromMetadata promotionSetEvent.Metadata
+                    |> Option.orElseWith (fun () -> tryGetMetadataGuid "ActorId" promotionSetEvent.Metadata)
             | ReviewEvent reviewEvent ->
                 match reviewEvent.Event with
                 | ReviewEventType.NotesUpserted notes -> notes.PromotionSetId
@@ -553,12 +602,6 @@ module Notification =
             |> Option.map (fun metadata -> metadata.CorrelationId)
             |> Option.defaultValue String.Empty
 
-        /// Reads a GUID metadata property used by projection source revalidation.
-        let private tryGetMetadataGuid propertyName (metadata: EventMetadata) =
-            match metadata.Properties.TryGetValue propertyName with
-            | true, rawValue -> parseGuid rawValue
-            | _ -> None
-
         /// Re-reads the current source for public projection fanout when the event carries an addressable source.
         let private currentSourceAllowsPublicProjection graceEvent correlationId =
             task {
@@ -566,7 +609,10 @@ module Notification =
                 | ReferenceEvent referenceEvent ->
                     match referenceEvent.Event with
                     | ReferenceEventType.Created (referenceId, _, _, repositoryId, _, _, _, _, _, _, _links) ->
-                        return! currentReferenceAllowsPublicProjection repositoryId referenceId correlationId
+                        if not (metadataAllowsPublicProjection referenceEvent.Metadata) then
+                            return Some false
+                        else
+                            return! currentReferenceAllowsPublicProjection repositoryId referenceId correlationId
                     | ReferenceEventType.Revealed _ ->
                         match tryGetRepositoryIdFromMetadata referenceEvent.Metadata, tryGetMetadataGuid "TerminalPromotionReferenceId" referenceEvent.Metadata
                             with
@@ -579,7 +625,10 @@ module Notification =
                     | Some metadata ->
                         match tryGetRepositoryIdFromMetadata metadata, tryGetPromotionSetProjectionId graceEvent with
                         | Some repositoryId, Some promotionSetId -> return! currentPromotionSetAllowsPublicProjection repositoryId promotionSetId correlationId
-                        | _ -> return None
+                        | _ ->
+                            match graceEvent with
+                            | PromotionSetEvent _ -> return Some false
+                            | _ -> return None
                     | None -> return None
             }
 
@@ -839,9 +888,9 @@ module Notification =
                                                   referenceText,
                                                   links) ->
                         let! currentReferenceProjection = currentReferenceAllowsPublicProjection repositoryId referenceId correlationId
-                        let referenceAllowsPublicNotification = shouldNotifyReferenceProjection currentReferenceProjection
+                        let referenceAllowsPublicNotification = shouldNotifyReferenceCreatedProjection referenceEvent.Metadata currentReferenceProjection
 
-                        if shouldRecordDerivedReferenceProjection currentReferenceProjection then
+                        if shouldRecordDerivedReferenceCreatedProjection referenceEvent.Metadata currentReferenceProjection then
                             do! DerivedComputation.handleReferenceEvent referenceEvent
 
                         match referenceType with

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -17,8 +17,11 @@ open Grace.Types.Automation
 open Grace.Types.Events
 open Grace.Types.Queue
 open Grace.Types.Reference
+open Grace.Types.Review
 open Grace.Types.Common
 open Grace.Types.Validation
+open Grace.Types.Visibility
+open Grace.Types.WorkItem
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.SignalR
 open Microsoft.Extensions.Configuration
@@ -412,9 +415,12 @@ module Notification =
 
         /// Gets try get promotion set id from metadata data needed by the server flow.
         let private tryGetPromotionSetIdFromMetadata (metadata: EventMetadata) =
-            match metadata.Properties.TryGetValue("ActorId") with
-            | true, actorId -> parseGuid actorId
-            | _ -> None
+            match metadata.Properties.TryGetValue(nameof PromotionSetId) with
+            | true, promotionSetId -> parseGuid promotionSetId
+            | _ ->
+                match metadata.Properties.TryGetValue("ActorId") with
+                | true, actorId -> parseGuid actorId
+                | _ -> None
 
         /// Gets try get terminal promotion set id data needed by the server flow.
         let private tryGetTerminalPromotionSetId (links: ReferenceLinkType seq) =
@@ -456,6 +462,118 @@ module Notification =
                     return Some(promotionSet, branch)
                 else
                     return None
+            }
+
+        /// Determines whether a current source visibility snapshot can be published to public projection surfaces.
+        let private allowsPublicProjection visibility ownership =
+            visibility = ResourceVisibility.Public
+            || ownership = ResourceOwnership.RepositoryOwned
+
+        /// Re-reads a PromotionSet before public projection so stale event metadata cannot publish hidden work.
+        let private currentPromotionSetAllowsPublicProjection repositoryId promotionSetId correlationId =
+            task {
+                let! promotionSetContext = getPromotionSetContext repositoryId promotionSetId correlationId
+
+                return
+                    promotionSetContext
+                    |> Option.map (fun (promotionSet, _) -> allowsPublicProjection promotionSet.Visibility promotionSet.Ownership)
+                    |> Option.defaultValue false
+                    |> Some
+            }
+
+        /// Re-reads a Reference before public projection so SignalR, automation, and webhook fanout use current visibility.
+        let private currentReferenceAllowsPublicProjection repositoryId referenceId correlationId =
+            task {
+                let! referenceDto = getReferenceDto referenceId repositoryId correlationId
+
+                if referenceDto.ReferenceId = ReferenceId.Empty then
+                    return Some false
+                else
+                    return Some(allowsPublicProjection referenceDto.Visibility referenceDto.Ownership)
+            }
+
+        /// Applies the current reference visibility decision before SignalR clients receive reference ids.
+        let internal shouldNotifyReferenceProjection currentReferenceProjection =
+            EventingPublisher.currentSourceAllowsPublicProjection currentReferenceProjection
+
+        /// Extracts the PromotionSet id that owns review, queue, validation, artifact, or work-item projection side effects.
+        let private tryGetPromotionSetProjectionId graceEvent =
+            match graceEvent with
+            | QueueEvent queueEvent ->
+                match queueEvent.Event with
+                | PromotionQueueEventType.PromotionSetEnqueued promotionSetId
+                | PromotionQueueEventType.PromotionSetDequeued promotionSetId -> Some promotionSetId
+                | _ -> None
+            | PromotionSetEvent promotionSetEvent -> tryGetPromotionSetIdFromMetadata promotionSetEvent.Metadata
+            | ReviewEvent reviewEvent ->
+                match reviewEvent.Event with
+                | ReviewEventType.NotesUpserted notes -> notes.PromotionSetId
+                | ReviewEventType.CheckpointAdded checkpoint -> checkpoint.PromotionSetId
+                | ReviewEventType.FindingResolved _ -> tryGetPromotionSetIdFromMetadata reviewEvent.Metadata
+            | ValidationResultEvent validationResultEvent ->
+                match validationResultEvent.Event with
+                | ValidationResultEventType.Recorded result -> result.PromotionSetId
+            | ArtifactEvent artifactEvent -> tryGetPromotionSetIdFromMetadata artifactEvent.Metadata
+            | WorkItemEvent workItemEvent ->
+                match workItemEvent.Event with
+                | WorkItemEventType.PromotionSetLinked promotionSetId
+                | WorkItemEventType.PromotionSetUnlinked promotionSetId -> Some promotionSetId
+                | _ -> tryGetPromotionSetIdFromMetadata workItemEvent.Metadata
+            | _ -> None
+
+        /// Returns event metadata for domain events that can participate in public projection fanout.
+        let private tryGetProjectionMetadata graceEvent =
+            match graceEvent with
+            | BranchEvent event -> Some event.Metadata
+            | DirectoryVersionEvent event -> Some event.Metadata
+            | OrganizationEvent event -> Some event.Metadata
+            | OwnerEvent event -> Some event.Metadata
+            | ReferenceEvent event -> Some event.Metadata
+            | RepositoryEvent event -> Some event.Metadata
+            | PolicyEvent event -> Some event.Metadata
+            | QueueEvent event -> Some event.Metadata
+            | PromotionSetEvent event -> Some event.Metadata
+            | ReviewEvent event -> Some event.Metadata
+            | ValidationSetEvent event -> Some event.Metadata
+            | ValidationResultEvent event -> Some event.Metadata
+            | ArtifactEvent event -> Some event.Metadata
+            | WorkItemEvent event -> Some event.Metadata
+            | ApprovalRequestEvent event -> Some event.Metadata
+
+        /// Reads the event correlation id without depending on each event arm's local logging binding.
+        let private getProjectionCorrelationId graceEvent =
+            tryGetProjectionMetadata graceEvent
+            |> Option.map (fun metadata -> metadata.CorrelationId)
+            |> Option.defaultValue String.Empty
+
+        /// Reads a GUID metadata property used by projection source revalidation.
+        let private tryGetMetadataGuid propertyName (metadata: EventMetadata) =
+            match metadata.Properties.TryGetValue propertyName with
+            | true, rawValue -> parseGuid rawValue
+            | _ -> None
+
+        /// Re-reads the current source for public projection fanout when the event carries an addressable source.
+        let private currentSourceAllowsPublicProjection graceEvent correlationId =
+            task {
+                match graceEvent with
+                | ReferenceEvent referenceEvent ->
+                    match referenceEvent.Event with
+                    | ReferenceEventType.Created (referenceId, _, _, repositoryId, _, _, _, _, _, _, _links) ->
+                        return! currentReferenceAllowsPublicProjection repositoryId referenceId correlationId
+                    | ReferenceEventType.Revealed _ ->
+                        match tryGetRepositoryIdFromMetadata referenceEvent.Metadata, tryGetMetadataGuid "TerminalPromotionReferenceId" referenceEvent.Metadata
+                            with
+                        | Some repositoryId, Some terminalReferenceId ->
+                            return! currentReferenceAllowsPublicProjection repositoryId terminalReferenceId correlationId
+                        | _ -> return Some false
+                    | _ -> return None
+                | _ ->
+                    match tryGetProjectionMetadata graceEvent with
+                    | Some metadata ->
+                        match tryGetRepositoryIdFromMetadata metadata, tryGetPromotionSetProjectionId graceEvent with
+                        | Some repositoryId, Some promotionSetId -> return! currentPromotionSetAllowsPublicProjection repositoryId promotionSetId correlationId
+                        | _ -> return None
+                    | None -> return None
             }
 
         /// Resolves try resolve automation branch context data from request or repository state.
@@ -715,6 +833,9 @@ module Notification =
                                                   referenceType,
                                                   referenceText,
                                                   links) ->
+                        let! currentReferenceProjection = currentReferenceAllowsPublicProjection repositoryId referenceId correlationId
+                        let referenceAllowsPublicNotification = shouldNotifyReferenceProjection currentReferenceProjection
+
                         match referenceType with
                         | ReferenceType.Promotion ->
                             let! branchDto = getBranchDto branchId repositoryId correlationId
@@ -751,7 +872,8 @@ module Notification =
                             let! branchDto = getBranchDto branchId repositoryId correlationId
                             let! parentBranchDto = getBranchDto branchDto.ParentBranchId repositoryId correlationId
 
-                            if not <| isNull hubContext then
+                            if referenceAllowsPublicNotification
+                               && not <| isNull hubContext then
                                 do!
                                     hubContext
                                         .Clients
@@ -796,7 +918,8 @@ module Notification =
                             let! branchDto = getBranchDto branchId repositoryId correlationId
                             let! parentBranchDto = getBranchDto branchDto.ParentBranchId repositoryId correlationId
 
-                            if not <| isNull hubContext then
+                            if referenceAllowsPublicNotification
+                               && not <| isNull hubContext then
                                 do!
                                     hubContext
                                         .Clients
@@ -833,7 +956,8 @@ module Notification =
                             let! branchDto = getBranchDto branchId repositoryId correlationId
                             let! parentBranchDto = getBranchDto branchDto.ParentBranchId repositoryId correlationId
 
-                            if not <| isNull hubContext then
+                            if referenceAllowsPublicNotification
+                               && not <| isNull hubContext then
                                 do!
                                     hubContext
                                         .Clients
@@ -891,11 +1015,12 @@ module Notification =
                         | ReferenceType.Rebase
                         | ReferenceType.External -> ()
 
-                        do!
-                            hubContext
-                                .Clients
-                                .Group($"{repositoryId}")
-                                .NotifyRepository(repositoryId, referenceId)
+                        if referenceAllowsPublicNotification then
+                            do!
+                                hubContext
+                                    .Clients
+                                    .Group($"{repositoryId}")
+                                    .NotifyRepository(repositoryId, referenceId)
                     | _ -> ()
                 | RepositoryEvent repositoryEvent ->
                     let correlationId = repositoryEvent.Metadata.CorrelationId
@@ -993,7 +1118,9 @@ module Notification =
                         correlationId
                     )
 
-                match EventingPublisher.tryCreateEnvelope graceEvent with
+                let! currentProjectionAllows = currentSourceAllowsPublicProjection graceEvent (getProjectionCorrelationId graceEvent)
+
+                match EventingPublisher.tryCreateEnvelopeWithCurrentVisibility currentProjectionAllows graceEvent with
                 | Some envelope ->
                     do! emitAutomationEvent hubContext envelope
 
@@ -1002,11 +1129,12 @@ module Notification =
                     use transport = new WebhookDispatch.HttpOutboundWebhookTransport(configuration, hostEnvironment)
 
                     let! _ =
-                        WebhookDispatch.dispatchCommittedEventAsync
+                        WebhookDispatch.dispatchCommittedEventAsyncWithCurrentVisibility
                             log
                             configuration
                             hostEnvironment
                             (transport :> WebhookDispatch.IOutboundWebhookTransport)
+                            currentProjectionAllows
                             graceEvent
                             CancellationToken.None
 

--- a/src/Grace.Server/WebhookDispatch.Server.fs
+++ b/src/Grace.Server/WebhookDispatch.Server.fs
@@ -232,11 +232,20 @@ module WebhookDispatch =
         | _ -> Option.None
 
     /// Selects the external webhook event projection supported for a Grace domain event.
-    let private tryCreateDispatchEvent graceEvent =
-        match graceEvent with
-        | GraceEvent.PromotionSetEvent promotionSetEvent -> tryCreatePromotionSetAppliedDispatchEvent promotionSetEvent
-        | GraceEvent.ReferenceEvent referenceEvent -> tryCreatePromotionSetAppliedDispatchEventFromReveal referenceEvent
-        | _ -> Option.None
+    let private tryCreateDispatchEvent currentSourceAllowsProjection graceEvent =
+        let currentSourceAllowsPublicProjection =
+            match currentSourceAllowsProjection with
+            | Option.Some false -> false
+            | Option.Some true
+            | Option.None -> true
+
+        if not currentSourceAllowsPublicProjection then
+            Option.None
+        else
+            match graceEvent with
+            | GraceEvent.PromotionSetEvent promotionSetEvent -> tryCreatePromotionSetAppliedDispatchEvent promotionSetEvent
+            | GraceEvent.ReferenceEvent referenceEvent -> tryCreatePromotionSetAppliedDispatchEventFromReveal referenceEvent
+            | _ -> Option.None
 
     /// Computes hmac sha256 hex data used by Grace Server.
     let private hmacSha256Hex (key: string) (material: byte array) =
@@ -560,17 +569,18 @@ module WebhookDispatch =
         }
 
     /// Coordinates dispatch committed event async processing for Grace Server.
-    let dispatchCommittedEventAsync
+    let dispatchCommittedEventAsyncWithCurrentVisibility
         (logger: ILogger)
         (configuration: IConfiguration)
         (hostEnvironment: IHostEnvironment)
         (transport: IOutboundWebhookTransport)
+        currentSourceAllowsProjection
         (graceEvent: GraceEvent)
         (cancellationToken: CancellationToken)
         =
         task {
             try
-                match tryCreateDispatchEvent graceEvent with
+                match tryCreateDispatchEvent currentSourceAllowsProjection graceEvent with
                 | Option.None -> return DispatchResult.Empty
                 | Option.Some (definition, scope, dedupeKey, payloadJson) ->
                     let rules = WebhookStore.listEnabledRulesForEvent scope definition.Name definition.Version
@@ -605,6 +615,17 @@ module WebhookDispatch =
                 logger.LogError(ex, "Webhook dispatch failed after source event commit; source workflow will not be blocked.")
                 return DispatchResult.Empty
         }
+
+    /// Coordinates dispatch committed event async processing for Grace Server.
+    let dispatchCommittedEventAsync
+        (logger: ILogger)
+        (configuration: IConfiguration)
+        (hostEnvironment: IHostEnvironment)
+        (transport: IOutboundWebhookTransport)
+        (graceEvent: GraceEvent)
+        (cancellationToken: CancellationToken)
+        =
+        dispatchCommittedEventAsyncWithCurrentVisibility logger configuration hostEnvironment transport Option.None graceEvent cancellationToken
 
     /// Coordinates drain scheduled retries once async processing for Grace Server.
     let drainScheduledRetriesOnceAsync

--- a/src/Grace.Server/WorkItem.Server.fs
+++ b/src/Grace.Server/WorkItem.Server.fs
@@ -617,6 +617,16 @@ module WorkItem =
     /// Coordinates add summary correlation id processing for Grace Server.
     let private addSummaryCorrelationId (baseCorrelationId: CorrelationId) (segment: string) = $"{baseCorrelationId}:add-summary:{segment}"
 
+    /// Builds add-summary event metadata so artifact creation, artifact links, and PromotionSet links share projection scope.
+    let internal addSummaryProjectionMetadata
+        (metadata: EventMetadata)
+        (baseCorrelationId: CorrelationId)
+        (segment: string)
+        (promotionSetId: PromotionSetId option)
+        =
+        withCorrelationId metadata (addSummaryCorrelationId baseCorrelationId segment)
+        |> withPromotionSetProjectionScope promotionSetId
+
     /// Determines whether duplicate correlation id error.
     let private isDuplicateCorrelationIdError (graceError: GraceError) =
         String.Equals(graceError.Error, WorkItemError.getErrorMessage WorkItemError.DuplicateCorrelationId, StringComparison.OrdinalIgnoreCase)
@@ -768,11 +778,9 @@ module WorkItem =
 
                         let promotionSetIdOption = tryParseNonEmptyGuid parameters.PromotionSetId
 
-                        let summaryArtifactMetadata = withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "summary-artifact")
+                        let summaryArtifactMetadata = addSummaryProjectionMetadata requestMetadata correlationId "summary-artifact" promotionSetIdOption
 
-                        let summaryLinkMetadata =
-                            withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "summary-link")
-                            |> withPromotionSetProjectionScope promotionSetIdOption
+                        let summaryLinkMetadata = addSummaryProjectionMetadata requestMetadata correlationId "summary-link" promotionSetIdOption
 
                         let! summaryArtifactResult =
                             createArtifactFromContent
@@ -811,11 +819,10 @@ module WorkItem =
                                     if hasPromptContent then
                                         async {
                                             let promptArtifactMetadata =
-                                                withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "prompt-artifact")
+                                                addSummaryProjectionMetadata requestMetadata correlationId "prompt-artifact" promotionSetIdOption
 
                                             let promptLinkMetadata =
-                                                withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "prompt-link")
-                                                |> withPromotionSetProjectionScope promotionSetIdOption
+                                                addSummaryProjectionMetadata requestMetadata correlationId "prompt-link" promotionSetIdOption
 
                                             let! createdPromptArtifactResult =
                                                 createArtifactFromContent
@@ -858,7 +865,7 @@ module WorkItem =
                                         match promotionSetIdOption with
                                         | Some promotionSetId ->
                                             let promotionSetLinkMetadata =
-                                                withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "promotion-set-link")
+                                                addSummaryProjectionMetadata requestMetadata correlationId "promotion-set-link" promotionSetIdOption
 
                                             handleWorkItemCommandAllowReplay
                                                 workItemActorProxy

--- a/src/Grace.Server/WorkItem.Server.fs
+++ b/src/Grace.Server/WorkItem.Server.fs
@@ -605,6 +605,15 @@ module WorkItem =
     /// Adds correlation id to the server request model.
     let private withCorrelationId (metadata: EventMetadata) (correlationId: CorrelationId) = { metadata with CorrelationId = correlationId }
 
+    /// Carries add-summary PromotionSet scope onto artifact link events emitted before the explicit PromotionSet link.
+    let internal withPromotionSetProjectionScope (promotionSetId: PromotionSetId option) (metadata: EventMetadata) =
+        match promotionSetId with
+        | Some promotionSetId ->
+            let properties = Dictionary<string, string>(metadata.Properties, StringComparer.OrdinalIgnoreCase)
+            properties[nameof PromotionSetId] <- $"{promotionSetId}"
+            { metadata with Properties = properties }
+        | None -> metadata
+
     /// Coordinates add summary correlation id processing for Grace Server.
     let private addSummaryCorrelationId (baseCorrelationId: CorrelationId) (segment: string) = $"{baseCorrelationId}:add-summary:{segment}"
 
@@ -757,9 +766,13 @@ module WorkItem =
                             repositoryActorProxy.Get correlationId
                             |> Async.AwaitTask
 
+                        let promotionSetIdOption = tryParseNonEmptyGuid parameters.PromotionSetId
+
                         let summaryArtifactMetadata = withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "summary-artifact")
 
-                        let summaryLinkMetadata = withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "summary-link")
+                        let summaryLinkMetadata =
+                            withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "summary-link")
+                            |> withPromotionSetProjectionScope promotionSetIdOption
 
                         let! summaryArtifactResult =
                             createArtifactFromContent
@@ -800,7 +813,9 @@ module WorkItem =
                                             let promptArtifactMetadata =
                                                 withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "prompt-artifact")
 
-                                            let promptLinkMetadata = withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "prompt-link")
+                                            let promptLinkMetadata =
+                                                withCorrelationId requestMetadata (addSummaryCorrelationId correlationId "prompt-link")
+                                                |> withPromotionSetProjectionScope promotionSetIdOption
 
                                             let! createdPromptArtifactResult =
                                                 createArtifactFromContent
@@ -839,8 +854,6 @@ module WorkItem =
                                         |> result400BadRequest (graceError |> withContext)
                                         |> Async.AwaitTask
                                 | Ok promptArtifactId ->
-                                    let promotionSetIdOption = tryParseNonEmptyGuid parameters.PromotionSetId
-
                                     let! promotionSetLinkResult =
                                         match promotionSetIdOption with
                                         | Some promotionSetId ->


### PR DESCRIPTION
Related to #649.

## Summary

- Adds projection-time visibility rechecks for public fanout so persisted event metadata is not the only privacy gate.
- Gates public automation/Eventing envelopes, webhook delivery creation, and SignalR/watch reference notifications when the current source is hidden or stale.
- Preserves reveal as the public publication point: reveal-time public publication remains exactly once, while old private apply history is not replayed.

## Surface Preflight Outcomes

- Webhooks: updated through `WebhookDispatch.dispatchCommittedEventAsyncWithCurrentVisibility` before delivery creation.
- Eventing/automation: updated through `tryCreateEnvelopeWithCurrentVisibility` before public automation envelopes are created.
- SignalR/watch notifications: updated so reference notifications re-read current reference visibility before sending reference ids to clients.
- Notifications: updated through the same SignalR automation routing path.
- Queues: already covered by #645 caller-visible queue projection and private metadata stamping on this branch.
- Review reports/candidates: already covered by #645 review metadata inheritance and caller-visible queue projection on this branch.
- Work items: covered by current fanout recheck when work-item events carry a PromotionSet source, plus #645 metadata inheritance.
- Artifacts: covered by current fanout recheck when artifact events inherit a PromotionSet source id, plus existing private automation suppression.
- Activity/search: no external activity/search projection route was found in the searched server modules; current activity usage is diagnostics instrumentation.
- Logs: no public log projection or delivery route was found for GV-10; structured server logs remain internal diagnostics.
- Docs/event reference: deferred to GV-15 because event names did not change.

## Validation

- `dotnet tool run fantomas src/Grace.Server/Eventing.Server.fs src/Grace.Server/WebhookDispatch.Server.fs src/Grace.Server/Notification.Server.fs src/Grace.Server.Unit.Tests/Eventing.Server.Tests.fs src/Grace.Server.Unit.Tests/WebhookDispatch.Server.Tests.fs` passed.
- `dotnet tool run fantomas src/Grace.Server/Notification.Server.fs src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs` passed.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj` passed.
- `dotnet test --no-build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj --filter "FullyQualifiedName~AutomationEventingTests|FullyQualifiedName~WebhookDispatchUnitTests|FullyQualifiedName~NotificationServerTests"` passed: 53 passed.
- `pwsh ./scripts/validate.ps1 -Fast` passed after the final diff.
- `git diff --check` passed.

## Review Status

- Current head: `5208291f`.
- PR-attached Validate: passed on run `29014521720`, job `86106064372`.
- Codex Code Review Bot: third substantive cycle completed on `5208291f` with three fresh source-scope findings.
- Stop notice posted on [#649](https://github.com/ScottArbeit/Grace/issues/649#issuecomment-4924641930) and [PR #695](https://github.com/ScottArbeit/Grace/pull/695#issuecomment-4924642050).
- Local unblock page: `C:\Users\scott\AppData\Local\Temp\grace-638-orchestration\grace-649-unblock-current.html`.
- Coding status: stopped. No further worker may be assigned until the maintainer approves the revised issue/ledger or explicitly directs continued patching.
