### PR TITLE
WS6.3: Normalize directory candidates by affected subtree

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -842,8 +842,12 @@ module WatchTests =
             scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt.AddMilliseconds(100.0))
             |> Option.get
 
+        scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt.AddMilliseconds(200.0))
+        |> Option.isSome
+        |> should equal true
+
         let finalCandidate =
-            scheduler.Observe(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt.AddMilliseconds(200.0))
+            scheduler.Observe(Watch.LocalFileSystem, Watch.Changed, fullPath, firstSeenAt.AddMilliseconds(300.0))
             |> Option.get
 
         let candidates = scheduler.Snapshot()
@@ -866,7 +870,7 @@ module WatchTests =
         |> should
             equal
             (firstSeenAt
-                .AddMilliseconds(200.0)
+                .AddMilliseconds(300.0)
                 .Add(quietWindow))
 
     /// Verifies a same-path file replacement queues both removal proof and final file upload work.
@@ -952,25 +956,34 @@ module WatchTests =
 
                 /// Reads status needed by the test scenario.
                 let readStatus () = Task.FromResult(status)
+
                 /// Records the stable retained-file identity that the storage seam would make available to status application.
                 let recordRetainedUpload filePath =
-                    match (Services.createLocalFileVersion (FileInfo(filePath))).GetAwaiter().GetResult() with
+                    match (Services.createLocalFileVersion (FileInfo(filePath)))
+                        .GetAwaiter()
+                        .GetResult()
+                        with
                     | Some localFileVersion -> Watch.recordUploadedFileVersionForWatchTests localFileVersion.ToFileVersion
                     | None -> Assert.Fail($"Expected a local file version for {filePath}.")
+
                 /// Builds upload test data used to exercise CLI watch behavior.
                 let upload _ filePath =
                     uploadCalls <- uploadCalls + 1
                     recordRetainedUpload filePath
                     Task.FromResult(())
+
                 /// Builds scan-oriented update test data used to exercise CLI watch behavior.
                 let updateGraceStatus status _ = Task.FromResult(Some status)
+
                 /// Fails the test if healthy directory processing attempts a repository scan instead of its bounded observation seam.
                 let scanForDifferences _ : Task<List<FileSystemDifference>> =
                     raise (InvalidOperationException("Healthy directory processing must not scan for differences."))
+
                 /// Builds event-derived status apply test data used to exercise CLI watch behavior.
                 let updateGraceStatusFromDifferences status differences _ =
                     observedDifferences <- differences
                     Task.FromResult(Some status)
+
                 /// Builds apply incremental test data used to exercise CLI watch behavior.
                 let applyIncremental _ _ _ = Task.FromResult(())
                 /// Builds update ipc test data used to exercise CLI watch behavior.
@@ -11299,7 +11312,9 @@ module WatchTests =
             let mutable observedDifferences = List<FileSystemDifference>()
 
             Directory.CreateDirectory(directoryPath) |> ignore
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
             Watch.OnCreated(createdEvent directoryPath)
+            Watch.OnChanged(changedEvent directoryPath)
 
             /// Reads status needed by the test scenario.
             let readStatus () = Task.FromResult(GraceStatus.Default)
@@ -11646,6 +11661,151 @@ module WatchTests =
             scanCalls |> should equal 0
             applyFromDifferencesCalls |> should equal 0)
 
+    /// Verifies that a changed-only file-to-directory replacement remains scoped pending until status classification becomes readable.
+    [<Test>]
+    let ``changed-only directory replacement retries unreadable status without partial apply`` () =
+        withTempRepo (fun root ->
+            let trackedRelativePath = "replace-me"
+            let replacementPath = Path.Combine(root, trackedRelativePath)
+            let status = graceStatusTracking [| trackedRelativePath |] Array.empty<string>
+            /// Tracks status application so unreadable classification cannot publish a partial replacement.
+            let mutable applyFromDifferencesCalls = 0
+            /// Tracks the final event-derived differences after status authority becomes readable.
+            let mutable observedDifferences = List<FileSystemDifference>()
+            let mutable statusIsReadable = false
+
+            Directory.CreateDirectory(replacementPath)
+            |> ignore
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setGraceStatusHasChangedForWatchTests true
+
+            Watch.setReadGraceStatusFileForWatchTests (fun () ->
+                if statusIsReadable then
+                    Task.FromResult(status)
+                else
+                    Task.FromException<GraceStatus>(IOException("transient Grace Status read failure")))
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent replacementPath)
+
+            let pendingWhileUnreadable = Watch.pendingWatchWorkSnapshotForTests ()
+
+            pendingWhileUnreadable.DirectoriesToProcess
+            |> should equal [| replacementPath |]
+
+            pendingWhileUnreadable.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pendingWhileUnreadable.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+            /// Builds upload test data used to prove the empty replacement has no file-derived partial result.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data that fails if retry escapes its bounded directory scope.
+            let scanForDifferences _ : Task<List<FileSystemDifference>> =
+                raise (InvalidOperationException("Changed-only directory replacement must not scan the repository root."))
+
+            /// Builds event-derived status apply test data used to observe retry completion.
+            let updateGraceStatusFromDifferences status differences _ =
+                applyFromDifferencesCalls <- applyFromDifferencesCalls + 1
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            statusIsReadable <- true
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            applyFromDifferencesCalls |> should equal 1
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equivalent
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, trackedRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, trackedRelativePath
+                |])
+
+    /// Verifies that case-insensitive changed-only replacement deletes the tracked file spelling before queuing final directory work.
+    [<Test>]
+    let ``case-insensitive changed-only directory replacement deletes canonical tracked file path`` () =
+        withTempRepo (fun root ->
+            let trackedRelativePath = "ReplaceMe"
+            let observedRelativePath = "replaceme"
+            let replacementPath = Path.Combine(root, observedRelativePath)
+            let status = graceStatusTracking [| trackedRelativePath |] Array.empty<string>
+            /// Tracks the final event-derived differences so the tracked file spelling is asserted independently of event casing.
+            let mutable observedDifferences = List<FileSystemDifference>()
+
+            Directory.CreateDirectory(replacementPath)
+            |> ignore
+
+            Watch.setWatchPathComparisonForWatchTests StringComparison.OrdinalIgnoreCase
+            Watch.setGraceStatusForWatchTests status
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent replacementPath)
+
+            /// Reads status needed by the test scenario.
+            let readStatus () = Task.FromResult(status)
+            /// Builds upload test data used to prove the empty replacement is structural rather than file-derived.
+            let upload _ _ = Task.FromResult(())
+
+            /// Builds scan-oriented update test data that fails if final directory handling scans outside the observation subtree.
+            let scanForDifferences _ : Task<List<FileSystemDifference>> =
+                raise (InvalidOperationException("Case-insensitive replacement must not scan the repository root."))
+
+            /// Builds event-derived status apply test data used to observe the canonical deletion and final directory add.
+            let updateGraceStatusFromDifferences status differences _ =
+                observedDifferences <- differences
+                Task.FromResult(Some status)
+
+            /// Builds apply incremental test data used to exercise CLI watch behavior.
+            let applyIncremental _ _ _ = Task.FromResult(())
+            /// Builds update ipc test data used to exercise CLI watch behavior.
+            let updateIpc _ _ = Task.FromResult(())
+
+            (Watch.processChangedFilesWithClients
+                readStatus
+                readStatus
+                upload
+                (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                scanForDifferences
+                updateGraceStatusFromDifferences
+                applyIncremental
+                updateIpc)
+                .GetAwaiter()
+                .GetResult()
+
+            observedDifferences
+            |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+            |> Seq.toArray
+            |> should
+                equivalent
+                [|
+                    DifferenceType.Delete, FileSystemEntryType.File, trackedRelativePath
+                    DifferenceType.Add, FileSystemEntryType.Directory, observedRelativePath
+                |])
+
     /// Verifies that a recreated directory invalidates a stale directory delete before status apply.
     [<Test>]
     let ``recreated directory suppresses stale directory delete without scan`` () =
