### PR TITLE
Reset WS4 pricing scope to owner identifiers

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -6,8 +6,8 @@ schema is intentionally narrow:
 - `ops.RawUsageFact` stores immutable `UsageFact` rows with `UsageFactId` as the duplicate-delivery boundary and keeps
   the exact accepted broker payload in `RawPayload` for replay and audit.
 - `ops.UsageAggregateMinute` stores one aggregate row per fact kind, Grace scope, storage pool, and UTC minute.
-- `ops.ChargePreviewLine` stores deterministic provisional customer charge lines rebuilt from compact immutable usage
-  facts and complete effective pricing. A rebuild atomically replaces one customer/repository/half-open-period scope;
+- `ops.ChargePreviewLine` stores deterministic provisional owner charge lines rebuilt from compact immutable usage
+  facts and complete effective pricing. A rebuild atomically replaces one owner/repository/half-open-period scope;
   these rows are neither invoices nor immutable ledger entries.
 - The EF migrations history table lives in `ops.__EFMigrationsHistory` so operations schema state stays with the
   operations schema.

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260709110000_AddPricingPlanRateAssignment.fs
@@ -4,7 +4,7 @@ open Grace.Operations.Data
 open Microsoft.EntityFrameworkCore
 open Microsoft.EntityFrameworkCore.Migrations
 
-/// Adds effective-dated pricing plans, billable mappings, rates, and customer assignments.
+/// Adds effective-dated pricing plans, billable mappings, rates, and owner assignments.
 [<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
 [<Migration("20260709110000_AddPricingPlanRateAssignment")>]
 type AddPricingPlanRateAssignment() =
@@ -96,27 +96,25 @@ END;
 
         migrationBuilder.Sql(
             $"""
-IF OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}', N'U') IS NULL
+IF OBJECT_ID(N'{OperationsPricingSql.PricingAssignmentTable}', N'U') IS NULL
 BEGIN
-    CREATE TABLE {OperationsPricingSql.CustomerPricingAssignmentTable}
+    CREATE TABLE {OperationsPricingSql.PricingAssignmentTable}
     (
-        CustomerPricingAssignmentId uniqueidentifier NOT NULL,
-        CustomerId uniqueidentifier NOT NULL,
+        PricingAssignmentId uniqueidentifier NOT NULL,
         OwnerId uniqueidentifier NOT NULL,
         OrganizationId uniqueidentifier NOT NULL,
         RepositoryId uniqueidentifier NOT NULL,
         PricingPlanId uniqueidentifier NOT NULL,
         EffectiveFromUtc datetime2(7) NOT NULL,
         EffectiveToUtc datetime2(7) NULL,
-        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_CustomerPricingAssignment_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
-        CONSTRAINT PK_ops_CustomerPricingAssignment PRIMARY KEY CLUSTERED (CustomerPricingAssignmentId),
-        CONSTRAINT FK_ops_CustomerPricingAssignment_PricingPlan FOREIGN KEY (PricingPlanId) REFERENCES {OperationsPricingSql.PricingPlanTable}(PricingPlanId),
-        CONSTRAINT CK_ops_CustomerPricingAssignment_Id_NotEmpty CHECK (CustomerPricingAssignmentId <> '00000000-0000-0000-0000-000000000000'),
-        CONSTRAINT CK_ops_CustomerPricingAssignment_CustomerId_NotEmpty CHECK (CustomerId <> '00000000-0000-0000-0000-000000000000'),
-        CONSTRAINT CK_ops_CustomerPricingAssignment_OwnerId_NotEmpty CHECK (OwnerId <> '00000000-0000-0000-0000-000000000000'),
-        CONSTRAINT CK_ops_CustomerPricingAssignment_OrganizationId_NotEmpty CHECK (OrganizationId <> '00000000-0000-0000-0000-000000000000'),
-        CONSTRAINT CK_ops_CustomerPricingAssignment_RepositoryId_NotEmpty CHECK (RepositoryId <> '00000000-0000-0000-0000-000000000000'),
-        CONSTRAINT CK_ops_CustomerPricingAssignment_EffectiveRange CHECK (EffectiveToUtc IS NULL OR EffectiveToUtc > EffectiveFromUtc)
+        CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_PricingAssignment_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        CONSTRAINT PK_ops_PricingAssignment PRIMARY KEY CLUSTERED (PricingAssignmentId),
+        CONSTRAINT FK_ops_PricingAssignment_PricingPlan FOREIGN KEY (PricingPlanId) REFERENCES {OperationsPricingSql.PricingPlanTable}(PricingPlanId),
+        CONSTRAINT CK_ops_PricingAssignment_Id_NotEmpty CHECK (PricingAssignmentId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_PricingAssignment_OwnerId_NotEmpty CHECK (OwnerId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_PricingAssignment_OrganizationId_NotEmpty CHECK (OrganizationId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_PricingAssignment_RepositoryId_NotEmpty CHECK (RepositoryId <> '00000000-0000-0000-0000-000000000000'),
+        CONSTRAINT CK_ops_PricingAssignment_EffectiveRange CHECK (EffectiveToUtc IS NULL OR EffectiveToUtc > EffectiveFromUtc)
     );
 END;
 """
@@ -204,36 +202,36 @@ IF NOT EXISTS
 (
     SELECT 1
     FROM sys.indexes
-    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
-    AND name = N'{OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName}'
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.PricingAssignmentTable}')
+    AND name = N'{OperationsPricingSql.PricingAssignmentPricingPlanIndexName}'
 )
 BEGIN
-    CREATE INDEX {OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName}
-        ON {OperationsPricingSql.CustomerPricingAssignmentTable}(PricingPlanId);
+    CREATE INDEX {OperationsPricingSql.PricingAssignmentPricingPlanIndexName}
+        ON {OperationsPricingSql.PricingAssignmentTable}(PricingPlanId);
 END;
 
 IF NOT EXISTS
 (
     SELECT 1
     FROM sys.indexes
-    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
-    AND name = N'UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom'
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.PricingAssignmentTable}')
+    AND name = N'UX_ops_PricingAssignment_ScopeEffectiveFrom'
 )
 BEGIN
-    CREATE UNIQUE INDEX UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom
-        ON {OperationsPricingSql.CustomerPricingAssignmentTable}(CustomerId, OwnerId, OrganizationId, RepositoryId, EffectiveFromUtc);
+    CREATE UNIQUE INDEX UX_ops_PricingAssignment_ScopeEffectiveFrom
+        ON {OperationsPricingSql.PricingAssignmentTable}(OwnerId, OrganizationId, RepositoryId, EffectiveFromUtc);
 END;
 
 IF NOT EXISTS
 (
     SELECT 1
     FROM sys.indexes
-    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}')
-    AND name = N'{OperationsPricingSql.CustomerPricingAssignmentScopeIndexName}'
+    WHERE object_id = OBJECT_ID(N'{OperationsPricingSql.PricingAssignmentTable}')
+    AND name = N'{OperationsPricingSql.PricingAssignmentScopeIndexName}'
 )
 BEGIN
-    CREATE INDEX {OperationsPricingSql.CustomerPricingAssignmentScopeIndexName}
-        ON {OperationsPricingSql.CustomerPricingAssignmentTable}(CustomerId, OwnerId, OrganizationId, RepositoryId, EffectiveFromUtc, EffectiveToUtc);
+    CREATE INDEX {OperationsPricingSql.PricingAssignmentScopeIndexName}
+        ON {OperationsPricingSql.PricingAssignmentTable}(OwnerId, OrganizationId, RepositoryId, EffectiveFromUtc, EffectiveToUtc);
 END;
 """
         )
@@ -323,8 +321,8 @@ END;');
 
         migrationBuilder.Sql(
             $"""
