### PR TITLE
WS7.5: Add lifecycle catch-up and bounded blocked retry

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1502,6 +1502,41 @@ module WatchTests =
             Watch.signalRAutomationEventTargetsWatchedParentBranchForWatchTests parentId
             |> should equal false)
 
+    /// Verifies that reconnect runs current-branch catch-up only after the active SignalR groups recover.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``signalr reconnect runs current branch catch-up after subscription recovery`` () =
+        let ordering = ResizeArray<string>()
+
+        let recovered =
+            (Watch.completeSignalRReconnectWithCatchUpForWatchTests
+                (fun () ->
+                    ordering.Add("subscriptions")
+                    true)
+                (fun () -> task { ordering.Add("catch-up") }))
+                .GetAwaiter()
+                .GetResult()
+
+        recovered |> should equal true
+
+        ordering.ToArray()
+        |> should equal [| "subscriptions"; "catch-up" |]
+
+        ordering.Clear()
+
+        let failed =
+            (Watch.completeSignalRReconnectWithCatchUpForWatchTests
+                (fun () ->
+                    ordering.Add("subscriptions-failed")
+                    false)
+                (fun () -> Task.FromException<unit>(InvalidOperationException("Failed subscription recovery must not start catch-up."))))
+                .GetAwaiter()
+                .GetResult()
+
+        failed |> should equal false
+
+        ordering.ToArray()
+        |> should equal [| "subscriptions-failed" |]
+
     /// Verifies that Watch uses Grace JSON options for typed SignalR payloads.
     [<Test>]
     let ``signalr json protocol uses grace serializer options`` () =
@@ -12139,6 +12174,52 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> should not' (equal None))
 
+    /// Verifies that startup starts remote catch-up only after local reconciliation published verified clean IPC.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``watch startup runs current branch catch-up after safe local publication`` () =
+        withTempRepo (fun _ ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let ordering = ResizeArray<string>()
+
+            (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.StartingUp
+
+            (Watch.publishStartupCatchUpPendingStatusForWatchTests status directoryIds Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            let updateIpc publishedStatus publishedDirectoryIds =
+                task {
+                    ordering.Add("ipc")
+                    do! Services.updateGraceWatchInterprocessFile publishedStatus publishedDirectoryIds
+                }
+
+            let catchUpCurrentBranchReference () =
+                task {
+                    readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                    |> should equal false
+
+                    readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+                    |> should equal true
+
+                    ordering.Add("catch-up")
+                }
+
+            (Watch.completeStartupRecoveryIfPendingWorkDrainedWithCatchUpForWatchTests
+                (fun () -> Task.FromResult(status))
+                updateIpc
+                (fun () -> Task.FromResult(()))
+                catchUpCurrentBranchReference)
+                .GetAwaiter()
+                .GetResult()
+
+            ordering.ToArray()
+            |> should equal [| "ipc"; "catch-up" |])
+
     /// Verifies that processing pending Watch work publishes the dirty-to-clean IPC transition.
     [<Test>]
     let ``watch clean status transition is published after pending work drains`` () =
@@ -14805,6 +14886,158 @@ module WatchTests =
             Blake3Hash = rootBlake3Hash
             ReferenceType = referenceType
         }
+
+    /// Verifies that lifecycle catch-up derives the exact coordinator input from BranchDto rather than a prior notification.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up routes BranchDto latest reference through coordinator`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let latestNotification =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "catch-up-root")
+                    (Blake3Hash "catch-up-root-blake3")
+
+            let branchDto = branchDtoWithLatestCurrentBranchReference latestNotification
+            let observedPayloads = ResizeArray<CurrentBranchReferenceNotification>()
+
+            let getCurrentBranch () = Task.FromResult(Ok(GraceReturnValue.Create branchDto "catch-up-source-test"))
+
+            let processReference payload =
+                task {
+                    observedPayloads.Add(payload)
+
+                    let outcome: Watch.CurrentBranchMaterializationCoordinatorOutcome =
+                        { ReferenceId = payload.ReferenceId; Reason = Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied; Decision = None }
+
+                    return outcome
+                }
+
+            let result, outcome =
+                (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests getCurrentBranch processReference)
+                    .GetAwaiter()
+                    .GetResult()
+
+            result
+            |> should equal Watch.CurrentBranchReferenceCatchUpResult.Processed
+
+            outcome |> should not' (equal None)
+
+            observedPayloads.ToArray() |> should haveLength 1
+
+            let payload = observedPayloads[0]
+
+            payload.ReferenceId
+            |> should equal latestNotification.ReferenceId
+
+            payload.DirectoryId
+            |> should equal latestNotification.DirectoryId
+
+            payload.Sha256Hash
+            |> should equal latestNotification.Sha256Hash
+
+            payload.Blake3Hash
+            |> should equal latestNotification.Blake3Hash
+
+            payload.ReferenceType
+            |> should equal latestNotification.ReferenceType)
+
+    /// Verifies that a BranchDto without a concrete latest Reference never invents deferred catch-up work.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up treats missing latest reference as a no-op`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let branchDto =
+                { Grace.Types.Branch.BranchDto.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    BranchName = BranchName "current-branch"
+                }
+
+            let getCurrentBranch () = Task.FromResult(Ok(GraceReturnValue.Create branchDto "catch-up-empty-latest-test"))
+
+            let processReference _ =
+                Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                    InvalidOperationException("A missing latest Reference must not enter the coordinator.")
+                )
+
+            let result, outcome =
+                (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests getCurrentBranch processReference)
+                    .GetAwaiter()
+                    .GetResult()
+
+            result
+            |> should equal Watch.CurrentBranchReferenceCatchUpResult.NoReference
+
+            outcome |> should equal None)
+
+    /// Verifies that a non-materializable overall latest Reference does not create current-branch apply work.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up ignores non-materializable latest reference types`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+
+            let latestReference =
+                { ReferenceDto.Default with
+                    ReferenceId = Guid.NewGuid()
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    ReferenceType = ReferenceType.Promotion
+                }
+
+            let branchDto =
+                { Grace.Types.Branch.BranchDto.Default with
+                    RepositoryId = currentRepositoryId
+                    BranchId = currentBranchId
+                    BranchName = BranchName "current-branch"
+                    LatestReference = latestReference
+                }
+
+            let getCurrentBranch () = Task.FromResult(Ok(GraceReturnValue.Create branchDto "catch-up-non-materializable-latest-test"))
+
+            let processReference _ =
+                Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                    InvalidOperationException("A non-materializable latest Reference must not enter the coordinator.")
+                )
+
+            let result, outcome =
+                (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests getCurrentBranch processReference)
+                    .GetAwaiter()
+                    .GetResult()
+
+            result
+            |> should equal Watch.CurrentBranchReferenceCatchUpResult.NoReference
+
+            outcome |> should equal None)
+
+    /// Verifies that a failed BranchDto refresh remains a retryable lifecycle result without creating payload-backed work.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up reports BranchDto refresh failure without coordinator work`` () =
+        withTempRepo (fun root ->
+            configureCurrentWatchIdentity root "current-repo" "current-branch"
+            |> ignore
+
+            let getCurrentBranch () = Task.FromResult(Error(GraceError.Create "catch-up BranchDto refresh failed" "catch-up-refresh-failure-test"))
+
+            let processReference _ =
+                Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                    InvalidOperationException("A failed BranchDto refresh must not enter the coordinator.")
+                )
+
+            let result, outcome =
+                (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests getCurrentBranch processReference)
+                    .GetAwaiter()
+                    .GetResult()
+
+            result
+            |> should equal Watch.CurrentBranchReferenceCatchUpResult.RefreshFailed
+
+            outcome |> should equal None)
 
     /// Verifies that protocol-invalid current-branch notifications are rejected before BranchDto latest authority.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -15335,6 +15335,99 @@ module WatchTests =
 
             scheduler.PendingGeneration |> should equal None)
 
