### PR TITLE
WS7.4.4: Verify final materialization publication and audit

### DIFF
--- a/docs/Current branch materialization final audit.md
+++ b/docs/Current branch materialization final audit.md
@@ -1,0 +1,104 @@
+# Current-Branch Materialization Final Audit
+
+This artifact is the WS7.4 completion audit for [#677](https://github.com/ScottArbeit/Grace/issues/677). It records
+the implementation and proof integrated through child PRs #683, #685, #698, #702, and this #681 branch. WS7.4
+replaces the closed, unimplemented #505 / PR #552 path; it does not revive it.
+
+## Scope And Status
+
+- Parent mini-epic: [#677](https://github.com/ScottArbeit/Grace/issues/677).
+- Final audit issue: [#681](https://github.com/ScottArbeit/Grace/issues/681).
+- Integration branch: `epic/677-current-branch-reference-materialization-rewrite`.
+- Audited base: `05e013dfe0b765e7e935fe93495de81f7609f67a` from merged #701 / PR #702.
+- ADR: [ADR 0010](adr/0010-current-branch-materialization-trust-boundary.md).
+- Status terms: `Implemented and proven` has committed code plus focused proof. `Deferred` is owned by a named
+  follow-up. `Rejected` is intentionally excluded from WS7.4.
+
+## Contract Propagation Map
+
+| Surface | WS7.4 disposition | Evidence |
+| ------- | ----------------- | -------- |
+| Watch runtime and serialized coordinator | Implemented and proven | `Watch.CLI.fs` validates, serializes, gates, applies, and publishes one exact Reference. |
+| Watch IPC and CLI JSON | Unchanged for blocked materialization | `GraceWatchStatus`, its private IPC contract, and `WatchStatusDto` are unchanged by #681. |
+| Durable local state | Implemented and proven | Exact apply replaces `GraceStatus` only inside the owned update-marker boundary. |
+| Apply coordinator and object cache | Implemented and proven | Exact target plan and cache preflight complete before target mutation. |
+| Docs and tests | Implemented and proven | This ADR/audit and `Watch.Tests.fs` capture the final trust and publication proofs. |
+| SDK, OpenAPI, server DTOs, and generated clients | N/A | WS7.4 preserves their existing public shapes; #701 audited existing strict Reference projections. |
+
+## Decision Traceability
+
+| ID | Binding #677 decision | Status | Current evidence |
+| -- | --------------------- | ------ | ---------------- |
+| D1 | Notifications carry concrete Reference and full dual-hash root identity. | Implemented and proven | `Services.currentBranchReferenceProtocolValidationDecision`; `current branch reference decision rejects missing root identity and empty reference id`. |
+| D2 | BranchDto latest Reference decides staleness. | Implemented and proven | `Services.decideLatestCurrentBranchReferenceMaterialization`; latest-mismatch, delayed cross-type, and arrival-order tests in `Watch.Tests.fs`. |
+| D3 | Exact References process one at a time without coalescing or reordering. | Implemented and proven | `WorkingDirectoryMaterialization.runSerializedLane`; coordinator tests keep accepted R1 ahead of later R2. |
+| D4 | Materialization has no broad repository or marker-window scan. | Implemented and proven | `buildCurrentBranchRemoteMaterializationPlanForWatchTests` uses the exact remote closure and target checks; the materialization path has no `scanForDifferences` call. |
+| D5 | The working tree becomes the exact Reference, including type swaps. | Implemented and proven | `applyCurrentBranchMaterializationTargets`; exact-plan tests cover file-to-directory and directory-to-file replacement. |
+| D6 | Ambiguous IPC degrades/resyncs and revalidates the exact Reference. | Implemented and proven | `currentBranchMaterializationStatusGate` and coordinator degraded-resync revalidation tests. |
+| D7 | Object-cache content is preflighted; apply never falls back to download. | Implemented and proven | `verifyCurrentBranchMaterializationObjectCache` runs before mutation; missing/corrupt cache tests assert no target mutation. |
+| D8 | Remote materialization never creates a local Save. | Implemented and proven | The exact-apply client boundary has no Save operation; apply-owned observation suppression tests prove mutated targets do not enter local Watch work. |
+| D9 | Blocked state remains internal; do not add CLI JSON, IPC DTO, or GraceWatchStatus fields. | Implemented and proven | #681 changes only coordinator/private test seams and docs. `Services.GraceWatchStatus` and `WatchCheckStatusDto` keep their existing shapes; blocked/degraded outcomes remain internal. |
+| D10 | Clean IPC follows successful apply, durable update, marker closure, and final verified publication. | Implemented and proven | `processCurrentBranchMaterializationNotification` now requires `PublishCleanIpcAfterApply`; new publication-order and unproven-publication tests prove clean ordering and dirty/degraded fallback. Existing exact-apply tests cover durable replacement and marker-retirement failure. |
+| D11 | A newer Reference may return to an old root only when BranchDto latest names it. | Implemented and proven | `latest current branch decision accepts newer reference that returns to older root value`. |
+| D12 | No new data-source construct, root history, or superseded-root policy. | Implemented and proven | Current code uses configuration lifecycle, BranchDto refresh, and serialized coordination only; source and diff review found no new ledger or root-history state. |
+| D13 | Stop before adding an unnamed materialization-domain construct. | Audited | #681 needed no new product concept or public contract. The final-publication seam is a private coordinator dependency, not a materialization data source or status model. |
+
+## Child-Issue Completion Map
+
+| Issue | Completion classification | Implementation and proof |
+| ----- | ------------------------- | ------------------------ |
+| [#678](https://github.com/ScottArbeit/Grace/issues/678) | Implemented and proven | Strict notification identity, overall/latest BranchDto authority, stale drop, and legitimate old-root return proof. |
+| [#679](https://github.com/ScottArbeit/Grace/issues/679) | Implemented and proven | Serialized lane, post-lease target revalidation, dirty/pending gate, durable local-state gate, and degraded resync. |
+| [#680](https://github.com/ScottArbeit/Grace/issues/680) | Implemented and proven | Exact-target apply, marker ownership, object-cache preflight, type swaps, no broad scan, and apply-owned observation suppression. |
+| [#701](https://github.com/ScottArbeit/Grace/issues/701) | Implemented and proven | Merged PR #702 makes current version identity strict for SHA-256 and BLAKE3 and preserves the narrow typed Reference sentinel contract. |
+| [#681](https://github.com/ScottArbeit/Grace/issues/681) | Implemented and proven | Final verified-clean publication gate, dirty reassertion on unproven final publication, ADR, and this traceability audit. |
+
+## Explicit Deferrals And Rejections
+
+- [#506](https://github.com/ScottArbeit/Grace/issues/506) owns startup/reconnect catch-up and recovery after
+  process-local pending work is lost. It must consume this BranchDto-confirmed materialization boundary.
+- WS6 owns normalized observation hardening and operability. It must not redefine the WS7.4 authority or publication
+  rules.
+- PR #552 is rejected as an implementation path. It is historical coordination evidence only.
+- WS7.4 has no public blocked-materialization status field, no notification-payload persistence, no broad-scan proof,
+  no missing-object apply fallback, and no root-history or superseded-root ledger.
+
+## Publication Side-Effect Audit
+
+The final publication sequence is deliberate:
+
+1. The coordinator publishes and verifies dirty/pending IPC before it calls the exact apply boundary.
+2. Exact apply preflights metadata, targets, and object cache; it mutates targets under its owned update marker.
+3. Exact apply persists replacement `GraceStatus` and closes the owned marker before returning success.
+4. Only then does the coordinator clear its internal pending marker and request verified clean IPC publication.
+5. An unproven final clean publication restores pending state, reasserts dirty IPC, requests degraded/resync, and returns
+   `WaitingForDegradedResync`, not `Applied`.
+
+The focused test `current branch materialization coordinator publishes clean only after successful apply completion`
+records durable-state and marker closure before clean publication. The paired unproven-publication test records dirty
+reassertion and degraded/resync rather than an applied clean result. Existing failed-apply coverage confirms a partial
+apply remains dirty and unusable.
+
+## Validation Record
+
+- Targeted Fantomas passed for `Watch.CLI.fs` and `Watch.Tests.fs`.
+- Focused `CurrentBranchMaterializationPublication` passed 2/2.
+- Focused `CurrentBranchMaterializationCoordinator` passed 36/36, including blocked, degraded, failed-apply, and
+  final-publication ordering cases.
+- MarkdownLint passed for this audit and ADR 0010 with the repository-local 120-column `MD013` limit.
+- `git diff --check` passed before final handoff.
+- The required `pwsh ./scripts/validate.ps1 -Full` gate was run twice because the first local transport detached after
+  build/test startup. The permitted clean-state retry visibly passed build with 0 warnings and 0 errors, Types 140/140,
+  Authorization 53/53, and Server.Unit 738/738, then started and cleaned up the Aspire-backed Server fixture. The
+  command transport detached before either Full run returned the final Server/CLI totals or exit code. This audit does
+  not claim a local Full pass; the orchestrator should use the PR's authoritative Full run or rerun the gate where its
+  exit status can be retained.
+
+This audit is committed with the code so the final PR can retain the decision map independently of issue-comment
+history.
+
+## Coordination Finding
+
+Issue #681 requests `docs/adr/0007-current-branch-materialization-trust-boundary.md`, but the integration branch
+already contains `docs/adr/0007-empty-directories-are-versioned-structure.md`, plus ADRs 0008 and 0009. This worker
+uses the next available number, ADR 0010. The orchestrator should patch #681's ADR path before closing the issue.

--- a/docs/adr/0010-current-branch-materialization-trust-boundary.md
+++ b/docs/adr/0010-current-branch-materialization-trust-boundary.md
@@ -1,0 +1,63 @@
+---
+status: accepted
+date: 2026-07-11
+decision-makers:
+  - Scott Arbeit
+consulted:
+  - Codex
+---
+
+# Trust current-branch materialization at the BranchDto boundary
+
+Grace Watch materializes a same-branch remote Reference only through a small, serialized trust boundary. The boundary
+keeps local work safe while allowing a server-confirmed Reference to make the working tree match its exact contents.
+
+## Context
+
+SignalR delivery is useful for promptly waking Watch, but delivery order and process-local payloads cannot establish
+which Reference is current. Watch also cannot safely overwrite local work when IPC, local durable state, or the
+object cache is incomplete. Earlier implementation attempts showed that treating a notification, an old root, or a
+local scan as authority creates unsafe materialization policy.
+
+## Decision
+
+- Notifications are triggers. A materializable notification carries a concrete `ReferenceId` and complete dual-hash
+  root identity, then Watch refreshes `BranchDto` before it applies anything.
+- `BranchDto` latest Reference is the server-side authority. A notification whose concrete id does not match is stale;
+  a newer Reference may legitimately return to an older root when the latest `BranchDto` names that Reference.
+- Same-branch materialization is one-at-a-time. Each exact Reference owns the serialized lane and is revalidated at
+  the defined safe points; arrival order does not select, merge, or replace work.
+- Materialization uses exact Reference targets. It does not broad-scan the repository, maintain root-history policy,
+  or download missing objects while applying. Required cached objects are preflighted before mutation.
+- Missing, stale, unreadable, blocked, or ambiguous IPC/local-state evidence is degraded or resync behavior. Watch
+  preserves the exact Reference for revalidation instead of treating uncertainty as clean or as a permanent stale
+  result.
+- Remote materialization creates no local Save. Its Grace-owned marker suppresses apply-owned observations while the
+  exact target plan mutates the working tree.
+- Watch publishes a clean IPC snapshot only after the exact apply succeeds, durable `GraceStatus` is updated, the
+  materialization update marker is closed, and the final clean snapshot is verified. If that final verification fails,
+  Watch reasserts dirty IPC and requests degraded/resync behavior rather than reporting an applied clean state.
+
+## Consequences
+
+This favors a conservative retry over a potentially clean but unproven state. A delayed or invalid notification can
+cost an additional BranchDto lookup or explicit resync, but it cannot make arrival order, stale roots, or incomplete
+local evidence authoritative. Startup/reconnect catch-up and durable recovery of process-local pending work remain
+the separate WS7.5 scope.
+
+## Rejected alternatives
+
+### Use SignalR payloads as durable latest authority
+
+SignalR can be delayed, duplicated, or reordered. A notification without a matching current `BranchDto` is not safe
+materialization work.
+
+### Broad-scan or record root history before applying
+
+Whole-repository scans and root-history ledgers add a second authority model. Exact target checks and the concrete
+Reference already provide the required boundary.
+
+### Publish clean before final verification
+
+Other Grace commands may trust a clean IPC snapshot. Publishing it before durable apply and marker closure, or when
+the final write cannot be verified, would let an unproven state cross that process boundary.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -12956,6 +12956,140 @@ module WatchTests =
             Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
             |> should equal true)
 
+    /// Verifies a newer resync that wins after clean verification is retired only after fresh dirty IPC replaces the provisional clean snapshot.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``newer resync after clean recovery verification republishes dirty ipc before stale attempt returns`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let clientPublications = ResizeArray<string>()
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            let updateIpc currentStatus directoryIds =
+                clientPublications.Add(
+                    if currentStatus.RootDirectoryId = status.RootDirectoryId then
+                        "clean"
+                    else
+                        "dirty"
+                )
+
+                Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+            Watch.setBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests (fun () ->
+                Watch.requestGraceWatchExplicitResyncForWatchTests "newer resync arrived after clean verification")
+
+            try
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+            finally
+                Watch.resetBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests ()
+
+            clientPublications.ToArray()
+            |> should equal [| "clean"; "dirty" |]
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+
+                inspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+            | None -> Assert.Fail("Expected verified dirty Watch IPC after newer resync won recovery retirement."))
+
+    /// Verifies an unproven dirty reassertion after a lost recovery retirement still retains fail-closed local retry evidence.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``newer resync dirty reassertion failure retains materialization latch and retry`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable clientPublicationCalls = 0
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            let updateIpc currentStatus directoryIds =
+                clientPublicationCalls <- clientPublicationCalls + 1
+
+                if clientPublicationCalls = 1 then
+                    Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+                else
+                    Task.FromException<unit>(InvalidOperationException("dirty reassertion write failed"))
+
+            Watch.setBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests (fun () ->
+                Watch.requestGraceWatchExplicitResyncForWatchTests "newer resync arrived after clean verification")
+
+            try
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+            finally
+                Watch.resetBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests ()
+
+            clientPublicationCalls |> should equal 2
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+            | None -> Assert.Fail("Expected existing dirty Watch IPC to remain fail-closed after dirty reassertion failed."))
+
     /// Verifies a swallowed clean recovery write retains the materialization latch and active resync retry.
     [<Test; Category("CurrentBranchMaterializationPublication")>]
     let ``swallowed resync clean publication retains materialization latch and retry`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -18362,6 +18362,86 @@ module WatchTests =
 
                 inspection.IsUsable |> should equal true)
 
+    /// Verifies a status advancement that drains its queues before the final probe cannot accept an older clean IPC identity.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization final clean publication rejects advanced durable status after queues drain`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let publishedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let advancedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable statusReadCount = 0
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                statusReadCount <- statusReadCount + 1
+
+                Task.FromResult(if statusReadCount = 1 then publishedStatus else advancedStatus))
+
+            Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
+            |> should equal false
+
+            statusReadCount |> should equal 2
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some status ->
+                status.RootDirectoryId
+                |> should equal publishedStatus.RootDirectoryId
+
+                status.RootDirectoryId
+                |> should not' (equal advancedStatus.RootDirectoryId)
+            | None -> Assert.Fail("Expected the older clean IPC snapshot to remain observable but rejected as stale."))
+
+    /// Verifies unchanged durable status keeps a fresh clean IPC publication eligible for materialization success.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization final clean publication accepts unchanged durable status`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let expectedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable statusReadCount = 0
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                statusReadCount <- statusReadCount + 1
+                Task.FromResult(expectedStatus))
+
+            Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
+            |> should equal true
+
+            statusReadCount |> should equal 2)
+
+    /// Verifies final proof compares only the current durable identity, so a legitimate return to an older root remains clean.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization final clean publication accepts durable status returned to exact older root`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let originalStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let newerStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable statusReadCount = 0
+            let mutable observedNewerStatus = None
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                statusReadCount <- statusReadCount + 1
+
+                if statusReadCount = 1 then
+                    Task.FromResult(originalStatus)
+                else
+                    observedNewerStatus <- Some newerStatus
+                    Task.FromResult(originalStatus))
+
+            Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
+            |> should equal true
+
+            observedNewerStatus
+            |> should equal (Some newerStatus)
+
+            newerStatus.RootDirectoryId
+            |> should not' (equal originalStatus.RootDirectoryId)
+
+            statusReadCount |> should equal 2)
+
     /// Verifies an unverified dirty replacement leaves materialization fail-closed on the existing degraded-resync path.
     [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
     let ``current branch materialization coordinator fails closed when dirty replacement is unproven`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -17448,6 +17448,154 @@ module WatchTests =
                 |> should equal true
             | None -> Assert.Fail("Expected stale materialization cleanup to publish clean Watch IPC."))
 
+    /// Verifies final clean IPC publication occurs only after apply reports durable state and marker-boundary completion.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization coordinator publishes clean only after successful apply completion`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let events = ResizeArray<string>()
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "final-publication-order-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("A verified final clean publication must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+
+            let applyReference _ _ =
+                task {
+                    events.Add("apply-targets")
+                    events.Add("durable-status-updated")
+                    events.Add("update-marker-closed")
+                }
+
+            let publishCleanIpcAfterApply () =
+                events.ToArray()
+                |> should
+                    equal
+                    [|
+                        "apply-targets"
+                        "durable-status-updated"
+                        "update-marker-closed"
+                    |]
+
+                events.Add("clean-ipc-verified")
+                true
+
+            let reassertDirtyIpcAfterFailedCleanPublication () = Assert.Fail("Verified clean publication must not reassert dirty IPC.")
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    publishCleanIpcAfterApply
+                    reassertDirtyIpcAfterFailedCleanPublication
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            events.ToArray()
+            |> should
+                equal
+                [|
+                    "apply-targets"
+                    "durable-status-updated"
+                    "update-marker-closed"
+                    "clean-ipc-verified"
+                |])
+
+    /// Verifies unproven final clean IPC publication remains dirty, degraded, and non-applied after a successful apply.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization coordinator reasserts dirty ipc when final clean publication is unproven`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let events = ResizeArray<string>()
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "final-publication-failure-test"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync reason = events.Add($"degraded:{reason}")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+
+            let applyReference _ _ =
+                task {
+                    events.Add("apply-targets")
+                    events.Add("durable-status-updated")
+                    events.Add("update-marker-closed")
+                }
+
+            let publishCleanIpcAfterApply () =
+                events.Add("clean-ipc-unproven")
+                false
+
+            let reassertDirtyIpcAfterFailedCleanPublication () =
+                Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+                |> should equal true
+
+                events.Add("dirty-ipc-reasserted")
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    publishCleanIpcAfterApply
+                    reassertDirtyIpcAfterFailedCleanPublication
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+            events.ToArray()
+            |> should
+                equal
+                [|
+                    "apply-targets"
+                    "durable-status-updated"
+                    "update-marker-closed"
+                    "clean-ipc-unproven"
+                    "dirty-ipc-reasserted"
+                    "degraded:materialization final clean Watch IPC/status publication failed"
+                |]
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true)
+
     /// Verifies that a failed apply cannot republish clean IPC from pre-apply status evidence.
     [<Test; Category("CurrentBranchMaterializationCoordinator")>]
     let ``current branch materialization coordinator keeps ipc dirty when apply fails`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -12922,6 +12922,8 @@ module WatchTests =
             let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
             let applyIncremental _ _ _ = Task.FromResult(())
 
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
             let updateIpc _ _ =
                 publicationLatchStates.Add(Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ())
                 publicationResyncStates.Add(Watch.isGraceWatchResyncPendingForWatchTests ())
@@ -12956,6 +12958,71 @@ module WatchTests =
             Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
             |> should equal true)
 
+    /// Verifies recovery leaves IPC dirty and keeps retry state when final durable identity is advanced, missing, or unreadable after queues drain.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``materialization resync recovery rejects mismatched or unreadable durable identity after clean publication`` () =
+        /// Runs one deterministic clean-recovery attempt against a final durable-status result that must remain fail-closed.
+        let verifyFailClosed durableStatusRead =
+            try
+                withTempRepo (fun _ ->
+                    Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+                    Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+                    let expectedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+                    let mutable finalDurableStatusReadCount = 0
+                    let readStatus () = Task.FromResult(expectedStatus)
+                    let upload _ _ = Task.FromResult(())
+                    let updateGraceStatus _ _ = Task.FromResult(Some expectedStatus)
+                    let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+                    let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+                    let applyIncremental _ _ _ = Task.FromResult(())
+
+                    Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () ->
+                        finalDurableStatusReadCount <- finalDurableStatusReadCount + 1
+                        durableStatusRead ())
+
+                    (Watch.processChangedFilesWithClients
+                        readStatus
+                        readStatus
+                        upload
+                        updateGraceStatus
+                        scanForDifferences
+                        updateGraceStatusFromDifferences
+                        applyIncremental
+                        Services.updateGraceWatchInterprocessFile)
+                        .GetAwaiter()
+                        .GetResult()
+
+                    finalDurableStatusReadCount |> should equal 1
+
+                    Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+                    |> should equal true
+
+                    Watch.isGraceWatchResyncPendingForWatchTests ()
+                    |> should equal true
+
+                    Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                    |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                    let inspection = Services.inspectGraceWatchStatus().Result
+
+                    match inspection.Status with
+                    | Some publishedStatus ->
+                        publishedStatus.HasPendingWatchWork
+                        |> should equal true
+
+                        publishedStatus.IsWorkingTreeClean
+                        |> should equal false
+                    | None -> Assert.Fail("Expected dirty Watch IPC when clean recovery durable identity is unproven."))
+            finally
+                Watch.clearPendingWatchWorkForTests ()
+
+        let advancedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+
+        verifyFailClosed (fun () -> Task.FromResult(advancedStatus))
+        verifyFailClosed (fun () -> Task.FromException<GraceStatus>(FileNotFoundException("Grace Status is missing")))
+        verifyFailClosed (fun () -> Task.FromException<GraceStatus>(IOException("Grace Status is unreadable")))
+
     /// Verifies a newer resync that wins after clean verification is retired only after fresh dirty IPC replaces the provisional clean snapshot.
     [<Test; Category("CurrentBranchMaterializationPublication")>]
     let ``newer resync after clean recovery verification republishes dirty ipc before stale attempt returns`` () =
@@ -12971,6 +13038,9 @@ module WatchTests =
             let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
             let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
             let applyIncremental _ _ _ = Task.FromResult(())
+            let mutable retirementProbeCalls = 0
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
 
             let updateIpc currentStatus directoryIds =
                 clientPublications.Add(
@@ -12983,6 +13053,7 @@ module WatchTests =
                 Services.updateGraceWatchInterprocessFile currentStatus directoryIds
 
             Watch.setBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests (fun () ->
+                retirementProbeCalls <- retirementProbeCalls + 1
                 Watch.requestGraceWatchExplicitResyncForWatchTests "newer resync arrived after clean verification")
 
             try
@@ -13002,6 +13073,8 @@ module WatchTests =
 
             clientPublications.ToArray()
             |> should equal [| "clean"; "dirty" |]
+
+            retirementProbeCalls |> should equal 1
 
             Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
             |> should equal true
@@ -13024,7 +13097,9 @@ module WatchTests =
 
                 inspection.EffectiveMode
                 |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
-            | None -> Assert.Fail("Expected verified dirty Watch IPC after newer resync won recovery retirement."))
+            | None -> Assert.Fail("Expected verified dirty Watch IPC after newer resync won recovery retirement.")
+
+            Watch.clearPendingWatchWorkForTests ())
 
     /// Verifies an unproven dirty reassertion after a lost recovery retirement still retains fail-closed local retry evidence.
     [<Test; Category("CurrentBranchMaterializationPublication")>]
@@ -13041,6 +13116,9 @@ module WatchTests =
             let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
             let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
             let applyIncremental _ _ _ = Task.FromResult(())
+            let mutable retirementProbeCalls = 0
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
 
             let updateIpc currentStatus directoryIds =
                 clientPublicationCalls <- clientPublicationCalls + 1
@@ -13051,6 +13129,7 @@ module WatchTests =
                     Task.FromException<unit>(InvalidOperationException("dirty reassertion write failed"))
 
             Watch.setBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests (fun () ->
+                retirementProbeCalls <- retirementProbeCalls + 1
                 Watch.requestGraceWatchExplicitResyncForWatchTests "newer resync arrived after clean verification")
 
             try
@@ -13070,6 +13149,8 @@ module WatchTests =
 
             clientPublicationCalls |> should equal 2
 
+            retirementProbeCalls |> should equal 1
+
             Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
             |> should equal true
 
@@ -13088,7 +13169,9 @@ module WatchTests =
 
                 publishedStatus.IsWorkingTreeClean
                 |> should equal false
-            | None -> Assert.Fail("Expected existing dirty Watch IPC to remain fail-closed after dirty reassertion failed."))
+            | None -> Assert.Fail("Expected existing dirty Watch IPC to remain fail-closed after dirty reassertion failed.")
+
+            Watch.clearPendingWatchWorkForTests ())
 
     /// Verifies a swallowed clean recovery write retains the materialization latch and active resync retry.
     [<Test; Category("CurrentBranchMaterializationPublication")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -17494,7 +17494,9 @@ module WatchTests =
                 events.Add("clean-ipc-verified")
                 true
 
-            let reassertDirtyIpcAfterFailedCleanPublication () = Assert.Fail("Verified clean publication must not reassert dirty IPC.")
+            let reassertDirtyIpcAfterFailedCleanPublication () =
+                Assert.Fail("Verified clean publication must not reassert dirty IPC.")
+                false
 
             let outcome =
                 (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
@@ -17522,7 +17524,7 @@ module WatchTests =
                     "clean-ipc-verified"
                 |])
 
-    /// Verifies unproven final clean IPC publication remains dirty, degraded, and non-applied after a successful apply.
+    /// Verifies a verified dirty replacement keeps final clean publication degraded and non-applied after a successful apply.
     [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
     let ``current branch materialization coordinator reasserts dirty ipc when final clean publication is unproven`` () =
         withTempRepo (fun root ->
@@ -17564,6 +17566,7 @@ module WatchTests =
                 |> should equal true
 
                 events.Add("dirty-ipc-reasserted")
+                true
 
             let outcome =
                 (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
@@ -17591,6 +17594,276 @@ module WatchTests =
                     "clean-ipc-unproven"
                     "dirty-ipc-reasserted"
                     "degraded:materialization final clean Watch IPC/status publication failed"
+                |]
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true)
+
+    /// Verifies a process-local queue observed during final clean publication prevents an applied result.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization coordinator rejects process local work queued during clean publication`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let events = ResizeArray<string>()
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "process-local-final-publication-race"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync reason = events.Add($"degraded:{reason}")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = task { events.Add("apply-complete") }
+
+            let publishCleanIpcAfterApply () =
+                events.Add("clean-write")
+                Watch.setGraceStatusHasChangedForWatchTests true
+
+                let processablePending, hasPendingEvidence = Watch.pendingWatchWorkEvidenceForWatchTests ()
+                processablePending |> should equal true
+                hasPendingEvidence |> should equal true
+                false
+
+            let reassertDirtyIpcAfterFailedCleanPublication () =
+                events.Add("dirty-verified")
+                true
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    publishCleanIpcAfterApply
+                    reassertDirtyIpcAfterFailedCleanPublication
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+            events.ToArray()
+            |> should
+                equal
+                [|
+                    "apply-complete"
+                    "clean-write"
+                    "dirty-verified"
+                    "degraded:materialization final clean Watch IPC/status publication failed"
+                |])
+
+    /// Verifies durable journal work observed during final clean publication prevents an applied result.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization coordinator rejects durable work queued during clean publication`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+            let mutable pendingRows = 0L
+
+            Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                Task.FromResult(
+                    {
+                        LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile
+                        AppliedThroughSequence = 0L
+                        PendingRowCount = pendingRows
+                    }
+                ))
+
+            try
+                let notification =
+                    validCurrentBranchReferenceNotification
+                        currentRepositoryId
+                        currentBranchId
+                        ReferenceType.Save
+                        (Guid.NewGuid())
+                        (Sha256Hash "remote-root")
+                        (Blake3Hash "remote-root-blake3")
+
+                let events = ResizeArray<string>()
+
+                let getBranch () =
+                    Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "durable-final-publication-race"))
+
+                let inspectStatus () = Task.FromResult(watchStatusInspection status)
+                let requestDegradedResync reason = events.Add($"degraded:{reason}")
+                let waitForSafePoint _ _ = Task.FromResult(())
+                let reestablishIpc _ _ = Task.FromResult(())
+                let applyReference _ _ = task { events.Add("apply-complete") }
+
+                let publishCleanIpcAfterApply () =
+                    events.Add("clean-write")
+                    pendingRows <- 1L
+
+                    let processablePending, hasPendingEvidence = Watch.pendingWatchWorkEvidenceForWatchTests ()
+                    processablePending |> should equal false
+                    hasPendingEvidence |> should equal true
+                    false
+
+                let reassertDirtyIpcAfterFailedCleanPublication () =
+                    events.Add("dirty-verified")
+                    true
+
+                let outcome =
+                    (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        publishCleanIpcAfterApply
+                        reassertDirtyIpcAfterFailedCleanPublication
+                        notification)
+                        .Result
+
+                outcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+                events.ToArray()
+                |> should
+                    equal
+                    [|
+                        "apply-complete"
+                        "clean-write"
+                        "dirty-verified"
+                        "degraded:materialization final clean Watch IPC/status publication failed"
+                    |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
+    /// Verifies a clean IPC snapshot already verified by another Watch pass completes materialization without another write.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization coordinator accepts already verified clean publication`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let events = ResizeArray<string>()
+
+            let getBranch () =
+                Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "already-clean-final-publication"))
+
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync _ = Assert.Fail("An already verified clean IPC snapshot must not request degraded resync.")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = task { events.Add("apply-complete") }
+
+            let publishCleanIpcAfterApply () =
+                events.Add("already-clean-verified")
+                true
+
+            let reassertDirtyIpcAfterFailedCleanPublication () =
+                Assert.Fail("An already verified clean IPC snapshot must not reassert dirty IPC.")
+                false
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    publishCleanIpcAfterApply
+                    reassertDirtyIpcAfterFailedCleanPublication
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+
+            events.ToArray()
+            |> should
+                equal
+                [|
+                    "apply-complete"
+                    "already-clean-verified"
+                |])
+
+    /// Verifies an unverified dirty replacement leaves materialization fail-closed on the existing degraded-resync path.
+    [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization coordinator fails closed when dirty replacement is unproven`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let status = liveWatchStatus (Guid.NewGuid())
+
+            let notification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Save
+                    (Guid.NewGuid())
+                    (Sha256Hash "remote-root")
+                    (Blake3Hash "remote-root-blake3")
+
+            let events = ResizeArray<string>()
+            let getBranch () = Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference notification) "dirty-reassertion-failure"))
+            let inspectStatus () = Task.FromResult(watchStatusInspection status)
+            let requestDegradedResync reason = events.Add($"degraded:{reason}")
+            let waitForSafePoint _ _ = Task.FromResult(())
+            let reestablishIpc _ _ = Task.FromResult(())
+            let applyReference _ _ = task { events.Add("apply-complete") }
+
+            let publishCleanIpcAfterApply () =
+                events.Add("clean-unproven")
+                false
+
+            let reassertDirtyIpcAfterFailedCleanPublication () =
+                Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+                |> should equal true
+
+                events.Add("dirty-unproven")
+                false
+
+            let outcome =
+                (Watch.handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+                    getBranch
+                    inspectStatus
+                    requestDegradedResync
+                    waitForSafePoint
+                    reestablishIpc
+                    applyReference
+                    publishCleanIpcAfterApply
+                    reassertDirtyIpcAfterFailedCleanPublication
+                    notification)
+                    .Result
+
+            outcome.Value.Reason
+            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+
+            events.ToArray()
+            |> should
+                equal
+                [|
+                    "apply-complete"
+                    "clean-unproven"
+                    "dirty-unproven"
+                    "degraded:materialization final clean Watch IPC/status publication failed and dirty replacement was unproven"
                 |]
 
             Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13023,6 +13023,157 @@ module WatchTests =
         verifyFailClosed (fun () -> Task.FromException<GraceStatus>(FileNotFoundException("Grace Status is missing")))
         verifyFailClosed (fun () -> Task.FromException<GraceStatus>(IOException("Grace Status is unreadable")))
 
+    /// Verifies a newer resync after verified provisional clean IPC is synchronously reasserted as dirty before the stale recovery returns.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``newer resync after provisional clean publication republishes verified dirty ipc before post-publication return`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let clientPublications = ResizeArray<string>()
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+            let mutable provisionalCleanProbeCalls = 0
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+            let updateIpc currentStatus directoryIds =
+                clientPublications.Add(
+                    if currentStatus.RootDirectoryId = status.RootDirectoryId then
+                        "clean"
+                    else
+                        "dirty"
+                )
+
+                Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+            Watch.setAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests (fun () ->
+                provisionalCleanProbeCalls <- provisionalCleanProbeCalls + 1
+                Watch.requestGraceWatchExplicitResyncForWatchTests "newer resync arrived after verified provisional clean IPC")
+
+            try
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+            finally
+                Watch.resetAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests ()
+
+            clientPublications.ToArray()
+            |> should equal [| "clean"; "dirty" |]
+
+            provisionalCleanProbeCalls |> should equal 1
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            Watch.lastPublishedHasPendingWatchWorkForWatchTests ()
+            |> should equal (Some true)
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+
+                inspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.Resynchronizing)
+            | None -> Assert.Fail("Expected verified dirty Watch IPC after newer resync replaced provisional clean recovery."))
+
+    /// Verifies failed dirty reassertion after provisional clean publication clears cached clean evidence while retaining retry anchors.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``newer resync dirty reassertion failure after provisional clean clears cache and retains retry`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable clientPublicationCalls = 0
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+            let mutable provisionalCleanProbeCalls = 0
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+            let updateIpc currentStatus directoryIds =
+                clientPublicationCalls <- clientPublicationCalls + 1
+
+                if clientPublicationCalls = 1 then
+                    Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+                else
+                    Task.FromException<unit>(InvalidOperationException("dirty reassertion write failed"))
+
+            Watch.setAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests (fun () ->
+                provisionalCleanProbeCalls <- provisionalCleanProbeCalls + 1
+                Watch.requestGraceWatchExplicitResyncForWatchTests "newer resync arrived after verified provisional clean IPC")
+
+            try
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+            finally
+                Watch.resetAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests ()
+
+            clientPublicationCalls |> should equal 2
+            provisionalCleanProbeCalls |> should equal 1
+
+            Watch.lastPublishedHasPendingWatchWorkForWatchTests ()
+            |> should equal None
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+            | None -> Assert.Fail("Expected pre-existing dirty Watch IPC to remain fail-closed after dirty reassertion failed."))
+
     /// Verifies a newer resync that wins after clean verification is retired only after fresh dirty IPC replaces the provisional clean snapshot.
     [<Test; Category("CurrentBranchMaterializationPublication")>]
     let ``newer resync after clean recovery verification republishes dirty ipc before stale attempt returns`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -12905,15 +12905,16 @@ module WatchTests =
             Watch.requestGraceWatchExplicitResyncForWatchTests "superseding recovery cancellation"
             Task.FromResult(List<FileSystemDifference>()))
 
-    /// Verifies successful active resync clears the materialization latch before clean IPC is republished and revalidated.
+    /// Verifies successful active resync retains its pending anchors until clean IPC is republished and verified.
     [<Test; Category("CurrentBranchMaterializationPublication")>]
-    let ``successful resync clears materialization pending latch before clean publication`` () =
+    let ``successful resync clears materialization pending latch only after verified clean publication`` () =
         withTempRepo (fun _ ->
             Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
             Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
 
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let publicationLatchStates = ResizeArray<bool>()
+            let publicationResyncStates = ResizeArray<bool>()
             let readStatus () = Task.FromResult(status)
             let upload _ _ = Task.FromResult(())
             let updateGraceStatus _ _ = Task.FromResult(Some status)
@@ -12923,7 +12924,8 @@ module WatchTests =
 
             let updateIpc _ _ =
                 publicationLatchStates.Add(Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ())
-                Task.FromResult(())
+                publicationResyncStates.Add(Watch.isGraceWatchResyncPendingForWatchTests ())
+                Services.updateGraceWatchInterprocessFile status (Some(HashSet<DirectoryVersionId>(status.Index.Keys)))
 
             (Watch.processChangedFilesWithClients
                 readStatus
@@ -12941,12 +12943,122 @@ module WatchTests =
             |> should equal false
 
             publicationLatchStates.ToArray()
-            |> should equal [| false |]
+            |> should equal [| true |]
+
+            publicationResyncStates.ToArray()
+            |> should equal [| true |]
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
 
             Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
 
             Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
             |> should equal true)
+
+    /// Verifies a swallowed clean recovery write retains the materialization latch and active resync retry.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``swallowed resync clean publication retains materialization latch and retry`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+            | None -> Assert.Fail("Expected existing dirty Watch IPC after swallowed clean recovery publication."))
+
+    /// Verifies new resync work observed during clean recovery publication keeps the IPC dirty and latch retained.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``pending work during resync clean publication retains materialization latch`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable publicationCalls = 0
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            let updateIpc currentStatus directoryIds =
+                publicationCalls <- publicationCalls + 1
+
+                if publicationCalls = 1 then
+                    Watch.requestGraceWatchExplicitResyncForWatchTests "pending work arrived during clean recovery publication"
+
+                Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            publicationCalls
+            |> should be (greaterThanOrEqualTo 2)
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+            | None -> Assert.Fail("Expected dirty Watch IPC after pending work arrived during clean recovery publication."))
 
     /// Verifies that scan-derived file uploads keep resync retryable instead of suspending Watch.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -13194,6 +13194,138 @@ module WatchTests =
                 |> should equal false
             | None -> Assert.Fail("Expected dirty Watch IPC after pending work arrived during clean recovery publication."))
 