-EXEC(N'CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName}
-ON {OperationsPricingSql.CustomerPricingAssignmentTable}
+EXEC(N'CREATE OR ALTER TRIGGER ops.{OperationsPricingSql.PricingAssignmentOverlapTriggerName}
+ON {OperationsPricingSql.PricingAssignmentTable}
 AFTER INSERT, UPDATE
 AS
 BEGIN
@@ -334,17 +332,16 @@ BEGIN
     (
         SELECT 1
         FROM inserted AS candidate
-        INNER JOIN {OperationsPricingSql.CustomerPricingAssignmentTable} AS existing WITH (UPDLOCK, HOLDLOCK)
-            ON existing.CustomerId = candidate.CustomerId
-            AND existing.OwnerId = candidate.OwnerId
+        INNER JOIN {OperationsPricingSql.PricingAssignmentTable} AS existing WITH (UPDLOCK, HOLDLOCK)
+            ON existing.OwnerId = candidate.OwnerId
             AND existing.OrganizationId = candidate.OrganizationId
             AND existing.RepositoryId = candidate.RepositoryId
-            AND existing.CustomerPricingAssignmentId <> candidate.CustomerPricingAssignmentId
+            AND existing.PricingAssignmentId <> candidate.PricingAssignmentId
             AND candidate.EffectiveFromUtc < ISNULL(existing.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
             AND existing.EffectiveFromUtc < ISNULL(candidate.EffectiveToUtc, CONVERT(datetime2(7), ''9999-12-31T23:59:59.9999999''))
     )
     BEGIN
-        THROW 57414, ''Customer pricing assignment effective windows cannot overlap for the same customer repository scope.'', 1;
+        THROW 57414, ''Owner pricing assignment effective windows cannot overlap for the same owner repository scope.'', 1;
     END;
 END;');
 """
@@ -353,7 +350,7 @@ END;');
 
     /// Removes the pricing foundation schema in reverse dependency order.
     override _.Down(migrationBuilder: MigrationBuilder) =
-        migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName};")
+        migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.PricingAssignmentOverlapTriggerName};")
         |> ignore
 
         migrationBuilder.Sql($"DROP TRIGGER IF EXISTS ops.{OperationsPricingSql.PricingRateOverlapTriggerName};")
@@ -366,7 +363,7 @@ END;');
         |> ignore
 
         migrationBuilder.Sql(
-            $"IF OBJECT_ID(N'{OperationsPricingSql.CustomerPricingAssignmentTable}', N'U') IS NOT NULL DROP TABLE {OperationsPricingSql.CustomerPricingAssignmentTable};"
+            $"IF OBJECT_ID(N'{OperationsPricingSql.PricingAssignmentTable}', N'U') IS NOT NULL DROP TABLE {OperationsPricingSql.PricingAssignmentTable};"
         )
         |> ignore
 
@@ -840,26 +837,20 @@ END;');
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
-        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+        let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
 
-        assignment.ToTable("CustomerPricingAssignment", "ops")
+        assignment.ToTable("PricingAssignment", "ops")
         |> ignore
 
         assignment
-            .HasKey([| "CustomerPricingAssignmentId" |])
-            .HasName("PK_ops_CustomerPricingAssignment")
+            .HasKey([| "PricingAssignmentId" |])
+            .HasName("PK_ops_PricingAssignment")
         |> ignore
 
         assignment
-            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .Property<System.Guid>("PricingAssignmentId")
             .HasColumnType("uniqueidentifier")
             .ValueGeneratedNever()
-        |> ignore
-
-        assignment
-            .Property<System.Guid>("CustomerId")
-            .HasColumnType("uniqueidentifier")
-            .IsRequired()
         |> ignore
 
         assignment
@@ -906,27 +897,25 @@ END;');
 
         assignment
             .HasIndex([| "PricingPlanId" |])
-            .HasDatabaseName("IX_CustomerPricingAssignment_PricingPlanId")
+            .HasDatabaseName("IX_PricingAssignment_PricingPlanId")
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
                     "EffectiveFromUtc"
                 |]
             )
-            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .HasDatabaseName("UX_ops_PricingAssignment_ScopeEffectiveFrom")
             .IsUnique()
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -934,13 +923,13 @@ END;');
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName("IX_ops_CustomerPricingAssignment_ScopeEffective")
+            .HasDatabaseName("IX_ops_PricingAssignment_ScopeEffective")
         |> ignore
 
         assignment
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
-            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
+            .HasConstraintName("FK_ops_PricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260711090000_AddChargePreviewLines.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260711090000_AddChargePreviewLines.fs
@@ -19,7 +19,6 @@ type AddChargePreviewLines() =
 CREATE TABLE ops.ChargePreviewLine
 (
     ChargePreviewLineId uniqueidentifier NOT NULL,
-    CustomerId uniqueidentifier NOT NULL,
     OwnerId uniqueidentifier NOT NULL,
     OrganizationId uniqueidentifier NOT NULL,
     RepositoryId uniqueidentifier NOT NULL,
@@ -28,7 +27,7 @@ CREATE TABLE ops.ChargePreviewLine
     FactKind int NOT NULL,
     BillableUsageKindMappingId uniqueidentifier NOT NULL,
     BillableUsageKind int NOT NULL,
-    CustomerPricingAssignmentId uniqueidentifier NOT NULL,
+    PricingAssignmentId uniqueidentifier NOT NULL,
     PricingPlanId uniqueidentifier NOT NULL,
     PricingRateId uniqueidentifier NOT NULL,
     CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL,
@@ -47,10 +46,10 @@ CREATE TABLE ops.ChargePreviewLine
     CONSTRAINT CK_ops_ChargePreviewLine_Currency CHECK (LEN(CurrencyCode) = 3 AND CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode) COLLATE Latin1_General_100_BIN2 AND CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE '%[^A-Z]%')
 );
 CREATE INDEX IX_ops_ChargePreviewLine_Scope
-    ON ops.ChargePreviewLine(CustomerId, OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc);
+    ON ops.ChargePreviewLine(OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc);
 CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
-    ON ops.ChargePreviewLine(CustomerId, OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc,
-        FactKind, BillableUsageKindMappingId, BillableUsageKind, CustomerPricingAssignmentId, PricingPlanId,
+    ON ops.ChargePreviewLine(OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc,
+        FactKind, BillableUsageKindMappingId, BillableUsageKind, PricingAssignmentId, PricingPlanId,
         PricingRateId, CurrencyCode, UnitName, UnitQuantity, UnitPriceMicros, EffectiveFromUtc, EffectiveToUtc);
 """
         )
@@ -520,26 +519,20 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
-        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+        let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
 
-        assignment.ToTable("CustomerPricingAssignment", "ops")
+        assignment.ToTable("PricingAssignment", "ops")
         |> ignore
 
         assignment
-            .HasKey([| "CustomerPricingAssignmentId" |])
-            .HasName("PK_ops_CustomerPricingAssignment")
+            .HasKey([| "PricingAssignmentId" |])
+            .HasName("PK_ops_PricingAssignment")
         |> ignore
 
         assignment
-            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .Property<System.Guid>("PricingAssignmentId")
             .HasColumnType("uniqueidentifier")
             .ValueGeneratedNever()
-        |> ignore
-
-        assignment
-            .Property<System.Guid>("CustomerId")
-            .HasColumnType("uniqueidentifier")
-            .IsRequired()
         |> ignore
 
         assignment
@@ -586,27 +579,25 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
 
         assignment
             .HasIndex([| "PricingPlanId" |])
-            .HasDatabaseName("IX_CustomerPricingAssignment_PricingPlanId")
+            .HasDatabaseName("IX_PricingAssignment_PricingPlanId")
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
                     "EffectiveFromUtc"
                 |]
             )
-            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .HasDatabaseName("UX_ops_PricingAssignment_ScopeEffectiveFrom")
             .IsUnique()
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -614,14 +605,14 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName("IX_ops_CustomerPricingAssignment_ScopeEffective")
+            .HasDatabaseName("IX_ops_PricingAssignment_ScopeEffective")
         |> ignore
 
         assignment
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
-            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
+            .HasConstraintName("FK_ops_PricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
@@ -667,12 +658,11 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
 
         for name in
             [
-                "CustomerId"
                 "OwnerId"
                 "OrganizationId"
                 "RepositoryId"
                 "BillableUsageKindMappingId"
-                "CustomerPricingAssignmentId"
+                "PricingAssignmentId"
                 "PricingPlanId"
                 "PricingRateId"
             ] do
@@ -730,7 +720,6 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
         line
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -744,7 +733,6 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
         line
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -753,7 +741,7 @@ CREATE UNIQUE INDEX UX_ops_ChargePreviewLine_CompleteGrain
                     "FactKind"
                     "BillableUsageKindMappingId"
                     "BillableUsageKind"
-                    "CustomerPricingAssignmentId"
+                    "PricingAssignmentId"
                     "PricingPlanId"
                     "PricingRateId"
                     "CurrencyCode"

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -470,26 +470,20 @@ type OperationsDbContextModelSnapshot() =
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
-        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+        let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
 
-        assignment.ToTable("CustomerPricingAssignment", "ops")
+        assignment.ToTable("PricingAssignment", "ops")
         |> ignore
 
         assignment
-            .HasKey([| "CustomerPricingAssignmentId" |])
-            .HasName("PK_ops_CustomerPricingAssignment")
+            .HasKey([| "PricingAssignmentId" |])
+            .HasName("PK_ops_PricingAssignment")
         |> ignore
 
         assignment
-            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .Property<System.Guid>("PricingAssignmentId")
             .HasColumnType("uniqueidentifier")
             .ValueGeneratedNever()
-        |> ignore
-
-        assignment
-            .Property<System.Guid>("CustomerId")
-            .HasColumnType("uniqueidentifier")
-            .IsRequired()
         |> ignore
 
         assignment
@@ -536,27 +530,25 @@ type OperationsDbContextModelSnapshot() =
 
         assignment
             .HasIndex([| "PricingPlanId" |])
-            .HasDatabaseName("IX_CustomerPricingAssignment_PricingPlanId")
+            .HasDatabaseName("IX_PricingAssignment_PricingPlanId")
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
                     "EffectiveFromUtc"
                 |]
             )