+    /// Verifies that a GraceStatus refresh samples pending work before clearing it and schedules one non-phantom recovery generation.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``GraceStatus refresh preserves blocked-to-safe catch-up generation without phantom rerun`` () =
+        let scheduler = Watch.CurrentBranchReferenceCatchUpScheduler(3)
+        let events = ResizeArray<string>()
+        let mutable pendingWork = true
+        let mutable requestedGenerations = 0
+
+        let refreshGraceStatusIfChanged () =
+            task {
+                events.Add("refresh")
+                pendingWork <- false
+            }
+
+        let hasPendingWork () =
+            events.Add("sample-pending")
+            pendingWork
+
+        let requestCatchUp _ =
+            requestedGenerations <- requestedGenerations + 1
+            scheduler.Request() |> ignore
+
+        (Watch.processWatchTimerLocalRecoveryWithCatchUpForWatchTests
+            refreshGraceStatusIfChanged
+            (fun () -> Task.FromResult(()))
+            (fun () -> Task.FromResult(()))
+            hasPendingWork
+            (fun () -> false)
+            requestCatchUp)
+            .GetAwaiter()
+            .GetResult()
+
+        events.IndexOf("sample-pending")
+        |> should be (lessThan (events.IndexOf("refresh")))
+
+        requestedGenerations |> should equal 1
+
+        scheduler.PendingGeneration
+        |> should equal (Some 1L)
+
+        (Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests
+            scheduler
+            (fun () -> Task.FromResult(Ok(GraceReturnValue.Create Grace.Types.Branch.BranchDto.Default "refresh-recovery")))
+            (fun _ ->
+                Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                    InvalidOperationException("A missing latest Reference must not enter the coordinator.")
+                )))
+            .GetAwaiter()
+            .GetResult()
+
+        scheduler.PendingGeneration |> should equal None
+
+        (Watch.processWatchTimerLocalRecoveryWithCatchUpForWatchTests
+            (fun () -> Task.FromResult(()))
+            (fun () -> Task.FromResult(()))
+            (fun () -> Task.FromResult(()))
+            hasPendingWork
+            (fun () -> false)
+            requestCatchUp)
+            .GetAwaiter()
+            .GetResult()
+
+        requestedGenerations |> should equal 1
+        scheduler.PendingGeneration |> should equal None
+
+    /// Verifies that failed or still-dirty GraceStatus refresh processing cannot request a premature recovery generation.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``GraceStatus refresh that remains dirty does not request premature catch-up`` () =
+        let scheduler = Watch.CurrentBranchReferenceCatchUpScheduler(3)
+        let mutable pendingWork = true
+        let mutable requestedGenerations = 0
+
+        let requestCatchUp _ =
+            requestedGenerations <- requestedGenerations + 1
+            scheduler.Request() |> ignore
+
+        (Watch.processWatchTimerLocalRecoveryWithCatchUpForWatchTests
+            (fun () ->
+                task {
+                    // Failed publication and a still-dirty refresh both retain pending-work evidence.
+                    pendingWork <- true
+                })
+            (fun () -> Task.FromResult(()))
+            (fun () -> Task.FromResult(()))
+            (fun () -> pendingWork)
+            (fun () -> false)
+            requestCatchUp)
+            .GetAwaiter()
+            .GetResult()
+
+        requestedGenerations |> should equal 0
+        scheduler.PendingGeneration |> should equal None
+
     /// Verifies that protocol-invalid current-branch notifications are rejected before BranchDto latest authority.
     [<Test>]
     let ``current branch reference decision rejects missing root identity and empty reference id`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -959,30 +959,38 @@ module WatchTests =
             let updateMarkerFile = Services.updateInProgressFileName ()
             let completedUtc = DateTime.UtcNow
 
-            Watch.setSignalRBranchSubscriptionForWatchTests branchId parentBranchId
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
 
-            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
-            |> ignore
+            try
+                Watch.setSignalRBranchSubscriptionForWatchTests branchId parentBranchId
 
-            File.WriteAllText(updateMarkerFile, "`grace watch` remote materialization is in progress.")
-            File.SetLastWriteTimeUtc(updateMarkerFile, completedUtc.AddSeconds(-1.0))
+                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                |> ignore
 
-            if observeCreation then
-                Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+                File.WriteAllText(updateMarkerFile, "`grace watch` remote materialization is in progress.")
+                File.SetLastWriteTimeUtc(updateMarkerFile, completedUtc.AddSeconds(-1.0))
 
-            File.WriteAllText(
-                updateMarkerFile + ".completed",
-                Services.serializeGraceUpdateMarkerCompletion Services.GraceUpdateMarkerPurpose.ReferenceMaterialization completedUtc
-            )
+                if observeCreation then
+                    Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
 
-            File.Delete(updateMarkerFile)
-            Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+                File.WriteAllText(
+                    updateMarkerFile + ".completed",
+                    Services.serializeGraceUpdateMarkerCompletion Services.GraceUpdateMarkerPurpose.ReferenceMaterialization completedUtc
+                )
 
-            let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
-            subscription.BranchId |> should equal branchId
+                File.Delete(updateMarkerFile)
+                Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
 
-            subscription.ParentBranchId
-            |> should equal parentBranchId)
+                Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                |> should equal (Some 1L)
+
+                let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
+                subscription.BranchId |> should equal branchId
+
+                subscription.ParentBranchId
+                |> should equal parentBranchId
+            finally
+                Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ())
 
     /// Verifies absent, legacy, unknown, and malformed purpose evidence cannot authorize branch-transition completion.
     [<TestCase("2026-07-10T12:00:00.0000000Z")>]
@@ -14946,6 +14954,127 @@ module WatchTests =
             payload.ReferenceType
             |> should equal latestNotification.ReferenceType)
 
+    /// Verifies that a completed same-branch materialization marker wakes a fresh BranchDto catch-up after bounded retries stopped.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``reference materialization marker deletion routes fresh BranchDto reference after bounded catch-up exhaustion`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let scheduler = Watch.CurrentBranchReferenceCatchUpScheduler(3)
+            let startedUtc = DateTime.UtcNow
+
+            let blockedReference =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "blocked-catch-up-root")
+                    (Blake3Hash "blocked-catch-up-root-blake3")
+
+            let blockedBranchDto = branchDtoWithLatestCurrentBranchReference blockedReference
+            let blockedCoordinatorCalls = ResizeArray<CurrentBranchReferenceNotification>()
+
+            let getBlockedBranch () = Task.FromResult(Ok(GraceReturnValue.Create blockedBranchDto "blocked-catch-up-source-test"))
+
+            let processBlockedReference (payload: CurrentBranchReferenceNotification) : Task<Watch.CurrentBranchMaterializationCoordinatorOutcome> =
+                task {
+                    blockedCoordinatorCalls.Add(payload)
+
+                    return
+                        {
+                            ReferenceId = payload.ReferenceId
+                            Reason = Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                            Decision = None
+                        }
+                }
+
+            scheduler.Request() |> should equal 1L
+
+            for nowUtc in
+                [|
+                    startedUtc
+                    startedUtc.AddSeconds(2.0)
+                    startedUtc.AddSeconds(6.0)
+                |] do
+                (Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsAtForWatchTests scheduler nowUtc getBlockedBranch processBlockedReference)
+                    .GetAwaiter()
+                    .GetResult()
+
+            blockedCoordinatorCalls.ToArray()
+            |> should haveLength 3
+
+            scheduler.PendingGeneration |> should equal None
+
+            (Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsAtForWatchTests
+                scheduler
+                (startedUtc.AddMinutes(1.0))
+                getBlockedBranch
+                processBlockedReference)
+                .GetAwaiter()
+                .GetResult()
+
+            blockedCoordinatorCalls.ToArray()
+            |> should haveLength 3
+
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
+
+            try
+                let updateMarkerFile = Services.updateInProgressFileName ()
+                let completedUtc = DateTime.UtcNow
+
+                let freshReference =
+                    validCurrentBranchReferenceNotification
+                        currentRepositoryId
+                        currentBranchId
+                        ReferenceType.Commit
+                        (Guid.NewGuid())
+                        (Sha256Hash "fresh-marker-catch-up-root")
+                        (Blake3Hash "fresh-marker-catch-up-root-blake3")
+
+                let freshBranchDto = branchDtoWithLatestCurrentBranchReference freshReference
+                let observedPayloads = ResizeArray<CurrentBranchReferenceNotification>()
+
+                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                |> ignore
+
+                File.WriteAllText(updateMarkerFile, "`grace watch` remote materialization is in progress.")
+                Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+
+                File.WriteAllText(
+                    updateMarkerFile + ".completed",
+                    Services.serializeGraceUpdateMarkerCompletion Services.GraceUpdateMarkerPurpose.ReferenceMaterialization completedUtc
+                )
+
+                File.Delete(updateMarkerFile)
+                Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
+                Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                |> should equal (Some 1L)
+
+                let getFreshBranch () = Task.FromResult(Ok(GraceReturnValue.Create freshBranchDto "fresh-marker-catch-up-source-test"))
+
+                let processFreshReference (payload: CurrentBranchReferenceNotification) : Task<Watch.CurrentBranchMaterializationCoordinatorOutcome> =
+                    task {
+                        observedPayloads.Add(payload)
+
+                        return
+                            { ReferenceId = payload.ReferenceId; Reason = Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied; Decision = None }
+                    }
+
+                (Watch.runCurrentBranchReferenceCatchUpIfDueForWatchTests getFreshBranch processFreshReference)
+                    .GetAwaiter()
+                    .GetResult()
+
+                observedPayloads.ToArray() |> should haveLength 1
+
+                observedPayloads[0].ReferenceId
+                |> should equal freshReference.ReferenceId
+
+                Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                |> should equal None
+            finally
+                Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ())
+
     /// Verifies that a BranchDto without a concrete latest Reference never invents deferred catch-up work.
     [<Test; Category("CurrentBranchCatchUp")>]
     let ``current branch catch-up treats missing latest reference as a no-op`` () =