+    /// Verifies process-local work that turns a recovery publication dirty cannot be mistaken for verified clean recovery.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``process local work during resync recovery publishes verified dirty ipc without retiring retry state`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable publicationCalls = 0
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            let updateIpc currentStatus directoryIds =
+                publicationCalls <- publicationCalls + 1
+
+                if publicationCalls = 1 then Watch.setGraceStatusHasChangedForWatchTests true
+
+                Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            publicationCalls
+            |> should be (greaterThanOrEqualTo 3)
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                publishedStatus.IsWorkingTreeClean
+                |> should equal false
+            | None -> Assert.Fail("Expected verified dirty Watch IPC after process-local work arrived during recovery publication."))
+
+    /// Verifies durable-only journal work that turns a recovery publication dirty cannot retire retry state.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``durable work during resync recovery publishes verified dirty ipc without retiring retry state`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let mutable pendingRows = 0L
+            let mutable publicationCalls = 0
+
+            Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                Task.FromResult(
+                    {
+                        LocalStateDb.WatchJournalPendingWorkSummary.DbPath = Current().GraceStatusFile
+                        AppliedThroughSequence = 0L
+                        PendingRowCount = pendingRows
+                    }
+                ))
+
+            try
+                let readStatus () = Task.FromResult(status)
+                let upload _ _ = Task.FromResult(())
+                let updateGraceStatus _ _ = Task.FromResult(Some status)
+                let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+                let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+                let applyIncremental _ _ _ = Task.FromResult(())
+
+                let updateIpc currentStatus directoryIds =
+                    publicationCalls <- publicationCalls + 1
+
+                    if publicationCalls = 1 then pendingRows <- 1L
+
+                    Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                publicationCalls
+                |> should be (greaterThanOrEqualTo 2)
+
+                Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+                |> should equal true
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal true
+
+                Watch.currentGraceWatchRuntimeModeForWatchTests ()
+                |> should equal Services.GraceWatchRuntimeMode.Resynchronizing
+
+                pendingRows |> should equal 1L
+
+                let inspection = Services.inspectGraceWatchStatus().Result
+
+                match inspection.Status with
+                | Some publishedStatus ->
+                    publishedStatus.HasPendingWatchWork
+                    |> should equal true
+
+                    publishedStatus.IsWorkingTreeClean
+                    |> should equal false
+                | None -> Assert.Fail("Expected verified dirty Watch IPC after durable work arrived during recovery publication.")
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ())
+
     /// Verifies that scan-derived file uploads keep resync retryable instead of suspending Watch.
     [<Test>]
     let ``resync retries after queued file uploads complete`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -12857,6 +12857,97 @@ module WatchTests =
                 .FilesToProcess
             |> should equal Array.empty<string>)
 
+    /// Verifies failed or superseded resync recovery retains the materialization dirty latch and fail-closed IPC state.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``materialization pending latch remains dirty after failed or superseded resync recovery`` () =
+        let verifyRetainedLatch recovery =
+            withTempRepo (fun _ ->
+                Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+                Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+                let status = graceStatusTracking Array.empty<string> Array.empty<string>
+                let readStatus () = Task.FromResult(status)
+                let upload _ _ = Task.FromResult(())
+                let updateGraceStatus _ _ = Task.FromResult(Some status)
+                let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+                let applyIncremental _ _ _ = Task.FromResult(())
+                let updateIpc _ _ = Task.FromResult(())
+
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    recovery
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+                |> should equal true
+
+                let inspection = Services.inspectGraceWatchStatus().Result
+
+                match inspection.Status with
+                | Some publishedStatus ->
+                    publishedStatus.HasPendingWatchWork
+                    |> should equal true
+
+                    publishedStatus.IsWorkingTreeClean
+                    |> should equal false
+                | None -> Assert.Fail("Expected fail-closed dirty Watch IPC after unsuccessful resync recovery."))
+
+        verifyRetainedLatch (fun _ -> Task.FromException<List<FileSystemDifference>>(InvalidOperationException("resync failed")))
+
+        verifyRetainedLatch (fun _ ->
+            Watch.requestGraceWatchExplicitResyncForWatchTests "superseding recovery cancellation"
+            Task.FromResult(List<FileSystemDifference>()))
+
+    /// Verifies successful active resync clears the materialization latch before clean IPC is republished and revalidated.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``successful resync clears materialization pending latch before clean publication`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let publicationLatchStates = ResizeArray<bool>()
+            let readStatus () = Task.FromResult(status)
+            let upload _ _ = Task.FromResult(())
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences currentStatus _ _ = Task.FromResult(Some currentStatus)
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            let updateIpc _ _ =
+                publicationLatchStates.Add(Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ())
+                Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal false
+
+            publicationLatchStates.ToArray()
+            |> should equal [| false |]
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+            Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
+            |> should equal true)
+
     /// Verifies that scan-derived file uploads keep resync retryable instead of suspending Watch.
     [<Test>]
     let ``resync retries after queued file uploads complete`` () =
