### PR TITLE
B4.1 pricing plan, rate, and assignment tables

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="OperationsUsageSql.fs" />
+    <Compile Include="OperationsPricingSql.fs" />
     <Compile Include="OperationsUsagePartitioningSql.fs" />
     <Compile Include="OperationsEntities.fs" />
     <Compile Include="OperationsDbContext.fs" />
@@ -23,6 +24,7 @@
     <Compile Include="Migrations\20260707140000_AddRawUsageFactRehydrationExpiry.fs" />
     <Compile Include="Migrations\20260708170000_AddRawUsageFactArchiveFailureState.fs" />
     <Compile Include="Migrations\20260709090000_AddRawUsageFactRehydrationExpiryIndex.fs" />
+    <Compile Include="Migrations\20260709110000_AddPricingPlanRateAssignment.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
@@ -541,7 +541,7 @@ END;');
 
         rawFact
             .HasIndex([| "RehydrationExpiresAtUtc" |])
-            .HasDatabaseName(OperationsUsageSql.TemporaryHotCleanupExpiryIndexName)
+            .HasDatabaseName("IX_ops_RawUsageFact_RehydrationExpiresAtUtc")
             .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
@@ -72,7 +72,7 @@ BEGIN
         PricingRateId uniqueidentifier NOT NULL,
         PricingPlanId uniqueidentifier NOT NULL,
         BillableUsageKind int NOT NULL,
-        CurrencyCode char({OperationsPricingSql.CurrencyCodeLength}) NOT NULL,
+        CurrencyCode char({OperationsPricingSql.CurrencyCodeLength}) COLLATE Latin1_General_100_BIN2 NOT NULL,
         UnitName nvarchar({OperationsPricingSql.UnitNameMaxLength}) NOT NULL,
         UnitQuantity bigint NOT NULL,
         UnitPriceMicros bigint NOT NULL,
@@ -83,7 +83,7 @@ BEGIN
         CONSTRAINT FK_ops_PricingRate_PricingPlan FOREIGN KEY (PricingPlanId) REFERENCES {OperationsPricingSql.PricingPlanTable}(PricingPlanId),
         CONSTRAINT CK_ops_PricingRate_Id_NotEmpty CHECK (PricingRateId <> '00000000-0000-0000-0000-000000000000'),
         CONSTRAINT CK_ops_PricingRate_BillableUsageKind_Positive CHECK (BillableUsageKind > 0),
-        CONSTRAINT CK_ops_PricingRate_CurrencyCode_Upper CHECK (CurrencyCode = UPPER(CurrencyCode) AND CurrencyCode NOT LIKE '%%[^A-Z]%%'),
+        CONSTRAINT CK_ops_PricingRate_CurrencyCode_Upper CHECK (CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode) COLLATE Latin1_General_100_BIN2 AND CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE '%%[^A-Z]%%'),
         CONSTRAINT CK_ops_PricingRate_UnitName_NotBlank CHECK (LEN(LTRIM(RTRIM(UnitName))) > 0),
         CONSTRAINT CK_ops_PricingRate_UnitQuantity_Positive CHECK (UnitQuantity > 0),
         CONSTRAINT CK_ops_PricingRate_UnitPriceMicros_NonNegative CHECK (UnitPriceMicros >= 0),
@@ -229,7 +229,7 @@ END;
 
         migrationBuilder.Sql(
             $"""
-CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingPlanOverlapTriggerName}
+EXEC(N'CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingPlanOverlapTriggerName}
 ON {OperationsPricingSql.PricingPlanTable}
 AFTER INSERT, UPDATE
 AS
@@ -240,23 +240,23 @@ BEGIN
     (
         SELECT 1
         FROM inserted AS candidate
-        INNER JOIN {OperationsPricingSql.PricingPlanTable} AS existing
+        INNER JOIN {OperationsPricingSql.PricingPlanTable} AS existing WITH (UPDLOCK, HOLDLOCK)
             ON existing.PlanCode = candidate.PlanCode
             AND existing.PricingPlanId <> candidate.PricingPlanId
-            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
-            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
     )
     BEGIN
-        THROW 57411, 'Pricing plan effective windows cannot overlap for the same plan code.', 1;
+        THROW 57411, ''Pricing plan effective windows cannot overlap for the same plan code.'', 1;
     END;
-END;
+END;');
 """
         )
         |> ignore
 
         migrationBuilder.Sql(
             $"""
-CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.BillableUsageKindMappingOverlapTriggerName}
+EXEC(N'CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.BillableUsageKindMappingOverlapTriggerName}
 ON {OperationsPricingSql.BillableUsageKindMappingTable}
 AFTER INSERT, UPDATE
 AS
@@ -267,23 +267,23 @@ BEGIN
     (
         SELECT 1
         FROM inserted AS candidate
-        INNER JOIN {OperationsPricingSql.BillableUsageKindMappingTable} AS existing
+        INNER JOIN {OperationsPricingSql.BillableUsageKindMappingTable} AS existing WITH (UPDLOCK, HOLDLOCK)
             ON existing.FactKind = candidate.FactKind
             AND existing.BillableUsageKindMappingId <> candidate.BillableUsageKindMappingId
-            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
-            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
     )
     BEGIN
-        THROW 57412, 'Billable usage-kind mapping effective windows cannot overlap for the same tracked fact kind.', 1;
+        THROW 57412, ''Billable usage-kind mapping effective windows cannot overlap for the same tracked fact kind.'', 1;
     END;
-END;
+END;');
 """
         )
         |> ignore
 
         migrationBuilder.Sql(
             $"""
-CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingRateOverlapTriggerName}
+EXEC(N'CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingRateOverlapTriggerName}
 ON {OperationsPricingSql.PricingRateTable}
 AFTER INSERT, UPDATE
 AS
@@ -294,24 +294,24 @@ BEGIN
     (
         SELECT 1
         FROM inserted AS candidate
-        INNER JOIN {OperationsPricingSql.PricingRateTable} AS existing
+        INNER JOIN {OperationsPricingSql.PricingRateTable} AS existing WITH (UPDLOCK, HOLDLOCK)
             ON existing.PricingPlanId = candidate.PricingPlanId
             AND existing.BillableUsageKind = candidate.BillableUsageKind
             AND existing.PricingRateId <> candidate.PricingRateId
-            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
-            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
     )
     BEGIN
-        THROW 57413, 'Pricing rate effective windows cannot overlap for the same plan and billable usage kind.', 1;
+        THROW 57413, ''Pricing rate effective windows cannot overlap for the same plan and billable usage kind.'', 1;
     END;
-END;
+END;');
 """
         )
         |> ignore
 
         migrationBuilder.Sql(
             $"""
-CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName}
+EXEC(N'CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName}
 ON {OperationsPricingSql.CustomerPricingAssignmentTable}
 AFTER INSERT, UPDATE
 AS
@@ -322,19 +322,19 @@ BEGIN
     (
         SELECT 1
         FROM inserted AS candidate
-        INNER JOIN {OperationsPricingSql.CustomerPricingAssignmentTable} AS existing
+        INNER JOIN {OperationsPricingSql.CustomerPricingAssignmentTable} AS existing WITH (UPDLOCK, HOLDLOCK)
             ON existing.CustomerId = candidate.CustomerId
             AND existing.OwnerId = candidate.OwnerId
             AND existing.OrganizationId = candidate.OrganizationId
             AND existing.RepositoryId = candidate.RepositoryId
             AND existing.CustomerPricingAssignmentId <> candidate.CustomerPricingAssignmentId
-            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
-            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
     )
     BEGIN
-        THROW 57414, 'Customer pricing assignment effective windows cannot overlap for the same customer repository scope.', 1;
+        THROW 57414, ''Customer pricing assignment effective windows cannot overlap for the same customer repository scope.'', 1;
     END;
-END;
+END;');
 """
         )
         |> ignore
