### PR TITLE
WS6.1: Add deterministic Watch candidate scheduler

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -410,6 +410,7 @@ module WatchTests =
             Services.clearShouldIgnoreCache ()
             deleteWatchStatusFileIfExists ()
             Watch.clearPendingWatchWorkForTests ()
+            Watch.setLocalObservationCandidateSchedulingForWatchTests false
             action tempDir
         finally
             Watch.clearPendingWatchWorkForTests ()
@@ -783,6 +784,194 @@ module WatchTests =
     /// Builds renamed event test data used to exercise CLI watch behavior.
     let private renamedEvent (oldFullPath: string) (fullPath: string) =
         RenamedEventArgs(WatcherChangeTypes.Renamed, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath), Path.GetFileName(oldFullPath))
+
+    /// Verifies that same-path local callbacks retain only the latest due generation and extend its quiet window.
+    [<Test>]
+    let ``local observation candidates collapse duplicate paths and extend due time`` () =
+        let quietWindow = TimeSpan.FromSeconds(1.0)
+        let scheduler = new Watch.WatchObservationCandidateScheduler(quietWindow, StringComparison.Ordinal)
+        let fullPath = Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "duplicate.txt")
+        let firstSeenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+
+        let firstCandidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt)
+            |> Option.get
+
+        let latestSeenAt = firstSeenAt.AddMilliseconds(250.0)
+
+        let latestCandidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, latestSeenAt)
+            |> Option.get
+
+        scheduler.Snapshot().Length |> should equal 1
+
+        latestCandidate.Generation
+        |> should be (greaterThan firstCandidate.Generation)
+
+        let pendingCandidate = scheduler.Snapshot()[0]
+
+        pendingCandidate.LastSeenAt
+        |> should equal latestSeenAt
+
+        pendingCandidate.DueAt
+        |> should equal (latestSeenAt.Add(quietWindow))
+
+    /// Verifies that a candidate becomes eligible exactly at its quiet-window boundary and never before it.
+    [<Test>]
+    let ``local observation candidate is eligible exactly at quiet boundary`` () =
+        let quietWindow = TimeSpan.FromSeconds(1.0)
+        let scheduler = new Watch.WatchObservationCandidateScheduler(quietWindow, StringComparison.Ordinal)
+        let seenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+
+        let candidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "boundary.txt"), seenAt)
+            |> Option.get
+
+        scheduler.SnapshotDue(seenAt.AddMilliseconds(999.0))
+        |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+        scheduler.SnapshotDue(candidate.DueAt)
+        |> should equal [| candidate |]
+
+        scheduler.TryClaim(candidate, candidate.DueAt)
+        |> should equal (Some candidate)
+
+        scheduler.Snapshot()
+        |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+    /// Verifies that a captured due snapshot cannot claim a same-path generation superseded before dispatch.
+    [<Test>]
+    let ``local observation candidate stale scheduled generation cannot emit`` () =
+        let scheduler = new Watch.WatchObservationCandidateScheduler(TimeSpan.Zero, StringComparison.Ordinal)
+        let fullPath = Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "stale.txt")
+        let firstSeenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+
+        let olderCandidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt)
+            |> Option.get
+
+        scheduler.SnapshotDue(firstSeenAt)
+        |> should equal [| olderCandidate |]
+
+        let newerCandidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.Deleted, fullPath, firstSeenAt.AddMilliseconds(1.0))
+            |> Option.get
+
+        scheduler.TryClaim(olderCandidate, newerCandidate.DueAt)
+        |> should equal None
+
+        scheduler.SnapshotDue(newerCandidate.DueAt)
+        |> should equal [| newerCandidate |]
+
+    /// Verifies that independent paths retain separate candidates and configured path case semantics choose their identity.
+    [<Test>]
+    let ``local observation candidates retain independent paths with configured case semantics`` () =
+        let seenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+        let root = Path.Combine(Path.GetTempPath(), "grace-watch-candidate")
+        let firstPath = Path.Combine(root, "first.txt")
+        let secondPath = Path.Combine(root, "second.txt")
+        let differentlyCasedPath = Path.Combine(root, "FIRST.txt")
+        let caseSensitiveScheduler = new Watch.WatchObservationCandidateScheduler(TimeSpan.Zero, StringComparison.Ordinal)
+        let caseInsensitiveScheduler = new Watch.WatchObservationCandidateScheduler(TimeSpan.Zero, StringComparison.OrdinalIgnoreCase)
+
+        caseSensitiveScheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, firstPath, seenAt)
+        |> Option.isSome
+        |> should equal true
+
+        caseSensitiveScheduler.Observe(Watch.LocalFileSystem, Watch.Deleted, secondPath, seenAt)
+        |> Option.isSome
+        |> should equal true
+
+        caseSensitiveScheduler.Observe(Watch.LocalFileSystem, Watch.Deleted, differentlyCasedPath, seenAt)
+        |> Option.isSome
+        |> should equal true
+
+        caseSensitiveScheduler.Snapshot().Length
+        |> should equal 3
+
+        caseSensitiveScheduler.SnapshotDue(seenAt)
+        |> Array.map (fun candidate -> candidate.FullPath)
+        |> should
+            equal
+            [|
+                firstPath
+                secondPath
+                differentlyCasedPath
+            |]
+
+        caseInsensitiveScheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, firstPath, seenAt)
+        |> Option.isSome
+        |> should equal true
+
+        caseInsensitiveScheduler.Observe(Watch.LocalFileSystem, Watch.Deleted, differentlyCasedPath, seenAt)
+        |> Option.isSome
+        |> should equal true
+
+        caseInsensitiveScheduler.Snapshot().Length
+        |> should equal 1
+
+    /// Verifies that remote Reference paths and disposed schedulers cannot create local observation candidates.
+    [<Test>]
+    let ``local observation scheduler rejects remote reference and disposal callbacks`` () =
+        let scheduler = new Watch.WatchObservationCandidateScheduler(TimeSpan.Zero, StringComparison.Ordinal)
+        let fullPath = Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "remote.txt")
+        let seenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+
+        scheduler.Observe(Watch.RemoteReference, Watch.CreatedOrChanged, fullPath, seenAt)
+        |> should equal None
+
+        scheduler.Snapshot()
+        |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+        (scheduler :> IDisposable).Dispose()
+
+        scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, seenAt)
+        |> should equal None
+
+        scheduler.Snapshot()
+        |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+    /// Verifies that raw callbacks record candidate metadata without content work and suppress Grace-owned marker effects.
+    [<Test>]
+    let ``raw Watch callbacks queue only local candidates and suppress marker effects`` () =
+        withTempRepo (fun root ->
+            let changedPath = Path.Combine(root, "candidate.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            File.WriteAllText(changedPath, "candidate payload")
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent changedPath)
+
+            Watch
+                .localObservationCandidateSnapshotForWatchTests()
+                .Length
+            |> should equal 1
+
+            let rawCallbackWork = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            rawCallbackWork.FilesToProcess
+            |> should equal Array.empty<string>
+
+            rawCallbackWork.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            rawCallbackWork.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            let queuesAfterEligibility = Watch.pendingWatchWorkSnapshotForTests ()
+
+            queuesAfterEligibility.FilesToProcess
+            |> should equal [| changedPath |]
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+            File.WriteAllText(changedPath, "Grace-owned payload")
+            Watch.OnChanged(changedEvent changedPath)
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>)
 
     /// Verifies that Grace-owned writes under the update marker do not enqueue Save-producing Watch work.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -428,6 +428,13 @@ module WatchTests =
                 with
                 | _ -> ()
 
+    /// Clears default empty ignore entries so replacement tests exercise eligible repository paths.
+    let private clearWatchIgnoreEntries () =
+        let configuration = Current()
+        configuration.GraceFileIgnoreEntries <- Array.empty
+        configuration.GraceDirectoryIgnoreEntries <- Array.empty
+        Services.clearShouldIgnoreCache ()
+
     /// Builds deleted event test data used to exercise CLI watch behavior.
     let private deletedEvent (fullPath: string) = FileSystemEventArgs(WatcherChangeTypes.Deleted, Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))
 
@@ -816,6 +823,149 @@ module WatchTests =
         pendingCandidate.DueAt
         |> should equal (latestSeenAt.Add(quietWindow))
 