@@ -17804,6 +17895,94 @@ module WatchTests =
                     "apply-complete"
                     "already-clean-verified"
                 |])
+
+    /// Verifies a matching stale IPC snapshot is rewritten and re-inspected before final materialization clean success.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization final clean publication rewrites matching stale ipc`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let expectedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            let matchingStaleStatus =
+                { liveWatchStatus expectedStatus.RootDirectoryId with
+                    UpdatedAt =
+                        getCurrentInstant()
+                            .Minus(Duration.FromMinutes(6.0))
+                    RootDirectorySha256Hash = expectedStatus.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = expectedStatus.RootDirectoryBlake3Hash
+                    DirectoryIds = HashSet<DirectoryVersionId>(expectedStatus.Index.Keys)
+                }
+
+            (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(expectedStatus))
+
+            writeWatchStatusJsonWithRuntimeSurface matchingStaleStatus
+            |> ignore
+
+            Services.inspectGraceWatchStatus().Result.IsUsable
+            |> should equal false
+
+            Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
+            |> should equal true
+
+            let inspection = Services.inspectGraceWatchStatus().Result
+
+            inspection.IsUsable |> should equal true
+
+            match inspection.Status with
+            | Some publishedStatus ->
+                publishedStatus.UpdatedAt > matchingStaleStatus.UpdatedAt
+                |> should equal true
+            | None -> Assert.Fail("Expected a fresh verified clean Watch IPC snapshot."))
+
+    /// Verifies matching clean snapshots with persisted degraded modes are rewritten before materialization accepts clean IPC.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``current branch materialization final clean publication rejects matching persisted degraded ipc`` () =
+        withTempRepo (fun _ ->
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            let expectedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            let matchingStatus =
+                { liveWatchStatus expectedStatus.RootDirectoryId with
+                    RootDirectorySha256Hash = expectedStatus.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = expectedStatus.RootDirectoryBlake3Hash
+                    DirectoryIds = HashSet<DirectoryVersionId>(expectedStatus.Index.Keys)
+                }
+
+            (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(expectedStatus))
+
+            for mode in
+                [|
+                    Services.GraceWatchRuntimeMode.Resynchronizing
+                    Services.GraceWatchRuntimeMode.Suspended
+                |] do
+                writeWatchStatusJsonWithPersistedMode mode matchingStatus
+                |> ignore
+
+                Services
+                    .inspectGraceWatchStatus()
+                    .Result
+                    .EffectiveMode
+                |> should equal (Some mode)
+
+                Watch.tryPublishCurrentBranchMaterializationCleanStatusForWatchTests ()
+                |> should equal true
+
+                let inspection = Services.inspectGraceWatchStatus().Result
+
+                inspection.EffectiveMode
+                |> should equal (Some Services.GraceWatchRuntimeMode.HealthyIncremental)
+
+                inspection.IsUsable |> should equal true)
 
     /// Verifies an unverified dirty replacement leaves materialization fail-closed on the existing degraded-resync path.
     [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("CurrentBranchMaterializationPublication")>]

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2297,6 +2297,16 @@ module Watch =
         && expectedRootDirectoryBlake3Hash currentStatus = expectedRootDirectoryBlake3Hash expectedStatus
         && expectedDirectoryIds.SetEquals(currentStatus.Index.Keys)
 