@@ -374,4 +374,554 @@ END;
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
-        OperationsModel.configure modelBuilder
+        // Deliberately keep this migration target model frozen with literals so future runtime model edits
+        // cannot change the historical reviewed migration point before a new migration updates it.
+        modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("ArchiveState").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveBlobName")
+            .HasMaxLength(512)
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveChecksumSha256Hex")
+            .HasMaxLength(64)
+            .IsFixedLength()
+            .IsUnicode(false)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<int64>>("ArchiveByteLength")
+            .HasColumnType("bigint")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchivedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("RehydrationExpiresAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<string>("LastArchiveFailureReason")
+            .HasMaxLength(400)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("LastArchiveFailureAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<int>("ArchiveFailureCount")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveRetiredAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "ArchiveState"
+                    "ObservedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ArchiveStateObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex([| "RehydrationExpiresAtUtc" |])
+            .HasDatabaseName(OperationsUsageSql.TemporaryHotCleanupExpiryIndexName)
+            .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable("UsageAggregateMinute", "ops")
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore
+
+        let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
+
+        pricingPlan.ToTable("PricingPlan", "ops")
+        |> ignore
+
+        pricingPlan
+            .HasKey([| "PricingPlanId" |])
+            .HasName("PK_ops_PricingPlan")
+        |> ignore
+
+        pricingPlan
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("PlanCode")
+            .HasMaxLength(128)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .HasIndex([| "PlanCode"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_PricingPlan_CodeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
+
+        mapping.ToTable("BillableUsageKindMapping", "ops")
+        |> ignore
+
+        mapping
+            .HasKey([| "BillableUsageKindMappingId" |])
+            .HasName("PK_ops_BillableUsageKindMapping")
+        |> ignore
+
+        mapping
+            .Property<System.Guid>("BillableUsageKindMappingId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        mapping.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        mapping
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .HasIndex([| "FactKind"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        mapping
+            .HasIndex(
+                [|
+                    "FactKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillableUsageKindMapping_FactKindEffective")
+        |> ignore
+
+        let pricingRate = modelBuilder.Entity<PricingRateEntity>()
+
+        pricingRate.ToTable("PricingRate", "ops")
+        |> ignore
+
+        pricingRate
+            .HasKey([| "PricingRateId" |])
+            .HasName("PK_ops_PricingRate")
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingRateId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("CurrencyCode")
+            .HasMaxLength(3)
+            .IsFixedLength()
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitQuantity")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitPriceMicros")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingRate_PlanUsageKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingRate_PlanUsageKindEffective")
+        |> ignore
+
+        pricingRate
+            .HasOne(fun rate -> rate.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+
+        assignment.ToTable("CustomerPricingAssignment", "ops")
+        |> ignore
+
+        assignment
+            .HasKey([| "CustomerPricingAssignmentId" |])
+            .HasName("PK_ops_CustomerPricingAssignment")
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_CustomerPricingAssignment_ScopeEffective")
+        |> ignore
+
+        assignment
+            .HasOne(fun assignment -> assignment.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
@@ -72,7 +72,7 @@ BEGIN
         PricingRateId uniqueidentifier NOT NULL,
         PricingPlanId uniqueidentifier NOT NULL,
         BillableUsageKind int NOT NULL,
-        CurrencyCode char({OperationsPricingSql.CurrencyCodeLength}) COLLATE Latin1_General_100_BIN2 NOT NULL,
+        CurrencyCode varchar({OperationsPricingSql.CurrencyCodeLength}) COLLATE Latin1_General_100_BIN2 NOT NULL,
         UnitName nvarchar({OperationsPricingSql.UnitNameMaxLength}) NOT NULL,
         UnitQuantity bigint NOT NULL,
         UnitPriceMicros bigint NOT NULL,
@@ -83,7 +83,7 @@ BEGIN
         CONSTRAINT FK_ops_PricingRate_PricingPlan FOREIGN KEY (PricingPlanId) REFERENCES {OperationsPricingSql.PricingPlanTable}(PricingPlanId),
         CONSTRAINT CK_ops_PricingRate_Id_NotEmpty CHECK (PricingRateId <> '00000000-0000-0000-0000-000000000000'),
         CONSTRAINT CK_ops_PricingRate_BillableUsageKind_Positive CHECK (BillableUsageKind > 0),
-        CONSTRAINT CK_ops_PricingRate_CurrencyCode_Upper CHECK (CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode) COLLATE Latin1_General_100_BIN2 AND CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE '%%[^A-Z]%%'),
+        CONSTRAINT CK_ops_PricingRate_CurrencyCode_Upper CHECK (LEN(CurrencyCode) = 3 AND CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode) COLLATE Latin1_General_100_BIN2 AND CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE '%%[^A-Z]%%'),
         CONSTRAINT CK_ops_PricingRate_UnitName_NotBlank CHECK (LEN(LTRIM(RTRIM(UnitName))) > 0),
         CONSTRAINT CK_ops_PricingRate_UnitQuantity_Positive CHECK (UnitQuantity > 0),
         CONSTRAINT CK_ops_PricingRate_UnitPriceMicros_NonNegative CHECK (UnitPriceMicros >= 0),
@@ -755,8 +755,8 @@ END;');
 
         pricingRate
             .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
             .HasMaxLength(3)
-            .IsFixedLength()
             .IsUnicode(false)
             .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
@@ -824,6 +824,7 @@ END;');
             .HasOne(fun rate -> rate.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingRate_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
@@ -923,5 +924,6 @@ END;');
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
@@ -205,6 +205,18 @@ IF NOT EXISTS
     SELECT 1
     FROM sys.indexes
     WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
+    AND name = N'{OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName}'
+)
+BEGIN
+    CREATE INDEX {OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName}
+        ON {OperationsPricingSql.CustomerPricingAssignmentTable}(PricingPlanId);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
     AND name = N'UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom'
 )
 BEGIN
@@ -890,6 +902,11 @@ END;');
             .HasColumnType("datetime2(7)")
             .HasDefaultValueSql("SYSUTCDATETIME()")
             .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex([| "PricingPlanId" |])
+            .HasDatabaseName("IX_CustomerPricingAssignment_PricingPlanId")
         |> ignore
 
         assignment

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
@@ -1,0 +1,377 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Migrations
+
+/// Adds effective-dated pricing plans, billable mappings, rates, and customer assignments.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260709110000_AddPricingPlanRateAssignment")>]
+type AddPricingPlanRateAssignment() =
+    inherit Migration()
+
+    /// Applies the pricing foundation schema required before previews or posted ledgers can exist.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.EnsureSchema(OperationsUsageSql.SchemaName)
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF OBJECT_ID(N'{OperationsPricingSql.PricingPlanTable}', N'U') IS NULL
+BEGIN
+    CREATE TABLE {OperationsPricingSql.PricingPlanTable}
+    (
+        PricingPlanId uniqueidentifier NOT NULL,
+        PlanCode nvarchar({OperationsPricingSql.PlanCodeMaxLength}) NOT NULL,
+        DisplayName nvarchar({OperationsPricingSql.DisplayNameMaxLength}) NOT NULL,
+        EffectiveFromUtc datetime2(7) NOT NULL,
+        EffectiveToUtc datetime2(7) NULL,
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_PricingPlan_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_PricingPlan PRIMARY KEY CLUSTERED (PricingPlanId),
+        CONSTRAINT CK_ops_PricingPlan_PricingPlanId_NotEmpty CHECK (PricingPlanId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_PricingPlan_PlanCode_NotBlank CHECK (LEN(LTRIM(RTRIM(PlanCode))) > 0),
+        CONSTRAINT CK_ops_PricingPlan_DisplayName_NotBlank CHECK (LEN(LTRIM(RTRIM(DisplayName))) > 0),
+        CONSTRAINT CK_ops_PricingPlan_EffectiveRange CHECK (EffectiveToUtc IS NULL OR EffectiveToUtc > EffectiveFromUtc)
+    );
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF OBJECT_ID(N'{OperationsPricingSql.BillableUsageKindMappingTable}', N'U') IS NULL
+BEGIN
+    CREATE TABLE {OperationsPricingSql.BillableUsageKindMappingTable}
+    (
+        BillableUsageKindMappingId uniqueidentifier NOT NULL,
+        FactKind int NOT NULL,
+        BillableUsageKind int NOT NULL,
+        DisplayName nvarchar({OperationsPricingSql.DisplayNameMaxLength}) NOT NULL,
+        EffectiveFromUtc datetime2(7) NOT NULL,
+        EffectiveToUtc datetime2(7) NULL,
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillableUsageKindMapping_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_BillableUsageKindMapping PRIMARY KEY CLUSTERED (BillableUsageKindMappingId),
+        CONSTRAINT CK_ops_BillableUsageKindMapping_Id_NotEmpty CHECK (BillableUsageKindMappingId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_BillableUsageKindMapping_FactKind_Positive CHECK (FactKind > 0),
+        CONSTRAINT CK_ops_BillableUsageKindMapping_BillableUsageKind_Positive CHECK (BillableUsageKind > 0),
+        CONSTRAINT CK_ops_BillableUsageKindMapping_DisplayName_NotBlank CHECK (LEN(LTRIM(RTRIM(DisplayName))) > 0),
+        CONSTRAINT CK_ops_BillableUsageKindMapping_EffectiveRange CHECK (EffectiveToUtc IS NULL OR EffectiveToUtc > EffectiveFromUtc)
+    );
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF OBJECT_ID(N'{OperationsPricingSql.PricingRateTable}', N'U') IS NULL
+BEGIN
+    CREATE TABLE {OperationsPricingSql.PricingRateTable}
+    (
+        PricingRateId uniqueidentifier NOT NULL,
+        PricingPlanId uniqueidentifier NOT NULL,
+        BillableUsageKind int NOT NULL,
+        CurrencyCode char({OperationsPricingSql.CurrencyCodeLength}) NOT NULL,
+        UnitName nvarchar({OperationsPricingSql.UnitNameMaxLength}) NOT NULL,
+        UnitQuantity bigint NOT NULL,
+        UnitPriceMicros bigint NOT NULL,
+        EffectiveFromUtc datetime2(7) NOT NULL,
+        EffectiveToUtc datetime2(7) NULL,
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_PricingRate_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_PricingRate PRIMARY KEY CLUSTERED (PricingRateId),
+        CONSTRAINT FK_ops_PricingRate_PricingPlan FOREIGN KEY (PricingPlanId) REFERENCES {OperationsPricingSql.PricingPlanTable}(PricingPlanId),
+        CONSTRAINT CK_ops_PricingRate_Id_NotEmpty CHECK (PricingRateId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_PricingRate_BillableUsageKind_Positive CHECK (BillableUsageKind > 0),
+        CONSTRAINT CK_ops_PricingRate_CurrencyCode_Upper CHECK (CurrencyCode = UPPER(CurrencyCode) AND CurrencyCode NOT LIKE '%%[^A-Z]%%'),
+        CONSTRAINT CK_ops_PricingRate_UnitName_NotBlank CHECK (LEN(LTRIM(RTRIM(UnitName))) > 0),
+        CONSTRAINT CK_ops_PricingRate_UnitQuantity_Positive CHECK (UnitQuantity > 0),
+        CONSTRAINT CK_ops_PricingRate_UnitPriceMicros_NonNegative CHECK (UnitPriceMicros >= 0),
+        CONSTRAINT CK_ops_PricingRate_EffectiveRange CHECK (EffectiveToUtc IS NULL OR EffectiveToUtc > EffectiveFromUtc)
+    );
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}', N'U') IS NULL
+BEGIN
+    CREATE TABLE {OperationsPricingSql.CustomerPricingAssignmentTable}
+    (
+        CustomerPricingAssignmentId uniqueidentifier NOT NULL,
+        CustomerId uniqueidentifier NOT NULL,
+        OwnerId uniqueidentifier NOT NULL,
+        OrganizationId uniqueidentifier NOT NULL,
+        RepositoryId uniqueidentifier NOT NULL,
+        PricingPlanId uniqueidentifier NOT NULL,
+        EffectiveFromUtc datetime2(7) NOT NULL,
+        EffectiveToUtc datetime2(7) NULL,
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_CustomerPricingAssignment_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_CustomerPricingAssignment PRIMARY KEY CLUSTERED (CustomerPricingAssignmentId),
+        CONSTRAINT FK_ops_CustomerPricingAssignment_PricingPlan FOREIGN KEY (PricingPlanId) REFERENCES {OperationsPricingSql.PricingPlanTable}(PricingPlanId),
+        CONSTRAINT CK_ops_CustomerPricingAssignment_Id_NotEmpty CHECK (CustomerPricingAssignmentId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_CustomerPricingAssignment_CustomerId_NotEmpty CHECK (CustomerId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_CustomerPricingAssignment_OwnerId_NotEmpty CHECK (OwnerId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_CustomerPricingAssignment_OrganizationId_NotEmpty CHECK (OrganizationId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_CustomerPricingAssignment_RepositoryId_NotEmpty CHECK (RepositoryId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_CustomerPricingAssignment_EffectiveRange CHECK (EffectiveToUtc IS NULL OR EffectiveToUtc > EffectiveFromUtc)
+    );
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.PricingPlanTable}')
+    AND name = N'UX_ops_PricingPlan_CodeEffectiveFrom'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_ops_PricingPlan_CodeEffectiveFrom
+        ON {OperationsPricingSql.PricingPlanTable}(PlanCode, EffectiveFromUtc);
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.BillableUsageKindMappingTable}')
+    AND name = N'UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom
+        ON {OperationsPricingSql.BillableUsageKindMappingTable}(FactKind, EffectiveFromUtc);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.BillableUsageKindMappingTable}')
+    AND name = N'{OperationsPricingSql.BillableUsageKindMappingEffectiveIndexName}'
+)
+BEGIN
+    CREATE INDEX {OperationsPricingSql.BillableUsageKindMappingEffectiveIndexName}
+        ON {OperationsPricingSql.BillableUsageKindMappingTable}(FactKind, EffectiveFromUtc, EffectiveToUtc);
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.PricingRateTable}')
+    AND name = N'UX_ops_PricingRate_PlanUsageKindEffectiveFrom'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_ops_PricingRate_PlanUsageKindEffectiveFrom
+        ON {OperationsPricingSql.PricingRateTable}(PricingPlanId, BillableUsageKind, EffectiveFromUtc);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.PricingRateTable}')
+    AND name = N'{OperationsPricingSql.PricingRateEffectiveIndexName}'
+)
+BEGIN
+    CREATE INDEX {OperationsPricingSql.PricingRateEffectiveIndexName}
+        ON {OperationsPricingSql.PricingRateTable}(PricingPlanId, BillableUsageKind, EffectiveFromUtc, EffectiveToUtc);
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
+    AND name = N'UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom'
+)
+BEGIN
+    CREATE UNIQUE INDEX UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom
+        ON {OperationsPricingSql.CustomerPricingAssignmentTable}(CustomerId, OwnerId, OrganizationId, RepositoryId, EffectiveFromUtc);
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM sys.indexes
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
+    AND name = N'{OperationsPricingSql.CustomerPricingAssignmentScopeIndexName}'
+)
+BEGIN
+    CREATE INDEX {OperationsPricingSql.CustomerPricingAssignmentScopeIndexName}
+        ON {OperationsPricingSql.CustomerPricingAssignmentTable}(CustomerId, OwnerId, OrganizationId, RepositoryId, EffectiveFromUtc, EffectiveToUtc);
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingPlanOverlapTriggerName}
+ON {OperationsPricingSql.PricingPlanTable}
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM inserted AS candidate
+        INNER JOIN {OperationsPricingSql.PricingPlanTable} AS existing
+            ON existing.PlanCode = candidate.PlanCode
+            AND existing.PricingPlanId <> candidate.PricingPlanId
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+    )
+    BEGIN
+        THROW 57411, 'Pricing plan effective windows cannot overlap for the same plan code.', 1;
+    END;
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.BillableUsageKindMappingOverlapTriggerName}
+ON {OperationsPricingSql.BillableUsageKindMappingTable}
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM inserted AS candidate
+        INNER JOIN {OperationsPricingSql.BillableUsageKindMappingTable} AS existing
+            ON existing.FactKind = candidate.FactKind
+            AND existing.BillableUsageKindMappingId <> candidate.BillableUsageKindMappingId
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+    )
+    BEGIN
+        THROW 57412, 'Billable usage-kind mapping effective windows cannot overlap for the same tracked fact kind.', 1;
+    END;
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingRateOverlapTriggerName}
+ON {OperationsPricingSql.PricingRateTable}
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM inserted AS candidate
+        INNER JOIN {OperationsPricingSql.PricingRateTable} AS existing
+            ON existing.PricingPlanId = candidate.PricingPlanId
+            AND existing.BillableUsageKind = candidate.BillableUsageKind
+            AND existing.PricingRateId <> candidate.PricingRateId
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+    )
+    BEGIN
+        THROW 57413, 'Pricing rate effective windows cannot overlap for the same plan and billable usage kind.', 1;
+    END;
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"""
+CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName}
+ON {OperationsPricingSql.CustomerPricingAssignmentTable}
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF EXISTS
+    (
+        SELECT 1
+        FROM inserted AS candidate
+        INNER JOIN {OperationsPricingSql.CustomerPricingAssignmentTable} AS existing
+            ON existing.CustomerId = candidate.CustomerId
+            AND existing.OwnerId = candidate.OwnerId
+            AND existing.OrganizationId = candidate.OrganizationId
+            AND existing.RepositoryId = candidate.RepositoryId
+            AND existing.CustomerPricingAssignmentId <> candidate.CustomerPricingAssignmentId
+            AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+            AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), '9999-12-31T23:59:59.9999999'))
+    )
+    BEGIN
+        THROW 57414, 'Customer pricing assignment effective windows cannot overlap for the same customer repository scope.', 1;
+    END;
+END;
+"""
+        )
+        |> ignore
+
+    /// Removes the pricing foundation schema in reverse dependency order.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName};")
+        |> ignore
+
+        migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.PricingRateOverlapTriggerName};")
+        |> ignore
+
+        migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.BillableUsageKindMappingOverlapTriggerName};")
+        |> ignore
+
+        migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.PricingPlanOverlapTriggerName};")
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"IF OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}', N'U') IS NOT NULL DROP TABLE {OperationsPricingSql.CustomerPricingAssignmentTable};"
+        )
+        |> ignore
+
+        migrationBuilder.Sql($"IF OBJECT_ID(N'{OperationsPricingSql.PricingRateTable}', N'U') IS NOT NULL DROP TABLE {OperationsPricingSql.PricingRateTable};")
+        |> ignore
+
+        migrationBuilder.Sql(
+            $"IF OBJECT_ID(N'{OperationsPricingSql.BillableUsageKindMappingTable}', N'U') IS NOT NULL DROP TABLE {OperationsPricingSql.BillableUsageKindMappingTable};"
+        )
+        |> ignore
+
+        migrationBuilder.Sql($"IF OBJECT_ID(N'{OperationsPricingSql.PricingPlanTable}', N'U') IS NOT NULL DROP TABLE {OperationsPricingSql.PricingPlanTable};")
+        |> ignore
+
+    /// Captures the pricing foundation model that future migrations diff against.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -398,6 +398,7 @@ type OperationsDbContextModelSnapshot() =
             .HasMaxLength(3)
             .IsFixedLength()
             .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -395,8 +395,8 @@ type OperationsDbContextModelSnapshot() =
 
         pricingRate
             .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
             .HasMaxLength(3)
-            .IsFixedLength()
             .IsUnicode(false)
             .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
