### PR TITLE
Implement rebuildable charge previews

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="OperationsPricingSql.fs" />
     <Compile Include="OperationsUsagePartitioningSql.fs" />
     <Compile Include="OperationsEntities.fs" />
+    <Compile Include="OperationsChargePreview.fs" />
     <Compile Include="OperationsDbContext.fs" />
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
     <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
@@ -25,6 +26,7 @@
     <Compile Include="Migrations\20260708170000_AddRawUsageFactArchiveFailureState.fs" />
     <Compile Include="Migrations\20260709090000_AddRawUsageFactRehydrationExpiryIndex.fs" />
     <Compile Include="Migrations\20260709110000_AddPricingPlanRateAssignment.fs" />
+    <Compile Include="Migrations\20260711090000_AddChargePreviewLines.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -6,6 +6,9 @@ schema is intentionally narrow:
 - `ops.RawUsageFact` stores immutable `UsageFact` rows with `UsageFactId` as the duplicate-delivery boundary and keeps
   the exact accepted broker payload in `RawPayload` for replay and audit.
 - `ops.UsageAggregateMinute` stores one aggregate row per fact kind, Grace scope, storage pool, and UTC minute.
+- `ops.ChargePreviewLine` stores deterministic provisional customer charge lines rebuilt from compact immutable usage
+  facts and complete effective pricing. A rebuild atomically replaces one customer/repository/half-open-period scope;
+  these rows are neither invoices nor immutable ledger entries.
 - The EF migrations history table lives in `ops.__EFMigrationsHistory` so operations schema state stays with the
   operations schema.
 
@@ -75,3 +78,13 @@ online rebuild options, lock hints for data backfills, and guarded data movement
 Do not put SQL Server physical-design choices in worker startup, request handlers, or ad hoc runtime bootstrap code.
 When raw SQL is used in a migration, keep it deterministic, name the Grace invariant it protects, and cover the emitted
 schema or behavior with Operations migration tests.