-            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .HasDatabaseName("UX_ops_PricingAssignment_ScopeEffectiveFrom")
             .IsUnique()
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -564,14 +556,14 @@ type OperationsDbContextModelSnapshot() =
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName("IX_ops_CustomerPricingAssignment_ScopeEffective")
+            .HasDatabaseName("IX_ops_PricingAssignment_ScopeEffective")
         |> ignore
 
         assignment
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
-            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
+            .HasConstraintName("FK_ops_PricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
@@ -617,12 +609,11 @@ type OperationsDbContextModelSnapshot() =
 
         for name in
             [
-                "CustomerId"
                 "OwnerId"
                 "OrganizationId"
                 "RepositoryId"
                 "BillableUsageKindMappingId"
-                "CustomerPricingAssignmentId"
+                "PricingAssignmentId"
                 "PricingPlanId"
                 "PricingRateId"
             ] do
@@ -680,7 +671,6 @@ type OperationsDbContextModelSnapshot() =
         line
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -694,7 +684,6 @@ type OperationsDbContextModelSnapshot() =
         line
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -703,7 +692,7 @@ type OperationsDbContextModelSnapshot() =
                     "FactKind"
                     "BillableUsageKindMappingId"
                     "BillableUsageKind"
-                    "CustomerPricingAssignmentId"
+                    "PricingAssignmentId"
                     "PricingPlanId"
                     "PricingRateId"
                     "CurrencyCode"

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
@@ -36,26 +36,26 @@ module OperationsChargePreviewSql =
 
     /// Deletes only the exact preview scope being atomically replaced.
     let DeleteScope =
-        "DELETE FROM ops.ChargePreviewLine WHERE CustomerId=@CustomerId AND OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND PeriodFromUtc=@PeriodFromUtc AND PeriodToUtc=@PeriodToUtc;"
+        "DELETE FROM ops.ChargePreviewLine WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND PeriodFromUtc=@PeriodFromUtc AND PeriodToUtc=@PeriodToUtc;"
 
     /// Reads compact immutable usage fields and every independently effective pricing prerequisite after scope locking.
     let SelectSourceAndPricing =
         """
 SELECT fact.UsageFactId, fact.FactKind, fact.Quantity, fact.ObservedAtUtc,
-       assignment.CustomerPricingAssignmentId, assignment.PricingPlanId AS AssignedPricingPlanId,
+       assignment.PricingAssignmentId, assignment.PricingPlanId AS AssignedPricingPlanId,
        plan.PricingPlanId, mapping.BillableUsageKindMappingId, mapping.BillableUsageKind,
        rate.PricingRateId, rate.CurrencyCode, rate.UnitName, rate.UnitQuantity, rate.UnitPriceMicros,
        applicability.EffectiveFromUtc, applicability.EffectiveToUtc
 FROM ops.RawUsageFact AS fact
 OUTER APPLY (
-    SELECT TOP (1) candidate.CustomerPricingAssignmentId, candidate.PricingPlanId,
+    SELECT TOP (1) candidate.PricingAssignmentId, candidate.PricingPlanId,
            candidate.EffectiveFromUtc, candidate.EffectiveToUtc
-    FROM ops.CustomerPricingAssignment AS candidate
-    WHERE candidate.CustomerId = @CustomerId AND candidate.OwnerId = @OwnerId
+    FROM ops.PricingAssignment AS candidate
+    WHERE candidate.OwnerId = @OwnerId
       AND candidate.OrganizationId = @OrganizationId AND candidate.RepositoryId = @RepositoryId
       AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
       AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
-    ORDER BY candidate.EffectiveFromUtc DESC, candidate.CustomerPricingAssignmentId
+    ORDER BY candidate.EffectiveFromUtc DESC, candidate.PricingAssignmentId
 ) AS assignment
 OUTER APPLY (
     SELECT TOP (1) candidate.PricingPlanId, candidate.EffectiveFromUtc, candidate.EffectiveToUtc
@@ -148,12 +148,11 @@ module OperationsChargePreviewModel =
 
         for name in
             [
-                "CustomerId"
                 "OwnerId"
                 "OrganizationId"
                 "RepositoryId"
                 "BillableUsageKindMappingId"
-                "CustomerPricingAssignmentId"
+                "PricingAssignmentId"
                 "PricingPlanId"
                 "PricingRateId"
             ] do
@@ -211,7 +210,6 @@ module OperationsChargePreviewModel =
         line
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -225,7 +223,6 @@ module OperationsChargePreviewModel =
         line
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -234,7 +231,7 @@ module OperationsChargePreviewModel =
                     "FactKind"
                     "BillableUsageKindMappingId"
                     "BillableUsageKind"
-                    "CustomerPricingAssignmentId"
+                    "PricingAssignmentId"
                     "PricingPlanId"
                     "PricingRateId"
                     "CurrencyCode"
@@ -249,8 +246,8 @@ module OperationsChargePreviewModel =
             .IsUnique()
         |> ignore
 
-/// Identifies one explicit customer/repository/half-open UTC preview rebuild scope.
-type ChargePreviewScope = { CustomerId: Guid; OwnerId: Guid; OrganizationId: Guid; RepositoryId: Guid; PeriodFromUtc: DateTime; PeriodToUtc: DateTime }
+/// Identifies one explicit owner/repository/half-open UTC preview rebuild scope.
+type ChargePreviewScope = { OwnerId: Guid; OrganizationId: Guid; RepositoryId: Guid; PeriodFromUtc: DateTime; PeriodToUtc: DateTime }
 
 /// Names an independently required pricing prerequisite that was absent for a usage fact.
 [<RequireQualifiedAccess>]
@@ -262,7 +259,7 @@ type MissingPricingPrerequisite =
 
 /// Reports why a complete charge-preview candidate could not be built.
 type ChargePreviewRebuildException(scope: ChargePreviewScope, usageFactId: Guid, prerequisite: MissingPricingPrerequisite) =
-    inherit InvalidOperationException($"Charge-preview rebuild for customer {scope.CustomerId}, repository {scope.RepositoryId}, period [{scope.PeriodFromUtc:o}, {scope.PeriodToUtc:o}) is missing pricing {prerequisite} for usage fact {usageFactId}.")
+    inherit InvalidOperationException($"Charge-preview rebuild for owner {scope.OwnerId}, repository {scope.RepositoryId}, period [{scope.PeriodFromUtc:o}, {scope.PeriodToUtc:o}) is missing pricing {prerequisite} for usage fact {usageFactId}.")
     /// Gets the rebuild scope that remains unchanged after this failure.
     member _.Scope = scope
     /// Gets the usage fact whose complete pricing could not be resolved.
@@ -277,7 +274,7 @@ type ChargePreviewPricedFact =
         FactKind: int
         Quantity: int64
         ObservedAtUtc: DateTime
-        CustomerPricingAssignmentId: Guid
+        PricingAssignmentId: Guid
         BillableUsageKindMappingId: Guid
         BillableUsageKind: int
         PricingPlanId: Guid
@@ -334,7 +331,6 @@ module ChargePreviewCalculation =
             String.Join(
                 "|",
                 [|
-                    scope.CustomerId.ToString("D")
                     scope.OwnerId.ToString("D")
                     scope.OrganizationId.ToString("D")
                     scope.RepositoryId.ToString("D")
@@ -343,7 +339,7 @@ module ChargePreviewCalculation =
                     fact.FactKind.ToString(CultureInfo.InvariantCulture)
                     fact.BillableUsageKindMappingId.ToString("D")
                     fact.BillableUsageKind.ToString(CultureInfo.InvariantCulture)
-                    fact.CustomerPricingAssignmentId.ToString("D")
+                    fact.PricingAssignmentId.ToString("D")
                     fact.PricingPlanId.ToString("D")
                     fact.PricingRateId.ToString("D")
                     fact.CurrencyCode
@@ -370,7 +366,7 @@ module ChargePreviewCalculation =
             fact.FactKind,
             fact.BillableUsageKindMappingId,
             fact.BillableUsageKind,
-            fact.CustomerPricingAssignmentId,
+            fact.PricingAssignmentId,
             fact.PricingPlanId,
             fact.PricingRateId,
             fact.CurrencyCode,
@@ -393,7 +389,6 @@ module ChargePreviewCalculation =
             let quantity = int64 total
             let entity = ChargePreviewLineEntity()
             entity.ChargePreviewLineId <- lineId scope first
-            entity.CustomerId <- scope.CustomerId
             entity.OwnerId <- scope.OwnerId
             entity.OrganizationId <- scope.OrganizationId
             entity.RepositoryId <- scope.RepositoryId
@@ -402,7 +397,7 @@ module ChargePreviewCalculation =
             entity.FactKind <- first.FactKind
             entity.BillableUsageKindMappingId <- first.BillableUsageKindMappingId
             entity.BillableUsageKind <- first.BillableUsageKind
-            entity.CustomerPricingAssignmentId <- first.CustomerPricingAssignmentId
+            entity.PricingAssignmentId <- first.PricingAssignmentId
             entity.PricingPlanId <- first.PricingPlanId
             entity.PricingRateId <- first.PricingRateId
             entity.CurrencyCode <- first.CurrencyCode
@@ -426,7 +421,6 @@ type IChargePreviewRebuilder =
 type SqlChargePreviewRebuilder(connectionString: string) =
 
     let addScopeParameters (command: SqlCommand) scope =
-        command.Parameters.Add("@CustomerId", SqlDbType.UniqueIdentifier).Value <- scope.CustomerId
         command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
         command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
         command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
@@ -464,7 +458,7 @@ type SqlChargePreviewRebuilder(connectionString: string) =
                     lockCommand.CommandTimeout <- 65
 
                     let lockIdentity =
-                        $"ops:charge-preview:{scope.CustomerId:D}:{scope.OwnerId:D}:{scope.OrganizationId:D}:{scope.RepositoryId:D}:{scope.PeriodFromUtc.Ticks}:{scope.PeriodToUtc.Ticks}"
+                        $"ops:charge-preview:{scope.OwnerId:D}:{scope.OrganizationId:D}:{scope.RepositoryId:D}:{scope.PeriodFromUtc.Ticks}:{scope.PeriodToUtc.Ticks}"
 
                     let lockHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes lockIdentity))
                     lockCommand.Parameters.Add("@LockResource", SqlDbType.NVarChar, 255).Value <- $"ops:charge-preview:{lockHash}"
@@ -501,7 +495,7 @@ type SqlChargePreviewRebuilder(connectionString: string) =
                                     FactKind = reader.GetInt32 1
                                     Quantity = reader.GetInt64 2
                                     ObservedAtUtc = reader.GetDateTime 3
-                                    CustomerPricingAssignmentId = reader.GetGuid 4
+                                    PricingAssignmentId = reader.GetGuid 4
                                     PricingPlanId = reader.GetGuid 6
                                     BillableUsageKindMappingId = reader.GetGuid 7
                                     BillableUsageKind = reader.GetInt32 8
@@ -533,7 +527,7 @@ type SqlChargePreviewRebuilder(connectionString: string) =
                         insert.Transaction <- transaction
 
                         insert.CommandText <-
-                            "INSERT INTO ops.ChargePreviewLine (ChargePreviewLineId,CustomerId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,CustomerPricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@Id,@CustomerId,@OwnerId,@OrganizationId,@RepositoryId,@PeriodFromUtc,@PeriodToUtc,@FactKind,@MappingId,@BillableKind,@AssignmentId,@PlanId,@RateId,@Currency,@UnitName,@UnitQuantity,@UnitPrice,@EffectiveFrom,@EffectiveTo,@TotalQuantity,@Charge);"
+                            "INSERT INTO ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@Id,@OwnerId,@OrganizationId,@RepositoryId,@PeriodFromUtc,@PeriodToUtc,@FactKind,@MappingId,@BillableKind,@AssignmentId,@PlanId,@RateId,@Currency,@UnitName,@UnitQuantity,@UnitPrice,@EffectiveFrom,@EffectiveTo,@TotalQuantity,@Charge);"
 
                         addScopeParameters insert scope
                         let add name dbType value = insert.Parameters.Add(name, dbType).Value <- value
@@ -541,7 +535,7 @@ type SqlChargePreviewRebuilder(connectionString: string) =
                         add "@FactKind" SqlDbType.Int line.FactKind
                         add "@MappingId" SqlDbType.UniqueIdentifier line.BillableUsageKindMappingId
                         add "@BillableKind" SqlDbType.Int line.BillableUsageKind
-                        add "@AssignmentId" SqlDbType.UniqueIdentifier line.CustomerPricingAssignmentId
+                        add "@AssignmentId" SqlDbType.UniqueIdentifier line.PricingAssignmentId
                         add "@PlanId" SqlDbType.UniqueIdentifier line.PricingPlanId
                         add "@RateId" SqlDbType.UniqueIdentifier line.PricingRateId
                         insert.Parameters.Add("@Currency", SqlDbType.VarChar, 3).Value <- line.CurrencyCode

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -48,22 +48,13 @@ type UsageAggregateMinuteKey =
 /// Describes the aggregate quantity projected for one Grace repository resource and UTC minute.
 type UsageAggregateMinute = { Key: UsageAggregateMinuteKey; Quantity: int64 }
 
-/// Carries one customer, repository scope, fact kind, and timestamp for effective pricing lookup.
-type PricingRateSelectionQuery =
-    {
-        CustomerId: Guid
-        OwnerId: OwnerId
-        OrganizationId: OrganizationId
-        RepositoryId: RepositoryId
-        FactKind: UsageFactKind
-        ObservedAt: Instant
-    }
+/// Carries one owner, repository scope, fact kind, and timestamp for effective pricing lookup.
+type PricingRateSelectionQuery = { OwnerId: OwnerId; OrganizationId: OrganizationId; RepositoryId: RepositoryId; FactKind: UsageFactKind; ObservedAt: Instant }
 
-/// Describes the effective customer rate selected for a tracked usage fact.
+/// Describes the effective owner rate selected for a tracked usage fact.
 type EffectivePricingRate =
     {
-        CustomerPricingAssignmentId: Guid
-        CustomerId: Guid
+        PricingAssignmentId: Guid
         OwnerId: OwnerId
         OrganizationId: OrganizationId
         RepositoryId: RepositoryId
@@ -107,11 +98,10 @@ type PricingRate =
         EffectiveTo: Instant option
     }
 
-/// Describes an effective-dated customer assignment to one pricing plan for a Grace repository scope.
-type CustomerPricingAssignment =
+/// Describes an effective-dated owner assignment to one pricing plan for a Grace repository scope.
+type PricingAssignment =
     {
-        CustomerPricingAssignmentId: Guid
-        CustomerId: Guid
+        PricingAssignmentId: Guid
         OwnerId: OwnerId
         OrganizationId: OrganizationId
         RepositoryId: RepositoryId
@@ -126,10 +116,10 @@ type PricingCatalogSnapshot =
         PricingPlans: PricingPlan list
         BillableUsageKindMappings: BillableUsageKindMapping list
         PricingRates: PricingRate list
-        CustomerPricingAssignments: CustomerPricingAssignment list
+        PricingAssignments: PricingAssignment list
     }
 
-/// Selects customer rates only when every effective-dated pricing prerequisite is present.
+/// Selects owner rates only when every effective-dated pricing prerequisite is present.
 [<RequireQualifiedAccess>]
 module PricingRateSelection =
 
@@ -151,7 +141,7 @@ module PricingRateSelection =
                 compare (identity left) (identity right))
         |> List.tryHead
 
-    /// Intersects selected pricing prerequisites into the complete customer-price applicability window.
+    /// Intersects selected pricing prerequisites into the complete owner-price applicability window.
     let private intersectEffectiveWindows windows =
         let effectiveFrom = windows |> List.map fst |> List.max
 
@@ -162,17 +152,16 @@ module PricingRateSelection =
 
         effectiveFrom, effectiveTo
 
-    /// Selects the effective rate for a customer usage fact without making unmapped tracked facts billable.
+    /// Selects the effective rate for a owner usage fact without making unmapped tracked facts billable.
     let trySelect (query: PricingRateSelectionQuery) (catalog: PricingCatalogSnapshot) =
         let assignment =
-            catalog.CustomerPricingAssignments
+            catalog.PricingAssignments
             |> List.filter (fun candidate ->
-                candidate.CustomerId = query.CustomerId
-                && candidate.OwnerId = query.OwnerId
+                candidate.OwnerId = query.OwnerId
                 && candidate.OrganizationId = query.OrganizationId
                 && candidate.RepositoryId = query.RepositoryId
                 && contains query.ObservedAt candidate.EffectiveFrom candidate.EffectiveTo)
-            |> latestBy (fun candidate -> candidate.EffectiveFrom) (fun candidate -> candidate.CustomerPricingAssignmentId)
+            |> latestBy (fun candidate -> candidate.EffectiveFrom) (fun candidate -> candidate.PricingAssignmentId)
 
         let plan =
             assignment
@@ -211,8 +200,7 @@ module PricingRateSelection =
 
             Some
                 {
-                    CustomerPricingAssignmentId = selectedAssignment.CustomerPricingAssignmentId
-                    CustomerId = selectedAssignment.CustomerId
+                    PricingAssignmentId = selectedAssignment.PricingAssignmentId
                     OwnerId = selectedAssignment.OwnerId
                     OrganizationId = selectedAssignment.OrganizationId
                     RepositoryId = selectedAssignment.RepositoryId
@@ -348,7 +336,7 @@ type IOperationsUsageArchiveStore =
     /// Clears expired temporary support rehydrations left behind after caller or process failure.
     abstract CleanupExpiredRehydratedPayloadsAsync: expiresBefore: Instant * batchSize: int * cancellationToken: CancellationToken -> Task<int>
 
-/// Selects effective customer pricing rates from the Operations pricing catalog.
+/// Selects effective owner pricing rates from the Operations pricing catalog.
 type IOperationsPricingCatalog =
 
     /// Returns a rate only when assignment, plan, usage-kind mapping, and rate rows are all effective.
@@ -380,7 +368,6 @@ type SqlOperationsPricingCatalog(connectionString: string) =
 
     /// Adds the effective-rate lookup parameters with the repository scope required to prevent leakage.
     let addSelectionParameters (command: SqlCommand) (query: PricingRateSelectionQuery) =
-        addParameter command "@CustomerId" SqlDbType.UniqueIdentifier query.CustomerId
         addParameter command "@OwnerId" SqlDbType.UniqueIdentifier query.OwnerId
         addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier query.OrganizationId
         addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier query.RepositoryId
@@ -399,8 +386,7 @@ type SqlOperationsPricingCatalog(connectionString: string) =
         let effectiveToOrdinal = reader.GetOrdinal("EffectiveToUtc")
 
         {
-            CustomerPricingAssignmentId = reader.GetGuid(reader.GetOrdinal("CustomerPricingAssignmentId"))
-            CustomerId = reader.GetGuid(reader.GetOrdinal("CustomerId"))
+            PricingAssignmentId = reader.GetGuid(reader.GetOrdinal("PricingAssignmentId"))
             OwnerId = reader.GetGuid(reader.GetOrdinal("OwnerId"))
             OrganizationId = reader.GetGuid(reader.GetOrdinal("OrganizationId"))
             RepositoryId = reader.GetGuid(reader.GetOrdinal("RepositoryId"))
@@ -419,7 +405,7 @@ type SqlOperationsPricingCatalog(connectionString: string) =
             EffectiveTo = readEffectiveTo reader effectiveToOrdinal
         }
 
-    /// Returns the effective customer rate selected by SQL, or None for non-billable usage.
+    /// Returns the effective owner rate selected by SQL, or None for non-billable usage.
     member _.TrySelectEffectiveRateAsync(query: PricingRateSelectionQuery, cancellationToken: CancellationToken) =
         task {
             use! connection = openConnectionAsync cancellationToken

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -467,26 +467,20 @@ module OperationsModel =
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
-        let assignment = modelBuilder.Entity<CustomerPricingAssignmentEntity>()
+        let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
 
-        assignment.ToTable(OperationsPricingSql.CustomerPricingAssignmentTableName, OperationsUsageSql.SchemaName)
+        assignment.ToTable(OperationsPricingSql.PricingAssignmentTableName, OperationsUsageSql.SchemaName)
         |> ignore
 
         assignment
-            .HasKey([| "CustomerPricingAssignmentId" |])
-            .HasName("PK_ops_CustomerPricingAssignment")
+            .HasKey([| "PricingAssignmentId" |])
+            .HasName("PK_ops_PricingAssignment")
         |> ignore
 
         assignment
-            .Property<System.Guid>("CustomerPricingAssignmentId")
+            .Property<System.Guid>("PricingAssignmentId")
             .HasColumnType("uniqueidentifier")
             .ValueGeneratedNever()
-        |> ignore
-
-        assignment
-            .Property<System.Guid>("CustomerId")
-            .HasColumnType("uniqueidentifier")
-            .IsRequired()
         |> ignore
 
         assignment
@@ -533,27 +527,25 @@ module OperationsModel =
 
         assignment
             .HasIndex([| "PricingPlanId" |])
-            .HasDatabaseName(OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+            .HasDatabaseName(OperationsPricingSql.PricingAssignmentPricingPlanIndexName)
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
                     "EffectiveFromUtc"
                 |]
             )
-            .HasDatabaseName("UX_ops_CustomerPricingAssignment_ScopeEffectiveFrom")
+            .HasDatabaseName("UX_ops_PricingAssignment_ScopeEffectiveFrom")
             .IsUnique()
         |> ignore
 
         assignment
             .HasIndex(
                 [|
-                    "CustomerId"
                     "OwnerId"
                     "OrganizationId"
                     "RepositoryId"
@@ -561,14 +553,14 @@ module OperationsModel =
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName(OperationsPricingSql.CustomerPricingAssignmentScopeIndexName)
+            .HasDatabaseName(OperationsPricingSql.PricingAssignmentScopeIndexName)
         |> ignore
 
         assignment
             .HasOne(fun assignment -> assignment.PricingPlan)
             .WithMany()
             .HasForeignKey("PricingPlanId")
-            .HasConstraintName("FK_ops_CustomerPricingAssignment_PricingPlan")
+            .HasConstraintName("FK_ops_PricingAssignment_PricingPlan")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
@@ -598,9 +590,9 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     [<DefaultValue>]
     val mutable private pricingRates: DbSet<PricingRateEntity>
 
-    /// Exposes customer pricing assignments for EF migrations and schema inspection.
+    /// Exposes owner-scoped pricing assignments for EF migrations and schema inspection.
     [<DefaultValue>]
-    val mutable private customerPricingAssignments: DbSet<CustomerPricingAssignmentEntity>
+    val mutable private pricingAssignments: DbSet<PricingAssignmentEntity>
 
     /// Provides EF access to provisional charge-preview lines.
     [<DefaultValue>]
@@ -631,10 +623,10 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
         with get () = this.pricingRates
         and set value = this.pricingRates <- value
 
-    /// Provides the EF set for customer pricing assignments.
-    member this.CustomerPricingAssignments
-        with get () = this.customerPricingAssignments
-        and set value = this.customerPricingAssignments <- value
+    /// Provides the EF set for owner-scoped pricing assignments.
+    member this.PricingAssignments
+        with get () = this.pricingAssignments
+        and set value = this.pricingAssignments <- value
 
     /// Provides the EF set for provisional charge-preview lines.
     member this.ChargePreviewLines

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -100,7 +100,7 @@ type UsageAggregateMinuteEntity() =
     /// Stores the SQL-created or SQL-updated UTC timestamp for the aggregate row.
     member val UpdatedAtUtc = DateTime.MinValue with get, set
 
-/// Represents one effective-dated customer pricing plan.
+/// Represents one effective-dated owner pricing plan.
 [<AllowNullLiteral>]
 type PricingPlanEntity() =
 
@@ -154,13 +154,13 @@ type PricingRateEntity() =
     /// Stores the durable pricing rate identity selected by later preview and ledger slices.
     member val PricingRateId = Guid.Empty with get, set
 
-    /// Stores the pricing plan whose customers can receive this rate.
+    /// Stores the pricing plan whose owners can receive this rate.
     member val PricingPlanId = Guid.Empty with get, set
 
     /// Stores the internal billable usage-kind integer priced by this rate.
     member val BillableUsageKind = 0 with get, set
 
-    /// Stores the customer billing currency for this rate without provider cost or margin data.
+    /// Stores the owner billing currency for this rate without provider cost or margin data.
     member val CurrencyCode = String.Empty with get, set
 
     /// Stores the rate unit label, such as byte-minute.
@@ -169,7 +169,7 @@ type PricingRateEntity() =
     /// Stores the measured quantity represented by one billable unit.
     member val UnitQuantity = 0L with get, set
 
-    /// Stores the customer price in micros of the configured currency per unit quantity.
+    /// Stores the owner price in micros of the configured currency per unit quantity.
     member val UnitPriceMicros = 0L with get, set
 
     /// Stores when the rate can first be selected.
@@ -184,26 +184,24 @@ type PricingRateEntity() =
     /// References the pricing plan for EF schema relationship generation.
     member val PricingPlan: PricingPlanEntity = null with get, set
 
-/// Represents one effective-dated assignment of a customer and repository scope to a pricing plan.
+/// Represents one effective-dated assignment of a owner and repository scope to a pricing plan.
 [<AllowNullLiteral>]
-type CustomerPricingAssignmentEntity() =
+type PricingAssignmentEntity() =
 
     /// Stores the durable assignment identity selected by later preview and ledger slices.
-    member val CustomerPricingAssignmentId = Guid.Empty with get, set
+    member val PricingAssignmentId = Guid.Empty with get, set
 
-    /// Stores the Operations customer identity receiving the assigned pricing plan.
-    member val CustomerId = Guid.Empty with get, set
-
-    /// Stores the Grace owner scope for the customer assignment.
+    /// Stores the Operations owner identity receiving the assigned pricing plan.
+    /// Stores the Grace owner scope for the owner assignment.
     member val OwnerId = Guid.Empty with get, set
 
-    /// Stores the Grace organization scope for the customer assignment.
+    /// Stores the Grace organization scope for the owner assignment.
     member val OrganizationId = Guid.Empty with get, set
 
-    /// Stores the Grace repository scope for the customer assignment.
+    /// Stores the Grace repository scope for the owner assignment.
     member val RepositoryId = Guid.Empty with get, set
 
-    /// Stores the pricing plan selected for this customer and repository scope.
+    /// Stores the pricing plan selected for this owner and repository scope.
     member val PricingPlanId = Guid.Empty with get, set
 
     /// Stores when the assignment can first be selected.
@@ -212,7 +210,7 @@ type CustomerPricingAssignmentEntity() =
     /// Stores the exclusive end of the assignment window, or null for open-ended assignments.
     member val EffectiveToUtc = Nullable<DateTime>() with get, set
 
-    /// Stores the SQL-created UTC timestamp for the customer assignment row.
+    /// Stores the SQL-created UTC timestamp for the owner assignment row.
     member val CreatedAtUtc = DateTime.MinValue with get, set
 
     /// References the pricing plan for EF schema relationship generation.
@@ -225,9 +223,7 @@ type ChargePreviewLineEntity() =
     /// Stores the deterministic identity derived from the complete preview-line grain.
     member val ChargePreviewLineId = Guid.Empty with get, set
 
-    /// Stores the customer whose provisional charge is represented.
-    member val CustomerId = Guid.Empty with get, set
-
+    /// Stores the owner whose provisional charge is represented.
     /// Stores the Grace owner scope for the charged repository.
     member val OwnerId = Guid.Empty with get, set
 
@@ -252,8 +248,8 @@ type ChargePreviewLineEntity() =
     /// Stores the billable usage kind selected by the mapping.
     member val BillableUsageKind = 0 with get, set
 
-    /// Stores the complete customer pricing assignment identity selected for the source facts.
-    member val CustomerPricingAssignmentId = Guid.Empty with get, set
+    /// Stores the complete owner pricing assignment identity selected for the source facts.
+    member val PricingAssignmentId = Guid.Empty with get, set
 
     /// Stores the complete pricing plan identity selected for the source facts.
     member val PricingPlanId = Guid.Empty with get, set
@@ -270,7 +266,7 @@ type ChargePreviewLineEntity() =
     /// Stores the measured quantity represented by one priced unit.
     member val UnitQuantity = 0L with get, set
 
-    /// Stores the selected customer price in whole currency micros per unit quantity.
+    /// Stores the selected owner price in whole currency micros per unit quantity.
     member val UnitPriceMicros = 0L with get, set
 
     /// Stores the inclusive start of the complete pricing applicability segment intersected with the preview period.

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsPricingSql.fs
@@ -28,13 +28,13 @@ module OperationsPricingSql =
     [<Literal>]
     let PricingRateTable = "ops.PricingRate"
 
-    /// Names the customer pricing assignment table without schema qualification for EF migrations.
+    /// Names the owner pricing assignment table without schema qualification for EF migrations.
     [<Literal>]
-    let CustomerPricingAssignmentTableName = "CustomerPricingAssignment"
+    let PricingAssignmentTableName = "PricingAssignment"
 
-    /// Names the customer pricing assignment table.
+    /// Names the owner pricing assignment table.
     [<Literal>]
-    let CustomerPricingAssignmentTable = "ops.CustomerPricingAssignment"
+    let PricingAssignmentTable = "ops.PricingAssignment"
 
     /// Limits stable pricing plan codes used by operator seed scripts and later APIs.
     [<Literal>]
@@ -48,7 +48,7 @@ module OperationsPricingSql =
     [<Literal>]
     let CurrencyCodeLength = 3
 
-    /// Limits billing unit labels such as byte-minute before later customer preview surfaces format them.
+    /// Limits billing unit labels such as byte-minute before later owner preview surfaces format them.
     [<Literal>]
     let UnitNameMaxLength = 64
 
@@ -64,17 +64,17 @@ module OperationsPricingSql =
     [<Literal>]
     let PricingRateOverlapTriggerName = "TR_ops_PricingRate_PreventOverlap"
 
-    /// Names the trigger that rejects overlapping customer assignments for the same repository scope.
+    /// Names the trigger that rejects overlapping owner assignments for the same repository scope.
     [<Literal>]
-    let CustomerPricingAssignmentOverlapTriggerName = "TR_ops_CustomerPricingAssignment_PreventOverlap"
+    let PricingAssignmentOverlapTriggerName = "TR_ops_PricingAssignment_PreventOverlap"
 
-    /// Names the indexed lookup path for effective customer plan assignments.
+    /// Names the indexed lookup path for effective owner plan assignments.
     [<Literal>]
-    let CustomerPricingAssignmentScopeIndexName = "IX_ops_CustomerPricingAssignment_ScopeEffective"
+    let PricingAssignmentScopeIndexName = "IX_ops_PricingAssignment_ScopeEffective"
 
-    /// Names the foreign-key lookup path from customer assignments to pricing plans.
+    /// Names the foreign-key lookup path from owner assignments to pricing plans.
     [<Literal>]
-    let CustomerPricingAssignmentPricingPlanIndexName = "IX_CustomerPricingAssignment_PricingPlanId"
+    let PricingAssignmentPricingPlanIndexName = "IX_PricingAssignment_PricingPlanId"
 
     /// Names the indexed lookup path for effective rate selection.
     [<Literal>]
@@ -84,13 +84,12 @@ module OperationsPricingSql =
     [<Literal>]
     let BillableUsageKindMappingEffectiveIndexName = "IX_ops_BillableUsageKindMapping_FactKindEffective"
 
-    /// Selects the effective customer pricing rate only when assignment, plan, billable mapping, and rate all exist.
+    /// Selects the effective owner pricing rate only when assignment, plan, billable mapping, and rate all exist.
     [<Literal>]
     let SelectEffectivePricingRate =
         """
 SELECT TOP (1)
-    assignment.CustomerPricingAssignmentId,
-    assignment.CustomerId,
+    assignment.PricingAssignmentId,
     assignment.OwnerId,
     assignment.OrganizationId,
     assignment.RepositoryId,
@@ -105,7 +104,7 @@ SELECT TOP (1)
     rate.UnitPriceMicros,
     applicability.EffectiveFromUtc,
     applicability.EffectiveToUtc
-FROM ops.CustomerPricingAssignment AS assignment WITH (READCOMMITTEDLOCK)
+FROM ops.PricingAssignment AS assignment WITH (READCOMMITTEDLOCK)
 INNER JOIN ops.PricingPlan AS plan WITH (READCOMMITTEDLOCK)
     ON plan.PricingPlanId = assignment.PricingPlanId
 INNER JOIN ops.BillableUsageKindMapping AS mapping WITH (READCOMMITTEDLOCK)
@@ -127,8 +126,7 @@ CROSS APPLY
             (rate.EffectiveFromUtc, rate.EffectiveToUtc)
     ) AS contributor(EffectiveFromUtc, EffectiveToUtc)
 ) AS applicability