@@ -464,6 +464,7 @@ type OperationsDbContextModelSnapshot() =
             .HasOne(fun rate -> rate.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingRate_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
@@ -563,5 +564,6 @@ type OperationsDbContextModelSnapshot() =
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -533,6 +533,11 @@ type OperationsDbContextModelSnapshot() =
         |> ignore
 
         assignment
+            .HasIndex([| "PricingPlanId" |])
+            .HasDatabaseName("IX_CustomerPricingAssignment_PricingPlanId")
+        |> ignore
+
+        assignment
             .HasIndex(
                 [|
                     "CustomerId"

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -248,3 +248,319 @@ type OperationsDbContextModelSnapshot() =
             )
             .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
         |> ignore
+
+        let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
+
+        pricingPlan.ToTable("PricingPlan", "ops")
+        |> ignore
+
+        pricingPlan
+            .HasKey([| "PricingPlanId" |])
+            .HasName("PK_ops_PricingPlan")
+        |> ignore
+
+        pricingPlan
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("PlanCode")
+            .HasMaxLength(128)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .HasIndex([| "PlanCode"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_PricingPlan_CodeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
+
+        mapping.ToTable("BillableUsageKindMapping", "ops")
+        |> ignore
+
+        mapping
+            .HasKey([| "BillableUsageKindMappingId" |])
+            .HasName("PK_ops_BillableUsageKindMapping")
+        |> ignore
+
+        mapping
+            .Property<System.Guid>("BillableUsageKindMappingId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        mapping.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        mapping
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .HasIndex([| "FactKind"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        mapping
+            .HasIndex(
+                [|
+                    "FactKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillableUsageKindMapping_FactKindEffective")
+        |> ignore
+
+        let pricingRate = modelBuilder.Entity<PricingRateEntity>()
+
+        pricingRate.ToTable("PricingRate", "ops")
+        |> ignore
+
+        pricingRate
+            .HasKey([| "PricingRateId" |])
+            .HasName("PK_ops_PricingRate")
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingRateId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("CurrencyCode")
+            .HasMaxLength(3)
+            .IsFixedLength()
+            .IsUnicode(false)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitQuantity")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitPriceMicros")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingRate_PlanUsageKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingRate_PlanUsageKindEffective")
+        |> ignore
+
+        pricingRate
+            .HasOne(fun rate -> rate.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+
+        assignment.ToTable("CustomerPricingAssignment", "ops")
+        |> ignore
+
+        assignment
+            .HasKey([| "CustomerPricingAssignmentId" |])
+            .HasName("PK_ops_CustomerPricingAssignment")
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_CustomerPricingAssignment_ScopeEffective")
+        |> ignore
+
+        assignment
+            .HasOne(fun assignment -> assignment.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -151,6 +151,17 @@ module PricingRateSelection =
                 compare (identity left) (identity right))
         |> List.tryHead
 
+    /// Intersects selected pricing prerequisites into the complete customer-price applicability window.
+    let private intersectEffectiveWindows windows =
+        let effectiveFrom = windows |> List.map fst |> List.max
+
+        let effectiveTo =
+            match windows |> List.choose snd with
+            | [] -> None
+            | finiteEnds -> finiteEnds |> List.min |> Some
+
+        effectiveFrom, effectiveTo
+
     /// Selects the effective rate for a customer usage fact without making unmapped tracked facts billable.
     let trySelect (query: PricingRateSelectionQuery) (catalog: PricingCatalogSnapshot) =
         let assignment =
@@ -192,6 +203,12 @@ module PricingRateSelection =
 
         match assignment, plan, mapping, rate with
         | Some selectedAssignment, Some selectedPlan, Some selectedMapping, Some selectedRate ->
+            let effectiveFrom, effectiveTo =
+                intersectEffectiveWindows [ selectedAssignment.EffectiveFrom, selectedAssignment.EffectiveTo
+                                            selectedPlan.EffectiveFrom, selectedPlan.EffectiveTo
+                                            selectedMapping.EffectiveFrom, selectedMapping.EffectiveTo
+                                            selectedRate.EffectiveFrom, selectedRate.EffectiveTo ]
+
             Some
                 {
                     CustomerPricingAssignmentId = selectedAssignment.CustomerPricingAssignmentId
@@ -208,8 +225,8 @@ module PricingRateSelection =
                     UnitName = selectedRate.UnitName
                     UnitQuantity = selectedRate.UnitQuantity
                     UnitPriceMicros = selectedRate.UnitPriceMicros
-                    EffectiveFrom = selectedRate.EffectiveFrom
-                    EffectiveTo = selectedRate.EffectiveTo
+                    EffectiveFrom = effectiveFrom
+                    EffectiveTo = effectiveTo
                 }
         | _ -> None
 

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -48,6 +48,171 @@ type UsageAggregateMinuteKey =
 /// Describes the aggregate quantity projected for one Grace repository resource and UTC minute.
 type UsageAggregateMinute = { Key: UsageAggregateMinuteKey; Quantity: int64 }
 
+/// Carries one customer, repository scope, fact kind, and timestamp for effective pricing lookup.
+type PricingRateSelectionQuery =
+    {
+        CustomerId: Guid
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        FactKind: UsageFactKind
+        ObservedAt: Instant
+    }
+
+/// Describes the effective customer rate selected for a tracked usage fact.
+type EffectivePricingRate =
+    {
+        CustomerPricingAssignmentId: Guid
+        CustomerId: Guid
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        PricingPlanId: Guid
+        PlanCode: string
+        BillableUsageKindMappingId: Guid
+        BillableUsageKind: int
+        PricingRateId: Guid
+        CurrencyCode: string
+        UnitName: string
+        UnitQuantity: int64
+        UnitPriceMicros: int64
+        EffectiveFrom: Instant
+        EffectiveTo: Instant option
+    }
+
+/// Describes an effective-dated pricing plan used by deterministic selection tests and seed validation.
+type PricingPlan = { PricingPlanId: Guid; PlanCode: string; EffectiveFrom: Instant; EffectiveTo: Instant option }
+
+/// Describes an effective-dated mapping from tracked usage to an internal billable usage kind.
+type BillableUsageKindMapping =
+    {
+        BillableUsageKindMappingId: Guid
+        FactKind: UsageFactKind
+        BillableUsageKind: int
+        EffectiveFrom: Instant
+        EffectiveTo: Instant option
+    }
+
+/// Describes an effective-dated rate for one plan and billable usage kind.
+type PricingRate =
+    {
+        PricingRateId: Guid
+        PricingPlanId: Guid
+        BillableUsageKind: int
+        CurrencyCode: string
+        UnitName: string
+        UnitQuantity: int64
+        UnitPriceMicros: int64
+        EffectiveFrom: Instant
+        EffectiveTo: Instant option
+    }
+
+/// Describes an effective-dated customer assignment to one pricing plan for a Grace repository scope.
+type CustomerPricingAssignment =
+    {
+        CustomerPricingAssignmentId: Guid
+        CustomerId: Guid
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        PricingPlanId: Guid
+        EffectiveFrom: Instant
+        EffectiveTo: Instant option
+    }
+
+/// Carries the in-memory pricing rows used to prove the same invariant enforced by Operations SQL.
+type PricingCatalogSnapshot =
+    {
+        PricingPlans: PricingPlan list
+        BillableUsageKindMappings: BillableUsageKindMapping list
+        PricingRates: PricingRate list
+        CustomerPricingAssignments: CustomerPricingAssignment list
+    }
+
+/// Selects customer rates only when every effective-dated pricing prerequisite is present.
+[<RequireQualifiedAccess>]
+module PricingRateSelection =
+
+    /// Returns true when a half-open effective interval contains the supplied timestamp.
+    let contains observedAt effectiveFrom effectiveTo =
+        effectiveFrom <= observedAt
+        && (effectiveTo
+            |> Option.forall (fun ending -> observedAt < ending))
+
+    /// Selects the latest effective row by start time and stable identity.
+    let private latestBy effectiveFrom identity rows =
+        rows
+        |> List.sortWith (fun left right ->
+            let fromComparison = compare (effectiveFrom right) (effectiveFrom left)
+
+            if fromComparison <> 0 then
+                fromComparison
+            else
+                compare (identity left) (identity right))
+        |> List.tryHead
+
+    /// Selects the effective rate for a customer usage fact without making unmapped tracked facts billable.
+    let trySelect (query: PricingRateSelectionQuery) (catalog: PricingCatalogSnapshot) =
+        let assignment =
+            catalog.CustomerPricingAssignments
+            |> List.filter (fun candidate ->
+                candidate.CustomerId = query.CustomerId
+                && candidate.OwnerId = query.OwnerId
+                && candidate.OrganizationId = query.OrganizationId
+                && candidate.RepositoryId = query.RepositoryId
+                && contains query.ObservedAt candidate.EffectiveFrom candidate.EffectiveTo)
+            |> latestBy (fun candidate -> candidate.EffectiveFrom) (fun candidate -> candidate.CustomerPricingAssignmentId)
+
+        let plan =
+            assignment
+            |> Option.bind (fun selectedAssignment ->
+                catalog.PricingPlans
+                |> List.filter (fun candidate ->
+                    candidate.PricingPlanId = selectedAssignment.PricingPlanId
+                    && contains query.ObservedAt candidate.EffectiveFrom candidate.EffectiveTo)
+                |> latestBy (fun candidate -> candidate.EffectiveFrom) (fun candidate -> candidate.PricingPlanId))
+
+        let mapping =
+            catalog.BillableUsageKindMappings
+            |> List.filter (fun candidate ->
+                candidate.FactKind = query.FactKind
+                && contains query.ObservedAt candidate.EffectiveFrom candidate.EffectiveTo)
+            |> latestBy (fun candidate -> candidate.EffectiveFrom) (fun candidate -> candidate.BillableUsageKindMappingId)
+
+        let rate =
+            match plan, mapping with
+            | Some selectedPlan, Some selectedMapping ->
+                catalog.PricingRates
+                |> List.filter (fun candidate ->
+                    candidate.PricingPlanId = selectedPlan.PricingPlanId
+                    && candidate.BillableUsageKind = selectedMapping.BillableUsageKind
+                    && contains query.ObservedAt candidate.EffectiveFrom candidate.EffectiveTo)
+                |> latestBy (fun candidate -> candidate.EffectiveFrom) (fun candidate -> candidate.PricingRateId)
+            | _ -> None
+
+        match assignment, plan, mapping, rate with
+        | Some selectedAssignment, Some selectedPlan, Some selectedMapping, Some selectedRate ->
+            Some
+                {
+                    CustomerPricingAssignmentId = selectedAssignment.CustomerPricingAssignmentId
+                    CustomerId = selectedAssignment.CustomerId
+                    OwnerId = selectedAssignment.OwnerId
+                    OrganizationId = selectedAssignment.OrganizationId
+                    RepositoryId = selectedAssignment.RepositoryId
+                    PricingPlanId = selectedPlan.PricingPlanId
+                    PlanCode = selectedPlan.PlanCode
+                    BillableUsageKindMappingId = selectedMapping.BillableUsageKindMappingId
+                    BillableUsageKind = selectedMapping.BillableUsageKind
+                    PricingRateId = selectedRate.PricingRateId
+                    CurrencyCode = selectedRate.CurrencyCode
+                    UnitName = selectedRate.UnitName
+                    UnitQuantity = selectedRate.UnitQuantity
+                    UnitPriceMicros = selectedRate.UnitPriceMicros
+                    EffectiveFrom = selectedRate.EffectiveFrom
+                    EffectiveTo = selectedRate.EffectiveTo
+                }
+        | _ -> None
+
 /// Carries the raw insert and aggregate update that must commit or roll back together.
 type UsageFactPersistencePlan = { RawFact: RawUsageFact; Aggregate: UsageAggregateMinute }
 
@@ -165,6 +330,96 @@ type IOperationsUsageArchiveStore =
 
     /// Clears expired temporary support rehydrations left behind after caller or process failure.
     abstract CleanupExpiredRehydratedPayloadsAsync: expiresBefore: Instant * batchSize: int * cancellationToken: CancellationToken -> Task<int>
+
+/// Selects effective customer pricing rates from the Operations pricing catalog.
+type IOperationsPricingCatalog =
+
+    /// Returns a rate only when assignment, plan, usage-kind mapping, and rate rows are all effective.
+    abstract TrySelectEffectiveRateAsync: query: PricingRateSelectionQuery * cancellationToken: CancellationToken -> Task<EffectivePricingRate option>
+
+/// Executes effective-rate selection through reviewed Operations SQL.
+type SqlOperationsPricingCatalog(connectionString: string) =
+
+    /// Opens one SQL connection for an effective-rate lookup.
+    let openConnectionAsync cancellationToken =
+        task {
+            let connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            return connection
+        }
+
+    /// Converts a NodaTime instant to the UTC SQL timestamp shape used by pricing tables.
+    let toUtcDateTime (instant: Instant) = instant.ToDateTimeUtc()
+
+    /// Converts a SQL UTC timestamp to the NodaTime shape returned to callers.
+    let toInstant (dateTime: DateTime) =
+        DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+        |> Instant.FromDateTimeUtc
+
+    /// Adds a SQL parameter and assigns the supplied value.
+    let addParameter (command: SqlCommand) name sqlDbType value =
+        let parameter = command.Parameters.Add(name, sqlDbType)
+        parameter.Value <- value
+
+    /// Adds the effective-rate lookup parameters with the repository scope required to prevent leakage.
+    let addSelectionParameters (command: SqlCommand) (query: PricingRateSelectionQuery) =
+        addParameter command "@CustomerId" SqlDbType.UniqueIdentifier query.CustomerId
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier query.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier query.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier query.RepositoryId
+        addParameter command "@FactKind" SqlDbType.Int (int query.FactKind)
+        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime query.ObservedAt)
+
+    /// Reads the nullable effective end timestamp for the selected rate.
+    let readEffectiveTo (reader: SqlDataReader) ordinal =
+        if reader.IsDBNull ordinal then
+            None
+        else
+            reader.GetDateTime ordinal |> toInstant |> Some
+
+    /// Reads one effective pricing-rate result from the SQL reader.
+    let readEffectiveRate (reader: SqlDataReader) =
+        let effectiveToOrdinal = reader.GetOrdinal("EffectiveToUtc")
+
+        {
+            CustomerPricingAssignmentId = reader.GetGuid(reader.GetOrdinal("CustomerPricingAssignmentId"))
+            CustomerId = reader.GetGuid(reader.GetOrdinal("CustomerId"))
+            OwnerId = reader.GetGuid(reader.GetOrdinal("OwnerId"))
+            OrganizationId = reader.GetGuid(reader.GetOrdinal("OrganizationId"))
+            RepositoryId = reader.GetGuid(reader.GetOrdinal("RepositoryId"))
+            PricingPlanId = reader.GetGuid(reader.GetOrdinal("PricingPlanId"))
+            PlanCode = reader.GetString(reader.GetOrdinal("PlanCode"))
+            BillableUsageKindMappingId = reader.GetGuid(reader.GetOrdinal("BillableUsageKindMappingId"))
+            BillableUsageKind = reader.GetInt32(reader.GetOrdinal("BillableUsageKind"))
+            PricingRateId = reader.GetGuid(reader.GetOrdinal("PricingRateId"))
+            CurrencyCode = reader.GetString(reader.GetOrdinal("CurrencyCode"))
+            UnitName = reader.GetString(reader.GetOrdinal("UnitName"))
+            UnitQuantity = reader.GetInt64(reader.GetOrdinal("UnitQuantity"))
+            UnitPriceMicros = reader.GetInt64(reader.GetOrdinal("UnitPriceMicros"))
+            EffectiveFrom =
+                reader.GetDateTime(reader.GetOrdinal("EffectiveFromUtc"))
+                |> toInstant
+            EffectiveTo = readEffectiveTo reader effectiveToOrdinal
+        }
+
+    /// Returns the effective customer rate selected by SQL, or None for non-billable usage.
+    member _.TrySelectEffectiveRateAsync(query: PricingRateSelectionQuery, cancellationToken: CancellationToken) =
+        task {
+            use! connection = openConnectionAsync cancellationToken
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+            command.CommandText <- OperationsPricingSql.SelectEffectivePricingRate
+            addSelectionParameters command query
+
+            use! reader = command.ExecuteReaderAsync cancellationToken
+            let! hasRow = reader.ReadAsync cancellationToken
+
+            if hasRow then return Some(readEffectiveRate reader) else return None
+        }
+
+    interface IOperationsPricingCatalog with
+
+        member this.TrySelectEffectiveRateAsync(query, cancellationToken) = this.TrySelectEffectiveRateAsync(query, cancellationToken)
 
 /// Chooses whether schema initialization may connect to `master` to create the operations database.
 type OperationsUsageSchemaBootstrapMode =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -394,8 +394,8 @@ module OperationsModel =
 
         pricingRate
             .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
             .HasMaxLength(OperationsPricingSql.CurrencyCodeLength)
-            .IsFixedLength()
             .IsUnicode(false)
             .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
@@ -463,6 +463,7 @@ module OperationsModel =
             .HasOne(fun rate -> rate.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingRate_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
@@ -562,6 +563,7 @@ module OperationsModel =
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -532,6 +532,11 @@ module OperationsModel =
         |> ignore
 
         assignment
+            .HasIndex([| "PricingPlanId" |])
+            .HasDatabaseName(OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+        |> ignore
+
+        assignment
             .HasIndex(
                 [|
                     "CustomerId"

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -397,6 +397,7 @@ module OperationsModel =
             .HasMaxLength(OperationsPricingSql.CurrencyCodeLength)
             .IsFixedLength()
             .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -248,6 +248,322 @@ module OperationsModel =
             .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
         |> ignore
 
+        let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
+
+        pricingPlan.ToTable(OperationsPricingSql.PricingPlanTableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+        pricingPlan
+            .HasKey([| "PricingPlanId" |])
+            .HasName("PK_ops_PricingPlan")
+        |> ignore
+
+        pricingPlan
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("PlanCode")
+            .HasMaxLength(OperationsPricingSql.PlanCodeMaxLength)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("DisplayName")
+            .HasMaxLength(OperationsPricingSql.DisplayNameMaxLength)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .HasIndex([| "PlanCode"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_PricingPlan_CodeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
+
+        mapping.ToTable(OperationsPricingSql.BillableUsageKindMappingTableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+        mapping
+            .HasKey([| "BillableUsageKindMappingId" |])
+            .HasName("PK_ops_BillableUsageKindMapping")
+        |> ignore
+
+        mapping
+            .Property<System.Guid>("BillableUsageKindMappingId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        mapping.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        mapping
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<string>("DisplayName")
+            .HasMaxLength(OperationsPricingSql.DisplayNameMaxLength)
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .HasIndex([| "FactKind"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        mapping
+            .HasIndex(
+                [|
+                    "FactKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName(OperationsPricingSql.BillableUsageKindMappingEffectiveIndexName)
+        |> ignore
+
+        let pricingRate = modelBuilder.Entity<PricingRateEntity>()
+
+        pricingRate.ToTable(OperationsPricingSql.PricingRateTableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+        pricingRate
+            .HasKey([| "PricingRateId" |])
+            .HasName("PK_ops_PricingRate")
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingRateId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("CurrencyCode")
+            .HasMaxLength(OperationsPricingSql.CurrencyCodeLength)
+            .IsFixedLength()
+            .IsUnicode(false)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("UnitName")
+            .HasMaxLength(OperationsPricingSql.UnitNameMaxLength)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitQuantity")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitPriceMicros")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingRate_PlanUsageKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName(OperationsPricingSql.PricingRateEffectiveIndexName)
+        |> ignore
+
+        pricingRate
+            .HasOne(fun rate -> rate.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+
+        assignment.ToTable(OperationsPricingSql.CustomerPricingAssignmentTableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+        assignment
+            .HasKey([| "CustomerPricingAssignmentId" |])
+            .HasName("PK_ops_CustomerPricingAssignment")
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName(OperationsPricingSql.CustomerPricingAssignmentScopeIndexName)
+        |> ignore
+
+        assignment
+            .HasOne(fun assignment -> assignment.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
 /// Owns the EF Core model for Grace Operations SQL Server schema evolution.
 type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     inherit DbContext(options)
@@ -260,6 +576,22 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     [<DefaultValue>]
     val mutable private usageAggregateMinutes: DbSet<UsageAggregateMinuteEntity>
 
+    /// Exposes pricing plans for EF migrations and schema inspection.
+    [<DefaultValue>]
+    val mutable private pricingPlans: DbSet<PricingPlanEntity>
+
+    /// Exposes billable usage-kind mappings for EF migrations and schema inspection.
+    [<DefaultValue>]
+    val mutable private billableUsageKindMappings: DbSet<BillableUsageKindMappingEntity>
+
+    /// Exposes pricing rates for EF migrations and schema inspection.
+    [<DefaultValue>]
+    val mutable private pricingRates: DbSet<PricingRateEntity>
+
+    /// Exposes customer pricing assignments for EF migrations and schema inspection.
+    [<DefaultValue>]
+    val mutable private customerPricingAssignments: DbSet<CustomerPricingAssignmentEntity>
+
     /// Provides the EF set for immutable usage fact rows.
     member this.RawUsageFacts
         with get () = this.rawUsageFacts
@@ -269,6 +601,26 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     member this.UsageAggregateMinutes
         with get () = this.usageAggregateMinutes
         and set value = this.usageAggregateMinutes <- value
+
+    /// Provides the EF set for effective-dated pricing plans.
+    member this.PricingPlans
+        with get () = this.pricingPlans
+        and set value = this.pricingPlans <- value
+
+    /// Provides the EF set for billable usage-kind mappings.
+    member this.BillableUsageKindMappings
+        with get () = this.billableUsageKindMappings
+        and set value = this.billableUsageKindMappings <- value
+
+    /// Provides the EF set for effective-dated pricing rates.
+    member this.PricingRates
+        with get () = this.pricingRates
+        and set value = this.pricingRates <- value
+
+    /// Provides the EF set for customer pricing assignments.
+    member this.CustomerPricingAssignments
+        with get () = this.customerPricingAssignments
+        and set value = this.customerPricingAssignments <- value
 
     /// Configures the Operations SQL Server schema shape that migrations must preserve.
     override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -99,3 +99,121 @@ type UsageAggregateMinuteEntity() =
 
     /// Stores the SQL-created or SQL-updated UTC timestamp for the aggregate row.
     member val UpdatedAtUtc = DateTime.MinValue with get, set
+
+/// Represents one effective-dated customer pricing plan.
+[<AllowNullLiteral>]
+type PricingPlanEntity() =
+
+    /// Stores the durable pricing plan identity used by assignments and rates.
+    member val PricingPlanId = Guid.Empty with get, set
+
+    /// Stores the operator-stable pricing plan code.
+    member val PlanCode = String.Empty with get, set
+
+    /// Stores the internal display label used by Operations tools.
+    member val DisplayName = String.Empty with get, set
+
+    /// Stores when the plan can first be selected for effective pricing.
+    member val EffectiveFromUtc = DateTime.MinValue with get, set
+
+    /// Stores the exclusive end of the plan selection window, or null for open-ended plans.
+    member val EffectiveToUtc = Nullable<DateTime>() with get, set
+
+    /// Stores the SQL-created UTC timestamp for the pricing plan row.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+/// Represents an effective-dated mapping from a tracked usage fact kind to a billable line item kind.
+[<AllowNullLiteral>]
+type BillableUsageKindMappingEntity() =
+
+    /// Stores the durable billable mapping identity used for audit and seed maintenance.
+    member val BillableUsageKindMappingId = Guid.Empty with get, set
+
+    /// Stores the tracked UsageFactKind integer that becomes billable only while this row is effective.
+    member val FactKind = 0 with get, set
+
+    /// Stores the internal billable usage-kind integer selected by pricing rates.
+    member val BillableUsageKind = 0 with get, set
+
+    /// Stores the internal display label used by Operations tools.
+    member val DisplayName = String.Empty with get, set
+
+    /// Stores when the tracked fact kind first maps to the billable usage kind.
+    member val EffectiveFromUtc = DateTime.MinValue with get, set
+
+    /// Stores the exclusive end of the mapping window, or null for open-ended mappings.
+    member val EffectiveToUtc = Nullable<DateTime>() with get, set
+
+    /// Stores the SQL-created UTC timestamp for the billable mapping row.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+/// Represents one effective-dated rate for a pricing plan and billable usage kind.
+[<AllowNullLiteral>]
+type PricingRateEntity() =
+
+    /// Stores the durable pricing rate identity selected by later preview and ledger slices.
+    member val PricingRateId = Guid.Empty with get, set
+
+    /// Stores the pricing plan whose customers can receive this rate.
+    member val PricingPlanId = Guid.Empty with get, set
+
+    /// Stores the internal billable usage-kind integer priced by this rate.
+    member val BillableUsageKind = 0 with get, set
+
+    /// Stores the customer billing currency for this rate without provider cost or margin data.
+    member val CurrencyCode = String.Empty with get, set
+
+    /// Stores the rate unit label, such as byte-minute.
+    member val UnitName = String.Empty with get, set
+
+    /// Stores the measured quantity represented by one billable unit.
+    member val UnitQuantity = 0L with get, set
+
+    /// Stores the customer price in micros of the configured currency per unit quantity.
+    member val UnitPriceMicros = 0L with get, set
+
+    /// Stores when the rate can first be selected.
+    member val EffectiveFromUtc = DateTime.MinValue with get, set
+
+    /// Stores the exclusive end of the rate window, or null for open-ended rates.
+    member val EffectiveToUtc = Nullable<DateTime>() with get, set
+
+    /// Stores the SQL-created UTC timestamp for the pricing rate row.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+    /// References the pricing plan for EF schema relationship generation.
+    member val PricingPlan: PricingPlanEntity = null with get, set
+
+/// Represents one effective-dated assignment of a customer and repository scope to a pricing plan.
+[<AllowNullLiteral>]
+type CustomerPricingAssignmentEntity() =
+
+    /// Stores the durable assignment identity selected by later preview and ledger slices.
+    member val CustomerPricingAssignmentId = Guid.Empty with get, set
+
+    /// Stores the Operations customer identity receiving the assigned pricing plan.
+    member val CustomerId = Guid.Empty with get, set
+
+    /// Stores the Grace owner scope for the customer assignment.
+    member val OwnerId = Guid.Empty with get, set
+
+    /// Stores the Grace organization scope for the customer assignment.
+    member val OrganizationId = Guid.Empty with get, set
+
+    /// Stores the Grace repository scope for the customer assignment.
+    member val RepositoryId = Guid.Empty with get, set
+
+    /// Stores the pricing plan selected for this customer and repository scope.
+    member val PricingPlanId = Guid.Empty with get, set
+
+    /// Stores when the assignment can first be selected.
+    member val EffectiveFromUtc = DateTime.MinValue with get, set
+
+    /// Stores the exclusive end of the assignment window, or null for open-ended assignments.
+    member val EffectiveToUtc = Nullable<DateTime>() with get, set
+
+    /// Stores the SQL-created UTC timestamp for the customer assignment row.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+    /// References the pricing plan for EF schema relationship generation.
+    member val PricingPlan: PricingPlanEntity = null with get, set

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
@@ -1,0 +1,131 @@
+namespace Grace.Operations.Data
+
+/// Provides SQL Server schema names and command text for Operations pricing tables.
+[<RequireQualifiedAccess>]
+module OperationsPricingSql =
+
+    /// Names the pricing plan table without schema qualification for EF migrations.
+    [<Literal>]
+    let PricingPlanTableName = "PricingPlan"
+
+    /// Names the pricing plan table.
+    [<Literal>]
+    let PricingPlanTable = "ops.PricingPlan"
+
+    /// Names the effective-dated billable usage-kind mapping table without schema qualification for EF migrations.
+    [<Literal>]
+    let BillableUsageKindMappingTableName = "BillableUsageKindMapping"
+
+    /// Names the effective-dated billable usage-kind mapping table.
+    [<Literal>]
+    let BillableUsageKindMappingTable = "ops.BillableUsageKindMapping"
+
+    /// Names the pricing rate table without schema qualification for EF migrations.
+    [<Literal>]
+    let PricingRateTableName = "PricingRate"
+
+    /// Names the pricing rate table.
+    [<Literal>]
+    let PricingRateTable = "ops.PricingRate"
+
+    /// Names the customer pricing assignment table without schema qualification for EF migrations.
+    [<Literal>]
+    let CustomerPricingAssignmentTableName = "CustomerPricingAssignment"
+
+    /// Names the customer pricing assignment table.
+    [<Literal>]
+    let CustomerPricingAssignmentTable = "ops.CustomerPricingAssignment"
+
+    /// Limits stable pricing plan codes used by operator seed scripts and later APIs.
+    [<Literal>]
+    let PlanCodeMaxLength = 128
+
+    /// Limits human-readable internal pricing labels.
+    [<Literal>]
+    let DisplayNameMaxLength = 200
+
+    /// Stores ISO 4217-style currency codes without provider-cost or margin data.
+    [<Literal>]
+    let CurrencyCodeLength = 3
+
+    /// Limits billing unit labels such as byte-minute before later customer preview surfaces format them.
+    [<Literal>]
+    let UnitNameMaxLength = 64
+
+    /// Names the trigger that rejects overlapping pricing plan validity windows for the same plan code.
+    [<Literal>]
+    let PricingPlanOverlapTriggerName = "TR_ops_PricingPlan_PreventOverlap"
+
+    /// Names the trigger that rejects overlapping usage-kind mapping windows for the same tracked fact kind.
+    [<Literal>]
+    let BillableUsageKindMappingOverlapTriggerName = "TR_ops_BillableUsageKindMapping_PreventOverlap"
+
+    /// Names the trigger that rejects overlapping rate windows for the same plan and billable usage kind.
+    [<Literal>]
+    let PricingRateOverlapTriggerName = "TR_ops_PricingRate_PreventOverlap"
+
+    /// Names the trigger that rejects overlapping customer assignments for the same repository scope.
+    [<Literal>]
+    let CustomerPricingAssignmentOverlapTriggerName = "TR_ops_CustomerPricingAssignment_PreventOverlap"
+
+    /// Names the indexed lookup path for effective customer plan assignments.
+    [<Literal>]
+    let CustomerPricingAssignmentScopeIndexName = "IX_ops_CustomerPricingAssignment_ScopeEffective"
+
+    /// Names the indexed lookup path for effective rate selection.
+    [<Literal>]
+    let PricingRateEffectiveIndexName = "IX_ops_PricingRate_PlanUsageKindEffective"
+
+    /// Names the indexed lookup path for effective usage-kind mapping selection.
+    [<Literal>]
+    let BillableUsageKindMappingEffectiveIndexName = "IX_ops_BillableUsageKindMapping_FactKindEffective"
+
+    /// Selects the effective customer pricing rate only when assignment, plan, billable mapping, and rate all exist.
+    [<Literal>]
+    let SelectEffectivePricingRate =
+        """
+SELECT TOP (1)
+    assignment.CustomerPricingAssignmentId,
+    assignment.CustomerId,
+    assignment.OwnerId,
+    assignment.OrganizationId,
+    assignment.RepositoryId,
+    plan.PricingPlanId,
+    plan.PlanCode,
+    mapping.BillableUsageKindMappingId,
+    mapping.BillableUsageKind,
+    rate.PricingRateId,
+    rate.CurrencyCode,
+    rate.UnitName,
+    rate.UnitQuantity,
+    rate.UnitPriceMicros,
+    rate.EffectiveFromUtc,
+    rate.EffectiveToUtc
+FROM ops.CustomerPricingAssignment AS assignment WITH (READCOMMITTEDLOCK)
+INNER JOIN ops.PricingPlan AS plan WITH (READCOMMITTEDLOCK)
+    ON plan.PricingPlanId = assignment.PricingPlanId
+INNER JOIN ops.BillableUsageKindMapping AS mapping WITH (READCOMMITTEDLOCK)
+    ON mapping.FactKind = @FactKind
+INNER JOIN ops.PricingRate AS rate WITH (READCOMMITTEDLOCK)
+    ON rate.PricingPlanId = assignment.PricingPlanId
+    AND rate.BillableUsageKind = mapping.BillableUsageKind
+WHERE assignment.CustomerId = @CustomerId
+AND assignment.OwnerId = @OwnerId
+AND assignment.OrganizationId = @OrganizationId
+AND assignment.RepositoryId = @RepositoryId
+AND assignment.EffectiveFromUtc <= @ObservedAtUtc
+AND (assignment.EffectiveToUtc IS NULL OR @ObservedAtUtc < assignment.EffectiveToUtc)
+AND plan.EffectiveFromUtc <= @ObservedAtUtc
+AND (plan.EffectiveToUtc IS NULL OR @ObservedAtUtc < plan.EffectiveToUtc)
+AND mapping.EffectiveFromUtc <= @ObservedAtUtc
+AND (mapping.EffectiveToUtc IS NULL OR @ObservedAtUtc < mapping.EffectiveToUtc)
+AND rate.EffectiveFromUtc <= @ObservedAtUtc
+AND (rate.EffectiveToUtc IS NULL OR @ObservedAtUtc < rate.EffectiveToUtc)
+ORDER BY
+    assignment.EffectiveFromUtc DESC,
+    rate.EffectiveFromUtc DESC,
+    mapping.EffectiveFromUtc DESC,
+    plan.EffectiveFromUtc DESC,
+    assignment.CustomerPricingAssignmentId ASC,
+    rate.PricingRateId ASC;
+"""

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
@@ -103,8 +103,8 @@ SELECT TOP (1)
     rate.UnitName,
     rate.UnitQuantity,
     rate.UnitPriceMicros,
-    rate.EffectiveFromUtc,
-    rate.EffectiveToUtc
+    applicability.EffectiveFromUtc,
+    applicability.EffectiveToUtc
 FROM ops.CustomerPricingAssignment AS assignment WITH (READCOMMITTEDLOCK)
 INNER JOIN ops.PricingPlan AS plan WITH (READCOMMITTEDLOCK)
     ON plan.PricingPlanId = assignment.PricingPlanId
@@ -113,6 +113,20 @@ INNER JOIN ops.BillableUsageKindMapping AS mapping WITH (READCOMMITTEDLOCK)
 INNER JOIN ops.PricingRate AS rate WITH (READCOMMITTEDLOCK)
     ON rate.PricingPlanId = assignment.PricingPlanId
     AND rate.BillableUsageKind = mapping.BillableUsageKind
+CROSS APPLY
+(
+    SELECT
+        MAX(contributor.EffectiveFromUtc) AS EffectiveFromUtc,
+        MIN(contributor.EffectiveToUtc) AS EffectiveToUtc
+    FROM
+    (
+        VALUES
+            (assignment.EffectiveFromUtc, assignment.EffectiveToUtc),
+            (plan.EffectiveFromUtc, plan.EffectiveToUtc),
+            (mapping.EffectiveFromUtc, mapping.EffectiveToUtc),
+            (rate.EffectiveFromUtc, rate.EffectiveToUtc)
+    ) AS contributor(EffectiveFromUtc, EffectiveToUtc)
+) AS applicability
 WHERE assignment.CustomerId = @CustomerId
 AND assignment.OwnerId = @OwnerId
 AND assignment.OrganizationId = @OrganizationId

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
@@ -72,6 +72,10 @@ module OperationsPricingSql =
     [<Literal>]
     let CustomerPricingAssignmentScopeIndexName = "IX_ops_CustomerPricingAssignment_ScopeEffective"
 
+    /// Names the foreign-key lookup path from customer assignments to pricing plans.
+    [<Literal>]
+    let CustomerPricingAssignmentPricingPlanIndexName = "IX_CustomerPricingAssignment_PricingPlanId"
+
     /// Names the indexed lookup path for effective rate selection.
     [<Literal>]
     let PricingRateEffectiveIndexName = "IX_ops_PricingRate_PlanUsageKindEffective"

--- a/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="OperationsSkeleton.Tests.fs" />
     <Compile Include="OperationsUsageStorage.Tests.fs" />
+    <Compile Include="OperationsPricing.Tests.fs" />
     <Compile Include="OperationsUsageArchive.Tests.fs" />
     <Compile Include="OperationsWorkerIngestion.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -167,6 +167,39 @@ type OperationsPricingTests() =
             |> Seq.exists (fun property -> property.Name = "PricingPlanId"))
         |> fun foreignKey -> foreignKey.GetConstraintName()
 
+    /// Narrows one contributor while leaving the selected pricing identities and amount unchanged.
+    let catalogWithContributorWindow contributor effectiveFrom effectiveTo =
+        match contributor with
+        | "assignment" ->
+            { OperationsPricingTestData.catalog with
+                CustomerPricingAssignments =
+                    [
+                        { OperationsPricingTestData.assignment with EffectiveFrom = effectiveFrom; EffectiveTo = effectiveTo }
+                    ]
+            }
+        | "plan" ->
+            { OperationsPricingTestData.catalog with
+                PricingPlans =
+                    [
+                        { OperationsPricingTestData.plan with EffectiveFrom = effectiveFrom; EffectiveTo = effectiveTo }
+                    ]
+            }
+        | "mapping" ->
+            { OperationsPricingTestData.catalog with
+                BillableUsageKindMappings =
+                    [
+                        { OperationsPricingTestData.mapping with EffectiveFrom = effectiveFrom; EffectiveTo = effectiveTo }
+                    ]
+            }
+        | "rate" ->
+            { OperationsPricingTestData.catalog with
+                PricingRates =
+                    [
+                        { OperationsPricingTestData.julyRate with EffectiveFrom = effectiveFrom; EffectiveTo = effectiveTo }
+                    ]
+            }
+        | _ -> invalidArg (nameof contributor) $"Unknown pricing contributor '{contributor}'."
+
     /// Verifies effective-rate selection requires customer assignment, mapping, and rate rows.
     [<Test>]
     member _.EffectiveRateSelectionFindsCustomerRateForBillableUsageKind() =
@@ -180,6 +213,93 @@ type OperationsPricingTests() =
                 Assert.That(selected.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
                 Assert.That(selected.Value.BillableUsageKind, Is.EqualTo(OperationsPricingTestData.repositoryStorageBillableUsageKind))
                 Assert.That(selected.Value.UnitPriceMicros, Is.EqualTo(10L)))
+        )
+
+    /// Verifies every open-ended contributor produces an open-ended complete applicability window.
+    [<Test>]
+    member _.EffectiveRateSelectionReturnsOpenWindowOnlyWhenEveryContributorIsOpenEnded() =
+        let openRate = { OperationsPricingTestData.julyRate with EffectiveTo = None }
+
+        let catalog = { OperationsPricingTestData.catalog with PricingRates = [ openRate ] }
+
+        let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) catalog
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(selected.Value.EffectiveFrom, Is.EqualTo(OperationsPricingTestData.julyStart))
+                Assert.That(selected.Value.EffectiveTo, Is.EqualTo(None)))
+        )
+
+    /// Verifies each effective-dated prerequisite independently constrains the complete returned window.
+    [<TestCase("assignment")>]
+    [<TestCase("plan")>]
+    [<TestCase("mapping")>]
+    [<TestCase("rate")>]
+    member _.EffectiveRateSelectionIntersectsEachContributingWindow(contributor: string) =
+        let effectiveFrom = Instant.FromUtc(2026, 7, 10, 0, 0)
+        let effectiveTo = Some(Instant.FromUtc(2026, 7, 20, 0, 0))
+        let catalog = catalogWithContributorWindow contributor effectiveFrom effectiveTo
+
+        let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) catalog
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(selected.Value.EffectiveFrom, Is.EqualTo(effectiveFrom))
+                Assert.That(selected.Value.EffectiveTo, Is.EqualTo(effectiveTo))
+                Assert.That(selected.Value.CustomerPricingAssignmentId, Is.EqualTo(OperationsPricingTestData.assignment.CustomerPricingAssignmentId))
+                Assert.That(selected.Value.PricingPlanId, Is.EqualTo(OperationsPricingTestData.plan.PricingPlanId))
+                Assert.That(selected.Value.BillableUsageKindMappingId, Is.EqualTo(OperationsPricingTestData.mapping.BillableUsageKindMappingId))
+                Assert.That(selected.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
+                Assert.That(selected.Value.UnitPriceMicros, Is.EqualTo(OperationsPricingTestData.julyRate.UnitPriceMicros)))
+        )
+
+    /// Verifies different contributors can independently provide the latest start and earliest finite end.
+    [<Test>]
+    member _.EffectiveRateSelectionUsesLatestStartAndEarliestFiniteEndAcrossContributors() =
+        let latestStart = Instant.FromUtc(2026, 7, 12, 0, 0)
+        let earliestEnd = Instant.FromUtc(2026, 7, 18, 0, 0)
+
+        let catalog =
+            { OperationsPricingTestData.catalog with
+                PricingPlans =
+                    [
+                        { OperationsPricingTestData.plan with EffectiveFrom = Instant.FromUtc(2026, 7, 5, 0, 0); EffectiveTo = Some earliestEnd }
+                    ]
+                BillableUsageKindMappings =
+                    [
+                        { OperationsPricingTestData.mapping with EffectiveFrom = latestStart; EffectiveTo = Some(Instant.FromUtc(2026, 7, 25, 0, 0)) }
+                    ]
+                PricingRates =
+                    [
+                        { OperationsPricingTestData.julyRate with EffectiveFrom = Instant.FromUtc(2026, 7, 8, 0, 0); EffectiveTo = None }
+                    ]
+            }
+
+        let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) catalog
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(selected.Value.EffectiveFrom, Is.EqualTo(latestStart))
+                Assert.That(selected.Value.EffectiveTo, Is.EqualTo(Some earliestEnd))
+                Assert.That(selected.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
+                Assert.That(selected.Value.UnitPriceMicros, Is.EqualTo(OperationsPricingTestData.julyRate.UnitPriceMicros)))
+        )
+
+    /// Verifies an end instant is excluded even when every other contributor remains effective.
+    [<Test>]
+    member _.EffectiveRateSelectionExcludesContributorEndBoundary() =
+        let boundary = Instant.FromUtc(2026, 7, 20, 0, 0)
+        let catalog = catalogWithContributorWindow "assignment" OperationsPricingTestData.julyStart (Some boundary)
+
+        let beforeBoundary = PricingRateSelection.trySelect (OperationsPricingTestData.query (boundary - Duration.FromTicks(1L))) catalog
+
+        let atBoundary = PricingRateSelection.trySelect (OperationsPricingTestData.query boundary) catalog
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(beforeBoundary.IsSome, Is.True)
+                Assert.That(beforeBoundary.Value.EffectiveTo, Is.EqualTo(Some boundary))
+                Assert.That(atBoundary, Is.EqualTo(None)))
         )
 
     /// Verifies tracked usage is not billable unless an explicit usage-kind mapping exists.
@@ -391,6 +511,13 @@ type OperationsPricingTests() =
                 Assert.That(sql, Does.Contain("assignment.OrganizationId = @OrganizationId"))
                 Assert.That(sql, Does.Contain("assignment.RepositoryId = @RepositoryId"))
                 Assert.That(sql, Does.Contain("mapping.FactKind = @FactKind"))
+                Assert.That(sql, Does.Contain("MAX(contributor.EffectiveFromUtc) AS EffectiveFromUtc"))
+                Assert.That(sql, Does.Contain("MIN(contributor.EffectiveToUtc) AS EffectiveToUtc"))
+                Assert.That(sql, Does.Contain("assignment.EffectiveFromUtc, assignment.EffectiveToUtc"))
+                Assert.That(sql, Does.Contain("plan.EffectiveFromUtc, plan.EffectiveToUtc"))
+                Assert.That(sql, Does.Contain("mapping.EffectiveFromUtc, mapping.EffectiveToUtc"))
+                Assert.That(sql, Does.Contain("rate.EffectiveFromUtc, rate.EffectiveToUtc"))
+                Assert.That(sql, Does.Not.Contain("9999-12-31"))
                 Assert.That(sql, Does.Contain("ORDER BY")))
         )
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -360,9 +360,9 @@ type OperationsPricingTests() =
                 Assert.That(script, Does.Contain("effective windows cannot overlap")))
         )
 
-    /// Verifies the reviewed pricing migration no longer delegates its historical target model to runtime configuration.
+    /// Verifies the reviewed pricing migration keeps historical schema metadata independent of runtime helpers.
     [<Test>]
-    member _.PricingMigrationTargetModelIsFrozenFromRuntimeConfigurator() =
+    member _.PricingMigrationTargetModelIsFrozenFromRuntimeSchemaHelpers() =
         let source = pricingMigrationSource ()
         let targetModelStart = source.IndexOf("override _.BuildTargetModel(modelBuilder: ModelBuilder) =", StringComparison.Ordinal)
         Assert.That(targetModelStart, Is.GreaterThanOrEqualTo(0))
@@ -370,9 +370,10 @@ type OperationsPricingTests() =
 
         Assert.Multiple(
             Action (fun () ->
-                Assert.That(targetModelSource, Does.Not.Contain("OperationsModel.configure"))
+                Assert.That(targetModelSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
                 Assert.That(targetModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
                 Assert.That(targetModelSource, Does.Contain("let pricingRate = modelBuilder.Entity<PricingRateEntity>()"))
+                Assert.That(targetModelSource, Does.Contain(".HasDatabaseName(\"IX_ops_RawUsageFact_RehydrationExpiresAtUtc\")"))
                 Assert.That(targetModelSource, Does.Contain(".UseCollation(\"Latin1_General_100_BIN2\")")))
         )
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -136,7 +136,9 @@ type OperationsPricingTests() =
     let entityType (entityClrType: Type) : IEntityType =
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsPricingMigrationModel;Integrated Security=true;"
 
-        context.Model.FindEntityType(entityClrType)
+        context
+            .GetService<IDesignTimeModel>()
+            .Model.FindEntityType(entityClrType)
 
     /// Resolves the Operations root from the compiled test assembly.
     let operationsRoot () =
@@ -151,6 +153,11 @@ type OperationsPricingTests() =
                 find directory.Parent
 
         find (DirectoryInfo(TestContext.CurrentContext.TestDirectory))
+
+    /// Reads the reviewed pricing migration source so frozen historical boundaries can be asserted directly.
+    let pricingMigrationSource () =
+        Path.Combine(operationsRoot (), "Grace.Operations.Data", "Migrations", "20260709110000_AddPricingPlanRateAssignment.fs")
+        |> File.ReadAllText
 
     /// Verifies effective-rate selection requires customer assignment, mapping, and rate rows.
     [<Test>]
@@ -224,6 +231,7 @@ type OperationsPricingTests() =
         let mapping = entityType typeof<BillableUsageKindMappingEntity>
         let rate = entityType typeof<PricingRateEntity>
         let assignment = entityType typeof<CustomerPricingAssignmentEntity>
+        let currencyCode = rate.FindProperty("CurrencyCode")
 
         let hasRateIndex =
             rate.GetIndexes()
@@ -240,6 +248,7 @@ type OperationsPricingTests() =
                 Assert.That(mapping.GetTableName(), Is.EqualTo(OperationsPricingSql.BillableUsageKindMappingTableName))
                 Assert.That(rate.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingRateTableName))
                 Assert.That(assignment.GetTableName(), Is.EqualTo(OperationsPricingSql.CustomerPricingAssignmentTableName))
+                Assert.That(currencyCode.GetCollation(), Is.EqualTo("Latin1_General_100_BIN2"))
                 Assert.That(hasRateIndex, Is.True)
                 Assert.That(hasAssignmentIndex, Is.True))
         )
@@ -262,6 +271,26 @@ type OperationsPricingTests() =
     member _.PricingMigrationScriptContainsEffectiveDatingTablesAndOverlapRejection() =
         let script = migrationScript ()
 
+        let lockHintCount =
+            script
+                .Split(
+                    [| "WITH (UPDLOCK, HOLDLOCK)" |],
+                    StringSplitOptions.None
+                )
+                .Length
+            - 1
+
+        let dynamicTriggerCount =
+            script
+                .Split(
+                    [|
+                        "EXEC(N'CREATE OR ALTER TRIGGER ops."
+                    |],
+                    StringSplitOptions.None
+                )
+                .Length
+            - 1
+
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(script, Does.Contain("CREATE TABLE ops.PricingPlan"))
@@ -269,9 +298,30 @@ type OperationsPricingTests() =
                 Assert.That(script, Does.Contain("CREATE TABLE ops.PricingRate"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.CustomerPricingAssignment"))
                 Assert.That(script, Does.Contain("CK_ops_PricingRate_EffectiveRange"))
+                Assert.That(script, Does.Contain("CurrencyCode char(3) COLLATE Latin1_General_100_BIN2 NOT NULL"))
+                Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode)"))
+                Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE"))
                 Assert.That(script, Does.Contain(OperationsPricingSql.PricingRateOverlapTriggerName))
                 Assert.That(script, Does.Contain(OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName))
+                Assert.That(lockHintCount, Is.EqualTo(4))
+                Assert.That(dynamicTriggerCount, Is.EqualTo(4))
                 Assert.That(script, Does.Contain("effective windows cannot overlap")))
+        )
+
+    /// Verifies the reviewed pricing migration no longer delegates its historical target model to runtime configuration.
+    [<Test>]
+    member _.PricingMigrationTargetModelIsFrozenFromRuntimeConfigurator() =
+        let source = pricingMigrationSource ()
+        let targetModelStart = source.IndexOf("override _.BuildTargetModel(modelBuilder: ModelBuilder) =", StringComparison.Ordinal)
+        Assert.That(targetModelStart, Is.GreaterThanOrEqualTo(0))
+        let targetModelSource = source.Substring(targetModelStart)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(targetModelSource, Does.Not.Contain("OperationsModel.configure"))
+                Assert.That(targetModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
+                Assert.That(targetModelSource, Does.Contain("let pricingRate = modelBuilder.Entity<PricingRateEntity>()"))
+                Assert.That(targetModelSource, Does.Contain(".UseCollation(\"Latin1_General_100_BIN2\")")))
         )
 
     /// Verifies the SQL selector cannot return a customer rate through missing mapping or loose scope matching.

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -159,6 +159,14 @@ type OperationsPricingTests() =
         Path.Combine(operationsRoot (), "Grace.Operations.Data", "Migrations", "20260709110000_AddPricingPlanRateAssignment.fs")
         |> File.ReadAllText
 
+    /// Reads the pricing-plan foreign key name from the supplied entity metadata.
+    let pricingPlanForeignKeyName (entityType: IEntityType) =
+        entityType.GetForeignKeys()
+        |> Seq.find (fun foreignKey ->
+            foreignKey.Properties
+            |> Seq.exists (fun property -> property.Name = "PricingPlanId"))
+        |> fun foreignKey -> foreignKey.GetConstraintName()
+
     /// Verifies effective-rate selection requires customer assignment, mapping, and rate rows.
     [<Test>]
     member _.EffectiveRateSelectionFindsCustomerRateForBillableUsageKind() =
@@ -232,6 +240,8 @@ type OperationsPricingTests() =
         let rate = entityType typeof<PricingRateEntity>
         let assignment = entityType typeof<CustomerPricingAssignmentEntity>
         let currencyCode = rate.FindProperty("CurrencyCode")
+        let rateForeignKeyName = pricingPlanForeignKeyName rate
+        let assignmentForeignKeyName = pricingPlanForeignKeyName assignment
 
         let hasRateIndex =
             rate.GetIndexes()
@@ -248,22 +258,44 @@ type OperationsPricingTests() =
                 Assert.That(mapping.GetTableName(), Is.EqualTo(OperationsPricingSql.BillableUsageKindMappingTableName))
                 Assert.That(rate.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingRateTableName))
                 Assert.That(assignment.GetTableName(), Is.EqualTo(OperationsPricingSql.CustomerPricingAssignmentTableName))
+                Assert.That(currencyCode.GetColumnType(), Is.EqualTo("varchar(3)"))
                 Assert.That(currencyCode.GetCollation(), Is.EqualTo("Latin1_General_100_BIN2"))
+                Assert.That(rateForeignKeyName, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
+                Assert.That(assignmentForeignKeyName, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
                 Assert.That(hasRateIndex, Is.True)
                 Assert.That(hasAssignmentIndex, Is.True))
         )
 
-    /// Verifies the latest model snapshot carries pricing entities for future migration drift checks.
+    /// Verifies the latest model snapshot carries pricing entities and reviewed FK names for future migration drift checks.
     [<Test>]
     member _.OperationsModelSnapshotContainsPricingFoundationEntities() =
         let snapshot = OperationsDbContextModelSnapshot()
+        let rate = snapshot.Model.FindEntityType(typeof<PricingRateEntity>)
+        let assignment = snapshot.Model.FindEntityType(typeof<CustomerPricingAssignmentEntity>)
 
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(snapshot.Model.FindEntityType(typeof<PricingPlanEntity>), Is.Not.Null)
                 Assert.That(snapshot.Model.FindEntityType(typeof<BillableUsageKindMappingEntity>), Is.Not.Null)
-                Assert.That(snapshot.Model.FindEntityType(typeof<PricingRateEntity>), Is.Not.Null)
-                Assert.That(snapshot.Model.FindEntityType(typeof<CustomerPricingAssignmentEntity>), Is.Not.Null))
+                Assert.That(rate, Is.Not.Null)
+                Assert.That(assignment, Is.Not.Null)
+                Assert.That(pricingPlanForeignKeyName rate, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
+                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan")))
+        )
+
+    /// Verifies the reviewed pricing migration target model preserves explicit FK names for future migration diffs.
+    [<Test>]
+    member _.PricingMigrationTargetModelContainsReviewedForeignKeyNames() =
+        let migration = AddPricingPlanRateAssignment()
+        let rate = migration.TargetModel.FindEntityType(typeof<PricingRateEntity>)
+        let assignment = migration.TargetModel.FindEntityType(typeof<CustomerPricingAssignmentEntity>)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(rate, Is.Not.Null)
+                Assert.That(assignment, Is.Not.Null)
+                Assert.That(pricingPlanForeignKeyName rate, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
+                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan")))
         )
 
     /// Verifies the migration script creates pricing tables and overlap rejection instead of relying on query tie-breaks.
@@ -298,9 +330,12 @@ type OperationsPricingTests() =
                 Assert.That(script, Does.Contain("CREATE TABLE ops.PricingRate"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.CustomerPricingAssignment"))
                 Assert.That(script, Does.Contain("CK_ops_PricingRate_EffectiveRange"))
-                Assert.That(script, Does.Contain("CurrencyCode char(3) COLLATE Latin1_General_100_BIN2 NOT NULL"))
+                Assert.That(script, Does.Contain("CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL"))
+                Assert.That(script, Does.Contain("LEN(CurrencyCode) = 3"))
                 Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode)"))
                 Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE"))
+                Assert.That(script, Does.Contain("CONSTRAINT FK_ops_PricingRate_PricingPlan FOREIGN KEY"))
+                Assert.That(script, Does.Contain("CONSTRAINT FK_ops_CustomerPricingAssignment_PricingPlan FOREIGN KEY"))
                 Assert.That(script, Does.Contain(OperationsPricingSql.PricingRateOverlapTriggerName))
                 Assert.That(script, Does.Contain(OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName))
                 Assert.That(lockHintCount, Is.EqualTo(4))

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -251,6 +251,10 @@ type OperationsPricingTests() =
             assignment.GetIndexes()
             |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentScopeIndexName)
 
+        let hasAssignmentPricingPlanIndex =
+            assignment.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(plan.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingPlanTableName))
@@ -263,7 +267,8 @@ type OperationsPricingTests() =
                 Assert.That(rateForeignKeyName, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
                 Assert.That(assignmentForeignKeyName, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
                 Assert.That(hasRateIndex, Is.True)
-                Assert.That(hasAssignmentIndex, Is.True))
+                Assert.That(hasAssignmentIndex, Is.True)
+                Assert.That(hasAssignmentPricingPlanIndex, Is.True))
         )
 
     /// Verifies the latest model snapshot carries pricing entities and reviewed FK names for future migration drift checks.
@@ -273,6 +278,10 @@ type OperationsPricingTests() =
         let rate = snapshot.Model.FindEntityType(typeof<PricingRateEntity>)
         let assignment = snapshot.Model.FindEntityType(typeof<CustomerPricingAssignmentEntity>)
 
+        let hasAssignmentPricingPlanIndex =
+            assignment.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(snapshot.Model.FindEntityType(typeof<PricingPlanEntity>), Is.Not.Null)
@@ -280,7 +289,8 @@ type OperationsPricingTests() =
                 Assert.That(rate, Is.Not.Null)
                 Assert.That(assignment, Is.Not.Null)
                 Assert.That(pricingPlanForeignKeyName rate, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
-                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan")))
+                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
+                Assert.That(hasAssignmentPricingPlanIndex, Is.True))
         )
 
     /// Verifies the reviewed pricing migration target model preserves explicit FK names for future migration diffs.