+
+## Callable Charge Previews
+
+The worker registers an internal `IChargePreviewRebuilder` that callers can invoke with an explicit UTC half-open
+period. The rebuild reads compact `RawUsageFact` index columns, so archived facts remain eligible when `RawPayload` is
+empty and Blob rehydration is neither performed nor required. Complete pricing is selected at each fact's observed
+timestamp, quantities are summed per applicability segment, and each line is rounded once to whole currency micros.
+
+This leaf intentionally adds no timer, schedule, billing-period state, close operation, HTTP route, or ledger posting.
+Missing pricing fails the rebuild and leaves the previously committed complete preview unchanged.

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260711090000_AddChargePreviewLines.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260711090000_AddChargePreviewLines.fs
@@ -3,6 +3,8 @@ namespace Grace.Operations.Data.Migrations
 open Grace.Operations.Data
 open Microsoft.EntityFrameworkCore
 open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
 
 /// Adds deterministic provisional charge-preview lines without introducing billing-period lifecycle state.
 [<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
@@ -64,4 +66,704 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
-        OperationsModel.configure modelBuilder
+        // Deliberately keep this migration target frozen with literals so future runtime model edits
+        // cannot change this reviewed migration point before a new migration updates the snapshot.
+        modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("ArchiveState").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveBlobName")
+            .HasMaxLength(512)
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveChecksumSha256Hex")
+            .HasMaxLength(64)
+            .IsFixedLength()
+            .IsUnicode(false)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<int64>>("ArchiveByteLength")
+            .HasColumnType("bigint")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchivedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("RehydrationExpiresAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<string>("LastArchiveFailureReason")
+            .HasMaxLength(400)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("LastArchiveFailureAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<int>("ArchiveFailureCount")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveRetiredAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "ArchiveState"
+                    "ObservedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ArchiveStateObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex([| "RehydrationExpiresAtUtc" |])
+            .HasDatabaseName("IX_ops_RawUsageFact_RehydrationExpiresAtUtc")
+            .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable("UsageAggregateMinute", "ops")
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore
+
+        let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
+
+        pricingPlan.ToTable("PricingPlan", "ops")
+        |> ignore
+
+        pricingPlan
+            .HasKey([| "PricingPlanId" |])
+            .HasName("PK_ops_PricingPlan")
+        |> ignore
+
+        pricingPlan
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("PlanCode")
+            .HasMaxLength(128)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .HasIndex([| "PlanCode"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_PricingPlan_CodeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
+
+        mapping.ToTable("BillableUsageKindMapping", "ops")
+        |> ignore
+
+        mapping
+            .HasKey([| "BillableUsageKindMappingId" |])
+            .HasName("PK_ops_BillableUsageKindMapping")
+        |> ignore
+
+        mapping
+            .Property<System.Guid>("BillableUsageKindMappingId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        mapping.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        mapping
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .HasIndex([| "FactKind"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        mapping
+            .HasIndex(
+                [|
+                    "FactKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillableUsageKindMapping_FactKindEffective")
+        |> ignore
+
+        let pricingRate = modelBuilder.Entity<PricingRateEntity>()
+
+        pricingRate.ToTable("PricingRate", "ops")
+        |> ignore
+
+        pricingRate
+            .HasKey([| "PricingRateId" |])
+            .HasName("PK_ops_PricingRate")
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingRateId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitQuantity")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitPriceMicros")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingRate_PlanUsageKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingRate_PlanUsageKindEffective")
+        |> ignore
+
+        pricingRate
+            .HasOne(fun rate -> rate.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingRate_PricingPlan")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+
+        assignment.ToTable("CustomerPricingAssignment", "ops")
+        |> ignore
+
+        assignment
+            .HasKey([| "CustomerPricingAssignmentId" |])
+            .HasName("PK_ops_CustomerPricingAssignment")
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("CustomerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex([| "PricingPlanId" |])
+            .HasDatabaseName("IX_CustomerPricingAssignment_PricingPlanId")
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_CustomerPricingAssignment_ScopeEffective")
+        |> ignore
+
+        assignment
+            .HasOne(fun assignment -> assignment.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let line = modelBuilder.Entity<ChargePreviewLineEntity>()
+
+        line.ToTable(
+            "ChargePreviewLine",
+            "ops",
+            fun (table: TableBuilder<ChargePreviewLineEntity>) ->
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_PeriodRange", "[PeriodFromUtc] < [PeriodToUtc]")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_EffectiveRange",
+                    "[PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc]"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_UnitQuantity", "[UnitQuantity] > 0")
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_Amounts", "[UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0 AND [ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        line
+            .HasKey([| "ChargePreviewLineId" |])
+            .HasName("PK_ops_ChargePreviewLine")
+        |> ignore
+
+        line
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "CustomerId"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillableUsageKindMappingId"
+                "CustomerPricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            line
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            line
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        line.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        line
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            line.Property<int64>(name).IsRequired() |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_ChargePreviewLine_Scope")
+        |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                    "FactKind"
+                    "BillableUsageKindMappingId"
+                    "BillableUsageKind"
+                    "CustomerPricingAssignmentId"
+                    "PricingPlanId"
+                    "PricingRateId"
+                    "CurrencyCode"
+                    "UnitName"
+                    "UnitQuantity"
+                    "UnitPriceMicros"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
+            .IsUnique()
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260711090000_AddChargePreviewLines.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260711090000_AddChargePreviewLines.fs
@@ -1,0 +1,67 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Migrations
+
+/// Adds deterministic provisional charge-preview lines without introducing billing-period lifecycle state.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260711090000_AddChargePreviewLines")>]
+type AddChargePreviewLines() =
+    inherit Migration()
+
+    /// Applies the constrained preview table and complete-grain indexes.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+CREATE TABLE ops.ChargePreviewLine
+(
+    ChargePreviewLineId uniqueidentifier NOT NULL,
+    CustomerId uniqueidentifier NOT NULL,
+    OwnerId uniqueidentifier NOT NULL,
+    OrganizationId uniqueidentifier NOT NULL,
+    RepositoryId uniqueidentifier NOT NULL,
+    PeriodFromUtc datetime2(7) NOT NULL,
+    PeriodToUtc datetime2(7) NOT NULL,
+    FactKind int NOT NULL,
+    BillableUsageKindMappingId uniqueidentifier NOT NULL,
+    BillableUsageKind int NOT NULL,
+    CustomerPricingAssignmentId uniqueidentifier NOT NULL,
+    PricingPlanId uniqueidentifier NOT NULL,
+    PricingRateId uniqueidentifier NOT NULL,
+    CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL,
+    UnitName nvarchar(64) NOT NULL,
+    UnitQuantity bigint NOT NULL,
+    UnitPriceMicros bigint NOT NULL,
+    EffectiveFromUtc datetime2(7) NOT NULL,
+    EffectiveToUtc datetime2(7) NOT NULL,
+    TotalQuantity bigint NOT NULL,
+    ChargeMicros bigint NOT NULL,
+    CONSTRAINT PK_ops_ChargePreviewLine PRIMARY KEY (ChargePreviewLineId),
+    CONSTRAINT CK_ops_ChargePreviewLine_PeriodRange CHECK (PeriodFromUtc < PeriodToUtc),
+    CONSTRAINT CK_ops_ChargePreviewLine_EffectiveRange CHECK (PeriodFromUtc <= EffectiveFromUtc AND EffectiveFromUtc < EffectiveToUtc AND EffectiveToUtc <= PeriodToUtc),
+    CONSTRAINT CK_ops_ChargePreviewLine_UnitQuantity CHECK (UnitQuantity > 0),
+    CONSTRAINT CK_ops_ChargePreviewLine_Amounts CHECK (UnitPriceMicros >= 0 AND TotalQuantity >= 0 AND ChargeMicros >= 0),
+    CONSTRAINT CK_ops_ChargePreviewLine_Currency CHECK (LEN(CurrencyCode) = 3 AND CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode) COLLATE Latin1_General_100_BIN2 AND CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE '%[^A-Z]%')
+);
+CREATE INDEX IX_ops_ChargePreviewLine_Scope
+    ON ops.ChargePreviewLine(CustomerId, OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc);
+CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
+    ON ops.ChargePreviewLine(CustomerId, OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc,
+        FactKind, BillableUsageKindMappingId, BillableUsageKind, CustomerPricingAssignmentId, PricingPlanId,
+        PricingRateId, CurrencyCode, UnitName, UnitQuantity, UnitPriceMicros, EffectiveFromUtc, EffectiveToUtc);
+"""
+        )
+        |> ignore
+
+    /// Removes only the provisional preview persistence introduced by this migration.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.DropTable(OperationsChargePreviewSql.TableName, OperationsUsageSql.SchemaName)
+        |> ignore
+
+    /// Captures the complete Operations model represented by this migration.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -572,3 +572,5 @@ type OperationsDbContextModelSnapshot() =
             .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
+
+        OperationsChargePreviewModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -3,6 +3,8 @@ namespace Grace.Operations.Data.Migrations
 open Grace.Operations.Data
 open Microsoft.EntityFrameworkCore
 open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
 
 /// Captures the current Operations EF model so future migrations can detect reviewed schema drift.
 [<DbContextAttribute(typeof<OperationsDbContext>)>]
@@ -169,7 +171,7 @@ type OperationsDbContextModelSnapshot() =
 
         rawFact
             .HasIndex([| "RehydrationExpiresAtUtc" |])
-            .HasDatabaseName(OperationsUsageSql.TemporaryHotCleanupExpiryIndexName)
+            .HasDatabaseName("IX_ops_RawUsageFact_RehydrationExpiresAtUtc")
             .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
         |> ignore
 
@@ -573,4 +575,145 @@ type OperationsDbContextModelSnapshot() =
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
-        OperationsChargePreviewModel.configure modelBuilder
+        let line = modelBuilder.Entity<ChargePreviewLineEntity>()
+
+        line.ToTable(
+            "ChargePreviewLine",
+            "ops",
+            fun (table: TableBuilder<ChargePreviewLineEntity>) ->
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_PeriodRange", "[PeriodFromUtc] < [PeriodToUtc]")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_EffectiveRange",
+                    "[PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc]"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_UnitQuantity", "[UnitQuantity] > 0")
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_Amounts", "[UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0 AND [ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        line
+            .HasKey([| "ChargePreviewLineId" |])
+            .HasName("PK_ops_ChargePreviewLine")
+        |> ignore
+
+        line
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "CustomerId"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillableUsageKindMappingId"
+                "CustomerPricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            line
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            line
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        line.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        line
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            line.Property<int64>(name).IsRequired() |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_ChargePreviewLine_Scope")
+        |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                    "FactKind"
+                    "BillableUsageKindMappingId"
+                    "BillableUsageKind"
+                    "CustomerPricingAssignmentId"
+                    "PricingPlanId"
+                    "PricingRateId"
+                    "CurrencyCode"
+                    "UnitName"
+                    "UnitQuantity"
+                    "UnitPriceMicros"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
+            .IsUnique()
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
@@ -1,0 +1,562 @@
+namespace Grace.Operations.Data
+
+open Microsoft.Data.SqlClient
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open NodaTime
+open System
+open System.Data
+open System.Globalization
+open System.Numerics
+open System.Runtime.ExceptionServices
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+/// Defines SQL names and reviewed commands for rebuildable charge previews.
+[<RequireQualifiedAccess>]
+module OperationsChargePreviewSql =
+
+    /// Names the provisional charge-preview table.
+    [<Literal>]
+    let TableName = "ChargePreviewLine"
+
+    /// Names the complete logical-grain uniqueness index.
+    [<Literal>]
+    let GrainIndexName = "UX_ops_ChargePreviewLine_CompleteGrain"
+
+    /// Names the scope lookup and replacement index.
+    [<Literal>]
+    let ScopeIndexName = "IX_ops_ChargePreviewLine_Scope"
+
+    /// Acquires a transaction-owned exclusive lock for one hashed preview scope.
+    let AcquireScopeLock =
+        "DECLARE @result int; EXEC @result = sys.sp_getapplock @Resource=@LockResource, @LockMode='Exclusive', @LockOwner='Transaction', @LockTimeout=60000; IF @result < 0 THROW 51000, 'Could not serialize charge-preview rebuild scope.', 1;"
+
+    /// Deletes only the exact preview scope being atomically replaced.
+    let DeleteScope =
+        "DELETE FROM ops.ChargePreviewLine WHERE CustomerId=@CustomerId AND OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND PeriodFromUtc=@PeriodFromUtc AND PeriodToUtc=@PeriodToUtc;"
+
+    /// Reads compact immutable usage fields and every independently effective pricing prerequisite after scope locking.
+    let SelectSourceAndPricing =
+        """
+SELECT fact.UsageFactId, fact.FactKind, fact.Quantity, fact.ObservedAtUtc,
+       assignment.CustomerPricingAssignmentId, assignment.PricingPlanId AS AssignedPricingPlanId,
+       plan.PricingPlanId, mapping.BillableUsageKindMappingId, mapping.BillableUsageKind,
+       rate.PricingRateId, rate.CurrencyCode, rate.UnitName, rate.UnitQuantity, rate.UnitPriceMicros,
+       applicability.EffectiveFromUtc, applicability.EffectiveToUtc
+FROM ops.RawUsageFact AS fact
+OUTER APPLY (
+    SELECT TOP (1) candidate.CustomerPricingAssignmentId, candidate.PricingPlanId,
+           candidate.EffectiveFromUtc, candidate.EffectiveToUtc
+    FROM ops.CustomerPricingAssignment AS candidate
+    WHERE candidate.CustomerId = @CustomerId AND candidate.OwnerId = @OwnerId
+      AND candidate.OrganizationId = @OrganizationId AND candidate.RepositoryId = @RepositoryId
+      AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
+      AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
+    ORDER BY candidate.EffectiveFromUtc DESC, candidate.CustomerPricingAssignmentId
+) AS assignment
+OUTER APPLY (
+    SELECT TOP (1) candidate.PricingPlanId, candidate.EffectiveFromUtc, candidate.EffectiveToUtc
+    FROM ops.PricingPlan AS candidate
+    WHERE candidate.PricingPlanId = assignment.PricingPlanId
+      AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
+      AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
+    ORDER BY candidate.EffectiveFromUtc DESC, candidate.PricingPlanId
+) AS plan
+OUTER APPLY (
+    SELECT TOP (1) candidate.BillableUsageKindMappingId, candidate.BillableUsageKind,
+           candidate.EffectiveFromUtc, candidate.EffectiveToUtc
+    FROM ops.BillableUsageKindMapping AS candidate
+    WHERE candidate.FactKind = fact.FactKind AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
+      AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
+    ORDER BY candidate.EffectiveFromUtc DESC, candidate.BillableUsageKindMappingId
+) AS mapping
+OUTER APPLY (
+    SELECT TOP (1) candidate.PricingRateId, candidate.CurrencyCode, candidate.UnitName,
+           candidate.UnitQuantity, candidate.UnitPriceMicros, candidate.EffectiveFromUtc, candidate.EffectiveToUtc
+    FROM ops.PricingRate AS candidate
+    WHERE candidate.PricingPlanId = plan.PricingPlanId
+      AND candidate.BillableUsageKind = mapping.BillableUsageKind
+      AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
+      AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
+    ORDER BY candidate.EffectiveFromUtc DESC, candidate.PricingRateId
+) AS rate
+OUTER APPLY (
+    SELECT MAX(boundary.EffectiveFromUtc) AS EffectiveFromUtc,
+           MIN(boundary.EffectiveToUtc) AS EffectiveToUtc
+    FROM (VALUES
+        (assignment.EffectiveFromUtc, ISNULL(assignment.EffectiveToUtc, @PeriodToUtc)),
+        (plan.EffectiveFromUtc, ISNULL(plan.EffectiveToUtc, @PeriodToUtc)),
+        (mapping.EffectiveFromUtc, ISNULL(mapping.EffectiveToUtc, @PeriodToUtc)),
+        (rate.EffectiveFromUtc, ISNULL(rate.EffectiveToUtc, @PeriodToUtc)),
+        (@PeriodFromUtc, @PeriodToUtc)
+    ) AS boundary(EffectiveFromUtc, EffectiveToUtc)
+) AS applicability
+WHERE fact.OwnerId = @OwnerId AND fact.OrganizationId = @OrganizationId
+  AND fact.RepositoryId = @RepositoryId AND fact.ObservedAtUtc >= @PeriodFromUtc
+  AND fact.ObservedAtUtc < @PeriodToUtc
+ORDER BY fact.ObservedAtUtc, fact.UsageFactId;
+"""
+
+/// Configures the persisted charge-preview model owned by Operations pricing.
+[<RequireQualifiedAccess>]
+module OperationsChargePreviewModel =
+
+    /// Adds charge-preview constraints and indexes to the Operations EF model.
+    let configure (modelBuilder: ModelBuilder) =
+        let line = modelBuilder.Entity<ChargePreviewLineEntity>()
+
+        line.ToTable(
+            OperationsChargePreviewSql.TableName,
+            OperationsUsageSql.SchemaName,
+            fun (table: TableBuilder<ChargePreviewLineEntity>) ->
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_PeriodRange", "[PeriodFromUtc] < [PeriodToUtc]")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_EffectiveRange",
+                    "[PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc]"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_UnitQuantity", "[UnitQuantity] > 0")
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_Amounts", "[UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0 AND [ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        line
+            .HasKey([| "ChargePreviewLineId" |])
+            .HasName("PK_ops_ChargePreviewLine")
+        |> ignore
+
+        line
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "CustomerId"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillableUsageKindMappingId"
+                "CustomerPricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            line
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            line
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        line.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        line
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("UnitName")
+            .HasMaxLength(OperationsPricingSql.UnitNameMaxLength)
+            .IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            line.Property<int64>(name).IsRequired() |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                |]
+            )
+            .HasDatabaseName(OperationsChargePreviewSql.ScopeIndexName)
+        |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "CustomerId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                    "FactKind"
+                    "BillableUsageKindMappingId"
+                    "BillableUsageKind"
+                    "CustomerPricingAssignmentId"
+                    "PricingPlanId"
+                    "PricingRateId"
+                    "CurrencyCode"
+                    "UnitName"
+                    "UnitQuantity"
+                    "UnitPriceMicros"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName(OperationsChargePreviewSql.GrainIndexName)
+            .IsUnique()
+        |> ignore
+
+/// Identifies one explicit customer/repository/half-open UTC preview rebuild scope.
+type ChargePreviewScope = { CustomerId: Guid; OwnerId: Guid; OrganizationId: Guid; RepositoryId: Guid; PeriodFromUtc: DateTime; PeriodToUtc: DateTime }
+
+/// Names an independently required pricing prerequisite that was absent for a usage fact.
+[<RequireQualifiedAccess>]
+type MissingPricingPrerequisite =
+    | Assignment
+    | Plan
+    | Mapping
+    | Rate
+
+/// Reports why a complete charge-preview candidate could not be built.
+type ChargePreviewRebuildException(scope: ChargePreviewScope, usageFactId: Guid, prerequisite: MissingPricingPrerequisite) =
+    inherit InvalidOperationException($"Charge-preview rebuild for customer {scope.CustomerId}, repository {scope.RepositoryId}, period [{scope.PeriodFromUtc:o}, {scope.PeriodToUtc:o}) is missing pricing {prerequisite} for usage fact {usageFactId}.")
+    /// Gets the rebuild scope that remains unchanged after this failure.
+    member _.Scope = scope
+    /// Gets the usage fact whose complete pricing could not be resolved.
+    member _.UsageFactId = usageFactId
+    /// Gets the independently missing pricing prerequisite.
+    member _.Prerequisite = prerequisite
+
+/// Carries compact usage and complete pricing fields read from SQL for one immutable source fact.
+type ChargePreviewPricedFact =
+    {
+        UsageFactId: Guid
+        FactKind: int
+        Quantity: int64
+        ObservedAtUtc: DateTime
+        CustomerPricingAssignmentId: Guid
+        BillableUsageKindMappingId: Guid
+        BillableUsageKind: int
+        PricingPlanId: Guid
+        PricingRateId: Guid
+        CurrencyCode: string
+        UnitName: string
+        UnitQuantity: int64
+        UnitPriceMicros: int64
+        EffectiveFromUtc: DateTime
+        EffectiveToUtc: DateTime
+    }
+
+/// Builds deterministic charge-preview lines from compact usage facts and complete pricing.
+[<RequireQualifiedAccess>]
+module ChargePreviewCalculation =
+
+    /// Identifies the first missing prerequisite in dependency order for clear rebuild diagnostics.
+    let missingPrerequisite hasAssignment hasPlan hasMapping hasRate =
+        if not hasAssignment then Some MissingPricingPrerequisite.Assignment
+        elif not hasPlan then Some MissingPricingPrerequisite.Plan
+        elif not hasMapping then Some MissingPricingPrerequisite.Mapping
+        elif not hasRate then Some MissingPricingPrerequisite.Rate
+        else None
+
+    /// Calculates one whole-micro charge with checked exact arithmetic and midpoint rounding away from zero.
+    let calculateChargeMicros totalQuantity unitPriceMicros unitQuantity =
+        if totalQuantity < 0L
+           || unitPriceMicros < 0L
+           || unitQuantity <= 0L then
+            invalidArg "pricing" "Charge-preview quantities and prices must be non-negative and unit quantity must be positive."
+
+        let numerator =
+            BigInteger(totalQuantity)
+            * BigInteger(unitPriceMicros)
+
+        let denominator = BigInteger(unitQuantity)
+        let quotient, remainder = BigInteger.DivRem(numerator, denominator)
+        let rounded = if remainder * 2I >= denominator then quotient + 1I else quotient
+
+        if rounded > BigInteger(Int64.MaxValue) then
+            raise (OverflowException("Charge-preview charge exceeds Int64 whole-micro storage."))
+
+        int64 rounded
+
+    /// Derives a stable GUID from the complete logical line grain without depending on insertion order.
+    let lineId (scope: ChargePreviewScope) (fact: ChargePreviewPricedFact) =
+        let storedUtcTicks (value: DateTime) =
+            if value.Kind = DateTimeKind.Local then
+                invalidArg "fact" "Charge-preview applicability timestamps cannot be local time."
+
+            value.Ticks.ToString(CultureInfo.InvariantCulture)
+
+        let canonical =
+            String.Join(
+                "|",
+                [|
+                    scope.CustomerId.ToString("D")
+                    scope.OwnerId.ToString("D")
+                    scope.OrganizationId.ToString("D")
+                    scope.RepositoryId.ToString("D")
+                    storedUtcTicks scope.PeriodFromUtc
+                    storedUtcTicks scope.PeriodToUtc
+                    fact.FactKind.ToString(CultureInfo.InvariantCulture)
+                    fact.BillableUsageKindMappingId.ToString("D")
+                    fact.BillableUsageKind.ToString(CultureInfo.InvariantCulture)
+                    fact.CustomerPricingAssignmentId.ToString("D")
+                    fact.PricingPlanId.ToString("D")
+                    fact.PricingRateId.ToString("D")
+                    fact.CurrencyCode
+                    fact.UnitName
+                    fact.UnitQuantity.ToString(CultureInfo.InvariantCulture)
+                    fact.UnitPriceMicros.ToString(CultureInfo.InvariantCulture)
+                    storedUtcTicks fact.EffectiveFromUtc
+                    storedUtcTicks fact.EffectiveToUtc
+                |]
+            )
+
+        let hash = SHA256.HashData(Encoding.UTF8.GetBytes canonical)
+        Guid(hash.AsSpan(0, 16))
+
+    /// Aggregates duplicate-safe source facts by complete applicability identity and rounds once per completed line.
+    let buildLines scope facts =
+        if facts
+           |> Seq.exists (fun fact -> fact.Quantity < 0L) then
+            invalidArg "facts" "Charge-preview source quantities cannot be negative."
+
+        facts
+        |> Seq.distinctBy (fun fact -> fact.UsageFactId)
+        |> Seq.groupBy (fun fact ->
+            fact.FactKind,
+            fact.BillableUsageKindMappingId,
+            fact.BillableUsageKind,
+            fact.CustomerPricingAssignmentId,
+            fact.PricingPlanId,
+            fact.PricingRateId,
+            fact.CurrencyCode,
+            fact.UnitName,
+            fact.UnitQuantity,
+            fact.UnitPriceMicros,
+            fact.EffectiveFromUtc,
+            fact.EffectiveToUtc)
+        |> Seq.map (fun (_, grouped) ->
+            let first = Seq.head grouped
+
+            let total =
+                grouped
+                |> Seq.fold (fun value fact -> value + BigInteger(fact.Quantity)) BigInteger.Zero
+
+            if total < BigInteger.Zero
+               || total > BigInteger(Int64.MaxValue) then
+                raise (OverflowException("Charge-preview summed quantity exceeds Int64 storage."))
+
+            let quantity = int64 total
+            let entity = ChargePreviewLineEntity()
+            entity.ChargePreviewLineId <- lineId scope first
+            entity.CustomerId <- scope.CustomerId
+            entity.OwnerId <- scope.OwnerId
+            entity.OrganizationId <- scope.OrganizationId
+            entity.RepositoryId <- scope.RepositoryId
+            entity.PeriodFromUtc <- scope.PeriodFromUtc
+            entity.PeriodToUtc <- scope.PeriodToUtc
+            entity.FactKind <- first.FactKind
+            entity.BillableUsageKindMappingId <- first.BillableUsageKindMappingId
+            entity.BillableUsageKind <- first.BillableUsageKind
+            entity.CustomerPricingAssignmentId <- first.CustomerPricingAssignmentId
+            entity.PricingPlanId <- first.PricingPlanId
+            entity.PricingRateId <- first.PricingRateId
+            entity.CurrencyCode <- first.CurrencyCode
+            entity.UnitName <- first.UnitName
+            entity.UnitQuantity <- first.UnitQuantity
+            entity.UnitPriceMicros <- first.UnitPriceMicros
+            entity.EffectiveFromUtc <- first.EffectiveFromUtc
+            entity.EffectiveToUtc <- first.EffectiveToUtc
+            entity.TotalQuantity <- quantity
+            entity.ChargeMicros <- calculateChargeMicros quantity first.UnitPriceMicros first.UnitQuantity
+            entity)
+        |> Seq.sortBy (fun line -> line.ChargePreviewLineId)
+        |> Seq.toArray
+
+/// Exposes the callable provisional charge-preview rebuild used by later billing leaves.
+type IChargePreviewRebuilder =
+    /// Atomically replaces one explicit preview scope and returns its complete committed lines.
+    abstract RebuildAsync: scope: ChargePreviewScope * cancellationToken: CancellationToken -> Task<ChargePreviewLineEntity array>
+
+/// Rebuilds charge-preview lines from compact SQL facts under a transaction-owned same-scope lock.
+type SqlChargePreviewRebuilder(connectionString: string) =
+
+    let addScopeParameters (command: SqlCommand) scope =
+        command.Parameters.Add("@CustomerId", SqlDbType.UniqueIdentifier).Value <- scope.CustomerId
+        command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+        command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+        command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+        command.Parameters.Add("@PeriodFromUtc", SqlDbType.DateTime2).Value <- scope.PeriodFromUtc
+        command.Parameters.Add("@PeriodToUtc", SqlDbType.DateTime2).Value <- scope.PeriodToUtc
+
+    let rollbackIgnoringFailure (transaction: SqlTransaction) =
+        task {
+            try
+                do! transaction.RollbackAsync CancellationToken.None
+            with
+            | _ -> ()
+        }
+
+    let validateScope scope =
+        if scope.PeriodFromUtc.Kind <> DateTimeKind.Utc
+           || scope.PeriodToUtc.Kind <> DateTimeKind.Utc
+           || scope.PeriodFromUtc >= scope.PeriodToUtc then
+            invalidArg "scope" "Charge-preview periods must be non-empty UTC half-open intervals."
+
+    interface IChargePreviewRebuilder with
+        member _.RebuildAsync(scope, cancellationToken) =
+            task {
+                validateScope scope
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync cancellationToken
+                use! rawTransaction = connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken)
+                use transaction = rawTransaction :?> SqlTransaction
+
+                try
+                    use lockCommand = connection.CreateCommand()
+                    lockCommand.Transaction <- transaction
+
+                    lockCommand.CommandText <- OperationsChargePreviewSql.AcquireScopeLock
+                    lockCommand.CommandTimeout <- 65
+
+                    let lockIdentity =
+                        $"ops:charge-preview:{scope.CustomerId:D}:{scope.OwnerId:D}:{scope.OrganizationId:D}:{scope.RepositoryId:D}:{scope.PeriodFromUtc.Ticks}:{scope.PeriodToUtc.Ticks}"
+
+                    let lockHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes lockIdentity))
+                    lockCommand.Parameters.Add("@LockResource", SqlDbType.NVarChar, 255).Value <- $"ops:charge-preview:{lockHash}"
+                    let! _ = lockCommand.ExecuteNonQueryAsync cancellationToken
+
+                    use readCommand = connection.CreateCommand()
+                    readCommand.Transaction <- transaction
+                    readCommand.CommandText <- OperationsChargePreviewSql.SelectSourceAndPricing
+                    addScopeParameters readCommand scope
+                    use! reader = readCommand.ExecuteReaderAsync cancellationToken
+                    let facts = ResizeArray<ChargePreviewPricedFact>()
+                    let mutable hasRow = true
+
+                    while hasRow do
+                        let! nextRow = reader.ReadAsync cancellationToken
+                        hasRow <- nextRow
+
+                        if hasRow then
+                            let usageFactId = reader.GetGuid 0
+
+                            match
+                                ChargePreviewCalculation.missingPrerequisite
+                                    (not (reader.IsDBNull 4))
+                                    (not (reader.IsDBNull 6))
+                                    (not (reader.IsDBNull 7))
+                                    (not (reader.IsDBNull 9))
+                                with
+                            | Some prerequisite -> raise (ChargePreviewRebuildException(scope, usageFactId, prerequisite))
+                            | None -> ()
+
+                            facts.Add
+                                {
+                                    UsageFactId = usageFactId
+                                    FactKind = reader.GetInt32 1
+                                    Quantity = reader.GetInt64 2
+                                    ObservedAtUtc = reader.GetDateTime 3
+                                    CustomerPricingAssignmentId = reader.GetGuid 4
+                                    PricingPlanId = reader.GetGuid 6
+                                    BillableUsageKindMappingId = reader.GetGuid 7
+                                    BillableUsageKind = reader.GetInt32 8
+                                    PricingRateId = reader.GetGuid 9
+                                    CurrencyCode = reader.GetString 10
+                                    UnitName = reader.GetString 11
+                                    UnitQuantity = reader.GetInt64 12
+                                    UnitPriceMicros = reader.GetInt64 13
+                                    EffectiveFromUtc = reader.GetDateTime 14
+                                    EffectiveToUtc = reader.GetDateTime 15
+                                }
+
+                    do! reader.CloseAsync()
+                    let lines = ChargePreviewCalculation.buildLines scope facts
+
+                    use deleteCommand = connection.CreateCommand()
+                    deleteCommand.Transaction <- transaction
+
+                    deleteCommand.CommandText <- OperationsChargePreviewSql.DeleteScope
+
+                    addScopeParameters deleteCommand scope
+                    let! _ = deleteCommand.ExecuteNonQueryAsync cancellationToken
+
+                    for line in lines do
+                        use insert = connection.CreateCommand()
+                        insert.Transaction <- transaction
+
+                        insert.CommandText <-
+                            "INSERT INTO ops.ChargePreviewLine (ChargePreviewLineId,CustomerId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,CustomerPricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@Id,@CustomerId,@OwnerId,@OrganizationId,@RepositoryId,@PeriodFromUtc,@PeriodToUtc,@FactKind,@MappingId,@BillableKind,@AssignmentId,@PlanId,@RateId,@Currency,@UnitName,@UnitQuantity,@UnitPrice,@EffectiveFrom,@EffectiveTo,@TotalQuantity,@Charge);"
+
+                        addScopeParameters insert scope
+                        let add name dbType value = insert.Parameters.Add(name, dbType).Value <- value
+                        add "@Id" SqlDbType.UniqueIdentifier line.ChargePreviewLineId
+                        add "@FactKind" SqlDbType.Int line.FactKind
+                        add "@MappingId" SqlDbType.UniqueIdentifier line.BillableUsageKindMappingId
+                        add "@BillableKind" SqlDbType.Int line.BillableUsageKind
+                        add "@AssignmentId" SqlDbType.UniqueIdentifier line.CustomerPricingAssignmentId
+                        add "@PlanId" SqlDbType.UniqueIdentifier line.PricingPlanId
+                        add "@RateId" SqlDbType.UniqueIdentifier line.PricingRateId
+                        insert.Parameters.Add("@Currency", SqlDbType.VarChar, 3).Value <- line.CurrencyCode
+                        insert.Parameters.Add("@UnitName", SqlDbType.NVarChar, OperationsPricingSql.UnitNameMaxLength).Value <- line.UnitName
+                        add "@UnitQuantity" SqlDbType.BigInt line.UnitQuantity
+                        add "@UnitPrice" SqlDbType.BigInt line.UnitPriceMicros
+                        add "@EffectiveFrom" SqlDbType.DateTime2 line.EffectiveFromUtc
+                        add "@EffectiveTo" SqlDbType.DateTime2 line.EffectiveToUtc
+                        add "@TotalQuantity" SqlDbType.BigInt line.TotalQuantity
+                        add "@Charge" SqlDbType.BigInt line.ChargeMicros
+                        let! _ = insert.ExecuteNonQueryAsync cancellationToken
+                        ()
+
+                    do! transaction.CommitAsync cancellationToken
+                    return lines
+                with
+                | ex ->
+                    do! rollbackIgnoringFailure transaction
+                    ExceptionDispatchInfo.Capture(ex).Throw()
+                    return Unchecked.defaultof<_>
+            }

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
@@ -525,7 +525,10 @@ type SqlChargePreviewRebuilder(connectionString: string) =
                     addScopeParameters deleteCommand scope
                     let! _ = deleteCommand.ExecuteNonQueryAsync cancellationToken
 
-                    for line in lines do
+                    let mutable lineIndex = 0
+
+                    while lineIndex < lines.Length do
+                        let line = lines[lineIndex]
                         use insert = connection.CreateCommand()
                         insert.Transaction <- transaction
 
@@ -550,7 +553,7 @@ type SqlChargePreviewRebuilder(connectionString: string) =
                         add "@TotalQuantity" SqlDbType.BigInt line.TotalQuantity
                         add "@Charge" SqlDbType.BigInt line.ChargeMicros
                         let! _ = insert.ExecuteNonQueryAsync cancellationToken
-                        ()
+                        lineIndex <- lineIndex + 1
 
                     do! transaction.CommitAsync cancellationToken
                     return lines

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -572,6 +572,8 @@ module OperationsModel =
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
+        OperationsChargePreviewModel.configure modelBuilder
+
 /// Owns the EF Core model for Grace Operations SQL Server schema evolution.
 type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     inherit DbContext(options)
@@ -599,6 +601,10 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     /// Exposes customer pricing assignments for EF migrations and schema inspection.
     [<DefaultValue>]
     val mutable private customerPricingAssignments: DbSet<CustomerPricingAssignmentEntity>
+
+    /// Provides EF access to provisional charge-preview lines.
+    [<DefaultValue>]
+    val mutable private chargePreviewLines: DbSet<ChargePreviewLineEntity>
 
     /// Provides the EF set for immutable usage fact rows.
     member this.RawUsageFacts
@@ -629,6 +635,11 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     member this.CustomerPricingAssignments
         with get () = this.customerPricingAssignments
         and set value = this.customerPricingAssignments <- value
+
+    /// Provides the EF set for provisional charge-preview lines.
+    member this.ChargePreviewLines
+        with get () = this.chargePreviewLines
+        and set value = this.chargePreviewLines <- value
 
     /// Configures the Operations SQL Server schema shape that migrations must preserve.
     override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -217,3 +217,70 @@ type CustomerPricingAssignmentEntity() =
 
     /// References the pricing plan for EF schema relationship generation.
     member val PricingPlan: PricingPlanEntity = null with get, set
+
+/// Represents one rebuildable provisional charge-preview line for a complete pricing applicability segment.
+[<AllowNullLiteral>]
+type ChargePreviewLineEntity() =
+
+    /// Stores the deterministic identity derived from the complete preview-line grain.
+    member val ChargePreviewLineId = Guid.Empty with get, set
+
+    /// Stores the customer whose provisional charge is represented.
+    member val CustomerId = Guid.Empty with get, set
+
+    /// Stores the Grace owner scope for the charged repository.
+    member val OwnerId = Guid.Empty with get, set
+
+    /// Stores the Grace organization scope for the charged repository.
+    member val OrganizationId = Guid.Empty with get, set
+
+    /// Stores the Grace repository scope for the charged usage.
+    member val RepositoryId = Guid.Empty with get, set
+
+    /// Stores the inclusive UTC start of the explicitly rebuilt preview period.
+    member val PeriodFromUtc = DateTime.MinValue with get, set
+
+    /// Stores the exclusive UTC end of the explicitly rebuilt preview period.
+    member val PeriodToUtc = DateTime.MinValue with get, set
+
+    /// Stores the tracked usage-fact kind contributing to this line.
+    member val FactKind = 0 with get, set
+
+    /// Stores the complete billable usage-kind mapping identity selected for the source facts.
+    member val BillableUsageKindMappingId = Guid.Empty with get, set
+
+    /// Stores the billable usage kind selected by the mapping.
+    member val BillableUsageKind = 0 with get, set
+
+    /// Stores the complete customer pricing assignment identity selected for the source facts.
+    member val CustomerPricingAssignmentId = Guid.Empty with get, set
+
+    /// Stores the complete pricing plan identity selected for the source facts.
+    member val PricingPlanId = Guid.Empty with get, set
+
+    /// Stores the complete pricing rate identity selected for the source facts.
+    member val PricingRateId = Guid.Empty with get, set
+
+    /// Stores the line currency without permitting cross-currency aggregation.
+    member val CurrencyCode = String.Empty with get, set
+
+    /// Stores the measured unit label carried by the selected rate.
+    member val UnitName = String.Empty with get, set
+
+    /// Stores the measured quantity represented by one priced unit.
+    member val UnitQuantity = 0L with get, set
+
+    /// Stores the selected customer price in whole currency micros per unit quantity.
+    member val UnitPriceMicros = 0L with get, set
+
+    /// Stores the inclusive start of the complete pricing applicability segment intersected with the preview period.
+    member val EffectiveFromUtc = DateTime.MinValue with get, set
+
+    /// Stores the exclusive end of the complete pricing applicability segment intersected with the preview period.
+    member val EffectiveToUtc = DateTime.MinValue with get, set
+
+    /// Stores source quantity summed before line-charge calculation.
+    member val TotalQuantity = 0L with get, set
+
+    /// Stores the once-rounded provisional charge in whole currency micros.
+    member val ChargeMicros = 0L with get, set

--- a/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="OperationsSkeleton.Tests.fs" />
     <Compile Include="OperationsUsageStorage.Tests.fs" />
     <Compile Include="OperationsPricing.Tests.fs" />
+    <Compile Include="OperationsChargePreview.Tests.fs" />
     <Compile Include="OperationsUsageArchive.Tests.fs" />
     <Compile Include="OperationsWorkerIngestion.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -254,6 +254,24 @@ type OperationsChargePreviewTests() =
         Assert.That(targetModelStart, Is.GreaterThanOrEqualTo(0))
         let targetModelSource = migrationSource.Substring(targetModelStart)
 
+        let snapshotPath =
+            Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "Grace.Operations.Data",
+                "Migrations",
+                "OperationsDbContextModelSnapshot.fs"
+            )
+            |> Path.GetFullPath
+
+        let snapshotSource = File.ReadAllText snapshotPath
+        let snapshotModelStart = snapshotSource.IndexOf("override _.BuildModel(modelBuilder: ModelBuilder) =", StringComparison.Ordinal)
+        Assert.That(snapshotModelStart, Is.GreaterThanOrEqualTo(0))
+        let snapshotModelSource = snapshotSource.Substring(snapshotModelStart)
+
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewModel;Integrated Security=true;"
         let runtime = context.GetService<IDesignTimeModel>().Model
         let snapshot = OperationsDbContextModelSnapshot().Model
@@ -262,6 +280,15 @@ type OperationsChargePreviewTests() =
         let modelShape (model: Microsoft.EntityFrameworkCore.Metadata.IModel) =
             model.GetEntityTypes()
             |> Seq.map (fun entity ->
+                let keys =
+                    entity.GetKeys()
+                    |> Seq.map (fun key ->
+                        key.GetName(),
+                        key.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> Seq.toList)
+                    |> Set.ofSeq
+
                 let properties =
                     entity.GetProperties()
                     |> Seq.map (fun property -> property.Name, property.ClrType.FullName, property.IsNullable)
@@ -281,6 +308,8 @@ type OperationsChargePreviewTests() =
                     entity.GetForeignKeys()
                     |> Seq.map (fun foreignKey ->
                         foreignKey.GetConstraintName(),
+                        foreignKey.PrincipalEntityType.Name,
+                        foreignKey.DeleteBehavior,
                         foreignKey.Properties
                         |> Seq.map (fun property -> property.Name)
                         |> Seq.toList)
@@ -291,7 +320,7 @@ type OperationsChargePreviewTests() =
                     |> Seq.map (fun constraint' -> constraint'.Name, constraint'.Sql)
                     |> Set.ofSeq
 
-                entity.Name, entity.GetSchema(), entity.GetTableName(), properties, indexes, foreignKeys, checkConstraints)
+                entity.Name, entity.GetSchema(), entity.GetTableName(), keys, properties, indexes, foreignKeys, checkConstraints)
             |> Set.ofSeq
 
         let runtimeShape = modelShape runtime
@@ -301,9 +330,15 @@ type OperationsChargePreviewTests() =
 
         ChargePreviewTestData.multiple (fun () ->
             Assert.That(targetModelSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
+            Assert.That(snapshotModelSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
+            Assert.That(targetModelSource, Does.Not.Match(@"(?im)^\s*[A-Za-z0-9_.]*(?:configure|configureModel)\s+modelBuilder\s*$"))
+            Assert.That(snapshotModelSource, Does.Not.Match(@"(?im)^\s*[A-Za-z0-9_.]*(?:configure|configureModel)\s+modelBuilder\s*$"))
             Assert.That(targetModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
+            Assert.That(snapshotModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
             Assert.That(targetModelSource, Does.Contain("let rawFact = modelBuilder.Entity<RawUsageFactEntity>()"))
+            Assert.That(snapshotModelSource, Does.Contain("let rawFact = modelBuilder.Entity<RawUsageFactEntity>()"))
             Assert.That(targetModelSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
+            Assert.That(snapshotModelSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
             Assert.That((migrationShape = snapshotShape), Is.True)
 
             Assert.That(

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -5,9 +5,11 @@ open Grace.Operations.Data.Migrations
 open Microsoft.EntityFrameworkCore
 open Microsoft.EntityFrameworkCore.Infrastructure
 open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata
 open Microsoft.Extensions.DependencyInjection
 open NUnit.Framework
 open System
+open System.IO
 open System.Threading
 
 /// Supplies independent fixtures for deterministic charge-preview proofs.
@@ -231,33 +233,114 @@ type OperationsChargePreviewTests() =
             Assert.That(sql, Does.Contain("MAX(boundary.EffectiveFromUtc)"))
             Assert.That(sql, Does.Contain("MIN(boundary.EffectiveToUtc)")))
 
-    /// Verifies the EF runtime model, snapshot, and migration target expose the same preview identity indexes.
+    /// Verifies the migration target is literal and the complete EF model agrees across all reviewed representations.
     [<Test>]
     member _.PreviewMigrationAndModelsAgreeOnPersistedIdentity() =
+        let migrationPath =
+            Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "Grace.Operations.Data",
+                "Migrations",
+                "20260711090000_AddChargePreviewLines.fs"
+            )
+            |> Path.GetFullPath
+
+        let migrationSource = File.ReadAllText migrationPath
+        let targetModelStart = migrationSource.IndexOf("override _.BuildTargetModel(modelBuilder: ModelBuilder) =", StringComparison.Ordinal)
+        Assert.That(targetModelStart, Is.GreaterThanOrEqualTo(0))
+        let targetModelSource = migrationSource.Substring(targetModelStart)
+
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewModel;Integrated Security=true;"
-        let runtime = context.Model.FindEntityType(typeof<ChargePreviewLineEntity>)
+        let runtime = context.GetService<IDesignTimeModel>().Model
+        let snapshot = OperationsDbContextModelSnapshot().Model
+        let migration = AddChargePreviewLines().TargetModel
 
-        let snapshot =
-            OperationsDbContextModelSnapshot()
-                .Model.FindEntityType(typeof<ChargePreviewLineEntity>)
+        let modelShape (model: Microsoft.EntityFrameworkCore.Metadata.IModel) =
+            model.GetEntityTypes()
+            |> Seq.map (fun entity ->
+                let properties =
+                    entity.GetProperties()
+                    |> Seq.map (fun property -> property.Name, property.ClrType.FullName, property.IsNullable)
+                    |> Set.ofSeq
 
-        let migration =
-            AddChargePreviewLines()
-                .TargetModel.FindEntityType(typeof<ChargePreviewLineEntity>)
+                let indexes =
+                    entity.GetIndexes()
+                    |> Seq.map (fun index ->
+                        index.GetDatabaseName(),
+                        index.IsUnique,
+                        index.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> Seq.toList)
+                    |> Set.ofSeq
 
-        let indexes (entity: Microsoft.EntityFrameworkCore.Metadata.IEntityType) =
-            entity.GetIndexes()
-            |> Seq.map (fun index -> index.GetDatabaseName())
+                let foreignKeys =
+                    entity.GetForeignKeys()
+                    |> Seq.map (fun foreignKey ->
+                        foreignKey.GetConstraintName(),
+                        foreignKey.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> Seq.toList)
+                    |> Set.ofSeq
+
+                let checkConstraints =
+                    entity.GetCheckConstraints()
+                    |> Seq.map (fun constraint' -> constraint'.Name, constraint'.Sql)
+                    |> Set.ofSeq
+
+                entity.Name, entity.GetSchema(), entity.GetTableName(), properties, indexes, foreignKeys, checkConstraints)
             |> Set.ofSeq
 
+        let runtimeShape = modelShape runtime
+        let snapshotShape = modelShape snapshot
+        let migrationShape = modelShape migration
+        let preview = runtime.FindEntityType(typeof<ChargePreviewLineEntity>)
+
         ChargePreviewTestData.multiple (fun () ->
-            Assert.That(runtime, Is.Not.Null)
-            Assert.That(snapshot, Is.Not.Null)
-            Assert.That(migration, Is.Not.Null)
-            Assert.That(indexes runtime :> obj, Is.EqualTo(indexes snapshot :> obj))
-            Assert.That(indexes runtime :> obj, Is.EqualTo(indexes migration :> obj))
-            Assert.That(indexes runtime, Does.Contain(OperationsChargePreviewSql.GrainIndexName))
-            Assert.That(indexes runtime, Does.Contain(OperationsChargePreviewSql.ScopeIndexName)))
+            Assert.That(targetModelSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
+            Assert.That(targetModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
+            Assert.That(targetModelSource, Does.Contain("let rawFact = modelBuilder.Entity<RawUsageFactEntity>()"))
+            Assert.That(targetModelSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
+            Assert.That((migrationShape = snapshotShape), Is.True)
+
+            Assert.That(
+                (migrationShape = runtimeShape),
+                Is.True,
+                $"Migration-only: {Set.difference migrationShape runtimeShape}; runtime-only: {Set.difference runtimeShape migrationShape}"
+            )
+
+            Assert.That(
+                preview.GetIndexes()
+                |> Seq.map (fun index -> index.GetDatabaseName()),
+                Does.Contain(OperationsChargePreviewSql.GrainIndexName)
+            )
+
+            Assert.That(
+                preview.GetIndexes()
+                |> Seq.map (fun index -> index.GetDatabaseName()),
+                Does.Contain(OperationsChargePreviewSql.ScopeIndexName)
+            ))
+
+    /// Verifies the transactional insertion path avoids resumable-CE enumeration while preserving ordered indexing.
+    [<Test>]
+    member _.RebuildInsertionUsesFs3511SafeIndexedLoop() =
+        let sourcePath =
+            Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Grace.Operations.Data", "OperationsChargePreview.fs")
+            |> Path.GetFullPath
+
+        let source = File.ReadAllText sourcePath
+        let rebuildStart = source.IndexOf("member _.RebuildAsync(scope, cancellationToken) =", StringComparison.Ordinal)
+        Assert.That(rebuildStart, Is.GreaterThanOrEqualTo(0))
+        let rebuildSource = source.Substring(rebuildStart)
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(rebuildSource, Does.Not.Match(@"\bfor\s+line\s+in\s+lines\s+do\b"))
+            Assert.That(rebuildSource, Does.Contain("while lineIndex < lines.Length do"))
+            Assert.That(rebuildSource, Does.Contain("let line = lines[lineIndex]"))
+            Assert.That(rebuildSource, Does.Contain("lineIndex <- lineIndex + 1")))
 
     /// Verifies generated migration SQL contains the atomic identity constraints expected by SQL Server.
     [<Test>]

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -1,0 +1,317 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Operations.Data.Migrations
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.Extensions.DependencyInjection
+open NUnit.Framework
+open System
+open System.Threading
+
+/// Supplies independent fixtures for deterministic charge-preview proofs.
+[<RequireQualifiedAccess>]
+module private ChargePreviewTestData =
+
+    let multiple action = Assert.Multiple(Action action)
+
+    let utc day hour = DateTime(2026, 7, day, hour, 0, 0, DateTimeKind.Utc)
+
+    let scope =
+        {
+            CustomerId = Guid.Parse "11111111-1111-1111-1111-111111111111"
+            OwnerId = Guid.Parse "22222222-2222-2222-2222-222222222222"
+            OrganizationId = Guid.Parse "33333333-3333-3333-3333-333333333333"
+            RepositoryId = Guid.Parse "44444444-4444-4444-4444-444444444444"
+            PeriodFromUtc = utc 1 0
+            PeriodToUtc = utc 31 0
+        }
+
+    let fact usageFactId quantity observedAt =
+        {
+            UsageFactId = usageFactId
+            FactKind = 1
+            Quantity = quantity
+            ObservedAtUtc = observedAt
+            CustomerPricingAssignmentId = Guid.Parse "55555555-5555-5555-5555-555555555555"
+            BillableUsageKindMappingId = Guid.Parse "66666666-6666-6666-6666-666666666666"
+            BillableUsageKind = 10
+            PricingPlanId = Guid.Parse "77777777-7777-7777-7777-777777777777"
+            PricingRateId = Guid.Parse "88888888-8888-8888-8888-888888888888"
+            CurrencyCode = "USD"
+            UnitName = "byte-minute"
+            UnitQuantity = 3L
+            UnitPriceMicros = 1L
+            EffectiveFromUtc = utc 1 0
+            EffectiveToUtc = utc 31 0
+        }
+
+/// Proves arithmetic, line grain, diagnostics, SQL locking, and model/migration agreement for issue 575.
+[<TestFixture>]
+type OperationsChargePreviewTests() =
+
+    /// Verifies many facts sum before one exact whole-micro calculation.
+    [<Test>]
+    member _.ManyFactsAggregateBeforeOneRoundedCalculation() =
+        let facts =
+            [
+                ChargePreviewTestData.fact (Guid.NewGuid()) 1L (ChargePreviewTestData.utc 2 0)
+                ChargePreviewTestData.fact (Guid.NewGuid()) 1L (ChargePreviewTestData.utc 3 0)
+            ]
+
+        let lines = ChargePreviewCalculation.buildLines ChargePreviewTestData.scope facts
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(lines, Has.Length.EqualTo(1))
+            Assert.That(lines[0].TotalQuantity, Is.EqualTo(2L))
+            Assert.That(lines[0].ChargeMicros, Is.EqualTo(1L)))
+
+    /// Verifies midpoint values round away from zero and exact divisions remain exact.
+    [<TestCase(1L, 1L, 2L, 1L)>]
+    [<TestCase(2L, 1L, 2L, 1L)>]
+    [<TestCase(5L, 2L, 5L, 2L)>]
+    member _.WholeMicroRoundingMatchesTheApprovedRule(quantity: int64, price: int64, unitQuantity: int64, expected: int64) =
+        Assert.That(ChargePreviewCalculation.calculateChargeMicros quantity price unitQuantity, Is.EqualTo(expected))
+
+    /// Verifies intentionally free pricing still emits an auditable zero-charge line.
+    [<Test>]
+    member _.ExplicitZeroPriceProducesAZeroChargeLine() =
+        let fact = { ChargePreviewTestData.fact (Guid.NewGuid()) 99L (ChargePreviewTestData.utc 2 0) with UnitPriceMicros = 0L }
+        let lines = ChargePreviewCalculation.buildLines ChargePreviewTestData.scope [ fact ]
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(lines, Has.Length.EqualTo(1))
+            Assert.That(lines[0].TotalQuantity, Is.EqualTo(99L))
+            Assert.That(lines[0].ChargeMicros, Is.Zero))
+
+    /// Verifies BigInteger intermediates avoid multiplication overflow while persisted overflow is rejected.
+    [<Test>]
+    member _.LargeIntermediateArithmeticIsExactAndPersistedOverflowIsRejected() =
+        Assert.That(ChargePreviewCalculation.calculateChargeMicros Int64.MaxValue Int64.MaxValue Int64.MaxValue, Is.EqualTo(Int64.MaxValue))
+
+        Assert.Throws<OverflowException>(
+            Action (fun () ->
+                ChargePreviewCalculation.calculateChargeMicros Int64.MaxValue Int64.MaxValue 1L
+                |> ignore)
+        )
+        |> ignore
+
+    /// Verifies duplicate immutable fact identities cannot contribute twice.
+    [<Test>]
+    member _.DuplicateUsageFactIdsAreCountedOnce() =
+        let id = Guid.NewGuid()
+        let fact = ChargePreviewTestData.fact id 6L (ChargePreviewTestData.utc 2 0)
+        let lines = ChargePreviewCalculation.buildLines ChargePreviewTestData.scope [ fact; fact ]
+        Assert.That(lines[0].TotalQuantity, Is.EqualTo(6L))
+
+    /// Verifies complete pricing identity, currency, and applicability boundaries each produce separate lines.
+    [<Test>]
+    member _.CompletePricingApplicabilityAndCurrenciesRemainSeparate() =
+        let baseline = ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 2 0)
+
+        let changedAssignment =
+            { ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 6 0) with
+                CustomerPricingAssignmentId = Guid.NewGuid()
+                EffectiveFromUtc = ChargePreviewTestData.utc 5 0
+            }
+
+        let changedPlan =
+            { ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 11 0) with
+                PricingPlanId = Guid.NewGuid()
+                EffectiveFromUtc = ChargePreviewTestData.utc 10 0
+            }
+
+        let changedMapping =
+            { ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 16 0) with
+                BillableUsageKindMappingId = Guid.NewGuid()
+                EffectiveFromUtc = ChargePreviewTestData.utc 15 0
+            }
+
+        let changedRate =
+            { ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 21 0) with
+                PricingRateId = Guid.NewGuid()
+                EffectiveFromUtc = ChargePreviewTestData.utc 20 0
+            }
+
+        let changedCurrency =
+            { ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 26 0) with
+                PricingRateId = Guid.NewGuid()
+                CurrencyCode = "EUR"
+                EffectiveFromUtc = ChargePreviewTestData.utc 25 0
+            }
+
+        let lines =
+            ChargePreviewCalculation.buildLines
+                ChargePreviewTestData.scope
+                [
+                    baseline
+                    changedAssignment
+                    changedPlan
+                    changedMapping
+                    changedRate
+                    changedCurrency
+                ]
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(lines, Has.Length.EqualTo(6))
+            Assert.That(lines |> Array.map (fun line -> line.CurrencyCode), Does.Contain("USD"))
+            Assert.That(lines |> Array.map (fun line -> line.CurrencyCode), Does.Contain("EUR")))
+
+    /// Verifies unchanged rebuild inputs produce stable identities and values regardless of fact order.
+    [<Test>]
+    member _.IdenticalRebuildsAreDeterministicAndIdempotent() =
+        let facts =
+            [
+                ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 2 0)
+                ChargePreviewTestData.fact (Guid.NewGuid()) 6L (ChargePreviewTestData.utc 3 0)
+            ]
+
+        let first = ChargePreviewCalculation.buildLines ChargePreviewTestData.scope facts
+        let second = ChargePreviewCalculation.buildLines ChargePreviewTestData.scope (List.rev facts)
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(second[0].ChargePreviewLineId, Is.EqualTo(first[0].ChargePreviewLineId))
+                Assert.That(second[0].TotalQuantity, Is.EqualTo(first[0].TotalQuantity))
+                Assert.That(second[0].ChargeMicros, Is.EqualTo(first[0].ChargeMicros)))
+        )
+
+    /// Verifies SQL datetime2 values do not make line identities depend on the rebuilding host's local timezone.
+    [<Test>]
+    member _.UnspecifiedSqlUtcTimestampsProduceTheSameIdentityAsUtcValues() =
+        let utcFact = ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 2 0)
+
+        let sqlFact =
+            { utcFact with
+                EffectiveFromUtc = DateTime.SpecifyKind(utcFact.EffectiveFromUtc, DateTimeKind.Unspecified)
+                EffectiveToUtc = DateTime.SpecifyKind(utcFact.EffectiveToUtc, DateTimeKind.Unspecified)
+            }
+
+        Assert.That(
+            ChargePreviewCalculation.lineId ChargePreviewTestData.scope sqlFact,
+            Is.EqualTo(ChargePreviewCalculation.lineId ChargePreviewTestData.scope utcFact)
+        )
+
+    /// Verifies each independently missing pricing prerequisite gets an exact diagnostic classification.
+    [<TestCase(false, true, true, true, "Assignment")>]
+    [<TestCase(true, false, true, true, "Plan")>]
+    [<TestCase(true, true, false, true, "Mapping")>]
+    [<TestCase(true, true, true, false, "Rate")>]
+    member _.MissingPricingPrerequisitesAreDistinguished(assignment, plan, mapping, rate, expected: string) =
+        Assert.That(
+            ChargePreviewCalculation.missingPrerequisite assignment plan mapping rate
+            |> Option.map string,
+            Is.EqualTo(Some expected)
+        )
+
+    /// Verifies compact fields drive pricing without any archived payload or Blob dependency.
+    [<Test>]
+    member _.PreviewSqlReadsArchivedCompactRowsWithoutPayloadRehydration() =
+        let sql = OperationsChargePreviewSql.SelectSourceAndPricing
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(sql, Does.Contain("fact.UsageFactId, fact.FactKind, fact.Quantity, fact.ObservedAtUtc"))
+            Assert.That(sql, Does.Not.Contain("RawPayload"))
+            Assert.That(sql, Does.Not.Contain("ArchiveState"))
+            Assert.That(sql, Does.Not.Contain("Blob")))
+
+    /// Verifies half-open source selection and every complete applicability contributor are explicit in SQL.
+    [<Test>]
+    member _.PreviewSqlUsesHalfOpenObservedTimeAndAllApplicabilityBoundaries() =
+        let sql = OperationsChargePreviewSql.SelectSourceAndPricing
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(sql, Does.Contain("fact.ObservedAtUtc >= @PeriodFromUtc"))
+            Assert.That(sql, Does.Contain("fact.ObservedAtUtc < @PeriodToUtc"))
+            Assert.That(sql, Does.Contain("assignment.EffectiveFromUtc"))
+            Assert.That(sql, Does.Contain("plan.EffectiveFromUtc"))
+            Assert.That(sql, Does.Contain("mapping.EffectiveFromUtc"))
+            Assert.That(sql, Does.Contain("rate.EffectiveFromUtc"))
+            Assert.That(sql, Does.Contain("MAX(boundary.EffectiveFromUtc)"))
+            Assert.That(sql, Does.Contain("MIN(boundary.EffectiveToUtc)")))
+
+    /// Verifies the EF runtime model, snapshot, and migration target expose the same preview identity indexes.
+    [<Test>]
+    member _.PreviewMigrationAndModelsAgreeOnPersistedIdentity() =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewModel;Integrated Security=true;"
+        let runtime = context.Model.FindEntityType(typeof<ChargePreviewLineEntity>)
+
+        let snapshot =
+            OperationsDbContextModelSnapshot()
+                .Model.FindEntityType(typeof<ChargePreviewLineEntity>)
+
+        let migration =
+            AddChargePreviewLines()
+                .TargetModel.FindEntityType(typeof<ChargePreviewLineEntity>)
+
+        let indexes (entity: Microsoft.EntityFrameworkCore.Metadata.IEntityType) =
+            entity.GetIndexes()
+            |> Seq.map (fun index -> index.GetDatabaseName())
+            |> Set.ofSeq
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(runtime, Is.Not.Null)
+            Assert.That(snapshot, Is.Not.Null)
+            Assert.That(migration, Is.Not.Null)
+            Assert.That(indexes runtime :> obj, Is.EqualTo(indexes snapshot :> obj))
+            Assert.That(indexes runtime :> obj, Is.EqualTo(indexes migration :> obj))
+            Assert.That(indexes runtime, Does.Contain(OperationsChargePreviewSql.GrainIndexName))
+            Assert.That(indexes runtime, Does.Contain(OperationsChargePreviewSql.ScopeIndexName)))
+
+    /// Verifies generated migration SQL contains the atomic identity constraints expected by SQL Server.
+    [<Test>]
+    member _.PreviewMigrationScriptContainsConstraintsAndCompleteGrainIndex() =
+        use context =
+            OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewMigration;Integrated Security=true;"
+
+        let script = context.GetService<IMigrator>().GenerateScript()
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(script, Does.Contain("CREATE TABLE ops.ChargePreviewLine"))
+            Assert.That(script, Does.Contain("CK_ops_ChargePreviewLine_EffectiveRange"))
+            Assert.That(script, Does.Contain("UX_ops_ChargePreviewLine_CompleteGrain"))
+            Assert.That(script, Does.Contain("CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2")))
+
+    /// Verifies runtime SQL uses parameterized scope values and transaction-owned application locking.
+    [<Test>]
+    member _.RebuildSourceAndMutationSqlAvoidValueInterpolationAndRequireScopeParameters() =
+        let source = OperationsChargePreviewSql.SelectSourceAndPricing
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(source, Does.Contain("@CustomerId"))
+            Assert.That(source, Does.Contain("@RepositoryId"))
+            Assert.That(source, Does.Not.Contain(ChargePreviewTestData.scope.CustomerId.ToString("D")))
+            Assert.That(OperationsChargePreviewSql.AcquireScopeLock, Does.Contain("sys.sp_getapplock"))
+            Assert.That(OperationsChargePreviewSql.AcquireScopeLock, Does.Contain("@LockOwner='Transaction'"))
+            Assert.That(OperationsChargePreviewSql.DeleteScope, Does.Contain("PeriodFromUtc=@PeriodFromUtc"))
+            Assert.That(OperationsChargePreviewSql.DeleteScope, Does.Contain("PeriodToUtc=@PeriodToUtc")))
+
+    /// Verifies invalid or non-UTC periods fail before a SQL connection or mutation can begin.
+    [<Test>]
+    member _.InvalidPeriodIsRejectedBeforeSqlMutation() =
+        task {
+            let invalidScope = { ChargePreviewTestData.scope with PeriodToUtc = ChargePreviewTestData.scope.PeriodFromUtc }
+
+            let rebuilder = SqlChargePreviewRebuilder("invalid connection string") :> IChargePreviewRebuilder
+
+            try
+                let! _ = rebuilder.RebuildAsync(invalidScope, CancellationToken.None)
+                Assert.Fail("Expected the empty preview period to be rejected.")
+            with
+            | :? ArgumentException as ex -> Assert.That(ex.ParamName, Is.EqualTo("scope"))
+        }
+
+    /// Verifies the worker exposes the callable rebuild service without registering scheduling state.
+    [<Test>]
+    member _.WorkerRegistersCallablePreviewRebuilderOnly() =
+        let sourcePath =
+            IO.Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "..", "Grace.Operations.Worker", "Program.fs")
+            |> IO.Path.GetFullPath
+
+        let source = IO.File.ReadAllText sourcePath
+
+        ChargePreviewTestData.multiple (fun () ->
+            Assert.That(source, Does.Contain("AddSingleton<IChargePreviewRebuilder>"))
+            Assert.That(source, Does.Not.Contain("ChargePreviewWorkerService"))
+            Assert.That(source, Does.Not.Contain("AddHostedService<ChargePreview")))

--- a/src/Grace.Operations/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/Program.fs
@@ -58,6 +58,9 @@ module Program =
             SqlOperationsUsageArchiveStore(settings.SqlConnectionString) :> IOperationsUsageArchiveStore)
         |> ignore
 
+        services.AddSingleton<IChargePreviewRebuilder>(fun _ -> SqlChargePreviewRebuilder(settings.SqlConnectionString) :> IChargePreviewRebuilder)
+        |> ignore
+
         services.AddSingleton<OperationsUsageIngestionProcessor>()
         |> ignore
 


### PR DESCRIPTION
## Purpose

Provide deterministic provisional charge visibility from accepted repository usage and effective customer pricing before
issue #576 posts immutable billing ledger entries.

Related to #575
Part of #560
Part of #554

## Implementation

- Persists auditable charge-preview lines at the customer/repository/period, usage-kind, currency, and complete pricing
  applicability grain.
- Reads compact immutable `RawUsageFact` fields, including archived facts whose payload has been cleared, without Blob
  rehydration.
- Selects assignment, plan, billable usage-kind mapping, and pricing rate at each fact's observed timestamp and segments
  lines at every complete applicability boundary.
- Sums quantities before exact `BigInteger` charge calculation, rounds once per line to the nearest whole currency micro
  with midpoint away from zero, and checks the persisted `int64` result.
- Treats missing pricing configuration as a rebuild failure while preserving explicit zero-priced lines.
- Uses a transaction-owned `sp_getapplock`, final source read, candidate validation, exact-scope replacement, and commit
  in one SQL transaction so same-scope rebuilds serialize and failures retain the previous complete preview.
- Registers an Operations-internal callable rebuild service only. No scheduler, billing-period lifecycle, ledger, HTTP,
  Grace Server, CLI, SDK, provider-cost, or external billing behavior is added.

## Validation

- Focused Operations data-project Release build: passed with 0 warnings and 0 errors.
- `OperationsChargePreviewTests`: passed 21/21 with 0 skipped.
- Fantomas on every touched F# file: passed.
- MarkdownLint on `MIGRATIONS.md`: passed with 0 errors.
- `git diff --check`: passed.
- Aspire SQL startup applied migration `20260711090000_AddChargePreviewLines` successfully.
- `pwsh ./scripts/validate.ps1 -Full`: both solution targets built with 0 warnings and 0 errors, the Operations worker
  became healthy, and the migration applied. The run did not complete green because the unrelated
  `ApprovalPolicyStoreIsProcessLocalWhileGeneratedRequestsRemainActorBackedAcrossRestart` test could not stop the
  `grace-server` Aspire resource; subsequent Grace.Server tests timed out against the unavailable service and the run
  was terminated after the causal failure was established.
- GitHub `full`: passed on current stabilization head `910cda0cfb402a989aa431a7ce7a90223e5b97f6`.
- `src/Grace.slnx`: untouched.

## First-Pass Review Readiness

- Bot-prevention self-review covered persisted identity, parameterized SQL and lock-resource construction,
  cancellation/rollback ordering, checked arithmetic and rounding, missing-pricing diagnostics, migration/model
  agreement, archived compact-row eligibility, and later-leaf exclusions.
- The issue body was expanded before implementation with the approved product contract and explicit positive, negative,
  regression, boundary, failure, and concurrency proof obligations.
- Residual risk: the current Operations test harness does not provide a dedicated two-connection SQL fixture for forcing
  concurrent rebuilds or injected mid-insert failures. The concrete SQL lock/transaction path and focused structural
  tests cover those invariants; GitHub `full` and Codex review remain blocking.

## Review Status

- Current head: `910cda0cfb402a989aa431a7ce7a90223e5b97f6`
- Bot state for current head: no issues; `THUMBS_UP`
- Manual trigger decision: not attempted
- Manual trigger lock: active; do not trigger while current-head acknowledgement/review is pending, and use
  `scripts/guard-codex-review-trigger.ps1` before any missed-ack exception.
- Bot review sessions observed: 3 completed current-head sessions
- Substantive review cycles: 2; persisted-shape stabilization ledger implemented and third review returned no issues
- Current open findings: none; the second-pass snapshot conversation is resolved after the stabilization fix
- Fix commits: `6fcf996049e58c739bf2115b72ae5e61384f9e22` froze the complete migration target and replaced
  the task-expression insertion loop; evidence replies: [migration target](https://github.com/ScottArbeit/Grace/pull/703#discussion_r3563880390),
  [FS3511-safe loop](https://github.com/ScottArbeit/Grace/pull/703#discussion_r3563880431).
  `910cda0cfb402a989aa431a7ce7a90223e5b97f6` froze the latest snapshot, removed the remaining
  mutable SQL-name helper, and strengthened complete independent-model proof
  ([evidence](https://github.com/ScottArbeit/Grace/pull/703#discussion_r3563922435)).
- Final no-issues bot status: `THUMBS_UP` on `910cda0cfb402a989aa431a7ce7a90223e5b97f6`; all review
  conversations resolved
- Prevention: acceptance-criteria / negative-proof gap; #575 now contains an independently frozen EF schema-history
  stabilization ledger, and future persisted-shape issue #576 inherits the same migration-target and snapshot proof.

## Docs Impact

`Grace.Operations.Data/MIGRATIONS.md` now distinguishes rebuildable provisional previews from immutable ledger records,
documents compact-row source reads, and states that #575 adds no scheduling.