+    /// Re-reads durable GraceStatus for a clean publication return boundary and fails closed when its identity is unavailable or changed.
+    let private tryVerifyCurrentGraceStatusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds =
+        try
+            readGraceStatusFileForPendingWorkTransition()
+                .GetAwaiter()
+                .GetResult()
+            |> graceStatusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds
+        with
+        | _ -> false
+
     /// Verifies the on-disk Watch IPC snapshot is the snapshot this publication attempt wrote.
     let private statusMatchesVerifiedPublication expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt (status: GraceWatchStatus) =
         status.UpdatedAt >= publicationStartedAt
@@ -2456,8 +2466,10 @@ module Watch =
 
                     if finalPendingEvidence.HasPendingWork then
                         UnverifiedRecoveryPublication
-                    else
+                    elif tryVerifyCurrentGraceStatusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds then
                         VerifiedCleanRecoveryPublication
+                    else
+                        UnverifiedRecoveryPublication
                 else
                     UnverifiedRecoveryPublication
             | UnverifiedPendingWorkPublication -> UnverifiedRecoveryPublication
@@ -2623,12 +2635,7 @@ module Watch =
                     let finalCleanPublicationVerified =
                         if cleanPublicationVerified
                            && finalPendingWorkIsEmpty then
-                            let currentStatus =
-                                readGraceStatusFileForPendingWorkTransition()
-                                    .GetAwaiter()
-                                    .GetResult()
-
-                            graceStatusMatchesExpectedPendingWorkPublication status directoryIds currentStatus
+                            tryVerifyCurrentGraceStatusMatchesExpectedPendingWorkPublication status directoryIds
                         else
                             false
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2104,6 +2104,14 @@ module Watch =
     /// Clears a specific resync attempt without losing a newer confidence-loss request.
     let private tryClearGraceWatchResyncAttempt attempt = Interlocked.CompareExchange(&graceWatchResyncGeneration, 0L, attempt) = attempt
 
+    let mutable private beforeGraceWatchResyncAttemptRetirementProbe = fun () -> ()
+
+    /// Overrides the exact resync-attempt retirement probe for deterministic Watch recovery race tests.
+    let internal setBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests probe = beforeGraceWatchResyncAttemptRetirementProbe <- probe
+
+    /// Restores the exact resync-attempt retirement probe after deterministic Watch recovery race tests.
+    let internal resetBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests () = beforeGraceWatchResyncAttemptRetirementProbe <- fun () -> ()
+
     let mutable private manualPendingWatchWorkStatusFlag = 0
 
     /// Reports whether a coordinator-owned side effect must keep Watch IPC dirty before normal queues can observe it.
@@ -2475,6 +2483,16 @@ module Watch =
         with
         | _ -> false
 
+    /// Verifies that the persisted IPC snapshot forces readers away from incremental shortcuts during resync.
+    let private isGraceWatchResyncRequiredStatusPublished (inspection: GraceWatchStatusInspection) =
+        inspection.Status
+        |> Option.exists (fun status ->
+            status.HasPendingWatchWork
+            && not status.IsWorkingTreeClean
+            && not inspection.IsUsable
+            && inspection.EffectiveMode
+               <> Some GraceWatchRuntimeMode.HealthyIncremental)
+
     /// Verifies an already-published clean snapshot through the inspected IPC trust boundary before final materialization success.
     let private tryVerifyCurrentBranchMaterializationCleanPublication expectedStatus expectedDirectoryIds =
         try
@@ -2592,16 +2610,6 @@ module Watch =
 
     /// Completes startup for tests that verify failed recovery does not resume incremental mode.
     let internal promoteStartupModeIfRecoverySucceededForWatchTests () = promoteStartupModeIfRecoverySucceeded ()
-
-    /// Verifies that the persisted IPC snapshot forces readers away from incremental shortcuts during resync.
-    let private isGraceWatchResyncRequiredStatusPublished (inspection: GraceWatchStatusInspection) =
-        inspection.Status
-        |> Option.exists (fun status ->
-            status.HasPendingWatchWork
-            && not status.IsWorkingTreeClean
-            && not inspection.IsUsable
-            && inspection.EffectiveMode
-               <> Some GraceWatchRuntimeMode.HealthyIncremental)
 
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
@@ -2978,6 +2986,7 @@ module Watch =
         readGraceStatusFileForTransitionCompletion <- readGraceStatusFile
         clearShouldIgnoreCache ()
         resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
+        resetBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests ()
         resetSignalRSubscriptionRefreshForWatchTests ()
         resetWatchJournalClientsForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
@@ -6297,9 +6306,11 @@ module Watch =
                                         updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 
                                 if cleanPublicationVerified then
-                                    setGraceWatchPendingWorkStatusFlag false
+                                    beforeGraceWatchResyncAttemptRetirementProbe ()
 
                                     if tryClearGraceWatchResyncAttempt resyncAttempt then
+                                        setGraceWatchPendingWorkStatusFlag false
+
                                         if signalRBranchSubscriptionRefreshNeededForTransition () then
                                             try
                                                 refreshSignalRSubscriptionsAfterTransitionCompletion ()
@@ -6318,9 +6329,24 @@ module Watch =
                                         setGraceWatchPendingWorkStatusFlag true
                                         setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
 
+                                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+
+                                        let dirtyPublicationVerified =
+                                            tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                                                updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
+                                            && (try
+                                                    inspectGraceWatchStatus().GetAwaiter().GetResult()
+                                                    |> isGraceWatchResyncRequiredStatusPublished
+                                                with
+                                                | _ -> false)
+
+                                        if not dirtyPublicationVerified then lastPublishedHasPendingWatchWork <- None
+
+                                        let dirtyPublicationOutcome = if dirtyPublicationVerified then "verified" else "unproven"
+
                                         logToAnsiConsole
-                                            Colors.Important
-                                            $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed clean publication."
+                                            (if dirtyPublicationVerified then Colors.Important else Colors.Error)
+                                            $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed provisional clean publication; dirty resync IPC was {dirtyPublicationOutcome} before return."
                                 else
                                     setGraceWatchPendingWorkStatusFlag true
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2436,6 +2436,17 @@ module Watch =
         with
         | _ -> false
 