@@ -11782,7 +11942,7 @@ module WatchTests =
             let fileRelativePath = $"{fileParentRelativePath}/asset.txt"
             let unrelatedRelativePath = "unrelated-empty"
             let filePath = Path.Combine(root, fileRelativePath)
-            let status = graceStatusTracking Array.empty<string> [| oldRelativePath |]
+            let status = graceStatusTracking Array.empty<string> [| oldRelativePath; newRelativePath |]
             /// Tracks upload Calls changes so the file-bearing part of the subtree is still processed.
             let mutable uploadCalls = 0
             /// Tracks apply-from-differences Calls changes so status work stays event-derived.
@@ -11803,6 +11963,7 @@ module WatchTests =
             Watch.setGraceStatusForWatchTests status
             Watch.setLocalObservationCandidateSchedulingForWatchTests true
             Watch.OnRenamed(renamedEvent oldPath newPath)
+            Watch.OnChanged(changedEvent newPath)
 
             /// Reads status needed by the test scenario.
             let readStatus () = Task.FromResult(status)
@@ -11849,7 +12010,6 @@ module WatchTests =
                 equivalent
                 [|
                     DifferenceType.Delete, FileSystemEntryType.Directory, oldRelativePath
-                    DifferenceType.Add, FileSystemEntryType.Directory, newRelativePath
                     DifferenceType.Add, FileSystemEntryType.Directory, fileParentRelativePath
                     DifferenceType.Add, FileSystemEntryType.Directory, emptyChildRelativePath
                     DifferenceType.Add, FileSystemEntryType.File, fileRelativePath

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -900,7 +900,7 @@ module WatchTests =
             Watch.localObservationCandidateSnapshotForWatchTests ()
             |> should equal Array.empty<Watch.WatchObservationCandidate>)
 
-    /// Verifies same-path file and directory replacements retain removal evidence without directory subtree expansion.
+    /// Verifies same-path file and directory replacements transfer stale file work into final directory subtree work.
     [<Test>]
     let ``local observation candidate replacements retain old kind removal and final kind work`` () =
         let verifyFileToDirectory () =
@@ -914,10 +914,18 @@ module WatchTests =
                 Watch.setLocalObservationCandidateSchedulingForWatchTests true
                 clearWatchIgnoreEntries ()
                 File.WriteAllText(fullPath, "old file")
+                Watch.OnChanged(changedEvent fullPath)
+
+                (Watch.pendingWatchWorkSnapshotForTests ())
+                    .FilesToProcess
+                |> should equal [| fullPath |]
+
                 File.Delete(fullPath)
                 Watch.OnDeleted(deletedEvent fullPath)
 
                 Directory.CreateDirectory(fullPath) |> ignore
+                let retainedFile = Path.Combine(fullPath, "retained.txt")
+                File.WriteAllText(retainedFile, "retained after replacement")
 
                 Watch.OnCreated(createdEvent fullPath)
 
@@ -926,10 +934,76 @@ module WatchTests =
                 pending.StatusUpdateTriggers
                 |> should equal [| relativePath |]
 
+                pending.FilesToProcess
+                |> should equal [| retainedFile |]
+
+                Watch.pendingFileStabilizationAttemptsForWatchTests fullPath
+                |> should equal None
+
                 Directory.Exists(fullPath) |> should equal true
 
                 Watch.localObservationCandidateSnapshotForWatchTests ()