@@ -290,12 +300,17 @@ type OperationsPricingTests() =
         let rate = migration.TargetModel.FindEntityType(typeof<PricingRateEntity>)
         let assignment = migration.TargetModel.FindEntityType(typeof<CustomerPricingAssignmentEntity>)
 
+        let hasAssignmentPricingPlanIndex =
+            assignment.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(rate, Is.Not.Null)
                 Assert.That(assignment, Is.Not.Null)
                 Assert.That(pricingPlanForeignKeyName rate, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
-                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan")))
+                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
+                Assert.That(hasAssignmentPricingPlanIndex, Is.True))
         )
 
     /// Verifies the migration script creates pricing tables and overlap rejection instead of relying on query tie-breaks.
@@ -336,6 +351,8 @@ type OperationsPricingTests() =
                 Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE"))
                 Assert.That(script, Does.Contain("CONSTRAINT FK_ops_PricingRate_PricingPlan FOREIGN KEY"))
                 Assert.That(script, Does.Contain("CONSTRAINT FK_ops_CustomerPricingAssignment_PricingPlan FOREIGN KEY"))
+                Assert.That(script, Does.Contain($"CREATE INDEX {OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName}"))
+                Assert.That(script, Does.Contain("ON ops.CustomerPricingAssignment(PricingPlanId)"))
                 Assert.That(script, Does.Contain(OperationsPricingSql.PricingRateOverlapTriggerName))
                 Assert.That(script, Does.Contain(OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName))
                 Assert.That(lockHintCount, Is.EqualTo(4))

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -1,0 +1,308 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Operations.Data.Migrations
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata
+open NodaTime
+open NUnit.Framework
+open System
+open System.IO
+
+/// Provides deterministic pricing catalog rows for Operations pricing tests.
+module OperationsPricingTestData =
+
+    /// Provides the customer that owns the default pricing assignment.
+    let customerId = Guid.Parse("57400000-1000-0000-0000-000000000001")
+
+    /// Provides a second customer used to prove customer isolation.
+    let otherCustomerId = Guid.Parse("57400000-1000-0000-0000-000000000002")
+
+    /// Provides the owner used by the default customer assignment.
+    let ownerId = OwnerId.Parse("57400000-2000-0000-0000-000000000001")
+
+    /// Provides the organization used by the default customer assignment.
+    let organizationId = OrganizationId.Parse("57400000-3000-0000-0000-000000000001")
+
+    /// Provides the repository used by the default customer assignment.
+    let repositoryId = RepositoryId.Parse("57400000-4000-0000-0000-000000000001")
+
+    /// Provides a second repository used to prove repository isolation.
+    let otherRepositoryId = RepositoryId.Parse("57400000-4000-0000-0000-000000000002")
+
+    /// Provides the pricing plan selected by the default customer assignment.
+    let planId = Guid.Parse("57400000-5000-0000-0000-000000000001")
+
+    /// Provides the internal billable usage-kind id for repository storage.
+    let repositoryStorageBillableUsageKind = 1
+
+    /// Provides the start of the initial pricing window.
+    let julyStart = Instant.FromUtc(2026, 7, 1, 0, 0)
+
+    /// Provides the first instant covered by a future pricing rate.
+    let augustStart = Instant.FromUtc(2026, 8, 1, 0, 0)
+
+    /// Builds a query for repository storage pricing at the supplied timestamp.
+    let query observedAt =
+        {
+            CustomerId = customerId
+            OwnerId = ownerId
+            OrganizationId = organizationId
+            RepositoryId = repositoryId
+            FactKind = UsageFactKind.RepositoryStorageBytesMinute
+            ObservedAt = observedAt
+        }
+
+    /// Provides one active pricing plan for selection tests.
+    let plan = { PricingPlanId = planId; PlanCode = "grace-standard-v1"; EffectiveFrom = julyStart; EffectiveTo = None }
+
+    /// Provides one active usage-kind mapping for repository storage.
+    let mapping =
+        {
+            BillableUsageKindMappingId = Guid.Parse("57400000-6000-0000-0000-000000000001")
+            FactKind = UsageFactKind.RepositoryStorageBytesMinute
+            BillableUsageKind = repositoryStorageBillableUsageKind
+            EffectiveFrom = julyStart
+            EffectiveTo = None
+        }
+
+    /// Provides the initial customer rate for repository storage.
+    let julyRate =
+        {
+            PricingRateId = Guid.Parse("57400000-7000-0000-0000-000000000001")
+            PricingPlanId = planId
+            BillableUsageKind = repositoryStorageBillableUsageKind
+            CurrencyCode = "USD"
+            UnitName = "byte-minute"
+            UnitQuantity = 1_073_741_824L
+            UnitPriceMicros = 10L
+            EffectiveFrom = julyStart
+            EffectiveTo = Some augustStart
+        }
+
+    /// Provides a future rate that must not rewrite historical July selections.
+    let augustRate =
+        {
+            PricingRateId = Guid.Parse("57400000-7000-0000-0000-000000000002")
+            PricingPlanId = planId
+            BillableUsageKind = repositoryStorageBillableUsageKind
+            CurrencyCode = "USD"
+            UnitName = "byte-minute"
+            UnitQuantity = 1_073_741_824L
+            UnitPriceMicros = 20L
+            EffectiveFrom = augustStart
+            EffectiveTo = None
+        }
+
+    /// Provides the customer assignment that makes the plan selectable for one repository scope.
+    let assignment =
+        {
+            CustomerPricingAssignmentId = Guid.Parse("57400000-8000-0000-0000-000000000001")
+            CustomerId = customerId
+            OwnerId = ownerId
+            OrganizationId = organizationId
+            RepositoryId = repositoryId
+            PricingPlanId = planId
+            EffectiveFrom = julyStart
+            EffectiveTo = None
+        }
+
+    /// Provides a complete catalog with one customer assignment and two effective rates.
+    let catalog =
+        {
+            PricingPlans = [ plan ]
+            BillableUsageKindMappings = [ mapping ]
+            PricingRates = [ julyRate; augustRate ]
+            CustomerPricingAssignments = [ assignment ]
+        }
+
+/// Covers Operations pricing schema, seed, and deterministic selection behavior.
+[<TestFixture>]
+type OperationsPricingTests() =
+
+    /// Generates the Operations migration script without connecting to SQL Server.
+    let migrationScript () =
+        use context =
+            OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsPricingMigrationScript;Integrated Security=true;"
+
+        let migrator = context.GetService<IMigrator>()
+        migrator.GenerateScript(options = MigrationsSqlGenerationOptions.Idempotent)
+
+    /// Reads the EF entity metadata that future migrations use for pricing schema drift.
+    let entityType (entityClrType: Type) : IEntityType =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsPricingMigrationModel;Integrated Security=true;"
+
+        context.Model.FindEntityType(entityClrType)
+
+    /// Resolves the Operations root from the compiled test assembly.
+    let operationsRoot () =
+        let rec find (directory: DirectoryInfo) =
+            let candidate = Path.Combine(directory.FullName, "Grace.Operations.slnx")
+
+            if File.Exists candidate then
+                directory.FullName
+            elif isNull directory.Parent then
+                failwith $"Could not find Grace.Operations.slnx above {TestContext.CurrentContext.TestDirectory}."
+            else
+                find directory.Parent
+
+        find (DirectoryInfo(TestContext.CurrentContext.TestDirectory))
+
+    /// Verifies effective-rate selection requires customer assignment, mapping, and rate rows.
+    [<Test>]
+    member _.EffectiveRateSelectionFindsCustomerRateForBillableUsageKind() =
+        let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) OperationsPricingTestData.catalog
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(selected.IsSome, Is.True)
+                Assert.That(selected.Value.CustomerId, Is.EqualTo(OperationsPricingTestData.customerId))
+                Assert.That(selected.Value.PricingPlanId, Is.EqualTo(OperationsPricingTestData.planId))
+                Assert.That(selected.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
+                Assert.That(selected.Value.BillableUsageKind, Is.EqualTo(OperationsPricingTestData.repositoryStorageBillableUsageKind))
+                Assert.That(selected.Value.UnitPriceMicros, Is.EqualTo(10L)))
+        )
+
+    /// Verifies tracked usage is not billable unless an explicit usage-kind mapping exists.
+    [<Test>]
+    member _.TrackedUsageWithoutBillableMappingSelectsNoRate() =
+        let catalog = { OperationsPricingTestData.catalog with BillableUsageKindMappings = [] }
+
+        let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) catalog
+
+        Assert.That(selected, Is.EqualTo(None))
+
+    /// Verifies mapped usage is still not billable unless the assigned plan has an effective rate.
+    [<Test>]
+    member _.BillableMappingWithoutEffectiveRateSelectsNoRate() =
+        let catalog = { OperationsPricingTestData.catalog with PricingRates = [] }
+
+        let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) catalog
+
+        Assert.That(selected, Is.EqualTo(None))
+
+    /// Verifies half-open effective windows preserve historical rate meaning after a later rate starts.
+    [<Test>]
+    member _.FutureRateChangePreservesHistoricalSelectionAtEffectiveBoundary() =
+        let beforeBoundary =
+            PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 31, 23, 59))) OperationsPricingTestData.catalog
+
+        let atBoundary =
+            PricingRateSelection.trySelect (OperationsPricingTestData.query OperationsPricingTestData.augustStart) OperationsPricingTestData.catalog
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(beforeBoundary.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
+                Assert.That(beforeBoundary.Value.UnitPriceMicros, Is.EqualTo(10L))
+                Assert.That(atBoundary.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.augustRate.PricingRateId))
+                Assert.That(atBoundary.Value.UnitPriceMicros, Is.EqualTo(20L)))
+        )
+
+    /// Verifies customer and repository identifiers must both match before pricing can be selected.
+    [<Test>]
+    member _.EffectiveRateSelectionDoesNotLeakAcrossCustomerOrRepositoryScope() =
+        let otherCustomerQuery =
+            { OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0)) with CustomerId = OperationsPricingTestData.otherCustomerId }
+
+        let otherRepositoryQuery =
+            { OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0)) with RepositoryId = OperationsPricingTestData.otherRepositoryId }
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(PricingRateSelection.trySelect otherCustomerQuery OperationsPricingTestData.catalog, Is.EqualTo(None))
+                Assert.That(PricingRateSelection.trySelect otherRepositoryQuery OperationsPricingTestData.catalog, Is.EqualTo(None)))
+        )
+
+    /// Verifies pricing entities are part of the runtime EF model with the expected keys and lookup indexes.
+    [<Test>]
+    member _.OperationsEfModelContainsPricingFoundationEntities() =
+        let plan = entityType typeof<PricingPlanEntity>
+        let mapping = entityType typeof<BillableUsageKindMappingEntity>
+        let rate = entityType typeof<PricingRateEntity>
+        let assignment = entityType typeof<CustomerPricingAssignmentEntity>
+
+        let hasRateIndex =
+            rate.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.PricingRateEffectiveIndexName)
+
+        let hasAssignmentIndex =
+            assignment.GetIndexes()
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentScopeIndexName)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(plan.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingPlanTableName))
+                Assert.That(plan.FindPrimaryKey().GetName(), Is.EqualTo("PK_ops_PricingPlan"))
+                Assert.That(mapping.GetTableName(), Is.EqualTo(OperationsPricingSql.BillableUsageKindMappingTableName))
+                Assert.That(rate.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingRateTableName))
+                Assert.That(assignment.GetTableName(), Is.EqualTo(OperationsPricingSql.CustomerPricingAssignmentTableName))
+                Assert.That(hasRateIndex, Is.True)
+                Assert.That(hasAssignmentIndex, Is.True))
+        )
+
+    /// Verifies the latest model snapshot carries pricing entities for future migration drift checks.
+    [<Test>]
+    member _.OperationsModelSnapshotContainsPricingFoundationEntities() =
+        let snapshot = OperationsDbContextModelSnapshot()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(snapshot.Model.FindEntityType(typeof<PricingPlanEntity>), Is.Not.Null)
+                Assert.That(snapshot.Model.FindEntityType(typeof<BillableUsageKindMappingEntity>), Is.Not.Null)
+                Assert.That(snapshot.Model.FindEntityType(typeof<PricingRateEntity>), Is.Not.Null)
+                Assert.That(snapshot.Model.FindEntityType(typeof<CustomerPricingAssignmentEntity>), Is.Not.Null))
+        )
+
+    /// Verifies the migration script creates pricing tables and overlap rejection instead of relying on query tie-breaks.
+    [<Test>]
+    member _.PricingMigrationScriptContainsEffectiveDatingTablesAndOverlapRejection() =
+        let script = migrationScript ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(script, Does.Contain("CREATE TABLE ops.PricingPlan"))
+                Assert.That(script, Does.Contain("CREATE TABLE ops.BillableUsageKindMapping"))
+                Assert.That(script, Does.Contain("CREATE TABLE ops.PricingRate"))
+                Assert.That(script, Does.Contain("CREATE TABLE ops.CustomerPricingAssignment"))
+                Assert.That(script, Does.Contain("CK_ops_PricingRate_EffectiveRange"))
+                Assert.That(script, Does.Contain(OperationsPricingSql.PricingRateOverlapTriggerName))
+                Assert.That(script, Does.Contain(OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName))
+                Assert.That(script, Does.Contain("effective windows cannot overlap")))
+        )
+
+    /// Verifies the SQL selector cannot return a customer rate through missing mapping or loose scope matching.
+    [<Test>]
+    member _.EffectiveRateSqlRequiresExplicitMappingRateAndRepositoryScope() =
+        let sql = OperationsPricingSql.SelectEffectivePricingRate
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(sql, Does.Contain("INNER JOIN ops.BillableUsageKindMapping AS mapping"))
+                Assert.That(sql, Does.Contain("INNER JOIN ops.PricingRate AS rate"))
+                Assert.That(sql, Does.Contain("assignment.CustomerId = @CustomerId"))
+                Assert.That(sql, Does.Contain("assignment.OwnerId = @OwnerId"))
+                Assert.That(sql, Does.Contain("assignment.OrganizationId = @OrganizationId"))
+                Assert.That(sql, Does.Contain("assignment.RepositoryId = @RepositoryId"))
+                Assert.That(sql, Does.Contain("mapping.FactKind = @FactKind"))
+                Assert.That(sql, Does.Contain("ORDER BY")))
+        )
+
+    /// Verifies the initial seed script exists and does not assign customers or post charges.
+    [<Test>]
+    member _.InitialPricingSeedScriptDocumentsFoundationRowsOnly() =
+        let seedPath = Path.Combine(operationsRoot (), "scripts", "seed-pricing-foundation.sql")
+        Assert.That(File.Exists seedPath, Is.True)
+        let script = File.ReadAllText seedPath
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(script, Does.Contain("ops.PricingPlan"))
+                Assert.That(script, Does.Contain("ops.BillableUsageKindMapping"))
+                Assert.That(script, Does.Contain("ops.PricingRate"))
+                Assert.That(script, Does.Not.Contain("INSERT INTO ops.CustomerPricingAssignment"))
+                Assert.That(script, Does.Not.Contain("ChargeLedger")))
+        )