+    /// Verifies an already-published clean snapshot through the inspected IPC trust boundary before final materialization success.
+    let private tryVerifyCurrentBranchMaterializationCleanPublication expectedStatus expectedDirectoryIds =
+        try
+            let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+            inspection.IsUsable
+            && (inspection.Status
+                |> Option.exists (statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds false))
+        with
+        | _ -> false
+
     /// Publishes a final clean materialization snapshot only while both pre- and post-publication pending-work probes are empty.
     let private tryPublishCurrentBranchMaterializationCleanStatus () =
         lock watchStatusPublishLock (fun () ->
@@ -2455,12 +2466,21 @@ module Watch =
                     let directoryIds = status.Index.Keys.ToHashSet()
 
                     let cleanPublicationVerified =
-                        if tryVerifyCurrentPendingWorkPublication status directoryIds false then
+                        if tryVerifyCurrentBranchMaterializationCleanPublication status directoryIds then
                             lastPublishedHasPendingWatchWork <- Some false
                             true
                         else
-                            tryPublishWatchIpcWithFreshPendingWorkProbe status directoryIds (fun () ->
-                                updateGraceWatchInterprocessFile status (Some directoryIds))
+                            let published =
+                                tryPublishWatchIpcWithFreshPendingWorkProbe status directoryIds (fun () ->
+                                    updateGraceWatchInterprocessFile status (Some directoryIds))
+
+                            let usableCleanPublication =
+                                published
+                                && tryVerifyCurrentBranchMaterializationCleanPublication status directoryIds
+
+                            if not usableCleanPublication then lastPublishedHasPendingWatchWork <- None
+
+                            usableCleanPublication
 
                     cleanPublicationVerified
                     && not (readPendingWatchWorkEvidence ()).HasPendingWork
@@ -2510,6 +2530,9 @@ module Watch =
                     lastPublishedHasPendingWatchWork <- None
                     logToAnsiConsole Colors.Error $"Grace Watch could not verify dirty materialization IPC/status publication: {ex.Message}"
                     false)
+
+    /// Publishes final clean materialization IPC through the production verification path for focused Watch tests.
+    let internal tryPublishCurrentBranchMaterializationCleanStatusForWatchTests () = tryPublishCurrentBranchMaterializationCleanStatus ()
 
     /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
     let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
@@ -6230,6 +6253,8 @@ module Watch =
                             let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 
                             if clearedResyncAttempt then
+                                setGraceWatchPendingWorkStatusFlag false
+
                                 publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
                                     updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2329,11 +2329,12 @@ module Watch =
         tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds writeSnapshot
         |> ignore
 
-    /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
-    let private publishPendingWatchWorkTransitionIfNeeded () =
+    /// Publishes a clean or dirty Watch IPC transition and reports whether the exact snapshot was verified on disk.
+    let private tryPublishPendingWatchWorkTransitionIfNeeded () =
         lock watchStatusPublishLock (fun () ->
             let pendingEvidence = readPendingWatchWorkEvidence ()
             let hasPendingWork = pendingEvidence.HasPendingWork
+            let mutable transitionWasPublished = false
 
             if
                 File.Exists(IpcFileName())
@@ -2394,7 +2395,7 @@ module Watch =
                         lastPublishedHasPendingWatchWork <- None
                         logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
-                    let transitionWasPublished =
+                    transitionWasPublished <-
                         try
                             let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
 
@@ -2411,7 +2412,14 @@ module Watch =
                         lastPublishedHasPendingWatchWork <- Some hasPendingWork
                     else
                         lastPublishedHasPendingWatchWork <- None
-                        logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check.")
+                        logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check."
+
+            transitionWasPublished)
+
+    /// Publishes only clean/dirty Watch IPC transitions so duplicate raw observations do not churn status.
+    let private publishPendingWatchWorkTransitionIfNeeded () =
+        tryPublishPendingWatchWorkTransitionIfNeeded ()
+        |> ignore
 
     /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
     let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
@@ -4444,6 +4452,8 @@ module Watch =
             WaitForSafePoint: CurrentBranchReferenceNotification -> CurrentBranchMaterializationStatusGate -> Task<unit>
             ReestablishIpc: CurrentBranchReferenceNotification -> string -> Task<unit>
             ApplyReference: CurrentBranchReferenceNotification -> GraceWatchStatus -> Task<unit>
+            PublishCleanIpcAfterApply: unit -> bool
+            ReassertDirtyIpcAfterFailedCleanPublication: unit -> unit
             MaxAttempts: int option
         }
 
@@ -4658,14 +4668,26 @@ module Watch =
                                                             do! clients.ApplyReference payload leaseStatus
 
                                                             setGraceWatchPendingWorkStatusFlag false
-                                                            publishPendingWatchWorkTransitionIfNeeded ()
 
-                                                            return
-                                                                {
-                                                                    ReferenceId = payload.ReferenceId
-                                                                    Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
-                                                                    Decision = Some acceptedDecision
-                                                                }
+                                                            if clients.PublishCleanIpcAfterApply() then
+                                                                return
+                                                                    {
+                                                                        ReferenceId = payload.ReferenceId
+                                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.Applied
+                                                                        Decision = Some acceptedDecision
+                                                                    }
+                                                            else
+                                                                setGraceWatchPendingWorkStatusFlag true
+                                                                clients.ReassertDirtyIpcAfterFailedCleanPublication()
+
+                                                                clients.RequestDegradedResync "materialization final clean Watch IPC/status publication failed"
+
+                                                                return
+                                                                    {
+                                                                        ReferenceId = payload.ReferenceId
+                                                                        Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync
+                                                                        Decision = Some acceptedDecision
+                                                                    }
                                                         with
                                                         | ex ->
                                                             setGraceWatchPendingWorkStatusFlag true
@@ -5007,6 +5029,8 @@ module Watch =
                 WaitForSafePoint = fun _ _ -> Task.FromResult(())
                 ReestablishIpc = fun _ _ -> Task.FromResult(())
                 ApplyReference = fun _ _ -> Task.FromResult(())
+                PublishCleanIpcAfterApply = fun () -> true
+                ReassertDirtyIpcAfterFailedCleanPublication = ignore
                 MaxAttempts = Some 3
             }
             payload
@@ -5023,6 +5047,11 @@ module Watch =
                         WaitForSafePoint = fun _ _ -> task { do! Task.Delay(TimeSpan.FromSeconds(1.0)) }
                         ReestablishIpc = fun _ _ -> task { do! Task.Delay(TimeSpan.FromSeconds(1.0)) }
                         ApplyReference = applyCurrentBranchReferenceMaterialization
+                        PublishCleanIpcAfterApply = tryPublishPendingWatchWorkTransitionIfNeeded
+                        ReassertDirtyIpcAfterFailedCleanPublication =
+                            fun () ->
+                                publishPendingWatchWorkTransitionIfNeeded ()
+                                |> ignore
                         MaxAttempts = None
                     }
                     payload
@@ -5058,6 +5087,42 @@ module Watch =
                             WaitForSafePoint = waitForSafePoint
                             ReestablishIpc = reestablishIpc
                             ApplyReference = applyReference
+                            PublishCleanIpcAfterApply = fun () -> true
+                            ReassertDirtyIpcAfterFailedCleanPublication = ignore
+                            MaxAttempts = Some 3
+                        }
+                        payload
+
+                return Some outcome
+            else
+                return None
+        }
+
+    /// Exposes final clean-publication success and failure ordering to focused coordinator tests.
+    let internal handleCurrentBranchReferenceMaterializationWithPublicationForWatchTests
+        getCurrentBranch
+        inspectLocalStatus
+        requestDegradedResync
+        waitForSafePoint
+        reestablishIpc
+        applyReference
+        publishCleanIpcAfterApply
+        reassertDirtyIpcAfterFailedCleanPublication
+        payload
+        =
+        task {
+            if currentBranchReferenceNotificationTargetsCurrentBranch payload then
+                let! outcome =
+                    runCurrentBranchMaterializationCoordinator
+                        {
+                            GetCurrentBranch = getCurrentBranch
+                            InspectLocalStatus = inspectLocalStatus
+                            RequestDegradedResync = requestDegradedResync
+                            WaitForSafePoint = waitForSafePoint
+                            ReestablishIpc = reestablishIpc
+                            ApplyReference = applyReference
+                            PublishCleanIpcAfterApply = publishCleanIpcAfterApply
+                            ReassertDirtyIpcAfterFailedCleanPublication = reassertDirtyIpcAfterFailedCleanPublication
                             MaxAttempts = Some 3
                         }
                         payload

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2245,22 +2245,25 @@ module Watch =
         else
             Blake3Hash String.Empty
 
-    /// Verifies the on-disk Watch IPC snapshot is the snapshot this publication attempt wrote.
-    let private statusMatchesVerifiedPublication
+    /// Verifies the on-disk Watch IPC snapshot has the exact pending-work and content identity expected by a publication.
+    let private statusMatchesExpectedPendingWorkPublication
         (expectedStatus: GraceStatus)
         (expectedDirectoryIds: HashSet<DirectoryVersionId>)
         hasPendingWork
-        publicationStartedAt
         (status: GraceWatchStatus)
         =
-        status.UpdatedAt >= publicationStartedAt
-        && status.HasPendingWatchWork = hasPendingWork
+        status.HasPendingWatchWork = hasPendingWork
         && status.IsWorkingTreeClean = not hasPendingWork
         && status.RootDirectoryId = expectedStatus.RootDirectoryId
         && status.RootDirectorySha256Hash = expectedStatus.RootDirectorySha256Hash
         && status.RootDirectoryBlake3Hash = expectedRootDirectoryBlake3Hash expectedStatus
         && not (isNull status.DirectoryIds)
         && status.DirectoryIds.SetEquals(expectedDirectoryIds)
+
+    /// Verifies the on-disk Watch IPC snapshot is the snapshot this publication attempt wrote.
+    let private statusMatchesVerifiedPublication expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt (status: GraceWatchStatus) =
+        status.UpdatedAt >= publicationStartedAt
+        && statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork status
 
     /// Advances the pending-work publication cache only after the exact IPC snapshot proves it reached disk.
     let private cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt =
@@ -2315,6 +2318,7 @@ module Watch =
                         cachePendingWatchWorkPublicationIfVerified statusForVerification directoryIdsForVerification hasPendingWork publicationStartedAt
                 with
                 | ex ->
+                    transitionWasPublished <- false
                     lastPublishedHasPendingWatchWork <- None
                     logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
@@ -2322,7 +2326,8 @@ module Watch =
                     (readPendingWatchWorkEvidence ()).HasPendingWork
                     <> hasPendingWork
 
-            transitionWasPublished)
+            transitionWasPublished
+            && not pendingWorkChangedDuringWrite)
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
     let private publishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds writeSnapshot =
@@ -2420,6 +2425,91 @@ module Watch =
     let private publishPendingWatchWorkTransitionIfNeeded () =
         tryPublishPendingWatchWorkTransitionIfNeeded ()
         |> ignore
+
+    /// Verifies the current Watch IPC file still represents the requested pending-work state and GraceStatus identity.
+    let private tryVerifyCurrentPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork =
+        try
+            let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+            inspection.Status
+            |> Option.exists (statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork)
+        with
+        | _ -> false
+
+    /// Publishes a final clean materialization snapshot only while both pre- and post-publication pending-work probes are empty.
+    let private tryPublishCurrentBranchMaterializationCleanStatus () =
+        lock watchStatusPublishLock (fun () ->
+            if (readPendingWatchWorkEvidence ()).HasPendingWork then
+                false
+            elif currentGraceWatchRuntimeMode ()
+                 <> GraceWatchRuntimeMode.HealthyIncremental
+                 || isGraceWatchResyncPending () then
+                false
+            else
+                try
+                    let status =
+                        readGraceStatusFileForPendingWorkTransition()
+                            .GetAwaiter()
+                            .GetResult()
+
+                    let directoryIds = status.Index.Keys.ToHashSet()
+
+                    let cleanPublicationVerified =
+                        if tryVerifyCurrentPendingWorkPublication status directoryIds false then
+                            lastPublishedHasPendingWatchWork <- Some false
+                            true
+                        else
+                            tryPublishWatchIpcWithFreshPendingWorkProbe status directoryIds (fun () ->
+                                updateGraceWatchInterprocessFile status (Some directoryIds))
+
+                    cleanPublicationVerified
+                    && not (readPendingWatchWorkEvidence ()).HasPendingWork
+                with
+                | ex ->
+                    lastPublishedHasPendingWatchWork <- None
+                    logToAnsiConsole Colors.Error $"Grace Watch could not prove final clean materialization IPC/status publication: {ex.Message}"
+                    false)
+
+    /// Replaces an unproven clean materialization snapshot with a verified dirty IPC state before degraded resync begins.
+    let private tryPublishCurrentBranchMaterializationDirtyStatus () =
+        lock watchStatusPublishLock (fun () ->
+            let pendingEvidence = readPendingWatchWorkEvidence ()
+
+            if not pendingEvidence.HasPendingWork then
+                false
+            else
+                try
+                    let runtimeMode = currentGraceWatchRuntimeMode ()
+
+                    let status, directoryIds =
+                        if pendingEvidence.HasDurableOnlyPendingWork then
+                            GraceStatus.Default, HashSet<DirectoryVersionId>()
+                        elif
+                            runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
+                            && not (isGraceWatchResyncPending ())
+                        then
+                            let status =
+                                readGraceStatusFileForPendingWorkTransition()
+                                    .GetAwaiter()
+                                    .GetResult()
+
+                            status, status.Index.Keys.ToHashSet()
+                        else
+                            GraceStatus.Default, HashSet<DirectoryVersionId>()
+
+                    if tryVerifyCurrentPendingWorkPublication status directoryIds true then
+                        lastPublishedHasPendingWatchWork <- Some true
+                        true
+                    else
+                        tryPublishWatchIpcWithFreshPendingWorkProbe status directoryIds (fun () ->
+                            match runtimeMode with
+                            | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode status (Some directoryIds)
+                            | _ -> updateGraceWatchInterprocessFile status (Some directoryIds))
+                with
+                | ex ->
+                    lastPublishedHasPendingWatchWork <- None
+                    logToAnsiConsole Colors.Error $"Grace Watch could not verify dirty materialization IPC/status publication: {ex.Message}"
+                    false)
 
     /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
     let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
