### PR TITLE
WS6.4: Harden Watch suppression and confidence loss

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2601,7 +2601,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 7"
+                |> should contain "schema_version is 8"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -3061,7 +3061,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 7"
+                        |> should contain "schema_version is 8"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -189,6 +189,7 @@ module LocalStateDbTests =
             WatchRoot = configuration.RootDirectory
             PathComparison = StringComparison.Ordinal
             RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
+            RootDirectorySha256Hash = Sha256Hash "test-root-sha256"
             RootDirectoryBlake3Hash = Blake3Hash "test-root-blake3"
             WatchMode = "repository-root"
         }
@@ -377,7 +378,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -1139,6 +1140,8 @@ module LocalStateDbTests =
 
                 let failedContinuity = { scope with RootDirectoryBlake3Hash = Blake3Hash "different-root-blake3" }
 
+                let failedSha256Continuity = { scope with RootDirectorySha256Hash = Sha256Hash "different-root-sha256" }
+
                 let observations =
                     [|
                         scopedWatchJournalObservation wrongRepository DifferenceType.Change FileSystemEntryType.File "wrong-repo.txt"
@@ -1146,6 +1149,7 @@ module LocalStateDbTests =
                         scopedWatchJournalObservation wrongWorkspace DifferenceType.Change FileSystemEntryType.File "wrong-workspace.txt"
                         scopedWatchJournalObservation wrongRoot DifferenceType.Change FileSystemEntryType.File "wrong-root.txt"
                         scopedWatchJournalObservation failedContinuity DifferenceType.Change FileSystemEntryType.File "failed-continuity.txt"
+                        scopedWatchJournalObservation failedSha256Continuity DifferenceType.Change FileSystemEntryType.File "failed-sha256-continuity.txt"
                         scopedWatchJournalObservation scope DifferenceType.Change FileSystemEntryType.File "compatible.txt"
                     |]
 
@@ -1153,7 +1157,7 @@ module LocalStateDbTests =
                 let! recovery = LocalStateDb.recoverWatchJournalForStartup configuration.GraceStatusFile scope
 
                 sequences
-                |> should equal [| 1L; 2L; 3L; 4L; 5L; 6L |]
+                |> should equal [| 1L; 2L; 3L; 4L; 5L; 6L; 7L |]
 
                 recovery.QuarantinedRows
                 |> Array.map (fun row -> row.Sequence, row.RelativePath, row.QuarantineReason)
@@ -1165,23 +1169,24 @@ module LocalStateDbTests =
                         3L, Some "wrong-workspace.txt", Some "wrong workspace root"
                         4L, Some "wrong-root.txt", Some "wrong watch root"
                         5L, Some "failed-continuity.txt", Some "failed root hash continuity"
+                        6L, Some "failed-sha256-continuity.txt", Some "failed root SHA-256 continuity"
                     |]
 
                 recovery.CompatibleReplayRows
                 |> Array.map (fun row -> row.Sequence, row.RelativePath)
-                |> should equal [| 6L, RelativePath "compatible.txt" |]
+                |> should equal [| 7L, RelativePath "compatible.txt" |]
 
                 let! appliedThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
-                appliedThrough |> should equal 5L
+                appliedThrough |> should equal 6L
 
                 let! quarantinedSnapshot = LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "quarantined" None 10
-                quarantinedSnapshot.Rows |> should haveLength 5
+                quarantinedSnapshot.Rows |> should haveLength 6
 
                 let! pendingSnapshot = LocalStateDb.readWatchJournalSnapshot configuration.GraceStatusFile "pending" None 10
 
                 pendingSnapshot.Rows
                 |> Array.map (fun row -> row.Sequence)
-                |> should equal [| 6L |]
+                |> should equal [| 7L |]
             })
 
     /// Verifies that lifecycle diagnostics are durable and explicitly non-replayable.
@@ -1233,8 +1238,8 @@ module LocalStateDbTests =
 
                 let lifecycleColumns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('watch_lifecycle_events');"
 
-                schemaVersion |> should equal "7"
-                lifecycleColumns |> should equal 12
+                schemaVersion |> should equal "8"
+                lifecycleColumns |> should equal 13
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1276,7 +1281,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1565,7 +1570,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -1602,7 +1607,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
                 sequencePk |> should equal 1
@@ -1654,7 +1659,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -1694,7 +1699,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -1734,7 +1739,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
@@ -1776,7 +1781,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let duplicateRows = executeScalarInt connection "SELECT COUNT(*) FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 duplicateRows |> should equal 1
 
@@ -1821,7 +1826,7 @@ module LocalStateDbTests =
                     with
                     | :? SqliteException -> false
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 duplicateInsertSucceeded |> should equal false
 
@@ -1860,7 +1865,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1899,7 +1904,7 @@ module LocalStateDbTests =
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
                 let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
                 allocationRows |> should equal 0
@@ -1937,7 +1942,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -1974,7 +1979,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2011,7 +2016,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2057,7 +2062,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2104,7 +2109,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2150,7 +2155,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2198,7 +2203,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2239,7 +2244,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2269,7 +2274,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2324,7 +2329,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "7")
+                |> should equal (Some "8")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -2369,7 +2374,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "7")
+                |> should equal (Some "8")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -2647,7 +2652,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -2684,7 +2689,7 @@ module LocalStateDbTests =
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
                 let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
                 readRootBlake3Hash |> should equal rootBlake3Hash
@@ -2740,7 +2745,7 @@ module LocalStateDbTests =
                 let watchJournalCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 watchJournalCount |> should equal 1
                 appliedThrough |> should equal "0"
 
@@ -2792,9 +2797,9 @@ module LocalStateDbTests =
 
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 hiddenRequiredColumns |> should equal 0
-                journalColumns |> should equal 14
+                journalColumns |> should equal 15
                 appliedThrough |> should equal "0"
 
                 let corruptAfter =
@@ -2829,7 +2834,7 @@ module LocalStateDbTests =
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 rootBlake3Columns |> should equal 1
                 statusMetaCount |> should equal 1
 
@@ -2870,7 +2875,7 @@ module LocalStateDbTests =
                 let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
                 statusDirectoryCount |> should equal 0
                 statusMetaCount |> should equal 1
 
@@ -3063,7 +3068,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -3090,7 +3095,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "7"
+                schemaVersion |> should equal "8"
             })
 
     /// Verifies that replace status snapshot fully clears old snapshot rows.
@@ -3404,7 +3409,7 @@ module LocalStateDbTests =
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '7');"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '8');"
 
                     executeNonQuery
                         connection
@@ -4314,7 +4319,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "7"
+                    schemaVersion |> should equal "8"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -18482,6 +18482,7 @@ module WatchTests =
                 |> ignore
 
                 File.WriteAllText(updateMarkerFile, "`grace watch` remote materialization is in progress.")
+                File.SetLastWriteTimeUtc(updateMarkerFile, completedUtc.AddSeconds(-1.0))
                 Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
 
                 File.WriteAllText(

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1883,21 +1883,142 @@ module WatchTests =
             Watch.isGraceWatchResyncPendingForWatchTests ()
             |> should equal true)
 