--- a/src/Grace.Operations/scripts/seed-pricing-foundation.sql
+++ b/src/Grace.Operations/scripts/seed-pricing-foundation.sql
@@ -1,0 +1,96 @@
+/*
+Seeds the first Operations pricing foundation rows without assigning any customer to a plan.
+
+This script intentionally creates:
+- one effective pricing plan shell,
+- one explicit billable mapping for UsageFactKind.RepositoryStorageBytesMinute,
+- one customer price for that mapped usage kind.
+
+Tracked usage remains non-billable for customers until an explicit row exists in ops.CustomerPricingAssignment.
+*/
+
+DECLARE @PlanId uniqueidentifier = '57400000-0000-0000-0000-000000000001';
+DECLARE @MappingId uniqueidentifier = '57400000-0000-0000-0000-000000000002';
+DECLARE @RateId uniqueidentifier = '57400000-0000-0000-0000-000000000003';
+DECLARE @EffectiveFromUtc datetime2(7) = '2026-07-01T00:00:00.0000000';
+DECLARE @RepositoryStorageBytesMinuteFactKind int = 1;
+DECLARE @RepositoryStorageBillableUsageKind int = 1;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM ops.PricingPlan
+    WHERE PricingPlanId = @PlanId
+)
+BEGIN
+    INSERT INTO ops.PricingPlan
+    (
+        PricingPlanId,
+        PlanCode,
+        DisplayName,
+        EffectiveFromUtc
+    )
+    VALUES
+    (
+        @PlanId,
+        N'grace-standard-v1',
+        N'Grace Standard v1',
+        @EffectiveFromUtc
+    );
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM ops.BillableUsageKindMapping
+    WHERE BillableUsageKindMappingId = @MappingId
+)
+BEGIN
+    INSERT INTO ops.BillableUsageKindMapping
+    (
+        BillableUsageKindMappingId,
+        FactKind,
+        BillableUsageKind,
+        DisplayName,
+        EffectiveFromUtc
+    )
+    VALUES
+    (
+        @MappingId,
+        @RepositoryStorageBytesMinuteFactKind,
+        @RepositoryStorageBillableUsageKind,
+        N'Repository Storage',
+        @EffectiveFromUtc
+    );
+END;
+
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM ops.PricingRate
+    WHERE PricingRateId = @RateId
+)
+BEGIN
+    INSERT INTO ops.PricingRate
+    (
+        PricingRateId,
+        PricingPlanId,
+        BillableUsageKind,
+        CurrencyCode,
+        UnitName,
+        UnitQuantity,
+        UnitPriceMicros,
+        EffectiveFromUtc
+    )
+    VALUES
+    (
+        @RateId,
+        @PlanId,
+        @RepositoryStorageBillableUsageKind,
+        'USD',
+        N'byte-minute',
+        1073741824,
+        0,
+        @EffectiveFromUtc
+    );
+END;

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -6,12 +6,14 @@ open Aspire.Hosting.Testing
 open Aspire.Hosting.Azure
 open Azure.Messaging.ServiceBus
 open Grace.Shared