-WHERE assignment.CustomerId = @CustomerId
-AND assignment.OwnerId = @OwnerId
+WHERE assignment.OwnerId = @OwnerId
 AND assignment.OrganizationId = @OrganizationId
 AND assignment.RepositoryId = @RepositoryId
 AND assignment.EffectiveFromUtc <= @ObservedAtUtc
@@ -144,6 +142,6 @@ ORDER BY
     rate.EffectiveFromUtc DESC,
     mapping.EffectiveFromUtc DESC,
     plan.EffectiveFromUtc DESC,
-    assignment.CustomerPricingAssignmentId ASC,
+    assignment.PricingAssignmentId ASC,
     rate.PricingRateId ASC;
 """

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -22,7 +22,6 @@ module private ChargePreviewTestData =
 
     let scope =
         {
-            CustomerId = Guid.Parse "11111111-1111-1111-1111-111111111111"
             OwnerId = Guid.Parse "22222222-2222-2222-2222-222222222222"
             OrganizationId = Guid.Parse "33333333-3333-3333-3333-333333333333"
             RepositoryId = Guid.Parse "44444444-4444-4444-4444-444444444444"
@@ -36,7 +35,7 @@ module private ChargePreviewTestData =
             FactKind = 1
             Quantity = quantity
             ObservedAtUtc = observedAt
-            CustomerPricingAssignmentId = Guid.Parse "55555555-5555-5555-5555-555555555555"
+            PricingAssignmentId = Guid.Parse "55555555-5555-5555-5555-555555555555"
             BillableUsageKindMappingId = Guid.Parse "66666666-6666-6666-6666-666666666666"
             BillableUsageKind = 10
             PricingPlanId = Guid.Parse "77777777-7777-7777-7777-777777777777"
@@ -114,7 +113,7 @@ type OperationsChargePreviewTests() =
 
         let changedAssignment =
             { ChargePreviewTestData.fact (Guid.NewGuid()) 3L (ChargePreviewTestData.utc 6 0) with
-                CustomerPricingAssignmentId = Guid.NewGuid()
+                PricingAssignmentId = Guid.NewGuid()
                 EffectiveFromUtc = ChargePreviewTestData.utc 5 0
             }
 
@@ -397,9 +396,8 @@ type OperationsChargePreviewTests() =
         let source = OperationsChargePreviewSql.SelectSourceAndPricing
 
         ChargePreviewTestData.multiple (fun () ->
-            Assert.That(source, Does.Contain("@CustomerId"))
+            Assert.That(source, Does.Not.Contain("@" + "Customer" + "Id"))
             Assert.That(source, Does.Contain("@RepositoryId"))
-            Assert.That(source, Does.Not.Contain(ChargePreviewTestData.scope.CustomerId.ToString("D")))
             Assert.That(OperationsChargePreviewSql.AcquireScopeLock, Does.Contain("sys.sp_getapplock"))
             Assert.That(OperationsChargePreviewSql.AcquireScopeLock, Does.Contain("@LockOwner='Transaction'"))
             Assert.That(OperationsChargePreviewSql.DeleteScope, Does.Contain("PeriodFromUtc=@PeriodFromUtc"))

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsPricing.Tests.fs
@@ -16,25 +16,22 @@ open System.IO
 /// Provides deterministic pricing catalog rows for Operations pricing tests.
 module OperationsPricingTestData =
 
-    /// Provides the customer that owns the default pricing assignment.
-    let customerId = Guid.Parse("57400000-1000-0000-0000-000000000001")
-
-    /// Provides a second customer used to prove customer isolation.
-    let otherCustomerId = Guid.Parse("57400000-1000-0000-0000-000000000002")
-
-    /// Provides the owner used by the default customer assignment.
+    /// Provides the owner used by the default pricing assignment.
     let ownerId = OwnerId.Parse("57400000-2000-0000-0000-000000000001")
 
-    /// Provides the organization used by the default customer assignment.
+    /// Provides a second owner used to prove owner isolation.
+    let otherOwnerId = OwnerId.Parse("57400000-2000-0000-0000-000000000002")
+
+    /// Provides the organization used by the default owner assignment.
     let organizationId = OrganizationId.Parse("57400000-3000-0000-0000-000000000001")
 
-    /// Provides the repository used by the default customer assignment.
+    /// Provides the repository used by the default owner assignment.
     let repositoryId = RepositoryId.Parse("57400000-4000-0000-0000-000000000001")
 
     /// Provides a second repository used to prove repository isolation.
     let otherRepositoryId = RepositoryId.Parse("57400000-4000-0000-0000-000000000002")
 
-    /// Provides the pricing plan selected by the default customer assignment.
+    /// Provides the pricing plan selected by the default owner assignment.
     let planId = Guid.Parse("57400000-5000-0000-0000-000000000001")
 
     /// Provides the internal billable usage-kind id for repository storage.
@@ -49,7 +46,6 @@ module OperationsPricingTestData =
     /// Builds a query for repository storage pricing at the supplied timestamp.
     let query observedAt =
         {
-            CustomerId = customerId
             OwnerId = ownerId
             OrganizationId = organizationId
             RepositoryId = repositoryId
@@ -70,7 +66,7 @@ module OperationsPricingTestData =
             EffectiveTo = None
         }
 
-    /// Provides the initial customer rate for repository storage.
+    /// Provides the initial owner rate for repository storage.
     let julyRate =
         {
             PricingRateId = Guid.Parse("57400000-7000-0000-0000-000000000001")
@@ -98,11 +94,10 @@ module OperationsPricingTestData =
             EffectiveTo = None
         }
 
-    /// Provides the customer assignment that makes the plan selectable for one repository scope.
+    /// Provides the owner assignment that makes the plan selectable for one repository scope.
     let assignment =
         {
-            CustomerPricingAssignmentId = Guid.Parse("57400000-8000-0000-0000-000000000001")
-            CustomerId = customerId
+            PricingAssignmentId = Guid.Parse("57400000-8000-0000-0000-000000000001")
             OwnerId = ownerId
             OrganizationId = organizationId
             RepositoryId = repositoryId
@@ -111,14 +106,9 @@ module OperationsPricingTestData =
             EffectiveTo = None
         }
 
-    /// Provides a complete catalog with one customer assignment and two effective rates.
+    /// Provides a complete catalog with one owner assignment and two effective rates.
     let catalog =
-        {
-            PricingPlans = [ plan ]
-            BillableUsageKindMappings = [ mapping ]
-            PricingRates = [ julyRate; augustRate ]
-            CustomerPricingAssignments = [ assignment ]
-        }
+        { PricingPlans = [ plan ]; BillableUsageKindMappings = [ mapping ]; PricingRates = [ julyRate; augustRate ]; PricingAssignments = [ assignment ] }
 
 /// Covers Operations pricing schema, seed, and deterministic selection behavior.
 [<TestFixture>]
@@ -172,7 +162,7 @@ type OperationsPricingTests() =
         match contributor with
         | "assignment" ->
             { OperationsPricingTestData.catalog with
-                CustomerPricingAssignments =
+                PricingAssignments =
                     [
                         { OperationsPricingTestData.assignment with EffectiveFrom = effectiveFrom; EffectiveTo = effectiveTo }
                     ]
@@ -200,15 +190,15 @@ type OperationsPricingTests() =
             }
         | _ -> invalidArg (nameof contributor) $"Unknown pricing contributor '{contributor}'."
 
-    /// Verifies effective-rate selection requires customer assignment, mapping, and rate rows.
+    /// Verifies effective-rate selection requires owner assignment, mapping, and rate rows.
     [<Test>]
-    member _.EffectiveRateSelectionFindsCustomerRateForBillableUsageKind() =
+    member _.EffectiveRateSelectionFindsOwnerRateForBillableUsageKind() =
         let selected = PricingRateSelection.trySelect (OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0))) OperationsPricingTestData.catalog
 
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(selected.IsSome, Is.True)
-                Assert.That(selected.Value.CustomerId, Is.EqualTo(OperationsPricingTestData.customerId))
+                Assert.That(selected.Value.OwnerId, Is.EqualTo(OperationsPricingTestData.ownerId))
                 Assert.That(selected.Value.PricingPlanId, Is.EqualTo(OperationsPricingTestData.planId))
                 Assert.That(selected.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
                 Assert.That(selected.Value.BillableUsageKind, Is.EqualTo(OperationsPricingTestData.repositoryStorageBillableUsageKind))
@@ -246,7 +236,7 @@ type OperationsPricingTests() =
             Action (fun () ->
                 Assert.That(selected.Value.EffectiveFrom, Is.EqualTo(effectiveFrom))
                 Assert.That(selected.Value.EffectiveTo, Is.EqualTo(effectiveTo))
-                Assert.That(selected.Value.CustomerPricingAssignmentId, Is.EqualTo(OperationsPricingTestData.assignment.CustomerPricingAssignmentId))
+                Assert.That(selected.Value.PricingAssignmentId, Is.EqualTo(OperationsPricingTestData.assignment.PricingAssignmentId))
                 Assert.That(selected.Value.PricingPlanId, Is.EqualTo(OperationsPricingTestData.plan.PricingPlanId))
                 Assert.That(selected.Value.BillableUsageKindMappingId, Is.EqualTo(OperationsPricingTestData.mapping.BillableUsageKindMappingId))
                 Assert.That(selected.Value.PricingRateId, Is.EqualTo(OperationsPricingTestData.julyRate.PricingRateId))
@@ -337,18 +327,17 @@ type OperationsPricingTests() =
                 Assert.That(atBoundary.Value.UnitPriceMicros, Is.EqualTo(20L)))
         )
 
-    /// Verifies customer and repository identifiers must both match before pricing can be selected.
+    /// Verifies owner and repository identifiers must both match before pricing can be selected.
     [<Test>]
-    member _.EffectiveRateSelectionDoesNotLeakAcrossCustomerOrRepositoryScope() =
-        let otherCustomerQuery =
-            { OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0)) with CustomerId = OperationsPricingTestData.otherCustomerId }
+    member _.EffectiveRateSelectionDoesNotLeakAcrossOwnerOrRepositoryScope() =
+        let otherOwnerQuery = { OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0)) with OwnerId = OperationsPricingTestData.otherOwnerId }
 
         let otherRepositoryQuery =
             { OperationsPricingTestData.query (Instant.FromUtc(2026, 7, 15, 12, 0)) with RepositoryId = OperationsPricingTestData.otherRepositoryId }
 
         Assert.Multiple(
             Action (fun () ->
-                Assert.That(PricingRateSelection.trySelect otherCustomerQuery OperationsPricingTestData.catalog, Is.EqualTo(None))
+                Assert.That(PricingRateSelection.trySelect otherOwnerQuery OperationsPricingTestData.catalog, Is.EqualTo(None))
                 Assert.That(PricingRateSelection.trySelect otherRepositoryQuery OperationsPricingTestData.catalog, Is.EqualTo(None)))
         )
 
@@ -358,7 +347,7 @@ type OperationsPricingTests() =
         let plan = entityType typeof<PricingPlanEntity>
         let mapping = entityType typeof<BillableUsageKindMappingEntity>
         let rate = entityType typeof<PricingRateEntity>
-        let assignment = entityType typeof<CustomerPricingAssignmentEntity>
+        let assignment = entityType typeof<PricingAssignmentEntity>
         let currencyCode = rate.FindProperty("CurrencyCode")
         let rateForeignKeyName = pricingPlanForeignKeyName rate
         let assignmentForeignKeyName = pricingPlanForeignKeyName assignment
@@ -369,11 +358,11 @@ type OperationsPricingTests() =
 
         let hasAssignmentIndex =
             assignment.GetIndexes()
-            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentScopeIndexName)
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.PricingAssignmentScopeIndexName)
 
         let hasAssignmentPricingPlanIndex =
             assignment.GetIndexes()
-            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.PricingAssignmentPricingPlanIndexName)
 
         Assert.Multiple(
             Action (fun () ->
@@ -381,11 +370,11 @@ type OperationsPricingTests() =
                 Assert.That(plan.FindPrimaryKey().GetName(), Is.EqualTo("PK_ops_PricingPlan"))
                 Assert.That(mapping.GetTableName(), Is.EqualTo(OperationsPricingSql.BillableUsageKindMappingTableName))
                 Assert.That(rate.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingRateTableName))
-                Assert.That(assignment.GetTableName(), Is.EqualTo(OperationsPricingSql.CustomerPricingAssignmentTableName))
+                Assert.That(assignment.GetTableName(), Is.EqualTo(OperationsPricingSql.PricingAssignmentTableName))
                 Assert.That(currencyCode.GetColumnType(), Is.EqualTo("varchar(3)"))
                 Assert.That(currencyCode.GetCollation(), Is.EqualTo("Latin1_General_100_BIN2"))
                 Assert.That(rateForeignKeyName, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
-                Assert.That(assignmentForeignKeyName, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
+                Assert.That(assignmentForeignKeyName, Is.EqualTo("FK_ops_PricingAssignment_PricingPlan"))
                 Assert.That(hasRateIndex, Is.True)
                 Assert.That(hasAssignmentIndex, Is.True)
                 Assert.That(hasAssignmentPricingPlanIndex, Is.True))
@@ -396,11 +385,11 @@ type OperationsPricingTests() =
     member _.OperationsModelSnapshotContainsPricingFoundationEntities() =
         let snapshot = OperationsDbContextModelSnapshot()
         let rate = snapshot.Model.FindEntityType(typeof<PricingRateEntity>)
-        let assignment = snapshot.Model.FindEntityType(typeof<CustomerPricingAssignmentEntity>)
+        let assignment = snapshot.Model.FindEntityType(typeof<PricingAssignmentEntity>)
 
         let hasAssignmentPricingPlanIndex =
             assignment.GetIndexes()
-            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.PricingAssignmentPricingPlanIndexName)
 
         Assert.Multiple(
             Action (fun () ->
@@ -409,7 +398,7 @@ type OperationsPricingTests() =
                 Assert.That(rate, Is.Not.Null)
                 Assert.That(assignment, Is.Not.Null)
                 Assert.That(pricingPlanForeignKeyName rate, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
-                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
+                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_PricingAssignment_PricingPlan"))
                 Assert.That(hasAssignmentPricingPlanIndex, Is.True))
         )
 
@@ -418,18 +407,18 @@ type OperationsPricingTests() =
     member _.PricingMigrationTargetModelContainsReviewedForeignKeyNames() =
         let migration = AddPricingPlanRateAssignment()
         let rate = migration.TargetModel.FindEntityType(typeof<PricingRateEntity>)
-        let assignment = migration.TargetModel.FindEntityType(typeof<CustomerPricingAssignmentEntity>)
+        let assignment = migration.TargetModel.FindEntityType(typeof<PricingAssignmentEntity>)
 
         let hasAssignmentPricingPlanIndex =
             assignment.GetIndexes()
-            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName)
+            |> Seq.exists (fun index -> index.GetDatabaseName() = OperationsPricingSql.PricingAssignmentPricingPlanIndexName)
 
         Assert.Multiple(
             Action (fun () ->
                 Assert.That(rate, Is.Not.Null)
                 Assert.That(assignment, Is.Not.Null)
                 Assert.That(pricingPlanForeignKeyName rate, Is.EqualTo("FK_ops_PricingRate_PricingPlan"))
-                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_CustomerPricingAssignment_PricingPlan"))
+                Assert.That(pricingPlanForeignKeyName assignment, Is.EqualTo("FK_ops_PricingAssignment_PricingPlan"))
                 Assert.That(hasAssignmentPricingPlanIndex, Is.True))
         )
 
@@ -463,18 +452,19 @@ type OperationsPricingTests() =
                 Assert.That(script, Does.Contain("CREATE TABLE ops.PricingPlan"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.BillableUsageKindMapping"))
                 Assert.That(script, Does.Contain("CREATE TABLE ops.PricingRate"))
-                Assert.That(script, Does.Contain("CREATE TABLE ops.CustomerPricingAssignment"))
+                Assert.That(script, Does.Contain("CREATE TABLE ops.PricingAssignment"))
                 Assert.That(script, Does.Contain("CK_ops_PricingRate_EffectiveRange"))
                 Assert.That(script, Does.Contain("CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL"))
                 Assert.That(script, Does.Contain("LEN(CurrencyCode) = 3"))
                 Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 = UPPER(CurrencyCode)"))
                 Assert.That(script, Does.Contain("CurrencyCode COLLATE Latin1_General_100_BIN2 NOT LIKE"))
                 Assert.That(script, Does.Contain("CONSTRAINT FK_ops_PricingRate_PricingPlan FOREIGN KEY"))
-                Assert.That(script, Does.Contain("CONSTRAINT FK_ops_CustomerPricingAssignment_PricingPlan FOREIGN KEY"))
-                Assert.That(script, Does.Contain($"CREATE INDEX {OperationsPricingSql.CustomerPricingAssignmentPricingPlanIndexName}"))
-                Assert.That(script, Does.Contain("ON ops.CustomerPricingAssignment(PricingPlanId)"))
+                Assert.That(script, Does.Contain("CONSTRAINT FK_ops_PricingAssignment_PricingPlan FOREIGN KEY"))
+                Assert.That(script, Does.Contain($"CREATE INDEX {OperationsPricingSql.PricingAssignmentPricingPlanIndexName}"))
+                Assert.That(script, Does.Contain("ON ops.PricingAssignment(PricingPlanId)"))
                 Assert.That(script, Does.Contain(OperationsPricingSql.PricingRateOverlapTriggerName))
-                Assert.That(script, Does.Contain(OperationsPricingSql.CustomerPricingAssignmentOverlapTriggerName))
+                Assert.That(script, Does.Contain(OperationsPricingSql.PricingAssignmentOverlapTriggerName))
+                Assert.That(script, Does.Contain("ON existing.OwnerId = candidate.OwnerId"))
                 Assert.That(lockHintCount, Is.EqualTo(4))
                 Assert.That(dynamicTriggerCount, Is.EqualTo(4))
                 Assert.That(script, Does.Contain("effective windows cannot overlap")))
@@ -497,7 +487,7 @@ type OperationsPricingTests() =
                 Assert.That(targetModelSource, Does.Contain(".UseCollation(\"Latin1_General_100_BIN2\")")))
         )
 
-    /// Verifies the SQL selector cannot return a customer rate through missing mapping or loose scope matching.
+    /// Verifies the SQL selector cannot return a owner rate through missing mapping or loose scope matching.
     [<Test>]
     member _.EffectiveRateSqlRequiresExplicitMappingRateAndRepositoryScope() =
         let sql = OperationsPricingSql.SelectEffectivePricingRate
@@ -506,8 +496,7 @@ type OperationsPricingTests() =
             Action (fun () ->
                 Assert.That(sql, Does.Contain("INNER JOIN ops.BillableUsageKindMapping AS mapping"))
                 Assert.That(sql, Does.Contain("INNER JOIN ops.PricingRate AS rate"))
-                Assert.That(sql, Does.Contain("assignment.CustomerId = @CustomerId"))
-                Assert.That(sql, Does.Contain("assignment.OwnerId = @OwnerId"))
+                Assert.That(sql, Does.Contain("WHERE assignment.OwnerId = @OwnerId"))
                 Assert.That(sql, Does.Contain("assignment.OrganizationId = @OrganizationId"))
                 Assert.That(sql, Does.Contain("assignment.RepositoryId = @RepositoryId"))
                 Assert.That(sql, Does.Contain("mapping.FactKind = @FactKind"))
@@ -521,7 +510,7 @@ type OperationsPricingTests() =
                 Assert.That(sql, Does.Contain("ORDER BY")))
         )
 
-    /// Verifies the initial seed script exists and does not assign customers or post charges.
+    /// Verifies the initial seed script exists and does not assign owners or post charges.
     [<Test>]
     member _.InitialPricingSeedScriptDocumentsFoundationRowsOnly() =
         let seedPath = Path.Combine(operationsRoot (), "scripts", "seed-pricing-foundation.sql")
@@ -533,6 +522,38 @@ type OperationsPricingTests() =
                 Assert.That(script, Does.Contain("ops.PricingPlan"))
                 Assert.That(script, Does.Contain("ops.BillableUsageKindMapping"))
                 Assert.That(script, Does.Contain("ops.PricingRate"))
-                Assert.That(script, Does.Not.Contain("INSERT INTO ops.CustomerPricingAssignment"))
+                Assert.That(script, Does.Not.Contain("INSERT INTO ops.PricingAssignment"))
                 Assert.That(script, Does.Not.Contain("ChargeLedger")))
         )
+
+    /// Proves the current Operations source contains no unsupported second-identity names.
+    [<Test>]
+    member _.OperationsSourceContainsNoUnsupportedPricingIdentityTerms() =
+        let forbiddenTerms =
+            [
+                "Customer" + "Id"
+                "Customer" + "PricingAssignment"
+            ]
+
+        let sourceFiles =
+            Directory.EnumerateFiles(operationsRoot (), "*", SearchOption.AllDirectories)
+            |> Seq.filter (fun path ->
+                let relativePath = Path.GetRelativePath(operationsRoot (), path)
+
+                not (relativePath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                && not (relativePath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)))
+
+        let residuals =
+            sourceFiles
+            |> Seq.collect (fun path ->
+                let source = File.ReadAllText path
+
+                forbiddenTerms
+                |> Seq.choose (fun term ->
+                    if source.Contains(term, StringComparison.Ordinal) then
+                        Some(path, term)
+                    else
+                        None))
+            |> Seq.toList
+
+        Assert.That(residuals, Is.Empty, $"Unsupported pricing identity terms remain: {residuals}")

--- a/src/Grace.Operations/scripts/seed-pricing-foundation.sql
+++ b/src/Grace.Operations/scripts/seed-pricing-foundation.sql
@@ -1,12 +1,12 @@
 /*
-Seeds the first Operations pricing foundation rows without assigning any customer to a plan.
+Seeds the first Operations pricing foundation rows without assigning any owner to a plan.
 
 This script intentionally creates:
 - one effective pricing plan shell,
 - one explicit billable mapping for UsageFactKind.RepositoryStorageBytesMinute,
-- one customer price for that mapped usage kind.
+- one owner price for that mapped usage kind.
 
-Tracked usage remains non-billable for customers until an explicit row exists in ops.CustomerPricingAssignment.
+Tracked usage remains non-billable for owners until an explicit row exists in ops.PricingAssignment.
 */
 
 DECLARE @PlanId uniqueidentifier = '57400000-0000-0000-0000-000000000001';


### PR DESCRIPTION
## Purpose

Reset WS4 pricing and preview scope to Grace's actual identifiers before billing-ledger work continues. `OwnerId`
identifies the billing subject; `OrganizationId` and `RepositoryId` narrow the scope. There is no second billing
identity.

Related to #708
Part of #560
Part of #554

## Implementation

- Renames `CustomerPricingAssignment` to `PricingAssignment` and its identifier to `PricingAssignmentId`.
- Removes the unsupported `CustomerId` field from runtime records, entities, SQL parameters, selectors, preview scope,
  deterministic identities, locks, persistence, migrations, frozen target models, snapshot, seed data, tests, and docs.
- Defines pricing and preview scope as exactly `OwnerId`, `OrganizationId`, and `RepositoryId`, plus the existing
  effective interval or preview grain.
- Rejects overlapping half-open assignment intervals for the same exact scope while allowing adjacent intervals.
- Resets the non-production schema directly without compatibility columns, aliases, views, conversions, or backfill.
- Leaves billing ledger, owner usage API, and Grace Server proxy work to #576, #577, and #578 after this prerequisite.

## Validation

- Fantomas: passed for all touched F# files.
- Focused Operations pricing and preview tests: 42/42 passed after final SQL corrections.
- Exact negative scan: no `CustomerId` or `CustomerPricingAssignment` remains in current Operations runtime, schema,
  tests, docs, seed, migration targets, or snapshot.
- `git diff --check`: passed.
- No unexpected deletions.
- `src/Grace.slnx`: untouched.
- Freshness: one commit ahead and zero behind `origin/epic/560-operations-pricing-billing-usage`.
- Local broad-gate caveat: the worker invoked `pwsh ./scripts/validate.ps1 -Full` twice, contrary to the one-gate rule.
  Both desktop wrappers detached before a trustworthy aggregate result or exit code was captured. Neither invocation is
  accepted as completion evidence, and no further local broad gate will be launched. GitHub `full` is the authoritative
  broad gate for this head.
- GitHub `full`: passed in 8m44s on `64fc136b8b37a13eb2a34ab32ff1753bfd9bc5c4`.

## First-Pass Review Readiness

- Actual-diff self-review covered contract propagation, owner-first SQL selection, half-open overlap protection,
  migration target independence, snapshot parity, deterministic preview identity, SQL bypass paths, docs, and forbidden
  residual terms.
- Self-review caught and fixed a missing overlap-trigger owner join and effective-rate selector owner predicate before
  commit.
- Residual risk is limited to the rejected local broad-gate evidence; exact-head GitHub `full` passed, and latest-head
  Codex review is the remaining blocking gate.

## Review Status

- Current head: `64fc136b8b37a13eb2a34ab32ff1753bfd9bc5c4`
- Bot state: latest-head automatic review completed with `THUMBS_UP`
- Bot review sessions: 0
- Current open findings: 0
- Final no-issues bot status: satisfied on `64fc136b8b37a13eb2a34ab32ff1753bfd9bc5c4`
- Manual trigger decision: not attempted
- Prevention: the unsupported identifier entered during issue decomposition rather than the supplied specification;
  #708 now encodes owner-scoped identity, complete contract propagation, and a negative source-tree proof.

## Docs Impact

`Grace.Operations.Data/MIGRATIONS.md` and the pricing seed now use owner-scoped `PricingAssignment` terminology and
schema objects. No public API or generated contract exists yet; #577 and #578 explicitly prohibit the removed field.