@@ -15038,6 +15167,173 @@ module WatchTests =
             |> should equal Watch.CurrentBranchReferenceCatchUpResult.RefreshFailed
 
             outcome |> should equal None)
+
+    /// Verifies that a newer lifecycle request survives while an older request is still reading a BranchDto that has no Reference.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up preserves newer generation after older BranchDto no-reference completion`` () =
+        let scheduler = Watch.CurrentBranchReferenceCatchUpScheduler(3)
+        let readStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        let olderBranchRead =
+            TaskCompletionSource<Result<GraceReturnValue<Grace.Types.Branch.BranchDto>, GraceError>>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+        let getOlderBranch () =
+            readStarted.TrySetResult(()) |> ignore
+
+            olderBranchRead.Task
+
+        let processReference _ =
+            Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                InvalidOperationException("A BranchDto with no Reference must not enter the coordinator.")
+            )
+
+        scheduler.Request() |> should equal 1L
+
+        let olderRun = Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests scheduler getOlderBranch processReference
+
+        readStarted.Task.GetAwaiter().GetResult()
+
+        scheduler.Request() |> should equal 2L
+
+        olderBranchRead.SetResult(Ok(GraceReturnValue.Create Grace.Types.Branch.BranchDto.Default "older-no-reference"))
+        olderRun.GetAwaiter().GetResult()
+
+        scheduler.PendingGeneration
+        |> should equal (Some 2L)
+
+        (Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests
+            scheduler
+            (fun () -> Task.FromResult(Ok(GraceReturnValue.Create Grace.Types.Branch.BranchDto.Default "newer-no-reference")))
+            processReference)
+            .GetAwaiter()
+            .GetResult()
+
+        scheduler.PendingGeneration |> should equal None
+
+    /// Verifies that a newer lifecycle request survives an older same-root coordinator result.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up preserves newer generation after older same-root completion`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let scheduler = Watch.CurrentBranchReferenceCatchUpScheduler(3)
+
+            let latestReference =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "same-root-catch-up")
+                    (Blake3Hash "same-root-catch-up-blake3")
+
+            let processStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let olderCompletion = TaskCompletionSource<Watch.CurrentBranchMaterializationCoordinatorOutcome>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let processOlderReference _ =
+                processStarted.TrySetResult(()) |> ignore
+
+                olderCompletion.Task
+
+            scheduler.Request() |> should equal 1L
+
+            let olderRun =
+                Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests
+                    scheduler
+                    (fun () -> Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference latestReference) "older-same-root")))
+                    processOlderReference
+
+            processStarted.Task.GetAwaiter().GetResult()
+
+            scheduler.Request() |> should equal 2L
+
+            olderCompletion.SetResult(
+                {
+                    ReferenceId = latestReference.ReferenceId
+                    Reason = Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected
+                    Decision =
+                        Some
+                            {
+                                NeedsMaterialization = false
+                                Reason = Services.LatestCurrentBranchReferenceDecisionReason.SameRoot
+                                Reference = Some latestReference
+                            }
+                }
+            )
+
+            olderRun.GetAwaiter().GetResult()
+
+            scheduler.PendingGeneration
+            |> should equal (Some 2L)
+
+            (Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests
+                scheduler
+                (fun () -> Task.FromResult(Ok(GraceReturnValue.Create Grace.Types.Branch.BranchDto.Default "newer-same-root")))
+                (fun _ ->
+                    Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                        InvalidOperationException("The newer no-reference BranchDto must not enter the coordinator.")
+                    )))
+                .GetAwaiter()
+                .GetResult()
+
+            scheduler.PendingGeneration |> should equal None)
+
+    /// Verifies that a newer lifecycle request survives an older serialized materialization-lane completion.
+    [<Test; Category("CurrentBranchCatchUp")>]
+    let ``current branch catch-up preserves newer generation after older serialized apply completion`` () =
+        withTempRepo (fun root ->
+            let currentRepositoryId, currentBranchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+            let scheduler = Watch.CurrentBranchReferenceCatchUpScheduler(3)
+
+            let latestReference =
+                validCurrentBranchReferenceNotification
+                    currentRepositoryId
+                    currentBranchId
+                    ReferenceType.Commit
+                    (Guid.NewGuid())
+                    (Sha256Hash "serialized-apply-catch-up")
+                    (Blake3Hash "serialized-apply-catch-up-blake3")
+
+            let laneEntered = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let olderCompletion = TaskCompletionSource<Watch.CurrentBranchMaterializationCoordinatorOutcome>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let processOlderReference payload =
+                laneEntered.TrySetResult(()) |> ignore
+
+                olderCompletion.Task
+
+            scheduler.Request() |> should equal 1L
+
+            let olderRun =
+                Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests
+                    scheduler
+                    (fun () ->
+                        Task.FromResult(Ok(GraceReturnValue.Create (branchDtoWithLatestCurrentBranchReference latestReference) "older-serialized-apply")))
+                    processOlderReference
+
+            laneEntered.Task.GetAwaiter().GetResult()
+
+            scheduler.Request() |> should equal 2L
+
+            olderCompletion.SetResult(
+                { ReferenceId = latestReference.ReferenceId; Reason = Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.Applied; Decision = None }
+            )
+
+            olderRun.GetAwaiter().GetResult()
+
+            scheduler.PendingGeneration
+            |> should equal (Some 2L)
+
+            (Watch.runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests
+                scheduler
+                (fun () -> Task.FromResult(Ok(GraceReturnValue.Create Grace.Types.Branch.BranchDto.Default "newer-after-serialized-apply")))
+                (fun _ ->
+                    Task.FromException<Watch.CurrentBranchMaterializationCoordinatorOutcome>(
+                        InvalidOperationException("The newer no-reference BranchDto must not enter the coordinator.")
+                    )))
+                .GetAwaiter()
+                .GetResult()
+
+            scheduler.PendingGeneration |> should equal None)
 
     /// Verifies that protocol-invalid current-branch notifications are rejected before BranchDto latest authority.
     [<Test>]

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -7470,6 +7470,45 @@ module Watch =
             processChangedFilesClient
             catchUpCurrentBranchReference
 
+    /// Preserves pending-work recovery evidence across GraceStatus refresh processing before queuing a lifecycle catch-up generation.
+    let private processWatchTimerLocalRecoveryWithCatchUp
+        refreshGraceStatusIfChanged
+        processChangedFilesClient
+        completeStartupRecovery
+        hasPendingWork
+        isResyncPending
+        requestCatchUp
+        =
+        task {
+            let localWorkWasPending = hasPendingWork ()
+            let resyncWasPending = isResyncPending ()
+
+            do! refreshGraceStatusIfChanged ()
+            do! processChangedFilesClient ()
+            do! completeStartupRecovery ()
+
+            if (localWorkWasPending && not (hasPendingWork ()))
+               || (resyncWasPending && not (isResyncPending ())) then
+                requestCatchUp "local Watch recovery"
+        }
+
+    /// Exposes timer recovery sequencing so Watch tests can prove a refresh cannot erase its blocked-to-safe wake-up.
+    let internal processWatchTimerLocalRecoveryWithCatchUpForWatchTests
+        refreshGraceStatusIfChanged
+        processChangedFilesClient
+        completeStartupRecovery
+        hasPendingWork
+        isResyncPending
+        requestCatchUp
+        =
+        processWatchTimerLocalRecoveryWithCatchUp
+            refreshGraceStatusIfChanged
+            processChangedFilesClient
+            completeStartupRecovery
+            hasPendingWork
+            isResyncPending
+            requestCatchUp
+
     /// Executes the watch command by binding ParseResult values to the SDK request and CLI output contract.
     type Watch() =
         inherit AsynchronousCommandLineAction()