+open Microsoft.Data.SqlClient
 open Microsoft.Azure.Cosmos
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Logging
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Data
 open System.Diagnostics
 open System.IO
 open System.Net.Http
@@ -71,6 +73,8 @@ module AspireTestHost =
     let private getTimeout (local: TimeSpan) (ci: TimeSpan) = if isCi then ci else local
 
     let private defaultWaitTimeout = getTimeout (TimeSpan.FromMinutes(5.0)) (TimeSpan.FromMinutes(3.0))
+
+    let private latestOperationsMigrationId = "20260709110000_AddPricingPlanRateAssignment"
 
     /// Defines log progress behavior for the surrounding tests used by the server integration aspire Test Host scenario.
     let private logProgress (message: string) =
@@ -482,6 +486,90 @@ module AspireTestHost =
                         $"Last logs:{Environment.NewLine}{lastLines}"
 
                 raise (Exception($"{resourceName} failed to start. {details}{Environment.NewLine}{logDetails}", ex))
+        }
+
+    /// Waits until the operations worker has completed EF migrations that gate Service Bus processing.
+    let private waitForOperationsSchemaReadyAsync (connectionString: string) (ct: CancellationToken) =
+        task {
+            logProgress "waiting for Operations SQL schema migrations to complete."
+            let stopwatch = Stopwatch.StartNew()
+            let mutable ready = false
+            let mutable lastMigration = "<none>"
+            let mutable rawUsageFactPresent = false
+            let mutable usageAggregatePresent = false
+            let mutable lastError = String.Empty
+
+            while not ready && not ct.IsCancellationRequested do
+                try
+                    use connection = new SqlConnection(connectionString)
+                    do! connection.OpenAsync ct
+                    use command = connection.CreateCommand()
+                    command.CommandType <- CommandType.Text
+
+                    command.CommandText <-
+                        $"""
+DECLARE @LatestMigrationId nvarchar(150) = N'';
+
+IF OBJECT_ID(N'ops.__EFMigrationsHistory', N'U') IS NOT NULL
+BEGIN
+    EXEC sys.sp_executesql
+        N'SELECT TOP (1) @MigrationId = MigrationId FROM ops.__EFMigrationsHistory WITH (READCOMMITTEDLOCK) ORDER BY MigrationId DESC;',
+        N'@MigrationId nvarchar(150) OUTPUT',
+        @MigrationId = @LatestMigrationId OUTPUT;
+END;
+
+SELECT
+    CASE WHEN OBJECT_ID(N'ops.RawUsageFact', N'U') IS NULL THEN 0 ELSE 1 END AS RawUsageFactPresent,
+    CASE WHEN OBJECT_ID(N'ops.UsageAggregateMinute', N'U') IS NULL THEN 0 ELSE 1 END AS UsageAggregateMinutePresent,
+    @LatestMigrationId AS LatestMigrationId;
+"""
+
+                    use! reader = command.ExecuteReaderAsync ct
+                    let! hasRow = reader.ReadAsync ct
+
+                    if hasRow then
+                        rawUsageFactPresent <- reader.GetInt32(0) = 1
+                        usageAggregatePresent <- reader.GetInt32(1) = 1
+                        lastMigration <- reader.GetString(2)
+
+                        ready <-
+                            rawUsageFactPresent
+                            && usageAggregatePresent
+                            && String.Compare(lastMigration, latestOperationsMigrationId, StringComparison.Ordinal)
+                               >= 0
+                    else
+                        rawUsageFactPresent <- false
+                        usageAggregatePresent <- false
+                        lastMigration <- "<history table missing>"
+
+                    lastError <- String.Empty
+                with
+                | :? OperationCanceledException when ct.IsCancellationRequested -> ()
+                | ex ->
+                    lastError <- ex.Message
+                    rawUsageFactPresent <- false
+                    usageAggregatePresent <- false
+
+                if not ready && not ct.IsCancellationRequested then
+                    try
+                        do! Task.Delay(TimeSpan.FromSeconds(1.0), ct)
+                    with
+                    | :? OperationCanceledException when ct.IsCancellationRequested -> ()
+
+            if ct.IsCancellationRequested && not ready then
+                let errorSuffix =
+                    if String.IsNullOrWhiteSpace lastError then
+                        ""
+                    else
+                        $" Last SQL error: {lastError}"
+
+                raise (
+                    TimeoutException(
+                        $"Timed out after {stopwatch.Elapsed.TotalSeconds:n1}s waiting for Operations SQL schema migrations. Expected at least migration '{latestOperationsMigrationId}'; actual latest migration '{lastMigration}'. RawUsageFactPresent={rawUsageFactPresent}; UsageAggregateMinutePresent={usageAggregatePresent}.{errorSuffix}"
+                    )
+                )
+
+            logProgress $"Operations SQL schema migrations complete at '{lastMigration}'."
         }
 
     /// Groups shared helpers for fixture diagnostics.