-                |> should equal Array.empty<Watch.WatchObservationCandidate>)
+                |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+                /// Tracks the retained nested file upload so the final directory outcome cannot depend on a second callback.
+                let mutable uploadCalls = 0
+                /// Tracks the normalized status differences so replacement ownership proves the complete final state exactly once.
+                let mutable observedDifferences = List<FileSystemDifference>()
+
+                /// Reads status needed by the test scenario.
+                let readStatus () = Task.FromResult(status)
+                /// Records the stable retained-file identity that the storage seam would make available to status application.
+                let recordRetainedUpload filePath =
+                    match (Services.createLocalFileVersion (FileInfo(filePath))).GetAwaiter().GetResult() with
+                    | Some localFileVersion -> Watch.recordUploadedFileVersionForWatchTests localFileVersion.ToFileVersion
+                    | None -> Assert.Fail($"Expected a local file version for {filePath}.")
+                /// Builds upload test data used to exercise CLI watch behavior.
+                let upload _ filePath =
+                    uploadCalls <- uploadCalls + 1
+                    recordRetainedUpload filePath
+                    Task.FromResult(())
+                /// Builds scan-oriented update test data used to exercise CLI watch behavior.
+                let updateGraceStatus status _ = Task.FromResult(Some status)
+                /// Fails the test if healthy directory processing attempts a repository scan instead of its bounded observation seam.
+                let scanForDifferences _ : Task<List<FileSystemDifference>> =
+                    raise (InvalidOperationException("Healthy directory processing must not scan for differences."))
+                /// Builds event-derived status apply test data used to exercise CLI watch behavior.
+                let updateGraceStatusFromDifferences status differences _ =
+                    observedDifferences <- differences
+                    Task.FromResult(Some status)
+                /// Builds apply incremental test data used to exercise CLI watch behavior.
+                let applyIncremental _ _ _ = Task.FromResult(())
+                /// Builds update ipc test data used to exercise CLI watch behavior.
+                let updateIpc _ _ = Task.FromResult(())
+
+                let processPendingWork () =
+                    (Watch.processChangedFilesWithClients
+                        readStatus
+                        readStatus
+                        upload
+                        updateGraceStatus
+                        scanForDifferences
+                        updateGraceStatusFromDifferences
+                        applyIncremental
+                        updateIpc)
+                        .GetAwaiter()
+                        .GetResult()
+
+                processPendingWork ()
+                processPendingWork ()
+
+                uploadCalls |> should equal 1
+
+                observedDifferences
+                |> Seq.map (fun difference -> difference.DifferenceType, difference.FileSystemEntryType, $"{difference.RelativePath}")
+                |> Seq.toArray
+                |> should
+                    equivalent
+                    [|
+                        DifferenceType.Delete, FileSystemEntryType.File, relativePath
+                        DifferenceType.Add, FileSystemEntryType.Directory, relativePath
+                        DifferenceType.Add, FileSystemEntryType.File, $"{relativePath}/retained.txt"
+                    |])
 
         let verifyDirectoryToFile () =
             withTempRepo (fun root ->
@@ -11530,6 +11604,7 @@ module WatchTests =
 
             Directory.CreateDirectory(directoryPath) |> ignore
             Directory.SetLastWriteTimeUtc(directoryPath, DateTime.UtcNow.AddMinutes(1.0))
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
             Watch.OnChanged(changedEvent directoryPath)
 
             /// Reads status needed by the test scenario.
@@ -11694,9 +11769,9 @@ module WatchTests =
                     DifferenceType.Add, FileSystemEntryType.Directory, newRelativePath
                 |])
 
-    /// Verifies that a renamed directory enumerates only its subtree and keeps empty child directories.
+    /// Verifies that a parent-only renamed-directory candidate enumerates only its subtree and keeps empty child directories.
     [<Test>]