+    /// Verifies that marker confidence loss rejects both existing and newly scheduled callbacks until exact resync recovery completes.
+    [<Test>]
+    let ``marker confidence loss blocks scheduled and immediate callbacks until exact recovery`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let existingScheduledPath = Path.Combine(root, "existing-scheduled-after-confidence-loss.txt")
+            let newScheduledPath = Path.Combine(root, "new-scheduled-after-confidence-loss.txt")
+            let immediatePath = Path.Combine(root, "immediate-after-confidence-loss.txt")
+            let recoveredPath = Path.Combine(root, "valid-after-exact-recovery.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let mutable uploadCalls = 0
+            let mutable incrementalCalls = 0
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            File.WriteAllText(existingScheduledPath, "existing scheduled callback")
+            Watch.OnChanged(changedEvent existingScheduledPath)
+            recordIncompleteUpdateMarkerDeletion updateMarkerFile
+
+            File.WriteAllText(newScheduledPath, "new scheduled callback")
+            Watch.OnChanged(changedEvent newScheduledPath)
+            Watch.processDueLocalObservationCandidatesForWatchTests (DateTime.UtcNow.AddSeconds(2.0))
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+            let blockedScheduledWork = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            blockedScheduledWork.FilesToProcess
+            |> should equal Array.empty<string>
+
+            blockedScheduledWork.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            blockedScheduledWork.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests false
+            File.WriteAllText(immediatePath, "immediate callback")
+            Watch.OnChanged(changedEvent immediatePath)
+
+            let blockedImmediateWork = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            blockedImmediateWork.FilesToProcess
+            |> should equal Array.empty<string>
+
+            blockedImmediateWork.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            blockedImmediateWork.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            (Watch.processChangedFilesWithClients
+                (fun () -> Task.FromResult(status))
+                (fun () -> Task.FromResult(status))
+                (fun _ _ ->
+                    uploadCalls <- uploadCalls + 1
+                    Task.FromResult(()))
+                (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                (fun _ -> Task.FromResult(List<FileSystemDifference>()))
+                (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                (fun _ _ _ ->
+                    incrementalCalls <- incrementalCalls + 1
+                    Task.FromResult(()))
+                Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+            incrementalCalls |> should equal 0
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            File.WriteAllText(recoveredPath, "valid callback after exact recovery")
+            Watch.OnChanged(changedEvent recoveredPath)
+
+            (Watch.pendingWatchWorkSnapshotForTests ())
+                .FilesToProcess
+            |> should equal [| recoveredPath |])
+
     /// Verifies a raw candidate never crosses a branch scope change into upload, journal, or status work.
     [<Test>]
     let ``raw local candidate scope change forces resync before upload or journal admission`` () =
         withTempRepo (fun root ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
             let changedPath = Path.Combine(root, "scope-change.txt")
+            let recoveredPath = Path.Combine(root, "scope-change-recovered.txt")
             let mutable uploadCalls = 0
 
             File.WriteAllText(changedPath, "candidate bytes")
             Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
 
             Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged changedPath DateTime.UtcNow
             |> ignore
 
             Current().BranchId <- Guid.NewGuid()
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
+
+            Watch.lastPublishedHasPendingWatchWorkForWatchTests ()
+            |> should equal (Some true)
 
             (Watch.processChangedFilesWithClients
                 (fun () -> Task.FromResult(status))
@@ -1920,7 +2041,14 @@ module WatchTests =
             |> should equal Array.empty<string>
 
             Watch.currentGraceWatchRuntimeModeForWatchTests ()
-            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental)
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental
+
+            File.WriteAllText(recoveredPath, "valid callback after scope recovery")
+            Watch.OnChanged(changedEvent recoveredPath)
+
+            (Watch.pendingWatchWorkSnapshotForTests ())
+                .FilesToProcess
+            |> should equal [| recoveredPath |])
 
     /// Verifies an ordinary callback can use the verified published root identity after transient in-flight status reset.
     [<Test>]
@@ -6814,7 +6942,7 @@ module WatchTests =
                 use command = connection.CreateCommand()
 
                 command.CommandText <-
-                    "INSERT INTO watch_journal (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $difference_type, $entry_type, $relative_path);"
+                    "INSERT INTO watch_journal (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_sha256_hash, $root_directory_blake3_hash, $watch_mode, $difference_type, $entry_type, $relative_path);"
 
                 command.Parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
                 |> ignore
@@ -6832,6 +6960,9 @@ module WatchTests =
                 |> ignore
 
                 command.Parameters.AddWithValue("$root_directory_version_id", scope.RootDirectoryId.ToString())
+                |> ignore
+
+                command.Parameters.AddWithValue("$root_directory_sha256_hash", string scope.RootDirectorySha256Hash)
                 |> ignore
 
                 command.Parameters.AddWithValue("$root_directory_blake3_hash", string scope.RootDirectoryBlake3Hash)

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -874,9 +874,9 @@ module WatchTests =
                 .AddMilliseconds(300.0)
                 .Add(quietWindow))
 
-    /// Verifies that delete proof survives same-scope replacement but cannot cross a repository scope change on the same path.
+    /// Verifies that a scope change starts a same-path candidate without inherited removal proof or semantic kind.
     [<Test>]
-    let ``local observation candidates drop inherited delete proof when their scope changes`` () =
+    let ``local observation candidates start fresh when their scope changes`` () =
         let quietWindow = TimeSpan.FromSeconds(1.0)
         let scheduler = new Watch.WatchObservationCandidateScheduler(quietWindow, StringComparison.Ordinal)
         let fullPath = Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "scope-replacement.txt")
@@ -917,8 +917,57 @@ module WatchTests =
         currentCandidate.Scope
         |> should equal (Some currentScope)
 
+        currentCandidate.Kind
+        |> should equal Watch.Changed
+
         currentCandidate.RequiresRemovalProof
         |> should equal false
+
+        currentCandidate.LastSeenAt
+        |> should equal (firstSeenAt.AddMilliseconds(200.0))
+
+        currentCandidate.DueAt
+        |> should equal (firstSeenAt.AddMilliseconds(200.0).Add(quietWindow))
+
+    /// Verifies an old-scope create cannot turn a new-scope metadata-only directory change into directory add work.
+    [<Test>]
+    let ``cross-scope created directory then changed metadata queues no directory work`` () =
+        withTempRepo (fun root ->
+            let status = GraceStatus.Default
+            let directoryPath = Path.Combine(root, "metadata-only-directory")
+            let firstSeenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            clearWatchIgnoreEntries ()
+            Directory.CreateDirectory(directoryPath) |> ignore
+
+            Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged directoryPath firstSeenAt
+            |> Option.isSome
+            |> should equal true
+
+            Current().BranchId <- Guid.NewGuid()
+
+            let changedCandidate =
+                Watch.recordLocalObservationCandidateForWatchTests Watch.Changed directoryPath (firstSeenAt.AddMilliseconds(1.0))
+                |> Option.get
+
+            changedCandidate.Kind
+            |> should equal Watch.Changed
+
+            Watch.processDueLocalObservationCandidatesForWatchTests (firstSeenAt.AddMilliseconds(1.0))
+
+            let pending = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>)
 
     /// Verifies a same-path file replacement queues both removal proof and final file upload work.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -874,6 +874,52 @@ module WatchTests =
                 .AddMilliseconds(300.0)
                 .Add(quietWindow))
 
+    /// Verifies that delete proof survives same-scope replacement but cannot cross a repository scope change on the same path.
+    [<Test>]
+    let ``local observation candidates drop inherited delete proof when their scope changes`` () =
+        let quietWindow = TimeSpan.FromSeconds(1.0)
+        let scheduler = new Watch.WatchObservationCandidateScheduler(quietWindow, StringComparison.Ordinal)
+        let fullPath = Path.Combine(Path.GetTempPath(), "grace-watch-candidate", "scope-replacement.txt")
+        let firstSeenAt = DateTime(2026, 7, 12, 1, 0, 0, DateTimeKind.Utc)
+        let current = Current()
+
+        let scope rootDirectoryId (rootSha256Hash: string) (rootBlake3Hash: string) : Watch.WatchObservationScope =
+            {
+                RepositoryId = current.RepositoryId
+                RepositoryName = current.RepositoryName
+                BranchId = current.BranchId
+                BranchName = current.BranchName
+                RootDirectory = current.RootDirectory
+                PathComparison = StringComparison.Ordinal
+                RootDirectoryId = rootDirectoryId
+                RootDirectorySha256Hash = Sha256Hash rootSha256Hash
+                RootDirectoryBlake3Hash = Blake3Hash rootBlake3Hash
+            }
+
+        let oldScope = scope (DirectoryVersionId "11111111-1111-1111-1111-111111111111") "old-root-sha256" "old-root-blake3"
+
+        let currentScope = scope (DirectoryVersionId "22222222-2222-2222-2222-222222222222") "current-root-sha256" "current-root-blake3"
+
+        scheduler.ObserveScoped(Watch.LocalFileSystem, Watch.Deleted, fullPath, firstSeenAt, Some oldScope)
+        |> Option.isSome
+        |> should equal true
+
+        scheduler.ObserveScoped(Watch.LocalFileSystem, Watch.CreatedOrChanged, fullPath, firstSeenAt.AddMilliseconds(100.0), Some oldScope)
+        |> Option.get
+        |> fun candidate ->
+            candidate.RequiresRemovalProof
+            |> should equal true
+
+        let currentCandidate =
+            scheduler.ObserveScoped(Watch.LocalFileSystem, Watch.Changed, fullPath, firstSeenAt.AddMilliseconds(200.0), Some currentScope)
+            |> Option.get
+
+        currentCandidate.Scope
+        |> should equal (Some currentScope)
+
+        currentCandidate.RequiresRemovalProof
+        |> should equal false
+
     /// Verifies a same-path file replacement queues both removal proof and final file upload work.
     [<Test>]
     let ``local observation candidate delete then file create preserves removal and upload work`` () =
@@ -1699,6 +1745,69 @@ module WatchTests =
 
             Watch.currentGraceWatchRuntimeModeForWatchTests ()
             |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental)
+
+    /// Verifies an ordinary callback can use the verified published root identity after transient in-flight status reset.
+    [<Test>]
+    let ``raw local candidate uses published status identity after transient cache reset`` () =
+        withTempRepo (fun root ->
+            let changedPath = Path.Combine(root, "published-identity.txt")
+
+            let status =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "published-root-sha256"
+                    RootDirectoryBlake3Hash = Blake3Hash "published-root-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let mutable uploadCalls = 0
+            let mutable scanCalls = 0
+
+            File.WriteAllText(changedPath, "ordinary user edit")
+            Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+            Watch.setGraceStatusForWatchTests status
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+
+            (Watch.publishGraceWatchInterprocessFileForCurrentConfidenceForWatchTests status directoryIds Services.updateGraceWatchInterprocessFile)
+                .GetAwaiter()
+                .GetResult()
+
+            (Watch.storeGraceStatusInMemoryStream ())
+                .GetAwaiter()
+                .GetResult()
+
+            Watch.graceStatusForWatchTests().RootDirectoryId
+            |> should equal GraceStatus.Default.RootDirectoryId
+
+            Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged changedPath DateTime.UtcNow
+            |> Option.isSome
+            |> should equal true
+
+            try
+                (Watch.processChangedFilesWithClients
+                    (fun () -> Task.FromResult(status))
+                    (fun () -> Task.FromResult(status))
+                    (fun _ _ ->
+                        uploadCalls <- uploadCalls + 1
+                        Task.FromResult(()))
+                    (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                    (fun _ ->
+                        scanCalls <- scanCalls + 1
+                        Task.FromResult(List<FileSystemDifference>()))
+                    (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                    (fun _ _ _ -> Task.FromResult(()))
+                    (fun _ _ -> Task.FromResult(())))
+                    .GetAwaiter()
+                    .GetResult()
+
+                uploadCalls |> should equal 1
+                scanCalls |> should equal 0
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal false
+            finally
+                (Watch.retrieveGraceStatusFromMemoryStream ())
+                    .GetAwaiter()
+                    .GetResult())
 
     /// Verifies same-branch completion never executes branch-transition subscription effects, including restart recovery.
     [<TestCase(true)>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -455,6 +455,7 @@ module WatchTests =
             WatchRoot = current.RootDirectory
             PathComparison = StringComparison.Ordinal
             RootDirectoryId = DirectoryVersionId("11111111-1111-1111-1111-111111111111")
+            RootDirectorySha256Hash = Sha256Hash "test-root-sha256"
             RootDirectoryBlake3Hash = Blake3Hash "test-root-blake3"
             WatchMode = "repository-root"
         }
@@ -1451,7 +1452,7 @@ module WatchTests =
             let pending = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
 
             pending.FilesToProcess
-            |> should equal [| preMarkerPath |]
+            |> should equal Array.empty<string>
 
             pending.DirectoriesToProcess
             |> should equal Array.empty<string>
@@ -1473,6 +1474,40 @@ module WatchTests =
                 File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
                 File.WriteAllText(changedFilePath, "Grace-owned branch switch payload")
                 Watch.OnChanged(changedEvent changedFilePath)
+
+                let pending = Watch.pendingWatchWorkSnapshotForTests ()
+
+                pending.FilesToProcess
+                |> should equal Array.empty<string>
+
+                pending.DirectoriesToProcess
+                |> should equal Array.empty<string>
+
+                pending.StatusUpdateTriggers
+                |> should equal Array.empty<string>
+            finally
+                if File.Exists(updateMarkerFile) then File.Delete(updateMarkerFile))
+
+    /// Verifies every filesystem callback shape inside an active marker window is terminal Grace-owned noise.
+    [<Test>]
+    let ``update marker suppresses create change delete and rename callback paths without local work`` () =
+        withTempRepo (fun root ->
+            let createdPath = Path.Combine(root, "grace-created.txt")
+            let deletedPath = Path.Combine(root, "grace-deleted.txt")
+            let renamedPath = Path.Combine(root, "grace-renamed.txt")
+            let updateMarkerFile = Services.updateInProgressFileName ()
+
+            Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+            |> ignore
+
+            try
+                File.WriteAllText(updateMarkerFile, "`grace switch` is in progress.")
+                File.WriteAllText(createdPath, "Grace-owned payload")
+                File.WriteAllText(renamedPath, "Grace-owned renamed payload")
+                Watch.OnCreated(createdEvent createdPath)
+                Watch.OnChanged(changedEvent createdPath)
+                Watch.OnDeleted(deletedEvent deletedPath)
+                Watch.OnRenamed(renamedEvent deletedPath renamedPath)
 
                 let pending = Watch.pendingWatchWorkSnapshotForTests ()
 
@@ -1599,9 +1634,9 @@ module WatchTests =
             File.Exists(completedSidecar)
             |> should equal false)
 
-    /// Verifies that marker deletion without a completion sidecar cannot authorize delayed suppression.
+    /// Verifies that marker deletion without completion evidence rejects delayed local work and requires resync.
     [<Test>]
-    let ``update marker deletion without completion sidecar does not suppress delayed changed observation`` () =
+    let ``update marker deletion without completion sidecar forces resync without delayed local work`` () =
         withTempRepo (fun root ->
             let changedFilePath = Path.Combine(root, "partial-switch-write.txt")
             let updateMarkerFile = Services.updateInProgressFileName ()
@@ -1615,13 +1650,55 @@ module WatchTests =
             let pending = Watch.pendingWatchWorkSnapshotForTests ()
 
             pending.FilesToProcess
-            |> should equal [| changedFilePath |]
+            |> should equal Array.empty<string>
 
             pending.DirectoriesToProcess
             |> should equal Array.empty<string>
 
             pending.StatusUpdateTriggers
-            |> should equal Array.empty<string>)
+            |> should equal Array.empty<string>
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal true)
+
+    /// Verifies a raw candidate never crosses a branch scope change into upload, journal, or status work.
+    [<Test>]
+    let ``raw local candidate scope change forces resync before upload or journal admission`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let changedPath = Path.Combine(root, "scope-change.txt")
+            let mutable uploadCalls = 0
+
+            File.WriteAllText(changedPath, "candidate bytes")
+            Watch.setGraceStatusForWatchTests status
+
+            Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged changedPath DateTime.UtcNow
+            |> ignore
+
+            Current().BranchId <- Guid.NewGuid()
+
+            (Watch.processChangedFilesWithClients
+                (fun () -> Task.FromResult(status))
+                (fun () -> Task.FromResult(status))
+                (fun _ _ ->
+                    uploadCalls <- uploadCalls + 1
+                    Task.FromResult(()))
+                (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                (fun _ -> Task.FromResult(List<FileSystemDifference>()))
+                (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                (fun _ _ _ -> Task.FromResult(()))
+                (fun _ _ -> Task.FromResult(())))
+                .GetAwaiter()
+                .GetResult()
+
+            uploadCalls |> should equal 0
+
+            (Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ())
+                .FilesToProcess
+            |> should equal Array.empty<string>
+
+            Watch.currentGraceWatchRuntimeModeForWatchTests ()
+            |> should equal Services.GraceWatchRuntimeMode.HealthyIncremental)
 
     /// Verifies same-branch completion never executes branch-transition subscription effects, including restart recovery.
     [<TestCase(true)>]
@@ -6189,7 +6266,13 @@ module WatchTests =
             let trackedAddPath = "tracked.txt"
             let status = graceStatusTracking [| trackedAddPath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             File.WriteAllText(Path.Combine(root, ghostChangePath), "untracked content")
             File.WriteAllText(Path.Combine(root, trackedAddPath), "tracked content")
@@ -6314,7 +6397,13 @@ module WatchTests =
                     .Value
 
             let status = graceStatusTrackingFileVersions [| trackedFile |]
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             try
                 (LocalStateDb.appendWatchJournalObservations
@@ -6419,7 +6508,13 @@ module WatchTests =
         withTempRepo (fun _ ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             (LocalStateDb.recoverWatchJournalForStartup dbPath scope)
                 .GetAwaiter()
@@ -6512,7 +6607,13 @@ module WatchTests =
             let directoryPath = Path.Combine(root, "new", "child")
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             Directory.CreateDirectory(directoryPath) |> ignore
 
@@ -6601,7 +6702,14 @@ module WatchTests =
             let relativePath = "startup-replay-scan-duplicate.txt"
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
+
             let ordering = ResizeArray<string>()
 
             try
@@ -6700,7 +6808,14 @@ module WatchTests =
             let scanPath = "casepath.txt"
             let status = graceStatusTracking [| replayPath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
+
             let ordering = ResizeArray<string>()
 
             try
@@ -6802,7 +6917,14 @@ module WatchTests =
             let changePath = "missing-replayed-change.txt"
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
+
             let lifecycleEvents = ResizeArray<string>()
 
             try
@@ -6906,7 +7028,14 @@ module WatchTests =
             let ignoredDirectoryFileRelativePath = "ignored-dir/live.txt"
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
+
             let lifecycleEvents = ResizeArray<string>()
 
             Directory.CreateDirectory(ignoredDirectory)
@@ -7042,7 +7171,14 @@ module WatchTests =
             let ignoredDirectoryRelativePath = "ignored-dir"
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
+
             let lifecycleEvents = ResizeArray<string>()
 
             Directory.CreateDirectory(ignoredDirectory)
@@ -7151,7 +7287,13 @@ module WatchTests =
             let directoryDeleteNowFile = "directory-delete-now-file"
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             Directory.CreateDirectory(Path.Combine(root, fileDeleteNowDirectory))
             |> ignore
@@ -7393,7 +7535,13 @@ module WatchTests =
             File.WriteAllText(filePath, "recreated")
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             try
                 (LocalStateDb.appendWatchJournalObservations
@@ -7474,7 +7622,13 @@ module WatchTests =
             let replayFilePath = Path.Combine(root, relativePath)
             let status = graceStatusTracking [| liveRelativePath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             try
                 File.WriteAllText(replayFilePath, "startup replay content still exists")
@@ -7555,7 +7709,13 @@ module WatchTests =
             let relativePath = "quarantined-startup-replay-delete.txt"
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
 
             try
                 let replaySequences =
@@ -7625,7 +7785,14 @@ module WatchTests =
             let filePath = Path.Combine(root, relativePath)
             let status = graceStatusTracking [| relativePath |] Array.empty<string>
             let dbPath = Current().GraceStatusFile
-            let scope = { (watchJournalScope ()) with RootDirectoryId = status.RootDirectoryId; RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash }
+
+            let scope =
+                { (watchJournalScope ()) with
+                    RootDirectoryId = status.RootDirectoryId
+                    RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                    RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+                }
+
             let appendedDifferences = ResizeArray<FileSystemDifference>()
             let advancedSequences = ResizeArray<int64>()
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -2113,7 +2113,124 @@ module WatchTests =
                     .GetAwaiter()
                     .GetResult())
 
-    /// Verifies same-branch completion never executes branch-transition subscription effects, including restart recovery.
+    /// Verifies a clean resync recovery retains its verified scope through a transient status reset and rejects a later branch mismatch.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``verified resync recovery retains scope through transient reset and rejects later branch mismatch`` () =
+        withTempRepo (fun root ->
+            let recoveredPath = Path.Combine(root, "recovered-scope-candidate.txt")
+            let originalBranchId = Current().BranchId
+
+            let status =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "recovered-scope-sha256"
+                    RootDirectoryBlake3Hash = Blake3Hash "recovered-scope-blake3"
+                }
+
+            let mutable uploadCalls = 0
+
+            try
+                Watch.setGraceStatusForWatchTests GraceStatus.Default
+                Watch.setGraceStatusForWatchTests status
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+                Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+                Watch.requestGraceWatchExplicitResyncForWatchTests "recover a verified observation scope"
+                Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+
+                (Watch.processChangedFilesWithClients
+                    (fun () -> Task.FromResult(status))
+                    (fun () -> Task.FromResult(status))
+                    (fun _ _ -> Task.FromResult(()))
+                    (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                    (fun _ -> Task.FromResult(List<FileSystemDifference>()))
+                    (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                    (fun _ _ _ -> Task.FromResult(()))
+                    Services.updateGraceWatchInterprocessFile)
+                    .GetAwaiter()
+                    .GetResult()
+
+                match Watch.lastPublishedWatchObservationScopeForWatchTests () with
+                | Some publishedScope ->
+                    publishedScope.BranchId
+                    |> should equal originalBranchId
+
+                    publishedScope.RootDirectoryId
+                    |> should equal status.RootDirectoryId
+
+                    publishedScope.RootDirectorySha256Hash
+                    |> should equal status.RootDirectorySha256Hash
+
+                    publishedScope.RootDirectoryBlake3Hash
+                    |> should equal status.RootDirectoryBlake3Hash
+                | None -> Assert.Fail("Verified resync recovery must retain the scope represented by its clean IPC status.")
+
+                (Watch.storeGraceStatusInMemoryStream ())
+                    .GetAwaiter()
+                    .GetResult()
+
+                File.WriteAllText(recoveredPath, "candidate admitted with recovered scope")
+
+                Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged recoveredPath DateTime.UtcNow
+                |> Option.isSome
+                |> should equal true
+
+                Current().BranchId <- Guid.NewGuid()
+                Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+                (Watch.processChangedFilesWithClients
+                    (fun () -> Task.FromResult(status))
+                    (fun () -> Task.FromResult(status))
+                    (fun _ _ ->
+                        uploadCalls <- uploadCalls + 1
+                        Task.FromResult(()))
+                    (fun currentStatus _ -> Task.FromResult(Some currentStatus))
+                    (fun _ -> Task.FromResult(List<FileSystemDifference>()))
+                    (fun currentStatus _ _ -> Task.FromResult(Some currentStatus))
+                    (fun _ _ _ -> Task.FromResult(()))
+                    Services.updateGraceWatchInterprocessFile)
+                    .GetAwaiter()
+                    .GetResult()
+
+                uploadCalls |> should equal 0
+            finally
+                Current().BranchId <- originalBranchId
+
+                (Watch.retrieveGraceStatusFromMemoryStream ())
+                    .GetAwaiter()
+                    .GetResult())
+
+    /// Verifies an IPC publication whose configuration changes during its write cannot overwrite newer scope evidence.
+    [<Test; Category("CurrentBranchMaterializationPublication")>]
+    let ``stale verified publication does not cache a superseded observation scope`` () =
+        withTempRepo (fun _ ->
+            let originalBranchId = Current().BranchId
+
+            let status =
+                { graceStatusTracking Array.empty<string> Array.empty<string> with
+                    RootDirectorySha256Hash = Sha256Hash "stale-publication-scope-sha256"
+                    RootDirectoryBlake3Hash = Blake3Hash "stale-publication-scope-blake3"
+                }
+
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            try
+                Watch.setGraceStatusForWatchTests GraceStatus.Default
+                Watch.setGraceStatusForWatchTests status
+                Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.HealthyIncremental
+
+                (Watch.publishGraceWatchInterprocessFileForCurrentConfidenceForWatchTests status directoryIds (fun publishedStatus publishedDirectoryIds ->
+                    task {
+                        Current().BranchId <- Guid.NewGuid()
+                        do! Services.updateGraceWatchInterprocessFile publishedStatus publishedDirectoryIds
+                    }))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.lastPublishedWatchObservationScopeForWatchTests ()
+                |> should equal None
+            finally
+                Current().BranchId <- originalBranchId)
+
+    /// Verifies same-branch completion requires current observed marker evidence without changing branch-transition subscriptions.
     [<TestCase(true)>]
     [<TestCase(false)>]
     [<Category("CurrentBranchMaterializationApplyBoundary")>]
@@ -2147,13 +2264,50 @@ module WatchTests =
                 Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
 
                 Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
-                |> should equal (Some 1L)
+                |> should equal (if observeCreation then Some 1L else None)
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal (not observeCreation)
 
                 let subscription = Watch.signalRBranchSubscriptionForWatchTests ()
                 subscription.BranchId |> should equal branchId
 
                 subscription.ParentBranchId
                 |> should equal parentBranchId
+            finally
+                Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ())
+
+    /// Verifies a recent sidecar from an earlier marker cannot authorize current Reference catch-up.
+    [<Test; Category("CurrentBranchMaterializationApplyBoundary")>]
+    let ``recent earlier reference completion sidecar forces exact recovery instead of catch-up`` () =
+        withTempRepo (fun _ ->
+            let updateMarkerFile = Services.updateInProgressFileName ()
+            let currentMarkerUtc = DateTime.UtcNow
+            let earlierCompletionUtc = currentMarkerUtc.AddSeconds(-1.0)
+
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
+
+            try
+                Directory.CreateDirectory(Path.GetDirectoryName(updateMarkerFile))
+                |> ignore
+
+                File.WriteAllText(updateMarkerFile, "`grace watch` remote materialization is in progress.")
+                File.SetLastWriteTimeUtc(updateMarkerFile, currentMarkerUtc)
+                Watch.OnGraceUpdateInProgressCreated(createdEvent updateMarkerFile)
+
+                File.WriteAllText(
+                    updateMarkerFile + ".completed",
+                    Services.serializeGraceUpdateMarkerCompletion Services.GraceUpdateMarkerPurpose.ReferenceMaterialization earlierCompletionUtc
+                )
+
+                File.Delete(updateMarkerFile)
+                Watch.OnGraceUpdateInProgressDeleted(deletedEvent updateMarkerFile)
+
+                Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                |> should equal None
+
+                Watch.isGraceWatchResyncPendingForWatchTests ()
+                |> should equal true
             finally
                 Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ())
 

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1298,6 +1298,182 @@ module WatchTests =
             |> Array.length
             |> should equal 1)
 
+    /// Verifies that a final directory metadata callback can clear candidate-derived dirty IPC without creating local work.
+    [<Test>]
+    let ``claimed metadata-only directory candidate reconciles dirty IPC to clean`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let metadataOnlyDirectory = Path.Combine(root, "metadata-only-directory")
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Directory.CreateDirectory(metadataOnlyDirectory)
+            |> ignore
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent metadataOnlyDirectory)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+            let pending = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true)
+
+    /// Verifies that a delayed Grace-owned callback clears candidate-derived dirty IPC without entering local Save work.
+    [<Test>]
+    let ``claimed delayed Grace-owned candidate reconciles dirty IPC without local work`` () =
+        withTempRepo (fun root ->
+            let relativePath = "delayed-grace-owned-candidate.txt"
+            let changedPath = Path.Combine(root, relativePath)
+            let status = graceStatusTracking [| relativePath |] Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let markerCompletedUtc = DateTime.UtcNow
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            File.WriteAllText(changedPath, "Grace-owned payload")
+            File.SetLastWriteTimeUtc(changedPath, markerCompletedUtc.AddSeconds(-1.0))
+            recordCompletedUpdateMarkerDeletion (Services.updateInProgressFileName ()) markerCompletedUtc
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent changedPath)
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+            let pending = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            pending.FilesToProcess
+            |> should equal Array.empty<string>
+
+            pending.DirectoriesToProcess
+            |> should equal Array.empty<string>
+
+            pending.StatusUpdateTriggers
+            |> should equal Array.empty<string>
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true)
+
+    /// Verifies that claiming a metadata-only candidate cannot clear dirty IPC while another candidate remains pending.
+    [<Test>]
+    let ``claimed metadata-only candidate retains dirty IPC for another candidate`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let metadataOnlyDirectory = Path.Combine(root, "metadata-only-directory")
+            let laterCandidatePath = Path.Combine(root, "later-candidate.txt")
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            Directory.CreateDirectory(metadataOnlyDirectory)
+            |> ignore
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent metadataOnlyDirectory)
+
+            Watch.recordLocalObservationCandidateForWatchTests Watch.CreatedOrChanged laterCandidatePath (DateTime.UtcNow.AddMinutes(1.0))
+            |> Option.isSome
+            |> should equal true
+
+            Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.map (fun candidate -> candidate.FullPath)
+            |> should equal [| laterCandidatePath |]
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false)
+
+    /// Verifies that claiming a metadata-only candidate cannot clear dirty IPC while queued file work remains.
+    [<Test>]
+    let ``claimed metadata-only candidate retains dirty IPC for queued file work`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let queuedFilePath = Path.Combine(root, "queued-file.txt")
+            let metadataOnlyDirectory = Path.Combine(root, "metadata-only-directory")
+
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            File.WriteAllText(queuedFilePath, "queued local work")
+            Watch.setLocalObservationCandidateSchedulingForWatchTests false
+            Watch.OnChanged(changedEvent queuedFilePath)
+
+            Directory.CreateDirectory(metadataOnlyDirectory)
+            |> ignore
+
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+            Watch.OnChanged(changedEvent metadataOnlyDirectory)
+            Watch.processDueLocalObservationCandidatesForWatchTests DateTime.UtcNow
+
+            let pending = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+
+            pending.FilesToProcess
+            |> should equal [| queuedFilePath |]
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal true
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal false)
+
     /// Verifies a failed immediate dirty publication retains the accepted candidate until the normal timer retry can drain it.
     [<Test>]
     let ``raw candidate dirty publication failure retains candidate for timer retry`` () =

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -105,7 +105,7 @@ module Doctor =
     let private ServerAuthPrincipalAvailableCheckId = "server.auth-principal.available"
 
     [<Literal>]
-    let private ExpectedLocalStateSchemaVersion = "7"
+    let private ExpectedLocalStateSchemaVersion = LocalStateDb.SchemaVersion
 
     [<Literal>]
     let private DoctorServerProbeTimeoutMilliseconds = 1500

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -704,13 +704,8 @@ module Watch =
         || status.RootDirectoryBlake3Hash
            <> GraceStatus.Default.RootDirectoryBlake3Hash
 
-    /// Retains the exact status identity that was verified in the latest IPC publication for the active Watch configuration.
-    let private rememberPublishedWatchObservationScope (status: GraceStatus) =
-        if hasWatchObservationRootIdentity status then
-            lastPublishedWatchObservationScope <- Some(watchObservationScopeForStatus status)
-
     /// Discards a published identity when its Watch lifetime ends so it cannot bridge a later configuration.
-    let private clearPublishedWatchObservationScope () = lastPublishedWatchObservationScope <- None
+    let private clearPublishedWatchObservationScope () = lock watchStatusPublishLock (fun () -> lastPublishedWatchObservationScope <- None)
 
     /// Checks whether a retained publication belongs to the configuration that currently owns callback admission.
     let private publishedWatchObservationScopeMatchesCurrentConfiguration (scope: WatchObservationScope) =
@@ -3086,6 +3081,9 @@ module Watch =
     /// Reports the cached pending-work result so recovery tests can prove failed dirty reassertion discards clean evidence.
     let internal lastPublishedHasPendingWatchWorkForWatchTests () = lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork)
 
+    /// Returns the exact verified status scope retained for callback admission in focused Watch tests.
+    let internal lastPublishedWatchObservationScopeForWatchTests () = lock watchStatusPublishLock (fun () -> lastPublishedWatchObservationScope)
+
     /// Reports whether the last verified IPC pending-work publication is stale against fresh evidence.
     let private pendingWatchWorkTransitionNeedsPublication () =
         File.Exists(IpcFileName())
@@ -3144,8 +3142,8 @@ module Watch =
         status.UpdatedAt >= publicationStartedAt
         && statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork status
 
-    /// Advances the pending-work publication cache only after the exact IPC snapshot proves it reached disk.
-    let private cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt =
+    /// Advances pending-work and observation-scope caches together only after the exact IPC snapshot proves it reached disk.
+    let private cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds expectedObservationScope hasPendingWork publicationStartedAt =
         let transitionWasPublished =
             try
                 let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
@@ -3155,7 +3153,14 @@ module Watch =
             with
             | _ -> false
 
-        lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- if transitionWasPublished then Some hasPendingWork else None)
+        lock watchStatusPublishLock (fun () ->
+            lastPublishedHasPendingWatchWork <- if transitionWasPublished then Some hasPendingWork else None
+
+            if transitionWasPublished then
+                match expectedObservationScope with
+                | Some observationScope when publishedWatchObservationScopeMatchesCurrentConfiguration observationScope ->
+                    lastPublishedWatchObservationScope <- Some observationScope
+                | _ -> ())
 
         if not transitionWasPublished then
             logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check."
@@ -3188,6 +3193,12 @@ module Watch =
                     else
                         expectedStatus, expectedDirectoryIds
 
+                let observationScopeForVerification =
+                    if hasWatchObservationRootIdentity statusForVerification then
+                        Some(watchObservationScopeForStatus statusForVerification)
+                    else
+                        None
+
                 try
                     if pendingEvidence.HasDurableOnlyPendingWork then
                         let emptyDirectoryIds = HashSet<DirectoryVersionId>()
@@ -3200,7 +3211,12 @@ module Watch =
                         writeSnapshot().GetAwaiter().GetResult()
 
                     transitionWasPublished <-
-                        cachePendingWatchWorkPublicationIfVerified statusForVerification directoryIdsForVerification hasPendingWork publicationStartedAt
+                        cachePendingWatchWorkPublicationIfVerified
+                            statusForVerification
+                            directoryIdsForVerification
+                            observationScopeForVerification
+                            hasPendingWork
+                            publicationStartedAt
 
                     publishedHasPendingWork <- if transitionWasPublished then Some hasPendingWork else None
                 with
@@ -3248,11 +3264,7 @@ module Watch =
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
     let private tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
-        let published = tryPublishWatchIpcWithPendingWorkEvidenceProbe readPendingWatchWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot
-
-        if published then rememberPublishedWatchObservationScope expectedStatus
-
-        published
+        tryPublishWatchIpcWithPendingWorkEvidenceProbe readPendingWatchWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot
 
     /// Reads new pending work while excluding only the current recovery attempt and its materialization latch.
     let private readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt =
@@ -7162,14 +7174,13 @@ module Watch =
                             Colors.Important
                             $"Update marker ended with incomplete completion evidence for {args.FullPath}; grace watch is resynchronizing before incremental work resumes."
                 | Some (GraceUpdateMarkerPurpose.ReferenceMaterialization, completedUtc) ->
-                    forgetObservedGraceUpdateMarkerInstance args.FullPath
-
-                    if isRecentGraceUpdateMarkerCompletion completedUtc then
+                    match classifyDeletedMarkerCompletedSidecar args.FullPath completedUtc with
+                    | ObservedCurrentMarker when isRecentGraceUpdateMarkerCompletion completedUtc ->
                         recordGraceUpdateMarkerCompletedUtc completedUtc
                         requestCurrentBranchReferenceCatchUp "current-branch reference materialization marker deletion"
                         logToAnsiConsole Colors.Important $"Reference materialization update has finished."
-                    else
-                        let reason = $"reference-materialization marker deletion had stale completion evidence for {args.FullPath}."
+                    | _ ->
+                        let reason = $"reference-materialization marker deletion did not provide current observed completion evidence for {args.FullPath}."
 
                         recordWatchBoundaryDiagnostic "marker-completion-confidence-loss" reason
                         requestGraceWatchMarkerCompletionConfidenceLossResync reason
@@ -7570,9 +7581,16 @@ module Watch =
         task {
             setGraceWatchPendingWorkStatusFlag true
             let publicationStartedAt = getCurrentInstant ()
+
+            let observationScopeForPublication =
+                if hasWatchObservationRootIdentity trustedStatus then
+                    Some(watchObservationScopeForStatus trustedStatus)
+                else
+                    None
+
             do! updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds)
 
-            cachePendingWatchWorkPublicationIfVerified trustedStatus directoryIds true publicationStartedAt
+            cachePendingWatchWorkPublicationIfVerified trustedStatus directoryIds observationScopeForPublication true publicationStartedAt
             |> ignore
         }
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -675,6 +675,58 @@ module Watch =
             Scope: WatchObservationScope option
         }
 
+    let mutable private lastPublishedWatchObservationScope: WatchObservationScope option = None
+
+    /// Captures the current configuration and the supplied status identity for callback admission or publication tracking.
+    let private watchObservationScopeForStatus (status: GraceStatus) =
+        let current = Current()
+
+        {
+            RepositoryId = current.RepositoryId
+            RepositoryName = current.RepositoryName
+            BranchId = current.BranchId
+            BranchName = current.BranchName
+            RootDirectory =
+                Path.GetFullPath(current.RootDirectory)
+                |> Path.TrimEndingDirectorySeparator
+            PathComparison = watchPathComparison
+            RootDirectoryId = status.RootDirectoryId
+            RootDirectorySha256Hash = status.RootDirectorySha256Hash
+            RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+        }
+
+    /// Identifies whether a status snapshot carries a root identity that can safely represent a published Watch scope.
+    let private hasWatchObservationRootIdentity (status: GraceStatus) =
+        status.RootDirectoryId
+        <> GraceStatus.Default.RootDirectoryId
+        || status.RootDirectorySha256Hash
+           <> GraceStatus.Default.RootDirectorySha256Hash
+        || status.RootDirectoryBlake3Hash
+           <> GraceStatus.Default.RootDirectoryBlake3Hash
+
+    /// Retains the exact status identity that was verified in the latest IPC publication for the active Watch configuration.
+    let private rememberPublishedWatchObservationScope (status: GraceStatus) =
+        if hasWatchObservationRootIdentity status then
+            lastPublishedWatchObservationScope <- Some(watchObservationScopeForStatus status)
+
+    /// Discards a published identity when its Watch lifetime ends so it cannot bridge a later configuration.
+    let private clearPublishedWatchObservationScope () = lastPublishedWatchObservationScope <- None
+
+    /// Checks whether a retained publication belongs to the configuration that currently owns callback admission.
+    let private publishedWatchObservationScopeMatchesCurrentConfiguration (scope: WatchObservationScope) =
+        let current = Current()
+
+        let rootDirectory =
+            Path.GetFullPath(current.RootDirectory)
+            |> Path.TrimEndingDirectorySeparator
+
+        scope.RepositoryId = current.RepositoryId
+        && String.Equals(scope.RepositoryName, current.RepositoryName, StringComparison.Ordinal)
+        && scope.BranchId = current.BranchId
+        && String.Equals(scope.BranchName, current.BranchName, StringComparison.Ordinal)
+        && String.Equals(scope.RootDirectory, rootDirectory, scope.PathComparison)
+        && scope.PathComparison = watchPathComparison
+
     /// Coalesces local filesystem observations until their deterministic quiet window has elapsed.
     type internal WatchObservationCandidateScheduler(quietWindow: TimeSpan, pathComparison: StringComparison) =
         let gate = obj ()
@@ -725,7 +777,7 @@ module Watch =
             | Changed, Some existing when existing.Kind = CreatedOrChanged -> CreatedOrChanged
             | _ -> incomingKind
 
-        /// Records one local observation, replacing any older generation while retaining same-path delete proof for a final replacement.
+        /// Records one local observation, replacing any older generation while retaining delete proof only within the same observation scope.
         member _.ObserveScoped
             (
                 origin: WatchObservationOrigin,
@@ -746,10 +798,13 @@ module Watch =
 
                     let mergedKind = mergeObservationKind kind existingCandidate
 
-                    let requiresRemovalProof =
-                        kind = Deleted
-                        || existingCandidate
-                           |> Option.exists (fun existing -> existing.RequiresRemovalProof)
+                    let carriesRemovalProofFromSameScope =
+                        existingCandidate
+                        |> Option.exists (fun existing ->
+                            existing.Scope = scope
+                            && existing.RequiresRemovalProof)
+
+                    let requiresRemovalProof = kind = Deleted || carriesRemovalProofFromSameScope
 
                     let candidate =
                         {
@@ -863,21 +918,12 @@ module Watch =
 
     /// Captures the current repository and exact root identity before a raw callback can be coalesced.
     let private currentWatchObservationScope () =
-        let current = Current()
-
-        {
-            RepositoryId = current.RepositoryId
-            RepositoryName = current.RepositoryName
-            BranchId = current.BranchId
-            BranchName = current.BranchName
-            RootDirectory =
-                Path.GetFullPath(current.RootDirectory)
-                |> Path.TrimEndingDirectorySeparator
-            PathComparison = watchPathComparison
-            RootDirectoryId = graceStatus.RootDirectoryId
-            RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
-            RootDirectoryBlake3Hash = graceStatus.RootDirectoryBlake3Hash
-        }
+        if hasWatchObservationRootIdentity graceStatus then
+            watchObservationScopeForStatus graceStatus
+        else
+            match lastPublishedWatchObservationScope with
+            | Some scope when publishedWatchObservationScopeMatchesCurrentConfiguration scope -> scope
+            | _ -> watchObservationScopeForStatus graceStatus
 
     /// Checks that a due raw candidate still belongs to its admission repository, branch, root, and exact root content.
     let private watchObservationScopeMatchesCurrent (scope: WatchObservationScope) =
@@ -1458,7 +1504,12 @@ module Watch =
                 | :? UnauthorizedAccessException -> false)
 
     /// Coordinates set grace status for watch tests behavior for this CLI command path.
-    let internal setGraceStatusForWatchTests status = graceStatus <- status
+    let internal setGraceStatusForWatchTests status =
+        graceStatus <- status
+
+        if not (hasWatchObservationRootIdentity status) then
+            clearPublishedWatchObservationScope ()
+
     /// Replaces Watch's cached directory identity set after a trusted GraceStatus reload.
     let internal updateGraceStatusDirectoryIds (status: GraceStatus) = graceStatusDirectoryIds <- status.Index.Keys.ToHashSet()
     /// Reads the in-memory Grace Status snapshot so transition-publication tests can prove state isolation.
@@ -3188,7 +3239,11 @@ module Watch =
 
     /// Publishes Watch IPC after reading queued work inside the serialized status boundary.
     let private tryPublishWatchIpcWithFreshPendingWorkProbe expectedStatus expectedDirectoryIds (writeSnapshot: unit -> Task<unit>) =
-        tryPublishWatchIpcWithPendingWorkEvidenceProbe readPendingWatchWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot
+        let published = tryPublishWatchIpcWithPendingWorkEvidenceProbe readPendingWatchWorkEvidence expectedStatus expectedDirectoryIds writeSnapshot
+
+        if published then rememberPublishedWatchObservationScope expectedStatus
+
+        published
 
     /// Reads new pending work while excluding only the current recovery attempt and its materialization latch.
     let private readPendingWatchWorkEvidenceForResyncRecoveryPublication attempt =
@@ -4146,6 +4201,7 @@ module Watch =
         stableFileIdentityNowForWatch <- fun () -> DateTime.UtcNow
 
         graceStatus <- GraceStatus.Default
+        clearPublishedWatchObservationScope ()
         graceStatusHasChanged <- false
 
         lock watchStatusPublishLock (fun () ->

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -875,19 +875,22 @@ module Watch =
     let mutable private immediateLocalObservationProcessingForWatchTests = 0
     let private localObservationConfidenceLossLock = obj ()
     let mutable private localObservationConfidenceLossReason: string option = None
+    let mutable private localObservationConfidenceLossActive = 0
 
-    /// Records one non-replayable raw-observation confidence loss for the timer path that owns resync transitions.
-    let private recordLocalObservationConfidenceLoss reason =
-        lock localObservationConfidenceLossLock (fun () ->
-            if localObservationConfidenceLossReason.IsNone then
-                localObservationConfidenceLossReason <- Some reason)
+    /// Reports whether raw-observation confidence loss still has an unconsumed diagnostic reason.
+    let private hasUnconsumedLocalObservationConfidenceLoss () = lock localObservationConfidenceLossLock (fun () -> localObservationConfidenceLossReason.IsSome)
 
-    /// Takes the oldest pending raw-observation confidence loss without allowing it to be rebound as local work.
-    let private takeLocalObservationConfidenceLoss () =
-        lock localObservationConfidenceLossLock (fun () ->
-            let pendingReason = localObservationConfidenceLossReason
-            localObservationConfidenceLossReason <- None
-            pendingReason)
+    /// Reports whether raw-observation confidence loss remains pending through its exact resync recovery boundary.
+    let private hasLocalObservationConfidenceLoss () =
+        hasUnconsumedLocalObservationConfidenceLoss ()
+        || Volatile.Read(&localObservationConfidenceLossActive)
+           <> 0
+
+    /// Reports whether marker or raw-observation confidence loss blocks all local incremental callback paths.
+    let private localObservationIncrementalWorkBlocked () =
+        Volatile.Read(&markerCompletionConfidenceLossActive)
+        <> 0
+        || hasLocalObservationConfidenceLoss ()
 
     /// Reports whether a live Watch lifetime has activated quiet-window candidate scheduling for raw callbacks.
     let private isLocalObservationCandidateSchedulingActive () =
@@ -2889,6 +2892,7 @@ module Watch =
         lock graceWatchResyncTransitionLock (fun () ->
             if tryClearGraceWatchResyncAttempt attempt then
                 Volatile.Write(&markerCompletionConfidenceLossActive, 0)
+                Volatile.Write(&localObservationConfidenceLossActive, 0)
                 true
             else
                 false)
@@ -2966,19 +2970,22 @@ module Watch =
             HasProcessablePendingWork: bool
             HasManualPendingStatusEvidence: bool
             HasDurableWatchJournalEvidence: bool
+            HasLocalObservationConfidenceLoss: bool
         }
 
-        /// Reports whether any Watch work or durable journal evidence must keep IPC dirty.
+        /// Reports whether Watch work, confidence loss, or durable journal evidence must keep IPC dirty.
         member this.HasPendingWork =
             this.HasProcessablePendingWork
             || this.HasManualPendingStatusEvidence
             || this.HasDurableWatchJournalEvidence
+            || this.HasLocalObservationConfidenceLoss
 
         /// Reports whether durable journal evidence is the only reason IPC must be dirty.
         member this.HasDurableOnlyPendingWork =
             this.HasDurableWatchJournalEvidence
             && not this.HasProcessablePendingWork
             && not this.HasManualPendingStatusEvidence
+            && not this.HasLocalObservationConfidenceLoss
 
     /// Distinguishes exact IPC verification from the pending-work state that snapshot advertises.
     type private PendingWatchWorkPublicationVerification =
@@ -3001,6 +3008,7 @@ module Watch =
     /// Reports whether Watch has queued process-local work other than a startup catch-up marker.
     let private hasProcessablePendingWatchWorkExceptManual () =
         isGraceWatchResyncPending ()
+        || hasLocalObservationConfidenceLoss ()
         || graceStatusHasChanged
         || hasPendingLocalObservationCandidates ()
         || not (
@@ -3033,6 +3041,7 @@ module Watch =
             HasProcessablePendingWork = hasProcessablePendingWork
             HasManualPendingStatusEvidence = hasManualPendingWatchWorkStatusFlag ()
             HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence ()
+            HasLocalObservationConfidenceLoss = hasLocalObservationConfidenceLoss ()
         }
 
     /// Exposes pending Watch work checks to tests without running the foreground timer loop.
@@ -3264,6 +3273,11 @@ module Watch =
                 )
             HasManualPendingStatusEvidence = false
             HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence ()
+            HasLocalObservationConfidenceLoss =
+                hasUnconsumedLocalObservationConfidenceLoss ()
+                || (not recoveryStillOwnsPublication
+                    && Volatile.Read(&localObservationConfidenceLossActive)
+                       <> 0)
         }
 
     /// Publishes clean IPC for one recovered resync attempt while retaining its own fail-closed pending anchors.
@@ -3401,6 +3415,26 @@ module Watch =
     let private publishPendingWatchWorkTransitionIfNeeded () =
         tryPublishPendingWatchWorkTransitionIfNeeded ()
         |> ignore
+
+    /// Records one non-replayable raw-observation confidence loss and immediately publishes its dirty Watch state.
+    let private recordLocalObservationConfidenceLoss reason =
+        let recorded =
+            lock localObservationConfidenceLossLock (fun () ->
+                if localObservationConfidenceLossReason.IsNone then
+                    localObservationConfidenceLossReason <- Some reason
+                    Volatile.Write(&localObservationConfidenceLossActive, 1)
+                    true
+                else
+                    false)
+
+        if recorded then publishPendingWatchWorkTransitionIfNeeded ()
+
+    /// Takes the oldest pending raw-observation confidence loss without allowing it to be rebound as local work.
+    let private takeLocalObservationConfidenceLoss () =
+        lock localObservationConfidenceLossLock (fun () ->
+            let pendingReason = localObservationConfidenceLossReason
+            localObservationConfidenceLossReason <- None
+            pendingReason)
 
     /// Verifies the current Watch IPC file still represents the requested pending-work state and GraceStatus identity.
     let private tryVerifyCurrentPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork =
@@ -3648,58 +3682,65 @@ module Watch =
         let mutable claimedCandidate = false
 
         for dueCandidate in dueCandidates do
-            match tryGetActiveGraceUpdateMarkerObservationBoundary () with
-            | ActiveMarker markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> logObservationSuppressed dueCandidate.FullPath
-            | markerBoundary ->
+            if localObservationIncrementalWorkBlocked () then
                 match tryClaimLocalObservationCandidate scheduler dueCandidate now with
                 | Some candidate ->
                     claimedCandidate <- true
-
-                    let candidateQueuedWork =
-                        match markerBoundary with
-                        | AmbiguousMarkerBoundary reason ->
-                            recordLocalObservationConfidenceLoss reason
-                            logObservationSuppressed candidate.FullPath
-                            false
-                        | ActiveMarker _ ->
-                            logObservationSuppressed candidate.FullPath
-                            false
-                        | NoActiveMarker ->
-                            match candidate.Scope with
-                            | Some scope when not (watchObservationScopeMatchesCurrent scope) ->
-                                recordLocalObservationConfidenceLoss
-                                    $"raw local observation scope changed before claim for {candidate.FullPath}; incremental work was rejected."
-
-                                false
-                            | _ ->
-                                match candidate.Kind with
-                                | CreatedOrChanged ->
-                                    let removalQueuedWork =
-                                        if candidate.RequiresRemovalProof then
-                                            applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                        else
-                                            false
-
-                                    let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-
-                                    removalQueuedWork || finalQueuedWork
-                                | Changed ->
-                                    let removalQueuedWork =
-                                        if candidate.RequiresRemovalProof then
-                                            applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                        else
-                                            false
-
-                                    let finalQueuedWork = applyChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-
-                                    removalQueuedWork || finalQueuedWork
-                                | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                | GraceStatusArtifact ->
-                                    markGraceStatusChangedAndPublishPendingWorkTransition ()
-                                    false
-
-                    queuedPendingWork <- queuedPendingWork || candidateQueuedWork
+                    logObservationSuppressed candidate.FullPath
                 | None -> ()
+            else
+                match tryGetActiveGraceUpdateMarkerObservationBoundary () with
+                | ActiveMarker markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> logObservationSuppressed dueCandidate.FullPath
+                | markerBoundary ->
+                    match tryClaimLocalObservationCandidate scheduler dueCandidate now with
+                    | Some candidate ->
+                        claimedCandidate <- true
+
+                        let candidateQueuedWork =
+                            match markerBoundary with
+                            | AmbiguousMarkerBoundary reason ->
+                                recordLocalObservationConfidenceLoss reason
+                                logObservationSuppressed candidate.FullPath
+                                false
+                            | ActiveMarker _ ->
+                                logObservationSuppressed candidate.FullPath
+                                false
+                            | NoActiveMarker ->
+                                match candidate.Scope with
+                                | Some scope when not (watchObservationScopeMatchesCurrent scope) ->
+                                    recordLocalObservationConfidenceLoss
+                                        $"raw local observation scope changed before claim for {candidate.FullPath}; incremental work was rejected."
+
+                                    false
+                                | _ ->
+                                    match candidate.Kind with
+                                    | CreatedOrChanged ->
+                                        let removalQueuedWork =
+                                            if candidate.RequiresRemovalProof then
+                                                applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                            else
+                                                false
+
+                                        let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                                        removalQueuedWork || finalQueuedWork
+                                    | Changed ->
+                                        let removalQueuedWork =
+                                            if candidate.RequiresRemovalProof then
+                                                applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                            else
+                                                false
+
+                                        let finalQueuedWork = applyChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                                        removalQueuedWork || finalQueuedWork
+                                    | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                    | GraceStatusArtifact ->
+                                        markGraceStatusChangedAndPublishPendingWorkTransition ()
+                                        false
+
+                        queuedPendingWork <- queuedPendingWork || candidateQueuedWork
+                    | None -> ()
 
         if claimedCandidate
            || queuedPendingWork
@@ -3711,10 +3752,7 @@ module Watch =
 
     /// Applies an observation immediately only for direct callback harnesses that did not start the Watch lifetime.
     let private processLocalObservationImmediately kind fullPath =
-        if
-            Volatile.Read(&markerCompletionConfidenceLossActive)
-            <> 0
-        then
+        if localObservationIncrementalWorkBlocked () then
             logObservationSuppressed fullPath
         else
             let observedAt = DateTime.UtcNow
@@ -4175,6 +4213,8 @@ module Watch =
         clearLocalObservationCandidateScheduler ()
         setLocalObservationCandidateSchedulingActive false
         Volatile.Write(&markerCompletionConfidenceLossActive, 0)
+        Volatile.Write(&localObservationConfidenceLossActive, 0)
+        lock localObservationConfidenceLossLock (fun () -> localObservationConfidenceLossReason <- None)
         filesToProcess.Clear()
         fileRecoveryEvidence.Clear()
         directoriesToProcess.Clear()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3641,10 +3641,11 @@ module Watch =
             else
                 false
 
-    /// Claims every candidate due at the supplied instant and performs the existing expensive Watch work after the claim boundary.
+    /// Claims every due candidate, then reconciles IPC from the complete post-claim pending state even when no local work was queued.
     let private processDueLocalObservationCandidates now =
         let scheduler, dueCandidates = dueLocalObservationCandidates now
         let mutable queuedPendingWork = false
+        let mutable claimedCandidate = false
 
         for dueCandidate in dueCandidates do
             match tryGetActiveGraceUpdateMarkerObservationBoundary () with
@@ -3652,6 +3653,8 @@ module Watch =
             | markerBoundary ->
                 match tryClaimLocalObservationCandidate scheduler dueCandidate now with
                 | Some candidate ->
+                    claimedCandidate <- true
+
                     let candidateQueuedWork =
                         match markerBoundary with
                         | AmbiguousMarkerBoundary reason ->
@@ -3698,7 +3701,8 @@ module Watch =
                     queuedPendingWork <- queuedPendingWork || candidateQueuedWork
                 | None -> ()
 
-        if queuedPendingWork
+        if claimedCandidate
+           || queuedPendingWork
            || hasPendingLocalObservationCandidates () then
             publishPendingWatchWorkTransitionIfNeeded ()
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -380,6 +380,7 @@ module Watch =
     let private graceUpdateMarkerDeletedObservationWindow = TimeSpan.FromSeconds(30.0)
     let private recentGraceUpdateMarkerCompletedUtc = List<DateTime>()
     let private observedGraceUpdateMarkerLastWriteUtc = Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase)
+    let mutable private markerCompletionConfidenceLossActive = 0
 
     /// Gets the completion sidecar written before the Grace update marker is removed.
     let private updateMarkerCompletedFileName () = updateInProgressFileName () + ".completed"
@@ -648,6 +649,20 @@ module Watch =
         | Deleted
         | GraceStatusArtifact
 
+    /// Captures the immutable repository and root identity that owned a raw local observation at admission.
+    type internal WatchObservationScope =
+        {
+            RepositoryId: RepositoryId
+            RepositoryName: string
+            BranchId: BranchId
+            BranchName: string
+            RootDirectory: string
+            PathComparison: StringComparison
+            RootDirectoryId: DirectoryVersionId
+            RootDirectorySha256Hash: Sha256Hash
+            RootDirectoryBlake3Hash: Blake3Hash
+        }
+
     /// Captures one coalesced local filesystem observation and the generation that owns its due work.
     type internal WatchObservationCandidate =
         {
@@ -657,6 +672,7 @@ module Watch =
             Generation: int64
             LastSeenAt: DateTime
             DueAt: DateTime
+            Scope: WatchObservationScope option
         }
 
     /// Coalesces local filesystem observations until their deterministic quiet window has elapsed.
@@ -710,7 +726,14 @@ module Watch =
             | _ -> incomingKind
 
         /// Records one local observation, replacing any older generation while retaining same-path delete proof for a final replacement.
-        member _.Observe(origin: WatchObservationOrigin, kind: WatchObservationKind, fullPath: string, seenAt: DateTime) =
+        member _.ObserveScoped
+            (
+                origin: WatchObservationOrigin,
+                kind: WatchObservationKind,
+                fullPath: string,
+                seenAt: DateTime,
+                scope: WatchObservationScope option
+            ) =
             lock gate (fun () ->
                 match origin, disposed, tryNormalizeCandidatePath fullPath with
                 | LocalFileSystem, false, Some normalizedPath ->
@@ -736,11 +759,16 @@ module Watch =
                             Generation = generation
                             LastSeenAt = seenAt
                             DueAt = seenAt + quietWindow
+                            Scope = scope
                         }
 
                     candidates[normalizedPath] <- candidate
                     Some candidate
                 | _ -> None)
+
+        /// Records a scheduler-only observation for tests that do not own a live repository scope.
+        member this.Observe(origin: WatchObservationOrigin, kind: WatchObservationKind, fullPath: string, seenAt: DateTime) =
+            this.ObserveScoped(origin, kind, fullPath, seenAt, None)
 
         /// Returns the current due snapshot without consuming it so a newer generation can still supersede it before dispatch.
         member _.SnapshotDue(now: DateTime) =
@@ -790,6 +818,21 @@ module Watch =
     let mutable private localObservationCandidateScheduler = new WatchObservationCandidateScheduler(TimeSpan.Zero, watchPathComparison)
     let mutable private localObservationCandidateSchedulingActive = 0
     let mutable private immediateLocalObservationProcessingForWatchTests = 0
+    let private localObservationConfidenceLossLock = obj ()
+    let mutable private localObservationConfidenceLossReason: string option = None
+
+    /// Records one non-replayable raw-observation confidence loss for the timer path that owns resync transitions.
+    let private recordLocalObservationConfidenceLoss reason =
+        lock localObservationConfidenceLossLock (fun () ->
+            if localObservationConfidenceLossReason.IsNone then
+                localObservationConfidenceLossReason <- Some reason)
+
+    /// Takes the oldest pending raw-observation confidence loss without allowing it to be rebound as local work.
+    let private takeLocalObservationConfidenceLoss () =
+        lock localObservationConfidenceLossLock (fun () ->
+            let pendingReason = localObservationConfidenceLossReason
+            localObservationConfidenceLossReason <- None
+            pendingReason)
 
     /// Reports whether a live Watch lifetime has activated quiet-window candidate scheduling for raw callbacks.
     let private isLocalObservationCandidateSchedulingActive () =
@@ -818,9 +861,44 @@ module Watch =
                 localObservationCandidateScheduler.Dispose()
                 localObservationCandidateScheduler <- new WatchObservationCandidateScheduler(quietWindow, watchPathComparison))
 
+    /// Captures the current repository and exact root identity before a raw callback can be coalesced.
+    let private currentWatchObservationScope () =
+        let current = Current()
+
+        {
+            RepositoryId = current.RepositoryId
+            RepositoryName = current.RepositoryName
+            BranchId = current.BranchId
+            BranchName = current.BranchName
+            RootDirectory =
+                Path.GetFullPath(current.RootDirectory)
+                |> Path.TrimEndingDirectorySeparator
+            PathComparison = watchPathComparison
+            RootDirectoryId = graceStatus.RootDirectoryId
+            RootDirectorySha256Hash = graceStatus.RootDirectorySha256Hash
+            RootDirectoryBlake3Hash = graceStatus.RootDirectoryBlake3Hash
+        }
+
+    /// Checks that a due raw candidate still belongs to its admission repository, branch, root, and exact root content.
+    let private watchObservationScopeMatchesCurrent (scope: WatchObservationScope) =
+        let currentScope = currentWatchObservationScope ()
+
+        scope.RepositoryId = currentScope.RepositoryId
+        && String.Equals(scope.RepositoryName, currentScope.RepositoryName, StringComparison.Ordinal)
+        && scope.BranchId = currentScope.BranchId
+        && String.Equals(scope.BranchName, currentScope.BranchName, StringComparison.Ordinal)
+        && String.Equals(scope.RootDirectory, currentScope.RootDirectory, scope.PathComparison)
+        && scope.PathComparison = currentScope.PathComparison
+        && scope.RootDirectoryId = currentScope.RootDirectoryId
+        && scope.RootDirectorySha256Hash = currentScope.RootDirectorySha256Hash
+        && scope.RootDirectoryBlake3Hash = currentScope.RootDirectoryBlake3Hash
+
     /// Records a raw local event without reading content, enumerating paths, or scheduling remote Reference work.
     let private recordLocalObservationCandidate kind fullPath seenAt =
-        lock localObservationCandidateSchedulerLock (fun () -> localObservationCandidateScheduler.Observe(LocalFileSystem, kind, fullPath, seenAt))
+        let scope = currentWatchObservationScope ()
+
+        lock localObservationCandidateSchedulerLock (fun () ->
+            localObservationCandidateScheduler.ObserveScoped(LocalFileSystem, kind, fullPath, seenAt, Some scope))
 
     /// Records a timestamped local candidate for deterministic Watch scheduler tests.
     let internal recordLocalObservationCandidateForWatchTests kind fullPath seenAt = recordLocalObservationCandidate kind fullPath seenAt
@@ -848,18 +926,24 @@ module Watch =
     /// Claims a due candidate only if no newer same-path raw event has superseded it.
     let private tryClaimLocalObservationCandidate (scheduler: WatchObservationCandidateScheduler) candidate now = scheduler.TryClaim(candidate, now)
 
+    /// Classifies whether a due candidate can trust the active update marker observation boundary.
+    type private GraceUpdateMarkerObservationBoundary =
+        | NoActiveMarker
+        | ActiveMarker of DateTime
+        | AmbiguousMarkerBoundary of string
+
     /// Reads the active Grace update marker observation boundary used to classify a due candidate before it is retired.
     let private tryGetActiveGraceUpdateMarkerObservationBoundary () =
         try
             let markerFileName = updateInProgressFileName ()
 
             if File.Exists(markerFileName) then
-                Some(File.GetLastWriteTimeUtc(markerFileName))
+                ActiveMarker(File.GetLastWriteTimeUtc(markerFileName))
             else
-                None
+                NoActiveMarker
         with
-        | :? IOException -> None
-        | :? UnauthorizedAccessException -> None
+        | :? IOException as ex -> AmbiguousMarkerBoundary $"could not read active update marker boundary: {ex.Message}"
+        | :? UnauthorizedAccessException as ex -> AmbiguousMarkerBoundary $"could not read active update marker boundary: {ex.Message}"
 
     /// Evaluates is grace status artifact against parsed options and command state.
     let private isGraceStatusArtifact (fullPath: string) =
@@ -1763,9 +1847,21 @@ module Watch =
             WatchRoot = Path.GetFullPath(Current().RootDirectory)
             PathComparison = watchPathComparison
             RootDirectoryId = status.RootDirectoryId
+            RootDirectorySha256Hash = status.RootDirectorySha256Hash
             RootDirectoryBlake3Hash = rootDirectoryBlake3HashForWatchJournal status
             WatchMode = "repository-root"
         }
+
+    /// Persists a terminal Watch boundary diagnostic without creating replayable local work.
+    let private recordWatchBoundaryDiagnostic eventType message =
+        try
+            (recordWatchLifecycleEventForWatch (
+                { Scope = currentWatchJournalScope graceStatus; EventType = eventType; Message = message }: Grace.CLI.LocalStateDb.WatchLifecycleEvent
+            ))
+                .GetAwaiter()
+                .GetResult()
+        with
+        | ex -> logToAnsiConsole Colors.Error $"Grace Watch could not record boundary diagnostic: {ex.Message}"
 
     /// Converts an already-normalized status difference into the replay payload owned by the local Watch journal.
     let private journalObservationForDifference (difference: FileSystemDifference) : Grace.CLI.LocalStateDb.WatchJournalObservation =
@@ -2737,6 +2833,15 @@ module Watch =
 
     let private graceWatchResyncTransitionLock = obj ()
 
+    /// Clears the direct-callback marker-completion block only after this exact resync attempt reached a clean recovery boundary.
+    let private tryClearGraceWatchResyncAttemptAndMarkerCompletionConfidenceLoss attempt =
+        lock graceWatchResyncTransitionLock (fun () ->
+            if tryClearGraceWatchResyncAttempt attempt then
+                Volatile.Write(&markerCompletionConfidenceLossActive, 0)
+                true
+            else
+                false)
+
     let mutable private beforeGraceWatchResyncEvidenceRetirementProbe = fun () -> ()
 
     /// Overrides the evidence-retirement interleaving probe for deterministic Watch resync transition tests.
@@ -3485,53 +3590,60 @@ module Watch =
     let private processDueLocalObservationCandidates now =
         let scheduler, dueCandidates = dueLocalObservationCandidates now
         let mutable queuedPendingWork = false
-        let mutable candidateConsumed = false
 
         for dueCandidate in dueCandidates do
             match tryGetActiveGraceUpdateMarkerObservationBoundary () with
-            | Some markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> logObservationSuppressed dueCandidate.FullPath
-            | activeMarkerBoundary ->
+            | ActiveMarker markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> logObservationSuppressed dueCandidate.FullPath
+            | markerBoundary ->
                 match tryClaimLocalObservationCandidate scheduler dueCandidate now with
                 | Some candidate ->
-                    candidateConsumed <- true
-
                     let candidateQueuedWork =
-                        match activeMarkerBoundary with
-                        | Some _ ->
+                        match markerBoundary with
+                        | AmbiguousMarkerBoundary reason ->
+                            recordLocalObservationConfidenceLoss reason
                             logObservationSuppressed candidate.FullPath
                             false
-                        | None ->
-                            match candidate.Kind with
-                            | CreatedOrChanged ->
-                                let removalQueuedWork =
-                                    if candidate.RequiresRemovalProof then
-                                        applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                    else
-                                        false
+                        | ActiveMarker _ ->
+                            logObservationSuppressed candidate.FullPath
+                            false
+                        | NoActiveMarker ->
+                            match candidate.Scope with
+                            | Some scope when not (watchObservationScopeMatchesCurrent scope) ->
+                                recordLocalObservationConfidenceLoss
+                                    $"raw local observation scope changed before claim for {candidate.FullPath}; incremental work was rejected."
 
-                                let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-
-                                removalQueuedWork || finalQueuedWork
-                            | Changed ->
-                                let removalQueuedWork =
-                                    if candidate.RequiresRemovalProof then
-                                        applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                    else
-                                        false
-
-                                let finalQueuedWork = applyChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-
-                                removalQueuedWork || finalQueuedWork
-                            | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                            | GraceStatusArtifact ->
-                                markGraceStatusChangedAndPublishPendingWorkTransition ()
                                 false
+                            | _ ->
+                                match candidate.Kind with
+                                | CreatedOrChanged ->
+                                    let removalQueuedWork =
+                                        if candidate.RequiresRemovalProof then
+                                            applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                        else
+                                            false
+
+                                    let finalQueuedWork = applyCreatedOrChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                                    removalQueuedWork || finalQueuedWork
+                                | Changed ->
+                                    let removalQueuedWork =
+                                        if candidate.RequiresRemovalProof then
+                                            applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                        else
+                                            false
+
+                                    let finalQueuedWork = applyChangedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+
+                                    removalQueuedWork || finalQueuedWork
+                                | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
+                                | GraceStatusArtifact ->
+                                    markGraceStatusChangedAndPublishPendingWorkTransition ()
+                                    false
 
                     queuedPendingWork <- queuedPendingWork || candidateQueuedWork
                 | None -> ()
 
-        if candidateConsumed
-           || queuedPendingWork
+        if queuedPendingWork
            || hasPendingLocalObservationCandidates () then
             publishPendingWatchWorkTransitionIfNeeded ()
 
@@ -3540,22 +3652,28 @@ module Watch =
 
     /// Applies an observation immediately only for direct callback harnesses that did not start the Watch lifetime.
     let private processLocalObservationImmediately kind fullPath =
-        let observedAt = DateTime.UtcNow
+        if
+            Volatile.Read(&markerCompletionConfidenceLossActive)
+            <> 0
+        then
+            logObservationSuppressed fullPath
+        else
+            let observedAt = DateTime.UtcNow
 
-        let queuedPendingWork =
-            match kind with
-            | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
-            | Changed -> applyChangedLocalObservationCandidate fullPath observedAt
-            | Deleted -> applyDeletedLocalObservationCandidate fullPath observedAt
-            | GraceStatusArtifact ->
-                if updateNotInProgress () then
-                    markGraceStatusChangedAndPublishPendingWorkTransition ()
-                else
-                    logObservationSuppressed fullPath
+            let queuedPendingWork =
+                match kind with
+                | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
+                | Changed -> applyChangedLocalObservationCandidate fullPath observedAt
+                | Deleted -> applyDeletedLocalObservationCandidate fullPath observedAt
+                | GraceStatusArtifact ->
+                    if updateNotInProgress () then
+                        markGraceStatusChangedAndPublishPendingWorkTransition ()
+                    else
+                        logObservationSuppressed fullPath
 
-                false
+                    false
 
-        if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
+            if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
 
     /// Drains zero-window test candidates before reporting whether Watch still owes a Grace Status refresh pass.
     let internal graceStatusHasChangedForWatchTests () =
@@ -3649,6 +3767,12 @@ module Watch =
 
     /// Requests a scan-derived resync and quarantines stale observations while retaining current-scope file evidence through recovery.
     let private requestGraceWatchExplicitResync reason = requestGraceWatchExplicitResyncCore reason pendingFileWorkMatchesCurrentScope
+
+    /// Blocks direct callbacks and requests exact resync after marker completion can no longer prove the source of a filesystem observation.
+    let private requestGraceWatchMarkerCompletionConfidenceLossResync reason =
+        lock graceWatchResyncTransitionLock (fun () ->
+            Volatile.Write(&markerCompletionConfidenceLossActive, 1)
+            requestGraceWatchExplicitResync reason)
 
     /// Requests a scan-derived resync while retaining every current-scope file whose final bytes still block clean recovery.
     let private requestGraceWatchExplicitResyncRetainingPendingFiles reason = requestGraceWatchExplicitResyncCore reason pendingFileWorkMatchesCurrentScope
@@ -3991,6 +4115,7 @@ module Watch =
     let internal clearPendingWatchWorkForTests () =
         clearLocalObservationCandidateScheduler ()
         setLocalObservationCandidateSchedulingActive false
+        Volatile.Write(&markerCompletionConfidenceLossActive, 0)
         filesToProcess.Clear()
         fileRecoveryEvidence.Clear()
         directoriesToProcess.Clear()
@@ -6901,16 +7026,26 @@ module Watch =
                             logToAnsiConsole Colors.Important $"Update has finished in another Grace instance."
                         else
                             recordGraceUpdateMarkerCompletedUtc completedUtc
+                            let reason = $"stale branch-transition marker deletion for {args.FullPath} could not complete the current transition."
+
+                            recordWatchBoundaryDiagnostic "marker-completion-confidence-loss" reason
+                            requestGraceWatchMarkerCompletionConfidenceLossResync reason
 
                             logToAnsiConsole
                                 Colors.Important
-                                $"Ignored stale update marker deletion for {args.FullPath}; current marker {updateInProgressFileName ()} is still live."
+                                $"Ignored stale update marker deletion for {args.FullPath}; grace watch is resynchronizing before incremental work resumes."
                     | UnobservedMarker when
                         deletedMarkerIsCurrentMarker args.FullPath
                         && isRecentGraceUpdateMarkerCompletion completedUtc
                         && persistedConfigurationChangedSinceWatchCached ()
                         ->
-                        requestGraceWatchExplicitResync "branch transition marker deletion had a fresh completion sidecar but no observed marker creation"
+                        requestGraceWatchMarkerCompletionConfidenceLossResync
+                            "branch transition marker deletion had a fresh completion sidecar but no observed marker creation"
+
+                        recordWatchBoundaryDiagnostic
+                            "marker-completion-confidence-loss"
+                            $"branch-transition marker deletion had a fresh completion sidecar but no observed marker creation for {args.FullPath}."
+
                         completeGraceUpdateTransitionAfterMarkerDeletion completedUtc
 
                         logToAnsiConsole
@@ -6918,17 +7053,35 @@ module Watch =
                             $"Update marker ended with an unobserved fresh completed sidecar for {args.FullPath}; grace watch is resynchronizing before incremental work resumes."
                     | ObservedStaleMarker
                     | UnobservedMarker ->
+                        let reason = $"branch-transition marker deletion did not provide current observed completion evidence for {args.FullPath}."
+
+                        recordWatchBoundaryDiagnostic "marker-completion-confidence-loss" reason
+                        requestGraceWatchMarkerCompletionConfidenceLossResync reason
+
                         logToAnsiConsole
                             Colors.Important
-                            $"Update marker ended with a stale completed sidecar for {args.FullPath}; delayed observations will be processed normally."
+                            $"Update marker ended with incomplete completion evidence for {args.FullPath}; grace watch is resynchronizing before incremental work resumes."
                 | Some (GraceUpdateMarkerPurpose.ReferenceMaterialization, completedUtc) ->
                     forgetObservedGraceUpdateMarkerInstance args.FullPath
-                    recordGraceUpdateMarkerCompletedUtc completedUtc
-                    requestCurrentBranchReferenceCatchUp "current-branch reference materialization marker deletion"
-                    logToAnsiConsole Colors.Important $"Reference materialization update has finished."
+
+                    if isRecentGraceUpdateMarkerCompletion completedUtc then
+                        recordGraceUpdateMarkerCompletedUtc completedUtc
+                        requestCurrentBranchReferenceCatchUp "current-branch reference materialization marker deletion"
+                        logToAnsiConsole Colors.Important $"Reference materialization update has finished."
+                    else
+                        let reason = $"reference-materialization marker deletion had stale completion evidence for {args.FullPath}."
+
+                        recordWatchBoundaryDiagnostic "marker-completion-confidence-loss" reason
+                        requestGraceWatchMarkerCompletionConfidenceLossResync reason
                 | None ->
                     forgetObservedGraceUpdateMarkerInstance args.FullPath
-                    logToAnsiConsole Colors.Important $"Update marker ended without a completed sidecar; delayed observations will be processed normally."
+                    let reason = $"update marker deletion had missing or malformed completion evidence for {args.FullPath}."
+                    recordWatchBoundaryDiagnostic "marker-completion-confidence-loss" reason
+                    requestGraceWatchMarkerCompletionConfidenceLossResync reason
+
+                    logToAnsiConsole
+                        Colors.Important
+                        $"Update marker ended without trustworthy completion evidence; grace watch is resynchronizing before incremental work resumes."
             else
                 logToAnsiConsole Colors.Important $"{updateInProgressFileName ()} should have been deleted, but it hasn't yet."
 
@@ -7594,6 +7747,12 @@ module Watch =
             configureWatchPathComparisonForCurrentRepository ()
             processDueLocalObservationCandidates DateTime.UtcNow
 
+            match takeLocalObservationConfidenceLoss () with
+            | Some reason ->
+                recordWatchBoundaryDiagnostic "local-observation-confidence-loss" reason
+                requestGraceWatchExplicitResync reason
+            | None -> ()
+
             // First, check if there's anything to process.
             if isGraceWatchResyncPending () then
                 let resyncAttempt = currentGraceWatchResyncAttempt ()
@@ -7705,7 +7864,7 @@ module Watch =
                                         | VerifiedCleanRecoveryPublication ->
                                             beforeGraceWatchResyncAttemptRetirementProbe ()
 
-                                            if tryClearGraceWatchResyncAttempt resyncAttempt then
+                                            if tryClearGraceWatchResyncAttemptAndMarkerCompletionConfidenceLoss resyncAttempt then
                                                 setGraceWatchPendingWorkStatusFlag false
 
                                                 if signalRBranchSubscriptionRefreshNeededForTransition () then
@@ -7749,7 +7908,7 @@ module Watch =
                                                 (if dirtyPublicationVerified then Colors.Important else Colors.Error)
                                                 $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was {recoveryPublicationOutcome}, not a verified clean recovery; dirty resync IPC was {dirtyPublicationOutcome} before return."
                                     else
-                                        let clearedResyncAttempt = tryClearGraceWatchResyncAttempt resyncAttempt
+                                        let clearedResyncAttempt = tryClearGraceWatchResyncAttemptAndMarkerCompletionConfidenceLoss resyncAttempt
 
                                         if clearedResyncAttempt then
                                             setGraceWatchPendingWorkStatusFlag false

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -791,13 +791,16 @@ module Watch =
                         | true, existing -> Some existing
                         | false, _ -> None
 
-                    let mergedKind = mergeObservationKind kind existingCandidate
+                    // Candidate state may cross the same path key only when its complete observation scope also matches.
+                    let existingCandidateInSameScope =
+                        existingCandidate
+                        |> Option.filter (fun existing -> existing.Scope = scope)
+
+                    let mergedKind = mergeObservationKind kind existingCandidateInSameScope
 
                     let carriesRemovalProofFromSameScope =
-                        existingCandidate
-                        |> Option.exists (fun existing ->
-                            existing.Scope = scope
-                            && existing.RequiresRemovalProof)
+                        existingCandidateInSameScope
+                        |> Option.exists (fun existing -> existing.RequiresRemovalProof)
 
                     let requiresRemovalProof = kind = Deleted || carriesRemovalProofFromSameScope
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -19,7 +19,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "7"
+    let private SchemaVersion = "8"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -31,6 +31,12 @@ module LocalStateDb =
 
     [<Literal>]
     let private BusyTimeoutMs = 30000
+
+    let private watchLifecycleEventInsertSql =
+        "INSERT INTO watch_lifecycle_events (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, "
+        + "root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, watch_mode, event_type, message, replayable) "
+        + "VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, "
+        + "$root_directory_sha256_hash, $root_directory_blake3_hash, $watch_mode, $event_type, $message, 0);"
 
     let private retryDelaysMs = [| 50; 100; 200; 400; 800; 1600 |]
 
@@ -186,8 +192,8 @@ module LocalStateDb =
             "CREATE INDEX IF NOT EXISTS ix_object_cache_children_parent ON object_cache_directory_children(parent_directory_version_id);"
             "CREATE TABLE IF NOT EXISTS object_cache_directory_files (directory_version_id TEXT NOT NULL, relative_path TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, PRIMARY KEY (directory_version_id, relative_path), FOREIGN KEY (directory_version_id) REFERENCES object_cache_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE INDEX IF NOT EXISTS ix_object_cache_files_path_hash ON object_cache_directory_files(relative_path, sha256_hash);"
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
-            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
+            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
         |]
 
     let private requiredTableNames =
@@ -738,7 +744,10 @@ module LocalStateDb =
     let private ensureWatchLifecycleEventTable (connection: SqliteConnection) =
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
+            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
+
+        if not (columnExists connection "watch_lifecycle_events" "root_directory_sha256_hash") then
+            executeNonQuery connection "ALTER TABLE watch_lifecycle_events ADD COLUMN root_directory_sha256_hash TEXT;"
 
     /// Migrates the v6 Watch journal shape by preserving rows and adding identity plus quarantine metadata.
     let private migrateWatchJournalV6ToV7 (connection: SqliteConnection) =
@@ -747,10 +756,16 @@ module LocalStateDb =
         addWatchJournalColumnIfMissing connection "workspace_root" "workspace_root TEXT"
         addWatchJournalColumnIfMissing connection "watch_root" "watch_root TEXT"
         addWatchJournalColumnIfMissing connection "root_directory_version_id" "root_directory_version_id TEXT"
+        addWatchJournalColumnIfMissing connection "root_directory_sha256_hash" "root_directory_sha256_hash TEXT"
         addWatchJournalColumnIfMissing connection "root_directory_blake3_hash" "root_directory_blake3_hash TEXT"
         addWatchJournalColumnIfMissing connection "watch_mode" "watch_mode TEXT"
         addWatchJournalColumnIfMissing connection "quarantined_at_unix_ticks" "quarantined_at_unix_ticks INTEGER"
         addWatchJournalColumnIfMissing connection "quarantine_reason" "quarantine_reason TEXT"
+        ensureWatchLifecycleEventTable connection
+
+    /// Adds root SHA-256 identity to Watch journal and lifecycle records; preexisting incomplete rows remain replay-incompatible.
+    let private migrateWatchJournalV7ToV8 (connection: SqliteConnection) =
+        addWatchJournalColumnIfMissing connection "root_directory_sha256_hash" "root_directory_sha256_hash TEXT"
         ensureWatchLifecycleEventTable connection
 
     /// Verifies that the Watch journal table can support ordered local recovery and retention operations.
@@ -766,6 +781,7 @@ module LocalStateDb =
                 "workspace_root"
                 "watch_root"
                 "root_directory_version_id"
+                "root_directory_sha256_hash"
                 "root_directory_blake3_hash"
                 "watch_mode"
                 "difference_type"
@@ -836,6 +852,7 @@ module LocalStateDb =
         && hasOptionalTextColumn "workspace_root"
         && hasOptionalTextColumn "watch_root"
         && hasOptionalTextColumn "root_directory_version_id"
+        && hasOptionalTextColumn "root_directory_sha256_hash"
         && hasOptionalTextColumn "root_directory_blake3_hash"
         && hasOptionalTextColumn "watch_mode"
         && hasRequiredTextColumn "difference_type"
@@ -858,6 +875,7 @@ module LocalStateDb =
                 "workspace_root"
                 "watch_root"
                 "root_directory_version_id"
+                "root_directory_sha256_hash"
                 "root_directory_blake3_hash"
                 "watch_mode"
                 "event_type"
@@ -926,6 +944,7 @@ module LocalStateDb =
         && hasOptionalTextColumn "workspace_root"
         && hasOptionalTextColumn "watch_root"
         && hasOptionalTextColumn "root_directory_version_id"
+        && hasOptionalTextColumn "root_directory_sha256_hash"
         && hasOptionalTextColumn "root_directory_blake3_hash"
         && hasOptionalTextColumn "watch_mode"
         && hasRequiredTextColumn "event_type"
@@ -1272,7 +1291,7 @@ module LocalStateDb =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
 
         ensureWatchLifecycleEventTable connection
 
@@ -1299,6 +1318,7 @@ module LocalStateDb =
             WatchRoot: string
             PathComparison: StringComparison
             RootDirectoryId: DirectoryVersionId
+            RootDirectorySha256Hash: Sha256Hash
             RootDirectoryBlake3Hash: Blake3Hash
             WatchMode: string
         }
@@ -1533,8 +1553,19 @@ module LocalStateDb =
                                                     if hasRequiredMetaKeyValueShape connection
                                                        && tableExists connection "watch_journal" then
                                                         try
-                                                            logTrace "migrating local state DB schema from v6 to v7"
+                                                            logTrace "migrating local state DB schema from v6 to v8"
                                                             migrateWatchJournalV6ToV7 connection
+                                                            setMetaValue connection "schema_version" SchemaVersion
+                                                        with
+                                                        | :? SqliteException -> recreate <- true
+                                                    else
+                                                        recreate <- true
+                                                | Some "7" ->
+                                                    if hasRequiredMetaKeyValueShape connection
+                                                       && tableExists connection "watch_journal" then
+                                                        try
+                                                            logTrace "migrating local state DB schema from v7 to v8"
+                                                            migrateWatchJournalV7ToV8 connection
                                                             setMetaValue connection "schema_version" SchemaVersion
                                                         with
                                                         | :? SqliteException -> recreate <- true
@@ -1906,7 +1937,7 @@ module LocalStateDb =
                                 use command = connection.CreateCommand()
 
                                 command.CommandText <-
-                                    "INSERT INTO watch_journal (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $difference_type, $entry_type, $relative_path) RETURNING sequence;"
+                                    "INSERT INTO watch_journal (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_sha256_hash, $root_directory_blake3_hash, $watch_mode, $difference_type, $entry_type, $relative_path) RETURNING sequence;"
 
                                 command.Parameters.Add("$created_at", SqliteType.Integer)
                                 |> ignore
@@ -1924,6 +1955,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 command.Parameters.Add("$root_directory_version_id", SqliteType.Text)
+                                |> ignore
+
+                                command.Parameters.Add("$root_directory_sha256_hash", SqliteType.Text)
                                 |> ignore
 
                                 command.Parameters.Add("$root_directory_blake3_hash", SqliteType.Text)
@@ -1950,6 +1984,7 @@ module LocalStateDb =
                                     command.Parameters["$workspace_root"].Value <- observation.Scope.WorkspaceRoot
                                     command.Parameters["$watch_root"].Value <- observation.Scope.WatchRoot
                                     command.Parameters["$root_directory_version_id"].Value <- observation.Scope.RootDirectoryId.ToString()
+                                    command.Parameters["$root_directory_sha256_hash"].Value <- string observation.Scope.RootDirectorySha256Hash
                                     command.Parameters["$root_directory_blake3_hash"].Value <- string observation.Scope.RootDirectoryBlake3Hash
                                     command.Parameters["$watch_mode"].Value <- observation.Scope.WatchMode
                                     command.Parameters["$difference_type"].Value <- getDiscriminatedUnionCaseName observation.DifferenceType
@@ -2122,10 +2157,10 @@ module LocalStateDb =
             Sequence = sequence
             CreatedAtUnixTicks = reader.GetInt64(1)
             State = Quarantined
-            DifferenceType = readJournalDiagnosticText reader 9 "difference_type"
-            EntryType = readJournalDiagnosticText reader 10 "entry_type"
-            RelativePath = readOptionalJournalDiagnosticText reader 11 "relative_path"
-            QuarantineReason = readOptionalJournalDiagnosticText reader 13 "quarantine_reason"
+            DifferenceType = readJournalDiagnosticText reader 10 "difference_type"
+            EntryType = readJournalDiagnosticText reader 11 "entry_type"
+            RelativePath = readOptionalJournalDiagnosticText reader 12 "relative_path"
+            QuarantineReason = readOptionalJournalDiagnosticText reader 14 "quarantine_reason"
         }
 
     /// Reads the identity and payload fields needed to classify one startup replay row.
@@ -2135,37 +2170,62 @@ module LocalStateDb =
               tryReadNullableJournalText reader 4 "workspace_root",
               tryReadNullableJournalText reader 5 "watch_root",
               tryReadNullableJournalText reader 6 "root_directory_version_id",
-              tryReadNullableJournalText reader 7 "root_directory_blake3_hash",
-              tryReadNullableJournalText reader 8 "watch_mode",
-              tryReadRequiredJournalText reader 9 "difference_type",
-              tryReadRequiredJournalText reader 10 "entry_type",
-              tryReadRequiredJournalText reader 11 "relative_path"
+              tryReadNullableJournalText reader 7 "root_directory_sha256_hash",
+              tryReadNullableJournalText reader 8 "root_directory_blake3_hash",
+              tryReadNullableJournalText reader 9 "watch_mode",
+              tryReadRequiredJournalText reader 10 "difference_type",
+              tryReadRequiredJournalText reader 11 "entry_type",
+              tryReadRequiredJournalText reader 12 "relative_path"
             with
         | Ok repositoryId,
           Ok branchId,
           Ok workspaceRoot,
           Ok watchRoot,
           Ok rootDirectoryId,
+          Ok rootDirectorySha256Hash,
           Ok rootDirectoryBlake3Hash,
           Ok watchMode,
           Ok differenceType,
           Ok entryType,
           Ok relativePath ->
-            Ok(repositoryId, branchId, workspaceRoot, watchRoot, rootDirectoryId, rootDirectoryBlake3Hash, watchMode, differenceType, entryType, relativePath)
-        | Error reason, _, _, _, _, _, _, _, _, _
-        | _, Error reason, _, _, _, _, _, _, _, _
-        | _, _, Error reason, _, _, _, _, _, _, _
-        | _, _, _, Error reason, _, _, _, _, _, _
-        | _, _, _, _, Error reason, _, _, _, _, _
-        | _, _, _, _, _, Error reason, _, _, _, _
-        | _, _, _, _, _, _, Error reason, _, _, _
-        | _, _, _, _, _, _, _, Error reason, _, _
-        | _, _, _, _, _, _, _, _, Error reason, _
-        | _, _, _, _, _, _, _, _, _, Error reason -> Error reason
+            Ok(
+                repositoryId,
+                branchId,
+                workspaceRoot,
+                watchRoot,
+                rootDirectoryId,
+                rootDirectorySha256Hash,
+                rootDirectoryBlake3Hash,
+                watchMode,
+                differenceType,
+                entryType,
+                relativePath
+            )
+        | Error reason, _, _, _, _, _, _, _, _, _, _
+        | _, Error reason, _, _, _, _, _, _, _, _, _
+        | _, _, Error reason, _, _, _, _, _, _, _, _
+        | _, _, _, Error reason, _, _, _, _, _, _, _
+        | _, _, _, _, Error reason, _, _, _, _, _, _
+        | _, _, _, _, _, Error reason, _, _, _, _, _
+        | _, _, _, _, _, _, Error reason, _, _, _, _
+        | _, _, _, _, _, _, _, Error reason, _, _, _
+        | _, _, _, _, _, _, _, _, Error reason, _, _
+        | _, _, _, _, _, _, _, _, _, Error reason, _
+        | _, _, _, _, _, _, _, _, _, _, Error reason -> Error reason
 
     /// Explains why an unapplied row cannot be trusted for startup replay in the current repository scope.
     let private tryFindWatchJournalReplayIncompatibility (scope: WatchJournalScope) row =
-        let (repositoryId, branchId, workspaceRoot, watchRoot, rootDirectoryId, rootDirectoryBlake3Hash, watchMode, differenceType, entryType, relativePath) =
+        let (repositoryId,
+             branchId,
+             workspaceRoot,
+             watchRoot,
+             rootDirectoryId,
+             rootDirectorySha256Hash,
+             rootDirectoryBlake3Hash,
+             watchMode,
+             differenceType,
+             entryType,
+             relativePath) =
             row
 
         let checks =
@@ -2200,6 +2260,11 @@ module LocalStateDb =
                 | Some value when String.Equals(value, scope.RootDirectoryId.ToString(), StringComparison.OrdinalIgnoreCase) -> None
                 | Some _ -> Some "failed root continuity"
                 | None -> Some "missing root continuity"
+
+                match rootDirectorySha256Hash with
+                | Some value when String.Equals(value, string scope.RootDirectorySha256Hash, StringComparison.OrdinalIgnoreCase) -> None
+                | Some _ -> Some "failed root SHA-256 continuity"
+                | None -> Some "missing root SHA-256 continuity"
 
                 match rootDirectoryBlake3Hash with
                 | Some value when String.Equals(value, string scope.RootDirectoryBlake3Hash, StringComparison.OrdinalIgnoreCase) -> None
@@ -2240,39 +2305,39 @@ module LocalStateDb =
                     task {
                         use connection = openConnection dbPath
 
-                        executeNonQueryWithParams
-                            connection
-                            "INSERT INTO watch_lifecycle_events (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, event_type, message, replayable) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $event_type, $message, 0);"
-                            (fun parameters ->
-                                parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
-                                |> ignore
+                        executeNonQueryWithParams connection watchLifecycleEventInsertSql (fun parameters ->
+                            parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
+                            |> ignore
 
-                                parameters.AddWithValue("$repository_id", event.Scope.RepositoryId.ToString())
-                                |> ignore
+                            parameters.AddWithValue("$repository_id", event.Scope.RepositoryId.ToString())
+                            |> ignore
 
-                                parameters.AddWithValue("$branch_id", event.Scope.BranchId.ToString())
-                                |> ignore
+                            parameters.AddWithValue("$branch_id", event.Scope.BranchId.ToString())
+                            |> ignore
 
-                                parameters.AddWithValue("$workspace_root", event.Scope.WorkspaceRoot)
-                                |> ignore
+                            parameters.AddWithValue("$workspace_root", event.Scope.WorkspaceRoot)
+                            |> ignore
 
-                                parameters.AddWithValue("$watch_root", event.Scope.WatchRoot)
-                                |> ignore
+                            parameters.AddWithValue("$watch_root", event.Scope.WatchRoot)
+                            |> ignore
 
-                                parameters.AddWithValue("$root_directory_version_id", event.Scope.RootDirectoryId.ToString())
-                                |> ignore
+                            parameters.AddWithValue("$root_directory_version_id", event.Scope.RootDirectoryId.ToString())
+                            |> ignore
 
-                                parameters.AddWithValue("$root_directory_blake3_hash", string event.Scope.RootDirectoryBlake3Hash)
-                                |> ignore
+                            parameters.AddWithValue("$root_directory_sha256_hash", string event.Scope.RootDirectorySha256Hash)
+                            |> ignore
 
-                                parameters.AddWithValue("$watch_mode", event.Scope.WatchMode)
-                                |> ignore
+                            parameters.AddWithValue("$root_directory_blake3_hash", string event.Scope.RootDirectoryBlake3Hash)
+                            |> ignore
 
-                                parameters.AddWithValue("$event_type", event.EventType)
-                                |> ignore
+                            parameters.AddWithValue("$watch_mode", event.Scope.WatchMode)
+                            |> ignore
 
-                                parameters.AddWithValue("$message", event.Message)
-                                |> ignore)
+                            parameters.AddWithValue("$event_type", event.EventType)
+                            |> ignore
+
+                            parameters.AddWithValue("$message", event.Message)
+                            |> ignore)
                     })
         }
 
@@ -2296,7 +2361,7 @@ module LocalStateDb =
                             use command = connection.CreateCommand()
 
                             command.CommandText <-
-                                "SELECT sequence, created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NULL ORDER BY sequence ASC;"
+                                "SELECT sequence, created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NULL ORDER BY sequence ASC;"
 
                             command.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
                             |> ignore
@@ -2315,7 +2380,7 @@ module LocalStateDb =
                                         match tryFindWatchJournalReplayIncompatibility scope rowIdentity with
                                         | Some reason -> rowsToQuarantine.Add(sequence, reason)
                                         | None ->
-                                            let (_, _, _, _, _, _, _, differenceTypeValue, entryTypeValue, relativePath) = rowIdentity
+                                            let (_, _, _, _, _, _, _, _, differenceTypeValue, entryTypeValue, relativePath) = rowIdentity
 
                                             compatibleRows.Add(
                                                 {
@@ -2365,47 +2430,44 @@ module LocalStateDb =
                                 if targetSequence > appliedThroughSequence then
                                     setMetaValue connection WatchJournalAppliedThroughSequenceMetaKey $"{targetSequence}"
 
-                                executeNonQueryWithParams
-                                    connection
-                                    "INSERT INTO watch_lifecycle_events (created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, event_type, message, replayable) VALUES ($created_at, $repository_id, $branch_id, $workspace_root, $watch_root, $root_directory_version_id, $root_directory_blake3_hash, $watch_mode, $event_type, $message, 0);"
-                                    (fun parameters ->
-                                        parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
-                                        |> ignore
+                                executeNonQueryWithParams connection watchLifecycleEventInsertSql (fun parameters ->
+                                    parameters.AddWithValue("$created_at", getCurrentInstant().ToUnixTimeTicks())
+                                    |> ignore
 
-                                        parameters.AddWithValue("$repository_id", scope.RepositoryId.ToString())
-                                        |> ignore
+                                    parameters.AddWithValue("$repository_id", scope.RepositoryId.ToString())
+                                    |> ignore
 
-                                        parameters.AddWithValue("$branch_id", scope.BranchId.ToString())
-                                        |> ignore
+                                    parameters.AddWithValue("$branch_id", scope.BranchId.ToString())
+                                    |> ignore
 
-                                        parameters.AddWithValue("$workspace_root", scope.WorkspaceRoot)
-                                        |> ignore
+                                    parameters.AddWithValue("$workspace_root", scope.WorkspaceRoot)
+                                    |> ignore
 
-                                        parameters.AddWithValue("$watch_root", scope.WatchRoot)
-                                        |> ignore
+                                    parameters.AddWithValue("$watch_root", scope.WatchRoot)
+                                    |> ignore
 
-                                        parameters.AddWithValue("$root_directory_version_id", scope.RootDirectoryId.ToString())
-                                        |> ignore
+                                    parameters.AddWithValue("$root_directory_version_id", scope.RootDirectoryId.ToString())
+                                    |> ignore
 
-                                        parameters.AddWithValue("$root_directory_blake3_hash", string scope.RootDirectoryBlake3Hash)
-                                        |> ignore
+                                    parameters.AddWithValue("$root_directory_sha256_hash", string scope.RootDirectorySha256Hash)
+                                    |> ignore
 
-                                        parameters.AddWithValue("$watch_mode", scope.WatchMode)
-                                        |> ignore
+                                    parameters.AddWithValue("$root_directory_blake3_hash", string scope.RootDirectoryBlake3Hash)
+                                    |> ignore
 
-                                        parameters.AddWithValue("$event_type", "startup-quarantine")
-                                        |> ignore
+                                    parameters.AddWithValue("$watch_mode", scope.WatchMode)
+                                    |> ignore
 
-                                        parameters.AddWithValue(
-                                            "$message",
-                                            $"Quarantined {rowsToQuarantine.Count} incompatible Watch journal rows before replay."
-                                        )
-                                        |> ignore)
+                                    parameters.AddWithValue("$event_type", "startup-quarantine")
+                                    |> ignore
+
+                                    parameters.AddWithValue("$message", $"Quarantined {rowsToQuarantine.Count} incompatible Watch journal rows before replay.")
+                                    |> ignore)
 
                             use quarantinedCommand = connection.CreateCommand()
 
                             quarantinedCommand.CommandText <-
-                                "SELECT sequence, created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NOT NULL ORDER BY sequence ASC;"
+                                "SELECT sequence, created_at_unix_ticks, repository_id, branch_id, workspace_root, watch_root, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, watch_mode, difference_type, entry_type, relative_path, quarantined_at_unix_ticks, quarantine_reason FROM watch_journal WHERE sequence > $applied_through AND quarantined_at_unix_ticks IS NOT NULL ORDER BY sequence ASC;"
 
                             quarantinedCommand.Parameters.AddWithValue("$applied_through", appliedThroughSequence)
                             |> ignore

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -19,7 +19,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let private SchemaVersion = "8"
+    let SchemaVersion = "8"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]


### PR DESCRIPTION
## Why this matters

Grace Watch must distinguish user edits from filesystem effects produced by Grace itself. If marker evidence or observation scope is incomplete, Watch must fail closed and recover without uploading, saving, or replaying an unsafe local candidate.

Related to #510. Part of #480 and #473.

## What changed

- suppress all Watch callback shapes while a Grace update marker exists without creating local pending work
- capture repository, branch, root path, root IDs, SHA-256, and BLAKE3 when raw candidates are admitted, then revalidate that scope before claim or side effects
- route missing, malformed, stale, unobserved, late, or unreadable marker-completion evidence through lifecycle diagnostics and exact resync
- include root SHA-256 in journal and lifecycle scope, advance the local-state schema to version 8, and quarantine rows that cannot prove the current root
- preserve manual pending-latch behavior, generation-protected resync retirement, serialized Reference materialization, and the prohibition on local Save/replay rows for Grace-owned materialization effects

## Scope

Changed:

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI/LocalStateDb.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`
- `src/Grace.CLI.Tests/LocalStateDb.Tests.fs`

`src/Grace.CLI/Services.CLI.fs` is N/A because the implementation did not require a service-boundary change.

Public CLI, DTO, IPC, OpenAPI, generated artifacts, and documentation are N/A. This pull request changes internal Watch admission/recovery and local SQLite persistence only.

## Validation

- targeted Fantomas: passed
- focused Watch and LocalStateDb confirmation: 564/564 passed
- `git diff --check`: passed before and after commit
- `pwsh ./scripts/validate.ps1 -Full` build: passed with 0 warnings and 0 errors
- `Grace.Server.Unit.Tests`: 738/738 passed
- `Grace.Types.Tests`: 140/140 passed
- `Grace.Authorization.Tests`: 53/53 passed
- Aspire-backed `Grace.Server.Tests`: 247/247 passed
- Initial current-head `Grace.CLI.Tests`: 1176/1192 passed; all 16 failures were traced to Doctor duplicating schema version 7 after #510 advanced LocalStateDb to schema version 8
- Session-1 fix confirmation: `DoctorCliTests` 86/86 passed and `WatchTests` 469/469 passed
- Session-5 fix confirmation: Release build passed and focused scope tests passed 27/27
- Current-head GitHub Full validation passed in 6m42s

## Review Status

- Current head: `86cf079d14c7184709c60e1b16602c7b01698655`
- Substantive Codex review cycles: 5
- Session 1: findings `3570705970` and `3570705972` fixed, replied to, and resolved
- Session 2: finding `3570974362` fixed through the posted stabilization ledger, replied to, and resolved
- Session 3: findings `3571214759`, `3571214763`, and `3571214768` fixed through the expanded stabilization ledger, replied to, and resolved
- Session 4: findings `3571566319` and `3571566328` fixed through the closure ledger, replied to, and resolved
- Session 4 CI correction: the valid catch-up fixture now observes the current marker before writing matching completion evidence; production classification was not relaxed
- Session 5: finding `3572204214` fixed through the scope-isolation closure, replied to, and resolved
- CI correction: Doctor now consumes `LocalStateDb.SchemaVersion`; the 16 cascading Doctor failures are fixed at their shared cause
- Validation note: the local Full gate reached Aspire-backed tests but was terminated after a confirmed 21-minute test-host stall; no local Full pass is claimed
- State: GitHub Full passed, Codex Code Review Bot gave current-head approval, all review conversations are resolved, and the branch is current with its epic base
- Repeated-theme prevention: pending-work IPC publication is reconciled after every successful candidate claim from the complete post-claim pending evidence, including no-op and suppressed claims
- Prevention: self-reviewed stable published-status identity, complete cross-scope candidate-state isolation, complete pending-state publication, retained confidence loss across both callback paths and exact recovery retirement, marker-completion classification across all entry paths, common verified-publication scope caching, malformed-row branch reachability, journal admission, resync generation ordering, Doctor schema consumption, and every posted #510 suppression-table row