@@ -7759,33 +7798,31 @@ module Watch =
 
                     while ticked
                           && not (cancellationToken.IsCancellationRequested) do
-                        // Grace Status may have changed from branch switch, or other commands.
-                        if graceStatusHasChanged then
-                            let refreshGeneration = currentGraceStatusRefreshGeneration ()
-                            let! updatedGraceStatus = readGraceStatusFile ()
-                            do! publishGraceStatusRefreshSnapshot refreshGeneration updatedGraceStatus updateGraceWatchInterprocessFile
-
-                        let localWorkWasPending = hasPendingWatchWork ()
-                        let resyncWasPending = isGraceWatchResyncPending ()
-
-                        do! processChangedFiles ()
-
                         do!
-                            completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
-                                readGraceStatusFile
-                                updateGraceWatchInterprocessFile
-                                processChangedFiles
+                            processWatchTimerLocalRecoveryWithCatchUp
                                 (fun () ->
                                     task {
-                                        requestCurrentBranchReferenceCatchUp "safe startup local reconciliation"
-                                        do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
-                                    })
+                                        // Grace Status may have changed from branch switch, or other commands.
+                                        if graceStatusHasChanged then
+                                            let refreshGeneration = currentGraceStatusRefreshGeneration ()
+                                            let! updatedGraceStatus = readGraceStatusFile ()
 
-                        if (localWorkWasPending
-                            && not (hasPendingWatchWork ()))
-                           || (resyncWasPending
-                               && not (isGraceWatchResyncPending ())) then
-                            requestCurrentBranchReferenceCatchUp "local Watch recovery"
+                                            do! publishGraceStatusRefreshSnapshot refreshGeneration updatedGraceStatus updateGraceWatchInterprocessFile
+                                    })
+                                processChangedFiles
+                                (fun () ->
+                                    completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
+                                        readGraceStatusFile
+                                        updateGraceWatchInterprocessFile
+                                        processChangedFiles
+                                        (fun () ->
+                                            task {
+                                                requestCurrentBranchReferenceCatchUp "safe startup local reconciliation"
+                                                do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
+                                            }))
+                                hasPendingWatchWork
+                                isGraceWatchResyncPending
+                                requestCurrentBranchReferenceCatchUp
 
                         do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
                         let! tick = periodicTimer.WaitForNextTickAsync()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -5437,53 +5437,140 @@ module Watch =
     let internal catchUpCurrentBranchReferenceWithClientsForWatchTests getCurrentBranch processReference =
         catchUpCurrentBranchReferenceWithClients getCurrentBranch processReference
 
-    /// Limits lifecycle catch-up retries until a later local-drain, resync, startup, or reconnect request obtains fresh evidence.
+    /// Identifies the one lifecycle request generation that a catch-up run may settle.
+    type internal CurrentBranchReferenceCatchUpClaim = { Generation: int64 }
+
+    /// Describes whether a terminal catch-up result settled its own request or left a newer one pending.
+    type internal CurrentBranchReferenceCatchUpCompletion =
+        /// The claimed lifecycle request completed and no later request remains.
+        | ClaimCompleted
+        /// A later lifecycle request arrived while the claim awaited BranchDto or the materialization lane.
+        | NewerRequestPending
+        /// The completion came from an obsolete or already-settled claim.
+        | ClaimNotCurrent
+
+    /// Describes the bounded retry outcome for the lifecycle request generation that requested it.
+    type internal CurrentBranchReferenceCatchUpRetry =
+        /// The claimed request remains pending until the reported bounded backoff elapses.
+        | RetryAfter of delaySeconds: int
+        /// The claimed request exhausted its bounded attempts and awaits fresh lifecycle evidence.
+        | RetryExhausted
+        /// A newer lifecycle request arrived before this claim could schedule another retry.
+        | RetrySupersededByNewerRequest
+        /// The retry came from an obsolete or already-settled claim.
+        | RetryClaimNotCurrent
+
+    /// Serializes lifecycle catch-up request generations so an older asynchronous run cannot consume newer evidence.
+    type internal CurrentBranchReferenceCatchUpScheduler(maximumAttempts: int) =
+        let schedulerLock = obj ()
+        let mutable nextGeneration = 0L
+        let mutable pendingGeneration: int64 option = None
+        let mutable claimedGeneration: int64 option = None
+        let mutable retryAttempts = 0
+        let mutable retryNotBeforeUtc = DateTime.MinValue
+
+        /// Records fresh lifecycle evidence without retaining a Reference payload as retry state.
+        member _.Request() =
+            lock schedulerLock (fun () ->
+                nextGeneration <- nextGeneration + 1L
+                pendingGeneration <- Some nextGeneration
+                retryAttempts <- 0
+                retryNotBeforeUtc <- DateTime.MinValue
+                nextGeneration)
+
+        /// Claims the due pending generation only when no earlier run is still awaiting external work.
+        member _.TryClaimDue(nowUtc: DateTime) =
+            lock schedulerLock (fun () ->
+                match claimedGeneration, pendingGeneration with
+                | None, Some generation when retryNotBeforeUtc <= nowUtc ->
+                    claimedGeneration <- Some generation
+                    Some { Generation = generation }
+                | _ -> None)
+
+        /// Settles only the pending generation held by the supplied claim.
+        member _.Complete(claim: CurrentBranchReferenceCatchUpClaim) =
+            lock schedulerLock (fun () ->
+                match claimedGeneration with
+                | Some generation when generation = claim.Generation ->
+                    claimedGeneration <- None
+
+                    match pendingGeneration with
+                    | Some pending when pending = claim.Generation ->
+                        pendingGeneration <- None
+                        retryAttempts <- 0
+                        retryNotBeforeUtc <- DateTime.MinValue
+                        ClaimCompleted
+                    | _ -> NewerRequestPending
+                | _ -> ClaimNotCurrent)
+
+        /// Retries only the pending generation held by the supplied claim and preserves newer lifecycle evidence.
+        member _.Retry(claim: CurrentBranchReferenceCatchUpClaim, nowUtc: DateTime) =
+            lock schedulerLock (fun () ->
+                match claimedGeneration with
+                | Some generation when generation = claim.Generation ->
+                    claimedGeneration <- None
+
+                    match pendingGeneration with
+                    | Some pending when pending = claim.Generation ->
+                        retryAttempts <- retryAttempts + 1
+
+                        if retryAttempts >= maximumAttempts then
+                            pendingGeneration <- None
+                            retryAttempts <- 0
+                            retryNotBeforeUtc <- DateTime.MinValue
+                            RetryExhausted
+                        else
+                            let delaySeconds = pown 2 retryAttempts
+                            retryNotBeforeUtc <- nowUtc.AddSeconds(float delaySeconds)
+                            RetryAfter delaySeconds
+                    | _ -> RetrySupersededByNewerRequest
+                | _ -> RetryClaimNotCurrent)
+
+        /// Clears all private scheduler state for isolated Watch tests.
+        member _.Reset() =
+            lock schedulerLock (fun () ->
+                nextGeneration <- 0L
+                pendingGeneration <- None
+                claimedGeneration <- None
+                retryAttempts <- 0
+                retryNotBeforeUtc <- DateTime.MinValue)
+
+        /// Reports the pending generation for false-positive-resistant lifecycle tests.
+        member _.PendingGeneration = lock schedulerLock (fun () -> pendingGeneration)
+
+    /// Limits lifecycle catch-up retries until a later local-drain, resync, startup, reconnect, or marker-deletion request obtains fresh evidence.
     let private currentBranchReferenceCatchUpMaximumAttempts = 3