-    let ``renamed subtree preserves empty child directory adds without root scan`` () =
+    let ``parent-only renamed directory candidate preserves nested files and empty child directory adds without root scan`` () =
         withTempRepo (fun root ->
             let oldRelativePath = "old-assets"
             let newRelativePath = "new-assets"
@@ -11726,6 +11801,7 @@ module WatchTests =
 
             File.WriteAllText(filePath, "renamed subtree content")
             Watch.setGraceStatusForWatchTests status
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
             Watch.OnRenamed(renamedEvent oldPath newPath)
 
             /// Reads status needed by the test scenario.

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -302,10 +302,24 @@ module Watch =
     /// Supplies deterministic time to file stabilization so tests can advance retry eligibility without sleeping.
     let mutable private stableFileIdentityNowForWatch = fun () -> DateTime.UtcNow
 
+    /// Holds one incomplete directory inspection together with the repository and branch scope allowed to retry its bounded subtree.
+    type private PendingDirectoryWorkSnapshot =
+        {
+            FullPath: string
+            Generation: int64
+            RepositoryId: RepositoryId
+            RepositoryName: string
+            BranchId: BranchId
+            BranchName: string
+            RootDirectory: string
+        }
+
     /// Holds a list of the created or changed directories that we need to process, as determined by the FileSystemWatcher.
     ///
-    /// Note: We're using ConcurrentDictionary because it's safe for multithreading, doesn't allow us to insert the same key twice, and for its algorithms. We're not using the values of the ConcurrentDictionary here, only the keys.
-    let private directoriesToProcess = ConcurrentDictionary<string, unit>()
+    /// Each value keeps retry ownership bound to the exact repository, branch, and root that admitted the final directory observation.
+    let private directoriesToProcess = ConcurrentDictionary<string, PendingDirectoryWorkSnapshot>()
+
+    let mutable private directoryWorkGeneration = 0L
 
     /// Defines structured data exchanged by CLI helpers.
     type private StatusUpdateTriggerSnapshot = { RelativePath: string; Generation: int64 }
@@ -630,6 +644,7 @@ module Watch =
     /// Describes the final local observation that should be interpreted after its quiet window elapses.
     type internal WatchObservationKind =
         | CreatedOrChanged
+        | Changed
         | Deleted
         | GraceStatusArtifact
 
@@ -1978,6 +1993,33 @@ module Watch =
 
         pendingFileWorkMatchesScope pendingFile currentScope
 
+    /// Checks whether an incomplete directory inspection still belongs to the repository, branch, and root that accepted it.
+    let private pendingDirectoryWorkMatchesCurrentScope (pendingDirectory: PendingDirectoryWorkSnapshot) =
+        let current = Current()
+
+        let repositoryMatches =
+            if pendingDirectory.RepositoryId
+               <> RepositoryId.Empty then
+                pendingDirectory.RepositoryId = current.RepositoryId
+            else
+                String.Equals(pendingDirectory.RepositoryName, current.RepositoryName, StringComparison.Ordinal)
+
+        let branchMatches =
+            if pendingDirectory.BranchId <> BranchId.Empty then
+                pendingDirectory.BranchId = current.BranchId
+            else
+                String.Equals(pendingDirectory.BranchName, current.BranchName, StringComparison.Ordinal)
+
+        repositoryMatches
+        && branchMatches
+        && String.Equals(
+            pendingDirectory.RootDirectory,
+            current.RootDirectory
+            |> Path.GetFullPath
+            |> Path.TrimEndingDirectorySeparator,
+            watchPathComparison
+        )
+
     /// Converts accepted file work to the relative path owned by its recorded repository root.
     let private relativePathForPendingFileWork (pendingFile: PendingFileWorkSnapshot) =
         Path.GetRelativePath(pendingFile.RootDirectory, pendingFile.FullPath)
@@ -2113,13 +2155,37 @@ module Watch =
         else
             false
 
-    /// Records a directory whose contents must be enumerated before related status triggers can apply.
+    /// Retains a final directory inspection that could not enumerate every required status or file descendant yet.
     let private enqueueDirectoryUploadRetry directoryPath =
         if
             Directory.Exists(directoryPath)
             && shouldNotIgnoreDirectory directoryPath
         then
-            directoriesToProcess.TryAdd(directoryPath, ())
+            let generation = Interlocked.Increment(&directoryWorkGeneration)
+
+            let pendingDirectory =
+                {
+                    FullPath = directoryPath
+                    Generation = generation
+                    RepositoryId = Current().RepositoryId
+                    RepositoryName = Current().RepositoryName
+                    BranchId = Current().BranchId
+                    BranchName = Current().BranchName
+                    RootDirectory =
+                        Current().RootDirectory
+                        |> Path.GetFullPath
+                        |> Path.TrimEndingDirectorySeparator
+                }
+
+            directoriesToProcess.AddOrUpdate(
+                directoryPath,
+                pendingDirectory,
+                (fun _ existing ->
+                    if pendingDirectory.Generation >= existing.Generation then
+                        pendingDirectory
+                    else
+                        existing)
+            )
             |> ignore
 
     /// Queues every non-ignored file under a directory and reports whether enumeration reached a durable answer.
@@ -2253,6 +2319,23 @@ module Watch =
 
         canceledFileUpload
 
+    /// Retires same-path file stabilization and status evidence when final-state inspection proves the path is now a directory.
+    let private transferFileWorkToDirectoryProcessing directoryPath =
+        removePendingFileUpload directoryPath |> ignore
+
+        match repositoryRelativePath directoryPath with
+        | Some relativePath ->
+            let directoryRelativePath = RelativePath relativePath
+            let mutable removedRecoveryEvidence = Unchecked.defaultof<PendingFileWorkSnapshot>
+
+            fileRecoveryEvidence.TryRemove(directoryPath, &removedRecoveryEvidence)
+            |> ignore
+
+            clearProcessedFileRelativePathsPendingStatusForPaths [ directoryRelativePath ]
+            clearCanceledFileUploadDeleteRelativePaths [ directoryRelativePath ]
+            removeUploadedFileVersionsForPaths [ directoryRelativePath ]
+        | None -> ()
+
     /// Checks whether two status differences represent the same repository path observation.
     let private statusDifferenceMatches (left: FileSystemDifference) (right: FileSystemDifference) =
         left.DifferenceType = right.DifferenceType
@@ -2366,11 +2449,11 @@ module Watch =
             for difference in differences do
                 clearStartupReplaySequenceForDifference difference)
 
-    /// Reads the best available GraceStatus snapshot for classifying directory-create observations.
+    /// Reads the GraceStatus snapshot that authorizes a bounded directory inspection, refusing to derive additions from an unavailable status.
     let private readGraceStatusForDirectoryAddClassification () =
         if (not graceStatusHasChanged)
            && graceStatus.Index.Count > 0 then
-            graceStatus
+            Some graceStatus
         else
             try
                 let refreshedStatus =
@@ -2379,19 +2462,70 @@ module Watch =
                         .GetResult()
 
                 graceStatus <- refreshedStatus
-                refreshedStatus
+                Some refreshedStatus
             with
-            | _ -> GraceStatus.Default
+            | ex ->
+                logToAnsiConsole
+                    Colors.Important
+                    $"Grace Watch deferred directory inspection because current Grace Status could not be read: {Markup.Escape(ex.Message)}"
 
-    /// Queues directory add differences and reports whether the affected subtree was fully enumerated.
+                None
+
+    /// Queues directory add differences and reports whether final-state inspection must enumerate the affected subtree.
     let private tryEnqueueDirectoryStatusAdds fullPath =
-        let status = readGraceStatusForDirectoryAddClassification ()
-        let directoryAddDifferences, completedEnumeration = tryDeriveDirectorySubtreeAddDifferences status fullPath
+        match readGraceStatusForDirectoryAddClassification () with
+        | Some status ->
+            match repositoryRelativePath fullPath with
+            | Some relativePath ->
+                let finalDirectoryRelativePath = RelativePath relativePath
 
-        for difference in directoryAddDifferences do
-            addPendingStatusDifference difference
+                let replacesTrackedFile =
+                    tryFindTrackedFile status finalDirectoryRelativePath
+                    |> Option.isSome
 