@@ -1322,6 +1410,7 @@ module AspireTestHost =
 
                 use operationsWorkerReadinessCts = new CancellationTokenSource(defaultWaitTimeout)
                 do! waitForResourceHealthyAsync notificationService app operationsWorkerResourceName operationsWorkerReadinessCts.Token
+                do! waitForOperationsSchemaReadyAsync operationsSqlConnectionString operationsWorkerReadinessCts.Token
             else
                 Console.WriteLine("Skipping Service Bus functional readiness checks (GRACE_TEST_SKIP_SERVICEBUS=1).")
 


### PR DESCRIPTION
# Summary

Related to #574.

Part of #560 and #554.

This implements the B4.1 pricing foundation for Grace.Operations. It adds effective-dated pricing plans, billable usage-kind mappings, pricing rates, and customer pricing assignments without adding customer APIs, charge previews, posted ledgers, external billing-provider integration, or CLI usage commands.

## Review Status

- Final head: `0f7858f21692ee171a7b24fa2476286dd648745a`.
- Freshness: 0 commits behind and 6 commits ahead of current `epic/560-operations-pricing-billing-usage`.
- Scoped diff: no deletions and no `src/Grace.slnx` change.
- Worker validation: targeted Fantomas passed; Release Operations test build passed with 0 warnings and 0 errors;
  focused `OperationsPricing` tests passed 19/19; both diff guards passed.