-    let private currentBranchReferenceCatchUpRetryLock = obj ()
-    let mutable private currentBranchReferenceCatchUpRetryPending = false
-    let mutable private currentBranchReferenceCatchUpRetryAttempts = 0
-    let mutable private currentBranchReferenceCatchUpRetryNotBeforeUtc = DateTime.MinValue
+    let private currentBranchReferenceCatchUpScheduler = CurrentBranchReferenceCatchUpScheduler(currentBranchReferenceCatchUpMaximumAttempts)
 
     /// Requests a new BranchDto-derived catch-up without retaining a notification or Reference outside the coordinator.
     let private requestCurrentBranchReferenceCatchUp reason =
-        lock currentBranchReferenceCatchUpRetryLock (fun () ->
-            currentBranchReferenceCatchUpRetryPending <- true
-            currentBranchReferenceCatchUpRetryAttempts <- 0
-            currentBranchReferenceCatchUpRetryNotBeforeUtc <- DateTime.MinValue)
+        currentBranchReferenceCatchUpScheduler.Request()
+        |> ignore
 
         logToAnsiConsole Colors.Verbose $"Current-branch Watch catch-up requested after {reason}."
 
-    /// Clears a completed lifecycle catch-up request after BranchDto or the coordinator reached a terminal result.
-    let private completeCurrentBranchReferenceCatchUp () =
-        lock currentBranchReferenceCatchUpRetryLock (fun () ->
-            currentBranchReferenceCatchUpRetryPending <- false
-            currentBranchReferenceCatchUpRetryAttempts <- 0
-            currentBranchReferenceCatchUpRetryNotBeforeUtc <- DateTime.MinValue)
+    /// Completes a claimed lifecycle request and deliberately leaves later requests pending.
+    let private completeCurrentBranchReferenceCatchUp (scheduler: CurrentBranchReferenceCatchUpScheduler) (claim: CurrentBranchReferenceCatchUpClaim) =
+        scheduler.Complete(claim) |> ignore
 
-    /// Schedules the next bounded BranchDto refresh without retaining the blocked Reference as retry truth.
-    let private retryCurrentBranchReferenceCatchUp reason =
-        let retryDelay =
-            lock currentBranchReferenceCatchUpRetryLock (fun () ->
-                currentBranchReferenceCatchUpRetryAttempts <- currentBranchReferenceCatchUpRetryAttempts + 1
-
-                if currentBranchReferenceCatchUpRetryAttempts
-                   >= currentBranchReferenceCatchUpMaximumAttempts then
-                    currentBranchReferenceCatchUpRetryPending <- false
-                    None
-                else
-                    let delaySeconds = pown 2 currentBranchReferenceCatchUpRetryAttempts
-                    currentBranchReferenceCatchUpRetryNotBeforeUtc <- DateTime.UtcNow.AddSeconds(float delaySeconds)
-                    Some delaySeconds)
-
-        match retryDelay with
-        | Some delaySeconds ->
+    /// Schedules a bounded retry only when the same claimed lifecycle request remains current.
+    let private retryCurrentBranchReferenceCatchUp
+        (scheduler: CurrentBranchReferenceCatchUpScheduler)
+        (nowUtc: DateTime)
+        (claim: CurrentBranchReferenceCatchUpClaim)
+        reason
+        =
+        match scheduler.Retry(claim, nowUtc) with
+        | RetryAfter delaySeconds ->
             logToAnsiConsole
                 Colors.Important
                 $"Current-branch Watch catch-up remains blocked: {reason}. It will refresh BranchDto again in {delaySeconds} seconds."
-        | None ->
+        | RetryExhausted ->
             logToAnsiConsole
                 Colors.Important
-                $"Current-branch Watch catch-up remains blocked after {currentBranchReferenceCatchUpMaximumAttempts} attempts: {reason}. It will retry when local work drains, resync completes, or SignalR reconnects."
+                $"Current-branch Watch catch-up remains blocked after {currentBranchReferenceCatchUpMaximumAttempts} attempts: {reason}. It will retry when local work drains, resync completes, SignalR reconnects, or a materialization marker is deleted."
+        | RetrySupersededByNewerRequest
+        | RetryClaimNotCurrent -> ()
 
     /// Uses one coordinator attempt per lifecycle retry so catch-up backoff is cancellable between fresh BranchDto reads.
     let private processCurrentBranchReferenceCatchUp payload =
@@ -5501,50 +5588,81 @@ module Watch =
             }
             payload
 
-    /// Runs a due lifecycle request only from a healthy local boundary and never after Watch cancellation begins.
-    let private runCurrentBranchReferenceCatchUpIfDue (cancellationToken: CancellationToken) =
+    /// Runs one due claimed lifecycle request without permitting it to clear a newer request that arrives while it awaits.
+    let private runCurrentBranchReferenceCatchUpIfDueWithClientsAt
+        (scheduler: CurrentBranchReferenceCatchUpScheduler)
+        (nowUtc: DateTime)
+        getCurrentBranch
+        processReference
+        =
         task {
-            let isDue =
-                lock currentBranchReferenceCatchUpRetryLock (fun () ->
-                    currentBranchReferenceCatchUpRetryPending
-                    && currentBranchReferenceCatchUpRetryNotBeforeUtc
-                       <= DateTime.UtcNow)
-
-            if
-                isDue
-                && not cancellationToken.IsCancellationRequested
-                && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
-                && not (isGraceWatchResyncPending ())
-                && not (hasPendingWatchWork ())
-            then
+            match scheduler.TryClaimDue(nowUtc) with
+            | Some claim ->
                 try
-                    let! result, outcome =
-                        catchUpCurrentBranchReferenceWithClients
-                            (fun () -> getCurrentBranchForCurrentBranchReferenceNotification CurrentBranchReferenceNotification.Default)
-                            processCurrentBranchReferenceCatchUp
+                    let! result, outcome = catchUpCurrentBranchReferenceWithClients getCurrentBranch processReference
 
                     match result, outcome with
-                    | CurrentBranchReferenceCatchUpResult.NoReference, _ -> completeCurrentBranchReferenceCatchUp ()
-                    | CurrentBranchReferenceCatchUpResult.RefreshFailed, _ -> retryCurrentBranchReferenceCatchUp "BranchDto refresh failed"
+                    | CurrentBranchReferenceCatchUpResult.NoReference, _ -> completeCurrentBranchReferenceCatchUp scheduler claim
+                    | CurrentBranchReferenceCatchUpResult.RefreshFailed, _ ->
+                        retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "BranchDto refresh failed"
                     | CurrentBranchReferenceCatchUpResult.Processed, Some coordinatorOutcome ->
                         match coordinatorOutcome.Reason, coordinatorOutcome.Decision with
                         | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint, _ ->
-                            retryCurrentBranchReferenceCatchUp "local Watch work is still pending"
+                            retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "local Watch work is still pending"
                         | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync, _ ->
-                            retryCurrentBranchReferenceCatchUp "local Watch state requires resync"
+                            retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "local Watch state requires resync"
                         | CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected, Some decision when
                             decision.Reason = LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
                             ->
-                            retryCurrentBranchReferenceCatchUp "BranchDto advanced while catch-up waited for the serialized lane"
-                        | _ -> completeCurrentBranchReferenceCatchUp ()
-                    | CurrentBranchReferenceCatchUpResult.Processed, None -> completeCurrentBranchReferenceCatchUp ()
-                    | _ -> completeCurrentBranchReferenceCatchUp ()
+                            retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "BranchDto advanced while catch-up waited for the serialized lane"
+                        | _ -> completeCurrentBranchReferenceCatchUp scheduler claim
+                    | CurrentBranchReferenceCatchUpResult.Processed, None -> completeCurrentBranchReferenceCatchUp scheduler claim
+                    | _ -> completeCurrentBranchReferenceCatchUp scheduler claim
                 with
                 | ex ->
                     logToAnsiConsole Colors.Error $"Current-branch Watch catch-up failed before a terminal coordinator result: {Markup.Escape(ex.Message)}."
 
-                    retryCurrentBranchReferenceCatchUp "catch-up processing failed"
+                    retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "catch-up processing failed"
+            | None -> ()
         }