-        directoryAddDifferences.Count > 0, completedEnumeration
+                let alreadyTrackedDirectory = isTrackedDirectory status finalDirectoryRelativePath
+
+                if replacesTrackedFile then
+                    addPendingStatusDifference (FileSystemDifference.Create Delete FileSystemEntryType.File finalDirectoryRelativePath)
+
+                if alreadyTrackedDirectory && not replacesTrackedFile then
+                    false, true, false
+                else
+                    let directoryAddDifferences, completedEnumeration = tryDeriveDirectorySubtreeAddDifferences status fullPath
+
+                    for difference in directoryAddDifferences do
+                        addPendingStatusDifference difference
+
+                    directoryAddDifferences.Count > 0
+                    || replacesTrackedFile,
+                    completedEnumeration,
+                    true
+            | None -> false, true, false
+        | None -> false, false, false
+
+    /// Queues the final directory state and all retained descendants, transferring stale same-path file work before bounded enumeration.
+    let private enqueueFinalDirectoryWork fullPath =
+        transferFileWorkToDirectoryProcessing fullPath
+
+        let directoryStatusAddQueued, directoryStatusEnumerationComplete, requiresSubtreeEnumeration = tryEnqueueDirectoryStatusAdds fullPath
+
+        let fileUploadWorkCountBefore = filesToProcess.Count
+
+        let fileUploadEnumerationComplete =
+            if directoryStatusEnumerationComplete
+               && requiresSubtreeEnumeration then
+                tryEnqueueDirectoryContentsForUpload fullPath
+            else
+                directoryStatusEnumerationComplete
+
+        if not directoryStatusEnumerationComplete
+           || not fileUploadEnumerationComplete then
+            enqueueDirectoryUploadRetry fullPath
+
+        directoryStatusAddQueued
+        || filesToProcess.Count > fileUploadWorkCountBefore
+        || not directoryStatusEnumerationComplete
+        || not fileUploadEnumerationComplete
 
     /// Captures the already-derived differences waiting for the shared status-application path.
     let private pendingStatusDifferencesSnapshot () = lock pendingStatusDifferencesLock (fun () -> pendingStatusDifferences.ToList())
@@ -2422,8 +2556,8 @@ module Watch =
     let private quarantinePendingWatchWork reason retainPendingFile =
         let mutable quarantinedCount = 0
         let mutable removedPendingFile = Unchecked.defaultof<PendingFileWorkSnapshot>
+        let mutable removedPendingDirectory = Unchecked.defaultof<PendingDirectoryWorkSnapshot>
         let mutable triggerGeneration = 0L
-        let mutable unitValue = ()
         let discardedEvidenceRelativePaths = List<RelativePath>()
 
         for pendingFile in filesToProcess.ToArray() do
@@ -2444,7 +2578,7 @@ module Watch =
                 quarantinedCount <- quarantinedCount + 1
 
         for pendingDirectory in directoriesToProcess.ToArray() do
-            if directoriesToProcess.TryRemove(pendingDirectory.Key, &unitValue) then
+            if directoriesToProcess.TryRemove(pendingDirectory.Key, &removedPendingDirectory) then
                 quarantineWatchObservation reason "directory" pendingDirectory.Key
                 quarantinedCount <- quarantinedCount + 1
 
@@ -3260,7 +3394,7 @@ module Watch =
 
         publishPendingWatchWorkTransitionIfNeeded ()
 
-    /// Applies a due create or change candidate after its quiet window has separated raw callbacks from filesystem work.
+    /// Applies a due create or rename candidate after its quiet window has separated raw callbacks from filesystem work.
     let private applyCreatedOrChangedLocalObservationCandidate fullPath observedAt =
         if updateNotInProgress ()
            && isGraceStatusArtifact fullPath then
@@ -3270,16 +3404,12 @@ module Watch =
             logObservationSuppressed fullPath
             false
         elif Directory.Exists(fullPath) then
-            let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds fullPath
+            let queuedDirectoryWork = enqueueFinalDirectoryWork fullPath
 
-            if directoryStatusAddQueued then
+            if queuedDirectoryWork then
                 logToAnsiConsole Colors.Added $"I saw that directory {fullPath} was created."
 
-            if not directoryStatusEnumerationComplete then
-                enqueueDirectoryUploadRetry fullPath
-
-            directoryStatusAddQueued
-            || not directoryStatusEnumerationComplete
+            queuedDirectoryWork
         elif isNotDirectory fullPath then
             if enqueueFileUpload fullPath then
                 logToAnsiConsole Colors.Changed $"I saw that {fullPath} changed."
@@ -3288,6 +3418,19 @@ module Watch =
                 false
         else
             false
+
+    /// Applies a change-only candidate, allowing a directory only when GraceStatus proves it replaced a tracked file.
+    let private applyChangedLocalObservationCandidate fullPath observedAt =
+        if Directory.Exists(fullPath) then
+            match readGraceStatusForDirectoryAddClassification (), repositoryRelativePath fullPath with
+            | Some status, Some relativePath when
+                tryFindTrackedFile status (RelativePath relativePath)
+                |> Option.isSome
+                ->
+                enqueueFinalDirectoryWork fullPath
+            | _ -> false
+        else
+            applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
 
     /// Applies a due delete candidate after the current marker and final filesystem state can be examined safely.
     let private applyDeletedLocalObservationCandidate fullPath observedAt =
@@ -3356,6 +3499,16 @@ module Watch =
                                 let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
 
                                 removalQueuedWork || finalQueuedWork
+                            | Changed ->
+                                let removalQueuedWork =
+                                    if candidate.RequiresRemovalProof then
+                                        applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                    else
+                                        false
+
+                                let finalQueuedWork = applyChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                                removalQueuedWork || finalQueuedWork
                             | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
                             | GraceStatusArtifact ->
                                 markGraceStatusChangedAndPublishPendingWorkTransition ()