+        pendingCandidate.RequiresRemovalProof
+        |> should equal false
+
+    /// Verifies same-path delete/create/change coalescing retains bounded removal proof and only final work generation.
+    [<Test>]
+    let ``local observation candidates retain delete proof through repeated replacements`` () =
+        let quietWindow = TimeSpan.FromSeconds(1.0)
+        let scheduler = new Watch.WatchObservationCandidateScheduler(quietWindow, StringComparison.Ordinal)
+        let fullPath = Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "replacement.txt")
+        let firstSeenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+
+        scheduler.Observe(Watch.LocalFileSystem, Watch.Deleted, fullPath, firstSeenAt)
+        |> Option.isSome
+        |> should equal true
+
+        let createdCandidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt.AddMilliseconds(100.0))
+            |> Option.get
+
+        let finalCandidate =
+            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt.AddMilliseconds(200.0))
+            |> Option.get
+
+        let candidates = scheduler.Snapshot()
+
+        candidates.Length |> should equal 1
+
+        candidates[0].Generation
+        |> should equal finalCandidate.Generation
+
+        candidates[0].Generation
+        |> should be (greaterThan createdCandidate.Generation)
+
+        candidates[0].Kind
+        |> should equal Watch.CreatedOrChanged
+
+        candidates[0].RequiresRemovalProof
+        |> should equal true
+
+        candidates[0].DueAt
+        |> should
+            equal
+            (firstSeenAt
+                .AddMilliseconds(200.0)
+                .Add(quietWindow))
+
+    /// Verifies a same-path file replacement queues both removal proof and final file upload work.
+    [<Test>]
+    let ``local observation candidate delete then file create preserves removal and upload work`` () =
+        withTempRepo (fun root ->
+            let relativePath = "replacement.txt"
+            let fullPath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            clearWatchIgnoreEntries ()
+            File.WriteAllText(fullPath, "old file")
+            File.Delete(fullPath)
+            Watch.OnDeleted(deletedEvent fullPath)
+
+            File.WriteAllText(fullPath, "replacement file")
+
+            Watch.OnCreated(createdEvent fullPath)
+
+            let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pending.StatusUpdateTriggers
+            |> should equal [| relativePath |]
+
+            pending.FilesToProcess
+            |> should equal [| fullPath |]
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>)
+
+    /// Verifies same-path file and directory replacements retain removal evidence without directory subtree expansion.
+    [<Test>]
+    let ``local observation candidate replacements retain old kind removal and final kind work`` () =
+        let verifyFileToDirectory () =
+            withTempRepo (fun root ->
+                let relativePath = "replacement"
+                let fullPath = Path.Combine(root, relativePath)
+                let status = graceStatusTracking [| relativePath |] Array.empty<string>
+
+                Watch.setGraceStatusForWatchTests status
+                Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+                Watch.setLocalObservationCandidateSchedulingForWatchTests true
+                clearWatchIgnoreEntries ()
+                File.WriteAllText(fullPath, "old file")
+                File.Delete(fullPath)
+                Watch.OnDeleted(deletedEvent fullPath)
+
+                Directory.CreateDirectory(fullPath) |> ignore
+
+                Watch.OnCreated(createdEvent fullPath)
+
+                let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+                pending.StatusUpdateTriggers
+                |> should equal [| relativePath |]
+
+                Directory.Exists(fullPath) |> should equal true
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> should equal Array.empty<Watch.WatchObservationCandidate>)
+
+        let verifyDirectoryToFile () =
+            withTempRepo (fun root ->
+                let relativePath = "replacement"
+                let fullPath = Path.Combine(root, relativePath)
+                let status = graceStatusTracking Array.empty<string> [| relativePath |]
+                let seenAt = DateTime.UtcNow
+
+                Watch.setGraceStatusForWatchTests status
+                Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+                Watch.setLocalObservationCandidateSchedulingForWatchTests true
+                clearWatchIgnoreEntries ()
+                Directory.CreateDirectory(fullPath) |> ignore
+                Directory.Delete(fullPath)
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.Deleted fullPath seenAt
+                |> ignore
+
+                File.WriteAllText(fullPath, "replacement file")
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged fullPath (seenAt.AddMilliseconds(1.0))
+                |> ignore
+
+                Watch.processDueLocalObservationCandidatesForWatchTests (seenAt.AddMilliseconds(1.0))
+
+                let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+                pending.StatusUpdateTriggers
+                |> should equal [| relativePath |]
+
+                pending.FilesToProcess
+                |> should equal [| fullPath |])
+
+        verifyFileToDirectory ()
+        verifyDirectoryToFile ()
+
     /// Verifies that a candidate becomes eligible exactly at its quiet-window boundary and never before it.
     [<Test>]
     let ``local observation candidate is eligible exactly at quiet boundary`` () =
@@ -972,6 +1122,60 @@ module WatchTests =
 
             Watch.localObservationCandidateSnapshotForWatchTests ()
             |> should equal Array.empty<Watch.WatchObservationCandidate>)
+
+    /// Verifies candidate observation time keeps pre-marker user work distinct from delayed Grace-owned marker effects.
+    [<Test>]
+    let ``candidate marker suppression respects observation time at deterministic boundary`` () =
+        withTempRepo (fun root ->
+            let preMarkerPath = Path.Combine(root, "pre-marker-user-write.txt")
+            let markerWindowPath = Path.Combine(root, "marker-window-grace-write.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let markerCompletedUtc = DateTime.UtcNow
+
+            File.WriteAllText(preMarkerPath, "user write observed before marker")
+            File.WriteAllText(markerWindowPath, "Grace-owned write observed after marker")
+            File.SetLastWriteTimeUtc(preMarkerPath, markerCompletedUtc.AddSeconds(-1.0))
+            File.SetLastWriteTimeUtc(markerWindowPath, markerCompletedUtc.AddSeconds(-1.0))
+
+            Watch.setGraceStatusForWatchTests (
+                graceStatusTracking
+                    [|
+                        "pre-marker-user-write.txt"
+                        "marker-window-grace-write.txt"
+                    |]
+                    Array.empty<string>
+            )
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () ->
+                Task.FromResult(
+                    graceStatusTracking
+                        [|
+                            "pre-marker-user-write.txt"
+                            "marker-window-grace-write.txt"
+                        |]
+                        Array.empty<string>
+                ))
+
+            Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged preMarkerPath (markerCompletedUtc.AddTicks(-1L))
+            |> ignore
+
+            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+
+            Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged markerWindowPath markerCompletedUtc
+            |> ignore
+
+            Watch.processDueLocalObservationCandidatesForWatchTests markerCompletedUtc
+
+            let pending = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| preMarkerPath |]
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
 
     /// Verifies that Grace-owned writes under the update marker do not enqueue Save-producing Watch work.
     [<Test>]
@@ -13705,6 +13909,103 @@ module WatchTests =
                 publishedStatus.IsWorkingTreeClean
                 |> should equal false
             | None -> Assert.Fail("Expected dirty Watch IPC after pending work arrived during clean recovery publication."))
+
+    /// Verifies candidate-only work blocks resync clean publication until the candidate has drained and its final work completes.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``candidate-only work during resync recovery retains latch until candidate drain`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+            Watch.requestGraceWatchExplicitResyncForWatchTests "materialization clean proof failed"
+
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let candidatePath = Path.Combine(root, "candidate-arrived-during-resync.txt")
+            let candidateSeenAt = DateTime.UtcNow.AddMinutes(1.0)
+            let clientPublications = ResizeArray<string>()
+            let readStatus () = Task.FromResult(status)
+
+            let upload _ filePath =
+                let fullPath = $"{filePath}"
+
+                if File.Exists(fullPath) then recordUploadedFileVersion fullPath
+
+                Task.FromResult(())
+
+            let updateGraceStatus _ _ = Task.FromResult(Some status)
+            let scanForDifferences _ = Task.FromResult(List<FileSystemDifference>())
+            let updateGraceStatusFromDifferences _ _ _ = Task.FromResult(Some status)
+            let applyIncremental _ _ _ = Task.FromResult(())
+
+            let updateIpc currentStatus directoryIds =
+                clientPublications.Add(
+                    if currentStatus.RootDirectoryId = status.RootDirectoryId then
+                        "clean"
+                    else
+                        "dirty"
+                )
+
+                Services.updateGraceWatchInterprocessFile currentStatus directoryIds
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+            Watch.setAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests (fun () ->
+                File.WriteAllText(candidatePath, "candidate captured after provisional clean")
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged candidatePath candidateSeenAt
+                |> ignore)
+
+            try
+                (Watch.processChangedFilesWithClients
+                    readStatus
+                    readStatus
+                    upload
+                    updateGraceStatus
+                    scanForDifferences
+                    updateGraceStatusFromDifferences
+                    applyIncremental
+                    updateIpc)
+                    .GetAwaiter()
+                    .GetResult()
+            finally
+                Watch.resetAfterGraceWatchResyncRecoveryProvisionalCleanPublicationProbeForWatchTests ()
+
+            clientPublications.ToArray()
+            |> should equal [| "clean"; "dirty" |]
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.length
+            |> should equal 1
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.processDueLocalObservationCandidatesForWatchTests candidateSeenAt
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                updateGraceStatus
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            clientPublications.ToArray()
+            |> should equal [| "clean"; "dirty"; "clean" |]
+
+            Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
+            |> should equal false
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false)
 
     /// Verifies process-local work that turns a recovery publication dirty cannot be mistaken for verified clean recovery.
     [<Test; Category("CurrentBranchMaterializationPublication")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1123,6 +1123,201 @@ module WatchTests =
             Watch.localObservationCandidateSnapshotForWatchTests ()
             |> should equal Array.empty<Watch.WatchObservationCandidate>)
 