+
+    /// Runs one due lifecycle request using the current instant for production Watch callbacks.
+    let private runCurrentBranchReferenceCatchUpIfDueWithClients scheduler getCurrentBranch processReference =
+        runCurrentBranchReferenceCatchUpIfDueWithClientsAt scheduler DateTime.UtcNow getCurrentBranch processReference
+
+    /// Runs a due lifecycle request only from a healthy local boundary and never after Watch cancellation begins.
+    let private runCurrentBranchReferenceCatchUpIfDue (cancellationToken: CancellationToken) =
+        task {
+            if
+                not cancellationToken.IsCancellationRequested
+                && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+                && not (isGraceWatchResyncPending ())
+                && not (hasPendingWatchWork ())
+            then
+                do!
+                    runCurrentBranchReferenceCatchUpIfDueWithClients
+                        currentBranchReferenceCatchUpScheduler
+                        (fun () -> getCurrentBranchForCurrentBranchReferenceNotification CurrentBranchReferenceNotification.Default)
+                        processCurrentBranchReferenceCatchUp
+        }
+
+    /// Resets the private lifecycle scheduler before a focused Watch test creates fresh request generations.
+    let internal resetCurrentBranchReferenceCatchUpSchedulerForWatchTests () = currentBranchReferenceCatchUpScheduler.Reset()
+
+    /// Reports the private pending lifecycle generation for focused marker-deletion and interleaving proofs.
+    let internal currentBranchReferenceCatchUpPendingGenerationForWatchTests () = currentBranchReferenceCatchUpScheduler.PendingGeneration
+
+    /// Runs one claimed lifecycle request against injectable BranchDto and coordinator clients for deterministic interleaving tests.
+    let internal runCurrentBranchReferenceCatchUpIfDueWithClientsForWatchTests scheduler getCurrentBranch processReference =
+        runCurrentBranchReferenceCatchUpIfDueWithClients scheduler getCurrentBranch processReference
+
+    /// Runs one lifecycle request at a deterministic instant so Watch tests can prove bounded retry timing without sleeping.
+    let internal runCurrentBranchReferenceCatchUpIfDueWithClientsAtForWatchTests scheduler nowUtc getCurrentBranch processReference =
+        runCurrentBranchReferenceCatchUpIfDueWithClientsAt scheduler nowUtc getCurrentBranch processReference
+
+    /// Runs the production lifecycle scheduler against injected clients after a real Watch callback queues fresh evidence.
+    let internal runCurrentBranchReferenceCatchUpIfDueForWatchTests getCurrentBranch processReference =
+        runCurrentBranchReferenceCatchUpIfDueWithClients currentBranchReferenceCatchUpScheduler getCurrentBranch processReference
 
     /// Exposes same-branch Reference notification identity matching to Watch tests without opening a HubConnection.
     let internal currentBranchReferenceNotificationTargetsCurrentBranchForWatchTests payload = currentBranchReferenceNotificationTargetsCurrentBranch payload
@@ -5952,6 +6070,7 @@ module Watch =
                 | Some (GraceUpdateMarkerPurpose.ReferenceMaterialization, completedUtc) ->
                     forgetObservedGraceUpdateMarkerInstance args.FullPath
                     recordGraceUpdateMarkerCompletedUtc completedUtc
+                    requestCurrentBranchReferenceCatchUp "current-branch reference materialization marker deletion"
                     logToAnsiConsole Colors.Important $"Reference materialization update has finished."
                 | None ->
                     forgetObservedGraceUpdateMarkerInstance args.FullPath

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -792,6 +792,20 @@ module Watch =
     /// Exposes SignalR reconnect refresh behavior to Watch tests without opening a HubConnection.
     let internal refreshSignalRSubscriptionsForActiveConnectionForWatchTests refresh = refreshSignalRSubscriptionsForActiveConnection refresh
 
+    /// Runs lifecycle catch-up only after SignalR subscription recovery succeeds for the active connection.
+    let private completeSignalRReconnectWithCatchUp refreshSignalRSubscriptions catchUpCurrentBranchReference =
+        task {
+            if refreshSignalRSubscriptions () then
+                do! catchUpCurrentBranchReference ()
+                return true
+            else
+                return false
+        }
+
+    /// Exposes SignalR reconnect ordering to Watch tests without opening a HubConnection.
+    let internal completeSignalRReconnectWithCatchUpForWatchTests refreshSignalRSubscriptions catchUpCurrentBranchReference =
+        completeSignalRReconnectWithCatchUp refreshSignalRSubscriptions catchUpCurrentBranchReference
+
     /// Installs the SignalR parent-branch refresh operation used by transition-completion tests.
     let internal setSignalRSubscriptionRefreshForWatchTests refresh =
         lock signalRSubscriptionRefreshLock (fun () -> refreshSignalRBranchSubscriptionsForTransitionCompletion <- refresh)
@@ -5356,11 +5370,180 @@ module Watch =
                         ApplyReference = applyCurrentBranchReferenceMaterialization
                         PublishCleanIpcAfterApply = tryPublishCurrentBranchMaterializationCleanStatus
                         ReassertDirtyIpcAfterFailedCleanPublication = tryPublishCurrentBranchMaterializationDirtyStatus
-                        MaxAttempts = None
+                        MaxAttempts = Some 3
                     }
                     payload
 
             return ()