@@ -3379,6 +3532,7 @@ module Watch =
         let queuedPendingWork =
             match kind with
             | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
+            | Changed -> applyChangedLocalObservationCandidate fullPath observedAt
             | Deleted -> applyDeletedLocalObservationCandidate fullPath observedAt
             | GraceStatusArtifact ->
                 if updateNotInProgress () then
@@ -3845,6 +3999,9 @@ module Watch =
         Interlocked.Exchange(&fileUploadWorkGeneration, 0L)
         |> ignore
 
+        Interlocked.Exchange(&directoryWorkGeneration, 0L)
+        |> ignore
+
         Interlocked.Exchange(&graceStatusRefreshGeneration, 0L)
         |> ignore
 
@@ -3917,10 +4074,10 @@ module Watch =
 
     /// Coordinates drain status only triggers behavior for this CLI command path.
     let private drainStatusOnlyTriggers (directorySnapshot: string array) (statusTriggerSnapshot: StatusUpdateTriggerSnapshot array) =
-        let mutable unitValue = ()
+        let mutable removedPendingDirectory = Unchecked.defaultof<PendingDirectoryWorkSnapshot>
 
         for directory in directorySnapshot do
-            directoriesToProcess.TryRemove(directory, &unitValue)
+            directoriesToProcess.TryRemove(directory, &removedPendingDirectory)
             |> ignore
 
         for statusTrigger in statusTriggerSnapshot do
@@ -3950,11 +4107,11 @@ module Watch =
                 |> Seq.map (fun difference -> string difference.RelativePath)
                 |> HashSet
 
-            let mutable unitValue = ()
+            let mutable removedPendingDirectory = Unchecked.defaultof<PendingDirectoryWorkSnapshot>
 
             for directory in directorySnapshot do
                 if directoryPathsToDrain.Contains(directory) then
-                    directoriesToProcess.TryRemove(directory, &unitValue)
+                    directoriesToProcess.TryRemove(directory, &removedPendingDirectory)
                     |> ignore
 
             for statusTrigger in statusTriggerSnapshot do
@@ -6595,28 +6752,15 @@ module Watch =
         if not (canCaptureFilesystemObservation ()) then
             logObservationSuppressed args.FullPath
         elif updateNotInProgress () then
-            let kind =
-                if isGraceStatusArtifact args.FullPath then
-                    GraceStatusArtifact
-                else
-                    CreatedOrChanged
+            let kind = if isGraceStatusArtifact args.FullPath then GraceStatusArtifact else Changed
 
             if isLocalObservationCandidateSchedulingActive () then
                 acceptLocalObservationCandidate kind args.FullPath DateTime.UtcNow
             elif useImmediateLocalObservationProcessingForWatchTests ()
                  && kind = GraceStatusArtifact then
                 processLocalObservationImmediately kind args.FullPath
-            elif useImmediateLocalObservationProcessingForWatchTests ()
-                 && isDelayedGraceOwnedFileObservation args.FullPath DateTime.UtcNow then
-                logObservationSuppressed args.FullPath
-            elif
-                useImmediateLocalObservationProcessingForWatchTests ()
-                && isNotDirectory args.FullPath
-                && not (shouldIgnoreFile args.FullPath)
-            then
-                logToAnsiConsole Colors.Changed $"I saw that {args.FullPath} changed."
-                enqueueFileUpload args.FullPath |> ignore
-                publishPendingWatchWorkTransitionIfNeeded ()
+            elif useImmediateLocalObservationProcessingForWatchTests () then
+                processLocalObservationImmediately kind args.FullPath
             elif not (useImmediateLocalObservationProcessingForWatchTests ()) then
                 logObservationSuppressed args.FullPath
         else
@@ -6625,18 +6769,34 @@ module Watch =
     /// Reads enqueue directory contents for upload data needed by the command workflow without changing remote state.
     let private enqueueDirectoryContentsForUpload directoryPath = tryEnqueueDirectoryContentsForUpload directoryPath
 
-    /// Retries directory content enumeration before status application consumes directory rename-old triggers.
+    /// Retries a scoped directory inspection before status application consumes its related delete or rename-old trigger.
     let private retryPendingDirectoryUploads () =
-        let mutable unitValue = ()
+        for pendingDirectory in directoriesToProcess.Values.ToArray() do
+            let pendingPair = KeyValuePair(pendingDirectory.FullPath, pendingDirectory)
 
-        for directoryPath in directoriesToProcess.Keys.ToArray() do
-            let _, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds directoryPath
-            let fileUploadEnumerationComplete = enqueueDirectoryContentsForUpload directoryPath
-
-            if directoryStatusEnumerationComplete
-               && fileUploadEnumerationComplete then
-                directoriesToProcess.TryRemove(directoryPath, &unitValue)
+            if not (pendingDirectoryWorkMatchesCurrentScope pendingDirectory) then
+                (directoriesToProcess :> ICollection<KeyValuePair<string, PendingDirectoryWorkSnapshot>>)
+                    .Remove(pendingPair)
                 |> ignore
+
+                requestGraceWatchExplicitResync $"Watch directory inspection scope changed before bounded retry for {pendingDirectory.FullPath}."
+            else
+                let _, directoryStatusEnumerationComplete, requiresSubtreeEnumeration = tryEnqueueDirectoryStatusAdds pendingDirectory.FullPath
+
+                let fileUploadEnumerationComplete =
+                    if directoryStatusEnumerationComplete then
+                        if requiresSubtreeEnumeration then
+                            enqueueDirectoryContentsForUpload pendingDirectory.FullPath
+                        else
+                            true
+                    else
+                        false
+
+                if directoryStatusEnumerationComplete
+                   && fileUploadEnumerationComplete then
+                    (directoriesToProcess :> ICollection<KeyValuePair<string, PendingDirectoryWorkSnapshot>>)
+                        .Remove(pendingPair)
+                    |> ignore
 
     /// Coordinates on deleted behavior for this CLI command path.
     let OnDeleted (args: FileSystemEventArgs) =