@@ -4453,7 +4543,7 @@ module Watch =
             ReestablishIpc: CurrentBranchReferenceNotification -> string -> Task<unit>
             ApplyReference: CurrentBranchReferenceNotification -> GraceWatchStatus -> Task<unit>
             PublishCleanIpcAfterApply: unit -> bool
-            ReassertDirtyIpcAfterFailedCleanPublication: unit -> unit
+            ReassertDirtyIpcAfterFailedCleanPublication: unit -> bool
             MaxAttempts: int option
         }
 
@@ -4678,9 +4768,15 @@ module Watch =
                                                                     }
                                                             else
                                                                 setGraceWatchPendingWorkStatusFlag true
-                                                                clients.ReassertDirtyIpcAfterFailedCleanPublication()
+                                                                let dirtyPublicationVerified = clients.ReassertDirtyIpcAfterFailedCleanPublication()
 
-                                                                clients.RequestDegradedResync "materialization final clean Watch IPC/status publication failed"
+                                                                let resyncReason =
+                                                                    if dirtyPublicationVerified then
+                                                                        "materialization final clean Watch IPC/status publication failed"
+                                                                    else
+                                                                        "materialization final clean Watch IPC/status publication failed and dirty replacement was unproven"
+
+                                                                clients.RequestDegradedResync resyncReason
 
                                                                 return
                                                                     {
@@ -5030,7 +5126,7 @@ module Watch =
                 ReestablishIpc = fun _ _ -> Task.FromResult(())
                 ApplyReference = fun _ _ -> Task.FromResult(())
                 PublishCleanIpcAfterApply = fun () -> true
-                ReassertDirtyIpcAfterFailedCleanPublication = ignore
+                ReassertDirtyIpcAfterFailedCleanPublication = fun () -> true
                 MaxAttempts = Some 3
             }
             payload
@@ -5047,11 +5143,8 @@ module Watch =
                         WaitForSafePoint = fun _ _ -> task { do! Task.Delay(TimeSpan.FromSeconds(1.0)) }
                         ReestablishIpc = fun _ _ -> task { do! Task.Delay(TimeSpan.FromSeconds(1.0)) }
                         ApplyReference = applyCurrentBranchReferenceMaterialization
-                        PublishCleanIpcAfterApply = tryPublishPendingWatchWorkTransitionIfNeeded
-                        ReassertDirtyIpcAfterFailedCleanPublication =
-                            fun () ->
-                                publishPendingWatchWorkTransitionIfNeeded ()
-                                |> ignore
+                        PublishCleanIpcAfterApply = tryPublishCurrentBranchMaterializationCleanStatus
+                        ReassertDirtyIpcAfterFailedCleanPublication = tryPublishCurrentBranchMaterializationDirtyStatus
                         MaxAttempts = None
                     }
                     payload
@@ -5088,7 +5181,7 @@ module Watch =
                             ReestablishIpc = reestablishIpc
                             ApplyReference = applyReference
                             PublishCleanIpcAfterApply = fun () -> true
-                            ReassertDirtyIpcAfterFailedCleanPublication = ignore
+                            ReassertDirtyIpcAfterFailedCleanPublication = fun () -> true
                             MaxAttempts = Some 3
                         }
                         payload

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2283,8 +2283,13 @@ module Watch =
 
         transitionWasPublished
 
-    /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
-    let private tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
+    /// Publishes Watch IPC after reading pending-work evidence inside the serialized status boundary.
+    let private tryPublishWatchIpcWithPendingWorkEvidenceProbe
+        (readPendingWorkEvidence: unit -> PendingWatchWorkEvidence)
+        expectedStatus
+        expectedDirectoryIds
+        (writeSnapshot: unit -> Task<unit>)
+        =
         lock watchStatusPublishLock (fun () ->
             let mutable attempts = 0
             let mutable transitionWasPublished = false
@@ -2292,7 +2297,7 @@ module Watch =
 
             while pendingWorkChangedDuringWrite && attempts < 2 do
                 attempts <- attempts + 1
-                let pendingEvidence = readPendingWatchWorkEvidence ()
+                let pendingEvidence = readPendingWorkEvidence ()
                 let hasPendingWork = pendingEvidence.HasPendingWork
                 setGraceWatchHasPendingWorkForStatus hasPendingWork
                 let publicationStartedAt = getCurrentInstant ()
@@ -2323,11 +2328,45 @@ module Watch =
                     logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
                 pendingWorkChangedDuringWrite <-
-                    (readPendingWatchWorkEvidence ()).HasPendingWork
+                    (readPendingWorkEvidence ()).HasPendingWork
                     <> hasPendingWork
 
             transitionWasPublished
             && not pendingWorkChangedDuringWrite)
+
+    /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
+    let private tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
+        tryPublishWatchIpcWithPendingWorkEvidenceProbe readPendingWatchWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot
+
+    /// Reads new pending work while excluding only the current recovery attempt and its materialization latch.
+    let private readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt =
+        let recoveryStillOwnsPublication =
+            isGraceWatchResyncAttemptCurrent attempt
+            && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+
+        {
+            HasProcessablePendingWork =
+                not recoveryStillOwnsPublication
+                || graceStatusHasChanged
+                || not (
+                    filesToProcess.IsEmpty
+                    && directoriesToProcess.IsEmpty
+                    && statusUpdateTriggers.IsEmpty
+                    && not (hasPendingStatusDifferences ())
+                )
+            HasManualPendingStatusEvidence = false
+            HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence ()
+        }
+
+    /// Publishes clean IPC for one recovered resync attempt while retaining its own fail-closed pending anchors.
+    let private tryPublishWatchIpcForResyncRecovery attempt expectedStatus expectedDirectoryIds writeSnapshot =
+        tryPublishWatchIpcWithPendingWorkEvidenceProbe
+            (fun () -> readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt)
+            expectedStatus
+            expectedDirectoryIds
+            writeSnapshot
+        && isGraceWatchResyncAttemptCurrent attempt
+        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
     let private publishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds writeSnapshot =
@@ -6248,36 +6287,90 @@ module Watch =
                             graceStatus <- newGraceStatus
                             updateGraceStatusDirectoryIds graceStatus
 
+                            let materializationPendingLatchOwned = hasManualPendingWatchWorkStatusFlag ()
+
                             setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
 