+        }
+
+    /// Names the result of deriving and processing one lifecycle catch-up request from the current BranchDto.
+    type internal CurrentBranchReferenceCatchUpResult =
+        /// The BranchDto did not name a concrete current-branch Reference eligible for materialization.
+        | NoReference = 0
+        /// The BranchDto refresh did not complete, so a bounded lifecycle retry may re-read it later.
+        | RefreshFailed = 1
+        /// The existing serialized coordinator processed the exact Reference derived from BranchDto.
+        | Processed = 2
+
+    /// Builds the coordinator input from the server's current BranchDto rather than any prior SignalR payload.
+    let private tryCreateCurrentBranchReferenceCatchUpNotification (branchDto: Grace.Types.Branch.BranchDto) correlationId =
+        let current = Current()
+        let latestReference = branchDto.LatestReference
+
+        if branchDto.RepositoryId <> current.RepositoryId
+           || branchDto.BranchId <> current.BranchId
+           || latestReference.ReferenceId = ReferenceId.Empty then
+            None
+        elif not (CurrentBranchReferenceNotification.IsEligibleReferenceType latestReference.ReferenceType) then
+            None
+        else
+            Some
+                { CurrentBranchReferenceNotification.Default with
+                    ReferenceId = latestReference.ReferenceId
+                    OwnerId = latestReference.OwnerId
+                    OrganizationId = latestReference.OrganizationId
+                    RepositoryId = latestReference.RepositoryId
+                    BranchId = latestReference.BranchId
+                    BranchName = branchDto.BranchName
+                    DirectoryId = latestReference.DirectoryId
+                    Sha256Hash = latestReference.Sha256Hash
+                    Blake3Hash = latestReference.Blake3Hash
+                    ReferenceType = latestReference.ReferenceType
+                    ReferenceText = latestReference.ReferenceText
+                    CorrelationId = correlationId
+                }
+
+    /// Re-reads BranchDto and sends its exact latest Reference through the existing serialized materialization lane.
+    let private catchUpCurrentBranchReferenceWithClients
+        (getCurrentBranch: unit -> Task<Result<GraceReturnValue<Grace.Types.Branch.BranchDto>, GraceError>>)
+        (processReference: CurrentBranchReferenceNotification -> Task<CurrentBranchMaterializationCoordinatorOutcome>)
+        =
+        task {
+            match! getCurrentBranch () with
+            | Error error ->
+                logToAnsiConsole Colors.Error $"Failed to refresh BranchDto for current-branch Watch catch-up: {Markup.Escape(error.ToString())}."
+
+                return CurrentBranchReferenceCatchUpResult.RefreshFailed, None
+            | Ok branchReturnValue ->
+                match tryCreateCurrentBranchReferenceCatchUpNotification branchReturnValue.ReturnValue (generateCorrelationId ()) with
+                | None -> return CurrentBranchReferenceCatchUpResult.NoReference, None
+                | Some payload ->
+                    let! outcome = processReference payload
+                    return CurrentBranchReferenceCatchUpResult.Processed, Some outcome
+        }
+
+    /// Exposes BranchDto-derived catch-up routing for deterministic Watch lifecycle tests.
+    let internal catchUpCurrentBranchReferenceWithClientsForWatchTests getCurrentBranch processReference =
+        catchUpCurrentBranchReferenceWithClients getCurrentBranch processReference
+
+    /// Limits lifecycle catch-up retries until a later local-drain, resync, startup, or reconnect request obtains fresh evidence.
+    let private currentBranchReferenceCatchUpMaximumAttempts = 3
+    let private currentBranchReferenceCatchUpRetryLock = obj ()
+    let mutable private currentBranchReferenceCatchUpRetryPending = false
+    let mutable private currentBranchReferenceCatchUpRetryAttempts = 0
+    let mutable private currentBranchReferenceCatchUpRetryNotBeforeUtc = DateTime.MinValue
+
+    /// Requests a new BranchDto-derived catch-up without retaining a notification or Reference outside the coordinator.
+    let private requestCurrentBranchReferenceCatchUp reason =
+        lock currentBranchReferenceCatchUpRetryLock (fun () ->
+            currentBranchReferenceCatchUpRetryPending <- true
+            currentBranchReferenceCatchUpRetryAttempts <- 0
+            currentBranchReferenceCatchUpRetryNotBeforeUtc <- DateTime.MinValue)
+
+        logToAnsiConsole Colors.Verbose $"Current-branch Watch catch-up requested after {reason}."
+
+    /// Clears a completed lifecycle catch-up request after BranchDto or the coordinator reached a terminal result.
+    let private completeCurrentBranchReferenceCatchUp () =
+        lock currentBranchReferenceCatchUpRetryLock (fun () ->
+            currentBranchReferenceCatchUpRetryPending <- false
+            currentBranchReferenceCatchUpRetryAttempts <- 0
+            currentBranchReferenceCatchUpRetryNotBeforeUtc <- DateTime.MinValue)
+
+    /// Schedules the next bounded BranchDto refresh without retaining the blocked Reference as retry truth.
+    let private retryCurrentBranchReferenceCatchUp reason =
+        let retryDelay =
+            lock currentBranchReferenceCatchUpRetryLock (fun () ->
+                currentBranchReferenceCatchUpRetryAttempts <- currentBranchReferenceCatchUpRetryAttempts + 1
+
+                if currentBranchReferenceCatchUpRetryAttempts
+                   >= currentBranchReferenceCatchUpMaximumAttempts then
+                    currentBranchReferenceCatchUpRetryPending <- false
+                    None
+                else
+                    let delaySeconds = pown 2 currentBranchReferenceCatchUpRetryAttempts
+                    currentBranchReferenceCatchUpRetryNotBeforeUtc <- DateTime.UtcNow.AddSeconds(float delaySeconds)
+                    Some delaySeconds)
+
+        match retryDelay with
+        | Some delaySeconds ->
+            logToAnsiConsole
+                Colors.Important
+                $"Current-branch Watch catch-up remains blocked: {reason}. It will refresh BranchDto again in {delaySeconds} seconds."
+        | None ->
+            logToAnsiConsole
+                Colors.Important
+                $"Current-branch Watch catch-up remains blocked after {currentBranchReferenceCatchUpMaximumAttempts} attempts: {reason}. It will retry when local work drains, resync completes, or SignalR reconnects."
+
+    /// Uses one coordinator attempt per lifecycle retry so catch-up backoff is cancellable between fresh BranchDto reads.
+    let private processCurrentBranchReferenceCatchUp payload =
+        runCurrentBranchMaterializationCoordinator
+            {
+                GetCurrentBranch = (fun () -> getCurrentBranchForCurrentBranchReferenceNotification payload)
+                InspectLocalStatus = inspectGraceWatchStatus
+                RequestDegradedResync = requestGraceWatchExplicitResync
+                WaitForSafePoint = fun _ _ -> Task.FromResult(())
+                ReestablishIpc = fun _ _ -> Task.FromResult(())
+                ApplyReference = applyCurrentBranchReferenceMaterialization
+                PublishCleanIpcAfterApply = tryPublishCurrentBranchMaterializationCleanStatus
+                ReassertDirtyIpcAfterFailedCleanPublication = tryPublishCurrentBranchMaterializationDirtyStatus
+                MaxAttempts = Some 1
+            }
+            payload
+
+    /// Runs a due lifecycle request only from a healthy local boundary and never after Watch cancellation begins.
+    let private runCurrentBranchReferenceCatchUpIfDue (cancellationToken: CancellationToken) =
+        task {
+            let isDue =
+                lock currentBranchReferenceCatchUpRetryLock (fun () ->
+                    currentBranchReferenceCatchUpRetryPending
+                    && currentBranchReferenceCatchUpRetryNotBeforeUtc
+                       <= DateTime.UtcNow)
+
+            if
+                isDue
+                && not cancellationToken.IsCancellationRequested
+                && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
+                && not (isGraceWatchResyncPending ())
+                && not (hasPendingWatchWork ())
+            then
+                try
+                    let! result, outcome =
+                        catchUpCurrentBranchReferenceWithClients
+                            (fun () -> getCurrentBranchForCurrentBranchReferenceNotification CurrentBranchReferenceNotification.Default)
+                            processCurrentBranchReferenceCatchUp
+
+                    match result, outcome with
+                    | CurrentBranchReferenceCatchUpResult.NoReference, _ -> completeCurrentBranchReferenceCatchUp ()
+                    | CurrentBranchReferenceCatchUpResult.RefreshFailed, _ -> retryCurrentBranchReferenceCatchUp "BranchDto refresh failed"
+                    | CurrentBranchReferenceCatchUpResult.Processed, Some coordinatorOutcome ->
+                        match coordinatorOutcome.Reason, coordinatorOutcome.Decision with
+                        | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint, _ ->
+                            retryCurrentBranchReferenceCatchUp "local Watch work is still pending"
+                        | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync, _ ->
+                            retryCurrentBranchReferenceCatchUp "local Watch state requires resync"
+                        | CurrentBranchMaterializationCoordinatorOutcomeReason.LatestAuthorityRejected, Some decision when
+                            decision.Reason = LatestCurrentBranchReferenceDecisionReason.StaleLatestReference
+                            ->
+                            retryCurrentBranchReferenceCatchUp "BranchDto advanced while catch-up waited for the serialized lane"
+                        | _ -> completeCurrentBranchReferenceCatchUp ()
+                    | CurrentBranchReferenceCatchUpResult.Processed, None -> completeCurrentBranchReferenceCatchUp ()
+                    | _ -> completeCurrentBranchReferenceCatchUp ()
+                with
+                | ex ->
+                    logToAnsiConsole Colors.Error $"Current-branch Watch catch-up failed before a terminal coordinator result: {Markup.Escape(ex.Message)}."
+
+                    retryCurrentBranchReferenceCatchUp "catch-up processing failed"
         }
 
     /// Exposes same-branch Reference notification identity matching to Watch tests without opening a HubConnection.
@@ -7087,8 +7270,13 @@ module Watch =
     /// Exposes startup journal recovery to tests without starting the foreground watcher loop.
     let internal recoverStartupWatchJournalAfterReconciliationForWatchTests status = recoverStartupWatchJournalAfterReconciliation status
 
-    /// Re-enters startup replay and promotion after delayed startup work drains on a later timer pass.
-    let private completeStartupRecoveryIfPendingWorkDrained readGraceStatusFileClient updateGraceWatchInterprocessFileClient processChangedFilesClient =
+    /// Re-enters startup replay, publishes a verified clean local boundary, and then starts lifecycle catch-up.
+    let private completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
+        readGraceStatusFileClient
+        updateGraceWatchInterprocessFileClient
+        processChangedFilesClient
+        catchUpCurrentBranchReference
+        =
         task {
             let mutable attemptedStartupCompletion = false
 
@@ -7128,8 +7316,19 @@ module Watch =
                         updateGraceWatchInterprocessFileClient
                         "startup catch-up"
 
-                if not cleanStartupStatusPublished then setGraceWatchPendingWorkStatusFlag true
+                if cleanStartupStatusPublished then
+                    do! catchUpCurrentBranchReference ()
+                else
+                    setGraceWatchPendingWorkStatusFlag true
         }