@@ -6671,45 +6831,8 @@ module Watch =
                 acceptLocalObservationCandidate Deleted args.OldFullPath seenAt
                 acceptLocalObservationCandidate kind args.FullPath seenAt
             elif useImmediateLocalObservationProcessingForWatchTests () then
-                let mutable queuedPendingWork = false
-                let newPathIsDirectory = Directory.Exists(args.FullPath)
-                let canceledFileUpload = cancelPendingUploadsForDeletedPath args.OldFullPath
-                let oldPathStatusQueued = enqueueStatusUpdateTrigger args.OldFullPath
-                queuedPendingWork <- queuedPendingWork || oldPathStatusQueued
-
-                if oldPathStatusQueued then
-                    if canceledFileUpload then
-                        match repositoryRelativePath args.OldFullPath with
-                        | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
-                        | None -> ()
-
-                    logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-
-                if newPathIsDirectory then
-                    let directoryStatusAddQueued, directoryStatusEnumerationComplete = tryEnqueueDirectoryStatusAdds args.FullPath
-                    queuedPendingWork <- queuedPendingWork || directoryStatusAddQueued
-
-                    if directoryStatusAddQueued
-                       && not oldPathStatusQueued then
-                        logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-
-                    let fileUploadWorkCountBefore = filesToProcess.Count
-                    let fileUploadEnumerationComplete = enqueueDirectoryContentsForUpload args.FullPath
-
-                    if not fileUploadEnumerationComplete then
-                        enqueueDirectoryUploadRetry args.FullPath
-                        queuedPendingWork <- true
-                    elif filesToProcess.Count > fileUploadWorkCountBefore then
-                        queuedPendingWork <- true
-
-                    if not directoryStatusEnumerationComplete then
-                        enqueueDirectoryUploadRetry args.FullPath
-                        queuedPendingWork <- true
-                elif enqueueFileUpload args.FullPath then
-                    logToAnsiConsole Colors.Changed $"I saw that {args.OldFullPath} was renamed to {args.FullPath}."
-                    queuedPendingWork <- true
-
-                if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+                processLocalObservationImmediately Deleted args.OldFullPath
+                processLocalObservationImmediately kind args.FullPath
             else
                 logObservationSuppressed args.FullPath
         else
@@ -8036,7 +8159,23 @@ module Watch =
 
         match difference.FileSystemEntryType, difference.DifferenceType with
         | Directory, _ ->
-            directoriesToProcess.TryAdd(difference.RelativePath, ())
+            let generation = Interlocked.Increment(&directoryWorkGeneration)
+
+            directoriesToProcess.TryAdd(
+                difference.RelativePath,
+                {
+                    FullPath = difference.RelativePath
+                    Generation = generation
+                    RepositoryId = Current().RepositoryId
+                    RepositoryName = Current().RepositoryName
+                    BranchId = Current().BranchId
+                    BranchName = Current().BranchName
+                    RootDirectory =
+                        Current().RootDirectory
+                        |> Path.GetFullPath
+                        |> Path.TrimEndingDirectorySeparator
+                }
+            )
             |> ignore
         | File, Delete ->
             let generation = Interlocked.Increment(&statusUpdateTriggerGeneration)

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -703,6 +703,12 @@ module Watch =
                 else
                     pathComparer.Compare(left.FullPath, right.FullPath)
 