-                            let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
+                            if materializationPendingLatchOwned then
+                                let cleanPublicationVerified =
+                                    tryPublishWatchIpcForResyncRecovery resyncAttempt graceStatus graceStatusDirectoryIds (fun () ->
+                                        updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 
-                            if clearedResyncAttempt then
-                                setGraceWatchPendingWorkStatusFlag false
+                                if cleanPublicationVerified then
+                                    setGraceWatchPendingWorkStatusFlag false
 
-                                publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
-                                    updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
+                                    if tryClearGraceWatchResyncAttempt resyncAttempt then
+                                        if signalRBranchSubscriptionRefreshNeededForTransition () then
+                                            try
+                                                refreshSignalRSubscriptionsAfterTransitionCompletion ()
+                                            with
+                                            | ex ->
+                                                completeSignalRBranchSubscriptionRefreshWithoutTrust ()
 
-                                if signalRBranchSubscriptionRefreshNeededForTransition () then
-                                    try
-                                        refreshSignalRSubscriptionsAfterTransitionCompletion ()
-                                    with
-                                    | ex ->
-                                        completeSignalRBranchSubscriptionRefreshWithoutTrust ()
+                                                logToAnsiConsole
+                                                    Colors.Error
+                                                    $"Grace Watch resync recovered local status but could not refresh SignalR parent subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}."
+
+                                        logToAnsiConsole
+                                            Colors.Important
+                                            $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                                    else
+                                        setGraceWatchPendingWorkStatusFlag true
+                                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                                        logToAnsiConsole
+                                            Colors.Important
+                                            $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed clean publication."
+                                else
+                                    setGraceWatchPendingWorkStatusFlag true
+
+                                    if isGraceWatchResyncAttemptCurrent resyncAttempt then
+                                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+
+                                        let dirtyPublicationVerified =
+                                            tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+                                                updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
+
+                                        if not dirtyPublicationVerified then lastPublishedHasPendingWatchWork <- None
 
                                         logToAnsiConsole
                                             Colors.Error
-                                            $"Grace Watch resync recovered local status but could not refresh SignalR parent subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}."
-
-                                logToAnsiConsole
-                                    Colors.Important
-                                    $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                                            $"Grace Watch retained resync attempt {resyncAttempt} because clean recovery IPC publication was unproven."
+                                    else
+                                        logToAnsiConsole
+                                            Colors.Important
+                                            $"Grace Watch retained materialization pending status because recovery publication for stale resync attempt {resyncAttempt} was unproven."
                             else
-                                setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+                                let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 
-                                logToAnsiConsole
-                                    Colors.Important
-                                    $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed."
+                                if clearedResyncAttempt then
+                                    setGraceWatchPendingWorkStatusFlag false
+
+                                    publishWatchIpcWithFreshPendingWorkProbe graceStatus graceStatusDirectoryIds (fun () ->
+                                        updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
+
+                                    if signalRBranchSubscriptionRefreshNeededForTransition () then
+                                        try
+                                            refreshSignalRSubscriptionsAfterTransitionCompletion ()
+                                        with
+                                        | ex ->
+                                            completeSignalRBranchSubscriptionRefreshWithoutTrust ()
+
+                                            logToAnsiConsole
+                                                Colors.Error
+                                                $"Grace Watch resync recovered local status but could not refresh SignalR parent subscription; parent-triggered auto-rebase is disabled until the next successful registration: {Markup.Escape(ex.Message)}."
+
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
+                                else
+                                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                                    logToAnsiConsole
+                                        Colors.Important
+                                        $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed."
                         | Some _ ->
                             logToAnsiConsole
                                 Colors.Important

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2286,6 +2286,17 @@ module Watch =
         && not (isNull status.DirectoryIds)
         && status.DirectoryIds.SetEquals(expectedDirectoryIds)
 
+    /// Verifies the current durable GraceStatus still has the exact identity represented by a clean IPC publication.
+    let private graceStatusMatchesExpectedPendingWorkPublication
+        (expectedStatus: GraceStatus)
+        (expectedDirectoryIds: HashSet<DirectoryVersionId>)
+        (currentStatus: GraceStatus)
+        =
+        currentStatus.RootDirectoryId = expectedStatus.RootDirectoryId
+        && currentStatus.RootDirectorySha256Hash = expectedStatus.RootDirectorySha256Hash
+        && expectedRootDirectoryBlake3Hash currentStatus = expectedRootDirectoryBlake3Hash expectedStatus
+        && expectedDirectoryIds.SetEquals(currentStatus.Index.Keys)
+
     /// Verifies the on-disk Watch IPC snapshot is the snapshot this publication attempt wrote.
     let private statusMatchesVerifiedPublication expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt (status: GraceWatchStatus) =
         status.UpdatedAt >= publicationStartedAt
@@ -2572,7 +2583,7 @@ module Watch =
     let private tryVerifyCurrentBranchMaterializationCleanPublication expectedStatus expectedDirectoryIds =
         tryVerifyUsableHealthyCleanPendingWorkPublication expectedStatus expectedDirectoryIds
 
-    /// Publishes a final clean materialization snapshot only while both pre- and post-publication pending-work probes are empty.
+    /// Publishes a final clean materialization snapshot only while pending work is empty and durable status identity remains current.
     let private tryPublishCurrentBranchMaterializationCleanStatus () =
         lock watchStatusPublishLock (fun () ->
             if (readPendingWatchWorkEvidence ()).HasPendingWork then
@@ -2607,8 +2618,24 @@ module Watch =
 
                             usableCleanPublication
 
-                    cleanPublicationVerified
-                    && not (readPendingWatchWorkEvidence ()).HasPendingWork
+                    let finalPendingWorkIsEmpty = not (readPendingWatchWorkEvidence ()).HasPendingWork
+
+                    let finalCleanPublicationVerified =
+                        if cleanPublicationVerified
+                           && finalPendingWorkIsEmpty then
+                            let currentStatus =
+                                readGraceStatusFileForPendingWorkTransition()
+                                    .GetAwaiter()
+                                    .GetResult()
+
+                            graceStatusMatchesExpectedPendingWorkPublication status directoryIds currentStatus
+                        else
+                            false
+
+                    if not finalCleanPublicationVerified then
+                        lastPublishedHasPendingWatchWork <- None
+
+                    finalCleanPublicationVerified
                 with
                 | ex ->
                     lastPublishedHasPendingWatchWork <- None

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2162,6 +2162,24 @@ module Watch =
             && not this.HasProcessablePendingWork
             && not this.HasManualPendingStatusEvidence
 
+    /// Distinguishes exact IPC verification from the pending-work state that snapshot advertises.
+    type private PendingWatchWorkPublicationVerification =
+        /// A verified IPC snapshot advertises no pending Watch work.
+        | VerifiedCleanPendingWorkPublication
+        /// A verified IPC snapshot advertises pending Watch work.
+        | VerifiedDirtyPendingWorkPublication
+        /// No stable IPC snapshot was verified for the attempted publication.
+        | UnverifiedPendingWorkPublication
+
+    /// Distinguishes a verified clean recovery from a verified dirty recovery publication that must retain retry state.
+    type private ResyncRecoveryPublicationResult =
+        /// The recovered status is clean, inspected as usable and healthy, and has no fresh pending-work evidence.
+        | VerifiedCleanRecoveryPublication
+        /// Recovery wrote and verified a dirty IPC snapshot, so latch and resync retirement remain forbidden.
+        | VerifiedDirtyRecoveryPublication
+        /// Recovery could not prove a clean result and must retain fail-closed pending state.
+        | UnverifiedRecoveryPublication
+
     /// Reports whether Watch has queued process-local work other than a startup catch-up marker.
     let private hasProcessablePendingWatchWorkExceptManual () =
         isGraceWatchResyncPending ()
@@ -2292,7 +2310,7 @@ module Watch =
         transitionWasPublished
 
     /// Publishes Watch IPC after reading pending-work evidence inside the serialized status boundary.
-    let private tryPublishWatchIpcWithPendingWorkEvidenceProbe
+    let private tryPublishWatchIpcWithPendingWorkEvidenceProbeResult
         (readPendingWorkEvidence: unit -> PendingWatchWorkEvidence)
         expectedStatus
         expectedDirectoryIds
@@ -2302,6 +2320,7 @@ module Watch =
             let mutable attempts = 0
             let mutable transitionWasPublished = false
             let mutable pendingWorkChangedDuringWrite = true
+            let mutable publishedHasPendingWork = None
 
             while pendingWorkChangedDuringWrite && attempts < 2 do
                 attempts <- attempts + 1
@@ -2329,9 +2348,12 @@ module Watch =
 
                     transitionWasPublished <-
                         cachePendingWatchWorkPublicationIfVerified statusForVerification directoryIdsForVerification hasPendingWork publicationStartedAt
+
+                    publishedHasPendingWork <- if transitionWasPublished then Some hasPendingWork else None
                 with
                 | ex ->
                     transitionWasPublished <- false
+                    publishedHasPendingWork <- None
                     lastPublishedHasPendingWatchWork <- None
                     logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
 
@@ -2339,8 +2361,37 @@ module Watch =
                     (readPendingWorkEvidence ()).HasPendingWork
                     <> hasPendingWork
 
-            transitionWasPublished
-            && not pendingWorkChangedDuringWrite)
+            match transitionWasPublished, pendingWorkChangedDuringWrite, publishedHasPendingWork with
+            | true, false, Some false -> VerifiedCleanPendingWorkPublication
+            | true, false, Some true -> VerifiedDirtyPendingWorkPublication
+            | _ -> UnverifiedPendingWorkPublication)
+
+    /// Reports whether a pending-work publication result proved that any exact IPC snapshot reached disk.
+    let private isPendingWatchWorkPublicationVerified publicationResult =
+        match publicationResult with
+        | VerifiedCleanPendingWorkPublication
+        | VerifiedDirtyPendingWorkPublication -> true
+        | UnverifiedPendingWorkPublication -> false
+
+    /// Publishes Watch IPC after reading pending-work evidence inside the serialized status boundary.
+    let private tryPublishWatchIpcWithPendingWorkEvidenceProbe readPendingWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot =
+        tryPublishWatchIpcWithPendingWorkEvidenceProbeResult readPendingWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot
+        |> isPendingWatchWorkPublicationVerified
+
+    /// Verifies that the inspected Watch IPC snapshot is a usable healthy clean publication of the expected status.
+    let private isUsableHealthyCleanPendingWorkPublication expectedStatus expectedDirectoryIds (inspection: GraceWatchStatusInspection) =
+        inspection.IsUsable
+        && inspection.EffectiveMode = Some GraceWatchRuntimeMode.HealthyIncremental
+        && (inspection.Status
+            |> Option.exists (statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds false))
+
+    /// Reads the inspected Watch IPC snapshot and proves it is usable, healthy, clean, and matches the expected status.
+    let private tryVerifyUsableHealthyCleanPendingWorkPublication expectedStatus expectedDirectoryIds =
+        try
+            inspectGraceWatchStatus().GetAwaiter().GetResult()
+            |> isUsableHealthyCleanPendingWorkPublication expectedStatus expectedDirectoryIds
+        with
+        | _ -> false
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
     let private tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
@@ -2368,13 +2419,37 @@ module Watch =
 
     /// Publishes clean IPC for one recovered resync attempt while retaining its own fail-closed pending anchors.
     let private tryPublishWatchIpcForResyncRecovery attempt expectedStatus expectedDirectoryIds writeSnapshot =
-        tryPublishWatchIpcWithPendingWorkEvidenceProbe
-            (fun () -> readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt)
-            expectedStatus
-            expectedDirectoryIds
-            writeSnapshot
-        && isGraceWatchResyncAttemptCurrent attempt
-        && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+        let publicationResult =
+            tryPublishWatchIpcWithPendingWorkEvidenceProbeResult
+                (fun () -> readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt)
+                expectedStatus
+                expectedDirectoryIds
+                writeSnapshot
+
+        if
+            not (isGraceWatchResyncAttemptCurrent attempt)
+            || currentGraceWatchRuntimeMode ()
+               <> GraceWatchRuntimeMode.HealthyIncremental
+        then
+            UnverifiedRecoveryPublication
+        else
+            match publicationResult with
+            | VerifiedDirtyPendingWorkPublication -> VerifiedDirtyRecoveryPublication
+            | VerifiedCleanPendingWorkPublication ->
+                let postPublicationEvidence = readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt
+
+                if postPublicationEvidence.HasPendingWork then
+                    UnverifiedRecoveryPublication
+                elif tryVerifyUsableHealthyCleanPendingWorkPublication expectedStatus expectedDirectoryIds then
+                    let finalPendingEvidence = readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt
+
+                    if finalPendingEvidence.HasPendingWork then
+                        UnverifiedRecoveryPublication
+                    else
+                        VerifiedCleanRecoveryPublication
+                else
+                    UnverifiedRecoveryPublication
+            | UnverifiedPendingWorkPublication -> UnverifiedRecoveryPublication
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
     let private publishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds writeSnapshot =
@@ -2495,14 +2570,7 @@ module Watch =
 
     /// Verifies an already-published clean snapshot through the inspected IPC trust boundary before final materialization success.
     let private tryVerifyCurrentBranchMaterializationCleanPublication expectedStatus expectedDirectoryIds =
-        try
-            let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
-
-            inspection.IsUsable
-            && (inspection.Status
-                |> Option.exists (statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds false))
-        with
-        | _ -> false
+        tryVerifyUsableHealthyCleanPendingWorkPublication expectedStatus expectedDirectoryIds
 
     /// Publishes a final clean materialization snapshot only while both pre- and post-publication pending-work probes are empty.
     let private tryPublishCurrentBranchMaterializationCleanStatus () =
@@ -6301,11 +6369,12 @@ module Watch =
                             setGraceWatchRuntimeMode GraceWatchRuntimeMode.HealthyIncremental
 
                             if materializationPendingLatchOwned then
-                                let cleanPublicationVerified =
+                                let recoveryPublication =
                                     tryPublishWatchIpcForResyncRecovery resyncAttempt graceStatus graceStatusDirectoryIds (fun () ->
                                         updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
 
-                                if cleanPublicationVerified then
+                                match recoveryPublication with
+                                | VerifiedCleanRecoveryPublication ->
                                     beforeGraceWatchResyncAttemptRetirementProbe ()
 
                                     if tryClearGraceWatchResyncAttempt resyncAttempt then
@@ -6347,7 +6416,7 @@ module Watch =
                                         logToAnsiConsole
                                             (if dirtyPublicationVerified then Colors.Important else Colors.Error)
                                             $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed provisional clean publication; dirty resync IPC was {dirtyPublicationOutcome} before return."
-                                else
+                                | recoveryPublication ->
                                     setGraceWatchPendingWorkStatusFlag true
 
                                     if isGraceWatchResyncAttemptCurrent resyncAttempt then
@@ -6361,13 +6430,19 @@ module Watch =
 
                                         if not dirtyPublicationVerified then lastPublishedHasPendingWatchWork <- None
 
+                                        let recoveryPublicationOutcome =
+                                            match recoveryPublication with
+                                            | VerifiedDirtyRecoveryPublication -> "verified dirty"
+                                            | UnverifiedRecoveryPublication -> "unproven"
+                                            | VerifiedCleanRecoveryPublication -> "unexpected verified clean"
+
                                         logToAnsiConsole
                                             Colors.Error
-                                            $"Grace Watch retained resync attempt {resyncAttempt} because clean recovery IPC publication was unproven."
+                                            $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was {recoveryPublicationOutcome}, not a verified clean recovery."
                                     else
                                         logToAnsiConsole
                                             Colors.Important
-                                            $"Grace Watch retained materialization pending status because recovery publication for stale resync attempt {resyncAttempt} was unproven."
+                                            $"Grace Watch retained materialization pending status because recovery publication for stale resync attempt {resyncAttempt} was not a verified clean recovery."
                             else
                                 let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -2112,6 +2112,16 @@ module Watch =
     /// Restores the exact resync-attempt retirement probe after deterministic Watch recovery race tests.
     let internal resetBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests () = beforeGraceWatchResyncAttemptRetirementProbe <- fun () -> ()
 
+    let mutable private afterGraceWatchResyncRecoveryProvisionalCleanPublicationProbe = fun () -> ()
+
+    /// Overrides the post-clean recovery probe for deterministic stale-attempt publication tests.
+    let internal setAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests probe =
+        afterGraceWatchResyncRecoveryProvisionalCleanPublicationProbe <- probe
+
+    /// Restores the post-clean recovery probe after deterministic stale-attempt publication tests.
+    let internal resetAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests () =
+        afterGraceWatchResyncRecoveryProvisionalCleanPublicationProbe <- fun () -> ()
+
     let mutable private manualPendingWatchWorkStatusFlag = 0
 
     /// Reports whether a coordinator-owned side effect must keep Watch IPC dirty before normal queues can observe it.
@@ -2253,6 +2263,9 @@ module Watch =
 
     /// Reports whether focused Watch tests still have the manual materialization pending marker set.
     let internal hasManualPendingWatchWorkStatusFlagForWatchTests () = hasManualPendingWatchWorkStatusFlag ()
+
+    /// Reports the cached pending-work result so recovery tests can prove failed dirty reassertion discards clean evidence.
+    let internal lastPublishedHasPendingWatchWorkForWatchTests () = lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork)
 
     /// Reports whether the last verified IPC pending-work publication is stale against fresh evidence.
     let private pendingWatchWorkTransitionNeedsPublication () =
@@ -2447,6 +2460,9 @@ module Watch =
                 expectedDirectoryIds
                 writeSnapshot
 
+        if publicationResult = VerifiedCleanPendingWorkPublication then
+            afterGraceWatchResyncRecoveryProvisionalCleanPublicationProbe ()
+
         if
             not (isGraceWatchResyncAttemptCurrent attempt)
             || currentGraceWatchRuntimeMode ()
@@ -2590,6 +2606,27 @@ module Watch =
             && not inspection.IsUsable
             && inspection.EffectiveMode
                <> Some GraceWatchRuntimeMode.HealthyIncremental)
+
+    /// Replaces provisional clean recovery IPC with verified dirty resync IPC before a recovery attempt returns without exact retirement.
+    let private reassertDirtyResyncIpcAfterProvisionalCleanRecovery attempt writeSnapshot =
+        setGraceWatchPendingWorkStatusFlag true
+
+        if isGraceWatchResyncAttemptCurrent attempt then
+            setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+
+        let dirtyPublicationVerified =
+            tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () -> writeSnapshot GraceStatus.Default emptyDirectoryIds)
+            && (try
+                    inspectGraceWatchStatus().GetAwaiter().GetResult()
+                    |> isGraceWatchResyncRequiredStatusPublished
+                with
+                | _ -> false)
+
+        if not dirtyPublicationVerified then lastPublishedHasPendingWatchWork <- None
+
+        dirtyPublicationVerified
 
     /// Verifies an already-published clean snapshot through the inspected IPC trust boundary before final materialization success.
     let private tryVerifyCurrentBranchMaterializationCleanPublication expectedStatus expectedDirectoryIds =
@@ -3089,6 +3126,7 @@ module Watch =
         clearShouldIgnoreCache ()
         resetBranchTransitionCompletionAfterRetireProbeForWatchTests ()
         resetBeforeGraceWatchResyncAttemptRetirementProbeForWatchTests ()
+        resetAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests ()
         resetSignalRSubscriptionRefreshForWatchTests ()
         resetWatchJournalClientsForWatchTests ()
         enumerateFilesForDirectoryUpload <- fun directoryPath -> Directory.EnumerateFiles(directoryPath, "*", SearchOption.AllDirectories)
@@ -6429,21 +6467,9 @@ module Watch =
                                             Colors.Important
                                             $"Grace Watch resync applied {scanDerivedDifferences.Count} scan-derived differences; incremental observations may resume."
                                     else
-                                        setGraceWatchPendingWorkStatusFlag true
-                                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
-
-                                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
-
                                         let dirtyPublicationVerified =
-                                            tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                                                updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
-                                            && (try
-                                                    inspectGraceWatchStatus().GetAwaiter().GetResult()
-                                                    |> isGraceWatchResyncRequiredStatusPublished
-                                                with
-                                                | _ -> false)
-
-                                        if not dirtyPublicationVerified then lastPublishedHasPendingWatchWork <- None
+                                            reassertDirtyResyncIpcAfterProvisionalCleanRecovery resyncAttempt (fun status directoryIds ->
+                                                updateGraceWatchInterprocessFileClient status (Some directoryIds))
 
                                         let dirtyPublicationOutcome = if dirtyPublicationVerified then "verified" else "unproven"
 