+
+    /// Re-enters startup replay and promotion after delayed startup work drains on a later timer pass.
+    let private completeStartupRecoveryIfPendingWorkDrained readGraceStatusFileClient updateGraceWatchInterprocessFileClient processChangedFilesClient =
+        completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
+            readGraceStatusFileClient
+            updateGraceWatchInterprocessFileClient
+            processChangedFilesClient
+            (fun () -> Task.FromResult(()))
 
     /// Exposes delayed startup replay completion to tests without starting the foreground watcher loop.
     let internal completeStartupRecoveryIfPendingWorkDrainedForWatchTests
@@ -7138,6 +7337,19 @@ module Watch =
         processChangedFilesClient
         =
         completeStartupRecoveryIfPendingWorkDrained readGraceStatusFileClient updateGraceWatchInterprocessFileClient processChangedFilesClient
+
+    /// Exposes the verified-startup-publication ordering before lifecycle catch-up for focused Watch tests.
+    let internal completeStartupRecoveryIfPendingWorkDrainedWithCatchUpForWatchTests
+        readGraceStatusFileClient
+        updateGraceWatchInterprocessFileClient
+        processChangedFilesClient
+        catchUpCurrentBranchReference
+        =
+        completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
+            readGraceStatusFileClient
+            updateGraceWatchInterprocessFileClient
+            processChangedFilesClient
+            catchUpCurrentBranchReference
 
     /// Executes the watch command by binding ParseResult values to the SDK request and CLI output contract.
     type Watch() =
@@ -7350,8 +7562,18 @@ module Watch =
                         task {
                             logToAnsiConsole Colors.Important $"SignalR connection reconnected: {connectionId}."
 
-                            refreshSignalRSubscriptionsForActiveConnection (fun () -> registerCurrentSignalRParentBranch signalRConnection cancellationToken)
-                            |> ignore
+                            let! _ =
+                                completeSignalRReconnectWithCatchUp
+                                    (fun () ->
+                                        refreshSignalRSubscriptionsForActiveConnection (fun () ->
+                                            registerCurrentSignalRParentBranch signalRConnection cancellationToken))
+                                    (fun () ->
+                                        task {
+                                            requestCurrentBranchReferenceCatchUp "SignalR subscription recovery"
+                                            do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
+                                        })
+
+                            ()
                         })
 
                     do! signalRConnection.StartAsync(cancellationToken)
@@ -7396,7 +7618,17 @@ module Watch =
                     // Process any changes that occurred while not running.
                     graceStatus <- GraceStatus.Default
                     do! processChangedFiles ()
-                    do! completeStartupRecoveryIfPendingWorkDrained readGraceStatusFile updateGraceWatchInterprocessFile processChangedFiles
+
+                    do!
+                        completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
+                            readGraceStatusFile
+                            updateGraceWatchInterprocessFile
+                            processChangedFiles
+                            (fun () ->
+                                task {
+                                    requestCurrentBranchReferenceCatchUp "safe startup local reconciliation"
+                                    do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
+                                })
 
                     // Create a timer to process the file changes detected by the FileSystemWatcher.
                     // This timer is the reason that there's a delay in stopping `grace watch`.
@@ -7414,8 +7646,29 @@ module Watch =
                             let! updatedGraceStatus = readGraceStatusFile ()
                             do! publishGraceStatusRefreshSnapshot refreshGeneration updatedGraceStatus updateGraceWatchInterprocessFile
 
+                        let localWorkWasPending = hasPendingWatchWork ()
+                        let resyncWasPending = isGraceWatchResyncPending ()
+
                         do! processChangedFiles ()
-                        do! completeStartupRecoveryIfPendingWorkDrained readGraceStatusFile updateGraceWatchInterprocessFile processChangedFiles
+
+                        do!
+                            completeStartupRecoveryIfPendingWorkDrainedWithCatchUp
+                                readGraceStatusFile
+                                updateGraceWatchInterprocessFile
+                                processChangedFiles
+                                (fun () ->
+                                    task {
+                                        requestCurrentBranchReferenceCatchUp "safe startup local reconciliation"
+                                        do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
+                                    })
+
+                        if (localWorkWasPending
+                            && not (hasPendingWatchWork ()))
+                           || (resyncWasPending
+                               && not (isGraceWatchResyncPending ())) then
+                            requestCurrentBranchReferenceCatchUp "local Watch recovery"
+
+                        do! runCurrentBranchReferenceCatchUpIfDue cancellationToken
                         let! tick = periodicTimer.WaitForNextTickAsync()
                         ticked <- tick
 


### PR DESCRIPTION
## Summary

Completes #506 by adding lifecycle catch-up and bounded blocked-sync retry on top of the merged #677 current-branch materialization boundary.

Related to #506. Part of #479 and #473.

## Behavior

- Startup requests current-branch catch-up only after startup reconciliation has published verified clean local status.
- SignalR reconnect requests catch-up only after subscription recovery succeeds.
- Pending-work drain and explicit resync completion request a fresh catch-up attempt.
- Every attempt fetches current BranchDto and reconstructs the exact latest materializable Reference; SignalR payloads are never persisted or replayed as catch-up truth.
- Catch-up feeds the exact Reference through the existing #677 serialized coordinator and preserves approved same-branch mailbox semantics.
- Blocked attempts use bounded 2-second then 4-second backoff, with at most three attempts before waiting for new safe lifecycle evidence.
- A generation-claim scheduler prevents an older asynchronous catch-up run from clearing a newer lifecycle request.
- Removing a same-branch Reference-materialization marker schedules fresh BranchDto catch-up without running branch-transition completion behavior.
- Persistent dirty, missing, ambiguous, or degraded local evidence remains fail-closed and cannot overwrite local work.

## Scope

- Changed only `src/Grace.CLI/Command/Watch.CLI.fs` and `src/Grace.CLI.Tests/Watch.Tests.fs`.
- No public CLI, Watch IPC, SDK, OpenAPI, server notification, generated client, or persisted-state contract changed.
- No broad materialization scan, local Save creation, durable notification payload, new Watch mode, or latest-only final apply gate was added.
- Documentation impact is N/A because this consumes the existing #677 decision and ADR boundary without changing a public contract.

## Validation

- Targeted Fantomas passed.
- Release `Grace.CLI.Tests` build passed with 0 warnings and 0 errors.
- `CurrentBranchCatchUp`: 10/10 passed.
- Existing `CurrentBranchMaterializationCoordinator` and publication coverage: 56/56 passed on the original implementation head.
- One local `pwsh ./scripts/validate.ps1 -Full` run completed its build and solution-level filtered test execution, but its detached wrapper did not preserve the final exit code or terminal output; it was not rerun to avoid duplicating the required final gate.
- `git diff --check` and bot-prevention structural self-review passed.

## Review Status

- Current head: `acd0f1375fc684980e4fbedc810e0b2bb99bdf3c`.
- Session 1 findings `3567022097` and `3567022100`: fixed by `e9bb29af` with marker-deletion wake-up scheduling, generation-claim settlement, and deterministic interleaving coverage.
- Session 2 finding `3567119615`: fixed by `acd0f137`; timer recovery samples pending work and resync before GraceStatus refresh processing can clear the evidence, then creates exactly one generation only after the sampled blocker drains.
- Substantive cycle count: 2 on the high-risk Watch lifecycle wake-up invariant family; stabilization ledger posted to #506 and this PR before further fix work.
- Local validation on `acd0f137`: Fantomas passed; Release `Grace.CLI.Tests` build passed; `CurrentBranchCatchUp` passed 12/12; captured Full transcript passed with 0 build warnings/errors and Types 140, Authorization 53, Server.Unit 738, CLI 1146, and Aspire Server 247 tests.
- GitHub Full: passed on `acd0f137` in 6m36s.
- Codex Code Review Bot: `👍` on current head with no new review threads.
- Prevention: lifecycle pending evidence must be sampled before processing can clear it, and every blocked-to-safe transition must create one scheduler generation that remains pending until claimed; each run may settle only its own generation.
- Freshness: current epic base is 0 commits ahead of the PR head; the PR is 3 commits ahead, the worktree is clean, local and remote heads match, and the scoped diff modifies only the two declared Watch files with no deletions.