+        /// Retains create or rename intent when a trailing change callback describes the same final directory state.
+        let mergeObservationKind incomingKind existingCandidate =
+            match incomingKind, existingCandidate with
+            | Changed, Some existing when existing.Kind = CreatedOrChanged -> CreatedOrChanged
+            | _ -> incomingKind
+
         /// Records one local observation, replacing any older generation while retaining same-path delete proof for a final replacement.
         member _.Observe(origin: WatchObservationOrigin, kind: WatchObservationKind, fullPath: string, seenAt: DateTime) =
             lock gate (fun () ->
@@ -710,16 +716,22 @@ module Watch =
                 | LocalFileSystem, false, Some normalizedPath ->
                     let generation = Interlocked.Increment(&nextGeneration)
 
+                    let existingCandidate =
+                        match candidates.TryGetValue(normalizedPath) with
+                        | true, existing -> Some existing
+                        | false, _ -> None
+
+                    let mergedKind = mergeObservationKind kind existingCandidate
+
                     let requiresRemovalProof =
                         kind = Deleted
-                        || match candidates.TryGetValue(normalizedPath) with
-                           | true, existing -> existing.RequiresRemovalProof
-                           | false, _ -> false
+                        || existingCandidate
+                           |> Option.exists (fun existing -> existing.RequiresRemovalProof)
 
                     let candidate =
                         {
                             FullPath = normalizedPath
-                            Kind = kind
+                            Kind = mergedKind
                             RequiresRemovalProof = requiresRemovalProof
                             Generation = generation
                             LastSeenAt = seenAt
@@ -2479,27 +2491,21 @@ module Watch =
             | Some relativePath ->
                 let finalDirectoryRelativePath = RelativePath relativePath
 
-                let replacesTrackedFile =
-                    tryFindTrackedFile status finalDirectoryRelativePath
-                    |> Option.isSome
+                let replacedTrackedFile = tryFindTrackedFile status finalDirectoryRelativePath
 
-                let alreadyTrackedDirectory = isTrackedDirectory status finalDirectoryRelativePath
+                match replacedTrackedFile with
+                | Some trackedFile -> addPendingStatusDifference (FileSystemDifference.Create Delete FileSystemEntryType.File trackedFile.RelativePath)
+                | None -> ()
 
-                if replacesTrackedFile then
-                    addPendingStatusDifference (FileSystemDifference.Create Delete FileSystemEntryType.File finalDirectoryRelativePath)
+                let directoryAddDifferences, completedEnumeration = tryDeriveDirectorySubtreeAddDifferences status fullPath
 
-                if alreadyTrackedDirectory && not replacesTrackedFile then
-                    false, true, false
-                else
-                    let directoryAddDifferences, completedEnumeration = tryDeriveDirectorySubtreeAddDifferences status fullPath
+                for difference in directoryAddDifferences do
+                    addPendingStatusDifference difference
 
-                    for difference in directoryAddDifferences do
-                        addPendingStatusDifference difference
-
-                    directoryAddDifferences.Count > 0
-                    || replacesTrackedFile,
-                    completedEnumeration,
-                    true
+                directoryAddDifferences.Count > 0
+                || replacedTrackedFile.IsSome,
+                completedEnumeration,
+                true
             | None -> false, true, false
         | None -> false, false, false
 
@@ -3419,16 +3425,23 @@ module Watch =
         else
             false
 
-    /// Applies a change-only candidate, allowing a directory only when GraceStatus proves it replaced a tracked file.
+    /// Applies a change-only candidate, retaining unreadable directory classification as scoped retry work while rejecting proven mtime-only noise.
     let private applyChangedLocalObservationCandidate fullPath observedAt =
         if Directory.Exists(fullPath) then
-            match readGraceStatusForDirectoryAddClassification (), repositoryRelativePath fullPath with
-            | Some status, Some relativePath when
-                tryFindTrackedFile status (RelativePath relativePath)
-                |> Option.isSome
-                ->
-                enqueueFinalDirectoryWork fullPath
-            | _ -> false
+            match repositoryRelativePath fullPath with
+            | Some relativePath ->
+                match readGraceStatusForDirectoryAddClassification () with
+                | Some status when
+                    tryFindTrackedFile status (RelativePath relativePath)
+                    |> Option.isSome
+                    ->
+                    enqueueFinalDirectoryWork fullPath
+                | Some _ -> false
+                | None ->
+                    transferFileWorkToDirectoryProcessing fullPath
+                    enqueueDirectoryUploadRetry fullPath
+                    true
+            | None -> false
         else
             applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
 


### PR DESCRIPTION
## Summary

Implements WS6.3 by normalizing directory final-state work through affected-subtree enumeration, including the inherited parent-only rename and file-to-directory replacement obligations.

Related to #509. Part of #480 and #473.

## Behavior

- Parent-only directory rename derives directory additions and queues every non-ignored retained file from the affected subtree without depending on child watcher callbacks.
- Directory retries retain repository, branch, root, path, and generation scope; stale scope uses the existing explicit resync path.
- Old-path and delete classification remains driven by current `GraceStatus`.
- File-to-directory replacement retires same-path stabilization, recovery evidence, processed-status, cancellation, and uploaded identity state before bounded directory processing takes ownership.
- Ownership transfer clears the stale cancellation marker so retained nested files cannot be re-enumerated and uploaded twice.
- Change-only directory observations remain distinct from create/rename observations, preserving no-save behavior for directory mtime noise.
- Empty directories, ignore pruning, duplicate/reordered convergence, marker/cancellation behavior, and the healthy-mode no-root-scan invariant are preserved.

## Scope

- Changed only `src/Grace.CLI/Command/Watch.CLI.fs` and `src/Grace.CLI.Tests/Watch.Tests.fs`.
- No CLI flags, DTOs, persisted/generated artifacts, docs, `Services.CLI.fs`, or #677 materialization constructs changed.
- Docs impact is N/A because this is internal Watch normalization behavior with no user-facing command or configuration change.

## Validation

- Targeted Fantomas passed for `Watch.CLI.fs`.
- Fantomas 4.7.9 repeatedly stalled while processing the approximately 1 MB `Watch.Tests.fs`; the file compiled cleanly in the focused Release build and final Fast gate.
- Release `Grace.CLI.Tests` build passed with 0 warnings and 0 errors.
- Inherited parent-only rename, file-to-directory replacement, and renamed-empty-directory proofs passed 3/3.
- Broader directory, rename, replacement, and candidate matrix passed 106/106.
- `pwsh ./scripts/validate.ps1 -Fast` passed with 0 build warnings/errors and 2,119 tests.
- `git diff --check` passed.
- Bot-prevention self-review found and corrected one duplicate-upload path before commit.

## Review Status

- Current head: `18d99c0672bc6f3660062f8fe5dae1ff5f744bda`.
- Codex Code Review Bot session 1: `3570032718`, `3570032724`, `3570032728`, and `3570032731` are fixed by `18d99c06`; unreadable status retains exact directory retry work, stronger create/rename intent survives trailing changes, accepted directory work always enumerates its bounded subtree, and replacement deletes use canonical tracked-file casing.
- Substantive cycle count: 1.
- GitHub Full on `d85b2016`: passed in 6m26s.
- Local validation on `18d99c06`: Fantomas; focused Release build with 0 warnings/errors; changed-only proofs 2/2; candidate/directory/no-root-scan proofs 26/26; Fast passed with CLI 1190, Types 140, Authorization 53, and Server.Unit 738; `git diff --check`; and bot-prevention self-review.
- GitHub Full on `18d99c06`: passed in 6m45s.
- Codex Code Review Bot: all session-1 threads are resolved; fresh current-head review on `18d99c06` completed with no findings and 👍.
- Prevention: one normalized final-directory transition owns bounded subtree enumeration and file-to-directory state transfer under complete repository/branch/root/path/generation scope; change-only noise cannot claim subtree ownership, stale scope cannot publish partial work, and duplicate/reordered events cannot duplicate final upload/status outcomes.
- Merge gate is satisfied on `18d99c06`; final freshness and scoped-diff audit is in progress.