+    /// Verifies first production candidate acceptance immediately replaces clean IPC and duplicate acceptance does not rewrite it.
+    [<Test>]
+    let ``raw candidate acceptance immediately publishes dirty IPC without duplicate rewrites`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let changedPath = Path.Combine(root, "candidate-dirty-ipc.txt")
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            File.WriteAllText(changedPath, "first candidate")
+            Watch.OnChanged(changedEvent changedPath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.length
+            |> should equal 1
+
+            let dirtyIpc = File.ReadAllText(Services.IpcFileName())
+
+            File.WriteAllText(changedPath, "duplicate candidate")
+            Watch.OnChanged(changedEvent changedPath)
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal dirtyIpc
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.length
+            |> should equal 1)
+
+    /// Verifies a failed immediate dirty publication retains the accepted candidate until the normal timer retry can drain it.
+    [<Test>]
+    let ``raw candidate dirty publication failure retains candidate for timer retry`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let changedPath = Path.Combine(root, "candidate-dirty-retry.txt")
+
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            File.WriteAllText(changedPath, "candidate retained after blocked IPC write")
+
+            use blockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            Watch.OnChanged(changedEvent changedPath)
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.length
+            |> should equal 1
+
+            blockedIpc.Dispose()
+            Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false)
+
+    /// Verifies active markers retain earlier create and delete candidates, consume marker-window candidates, and drain retained work once after deletion.
+    [<Test>]
+    let ``active marker preserves pre-marker candidates and consumes marker-window candidates`` () =
+        let verifyCreate () =
+            withTempRepo (fun root ->
+                let status = graceStatusTracking Array.empty<string> Array.empty<string>
+                let changedPath = Path.Combine(root, "pre-marker-create.txt")
+                let updateMarkerFile = Services.updateInProgressFileName ()
+                let markerStartedAt = DateTime.UtcNow
+
+                File.WriteAllText(changedPath, "pre-marker user work")
+                Watch.setGraceStatusForWatchTests status
+                Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged changedPath (markerStartedAt.AddTicks(-1L))
+                |> ignore
+
+                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                |> ignore
+
+                File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+                File.SetLastWriteTimeUtc(updateMarkerFile, markerStartedAt)
+
+                Watch.processDueLocalObservationCandidatesForWatchTests markerStartedAt
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> Array.length
+                |> should equal 1
+
+                (Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ())
+                    .FilesToProcess
+                |> should equal Array.empty<string>
+
+                File.Delete(updateMarkerFile)
+                Watch.processDueLocalObservationCandidatesForWatchTests (markerStartedAt.AddTicks(1L))
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+                (Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ())
+                    .FilesToProcess
+                |> should equal [| changedPath |]
+
+                Watch.processDueLocalObservationCandidatesForWatchTests (markerStartedAt.AddTicks(2L))
+
+                (Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ())
+                    .FilesToProcess
+                |> should equal [| changedPath |])
+
+        let verifyDelete () =
+            withTempRepo (fun root ->
+                let relativePath = "pre-marker-delete.txt"
+                let changedPath = Path.Combine(root, relativePath)
+                let status = graceStatusTracking [| relativePath |] Array.empty<string>
+                let updateMarkerFile = Services.updateInProgressFileName ()
+                let markerStartedAt = DateTime.UtcNow
+
+                Watch.setGraceStatusForWatchTests status
+                Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.Deleted changedPath (markerStartedAt.AddTicks(-1L))
+                |> ignore
+
+                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                |> ignore
+
+                File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+                File.SetLastWriteTimeUtc(updateMarkerFile, markerStartedAt)
+
+                Watch.processDueLocalObservationCandidatesForWatchTests markerStartedAt
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> Array.length
+                |> should equal 1
+
+                File.Delete(updateMarkerFile)
+                Watch.processDueLocalObservationCandidatesForWatchTests (markerStartedAt.AddTicks(1L))
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+                (Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ())
+                    .StatusUpdateTriggers
+                |> should equal [| relativePath |])
+
+        let verifyMarkerWindowSuppression () =
+            withTempRepo (fun root ->
+                let status = graceStatusTracking Array.empty<string> Array.empty<string>
+                let changedPath = Path.Combine(root, "marker-window.txt")
+                let updateMarkerFile = Services.updateInProgressFileName ()
+                let markerStartedAt = DateTime.UtcNow
+
+                File.WriteAllText(changedPath, "Grace-owned marker-window work")
+                Watch.setGraceStatusForWatchTests status
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged changedPath markerStartedAt
+                |> ignore
+
+                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                |> ignore
+
+                File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+                File.SetLastWriteTimeUtc(updateMarkerFile, markerStartedAt.AddTicks(-1L))
+
+                Watch.processDueLocalObservationCandidatesForWatchTests markerStartedAt
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+                (Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ())
+                    .FilesToProcess
+                |> should equal Array.empty<string>)
+
+        verifyCreate ()
+        verifyDelete ()
+        verifyMarkerWindowSuppression ()
+
     /// Verifies candidate observation time keeps pre-marker user work distinct from delayed Grace-owned marker effects.
     [<Test>]
     let ``candidate marker suppression respects observation time at deterministic boundary`` () =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -595,6 +595,189 @@ module Watch =
 
                 watchPathComparisonConfiguredRoot <- Some normalizedRoot
 