- GitHub `full`: passed on the final head.
- Latest-head Codex review: `+1` no-issues result at 2026-07-10T21:42:38Z.
- Review conversations: all resolved; no current-head findings remain.
- Merge state: clean and ready to merge into the WS4 integration branch.
- Tracker propagation: #574 contains the complete applicability-window implementation/proof contract and #575
  contains the downstream charge-preview consumer rule.
- Manual review trigger: not used.
- Prevention: pricing-result contract gap; #574 and #575 now define and prove the selected price's complete
  applicability interval across all four effective-dated prerequisites.

## What Changed

- Added Operations SQL pricing foundation tables for pricing plans, billable usage-kind mappings, pricing rates, and customer pricing assignments.
- Added effective-date constraints, lookup indexes, foreign keys, and SQL overlap-rejection triggers for pricing and assignment windows.
- Added `PricingRateSelection` and `SqlOperationsPricingCatalog` so effective-rate lookup only succeeds when customer assignment, plan, billable mapping, and rate are all effective.
- Added focused Operations pricing tests for positive selection, no implicit billability, half-open effective boundaries, future-rate history preservation, customer/repository isolation, migration/model snapshot coverage, selector SQL shape, and seed-script scope.
- Added initial seed script path: `src/Grace.Operations/scripts/seed-pricing-foundation.sql`. The script seeds foundation rows only and does not assign customers or post charges.

## Scope Boundaries

- No charge preview implementation; #575 owns rebuildable previews.
- No billing period close or immutable charge ledger; #576 owns posted ledger work.
- No customer usage endpoints or Grace Server proxy; #577 and #578 own those surfaces.
- No operator analytics; #579 owns that work.
- No external billing-provider integration.
- Root `src/Grace.slnx` was not modified.

## Validation

Worker validation for `c3a1b445c55fcc032e22b9ad5f7e34faeed27001`:

- Targeted Fantomas on touched F# files passed.
- `dotnet build C:\Source\Grace-574-pricing-plan-rate-assignment\src\Grace.Operations\Grace.Operations.slnx --configuration Release` passed.
- `dotnet test C:\Source\Grace-574-pricing-plan-rate-assignment\src\Grace.Operations\Grace.Operations.Tests\Grace.Operations.Tests.fsproj --configuration Release --no-build --logger "console;verbosity=minimal"` passed, 146 tests.
- `pwsh ./scripts/validate.ps1 -Fast` passed.
- `git diff --check` passed.
- `src/Grace.slnx` has no diff.

## Residual Risks

- SQL overlap triggers are covered through generated migration-script assertions, not by executing against a live SQL Server instance in this slice.
- The seed script provides foundation rows only; customer assignment rows and real pricing policy values remain future/operator inputs.
- `-Full` was not run because this leaf does not add Aspire/emulator runtime behavior beyond the normal final `-Fast` gate.






### First Review Fix Evidence

- Fix commit: `0a143638c6ded1997f80f5c5fdead11ce576cff9`.
- Addressed all four fresh Codex Code Review Bot findings from `c3a1b445c55fcc032e22b9ad5f7e34faeed27001`:
  - All four pricing overlap triggers now read their target table with `WITH (UPDLOCK, HOLDLOCK)` in the self-join, covering pricing plans, billable mappings, pricing rates, and customer assignments.
  - `CurrencyCode` now uses `Latin1_General_100_BIN2` binary collation in SQL DDL and EF runtime/snapshot metadata, and the check constraint validates under that binary collation.
  - Each `CREATE OR ALTER TRIGGER` is wrapped in dynamic SQL so EF idempotent migration-history guards do not put raw trigger DDL behind an `IF` in the same batch.
  - The migration target model is frozen in `20260709110000_AddPricingPlanRateAssignment` and no longer calls live `OperationsModel.configure`.
- Worker validation for `0a143638c6ded1997f80f5c5fdead11ce576cff9`:
  - Targeted Fantomas passed.
  - Focused `OperationsPricingTests` passed 11/11.
  - `pwsh ./scripts/validate.ps1 -Fast` passed; root and Operations builds passed; Operations tests passed 147/147.
  - `git diff --check` passed.
  - Root `src/Grace.slnx` has no diff.
- Prevention: pricing migration tests now assert the lock-hint count, dynamic trigger wrapper count, frozen migration-model boundary, and binary currency validation/model metadata.




### Second Review Fix Evidence

- Fix commit: `b0bf3bced4ccb42238beac911e93c54dbf71d7cc`.
- Addressed the two fresh Codex Code Review Bot findings from `0a143638c6ded1997f80f5c5fdead11ce576cff9`:
  - Added explicit pricing-plan FK constraint metadata in the runtime EF model, frozen migration target model, and model snapshot for `FK_ops_PricingRate_PricingPlan` and `FK_ops_CustomerPricingAssignment_PricingPlan`.
  - Changed `CurrencyCode` from padded `char(3)` to non-padded `varchar(3)` and added `LEN(CurrencyCode) = 3` to the generated SQL check while preserving binary collation and uppercase alphabetic validation.
- Worker validation for `b0bf3bced4ccb42238beac911e93c54dbf71d7cc`:
  - Targeted Fantomas on touched F# files passed.
  - Focused `OperationsPricingTests` passed 12/12.
  - `pwsh ./scripts/validate.ps1 -Fast` passed; root fast suite passed; Operations-local suite passed with 148 tests.
  - `git diff --check` passed.
  - Root `src/Grace.slnx` has no diff.
- CI failure assessment: the previous GitHub `full` failure on the Operations tracer-bullet path reported `Invalid object name 'ops.RawUsageFact'`. The worker attempted the exact focused repro locally, but the local environment failed earlier while opening `GraceOperations` for `sa`. The #574 diff does not touch AppHost, worker startup, shared Operations schema initialization, or the tracer-bullet test path, so no startup/runtime change was made in this pricing-owned fix.
- Prevention: this second substantive review cycle was on persisted pricing schema-contract drift. The branch now has assertions that the migration script, runtime model, snapshot, and frozen migration target model agree on FK names, currency store type, exact length, binary collation, and prior trigger/migration invariants before another bot review is relied on.


### CI Stabilization Evidence

- Fix commit: `c8b2e6d48c85099c253f2edd9ef7d884bf9cfa76`.
- Addressed the repeated GitHub `full` failure where `DevTestUsageFactPublishesThroughWorkerToRawSqlAndAggregateOnce` timed out with `Invalid object name 'ops.RawUsageFact'` while the operational message stayed active.
- Root cause: `Grace.Server.Tests` could publish an operational usage fact after the `grace-operations-worker` resource was healthy but before Operations SQL migrations had completed. The fix adds an Operations SQL schema readiness wait in the Aspire test host before Service Bus-backed server tests run.
- Also fixed the pricing migration drift exposed during diagnosis: `CustomerPricingAssignment.PricingPlanId` was missing its conventional FK lookup index metadata in the migration target/snapshot path. The branch now explicitly carries and tests `IX_ops_CustomerPricingAssignment_PricingPlanId` across SQL, runtime EF metadata, the frozen migration target model, and the model snapshot.
- Worker validation for `c8b2e6d48c85099c253f2edd9ef7d884bf9cfa76`:
  - Targeted Fantomas on touched F# files passed.
  - `dotnet build --configuration Release src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj` passed.
  - `dotnet test --configuration Release --no-build src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj --filter FullyQualifiedName~OperationsPricing` passed 12/12.
  - `dotnet build --configuration Release src/Grace.Server.Tests/Grace.Server.Tests.fsproj` passed.
  - `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj --filter FullyQualifiedName~DevTestUsageFactPublishesThroughWorkerToRawSqlAndAggregateOnce` passed 1/1 and logged `Operations SQL schema migrations complete at '20260709110000_AddPricingPlanRateAssignment'`.
  - `git diff --check` passed.
  - Root `src/Grace.slnx` has no diff.
- Residual risk: the prior local `validate -Full` run had already passed the Operations SQL schema readiness point and then failed later in an apparently unrelated Aspire restart/cascade path. This commit targets the repeated `ops.RawUsageFact` readiness failure now blocking GitHub `full`; GitHub `full` is running again on the new head.



### Review Stabilization Ledger: persisted schema freeze invariants

Coding is paused for PR #698 after the third substantive Codex Code Review Bot cycle on persisted Operations schema/model invariants. Do not assign another routine fix worker until the maintainer approves this ledger or explicitly directs continued patching.

#### Review Timeline

- Initial implementation head `c3a1b445c55fcc032e22b9ad5f7e34faeed27001`: Codex found four persisted schema/model issues: overlap triggers under row-versioned reads, case-insensitive currency validation, idempotent trigger DDL batching, and a migration target model rebuilt from live runtime configuration.
- First fix head `0a143638c6ded1997f80f5c5fdead11ce576cff9`: Codex found two fresh persisted schema-contract issues: explicit database FK names missing from EF metadata, and padded `char(3)` currency storage allowing short codes under SQL Server string semantics.
- Second fix head `b0bf3bced4ccb42238beac911e93c54dbf71d7cc`: GitHub `full` repeatedly failed before Operations SQL schema was ready, and worker diagnosis found pending migration drift from a missing `CustomerPricingAssignment.PricingPlanId` lookup-index metadata path.
- CI stabilization head `c8b2e6d48c85099c253f2edd9ef7d884bf9cfa76`: GitHub `full` passed, but Codex found one fresh current-head schema-freeze issue: `BuildTargetModel` still reads `OperationsUsageSql.TemporaryHotCleanupExpiryIndexName`, so a future runtime constant rename could mutate the historical migration target model.

#### Suspected Missing Invariant Family

Frozen Operations migration target models must be self-contained historical schema ledgers. They must not call live model configuration, and they must not read runtime schema constants, SQL helper constants, or mutable shared names for database object names, store types, indexes, constraints, triggers, collations, or generated metadata. Later runtime/schema helper changes must not recompile an already-reviewed migration target model into a different historical shape.

#### Proposed Stabilization Obligation

Approve a narrow stabilization worker scoped to this invariant family:

- Inline the remaining mutable index-name reference in `20260709110000_AddPricingPlanRateAssignment.BuildTargetModel` as the historical literal `IX_ops_RawUsageFact_RehydrationExpiresAtUtc`.
- Audit that frozen target model for any other live Grace Operations schema-name/configuration references and replace only true historical schema literals needed by the migration target model.
- Add a regression proof that the frozen target model no longer references live Operations schema/configuration helpers for database object names, including the temporary-hot cleanup index, while preserving the already-added pricing FK/index/currency/trigger assertions.
- Keep `src/Grace.slnx` untouched.
- Run targeted formatting, focused Operations pricing/schema tests, `git diff --check`, and verify no `src/Grace.slnx` diff. Rely on the already-green GitHub `full` only until a new commit is pushed; after the patch, wait for the new GitHub `full` and latest-head Codex review again.

#### Product Decisions Needed

No product behavior decision appears needed. This is a historical-migration freeze/proof obligation. Maintainer approval is needed only because the PR has reached the third substantive review cycle and the process requires approval before more coding.

Recommended maintainer response: approve the stabilization ledger and assign one fresh worker scoped only to the frozen migration target-model invariant above.