@@ -6451,32 +6477,21 @@ module Watch =
                                             (if dirtyPublicationVerified then Colors.Important else Colors.Error)
                                             $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed provisional clean publication; dirty resync IPC was {dirtyPublicationOutcome} before return."
                                 | recoveryPublication ->
-                                    setGraceWatchPendingWorkStatusFlag true
+                                    let dirtyPublicationVerified =
+                                        reassertDirtyResyncIpcAfterProvisionalCleanRecovery resyncAttempt (fun status directoryIds ->
+                                            updateGraceWatchInterprocessFileClient status (Some directoryIds))
 
-                                    if isGraceWatchResyncAttemptCurrent resyncAttempt then
-                                        setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+                                    let recoveryPublicationOutcome =
+                                        match recoveryPublication with
+                                        | VerifiedDirtyRecoveryPublication -> "verified dirty"
+                                        | UnverifiedRecoveryPublication -> "unproven"
+                                        | VerifiedCleanRecoveryPublication -> "unexpected verified clean"
 
-                                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                                    let dirtyPublicationOutcome = if dirtyPublicationVerified then "verified" else "unproven"
 
-                                        let dirtyPublicationVerified =
-                                            tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                                                updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
-
-                                        if not dirtyPublicationVerified then lastPublishedHasPendingWatchWork <- None
-
-                                        let recoveryPublicationOutcome =
-                                            match recoveryPublication with
-                                            | VerifiedDirtyRecoveryPublication -> "verified dirty"
-                                            | UnverifiedRecoveryPublication -> "unproven"
-                                            | VerifiedCleanRecoveryPublication -> "unexpected verified clean"
-
-                                        logToAnsiConsole
-                                            Colors.Error
-                                            $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was {recoveryPublicationOutcome}, not a verified clean recovery."
-                                    else
-                                        logToAnsiConsole
-                                            Colors.Important
-                                            $"Grace Watch retained materialization pending status because recovery publication for stale resync attempt {resyncAttempt} was not a verified clean recovery."
+                                    logToAnsiConsole
+                                        (if dirtyPublicationVerified then Colors.Important else Colors.Error)
+                                        $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was {recoveryPublicationOutcome}, not a verified clean recovery; dirty resync IPC was {dirtyPublicationOutcome} before return."
                             else
                                 let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
 


### PR DESCRIPTION
## Summary

Completes #681, the final #677 WS7.4 rewrite leaf.

Clean materialized Watch IPC is now acknowledged as successful only after exact Reference apply, durable status persistence, update-marker closure, and verified final clean publication. If final clean publication cannot be proven, Watch restores its internal pending marker, reasserts dirty IPC, requests degraded/resync, and does not report the Reference as applied.

Related to #681. Part of #677, #479, and #473.

## Scope

- Makes final clean IPC publication return a verified success/failure result to the materialization coordinator.
- Adds deterministic success-ordering and failed-publication dirty/degraded proofs.
- Preserves public CLI JSON, Watch IPC DTO, and `GraceWatchStatus` shapes.
- Adds ADR 0010 for the current-branch materialization trust boundary.
- Adds a durable final WS7.4 audit mapping all thirteen #677 decisions and every child leaf to implementation and proof.

## Product Contract

- Notifications remain triggers; BranchDto latest Reference is the server-side staleness check.
- Same-branch materialization remains exact and serialized.
- No broad scans, apply-time object downloads, local Saves, root-history ledgers, or new public blocked-state fields.
- Ambiguous or unproven state remains dirty and enters degraded/resync.
- Clean status is published only after apply, durable update, marker closure, and verified publication.

## Validation

- Targeted Fantomas passed.
- `CurrentBranchMaterializationPublication`: 2/2 passed.
- `CurrentBranchMaterializationCoordinator`: 36/36 passed.
- MarkdownLint passed for ADR and audit with repo MD013=120.
- `git diff --check` and bot-prevention structural self-review passed.
- Local Full retry visibly passed build with 0 warnings/errors, Types 140/140, Authorization 53/53, and Server.Unit 738/738, but the command transport detached before final Aspire/CLI totals and exit code; no local Full pass is claimed.
- GitHub Full on the PR head is the authoritative full-suite gate.

## Review Status

- Current head: `3be2182dee73803a513b5b822c9e6c89fc47a98d`.
- Session 6 stabilization extension: implemented; finding replied to and resolved.
- Focused validation: Fantomas and Release build passed; publication/coordinator tests 53/53; `git diff --check` and bot-prevention self-review passed.
- Local Full: build completed; captured Full test phase passed CLI 1,131, Types 140, Authorization 53, Server.Unit 738, Aspire Server 247.
- GitHub Full: running on current head.
- Codex Code Review Bot: awaiting fresh current-head result.
- Prevention: final empty pending probe is followed by exact current durable status identity comparison; advanced status rejects older clean IPC, with no history-based root ban.
- Merge remains blocked until GitHub Full and current-head no-findings Codex review pass.
## Docs And Audit

- ADR: `docs/adr/0010-current-branch-materialization-trust-boundary.md` because ADRs 0007-0009 already exist.
- Audit: `docs/Current branch materialization final audit.md`.
- #506 and WS6 tracker boundaries were audited and already align with #677; no correction is required.

## Session 2 Structural Stabilization Ledger

Codex reviewed current head `20680d64aa083d4e3556d26814ea5d961b0071eb` after GitHub Full passed and found two implementation defects in the final-publication lifecycle:

1. `3565809728`: the already-verified clean shortcut checks matching status identity but not IPC freshness/effective healthy mode, so stale or degraded snapshots can be accepted as final clean.
2. `3565809732`: failed final publication restores the manual materialization pending latch, but successful degraded/resync recovery does not clear that latch, leaving materialization blocked indefinitely.

This is the second substantive review cycle on the high-risk Watch/IPC/side-effect-ordering surface, so ordinary one-off patching is replaced by this structural ledger before more coding.

No product decision or new domain construct is required. Existing #677/#681 decisions and current IPC inspection/recovery constructs determine the fix.

### Missing Lifecycle Invariants

1. **Final clean proof means usable clean IPC.** A shortcut may accept an existing snapshot only when the inspection proves freshness, effective healthy mode, matching branch/root identity, clean pending-work state, and the intended durable status. Raw status equality is insufficient.
2. **The manual materialization pending latch has bounded ownership.** It is set to preserve dirty IPC while final clean is unproven, remains set through degraded/resync work, and is cleared exactly when that requested recovery succeeds and before the clean republish/revalidation that follows. Failure/cancellation keeps it fail-closed.
3. **Recovery cannot self-block forever.** A latch created solely for dirty reassertion must not remain as artificial process-local work after successful recovery.
4. **Publication and recovery share one proof vocabulary.** Existing inspection freshness/effective-mode rules and pending-work evidence determine usable clean/dirty outcomes; do not create parallel trust predicates.

### Required Proof

- Matching but stale clean IPC is not accepted without a fresh verified write.
- Matching clean IPC with persisted/effective degraded or resync mode is not accepted.
- Successful degraded recovery clears the manual materialization latch at the correct safe point and permits subsequent clean publication/materialization.
- Failed or cancelled degraded recovery retains the latch and remains dirty/fail-closed.
- Existing process-local/durable race, verified-dirty, already-clean-healthy, and failed-dirty-reassertion proofs remain green.
- Self-review every set/clear site for the manual pending latch and every shortcut that accepts existing IPC.

One fresh GPT-5.6-Terra High structural worker may implement this ledger. Public status shapes and the materialization state model remain unchanged.

## Session 3 Stabilization Ledger Extension

Codex reviewed current head `c1da8b04ffbef9de3daca54bf8ec2dbb28b1a2a4` after GitHub Full passed and found one remaining lifecycle defect:

- `3565841268`: the active recovery path clears the manual materialization pending latch and resync attempt before checking whether the clean IPC republish was verified. A failed/swallowed IPC write can therefore drop the only process-local pending evidence while final clean remains unproven.

No product decision or new construct is required. This completes the existing Session 2 latch-ownership invariant rather than changing the product model.

### Revised Recovery Invariant

A materialization-triggered degraded recovery is successful only when all of these are true in order:

1. the active resync attempt still wins;
2. scan/status recovery succeeds;
3. the manual pending latch remains set while clean IPC publication is attempted;
4. fresh pending-work proof and clean IPC write/verification succeed;
5. only then are the manual latch and completed resync attempt retired.

If publication or verification fails, the latch remains or is restored, IPC remains dirty/fail-closed, and the existing degraded/resync retry path remains active. Do not clear the only pending evidence or report recovery complete before verified clean publication.

### Required Proof

- Successful recovery publication clears the latch and retires the resync attempt only after verification.
- Failed or swallowed recovery clean write retains/restores the latch and retry state.
- Pending work arriving during recovery publication remains dirty and does not retire the latch.
- Superseded/cancelled recovery remains fail-closed.
- All Session 1-2 publication/coordinator tests remain green.

One fresh GPT-5.6-Terra High worker may implement this ledger extension. No public shape or materialization state construct may be added.

## Session 4 Stabilization Ledger Extension

Codex reviewed current head `43d85a2cea81c84bc89f06d4a8846a2a2907be1e` after GitHub Full passed and found one remaining compare-exchange race:

- `3565889644`: after verified clean recovery publication, a newer resync can win before the old exact attempt is cleared. The failed clear branch restores only process-local latch/mode and leaves the just-written clean IPC snapshot visible to other commands.

No product decision or new construct is required. This is the final commit-point case of the existing recovery transaction.

### Commit-Point Invariant

Verified clean publication is provisional until the exact resync attempt is retired successfully. If `tryClearGraceWatchResyncAttempt` loses to a newer attempt after clean publication:

1. restore/retain the manual materialization latch;
2. publish and verify dirty/resync-required IPC for the current newer attempt/state;
3. do not report the old recovery as complete or clean;
4. keep the newer resync pending and fail-closed.

The external IPC snapshot and process-local latch/resync state must agree at every return boundary. A provisional clean write cannot escape when exact-attempt retirement fails.

### Required Proof

- Newer resync arriving between final clean verification and compare-exchange clear produces verified dirty/resync IPC and retains pending state.
- Dirty reassertion failure remains fail-closed with latch/retry evidence.
- Normal successful exact-attempt retirement still clears latch and remains clean.
- All Session 1-3 publication/recovery and full CLI tests remain green.
- Self-review every return after provisional clean publication and before/after exact-attempt retirement.

One fresh GPT-5.6-Terra High worker may implement this focused extension. Public contracts and state constructs remain unchanged.

## Session 5 Stabilization Ledger Extension

Codex reviewed current head `a409225de991c564198069bc6d6fdb87a4651eec` after GitHub Full passed and found one semantic-result defect:

- `3565930325`: `tryPublishWatchIpcWithPendingWorkEvidenceProbe` returns true for any stable verified publication, including a verified dirty snapshot produced when work arrives during recovery. The recovery caller interprets true as verified clean and can retire latch/resync while pending work exists.

No product decision or new construct is required. This is a type/meaning violation inside the existing clean-retirement ledger.

### Clean-Only Result Invariant

The recovery publication helper used to authorize latch/resync retirement may return success only when post-publication evidence proves:

- the publication is verified;
- `HasPendingWatchWork = false`;
- fresh process-local and durable pending-work evidence remains empty;
- IPC inspection is usable/healthy and matches the intended recovered status.

A verified dirty publication is a successful dirty write but is not clean recovery success. It must keep the materialization latch and resync attempt pending.

### Required Proof

- Process-local work arriving during recovery publishes/verifies dirty state but returns clean-recovery false and retains latch/resync.
- Durable-only journal work behaves the same.
- Stable verified clean returns true and retires exact attempt normally.
- Failed verification and newer-attempt races remain fail-closed.
- Prefer a result shape/name that cannot conflate “publication verified” with “clean recovery verified,” using existing internal types or a minimal private discriminated result if needed; no public contract change.
- All prior Session 1-4 proofs and full CLI remain green.

One fresh GPT-5.6-Terra High worker may implement this focused semantic correction.

## Session 6 Stabilization Ledger Extension

Codex reviewed current head `6f47b1ccfc778365a545a57058b8262f6701efaf` after GitHub Full passed and found one final status-identity race:

- `3565970069`: after the helper reads status and publishes, another Watch path can process/drain a new observation, advance durable `GraceStatus`, and block on the IPC lock. The final pending-work probe then sees empty queues, allowing the older clean IPC identity to be accepted while durable status has advanced.

No product decision or new construct is required. This is a missing final identity check in the existing clean-only publication proof.

### Final Identity Invariant

After the final pending-work probe reports empty, clean publication success must re-read or compare the current durable `GraceStatus` identity/generation against the exact status represented by the verified IPC snapshot. Success requires both:

- no pending local/durable work; and
- durable status identity still equals the verified clean publication identity at the return boundary.

If durable status advanced, the publication is stale even though queues are empty. Return non-clean/fail-closed so the newer Watch path publishes its current status; do not report materialization `Applied` from the older snapshot.

### Required Proof

- Observation processed and queues drained between status read and final probe advances durable status; older clean publication is rejected.
- Stable unchanged durable status still accepts verified clean.
- Status changes to a newer root and legitimate status changes back are compared by exact current identity, not permanently banned history.
- Process-local/durable pending, verified dirty, recovery latch, CAS-race, and all Session 1-5 proofs remain green.
- Reuse existing status identity/generation fields; no root-history or new public contract.

One fresh GPT-5.6-Terra High worker may implement this focused identity closure.