+    /// Identifies the origin allowed to create a local Watch scheduling candidate.
+    type internal WatchObservationOrigin =
+        | LocalFileSystem
+        | RemoteReference
+
+    /// Describes the final local observation that should be interpreted after its quiet window elapses.
+    type internal WatchObservationKind =
+        | CreatedOrChanged
+        | Deleted
+        | GraceStatusArtifact
+
+    /// Captures one coalesced local filesystem observation and the generation that owns its due work.
+    type internal WatchObservationCandidate = { FullPath: string; Kind: WatchObservationKind; Generation: int64; LastSeenAt: DateTime; DueAt: DateTime }
+
+    /// Coalesces local filesystem observations until their deterministic quiet window has elapsed.
+    type internal WatchObservationCandidateScheduler(quietWindow: TimeSpan, pathComparison: StringComparison) =
+        let gate = obj ()
+
+        let pathComparer =
+            match pathComparison with
+            | StringComparison.Ordinal -> StringComparer.Ordinal
+            | StringComparison.OrdinalIgnoreCase -> StringComparer.OrdinalIgnoreCase
+            | StringComparison.InvariantCulture -> StringComparer.InvariantCulture
+            | StringComparison.InvariantCultureIgnoreCase -> StringComparer.InvariantCultureIgnoreCase
+            | StringComparison.CurrentCulture -> StringComparer.CurrentCulture
+            | StringComparison.CurrentCultureIgnoreCase -> StringComparer.CurrentCultureIgnoreCase
+            | _ -> StringComparer.Ordinal
+
+        let candidates = Dictionary<string, WatchObservationCandidate>(pathComparer)
+        let mutable nextGeneration = 0L
+        let mutable disposed = false
+
+        /// Normalizes a callback path without touching the filesystem so equivalent spellings share one candidate key.
+        let tryNormalizeCandidatePath (fullPath: string) =
+            try
+                if String.IsNullOrWhiteSpace(fullPath) then
+                    None
+                else
+                    Some(Path.GetFullPath(fullPath))
+            with
+            | :? ArgumentException
+            | :? NotSupportedException
+            | :? PathTooLongException -> None
+
+        /// Orders due candidates independently of callback arrival order when their due instants match.
+        let compareDueCandidates (left: WatchObservationCandidate) (right: WatchObservationCandidate) =
+            let dueComparison = left.DueAt.CompareTo(right.DueAt)
+
+            if dueComparison <> 0 then
+                dueComparison
+            else
+                let generationComparison = left.Generation.CompareTo(right.Generation)
+
+                if generationComparison <> 0 then
+                    generationComparison
+                else
+                    pathComparer.Compare(left.FullPath, right.FullPath)
+
+        /// Records one local observation, replacing any older generation for the same normalized path.
+        member _.Observe(origin: WatchObservationOrigin, kind: WatchObservationKind, fullPath: string, seenAt: DateTime) =
+            lock gate (fun () ->
+                match origin, disposed, tryNormalizeCandidatePath fullPath with
+                | LocalFileSystem, false, Some normalizedPath ->
+                    let generation = Interlocked.Increment(&nextGeneration)
+
+                    let candidate = { FullPath = normalizedPath; Kind = kind; Generation = generation; LastSeenAt = seenAt; DueAt = seenAt + quietWindow }
+
+                    candidates[normalizedPath] <- candidate
+                    Some candidate
+                | _ -> None)
+
+        /// Returns the current due snapshot without consuming it so a newer generation can still supersede it before dispatch.
+        member _.SnapshotDue(now: DateTime) =
+            lock gate (fun () ->
+                candidates.Values
+                |> Seq.filter (fun candidate -> candidate.DueAt <= now)
+                |> Seq.sortWith compareDueCandidates
+                |> Seq.toArray)
+
+        /// Claims a due candidate only when the snapshot generation remains current at the dispatch boundary.
+        member _.TryClaim(candidate: WatchObservationCandidate, now: DateTime) =
+            lock gate (fun () ->
+                match candidates.TryGetValue(candidate.FullPath) with
+                | true, current when
+                    current.Generation = candidate.Generation
+                    && current.DueAt <= now
+                    ->
+                    candidates.Remove(candidate.FullPath) |> ignore
+
+                    Some current
+                | _ -> None)
+
+        /// Lists pending candidates for deterministic tests without exposing the scheduler's mutable dictionary.
+        member _.Snapshot() =
+            lock gate (fun () ->
+                candidates.Values
+                |> Seq.sortWith compareDueCandidates
+                |> Seq.toArray)
+
+        /// Reports whether local observations still await a due claim.
+        member _.HasPending = lock gate (fun () -> candidates.Count > 0)
+
+        /// Clears process-local candidates during Watch reset or shutdown.
+        member _.Clear() = lock gate (fun () -> candidates.Clear())
+
+        /// Retires all candidates and rejects later callbacks after the owning Watch lifetime ends.
+        member _.Dispose() =
+            lock gate (fun () ->
+                disposed <- true
+                candidates.Clear())
+
+        interface IDisposable with
+            member this.Dispose() = this.Dispose()
+
+    let private localObservationCandidateSchedulerLock = obj ()
+    let private liveLocalObservationQuietWindow = TimeSpan.FromSeconds(1.0)
+    let mutable private localObservationCandidateScheduler = new WatchObservationCandidateScheduler(TimeSpan.Zero, watchPathComparison)
+    let mutable private localObservationCandidateSchedulingActive = 0
+    let mutable private immediateLocalObservationProcessingForWatchTests = 0
+
+    /// Reports whether a live Watch lifetime has activated quiet-window candidate scheduling for raw callbacks.
+    let private isLocalObservationCandidateSchedulingActive () =
+        Volatile.Read(&localObservationCandidateSchedulingActive)
+        <> 0
+
+    /// Activates or clears candidate scheduling for the live Watch lifetime.
+    let private setLocalObservationCandidateSchedulingActive active = Volatile.Write(&localObservationCandidateSchedulingActive, (if active then 1 else 0))
+
+    /// Reports whether a direct callback test intentionally preserves its immediate legacy harness behavior.
+    let private useImmediateLocalObservationProcessingForWatchTests () =
+        Volatile.Read(&immediateLocalObservationProcessingForWatchTests)
+        <> 0
+
+    /// Selects candidate scheduling or the explicit direct-callback compatibility seam for focused Watch tests.
+    let internal setLocalObservationCandidateSchedulingForWatchTests active =
+        Volatile.Write(&immediateLocalObservationProcessingForWatchTests, (if active then 0 else 1))
+        setLocalObservationCandidateSchedulingActive active
+
+    /// Aligns candidate coalescing with the active repository path comparison before Watch starts accepting callbacks.
+    let private configureLocalObservationCandidateScheduler quietWindow =
+        lock localObservationCandidateSchedulerLock (fun () ->
+            if localObservationCandidateScheduler.HasPending then
+                ()
+            else
+                localObservationCandidateScheduler.Dispose()
+                localObservationCandidateScheduler <- new WatchObservationCandidateScheduler(quietWindow, watchPathComparison))
+
+    /// Records a raw local event without reading content, enumerating paths, or scheduling remote Reference work.
+    let private recordLocalObservationCandidate kind fullPath seenAt =
+        lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.Observe(LocalFileSystem, kind, fullPath, seenAt))
+
+    /// Reads the active scheduler snapshot after a test has installed a deterministic clock or direct candidate sequence.
+    let internal localObservationCandidateSnapshotForWatchTests () =
+        lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.Snapshot())
+
+    /// Clears local candidate state without affecting the independent current-branch Reference catch-up scheduler.
+    let private clearLocalObservationCandidateScheduler () = lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.Clear())
+
+    /// Retires candidate state when a Watch lifetime ends so later lifetimes cannot observe stale paths.
+    let private retireLocalObservationCandidateScheduler () =
+        setLocalObservationCandidateSchedulingActive false
+
+        lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.Dispose())
+
+    /// Reports whether candidate metadata alone keeps the Watch process locally dirty.
+    let private hasPendingLocalObservationCandidates () = lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.HasPending)
+
+    /// Captures due candidates while retaining generation checks for the subsequent claim boundary.
+    let private dueLocalObservationCandidates now =
+        lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler, localObservationCandidateScheduler.SnapshotDue(now))
+
+    /// Claims a due candidate only if no newer same-path raw event has superseded it.
+    let private tryClaimLocalObservationCandidate (scheduler: WatchObservationCandidateScheduler) candidate now = scheduler.TryClaim(candidate, now)
+
+    /// Evaluates is grace status artifact against parsed options and command state.
+    let private isGraceStatusArtifact (fullPath: string) =
+        let statusFile = Current().GraceStatusFile
+
+        fullPath.Equals(statusFile, StringComparison.InvariantCultureIgnoreCase)
+        || fullPath.Equals(statusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
+        || fullPath.Equals(statusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
+        || fullPath.Equals(statusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
+
     /// Compares delete-trigger paths against GraceStatus with the legacy status delete semantics.
     let private deletedPathComparison = StringComparison.OrdinalIgnoreCase
 
@@ -1089,8 +1272,6 @@ module Watch =
     let internal graceStatusForWatchTests () = graceStatus
     /// Reads the in-memory Grace Status directory identities so transition-publication tests can prove state isolation.
     let internal graceStatusDirectoryIdsForWatchTests () = graceStatusDirectoryIds
-    /// Reports whether the Watch timer still owes a Grace Status refresh pass.
-    let internal graceStatusHasChangedForWatchTests () = graceStatusHasChanged
 
     /// Checks whether set grace status has changed for watch tests is true for the parsed command input.
     let internal setGraceStatusHasChangedForWatchTests hasChanged =
@@ -1121,6 +1302,7 @@ module Watch =
     let internal setWatchPathComparisonForWatchTests comparison =
         watchPathComparison <- comparison
         watchPathComparisonOverride <- Some comparison
+        configureLocalObservationCandidateScheduler TimeSpan.Zero
 
     /// Installs the repository case-sensitivity detector used by watch tests.
     let internal setRepositoryPathCaseInsensitiveLookupForWatchTests detector =
@@ -2208,6 +2390,7 @@ module Watch =
     let private hasProcessablePendingWatchWorkExceptManual () =
         isGraceWatchResyncPending ()
         || graceStatusHasChanged
+        || hasPendingLocalObservationCandidates ()
         || not (
             filesToProcess.IsEmpty
             && directoriesToProcess.IsEmpty
@@ -2753,6 +2936,123 @@ module Watch =
 
         publishPendingWatchWorkTransitionIfNeeded ()
 
+    /// Applies a due create or change candidate after its quiet window has separated raw callbacks from filesystem work.
+    let private applyCreatedOrChangedLocalObservationCandidate fullPath =
+        if updateNotInProgress ()
+           && isGraceStatusArtifact fullPath then
+            markGraceStatusChangedAndPublishPendingWorkTransition ()
+            false
+        elif not (updateNotInProgress ()) then
+            logObservationSuppressed fullPath
+            false
+        elif isDelayedGraceOwnedFileObservation fullPath then
+            logObservationSuppressed fullPath
+            false
+        elif Directory.Exists(fullPath) then
+            let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds fullPath
+
+            if directoryStatusAddQueued then
+                logToAnsiConsole Colors.Added $"I saw that directory {fullPath} was created."
+
+            if not directoryStatusEnumerationComplete then
+                enqueueDirectoryUploadRetry fullPath
+
+            directoryStatusAddQueued
+            || not directoryStatusEnumerationComplete
+        elif isNotDirectory fullPath then
+            if enqueueFileUpload fullPath then
+                logToAnsiConsole Colors.Changed $"I saw that {fullPath} changed."
+                true
+            else
+                false
+        else
+            false
+
+    /// Applies a due delete candidate after the current marker and final filesystem state can be examined safely.
+    let private applyDeletedLocalObservationCandidate fullPath =
+        if updateNotInProgress ()
+           && isGraceStatusArtifact fullPath then
+            markGraceStatusChangedAndPublishPendingWorkTransition ()
+            false
+        elif not (updateNotInProgress ()) then
+            logObservationSuppressed fullPath
+            false
+        else
+            let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
+
+            if isDelayedGraceOwnedFileObservation fullPath
+               && not canceledFileUpload then
+                logObservationSuppressed fullPath
+                false
+            elif enqueueStatusUpdateTrigger fullPath then
+                match repositoryRelativePath fullPath with
+                | Some relativePath ->
+                    let invalidatedRelativePath = RelativePath relativePath
+
+                    if
+                        canceledFileUpload
+                        || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
+                    then
+                        clearProcessedFileRelativePathsPendingStatus [ invalidatedRelativePath ]
+                        removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+                | None -> ()
+
+                if canceledFileUpload then
+                    match repositoryRelativePath fullPath with
+                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
+                    | None -> ()
+
+                logToAnsiConsole Colors.Deleted $"I saw that {fullPath} was deleted."
+                true
+            else
+                false
+
+    /// Claims every candidate due at the supplied instant and performs the existing expensive Watch work after the claim boundary.
+    let private processDueLocalObservationCandidates now =
+        let scheduler, dueCandidates = dueLocalObservationCandidates now
+        let mutable queuedPendingWork = false
+
+        for dueCandidate in dueCandidates do
+            match tryClaimLocalObservationCandidate scheduler dueCandidate now with
+            | Some candidate ->
+                let candidateQueuedWork =
+                    match candidate.Kind with
+                    | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate candidate.FullPath
+                    | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath
+                    | GraceStatusArtifact ->
+                        if updateNotInProgress () then
+                            markGraceStatusChangedAndPublishPendingWorkTransition ()
+                        else
+                            logObservationSuppressed candidate.FullPath
+
+                        false
+
+                queuedPendingWork <- queuedPendingWork || candidateQueuedWork
+            | None -> ()
+
+        if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+
+    /// Applies an observation immediately only for direct callback harnesses that did not start the Watch lifetime.
+    let private processLocalObservationImmediately kind fullPath =
+        let queuedPendingWork =
+            match kind with
+            | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath
+            | Deleted -> applyDeletedLocalObservationCandidate fullPath
+            | GraceStatusArtifact ->
+                if updateNotInProgress () then
+                    markGraceStatusChangedAndPublishPendingWorkTransition ()
+                else
+                    logObservationSuppressed fullPath
+
+                false
+
+        if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+
+    /// Drains zero-window test candidates before reporting whether Watch still owes a Grace Status refresh pass.
+    let internal graceStatusHasChangedForWatchTests () =
+        processDueLocalObservationCandidates DateTime.UtcNow
+        graceStatusHasChanged
+
     /// Completes startup only when recovery did not leave Watch in another runtime mode or with pending resync work.
     let private promoteStartupModeIfRecoverySucceeded () =
         if
@@ -3104,6 +3404,8 @@ module Watch =
 
     /// Clears inherited pending watch work for tests values so explicitly scoped access commands do not target child resources accidentally.
     let internal clearPendingWatchWorkForTests () =
+        clearLocalObservationCandidateScheduler ()
+        setLocalObservationCandidateSchedulingActive false
         filesToProcess.Clear()
         directoriesToProcess.Clear()
         statusUpdateTriggers.Clear()
@@ -3150,6 +3452,7 @@ module Watch =
         watchPathComparison <- defaultWatchPathComparison ()
         watchPathComparisonOverride <- None
         watchPathComparisonConfiguredRoot <- None
+        configureLocalObservationCandidateScheduler TimeSpan.Zero
         repositoryPathCaseInsensitiveLookupForWatch <- detectRepositoryPathCaseInsensitiveLookup
         fileExistsForWatchFinalPath <- File.Exists
         directoryExistsForWatchFinalPath <- Directory.Exists
@@ -3159,6 +3462,16 @@ module Watch =
 
     /// Coordinates pending watch work snapshot for tests behavior for this CLI command path.
     let internal pendingWatchWorkSnapshotForTests () =
+        processDueLocalObservationCandidates DateTime.UtcNow
+
+        {
+            FilesToProcess = filesToProcess.Keys.OrderBy(id).ToArray()
+            DirectoriesToProcess = directoriesToProcess.Keys.OrderBy(id).ToArray()
+            StatusUpdateTriggers = statusUpdateTriggers.Keys.OrderBy(id).ToArray()
+        }
+
+    /// Reads queued Watch work without draining a due local observation candidate for raw-callback boundary tests.
+    let internal pendingWatchWorkSnapshotWithoutCandidateDrainForTests () =
         {
             FilesToProcess = filesToProcess.Keys.OrderBy(id).ToArray()
             DirectoriesToProcess = directoriesToProcess.Keys.OrderBy(id).ToArray()
@@ -5835,67 +6148,59 @@ module Watch =
                 signalRConnection.InvokeAsync("RegisterParentBranch", branchId, parentBranchId, cancellationToken))
             cancellationToken
 
-    /// Evaluates is grace status artifact against parsed options and command state.
-    let private isGraceStatusArtifact (fullPath: string) =
-        let statusFile = Current().GraceStatusFile
-
-        fullPath.Equals(statusFile, StringComparison.InvariantCultureIgnoreCase)
-        || fullPath.Equals(statusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
-        || fullPath.Equals(statusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
-        || fullPath.Equals(statusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
-
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
-        elif updateNotInProgress ()
-             && isGraceStatusArtifact args.FullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
-        elif isDelayedGraceOwnedFileObservation args.FullPath then
+        elif updateNotInProgress () then
+            let kind =
+                if isGraceStatusArtifact args.FullPath then
+                    GraceStatusArtifact
+                else
+                    CreatedOrChanged
+
+            if isLocalObservationCandidateSchedulingActive () then
+                recordLocalObservationCandidate kind args.FullPath DateTime.UtcNow
+                |> ignore
+            elif useImmediateLocalObservationProcessingForWatchTests () then
+                processLocalObservationImmediately kind args.FullPath
+            else
+                logObservationSuppressed args.FullPath
+        else
             logObservationSuppressed args.FullPath
-        elif
-            updateNotInProgress ()
-            && Directory.Exists(args.FullPath)
-        then
-            let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
-
-            if directoryStatusAddQueued then
-                logToAnsiConsole Colors.Added $"I saw that directory {args.FullPath} was created."
-
-            if not directoryStatusEnumerationComplete then
-                enqueueDirectoryUploadRetry args.FullPath
-
-            if directoryStatusAddQueued
-               || not directoryStatusEnumerationComplete then
-                publishPendingWatchWorkTransitionIfNeeded ()
-        elif updateNotInProgress ()
-             && isNotDirectory args.FullPath then
-            if enqueueFileUpload args.FullPath then
-                logToAnsiConsole Colors.Added $"I saw that {args.FullPath} was created."
-                publishPendingWatchWorkTransitionIfNeeded ()
-
-            if isGraceStatusArtifact args.FullPath then
-                markGraceStatusChangedAndPublishPendingWorkTransition ()
 
     /// Coordinates on changed behavior for this CLI command path.
     let OnChanged (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
-        elif updateNotInProgress ()
-             && isGraceStatusArtifact args.FullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
-            logToAnsiConsole Colors.Important $"Grace Status file has been updated."
-        elif isDelayedGraceOwnedFileObservation args.FullPath then
-            logObservationSuppressed args.FullPath
-        elif updateNotInProgress ()
-             && isNotDirectory args.FullPath then
-            let shouldIgnore = shouldIgnoreFile args.FullPath
-            //logToAnsiConsole Colors.Verbose $"Should ignore {args.FullPath}: {shouldIgnore}."
+        elif updateNotInProgress () then
+            let kind =
+                if isGraceStatusArtifact args.FullPath then
+                    GraceStatusArtifact
+                else
+                    CreatedOrChanged
 
-            if not <| shouldIgnore then
+            if isLocalObservationCandidateSchedulingActive () then
+                recordLocalObservationCandidate kind args.FullPath DateTime.UtcNow
+                |> ignore
+            elif useImmediateLocalObservationProcessingForWatchTests ()
+                 && kind = GraceStatusArtifact then
+                processLocalObservationImmediately kind args.FullPath
+            elif useImmediateLocalObservationProcessingForWatchTests ()
+                 && isDelayedGraceOwnedFileObservation args.FullPath then
+                logObservationSuppressed args.FullPath
+            elif
+                useImmediateLocalObservationProcessingForWatchTests ()
+                && isNotDirectory args.FullPath
+                && not (shouldIgnoreFile args.FullPath)
+            then
                 logToAnsiConsole Colors.Changed $"I saw that {args.FullPath} changed."
                 enqueueFileUpload args.FullPath |> ignore
                 publishPendingWatchWorkTransitionIfNeeded ()
+            elif not (useImmediateLocalObservationProcessingForWatchTests ()) then
+                logObservationSuppressed args.FullPath
+        else
+            logObservationSuppressed args.FullPath
 
     /// Reads enqueue directory contents for upload data needed by the command workflow without changing remote state.
     let private enqueueDirectoryContentsForUpload directoryPath = tryEnqueueDirectoryContentsForUpload directoryPath
@@ -5917,85 +6222,82 @@ module Watch =
     let OnDeleted (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
-        elif updateNotInProgress ()
-             && isGraceStatusArtifact args.FullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
         elif updateNotInProgress () then
-            let canceledFileUpload = cancelPendingUploadsForDeletedPath args.FullPath
+            let kind = if isGraceStatusArtifact args.FullPath then GraceStatusArtifact else Deleted
 
-            if isDelayedGraceOwnedFileObservation args.FullPath
-               && not canceledFileUpload then
+            if isLocalObservationCandidateSchedulingActive () then
+                recordLocalObservationCandidate kind args.FullPath DateTime.UtcNow
+                |> ignore
+            elif useImmediateLocalObservationProcessingForWatchTests () then
+                processLocalObservationImmediately kind args.FullPath
+            else
                 logObservationSuppressed args.FullPath
-            elif enqueueStatusUpdateTrigger args.FullPath then
-                match repositoryRelativePath args.FullPath with
-                | Some relativePath ->
-                    let invalidatedRelativePath = RelativePath relativePath
-
-                    if
-                        canceledFileUpload
-                        || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
-                    then
-                        clearProcessedFileRelativePathsPendingStatus [ invalidatedRelativePath ]
-                        removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
-                | None -> ()
-
-                if canceledFileUpload then
-                    match repositoryRelativePath args.FullPath with
-                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
-                    | None -> ()
-
-                logToAnsiConsole Colors.Deleted $"I saw that {args.FullPath} was deleted."
-                publishPendingWatchWorkTransitionIfNeeded ()
-
-            if isGraceStatusArtifact args.FullPath then
-                markGraceStatusChangedAndPublishPendingWorkTransition ()
+        else
+            logObservationSuppressed args.FullPath
 
     /// Coordinates on renamed behavior for this CLI command path.
     let OnRenamed (args: RenamedEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
         elif updateNotInProgress () then
-            let mutable queuedPendingWork = false
-            let newPathIsDirectory = Directory.Exists(args.FullPath)
+            let seenAt = DateTime.UtcNow
 
-            let canceledFileUpload = cancelPendingUploadsForDeletedPath args.OldFullPath
+            let kind =
+                if isGraceStatusArtifact args.FullPath then
+                    GraceStatusArtifact
+                else
+                    CreatedOrChanged
 
-            let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
-            queuedPendingWork <- queuedPendingWork || oldPathStatusQueued
+            if isLocalObservationCandidateSchedulingActive () then
+                recordLocalObservationCandidate Deleted args.OldFullPath seenAt
+                |> ignore
 
-            if oldPathStatusQueued then
-                if canceledFileUpload then
-                    match repositoryRelativePath args.OldFullPath with
-                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
-                    | None -> ()
+                recordLocalObservationCandidate kind args.FullPath seenAt
+                |> ignore
+            elif useImmediateLocalObservationProcessingForWatchTests () then
+                let mutable queuedPendingWork = false
+                let newPathIsDirectory = Directory.Exists(args.FullPath)
+                let canceledFileUpload = cancelPendingUploadsForDeletedPath args.OldFullPath
+                let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
+                queuedPendingWork <- queuedPendingWork || oldPathStatusQueued
 
-                logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
+                if oldPathStatusQueued then
+                    if canceledFileUpload then
+                        match repositoryRelativePath args.OldFullPath with
+                        | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
+                        | None -> ()
 
-            if newPathIsDirectory then
-                let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
-                queuedPendingWork <- queuedPendingWork || directoryStatusAddQueued
-
-                if directoryStatusAddQueued
-                   && not oldPathStatusQueued then
                     logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
 
-                let fileUploadWorkCountBefore = filesToProcess.Count
-                let fileUploadEnumerationComplete = enqueueDirectoryContentsForUpload args.FullPath
+                if newPathIsDirectory then
+                    let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
+                    queuedPendingWork <- queuedPendingWork || directoryStatusAddQueued
 
-                if not fileUploadEnumerationComplete then
-                    enqueueDirectoryUploadRetry args.FullPath
-                    queuedPendingWork <- true
-                elif filesToProcess.Count > fileUploadWorkCountBefore then
+                    if directoryStatusAddQueued
+                       && not oldPathStatusQueued then
+                        logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
+
+                    let fileUploadWorkCountBefore = filesToProcess.Count
+                    let fileUploadEnumerationComplete = enqueueDirectoryContentsForUpload args.FullPath
+
+                    if not fileUploadEnumerationComplete then
+                        enqueueDirectoryUploadRetry args.FullPath
+                        queuedPendingWork <- true
+                    elif filesToProcess.Count > fileUploadWorkCountBefore then
+                        queuedPendingWork <- true
+
+                    if not directoryStatusEnumerationComplete then
+                        enqueueDirectoryUploadRetry args.FullPath
+                        queuedPendingWork <- true
+                elif enqueueFileUpload args.FullPath then
+                    logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
                     queuedPendingWork <- true
 
-                if not directoryStatusEnumerationComplete then
-                    enqueueDirectoryUploadRetry args.FullPath
-                    queuedPendingWork <- true
-            elif enqueueFileUpload args.FullPath then
-                logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                queuedPendingWork <- true
-
-            if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+                if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+            else
+                logObservationSuppressed args.FullPath
+        else
+            logObservationSuppressed args.FullPath
 
     /// Coordinates on error behavior for this CLI command path.
     let OnError (args: ErrorEventArgs) =
@@ -6666,6 +6968,7 @@ module Watch =
         =
         task {
             configureWatchPathComparisonForCurrentRepository ()
+            processDueLocalObservationCandidates DateTime.UtcNow
 
             // First, check if there's anything to process.
             if isGraceWatchResyncPending () then
@@ -7516,6 +7819,11 @@ module Watch =
         /// Runs the asynchronous watch action when System.CommandLine dispatches the parsed command.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) =
             task {
+                use localObservationCandidateLifetime =
+                    { new IDisposable with
+                        member _.Dispose() = retireLocalObservationCandidateScheduler ()
+                    }
+
                 try
                     if isCheckRequested parseResult then
                         let! watchStatusInspection = inspectGraceWatchStatus ()
@@ -7531,6 +7839,10 @@ module Watch =
 
                     setGraceWatchRuntimeMode GraceWatchRuntimeMode.StartingUp
                     configureWatchPathComparisonForCurrentRepository ()
+
+                    // A live watcher waits one timer interval after the most recent raw callback before it reads filesystem state.
+                    configureLocalObservationCandidateScheduler liveLocalObservationQuietWindow
+                    setLocalObservationCandidateSchedulingActive true
 
                     // Create the FileSystemWatcher, but don't enable it yet.
                     use rootDirectoryFileSystemWatcher = createFileSystemWatcher (Current().RootDirectory)

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -607,7 +607,15 @@ module Watch =
         | GraceStatusArtifact
 
     /// Captures one coalesced local filesystem observation and the generation that owns its due work.
-    type internal WatchObservationCandidate = { FullPath: string; Kind: WatchObservationKind; Generation: int64; LastSeenAt: DateTime; DueAt: DateTime }
+    type internal WatchObservationCandidate =
+        {
+            FullPath: string
+            Kind: WatchObservationKind
+            RequiresRemovalProof: bool
+            Generation: int64
+            LastSeenAt: DateTime
+            DueAt: DateTime
+        }
 
     /// Coalesces local filesystem observations until their deterministic quiet window has elapsed.
     type internal WatchObservationCandidateScheduler(quietWindow: TimeSpan, pathComparison: StringComparison) =
@@ -653,14 +661,28 @@ module Watch =
                 else
                     pathComparer.Compare(left.FullPath, right.FullPath)
 
-        /// Records one local observation, replacing any older generation for the same normalized path.
+        /// Records one local observation, replacing any older generation while retaining same-path delete proof for a final replacement.
         member _.Observe(origin: WatchObservationOrigin, kind: WatchObservationKind, fullPath: string, seenAt: DateTime) =
             lock gate (fun () ->
                 match origin, disposed, tryNormalizeCandidatePath fullPath with
                 | LocalFileSystem, false, Some normalizedPath ->
                     let generation = Interlocked.Increment(&nextGeneration)
 
-                    let candidate = { FullPath = normalizedPath; Kind = kind; Generation = generation; LastSeenAt = seenAt; DueAt = seenAt + quietWindow }
+                    let requiresRemovalProof =
+                        kind = Deleted
+                        || match candidates.TryGetValue(normalizedPath) with
+                           | true, existing -> existing.RequiresRemovalProof
+                           | false, _ -> false
+
+                    let candidate =
+                        {
+                            FullPath = normalizedPath
+                            Kind = kind
+                            RequiresRemovalProof = requiresRemovalProof
+                            Generation = generation
+                            LastSeenAt = seenAt
+                            DueAt = seenAt + quietWindow
+                        }
 
                     candidates[normalizedPath] <- candidate
                     Some candidate
@@ -745,6 +767,9 @@ module Watch =
     /// Records a raw local event without reading content, enumerating paths, or scheduling remote Reference work.
     let private recordLocalObservationCandidate kind fullPath seenAt =
         lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.Observe(LocalFileSystem, kind, fullPath, seenAt))
+
+    /// Records a timestamped local candidate for deterministic Watch scheduler tests.
+    let internal recordLocalObservationCandidateForWatchTests kind fullPath seenAt = recordLocalObservationCandidate kind fullPath seenAt
 
     /// Reads the active scheduler snapshot after a test has installed a deterministic clock or direct candidate sequence.
     let internal localObservationCandidateSnapshotForWatchTests () =
@@ -1242,9 +1267,10 @@ module Watch =
             | _ -> false
 
     /// Identifies delayed callbacks for writes that completed while a Grace update marker was still present.
-    let private isDelayedGraceOwnedFileObservation fullPath =
+    let private isDelayedGraceOwnedFileObservation fullPath observedAt =
         match tryRecentGraceUpdateMarkerCompletedUtc () with
         | None -> false
+        | Some markerCompletedUtc when observedAt < markerCompletedUtc -> false
         | Some markerCompletedUtc when
             not (File.Exists fullPath)
             && not (Directory.Exists fullPath)
@@ -2638,6 +2664,7 @@ module Watch =
             HasProcessablePendingWork =
                 not recoveryStillOwnsPublication
                 || graceStatusHasChanged
+                || hasPendingLocalObservationCandidates ()
                 || not (
                     filesToProcess.IsEmpty
                     && directoriesToProcess.IsEmpty
@@ -2937,7 +2964,7 @@ module Watch =
         publishPendingWatchWorkTransitionIfNeeded ()
 
     /// Applies a due create or change candidate after its quiet window has separated raw callbacks from filesystem work.
-    let private applyCreatedOrChangedLocalObservationCandidate fullPath =
+    let private applyCreatedOrChangedLocalObservationCandidate fullPath observedAt =
         if updateNotInProgress ()
            && isGraceStatusArtifact fullPath then
             markGraceStatusChangedAndPublishPendingWorkTransition ()
@@ -2945,7 +2972,7 @@ module Watch =
         elif not (updateNotInProgress ()) then
             logObservationSuppressed fullPath
             false
-        elif isDelayedGraceOwnedFileObservation fullPath then
+        elif isDelayedGraceOwnedFileObservation fullPath observedAt then
             logObservationSuppressed fullPath
             false
         elif Directory.Exists(fullPath) then
@@ -2969,7 +2996,7 @@ module Watch =
             false
 
     /// Applies a due delete candidate after the current marker and final filesystem state can be examined safely.
-    let private applyDeletedLocalObservationCandidate fullPath =
+    let private applyDeletedLocalObservationCandidate fullPath observedAt =
         if updateNotInProgress ()
            && isGraceStatusArtifact fullPath then
             markGraceStatusChangedAndPublishPendingWorkTransition ()
@@ -2980,7 +3007,7 @@ module Watch =
         else
             let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
 
-            if isDelayedGraceOwnedFileObservation fullPath
+            if isDelayedGraceOwnedFileObservation fullPath observedAt
                && not canceledFileUpload then
                 logObservationSuppressed fullPath
                 false
@@ -3017,8 +3044,17 @@ module Watch =
             | Some candidate ->
                 let candidateQueuedWork =
                     match candidate.Kind with
-                    | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate candidate.FullPath
-                    | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath
+                    | CreatedOrChanged ->
+                        let removalQueuedWork =
+                            if candidate.RequiresRemovalProof then
+                                applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                            else
+                                false
+
+                        let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                        removalQueuedWork || finalQueuedWork
+                    | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
                     | GraceStatusArtifact ->
                         if updateNotInProgress () then
                             markGraceStatusChangedAndPublishPendingWorkTransition ()
@@ -3032,12 +3068,17 @@ module Watch =
 
         if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
 
+    /// Drains due local candidates at a caller-supplied instant for deterministic Watch tests.
+    let internal processDueLocalObservationCandidatesForWatchTests now = processDueLocalObservationCandidates now
+
     /// Applies an observation immediately only for direct callback harnesses that did not start the Watch lifetime.
     let private processLocalObservationImmediately kind fullPath =
+        let observedAt = DateTime.UtcNow
+
         let queuedPendingWork =
             match kind with
-            | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath
-            | Deleted -> applyDeletedLocalObservationCandidate fullPath
+            | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
+            | Deleted -> applyDeletedLocalObservationCandidate fullPath observedAt
             | GraceStatusArtifact ->
                 if updateNotInProgress () then
                     markGraceStatusChangedAndPublishPendingWorkTransition ()
@@ -6187,7 +6228,7 @@ module Watch =
                  && kind = GraceStatusArtifact then
                 processLocalObservationImmediately kind args.FullPath
             elif useImmediateLocalObservationProcessingForWatchTests ()
-                 && isDelayedGraceOwnedFileObservation args.FullPath then
+                 && isDelayedGraceOwnedFileObservation args.FullPath DateTime.UtcNow then
                 logObservationSuppressed args.FullPath
             elif
                 useImmediateLocalObservationProcessingForWatchTests ()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -794,6 +794,19 @@ module Watch =
     /// Claims a due candidate only if no newer same-path raw event has superseded it.
     let private tryClaimLocalObservationCandidate (scheduler: WatchObservationCandidateScheduler) candidate now = scheduler.TryClaim(candidate, now)
 
+    /// Reads the active Grace update marker observation boundary used to classify a due candidate before it is retired.
+    let private tryGetActiveGraceUpdateMarkerObservationBoundary () =
+        try
+            let markerFileName = updateInProgressFileName ()
+
+            if File.Exists(markerFileName) then
+                Some(File.GetLastWriteTimeUtc(markerFileName))
+            else
+                None
+        with
+        | :? IOException -> None
+        | :? UnauthorizedAccessException -> None
+
     /// Evaluates is grace status artifact against parsed options and command state.
     let private isGraceStatusArtifact (fullPath: string) =
         let statusFile = Current().GraceStatusFile
@@ -2957,6 +2970,12 @@ module Watch =
     /// Publishes a pending-work transition through the normal Watch IPC writer for deterministic Watch tests.
     let internal publishPendingWatchWorkTransitionIfNeededForWatchTests () = publishPendingWatchWorkTransitionIfNeeded ()
 
+    /// Records an accepted production candidate and immediately publishes its pending local-work transition.
+    let private acceptLocalObservationCandidate kind fullPath seenAt =
+        match recordLocalObservationCandidate kind fullPath seenAt with
+        | Some _ -> publishPendingWatchWorkTransitionIfNeeded ()
+        | None -> ()
+
     /// Records that durable Grace Status changed and immediately advertises pending Watch work to other commands.
     let private markGraceStatusChangedAndPublishPendingWorkTransition () =
         recordGraceStatusRefreshObservation ()
@@ -2968,9 +2987,6 @@ module Watch =
         if updateNotInProgress ()
            && isGraceStatusArtifact fullPath then
             markGraceStatusChangedAndPublishPendingWorkTransition ()
-            false
-        elif not (updateNotInProgress ()) then
-            logObservationSuppressed fullPath
             false
         elif isDelayedGraceOwnedFileObservation fullPath observedAt then
             logObservationSuppressed fullPath
@@ -3000,9 +3016,6 @@ module Watch =
         if updateNotInProgress ()
            && isGraceStatusArtifact fullPath then
             markGraceStatusChangedAndPublishPendingWorkTransition ()
-            false
-        elif not (updateNotInProgress ()) then
-            logObservationSuppressed fullPath
             false
         else
             let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
@@ -3038,35 +3051,45 @@ module Watch =
     let private processDueLocalObservationCandidates now =
         let scheduler, dueCandidates = dueLocalObservationCandidates now
         let mutable queuedPendingWork = false
+        let mutable candidateConsumed = false
 
         for dueCandidate in dueCandidates do
-            match tryClaimLocalObservationCandidate scheduler dueCandidate now with
-            | Some candidate ->
-                let candidateQueuedWork =
-                    match candidate.Kind with
-                    | CreatedOrChanged ->
-                        let removalQueuedWork =
-                            if candidate.RequiresRemovalProof then
-                                applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                            else
+            match tryGetActiveGraceUpdateMarkerObservationBoundary () with
+            | Some markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> logObservationSuppressed dueCandidate.FullPath
+            | activeMarkerBoundary ->
+                match tryClaimLocalObservationCandidate scheduler dueCandidate now with
+                | Some candidate ->
+                    candidateConsumed <- true
+
+                    let candidateQueuedWork =
+                        match activeMarkerBoundary with
+                        | Some _ ->
+                            logObservationSuppressed candidate.FullPath
+                            false
+                        | None ->
+                            match candidate.Kind with
+                            | CreatedOrChanged ->
+                                let removalQueuedWork =
+                                    if candidate.RequiresRemovalProof then
+                                        applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                    else
+                                        false
+
+                                let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                                removalQueuedWork || finalQueuedWork
+                            | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                            | GraceStatusArtifact ->
+                                markGraceStatusChangedAndPublishPendingWorkTransition ()
                                 false
 
-                        let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                    queuedPendingWork <- queuedPendingWork || candidateQueuedWork
+                | None -> ()
 
-                        removalQueuedWork || finalQueuedWork
-                    | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                    | GraceStatusArtifact ->
-                        if updateNotInProgress () then
-                            markGraceStatusChangedAndPublishPendingWorkTransition ()
-                        else
-                            logObservationSuppressed candidate.FullPath
-
-                        false
-
-                queuedPendingWork <- queuedPendingWork || candidateQueuedWork
-            | None -> ()
-
-        if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+        if candidateConsumed
+           || queuedPendingWork
+           || hasPendingLocalObservationCandidates () then
+            publishPendingWatchWorkTransitionIfNeeded ()
 
     /// Drains due local candidates at a caller-supplied instant for deterministic Watch tests.
     let internal processDueLocalObservationCandidatesForWatchTests now = processDueLocalObservationCandidates now
@@ -6201,8 +6224,7 @@ module Watch =
                     CreatedOrChanged
 
             if isLocalObservationCandidateSchedulingActive () then
-                recordLocalObservationCandidate kind args.FullPath DateTime.UtcNow
-                |> ignore
+                acceptLocalObservationCandidate kind args.FullPath DateTime.UtcNow
             elif useImmediateLocalObservationProcessingForWatchTests () then
                 processLocalObservationImmediately kind args.FullPath
             else
@@ -6222,8 +6244,7 @@ module Watch =
                     CreatedOrChanged
 
             if isLocalObservationCandidateSchedulingActive () then
-                recordLocalObservationCandidate kind args.FullPath DateTime.UtcNow
-                |> ignore
+                acceptLocalObservationCandidate kind args.FullPath DateTime.UtcNow
             elif useImmediateLocalObservationProcessingForWatchTests ()
                  && kind = GraceStatusArtifact then
                 processLocalObservationImmediately kind args.FullPath
@@ -6267,8 +6288,7 @@ module Watch =
             let kind = if isGraceStatusArtifact args.FullPath then GraceStatusArtifact else Deleted
 
             if isLocalObservationCandidateSchedulingActive () then
-                recordLocalObservationCandidate kind args.FullPath DateTime.UtcNow
-                |> ignore
+                acceptLocalObservationCandidate kind args.FullPath DateTime.UtcNow
             elif useImmediateLocalObservationProcessingForWatchTests () then
                 processLocalObservationImmediately kind args.FullPath
             else
@@ -6290,11 +6310,8 @@ module Watch =
                     CreatedOrChanged
 
             if isLocalObservationCandidateSchedulingActive () then
-                recordLocalObservationCandidate Deleted args.OldFullPath seenAt
-                |> ignore
-
-                recordLocalObservationCandidate kind args.FullPath seenAt
-                |> ignore
+                acceptLocalObservationCandidate Deleted args.OldFullPath seenAt
+                acceptLocalObservationCandidate kind args.FullPath seenAt
             elif useImmediateLocalObservationProcessingForWatchTests () then
                 let mutable queuedPendingWork = false
                 let newPathIsDirectory = Directory.Exists(args.FullPath)


### PR DESCRIPTION
## Summary

Implements WS6.1 by introducing a deterministic local-observation candidate scheduler for `grace watch`.

Related to #507. Part of #480 and #473.

## Behavior

- Live raw filesystem callbacks record candidate metadata only.
- Candidate eligibility is `DueAt = LastSeenAt + quietWindow`.
- Duplicate normalized paths coalesce, newer generations invalidate stale due snapshots, and independent paths dispatch deterministically.
- Expensive filesystem and queue work starts only after the timer claims an eligible candidate.
- Remote Reference work is rejected by the local-observation scheduler, preserving the independent #506 catch-up path.
- Grace-owned marker effects remain suppressed and do not become local observation work.
- Candidate state retires after successful claim and when the Watch command scope is disposed.
- The immediate direct-callback path is restricted to an explicit Watch test-harness seam and is not production-reachable.

## Scope

- Changed only `src/Grace.CLI/Command/Watch.CLI.fs` and `src/Grace.CLI.Tests/Watch.Tests.fs`.
- No CLI option, output, API, SDK, OpenAPI, persisted shape, or public contract changed.
- Stable file identity, bounded file retry, directory normalization, durable-journal integration, real-filesystem harness expansion, and docs polish remain owned by later WS6 leaves.
- Docs impact is N/A because this is an internal scheduling seam with no user-visible contract change.

## Validation

- Targeted Fantomas passed.
- Release `Grace.CLI.Tests` build passed with 0 warnings and 0 errors.
- Focused Watch tests passed: 427/427.
- `git diff --check` passed before and after commit.
- One local `pwsh ./scripts/validate.ps1 -Fast` run completed restore/build and its child process exited, but the execution channel lost the final test summary and exit code; it was not duplicated.
- Bot-prevention self-review covered timer ordering, stale generations, disposal, path comparison, candidate retirement, the explicit test-only seam, #508 scope, and #506 isolation.

## Review Status

- Current head: `353fd5b8b2c3447ad53b3124387bede05dba7be5`.
- Codex Code Review Bot session 1: `3567223486` remains deferred to #509; `3567223489`, `3567223491`, and `3567223492` are fixed by `93b0968d`.
- Codex Code Review Bot session 2: `3567292633` and `3567292635` are fixed by `353fd5b8`; candidate acceptance publishes dirty immediately, marker timing is classified before claim, and pre-marker create/delete candidates remain pending for one-time safe drain.
- Codex Code Review Bot session 3: `3567334455` is valid and deferred to #510, which owns confidence-loss quarantine and now records the exact invariant and proof obligations; no #507 code change addresses it.
- Substantive cycle count: 2; candidate-acceptance lifecycle stabilization ledger posted to #507 and this PR before further fix work.
- Local validation on `353fd5b8`: Fantomas passed; Release build passed with 0 warnings/errors; focused Watch tests passed 435/435; `git diff --check` passed; Fast passed in 1m17.960s with CLI 1160, Types 140, Authorization 53, and Server.Unit 738 tests passing.
- GitHub Full: passed on `353fd5b8` in 6m38s.
- Codex Code Review Bot: current-head review complete; all #507 findings are fixed, and the confidence-loss finding is recorded in #510 as an accepted sibling deferral.
- Prevention: production candidate acceptance must publish the pending transition immediately, and marker classification must compare observation time before claim/removal so pre-marker user work is retained through active updates.
- Freshness: current epic base is 0 commits ahead of the PR head; the PR is 3 commits ahead, the worktree is clean, local and remote heads match, all review threads are resolved, and the scoped diff modifies only the two declared Watch files with no deletions.
