### PR TITLE
GC-16: Add cache-local SQLite store

### DIFF
--- a/src/Grace.Cache.Tests/CacheStore.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheStore.Tests.fs
@@ -5,6 +5,7 @@ open System.Collections.Concurrent
 open System.Diagnostics
 open System.IO
 open System.Reflection
+open System.Threading
 open System.Threading.Tasks
 open Grace.Cache
 open Microsoft.Data.Sqlite
@@ -560,6 +561,72 @@ type CacheStoreTests() =
         finally
             CacheStoreTestSupport.deleteDatabasePath databasePath
 
+    /// Verifies non-lowercase SHA-256 text cannot create durable identity and a canonical retry remains publishable.
+    [<Test>]
+    member _.NonCanonicalDigestIsRejectedBeforePersistenceAndCanonicalRetrySucceeds() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+
+        let canonical = { CacheStoreTestSupport.descriptor "artifact-a" "root-a" 27 with Digest = String.replicate 64 "a" }
+
+        let uppercase = { canonical with Digest = canonical.Digest.ToUpperInvariant() }
+        let mixedCase = { canonical with Digest = canonical.Digest.Substring(0, 63) + "A" }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+
+            Assert.That(CacheStoreTestSupport.isBeginRejected (CacheStore.beginIngest opened.Store uppercase), Is.True)
+
+            Assert.That(
+                CacheStoreTestSupport.isCommitRejected (
+                    CacheStore.commitPromotedIngest opened.Store mixedCase (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
+                ),
+                Is.True
+            )
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts;", Is.EqualTo(0))
+            Assert.That(CacheStore.beginIngest opened.Store canonical, Is.EqualTo(CacheIngestBeginResult.Pending))
+
+            Assert.That(
+                CacheStore.commitPromotedIngest opened.Store canonical (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a"),
+                Is.EqualTo(CacheIngestCommitResult.Published)
+            )
+
+            let artifacts = CacheStore.getValidArtifacts opened.Store
+            Assert.That(artifacts, Has.Length.EqualTo(1))
+            Assert.That(artifacts[0].Digest, Is.EqualTo(canonical.Digest))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies cache ownership registry keys follow the runtime platform's case-sensitive path behavior.
+    [<Test>]
+    member _.CanonicalPathRegistryUsesPlatformCaseSemantics() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let caseVariant = Path.Combine(Path.GetDirectoryName(databasePath), "CACHE-STATE.DB")
+        let first = CacheStoreTestSupport.openStore databasePath
+
+        try
+            let second = CacheStoreTestSupport.openStore caseVariant
+
+            try
+                if OperatingSystem.IsWindows() then
+                    let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 28
+                    Assert.That(CacheStore.beginIngest first.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+                    Assert.That(CacheStore.beginIngest second.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+                    Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+                else
+                    let firstSource = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 28
+                    let secondSource = CacheStoreTestSupport.descriptor "artifact-b" "root-b" 29
+                    Assert.That(CacheStore.beginIngest first.Store firstSource, Is.EqualTo(CacheIngestBeginResult.Pending))
+                    Assert.That(CacheStore.beginIngest second.Store secondSource, Is.EqualTo(CacheIngestBeginResult.Pending))
+                    Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+                    Assert.That(CacheStoreTestSupport.readScalarInt caseVariant "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+            finally
+                CacheStore.disposeStore second.Store
+        finally
+            CacheStore.disposeStore first.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
     /// Verifies canonical aliases share one in-process owner, skip recovery, and survive another caller's disposal.
     [<Test>]
     member _.SameProcessReopenReusesOwnershipAndPreservesLivePendingIngest() =
@@ -608,6 +675,67 @@ type CacheStoreTests() =
             Assert.That(competingProcess.WaitForExit(10000), Is.True)
             Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
             Assert.That(CacheStore.getValidArtifacts owner.Store, Is.Empty)
+        finally
+            CacheStore.disposeStore owner.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies final lease disposal retains process ownership through an in-flight exception before recovery may run.
+    [<Test>]
+    member _.FinalLeaseDisposalWaitsForInFlightOperationAndExceptionReleasesOwnership() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 31
+        let owner = CacheStoreTestSupport.openStore databasePath
+        use entered = new ManualResetEventSlim(false)
+        use release = new ManualResetEventSlim(false)
+
+        try
+            Assert.That(CacheStore.beginIngest owner.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+
+            let operation = Task.Run(fun () -> CacheStore.runBlockedOperationForTest owner.Store entered release true)
+
+            Assert.That(entered.Wait(TimeSpan.FromSeconds(10.0)), Is.True)
+            CacheStore.disposeStore owner.Store
+
+            use competingProcess = CacheStoreTestSupport.startStoreProcess "--attempt-store-open" databasePath
+            Assert.That(CacheStoreTestSupport.readProcessLine competingProcess, Is.EqualTo("DATABASE-IN-USE"))
+            Assert.That(competingProcess.WaitForExit(10000), Is.True)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+
+            release.Set()
+
+            Assert.That(
+                Action (fun () ->
+                    operation.Wait(TimeSpan.FromSeconds(10.0))
+                    |> ignore),
+                Throws.TypeOf<AggregateException>()
+            )
+
+            Assert.That(operation.IsFaulted, Is.True)
+
+            use recoveredProcess = CacheStoreTestSupport.startStoreProcess "--attempt-store-open" databasePath
+            Assert.That(CacheStoreTestSupport.readProcessLine recoveredProcess, Is.EqualTo("OPENED"))
+            Assert.That(recoveredProcess.WaitForExit(10000), Is.True)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+        finally
+            release.Set()
+            CacheStore.disposeStore owner.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies a released caller lease stays unusable while repeated disposal leaves the ownership lifecycle stable.
+    [<Test>]
+    member _.DisposedLeaseRejectsNewOperationsAndDisposalIsIdempotent() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let owner = CacheStoreTestSupport.openStore databasePath
+
+        try
+            CacheStore.disposeStore owner.Store
+            CacheStore.disposeStore owner.Store
+
+            Assert.That(Action(fun () -> CacheStore.getValidArtifacts owner.Store |> ignore), Throws.TypeOf<InvalidOperationException>())
+
+            use reopenedProcess = CacheStoreTestSupport.startStoreProcess "--attempt-store-open" databasePath
+            Assert.That(CacheStoreTestSupport.readProcessLine reopenedProcess, Is.EqualTo("OPENED"))
+            Assert.That(reopenedProcess.WaitForExit(10000), Is.True)
         finally
             CacheStore.disposeStore owner.Store
             CacheStoreTestSupport.deleteDatabasePath databasePath

--- a/src/Grace.Cache.Tests/CacheStore.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheStore.Tests.fs
@@ -1,7 +1,10 @@
 namespace Grace.Cache.Tests
 
 open System
+open System.Collections.Concurrent
+open System.Diagnostics
 open System.IO
+open System.Reflection
 open System.Threading.Tasks
 open Grace.Cache
 open Microsoft.Data.Sqlite
@@ -9,6 +12,18 @@ open NUnit.Framework
 
 /// Provides isolated cache database paths and descriptor fixtures for SQLite store proof.
 module private CacheStoreTestSupport =
+
+    let private openedStores = ConcurrentBag<CacheStore>()
+
+    /// Opens one cache store and tracks its lease so fixture cleanup cannot retain ownership locks across tests.
+    let openStore databasePath =
+        let result = CacheStore.openStore databasePath
+
+        match result with
+        | Opened (store, _) -> openedStores.Add(store)
+        | CacheDatabaseInUse -> ()
+
+        result
 
     /// Creates a unique temporary database path unrelated to a working-copy local-state database.
     let createDatabasePath () =
@@ -19,6 +34,10 @@ module private CacheStoreTestSupport =
     /// Removes an isolated SQLite test directory after clearing pooled handles that could retain WAL sidecar files.
     let deleteDatabasePath (databasePath: string) =
         let directory = Path.GetDirectoryName(databasePath)
+
+        for store in openedStores do
+            CacheStore.disposeStore store
+
         SqliteConnection.ClearAllPools()
 
         if Directory.Exists(directory) then Directory.Delete(directory, true)
@@ -46,6 +65,16 @@ module private CacheStoreTestSupport =
                 ]
         }
 
+    /// Creates overlapping-root metadata whose shared directory has one immutable empty membership set.
+    let metadataWithSharedDirectory (rootId: string) (sharedDirectoryId: string) (artifactId: string) : CacheRecursiveMetadata =
+        {
+            Directories =
+                [
+                    { DirectoryVersionId = rootId; ChildDirectoryVersionIds = [ sharedDirectoryId ]; ArtifactIds = [ artifactId ] }
+                    { DirectoryVersionId = sharedDirectoryId; ChildDirectoryVersionIds = []; ArtifactIds = [] }
+                ]
+        }
+
     /// Executes a raw read-only assertion over the test database without becoming a production store surface.
     let readScalarInt (databasePath: string) (sql: string) =
         use connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly")
@@ -61,6 +90,27 @@ module private CacheStoreTestSupport =
         use command = connection.CreateCommand()
         command.CommandText <- sql
         command.ExecuteNonQuery() |> ignore
+
+    /// Starts this test assembly in a separate process so ownership behavior is proven across OS process boundaries.
+    let startStoreProcess mode (databasePath: string) =
+        let startInfo = ProcessStartInfo()
+        startInfo.FileName <- "dotnet"
+        startInfo.UseShellExecute <- false
+        startInfo.RedirectStandardOutput <- true
+        startInfo.RedirectStandardError <- true
+        startInfo.ArgumentList.Add(Assembly.GetExecutingAssembly().Location)
+        startInfo.ArgumentList.Add(mode)
+        startInfo.ArgumentList.Add(databasePath)
+        Process.Start(startInfo)
+
+    /// Reads a child-process readiness line within the bounded test timeout.
+    let readProcessLine (childProcess: Process) =
+        let lineTask = childProcess.StandardOutput.ReadLineAsync()
+
+        if not (lineTask.Wait(TimeSpan.FromSeconds(10.0))) then
+            Assert.Fail("The cache ownership child process did not report readiness within ten seconds.")
+
+        lineTask.Result
 
     /// Recognizes a rejected begin result without depending on F# union-case runtime implementation details.
     let isBeginRejected result =
@@ -84,7 +134,7 @@ type CacheStoreTests() =
         let databasePath = CacheStoreTestSupport.createDatabasePath ()
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
             let diagnostics = CacheStore.getDiagnostics opened.Store
             Assert.That(diagnostics.SchemaVersion, Is.EqualTo(1))
             Assert.That(diagnostics.JournalMode, Is.EqualTo("wal"))
@@ -101,7 +151,7 @@ type CacheStoreTests() =
         let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 1
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
             Assert.That(CacheStore.beginIngest opened.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
 
             let changed = { source with FillToken = "replacement-token" }
@@ -118,7 +168,7 @@ type CacheStoreTests() =
         let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 2
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest opened.Store source
             |> ignore
@@ -140,18 +190,18 @@ type CacheStoreTests() =
         let second = CacheStoreTestSupport.descriptor "artifact-b" "root-b" 4
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest opened.Store first
             |> ignore
 
-            CacheStore.commitPromotedIngest opened.Store first (CacheStoreTestSupport.metadata "root-a" "shared" "artifact-a")
+            CacheStore.commitPromotedIngest opened.Store first (CacheStoreTestSupport.metadataWithSharedDirectory "root-a" "shared" "artifact-a")
             |> ignore
 
             CacheStore.beginIngest opened.Store second
             |> ignore
 
-            CacheStore.commitPromotedIngest opened.Store second (CacheStoreTestSupport.metadata "root-b" "shared" "artifact-b")
+            CacheStore.commitPromotedIngest opened.Store second (CacheStoreTestSupport.metadataWithSharedDirectory "root-b" "shared" "artifact-b")
             |> ignore
 
             Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_versions;", Is.EqualTo(3))
@@ -173,7 +223,7 @@ type CacheStoreTests() =
         let second = { first with RootDirectoryVersionId = "root-b"; FillToken = "fill-artifact-shared-root-b" }
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest opened.Store first
             |> ignore
@@ -209,7 +259,7 @@ type CacheStoreTests() =
         let recursiveMetadata = CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a"
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest opened.Store source
             |> ignore
@@ -233,7 +283,7 @@ type CacheStoreTests() =
             { ArtifactId = "artifact-a"; Digest = "not-a-digest"; UncompressedSize = -1L; RootDirectoryVersionId = "root-a"; FillToken = "fill-a" }
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
             Assert.That(CacheStoreTestSupport.isBeginRejected (CacheStore.beginIngest opened.Store invalid), Is.True)
             Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
             Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
@@ -247,14 +297,15 @@ type CacheStoreTests() =
         let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 6
 
         try
-            let firstOpen = CacheStore.openStore databasePath
+            let firstOpen = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest firstOpen.Store source
             |> ignore
 
             let invalidMetadata: CacheRecursiveMetadata = { Directories = [] }
             let result = CacheStore.commitPromotedIngest firstOpen.Store source invalidMetadata
-            let restarted = CacheStore.openStore databasePath
+            CacheStore.disposeStore firstOpen.Store
+            let restarted = CacheStoreTestSupport.openStore databasePath
             Assert.That(CacheStoreTestSupport.isCommitRejected result, Is.True)
             Assert.That(restarted.RecoveredIncomplete, Has.Length.EqualTo(1))
             Assert.That(restarted.RecoveredIncomplete[0].ArtifactId, Is.EqualTo("artifact-a"))
@@ -271,7 +322,7 @@ type CacheStoreTests() =
         let incomplete = CacheStoreTestSupport.descriptor "artifact-pending" "root-pending" 8
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest opened.Store valid
             |> ignore
@@ -291,7 +342,8 @@ type CacheStoreTests() =
                 }
 
             Assert.That(CacheStoreTestSupport.isCommitRejected (CacheStore.commitPromotedIngest opened.Store incomplete missingChild), Is.True)
-            let restarted = CacheStore.openStore databasePath
+            CacheStore.disposeStore opened.Store
+            let restarted = CacheStoreTestSupport.openStore databasePath
             let artifacts = CacheStore.getValidArtifacts restarted.Store
             Assert.That(restarted.RecoveredIncomplete, Has.Length.EqualTo(1))
             Assert.That(artifacts, Has.Length.EqualTo(1))
@@ -313,12 +365,12 @@ type CacheStoreTests() =
 
         let ingest (source: CacheArtifactDescriptor) root child =
             Task.Run (fun () ->
-                let opened = CacheStore.openStore databasePath
+                let opened = CacheStoreTestSupport.openStore databasePath
 
                 CacheStore.beginIngest opened.Store source
                 |> ignore
 
-                CacheStore.commitPromotedIngest opened.Store source (CacheStoreTestSupport.metadata root child source.ArtifactId)
+                CacheStore.commitPromotedIngest opened.Store source (CacheStoreTestSupport.metadataWithSharedDirectory root child source.ArtifactId)
                 |> ignore)
 
         try
@@ -332,7 +384,7 @@ type CacheStoreTests() =
                 .GetAwaiter()
                 .GetResult()
 
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
             Assert.That(CacheStore.getValidArtifacts opened.Store, Has.Length.EqualTo(2))
 
             Assert.That(
@@ -353,8 +405,12 @@ type CacheStoreTests() =
         let databasePath = CacheStoreTestSupport.createDatabasePath ()
 
         try
-            CacheStore.openStore databasePath |> ignore
-            CacheStore.openStore databasePath |> ignore
+            CacheStoreTestSupport.openStore databasePath
+            |> ignore
+
+            CacheStoreTestSupport.openStore databasePath
+            |> ignore
+
             Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM cache_schema;", Is.EqualTo(1))
 
             Assert.That(
@@ -369,6 +425,228 @@ type CacheStoreTests() =
         finally
             CacheStoreTestSupport.deleteDatabasePath databasePath
 
+    /// Verifies a second root cannot claim a pending artifact id with divergent immutable identity.
+    [<Test>]
+    member _.CrossRootPendingIdentityConflictIsRejected() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let first = CacheStoreTestSupport.descriptor "artifact-shared" "root-a" 21
+
+        let conflicting = { first with RootDirectoryVersionId = "root-b"; Digest = CacheStoreTestSupport.digest 22; FillToken = "fill-artifact-shared-root-b" }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+            Assert.That(CacheStore.beginIngest opened.Store first, Is.EqualTo(CacheIngestBeginResult.Pending))
+            Assert.That(CacheStoreTestSupport.isBeginRejected (CacheStore.beginIngest opened.Store conflicting), Is.True)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies an immutable directory version rejects a later metadata graph with different memberships.
+    [<Test>]
+    member _.DivergentExistingDirectoryMetadataIsRejected() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let first = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 23
+        let second = CacheStoreTestSupport.descriptor "artifact-b" "root-b" 24
+
+        let divergent: CacheRecursiveMetadata =
+            {
+                Directories =
+                    [
+                        { DirectoryVersionId = "root-b"; ChildDirectoryVersionIds = [ "shared" ]; ArtifactIds = [ "artifact-b" ] }
+                        { DirectoryVersionId = "shared"; ChildDirectoryVersionIds = []; ArtifactIds = [ "artifact-b" ] }
+                    ]
+            }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+
+            CacheStore.beginIngest opened.Store first
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store first (CacheStoreTestSupport.metadata "root-a" "shared" "artifact-a")
+            |> ignore
+
+            CacheStore.beginIngest opened.Store second
+            |> ignore
+
+            Assert.That(CacheStoreTestSupport.isCommitRejected (CacheStore.commitPromotedIngest opened.Store second divergent), Is.True)
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Has.Length.EqualTo(1))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_artifact_memberships WHERE directory_version_id = 'shared';",
+                Is.EqualTo(1)
+            )
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies recursive metadata containing an indirect cycle cannot become valid cache state.
+    [<Test>]
+    member _.CyclicRecursiveMetadataIsRejected() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 25
+
+        let cyclic: CacheRecursiveMetadata =
+            {
+                Directories =
+                    [
+                        { DirectoryVersionId = "root-a"; ChildDirectoryVersionIds = [ "child-a" ]; ArtifactIds = [ "artifact-a" ] }
+                        { DirectoryVersionId = "child-a"; ChildDirectoryVersionIds = [ "root-a" ]; ArtifactIds = [ "artifact-a" ] }
+                    ]
+            }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+
+            CacheStore.beginIngest opened.Store source
+            |> ignore
+
+            Assert.That(CacheStoreTestSupport.isCommitRejected (CacheStore.commitPromotedIngest opened.Store source cyclic), Is.True)
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_versions;", Is.EqualTo(0))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies an idempotent publish result establishes the requested root membership for a canonical artifact.
+    [<Test>]
+    member _.ExistingArtifactCommitCreatesMissingRootMembership() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let first = CacheStoreTestSupport.descriptor "artifact-shared" "root-a" 26
+        let second = { first with RootDirectoryVersionId = "root-b"; FillToken = "fill-artifact-shared-root-b" }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+
+            CacheStore.beginIngest opened.Store first
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store first (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-shared")
+            |> ignore
+
+            Assert.That(
+                CacheStore.commitPromotedIngest opened.Store second (CacheStoreTestSupport.metadata "root-b" "child-b" "artifact-shared"),
+                Is.EqualTo(CacheIngestCommitResult.AlreadyPublished)
+            )
+
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Has.Length.EqualTo(2))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt
+                    databasePath
+                    "SELECT COUNT(*) FROM root_artifact_memberships WHERE root_directory_version_id = 'root-b' AND artifact_id = 'artifact-shared';",
+                Is.EqualTo(1)
+            )
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies null digests fail closed through the normal begin and commit result unions.
+    [<Test>]
+    member _.NullDigestIsRejectedWithoutThrowing() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let malformed = { CacheStoreTestSupport.descriptor "artifact-a" "root-a" 27 with Digest = null }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+            Assert.That(CacheStoreTestSupport.isBeginRejected (CacheStore.beginIngest opened.Store malformed), Is.True)
+
+            Assert.That(
+                CacheStoreTestSupport.isCommitRejected (
+                    CacheStore.commitPromotedIngest opened.Store malformed (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
+                ),
+                Is.True
+            )
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies canonical aliases share one in-process owner, skip recovery, and survive another caller's disposal.
+    [<Test>]
+    member _.SameProcessReopenReusesOwnershipAndPreservesLivePendingIngest() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let alias = Path.Combine(Path.GetDirectoryName(databasePath), ".", Path.GetFileName(databasePath))
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 28
+        let first = CacheStoreTestSupport.openStore databasePath
+
+        try
+            Assert.That(CacheStore.beginIngest first.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+            let second = CacheStoreTestSupport.openStore alias
+
+            try
+                Assert.That(second.RecoveredIncomplete, Is.Empty)
+                CacheStore.disposeStore first.Store
+
+                Assert.That(
+                    CacheStore.commitPromotedIngest second.Store source (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a"),
+                    Is.EqualTo(CacheIngestCommitResult.Published)
+                )
+
+                let third = CacheStoreTestSupport.openStore databasePath
+
+                try
+                    Assert.That(third.RecoveredIncomplete, Is.Empty)
+                    Assert.That(CacheStore.getValidArtifacts third.Store, Has.Length.EqualTo(1))
+                finally
+                    CacheStore.disposeStore third.Store
+            finally
+                CacheStore.disposeStore second.Store
+        finally
+            CacheStore.disposeStore first.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies a competing process receives the stable in-use result before it can clean or mutate live pending state.
+    [<Test>]
+    member _.CompetingProcessIsRejectedWithoutMutatingLivePendingIngest() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 29
+        let owner = CacheStoreTestSupport.openStore databasePath
+
+        try
+            Assert.That(CacheStore.beginIngest owner.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+            use competingProcess = CacheStoreTestSupport.startStoreProcess "--attempt-store-open" databasePath
+            Assert.That(CacheStoreTestSupport.readProcessLine competingProcess, Is.EqualTo("DATABASE-IN-USE"))
+            Assert.That(competingProcess.WaitForExit(10000), Is.True)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+            Assert.That(CacheStore.getValidArtifacts owner.Store, Is.Empty)
+        finally
+            CacheStore.disposeStore owner.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies process termination releases ownership so the next owner recovers abandoned pending state without removing valid rows.
+    [<Test>]
+    member _.ProcessExitReleasesOwnershipAndNextOwnerRecoversOnlyAbandonedPendingState() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let valid = CacheStoreTestSupport.descriptor "artifact-valid" "root-valid" 30
+        let initialOwner = CacheStoreTestSupport.openStore databasePath
+
+        try
+            CacheStore.beginIngest initialOwner.Store valid
+            |> ignore
+
+            CacheStore.commitPromotedIngest initialOwner.Store valid (CacheStoreTestSupport.metadata "root-valid" "child-valid" "artifact-valid")
+            |> ignore
+
+            CacheStore.disposeStore initialOwner.Store
+
+            use childProcess = CacheStoreTestSupport.startStoreProcess "--hold-store" databasePath
+            Assert.That(CacheStoreTestSupport.readProcessLine childProcess, Is.EqualTo("READY"))
+            childProcess.Kill(true)
+            Assert.That(childProcess.WaitForExit(10000), Is.True)
+
+            let recoveredOwner = CacheStoreTestSupport.openStore databasePath
+
+            try
+                Assert.That(recoveredOwner.RecoveredIncomplete, Has.Length.EqualTo(1))
+                Assert.That(recoveredOwner.RecoveredIncomplete[0].ArtifactId, Is.EqualTo("child-pending-artifact"))
+                let artifacts = CacheStore.getValidArtifacts recoveredOwner.Store
+                Assert.That(artifacts, Has.Length.EqualTo(1))
+                Assert.That(artifacts[0].ArtifactId, Is.EqualTo("artifact-valid"))
+            finally
+                CacheStore.disposeStore recoveredOwner.Store
+        finally
+            CacheStore.disposeStore initialOwner.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
     /// Verifies a reopened store rejects SQLite foreign-key corruption rather than serving a partially damaged valid graph.
     [<Test>]
     member _.ReopenFailsClosedOnForeignKeyCorruption() =
@@ -376,7 +654,7 @@ type CacheStoreTests() =
         let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 11
 
         try
-            let opened = CacheStore.openStore databasePath
+            let opened = CacheStoreTestSupport.openStore databasePath
 
             CacheStore.beginIngest opened.Store source
             |> ignore
@@ -384,8 +662,15 @@ type CacheStoreTests() =
             CacheStore.commitPromotedIngest opened.Store source (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
             |> ignore
 
+            CacheStore.disposeStore opened.Store
             CacheStoreTestSupport.executeNonQuery databasePath "PRAGMA foreign_keys = OFF;"
             CacheStoreTestSupport.executeNonQuery databasePath "DELETE FROM directory_versions WHERE directory_version_id = 'root-a';"
-            Assert.That(Action(fun () -> CacheStore.openStore databasePath |> ignore), Throws.TypeOf<InvalidOperationException>())
+
+            Assert.That(
+                Action (fun () ->
+                    CacheStoreTestSupport.openStore databasePath
+                    |> ignore),
+                Throws.TypeOf<InvalidOperationException>()
+            )
         finally
             CacheStoreTestSupport.deleteDatabasePath databasePath

--- a/src/Grace.Cache.Tests/CacheStore.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheStore.Tests.fs
@@ -1,0 +1,391 @@
+namespace Grace.Cache.Tests
+
+open System
+open System.IO
+open System.Threading.Tasks
+open Grace.Cache
+open Microsoft.Data.Sqlite
+open NUnit.Framework
+
+/// Provides isolated cache database paths and descriptor fixtures for SQLite store proof.
+module private CacheStoreTestSupport =
+
+    /// Creates a unique temporary database path unrelated to a working-copy local-state database.
+    let createDatabasePath () =
+        let directory = Path.Combine(Path.GetTempPath(), "grace-cache-store-tests", Guid.NewGuid().ToString("N"))
+        Directory.CreateDirectory(directory) |> ignore
+        Path.Combine(directory, "cache-state.db")
+
+    /// Removes an isolated SQLite test directory after clearing pooled handles that could retain WAL sidecar files.
+    let deleteDatabasePath (databasePath: string) =
+        let directory = Path.GetDirectoryName(databasePath)
+        SqliteConnection.ClearAllPools()
+
+        if Directory.Exists(directory) then Directory.Delete(directory, true)
+
+    /// Creates a deterministic SHA-256-shaped digest accepted by the store's source-integrity validation.
+    let digest (suffix: int) = suffix.ToString("x").PadLeft(64, '0')
+
+    /// Creates a descriptor whose fill token is revalidated immediately before valid publication.
+    let descriptor (artifactId: string) (rootId: string) (suffix: int) : CacheArtifactDescriptor =
+        {
+            ArtifactId = artifactId
+            Digest = digest suffix
+            UncompressedSize = 4096L
+            RootDirectoryVersionId = rootId
+            FillToken = $"fill-{artifactId}-{rootId}"
+        }
+
+    /// Creates recursive metadata containing the root and one nested directory that both retain the promoted artifact.
+    let metadata (rootId: string) (childId: string) (artifactId: string) : CacheRecursiveMetadata =
+        {
+            Directories =
+                [
+                    { DirectoryVersionId = rootId; ChildDirectoryVersionIds = [ childId ]; ArtifactIds = [ artifactId ] }
+                    { DirectoryVersionId = childId; ChildDirectoryVersionIds = []; ArtifactIds = [ artifactId ] }
+                ]
+        }
+
+    /// Executes a raw read-only assertion over the test database without becoming a production store surface.
+    let readScalarInt (databasePath: string) (sql: string) =
+        use connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly")
+        connection.Open()
+        use command = connection.CreateCommand()
+        command.CommandText <- sql
+        command.ExecuteScalar() |> Convert.ToInt32
+
+    /// Executes test-only controlled corruption to prove the production store fails closed at its integrity boundary.
+    let executeNonQuery (databasePath: string) (sql: string) =
+        use connection = new SqliteConnection($"Data Source={databasePath}")
+        connection.Open()
+        use command = connection.CreateCommand()
+        command.CommandText <- sql
+        command.ExecuteNonQuery() |> ignore
+
+    /// Recognizes a rejected begin result without depending on F# union-case runtime implementation details.
+    let isBeginRejected result =
+        match result with
+        | CacheIngestBeginResult.Rejected _ -> true
+        | _ -> false
+
+    /// Recognizes a rejected commit result without depending on F# union-case runtime implementation details.
+    let isCommitRejected result =
+        match result with
+        | CacheIngestCommitResult.Rejected _ -> true
+        | _ -> false
+
+/// Verifies cache-local SQLite schema, publication, recovery, integrity, and concurrency contracts.
+[<TestFixture>]
+type CacheStoreTests() =
+
+    /// Verifies schema initialization configures and reports required SQLite connection invariants.
+    [<Test>]
+    member _.OpenCreatesVersionedWalForeignKeyStore() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+
+        try
+            let opened = CacheStore.openStore databasePath
+            let diagnostics = CacheStore.getDiagnostics opened.Store
+            Assert.That(diagnostics.SchemaVersion, Is.EqualTo(1))
+            Assert.That(diagnostics.JournalMode, Is.EqualTo("wal"))
+            Assert.That(diagnostics.ForeignKeysEnabled, Is.True)
+            Assert.That(diagnostics.BusyTimeoutMilliseconds, Is.GreaterThan(0))
+            Assert.That(opened.RecoveredIncomplete, Is.Empty)
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies an unconfirmed or stale source descriptor cannot turn a pending artifact into a valid result.
+    [<Test>]
+    member _.MismatchedPromotionIsRejectedAndNeverPublished() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 1
+
+        try
+            let opened = CacheStore.openStore databasePath
+            Assert.That(CacheStore.beginIngest opened.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+
+            let changed = { source with FillToken = "replacement-token" }
+            let result = CacheStore.commitPromotedIngest opened.Store changed (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
+            Assert.That(CacheStoreTestSupport.isCommitRejected result, Is.True)
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies confirmed promotion atomically publishes recursive metadata and an eligible artifact.
+    [<Test>]
+    member _.ConfirmedPromotionPublishesRecursiveMetadata() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 2
+
+        try
+            let opened = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest opened.Store source
+            |> ignore
+
+            let result = CacheStore.commitPromotedIngest opened.Store source (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
+            let artifacts = CacheStore.getValidArtifacts opened.Store
+            Assert.That(result, Is.EqualTo(CacheIngestCommitResult.Published))
+            Assert.That(artifacts, Has.Length.EqualTo(1))
+            Assert.That(artifacts[0].ArtifactId, Is.EqualTo("artifact-a"))
+            Assert.That(artifacts[0].RootDirectoryVersionId, Is.EqualTo("root-a"))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies overlapping roots preserve one canonical directory row while retaining both root memberships.
+    [<Test>]
+    member _.OverlappingRootsShareCanonicalRowsAndKeepMemberships() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let first = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 3
+        let second = CacheStoreTestSupport.descriptor "artifact-b" "root-b" 4
+
+        try
+            let opened = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest opened.Store first
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store first (CacheStoreTestSupport.metadata "root-a" "shared" "artifact-a")
+            |> ignore
+
+            CacheStore.beginIngest opened.Store second
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store second (CacheStoreTestSupport.metadata "root-b" "shared" "artifact-b")
+            |> ignore
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_versions;", Is.EqualTo(3))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM root_directory_memberships WHERE directory_version_id = 'shared';",
+                Is.EqualTo(2)
+            )
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts WHERE lifecycle_state = 'Valid';", Is.EqualTo(2))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies the same immutable artifact can be retained under two roots without duplicating its canonical artifact row.
+    [<Test>]
+    member _.OverlappingRootsShareCanonicalArtifactRows() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let first = CacheStoreTestSupport.descriptor "artifact-shared" "root-a" 12
+        let second = { first with RootDirectoryVersionId = "root-b"; FillToken = "fill-artifact-shared-root-b" }
+
+        try
+            let opened = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest opened.Store first
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store first (CacheStoreTestSupport.metadata "root-a" "shared-a" "artifact-shared")
+            |> ignore
+
+            Assert.That(CacheStore.beginIngest opened.Store second, Is.EqualTo(CacheIngestBeginResult.Pending))
+
+            Assert.That(
+                CacheStore.commitPromotedIngest opened.Store second (CacheStoreTestSupport.metadata "root-b" "shared-b" "artifact-shared"),
+                Is.EqualTo(CacheIngestCommitResult.Published)
+            )
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts WHERE artifact_id = 'artifact-shared';", Is.EqualTo(1))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt
+                    databasePath
+                    "SELECT COUNT(*) FROM root_directory_memberships WHERE root_directory_version_id IN ('root-a', 'root-b');",
+                Is.EqualTo(4)
+            )
+
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Has.Length.EqualTo(2))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies a repeated confirmed ingest is idempotent and does not duplicate artifact or membership rows.
+    [<Test>]
+    member _.RepeatedConfirmedIngestIsIdempotent() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 5
+        let recursiveMetadata = CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a"
+
+        try
+            let opened = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest opened.Store source
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store source recursiveMetadata
+            |> ignore
+
+            Assert.That(CacheStore.beginIngest opened.Store source, Is.EqualTo(CacheIngestBeginResult.AlreadyValid))
+            Assert.That(CacheStore.commitPromotedIngest opened.Store source recursiveMetadata, Is.EqualTo(CacheIngestCommitResult.AlreadyPublished))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts;", Is.EqualTo(1))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_artifact_memberships;", Is.EqualTo(2))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies malformed digest and size inputs are rejected before any pending artifact state is persisted.
+    [<Test>]
+    member _.InvalidDescriptorDoesNotCreatePendingState() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+
+        let invalid: CacheArtifactDescriptor =
+            { ArtifactId = "artifact-a"; Digest = "not-a-digest"; UncompressedSize = -1L; RootDirectoryVersionId = "root-a"; FillToken = "fill-a" }
+
+        try
+            let opened = CacheStore.openStore databasePath
+            Assert.That(CacheStoreTestSupport.isBeginRejected (CacheStore.beginIngest opened.Store invalid), Is.True)
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies incomplete metadata remains non-publishable and restart returns its cleanup identity after transactional removal.
+    [<Test>]
+    member _.RestartRecoversIncompleteIngestWithoutPublishingIt() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 6
+
+        try
+            let firstOpen = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest firstOpen.Store source
+            |> ignore
+
+            let invalidMetadata: CacheRecursiveMetadata = { Directories = [] }
+            let result = CacheStore.commitPromotedIngest firstOpen.Store source invalidMetadata
+            let restarted = CacheStore.openStore databasePath
+            Assert.That(CacheStoreTestSupport.isCommitRejected result, Is.True)
+            Assert.That(restarted.RecoveredIncomplete, Has.Length.EqualTo(1))
+            Assert.That(restarted.RecoveredIncomplete[0].ArtifactId, Is.EqualTo("artifact-a"))
+            Assert.That(CacheStore.getValidArtifacts restarted.Store, Is.Empty)
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies a rejected recursive graph leaves no dangling membership and preserves shared valid artifacts through recovery.
+    [<Test>]
+    member _.RejectedRecursiveGraphCannotRemoveSharedValidArtifact() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let valid = CacheStoreTestSupport.descriptor "artifact-valid" "root-valid" 7
+        let incomplete = CacheStoreTestSupport.descriptor "artifact-pending" "root-pending" 8
+
+        try
+            let opened = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest opened.Store valid
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store valid (CacheStoreTestSupport.metadata "root-valid" "shared" "artifact-valid")
+            |> ignore
+
+            CacheStore.beginIngest opened.Store incomplete
+            |> ignore
+
+            let missingChild: CacheRecursiveMetadata =
+                {
+                    Directories =
+                        [
+                            { DirectoryVersionId = "root-pending"; ChildDirectoryVersionIds = [ "absent-child" ]; ArtifactIds = [ "artifact-pending" ] }
+                        ]
+                }
+
+            Assert.That(CacheStoreTestSupport.isCommitRejected (CacheStore.commitPromotedIngest opened.Store incomplete missingChild), Is.True)
+            let restarted = CacheStore.openStore databasePath
+            let artifacts = CacheStore.getValidArtifacts restarted.Store
+            Assert.That(restarted.RecoveredIncomplete, Has.Length.EqualTo(1))
+            Assert.That(artifacts, Has.Length.EqualTo(1))
+            Assert.That(artifacts[0].ArtifactId, Is.EqualTo("artifact-valid"))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_artifact_memberships WHERE artifact_id = 'artifact-pending';",
+                Is.EqualTo(0)
+            )
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies concurrent overlapping ingests serialize through SQLite without duplicate canonical metadata.
+    [<Test>]
+    member _.ConcurrentOverlappingIngestsRemainCanonical() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let first = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 9
+        let second = CacheStoreTestSupport.descriptor "artifact-b" "root-b" 10
+
+        let ingest (source: CacheArtifactDescriptor) root child =
+            Task.Run (fun () ->
+                let opened = CacheStore.openStore databasePath
+
+                CacheStore.beginIngest opened.Store source
+                |> ignore
+
+                CacheStore.commitPromotedIngest opened.Store source (CacheStoreTestSupport.metadata root child source.ArtifactId)
+                |> ignore)
+
+        try
+            Task
+                .WhenAll(
+                    [|
+                        ingest first "root-a" "shared"
+                        ingest second "root-b" "shared"
+                    |]
+                )
+                .GetAwaiter()
+                .GetResult()
+
+            let opened = CacheStore.openStore databasePath
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Has.Length.EqualTo(2))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_versions WHERE directory_version_id = 'shared';",
+                Is.EqualTo(1)
+            )
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM root_directory_memberships WHERE directory_version_id = 'shared';",
+                Is.EqualTo(2)
+            )
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies schema initialization is repeatable and does not introduce durable prefetch workflow tables.
+    [<Test>]
+    member _.SchemaInitializationIsRepeatableWithoutPrefetchState() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+
+        try
+            CacheStore.openStore databasePath |> ignore
+            CacheStore.openStore databasePath |> ignore
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM cache_schema;", Is.EqualTo(1))
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE '%prefetch%';",
+                Is.EqualTo(0)
+            )
+
+            Assert.That(
+                CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE '%queue%';",
+                Is.EqualTo(0)
+            )
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies a reopened store rejects SQLite foreign-key corruption rather than serving a partially damaged valid graph.
+    [<Test>]
+    member _.ReopenFailsClosedOnForeignKeyCorruption() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 11
+
+        try
+            let opened = CacheStore.openStore databasePath
+
+            CacheStore.beginIngest opened.Store source
+            |> ignore
+
+            CacheStore.commitPromotedIngest opened.Store source (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
+            |> ignore
+
+            CacheStoreTestSupport.executeNonQuery databasePath "PRAGMA foreign_keys = OFF;"
+            CacheStoreTestSupport.executeNonQuery databasePath "DELETE FROM directory_versions WHERE directory_version_id = 'root-a';"
+            Assert.That(Action(fun () -> CacheStore.openStore databasePath |> ignore), Throws.TypeOf<InvalidOperationException>())
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath

--- a/src/Grace.Cache.Tests/CacheStore.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheStore.Tests.fs
@@ -561,6 +561,123 @@ type CacheStoreTests() =
         finally
             CacheStoreTestSupport.deleteDatabasePath databasePath
 
+    /// Verifies a null descriptor and each nullable descriptor identity field reject through both write boundaries without state changes.
+    [<Test>]
+    member _.NullDescriptorAndFieldsAreRejectedWithoutMutation() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let canonical = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 32
+
+        let malformedDescriptors: CacheArtifactDescriptor list =
+            [
+                Unchecked.defaultof<CacheArtifactDescriptor>
+                { canonical with ArtifactId = null }
+                { canonical with Digest = null }
+                { canonical with RootDirectoryVersionId = null }
+                { canonical with FillToken = null }
+            ]
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+
+            for malformed in malformedDescriptors do
+                Assert.That(CacheStoreTestSupport.isBeginRejected (CacheStore.beginIngest opened.Store malformed), Is.True)
+
+                Assert.That(
+                    CacheStoreTestSupport.isCommitRejected (
+                        CacheStore.commitPromotedIngest opened.Store malformed (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a")
+                    ),
+                    Is.True
+                )
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts;", Is.EqualTo(0))
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies malformed source identity rejects before a hostile metadata graph can be traversed or mutate cache state.
+    [<Test>]
+    member _.DescriptorValidationShortCircuitsHostileMetadataWithoutMutation() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let malformed = { CacheStoreTestSupport.descriptor "artifact-a" "root-a" 33 with RootDirectoryVersionId = null }
+        let hostile: CacheRecursiveMetadata = { Directories = Unchecked.defaultof<CacheDirectoryMetadata list> }
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+
+            Assert.That(CacheStoreTestSupport.isCommitRejected (CacheStore.commitPromotedIngest opened.Store malformed hostile), Is.True)
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(0))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts;", Is.EqualTo(0))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_versions;", Is.EqualTo(0))
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies every nullable recursive metadata collection, entry, and identifier rejects without publishing metadata.
+    [<Test>]
+    member _.NullRecursiveMetadataShapesAreRejectedWithoutMetadataMutation() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 34
+
+        let root: CacheDirectoryMetadata = { DirectoryVersionId = "root-a"; ChildDirectoryVersionIds = []; ArtifactIds = [ "artifact-a" ] }
+
+        let malformedMetadata: CacheRecursiveMetadata list =
+            [
+                Unchecked.defaultof<CacheRecursiveMetadata>
+                { Directories = Unchecked.defaultof<CacheDirectoryMetadata list> }
+                {
+                    Directories =
+                        [
+                            Unchecked.defaultof<CacheDirectoryMetadata>
+                        ]
+                }
+                {
+                    Directories =
+                        [
+                            { root with DirectoryVersionId = null }
+                        ]
+                }
+                {
+                    Directories =
+                        [
+                            { root with ChildDirectoryVersionIds = Unchecked.defaultof<string list> }
+                        ]
+                }
+                {
+                    Directories =
+                        [
+                            { root with ArtifactIds = Unchecked.defaultof<string list> }
+                        ]
+                }
+                {
+                    Directories =
+                        [
+                            { root with ChildDirectoryVersionIds = [ Unchecked.defaultof<string> ] }
+                        ]
+                }
+                {
+                    Directories =
+                        [
+                            { root with ArtifactIds = [ Unchecked.defaultof<string> ] }
+                        ]
+                }
+            ]
+
+        try
+            let opened = CacheStoreTestSupport.openStore databasePath
+            Assert.That(CacheStore.beginIngest opened.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+
+            for metadata in malformedMetadata do
+                Assert.That(CacheStoreTestSupport.isCommitRejected (CacheStore.commitPromotedIngest opened.Store source metadata), Is.True)
+
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM artifacts;", Is.EqualTo(0))
+            Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM directory_versions;", Is.EqualTo(0))
+            Assert.That(CacheStore.getValidArtifacts opened.Store, Is.Empty)
+        finally
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
     /// Verifies non-lowercase SHA-256 text cannot create durable identity and a canonical retry remains publishable.
     [<Test>]
     member _.NonCanonicalDigestIsRejectedBeforePersistenceAndCanonicalRetrySucceeds() =
@@ -659,6 +776,53 @@ type CacheStoreTests() =
                 CacheStore.disposeStore second.Store
         finally
             CacheStore.disposeStore first.Store
+            CacheStoreTestSupport.deleteDatabasePath databasePath
+
+    /// Verifies parent-directory symlink aliases retain one physical database owner before and after SQLite creates the database file.
+    [<Test>]
+    member _.SymlinkedParentAliasSharesStablePreAndPostCreationOwnership() =
+        let databasePath = CacheStoreTestSupport.createDatabasePath ()
+        let physicalDirectory = Path.GetDirectoryName(databasePath)
+        let aliasDirectory = physicalDirectory + "-alias"
+        let aliasDatabasePath = Path.Combine(aliasDirectory, Path.GetFileName(databasePath))
+        let source = CacheStoreTestSupport.descriptor "artifact-a" "root-a" 35
+
+        try
+            Directory.CreateSymbolicLink(aliasDirectory, physicalDirectory)
+            |> ignore
+
+            let beforeCreation = CacheStoreTestSupport.openStore aliasDatabasePath
+
+            try
+                Assert.That(CacheStore.beginIngest beforeCreation.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+
+                let resolvedPath = CacheStoreTestSupport.openStore databasePath
+
+                try
+                    Assert.That(resolvedPath.RecoveredIncomplete, Is.Empty)
+
+                    let afterCreation = CacheStoreTestSupport.openStore aliasDatabasePath
+
+                    try
+                        Assert.That(afterCreation.RecoveredIncomplete, Is.Empty)
+                        Assert.That(CacheStore.beginIngest afterCreation.Store source, Is.EqualTo(CacheIngestBeginResult.Pending))
+                        Assert.That(CacheStoreTestSupport.readScalarInt databasePath "SELECT COUNT(*) FROM pending_ingests;", Is.EqualTo(1))
+
+                        CacheStore.disposeStore beforeCreation.Store
+                        CacheStore.disposeStore resolvedPath.Store
+
+                        Assert.That(
+                            CacheStore.commitPromotedIngest afterCreation.Store source (CacheStoreTestSupport.metadata "root-a" "child-a" "artifact-a"),
+                            Is.EqualTo(CacheIngestCommitResult.Published)
+                        )
+                    finally
+                        CacheStore.disposeStore afterCreation.Store
+                finally
+                    CacheStore.disposeStore resolvedPath.Store
+            finally
+                CacheStore.disposeStore beforeCreation.Store
+        finally
+            if Directory.Exists(aliasDirectory) then Directory.Delete(aliasDirectory)
             CacheStoreTestSupport.deleteDatabasePath databasePath
 
     /// Verifies a competing process receives the stable in-use result before it can clean or mutate live pending state.

--- a/src/Grace.Cache.Tests/Grace.Cache.Tests.fsproj
+++ b/src/Grace.Cache.Tests/Grace.Cache.Tests.fsproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="CacheHost.Tests.fs" />
+    <Compile Include="CacheStore.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -17,6 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Cache.Tests/Program.fs
+++ b/src/Grace.Cache.Tests/Program.fs
@@ -1,10 +1,55 @@
 namespace Grace.Cache.Tests
 
+open System
+open Grace.Cache
 open NUnit.Framework
 
 /// Hosts the focused F# cache service test assembly.
 module Program =
 
+    /// Hosts a child process that retains a pending ingest until the parent terminates it to prove crash recovery.
+    let private holdStoreUntilTerminated databasePath =
+        let descriptor: CacheArtifactDescriptor =
+            {
+                ArtifactId = "child-pending-artifact"
+                Digest = String.replicate 64 "a"
+                UncompressedSize = 4096L
+                RootDirectoryVersionId = "child-pending-root"
+                FillToken = "child-pending-fill"
+            }
+
+        match CacheStore.openStore databasePath with
+        | Opened (store, _) ->
+            match CacheStore.beginIngest store descriptor with
+            | CacheIngestBeginResult.Pending ->
+                Console.Out.WriteLine("READY")
+                Console.Out.Flush()
+                Console.ReadLine() |> ignore
+                CacheStore.disposeStore store
+                0
+            | _ -> 3
+        | CacheDatabaseInUse ->
+            Console.Out.WriteLine("DATABASE-IN-USE")
+            Console.Out.Flush()
+            2
+
+    /// Hosts a child process that attempts cache ownership without opening SQLite when another process owns the path.
+    let private attemptStoreOpen databasePath =
+        match CacheStore.openStore databasePath with
+        | Opened (store, _) ->
+            CacheStore.disposeStore store
+            Console.Out.WriteLine("OPENED")
+            Console.Out.Flush()
+            0
+        | CacheDatabaseInUse ->
+            Console.Out.WriteLine("DATABASE-IN-USE")
+            Console.Out.Flush()
+            0
+
     /// Runs the NUnit test host without adding a cache CLI surface.
     [<EntryPoint>]
-    let main args = 0
+    let main args =
+        match args with
+        | [| "--hold-store"; databasePath |] -> holdStoreUntilTerminated databasePath
+        | [| "--attempt-store-open"; databasePath |] -> attemptStoreOpen databasePath
+        | _ -> 0

--- a/src/Grace.Cache/CacheStore.fs
+++ b/src/Grace.Cache/CacheStore.fs
@@ -158,31 +158,51 @@ module CacheStore =
         executeScalarString connection transaction sql configure
         |> Option.map (fun value -> Int32.Parse(value, CultureInfo.InvariantCulture))
 
-    /// Resolves a cache database path to one registry key so relative and link aliases cannot obtain separate owners.
+    /// Resolves every existing path component before preserving a non-existent suffix so one physical database always has one registry key.
     let private canonicalizeDatabasePath (databasePath: string) =
         if String.IsNullOrWhiteSpace databasePath then
             invalidArg (nameof databasePath) "Cache database path is required."
 
         let fullPath = Path.GetFullPath(databasePath)
-        let file = FileInfo(fullPath)
+        let root = Path.GetPathRoot(fullPath)
 
-        if file.Exists then
-            match file.ResolveLinkTarget(true) with
-            | null -> file.FullName
-            | target -> target.FullName
-        else
-            let directoryPath = Path.GetDirectoryName(fullPath)
-            let directory = DirectoryInfo(directoryPath)
+        if String.IsNullOrWhiteSpace root then
+            invalidOp "Cache database path did not resolve to a rooted path."
 
-            let resolvedDirectory =
-                if directory.Exists then
-                    match directory.ResolveLinkTarget(true) with
-                    | :? DirectoryInfo as target -> target.FullName
-                    | _ -> directory.FullName
+        let components =
+            fullPath[root.Length ..]
+                .Split(
+                    [|
+                        Path.DirectorySeparatorChar
+                        Path.AltDirectorySeparatorChar
+                    |],
+                    StringSplitOptions.RemoveEmptyEntries
+                )
+
+        let mutable canonicalPath = root
+        let mutable preservesNonExistentSuffix = false
+
+        for index in 0 .. components.Length - 1 do
+            let candidate = Path.Combine(canonicalPath, components[index])
+
+            if preservesNonExistentSuffix then
+                canonicalPath <- candidate
+            else
+                let pathInfo: FileSystemInfo =
+                    if index = components.Length - 1 then
+                        FileInfo(candidate) :> FileSystemInfo
+                    else
+                        DirectoryInfo(candidate) :> FileSystemInfo
+
+                if pathInfo.Exists then
+                    match pathInfo.ResolveLinkTarget(true) with
+                    | null -> canonicalPath <- pathInfo.FullName
+                    | target -> canonicalPath <- target.FullName
                 else
-                    directory.FullName
+                    canonicalPath <- candidate
+                    preservesNonExistentSuffix <- true
 
-            Path.Combine(resolvedDirectory, file.Name)
+        canonicalPath
 
     /// Acquires the sidecar byte-range lock that proves this process exclusively owns a canonical cache database path.
     let private tryAcquireOwnershipLock (databasePath: string) =
@@ -468,8 +488,9 @@ module CacheStore =
 
     /// Validates source identity before it can become either pending state or a valid artifact row.
     let private validateDescriptor (descriptor: CacheArtifactDescriptor) =
-
-        if String.IsNullOrWhiteSpace descriptor.ArtifactId then
+        if obj.ReferenceEquals(descriptor, null) then
+            Error "Artifact descriptor is required."
+        elif String.IsNullOrWhiteSpace descriptor.ArtifactId then
             Error "Artifact id is required."
         elif not (isCanonicalSha256Digest descriptor.Digest) then
             Error "Artifact digest must be a canonical lowercase 64-character hexadecimal SHA-256 value."
@@ -484,14 +505,20 @@ module CacheStore =
 
     /// Validates that recursive metadata is non-empty, canonical, root-reachable, and tied only to the promoted artifact.
     let private validateMetadata (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) =
-        if List.isEmpty metadata.Directories then
+        if obj.ReferenceEquals(metadata, null) then
+            Error "Recursive metadata is required."
+        elif obj.ReferenceEquals(metadata.Directories, null) then
+            Error "Recursive metadata directories are required."
+        elif List.isEmpty metadata.Directories then
             Error "Recursive metadata must contain the promoted root directory."
         else
             let directories = Dictionary<string, CacheDirectoryMetadata>(StringComparer.Ordinal)
             let mutable error = None
 
             for directory in metadata.Directories do
-                if String.IsNullOrWhiteSpace directory.DirectoryVersionId then
+                if obj.ReferenceEquals(directory, null) then
+                    error <- Some "Recursive metadata directory entries are required."
+                elif String.IsNullOrWhiteSpace directory.DirectoryVersionId then
                     error <- Some "Directory version ids are required."
                 elif directories.ContainsKey(directory.DirectoryVersionId) then
                     error <- Some "Recursive metadata cannot repeat a directory version id."
@@ -509,24 +536,30 @@ module CacheStore =
                     let childIds = HashSet<string>(StringComparer.Ordinal)
                     let artifactIds = HashSet<string>(StringComparer.Ordinal)
 
-                    for childId in directory.ChildDirectoryVersionIds do
-                        if
-                            String.IsNullOrWhiteSpace childId
-                            || not (directories.ContainsKey(childId))
-                        then
-                            error <- Some "Every child directory membership must reference supplied recursive metadata."
-                        elif not (childIds.Add(childId)) then
-                            error <- Some "Recursive metadata cannot repeat a child directory membership."
-                        elif childId = directory.DirectoryVersionId then
-                            error <- Some "A directory cannot be its own child."
+                    if obj.ReferenceEquals(directory.ChildDirectoryVersionIds, null) then
+                        error <- Some "Recursive metadata child directory collections are required."
+                    elif obj.ReferenceEquals(directory.ArtifactIds, null) then
+                        error <- Some "Recursive metadata artifact collections are required."
+                    else
+                        for childId in directory.ChildDirectoryVersionIds do
+                            if
+                                String.IsNullOrWhiteSpace childId
+                                || not (directories.ContainsKey(childId))
+                            then
+                                error <- Some "Every child directory membership must reference supplied recursive metadata."
+                            elif not (childIds.Add(childId)) then
+                                error <- Some "Recursive metadata cannot repeat a child directory membership."
+                            elif childId = directory.DirectoryVersionId then
+                                error <- Some "A directory cannot be its own child."
 
-                    for artifactId in directory.ArtifactIds do
-                        if artifactId <> descriptor.ArtifactId then
-                            error <- Some "Recursive metadata cannot reference an artifact that was not confirmed for this ingest."
-                        elif not (artifactIds.Add(artifactId)) then
-                            error <- Some "Recursive metadata cannot repeat an artifact membership."
-                        else
-                            hasPromotedArtifact <- true
+                        for artifactId in directory.ArtifactIds do
+                            if String.IsNullOrWhiteSpace artifactId
+                               || artifactId <> descriptor.ArtifactId then
+                                error <- Some "Recursive metadata cannot reference an artifact that was not confirmed for this ingest."
+                            elif not (artifactIds.Add(artifactId)) then
+                                error <- Some "Recursive metadata cannot repeat an artifact membership."
+                            else
+                                hasPromotedArtifact <- true
 
                 if error.IsSome then
                     Error error.Value
@@ -889,18 +922,40 @@ module CacheStore =
     /// Atomically publishes one confirmed artifact and its complete recursive metadata only while the original pending identity remains current.
     let commitPromotedIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) : CacheIngestCommitResult =
         withStoreOperation store (fun sharedStore ->
-            match validateDescriptor descriptor, validateMetadata descriptor metadata with
-            | Error reason, _
-            | _, Error reason -> CacheIngestCommitResult.Rejected reason
-            | Ok (), Ok () ->
-                withBusyRetry (fun () ->
-                    use connection = openConnection sharedStore.DatabasePath
-                    use transaction = connection.BeginTransaction()
+            match validateDescriptor descriptor with
+            | Error reason -> CacheIngestCommitResult.Rejected reason
+            | Ok () ->
+                match validateMetadata descriptor metadata with
+                | Error reason -> CacheIngestCommitResult.Rejected reason
+                | Ok () ->
+                    withBusyRetry (fun () ->
+                        use connection = openConnection sharedStore.DatabasePath
+                        use transaction = connection.BeginTransaction()
 
-                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                    | None ->
-                        match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
-                        | Some valid when descriptorMatches descriptor valid ->
+                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                        | None ->
+                            match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
+                            | Some valid when descriptorMatches descriptor valid ->
+                                match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
+                                | Error reason ->
+                                    transaction.Rollback()
+                                    CacheIngestCommitResult.Rejected reason
+                                | Ok () ->
+                                    insertMetadata connection (Some transaction) descriptor metadata
+
+                                    if isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId then
+                                        transaction.Commit()
+                                        CacheIngestCommitResult.AlreadyPublished
+                                    else
+                                        transaction.Rollback()
+                                        CacheIngestCommitResult.Rejected "Existing artifact publication could not establish the requested root membership."
+                            | _ ->
+                                transaction.Rollback()
+                                CacheIngestCommitResult.Rejected "No current pending ingest exists for the promoted artifact."
+                        | Some pending when not (descriptorMatches descriptor pending) ->
+                            transaction.Rollback()
+                            CacheIngestCommitResult.Rejected "Pending ingest identity changed before promoted publication."
+                        | Some _ ->
                             match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
                             | Error reason ->
                                 transaction.Rollback()
@@ -908,44 +963,25 @@ module CacheStore =
                             | Ok () ->
                                 insertMetadata connection (Some transaction) descriptor metadata
 
-                                if isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId then
+                                match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId
+                                    with
+                                | Some current when descriptorMatches descriptor current ->
+                                    executeNonQuery
+                                        connection
+                                        (Some transaction)
+                                        "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
+                                        (fun parameters ->
+                                            parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                                            |> ignore
+
+                                            parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                                            |> ignore)
+
                                     transaction.Commit()
-                                    CacheIngestCommitResult.AlreadyPublished
-                                else
+                                    CacheIngestCommitResult.Published
+                                | _ ->
                                     transaction.Rollback()
-                                    CacheIngestCommitResult.Rejected "Existing artifact publication could not establish the requested root membership."
-                        | _ ->
-                            transaction.Rollback()
-                            CacheIngestCommitResult.Rejected "No current pending ingest exists for the promoted artifact."
-                    | Some pending when not (descriptorMatches descriptor pending) ->
-                        transaction.Rollback()
-                        CacheIngestCommitResult.Rejected "Pending ingest identity changed before promoted publication."
-                    | Some _ ->
-                        match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
-                        | Error reason ->
-                            transaction.Rollback()
-                            CacheIngestCommitResult.Rejected reason
-                        | Ok () ->
-                            insertMetadata connection (Some transaction) descriptor metadata
-
-                            match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                            | Some current when descriptorMatches descriptor current ->
-                                executeNonQuery
-                                    connection
-                                    (Some transaction)
-                                    "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
-                                    (fun parameters ->
-                                        parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
-                                        |> ignore
-
-                                        parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
-                                        |> ignore)
-
-                                transaction.Commit()
-                                CacheIngestCommitResult.Published
-                            | _ ->
-                                transaction.Rollback()
-                                CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication."))
+                                    CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication."))
 
     /// Lists only artifact rows committed as valid; pending and rejected state never crosses this query boundary.
     let getValidArtifacts (store: CacheStore) : CacheValidArtifact array =

--- a/src/Grace.Cache/CacheStore.fs
+++ b/src/Grace.Cache/CacheStore.fs
@@ -21,14 +21,37 @@ type CacheRecursiveMetadata = { Directories: CacheDirectoryMetadata list }
 /// Reports the durable SQLite invariants established for a cache store connection.
 type CacheStoreDiagnostics = { SchemaVersion: int; JournalMode: string; ForeignKeysEnabled: bool; BusyTimeoutMilliseconds: int }
 
+/// Holds one process-owned cache database lock and the reference count for its in-process store leases.
+type private CacheStoreShared =
+    {
+        DatabasePath: string
+        Diagnostics: CacheStoreDiagnostics
+        OwnershipLock: FileStream
+        LifecycleGate: obj
+        mutable ReferenceCount: int
+    }
+
 /// Represents the private cache database handle used only by the cache runtime's narrow store API.
-type CacheStore = private { DatabasePath: string; Diagnostics: CacheStoreDiagnostics }
+type CacheStore = private { Shared: CacheStoreShared; mutable Released: int }
 
 /// Identifies a pending artifact that restart recovery removed and the filesystem owner must clean up.
 type CacheRecoveredIncompleteIngest = { ArtifactId: string; RootDirectoryVersionId: string; Digest: string; UncompressedSize: int64; FillToken: string }
 
-/// Returns a store after startup recovery has removed every incomplete ingest from its SQLite boundary.
-type CacheStoreOpenResult = { Store: CacheStore; RecoveredIncomplete: CacheRecoveredIncompleteIngest array }
+/// Returns the result of acquiring the cache database's exclusive process ownership.
+type CacheStoreOpenResult =
+    | Opened of store: CacheStore * recoveredIncomplete: CacheRecoveredIncompleteIngest array
+    | CacheDatabaseInUse
+    /// Exposes an opened store while making an in-use result fail loudly if a caller skips result handling.
+    member this.Store =
+        match this with
+        | Opened (store, _) -> store
+        | CacheDatabaseInUse -> invalidOp "Cache database is already owned by another process."
+
+    /// Exposes restart recovery only for the process that acquired exclusive ownership.
+    member this.RecoveredIncomplete =
+        match this with
+        | Opened (_, recoveredIncomplete) -> recoveredIncomplete
+        | CacheDatabaseInUse -> [||]
 
 /// Distinguishes a new pending ingest from an idempotent valid or rejected source descriptor.
 type CacheIngestBeginResult =
@@ -60,6 +83,8 @@ module CacheStore =
              true)
 
     let private initializationLocks = ConcurrentDictionary<string, obj>(StringComparer.OrdinalIgnoreCase)
+
+    let private sharedStores = ConcurrentDictionary<string, CacheStoreShared>(StringComparer.OrdinalIgnoreCase)
 
     let private schemaTables =
         [|
@@ -120,6 +145,70 @@ module CacheStore =
     let private executeScalarInt connection transaction sql configure =
         executeScalarString connection transaction sql configure
         |> Option.map (fun value -> Int32.Parse(value, CultureInfo.InvariantCulture))
+
+    /// Resolves a cache database path to one registry key so relative and link aliases cannot obtain separate owners.
+    let private canonicalizeDatabasePath (databasePath: string) =
+        if String.IsNullOrWhiteSpace databasePath then
+            invalidArg (nameof databasePath) "Cache database path is required."
+
+        let fullPath = Path.GetFullPath(databasePath)
+        let file = FileInfo(fullPath)
+
+        if file.Exists then
+            match file.ResolveLinkTarget(true) with
+            | null -> file.FullName
+            | target -> target.FullName
+        else
+            let directoryPath = Path.GetDirectoryName(fullPath)
+            let directory = DirectoryInfo(directoryPath)
+
+            let resolvedDirectory =
+                if directory.Exists then
+                    match directory.ResolveLinkTarget(true) with
+                    | :? DirectoryInfo as target -> target.FullName
+                    | _ -> directory.FullName
+                else
+                    directory.FullName
+
+            Path.Combine(resolvedDirectory, file.Name)
+
+    /// Acquires the sidecar byte-range lock that proves this process exclusively owns a canonical cache database path.
+    let private tryAcquireOwnershipLock (databasePath: string) =
+        let directory = Path.GetDirectoryName(databasePath)
+
+        if not (String.IsNullOrWhiteSpace directory) then
+            Directory.CreateDirectory(directory) |> ignore
+
+        let lockPath = databasePath + ".owner.lock"
+
+        try
+            let ownershipLock = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite ||| FileShare.Delete)
+
+            try
+                ownershipLock.Lock(0L, 1L)
+                Some ownershipLock
+            with
+            | :? IOException ->
+                ownershipLock.Dispose()
+                None
+        with
+        | :? IOException -> None
+
+    /// Creates a caller lease over a live shared process owner without rerunning startup recovery.
+    let private createStoreLease (sharedStore: CacheStoreShared) =
+        lock sharedStore.LifecycleGate (fun () ->
+            if sharedStore.ReferenceCount <= 0 then
+                invalidOp "Cache database ownership ended before a new store lease could be created."
+
+            sharedStore.ReferenceCount <- sharedStore.ReferenceCount + 1
+            { Shared = sharedStore; Released = 0 })
+
+    /// Rejects use of a store handle after that caller has released its shared ownership lease.
+    let private requireLiveStore (store: CacheStore) =
+        if Volatile.Read(&store.Released) <> 0 then
+            invalidOp "Cache store lease has already been released."
+
+        store.Shared
 
     /// Opens a cache-local connection and verifies every required SQLite setting instead of inheriting process defaults.
     let private openConnection (databasePath: string) =
@@ -256,6 +345,40 @@ module CacheStore =
         else
             None
 
+    /// Compares the immutable artifact identity that must agree across roots even when fill tokens differ.
+    let private artifactIdentityMatches (expected: CacheArtifactDescriptor) (actual: CacheArtifactDescriptor) =
+        expected.ArtifactId = actual.ArtifactId
+        && expected.Digest = actual.Digest
+        && expected.UncompressedSize = actual.UncompressedSize
+
+    /// Detects whether another root already holds a pending row for the artifact with a divergent immutable identity.
+    let private hasPendingArtifactIdentityConflict connection transaction (descriptor: CacheArtifactDescriptor) =
+        use command =
+            createCommand
+                connection
+                transaction
+                "SELECT artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token FROM pending_ingests WHERE artifact_id = @artifactId;"
+                (fun parameters ->
+                    parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                    |> ignore)
+
+        use reader = command.ExecuteReader()
+        let mutable conflict = false
+
+        while reader.Read() do
+            let pending: CacheArtifactDescriptor =
+                {
+                    ArtifactId = reader.GetString(0)
+                    Digest = reader.GetString(1)
+                    UncompressedSize = reader.GetInt64(2)
+                    RootDirectoryVersionId = reader.GetString(3)
+                    FillToken = reader.GetString(4)
+                }
+
+            if not (artifactIdentityMatches descriptor pending) then conflict <- true
+
+        conflict
+
     /// Compares the complete stale-sensitive identity tuple used for pending and valid publication decisions.
     let private descriptorMatches (expected: CacheArtifactDescriptor) (actual: CacheArtifactDescriptor) =
         expected.ArtifactId = actual.ArtifactId
@@ -285,7 +408,8 @@ module CacheStore =
     /// Validates source identity before it can become either pending state or a valid artifact row.
     let private validateDescriptor (descriptor: CacheArtifactDescriptor) =
         let hasSha256Shape (value: string) =
-            value.Length = 64
+            not (isNull value)
+            && value.Length = 64
             && value
                |> Seq.forall (fun character -> Uri.IsHexDigit(character))
 
@@ -326,18 +450,25 @@ module CacheStore =
                 let mutable hasPromotedArtifact = false
 
                 for directory in metadata.Directories do
+                    let childIds = HashSet<string>(StringComparer.Ordinal)
+                    let artifactIds = HashSet<string>(StringComparer.Ordinal)
+
                     for childId in directory.ChildDirectoryVersionIds do
                         if
                             String.IsNullOrWhiteSpace childId
                             || not (directories.ContainsKey(childId))
                         then
                             error <- Some "Every child directory membership must reference supplied recursive metadata."
+                        elif not (childIds.Add(childId)) then
+                            error <- Some "Recursive metadata cannot repeat a child directory membership."
                         elif childId = directory.DirectoryVersionId then
                             error <- Some "A directory cannot be its own child."
 
                     for artifactId in directory.ArtifactIds do
                         if artifactId <> descriptor.ArtifactId then
                             error <- Some "Recursive metadata cannot reference an artifact that was not confirmed for this ingest."
+                        elif not (artifactIds.Add(artifactId)) then
+                            error <- Some "Recursive metadata cannot repeat an artifact membership."
                         else
                             hasPromotedArtifact <- true
 
@@ -360,7 +491,35 @@ module CacheStore =
                     if reachable.Count <> directories.Count then
                         Error "Recursive metadata cannot contain directories unreachable from the descriptor root."
                     else
-                        Ok()
+                        let incomingEdges = Dictionary<string, int>(StringComparer.Ordinal)
+
+                        for directory in metadata.Directories do
+                            incomingEdges.Add(directory.DirectoryVersionId, 0)
+
+                        for directory in metadata.Directories do
+                            for childId in directory.ChildDirectoryVersionIds do
+                                incomingEdges[childId] <- incomingEdges[childId] + 1
+
+                        let roots = Queue<string>()
+
+                        for directoryId in incomingEdges.Keys do
+                            if incomingEdges[directoryId] = 0 then roots.Enqueue(directoryId)
+
+                        let mutable visited = 0
+
+                        while roots.Count > 0 do
+                            let directoryId = roots.Dequeue()
+                            visited <- visited + 1
+
+                            for childId in directories[directoryId].ChildDirectoryVersionIds do
+                                incomingEdges[childId] <- incomingEdges[childId] - 1
+
+                                if incomingEdges[childId] = 0 then roots.Enqueue(childId)
+
+                        if visited <> directories.Count then
+                            Error "Recursive metadata cannot contain cycles."
+                        else
+                            Ok()
 
     /// Executes a write operation again only when SQLite reports a bounded busy or locked condition.
     let private withBusyRetry operation =
@@ -377,6 +536,58 @@ module CacheStore =
                 execute (attempt + 1)
 
         execute 0
+
+    /// Reads one immutable directory's direct membership ids without exposing the relational schema to callers.
+    let private readDirectoryMembershipIds connection transaction tableName columnName directoryVersionId =
+        use command =
+            createCommand
+                connection
+                transaction
+                $"SELECT {columnName} FROM {tableName} WHERE directory_version_id = @directoryVersionId ORDER BY {columnName};"
+                (fun parameters ->
+                    parameters.AddWithValue("@directoryVersionId", directoryVersionId)
+                    |> ignore)
+
+        use reader = command.ExecuteReader()
+        let memberships = HashSet<string>(StringComparer.Ordinal)
+
+        while reader.Read() do
+            memberships.Add(reader.GetString(0)) |> ignore
+
+        memberships
+
+    /// Verifies that a reused immutable directory version has exactly the same direct recursive metadata.
+    let private validateCanonicalDirectoryMetadata connection transaction (metadata: CacheRecursiveMetadata) =
+        let mutable error = None
+
+        for directory in metadata.Directories do
+            let exists =
+                executeScalarInt
+                    connection
+                    transaction
+                    "SELECT COUNT(*) FROM directory_versions WHERE directory_version_id = @directoryVersionId;"
+                    (fun parameters ->
+                        parameters.AddWithValue("@directoryVersionId", directory.DirectoryVersionId)
+                        |> ignore)
+                |> Option.map (fun count -> count > 0)
+                |> Option.defaultValue false
+
+            if exists then
+                let existingChildren =
+                    readDirectoryMembershipIds connection transaction "directory_child_memberships" "child_directory_version_id" directory.DirectoryVersionId
+
+                let existingArtifacts =
+                    readDirectoryMembershipIds connection transaction "directory_artifact_memberships" "artifact_id" directory.DirectoryVersionId
+
+                if
+                    not (existingChildren.SetEquals(directory.ChildDirectoryVersionIds))
+                    || not (existingArtifacts.SetEquals(directory.ArtifactIds))
+                then
+                    error <- Some "Directory version id already belongs to different immutable recursive metadata."
+
+        match error with
+        | Some reason -> Error reason
+        | None -> Ok()
 
     /// Inserts a canonical row or retains the prior identical canonical row without exposing an upsert API.
     let private insertDirectory connection transaction directoryId =
@@ -486,41 +697,107 @@ module CacheStore =
         transaction.Commit()
         recovered.ToArray()
 
-    /// Creates or verifies the cache schema, checks integrity, and recovers incomplete transactions before exposing a store.
-    let openStore databasePath =
-        if String.IsNullOrWhiteSpace databasePath then
-            invalidArg (nameof databasePath) "Cache database path is required."
+    /// Inserts the root-specific pending state only after immutable artifact identity has been revalidated.
+    let private insertPendingIngest connection transaction (descriptor: CacheArtifactDescriptor) =
+        executeNonQuery
+            connection
+            transaction
+            "INSERT INTO pending_ingests (artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token) VALUES (@artifactId, @digest, @uncompressedSize, @rootDirectoryVersionId, @fillToken);"
+            (fun parameters ->
+                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                |> ignore
 
-        let fullPath = Path.GetFullPath(databasePath)
-        let initializationLock = initializationLocks.GetOrAdd(fullPath, (fun _ -> obj ()))
+                parameters.AddWithValue("@digest", descriptor.Digest)
+                |> ignore
+
+                parameters.AddWithValue("@uncompressedSize", descriptor.UncompressedSize)
+                |> ignore
+
+                parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                |> ignore
+
+                parameters.AddWithValue("@fillToken", descriptor.FillToken)
+                |> ignore)
+
+    /// Acquires exclusive process ownership before schema work and returns a shared lease for same-process callers.
+    let openStore databasePath =
+        let canonicalPath = canonicalizeDatabasePath databasePath
+        let initializationLock = initializationLocks.GetOrAdd(canonicalPath, (fun _ -> obj ()))
 
         lock initializationLock (fun () ->
-            use connection = openConnection fullPath
-            ensureSchema connection
-            verifyIntegrity connection
-            let recovered = recoverIncompleteIngests connection
-            verifyIntegrity connection
+            match sharedStores.TryGetValue(canonicalPath) with
+            | true, sharedStore -> Opened(createStoreLease sharedStore, [||])
+            | false, _ ->
+                match tryAcquireOwnershipLock canonicalPath with
+                | None -> CacheDatabaseInUse
+                | Some ownershipLock ->
+                    try
+                        use connection = openConnection canonicalPath
+                        ensureSchema connection
+                        verifyIntegrity connection
+                        let recovered = recoverIncompleteIngests connection
+                        verifyIntegrity connection
 
-            {
-                Store =
-                    {
-                        DatabasePath = fullPath
-                        Diagnostics =
-                            { SchemaVersion = SchemaVersion; JournalMode = "wal"; ForeignKeysEnabled = true; BusyTimeoutMilliseconds = BusyTimeoutMilliseconds }
-                    }
-                RecoveredIncomplete = recovered
-            })
+                        let sharedStore =
+                            {
+                                DatabasePath = canonicalPath
+                                Diagnostics =
+                                    {
+                                        SchemaVersion = SchemaVersion
+                                        JournalMode = "wal"
+                                        ForeignKeysEnabled = true
+                                        BusyTimeoutMilliseconds = BusyTimeoutMilliseconds
+                                    }
+                                OwnershipLock = ownershipLock
+                                LifecycleGate = obj ()
+                                ReferenceCount = 1
+                            }
 
-    /// Returns the verified connection settings captured while the store was opened.
-    let getDiagnostics (store: CacheStore) = store.Diagnostics
+                        if not (sharedStores.TryAdd(canonicalPath, sharedStore)) then
+                            ownershipLock.Dispose()
+                            invalidOp "Cache database ownership registry changed during initialization."
+
+                        Opened({ Shared = sharedStore; Released = 0 }, recovered)
+                    with
+                    | error ->
+                        ownershipLock.Dispose()
+                        raise error)
+
+    /// Releases one caller lease and unlocks the database only after the last same-process caller has released it.
+    let disposeStore (store: CacheStore) =
+        if Interlocked.Exchange(&store.Released, 1) = 0 then
+            let sharedStore = store.Shared
+            let initializationLock = initializationLocks.GetOrAdd(sharedStore.DatabasePath, (fun _ -> obj ()))
+
+            lock initializationLock (fun () ->
+                lock sharedStore.LifecycleGate (fun () ->
+                    sharedStore.ReferenceCount <- sharedStore.ReferenceCount - 1
+
+                    if sharedStore.ReferenceCount < 0 then
+                        invalidOp "Cache store ownership reference count became negative."
+
+                    if sharedStore.ReferenceCount = 0 then
+                        let mutable removed = Unchecked.defaultof<CacheStoreShared>
+
+                        sharedStores.TryRemove(sharedStore.DatabasePath, &removed)
+                        |> ignore
+
+                        sharedStore.OwnershipLock.Dispose()))
+
+    /// Returns the verified connection settings captured while the shared store owner was opened.
+    let getDiagnostics (store: CacheStore) =
+        let sharedStore = requireLiveStore store
+        sharedStore.Diagnostics
 
     /// Records a valid source descriptor as pending while rejecting malformed or stale identities before persistence.
     let beginIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) : CacheIngestBeginResult =
+        let sharedStore = requireLiveStore store
+
         match validateDescriptor descriptor with
         | Error reason -> CacheIngestBeginResult.Rejected reason
         | Ok () ->
             withBusyRetry (fun () ->
-                use connection = openConnection store.DatabasePath
+                use connection = openConnection sharedStore.DatabasePath
                 use transaction = connection.BeginTransaction()
 
                 match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
@@ -530,45 +807,24 @@ module CacheStore =
                     ->
                     transaction.Commit()
                     CacheIngestBeginResult.AlreadyValid
-                | Some _ ->
-                    match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
-                    | Some valid when descriptorMatches descriptor valid ->
-                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                        | Some pending when descriptorMatches descriptor pending ->
-                            transaction.Commit()
-                            CacheIngestBeginResult.Pending
-                        | Some _ ->
-                            transaction.Rollback()
-                            CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
-                        | None ->
-                            executeNonQuery
-                                connection
-                                (Some transaction)
-                                "INSERT INTO pending_ingests (artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token) VALUES (@artifactId, @digest, @uncompressedSize, @rootDirectoryVersionId, @fillToken);"
-                                (fun parameters ->
-                                    parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
-                                    |> ignore
-
-                                    parameters.AddWithValue("@digest", descriptor.Digest)
-                                    |> ignore
-
-                                    parameters.AddWithValue("@uncompressedSize", descriptor.UncompressedSize)
-                                    |> ignore
-
-                                    parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
-                                    |> ignore
-
-                                    parameters.AddWithValue("@fillToken", descriptor.FillToken)
-                                    |> ignore)
-
-                            transaction.Commit()
-                            CacheIngestBeginResult.Pending
+                | Some valid when descriptorMatches descriptor valid ->
+                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                    | Some pending when descriptorMatches descriptor pending ->
+                        transaction.Commit()
+                        CacheIngestBeginResult.Pending
                     | Some _ ->
                         transaction.Rollback()
-                        CacheIngestBeginResult.Rejected "Artifact id already belongs to a different valid immutable descriptor."
+                        CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
                     | None ->
-                        transaction.Rollback()
-                        CacheIngestBeginResult.Rejected "Artifact state changed before the root-specific pending ingest could be recorded."
+                        insertPendingIngest connection (Some transaction) descriptor
+                        transaction.Commit()
+                        CacheIngestBeginResult.Pending
+                | Some _ ->
+                    transaction.Rollback()
+                    CacheIngestBeginResult.Rejected "Artifact id already belongs to a different valid immutable descriptor."
+                | None when hasPendingArtifactIdentityConflict connection (Some transaction) descriptor ->
+                    transaction.Rollback()
+                    CacheIngestBeginResult.Rejected "Artifact id already has a cross-root pending ingest with a different immutable identity."
                 | None ->
                     match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
                     | Some pending when descriptorMatches descriptor pending ->
@@ -576,47 +832,41 @@ module CacheStore =
                         CacheIngestBeginResult.Pending
                     | Some _ ->
                         transaction.Rollback()
-                        CacheIngestBeginResult.Rejected "Artifact id already has a pending ingest with a different stale-sensitive identity."
+                        CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
                     | None ->
-                        executeNonQuery
-                            connection
-                            (Some transaction)
-                            "INSERT INTO pending_ingests (artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token) VALUES (@artifactId, @digest, @uncompressedSize, @rootDirectoryVersionId, @fillToken);"
-                            (fun parameters ->
-                                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
-                                |> ignore
-
-                                parameters.AddWithValue("@digest", descriptor.Digest)
-                                |> ignore
-
-                                parameters.AddWithValue("@uncompressedSize", descriptor.UncompressedSize)
-                                |> ignore
-
-                                parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
-                                |> ignore
-
-                                parameters.AddWithValue("@fillToken", descriptor.FillToken)
-                                |> ignore)
-
+                        insertPendingIngest connection (Some transaction) descriptor
                         transaction.Commit()
                         CacheIngestBeginResult.Pending)
 
     /// Atomically publishes one confirmed artifact and its complete recursive metadata only while the original pending identity remains current.
     let commitPromotedIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) : CacheIngestCommitResult =
+        let sharedStore = requireLiveStore store
+
         match validateDescriptor descriptor, validateMetadata descriptor metadata with
         | Error reason, _
         | _, Error reason -> CacheIngestCommitResult.Rejected reason
         | Ok (), Ok () ->
             withBusyRetry (fun () ->
-                use connection = openConnection store.DatabasePath
+                use connection = openConnection sharedStore.DatabasePath
                 use transaction = connection.BeginTransaction()
 
                 match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
                 | None ->
                     match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
                     | Some valid when descriptorMatches descriptor valid ->
-                        transaction.Commit()
-                        CacheIngestCommitResult.AlreadyPublished
+                        match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
+                        | Error reason ->
+                            transaction.Rollback()
+                            CacheIngestCommitResult.Rejected reason
+                        | Ok () ->
+                            insertMetadata connection (Some transaction) descriptor metadata
+
+                            if isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId then
+                                transaction.Commit()
+                                CacheIngestCommitResult.AlreadyPublished
+                            else
+                                transaction.Rollback()
+                                CacheIngestCommitResult.Rejected "Existing artifact publication could not establish the requested root membership."
                     | _ ->
                         transaction.Rollback()
                         CacheIngestCommitResult.Rejected "No current pending ingest exists for the promoted artifact."
@@ -624,30 +874,36 @@ module CacheStore =
                     transaction.Rollback()
                     CacheIngestCommitResult.Rejected "Pending ingest identity changed before promoted publication."
                 | Some _ ->
-                    insertMetadata connection (Some transaction) descriptor metadata
-
-                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                    | Some current when descriptorMatches descriptor current ->
-                        executeNonQuery
-                            connection
-                            (Some transaction)
-                            "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
-                            (fun parameters ->
-                                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
-                                |> ignore
-
-                                parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
-                                |> ignore)
-
-                        transaction.Commit()
-                        CacheIngestCommitResult.Published
-                    | _ ->
+                    match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
+                    | Error reason ->
                         transaction.Rollback()
-                        CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication.")
+                        CacheIngestCommitResult.Rejected reason
+                    | Ok () ->
+                        insertMetadata connection (Some transaction) descriptor metadata
+
+                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                        | Some current when descriptorMatches descriptor current ->
+                            executeNonQuery
+                                connection
+                                (Some transaction)
+                                "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
+                                (fun parameters ->
+                                    parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                                    |> ignore
+
+                                    parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                                    |> ignore)
+
+                            transaction.Commit()
+                            CacheIngestCommitResult.Published
+                        | _ ->
+                            transaction.Rollback()
+                            CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication.")
 
     /// Lists only artifact rows committed as valid; pending and rejected state never crosses this query boundary.
     let getValidArtifacts (store: CacheStore) : CacheValidArtifact array =
-        use connection = openConnection store.DatabasePath
+        let sharedStore = requireLiveStore store
+        use connection = openConnection sharedStore.DatabasePath
 
         use command =
             createCommand

--- a/src/Grace.Cache/CacheStore.fs
+++ b/src/Grace.Cache/CacheStore.fs
@@ -5,9 +5,13 @@ open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Globalization
 open System.IO
+open System.Runtime.CompilerServices
 open System.Threading
 open Microsoft.Data.Sqlite
 open SQLitePCL
+
+[<assembly: InternalsVisibleTo("Grace.Cache.Tests")>]
+do ()
 
 /// Identifies immutable promoted content and the root whose metadata will retain it.
 type CacheArtifactDescriptor = { ArtifactId: string; Digest: string; UncompressedSize: int64; RootDirectoryVersionId: string; FillToken: string }
@@ -29,6 +33,7 @@ type private CacheStoreShared =
         OwnershipLock: FileStream
         LifecycleGate: obj
         mutable ReferenceCount: int
+        mutable ActiveOperationCount: int
     }
 
 /// Represents the private cache database handle used only by the cache runtime's narrow store API.
@@ -82,9 +87,16 @@ module CacheStore =
             (Batteries_V2.Init()
              true)
 
-    let private initializationLocks = ConcurrentDictionary<string, obj>(StringComparer.OrdinalIgnoreCase)
+    /// Compares canonical cache paths according to the runtime platform's path case behavior.
+    let private cachePathComparer =
+        if OperatingSystem.IsWindows() then
+            StringComparer.OrdinalIgnoreCase
+        else
+            StringComparer.Ordinal
 
-    let private sharedStores = ConcurrentDictionary<string, CacheStoreShared>(StringComparer.OrdinalIgnoreCase)
+    let private initializationLocks = ConcurrentDictionary<string, obj>(cachePathComparer)
+
+    let private sharedStores = ConcurrentDictionary<string, CacheStoreShared>(cachePathComparer)
 
     let private schemaTables =
         [|
@@ -197,18 +209,58 @@ module CacheStore =
     /// Creates a caller lease over a live shared process owner without rerunning startup recovery.
     let private createStoreLease (sharedStore: CacheStoreShared) =
         lock sharedStore.LifecycleGate (fun () ->
-            if sharedStore.ReferenceCount <= 0 then
-                invalidOp "Cache database ownership ended before a new store lease could be created."
+            if sharedStore.ReferenceCount < 0 then
+                invalidOp "Cache database ownership reference count became negative before a new store lease could be created."
 
             sharedStore.ReferenceCount <- sharedStore.ReferenceCount + 1
             { Shared = sharedStore; Released = 0 })
 
-    /// Rejects use of a store handle after that caller has released its shared ownership lease.
-    let private requireLiveStore (store: CacheStore) =
-        if Volatile.Read(&store.Released) <> 0 then
-            invalidOp "Cache store lease has already been released."
+    /// Removes and unlocks an unused shared owner while the initialization and lifecycle gates are both held.
+    let private releaseSharedStoreIfUnused (sharedStore: CacheStoreShared) =
+        if sharedStore.ReferenceCount = 0
+           && sharedStore.ActiveOperationCount = 0 then
+            let mutable removed = Unchecked.defaultof<CacheStoreShared>
 
-        store.Shared
+            if sharedStores.TryRemove(sharedStore.DatabasePath, &removed) then
+                if not (Object.ReferenceEquals(removed, sharedStore)) then
+                    invalidOp "Cache database ownership registry removed a different shared store."
+
+                sharedStore.OwnershipLock.Dispose()
+
+    /// Starts one store operation only while its caller lease remains live and retains process ownership until completion.
+    let private beginStoreOperation (store: CacheStore) =
+        let sharedStore = store.Shared
+
+        lock sharedStore.LifecycleGate (fun () ->
+            if Volatile.Read(&store.Released) <> 0 then
+                invalidOp "Cache store lease has already been released."
+
+            if sharedStore.ReferenceCount <= 0 then
+                invalidOp "Cache database ownership ended before a store operation could begin."
+
+            sharedStore.ActiveOperationCount <- sharedStore.ActiveOperationCount + 1
+            sharedStore)
+
+    /// Ends one store operation and releases process ownership only after its last caller lease and operation exit.
+    let private endStoreOperation (sharedStore: CacheStoreShared) =
+        let initializationLock = initializationLocks.GetOrAdd(sharedStore.DatabasePath, (fun _ -> obj ()))
+
+        lock initializationLock (fun () ->
+            lock sharedStore.LifecycleGate (fun () ->
+                if sharedStore.ActiveOperationCount <= 0 then
+                    invalidOp "Cache store operation count became negative."
+
+                sharedStore.ActiveOperationCount <- sharedStore.ActiveOperationCount - 1
+                releaseSharedStoreIfUnused sharedStore))
+
+    /// Runs a cache store action while holding process ownership through every success and exception path.
+    let private withStoreOperation (store: CacheStore) operation =
+        let sharedStore = beginStoreOperation store
+
+        try
+            operation sharedStore
+        finally
+            endStoreOperation sharedStore
 
     /// Opens a cache-local connection and verifies every required SQLite setting instead of inheriting process defaults.
     let private openConnection (databasePath: string) =
@@ -405,18 +457,22 @@ module CacheStore =
 
         count |> Option.defaultValue 0 > 0
 
+    /// Recognizes Grace's canonical lowercase hexadecimal SHA-256 text before it becomes durable artifact identity.
+    let private isCanonicalSha256Digest (value: string) =
+        not (isNull value)
+        && value.Length = 64
+        && (value
+            |> Seq.forall (fun character ->
+                (character >= '0' && character <= '9')
+                || (character >= 'a' && character <= 'f')))
+
     /// Validates source identity before it can become either pending state or a valid artifact row.
     let private validateDescriptor (descriptor: CacheArtifactDescriptor) =
-        let hasSha256Shape (value: string) =
-            not (isNull value)
-            && value.Length = 64
-            && value
-               |> Seq.forall (fun character -> Uri.IsHexDigit(character))
 
         if String.IsNullOrWhiteSpace descriptor.ArtifactId then
             Error "Artifact id is required."
-        elif not (hasSha256Shape descriptor.Digest) then
-            Error "Artifact digest must be a 64-character hexadecimal SHA-256 value."
+        elif not (isCanonicalSha256Digest descriptor.Digest) then
+            Error "Artifact digest must be a canonical lowercase 64-character hexadecimal SHA-256 value."
         elif descriptor.UncompressedSize < 0L then
             Error "Artifact uncompressed size cannot be negative."
         elif String.IsNullOrWhiteSpace descriptor.RootDirectoryVersionId then
@@ -751,6 +807,7 @@ module CacheStore =
                                 OwnershipLock = ownershipLock
                                 LifecycleGate = obj ()
                                 ReferenceCount = 1
+                                ActiveOperationCount = 0
                             }
 
                         if not (sharedStores.TryAdd(canonicalPath, sharedStore)) then
@@ -776,84 +833,94 @@ module CacheStore =
                     if sharedStore.ReferenceCount < 0 then
                         invalidOp "Cache store ownership reference count became negative."
 
-                    if sharedStore.ReferenceCount = 0 then
-                        let mutable removed = Unchecked.defaultof<CacheStoreShared>
-
-                        sharedStores.TryRemove(sharedStore.DatabasePath, &removed)
-                        |> ignore
-
-                        sharedStore.OwnershipLock.Dispose()))
+                    releaseSharedStoreIfUnused sharedStore))
 
     /// Returns the verified connection settings captured while the shared store owner was opened.
-    let getDiagnostics (store: CacheStore) =
-        let sharedStore = requireLiveStore store
-        sharedStore.Diagnostics
+    let getDiagnostics (store: CacheStore) = withStoreOperation store (fun sharedStore -> sharedStore.Diagnostics)
 
     /// Records a valid source descriptor as pending while rejecting malformed or stale identities before persistence.
     let beginIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) : CacheIngestBeginResult =
-        let sharedStore = requireLiveStore store
+        withStoreOperation store (fun sharedStore ->
+            match validateDescriptor descriptor with
+            | Error reason -> CacheIngestBeginResult.Rejected reason
+            | Ok () ->
+                withBusyRetry (fun () ->
+                    use connection = openConnection sharedStore.DatabasePath
+                    use transaction = connection.BeginTransaction()
 
-        match validateDescriptor descriptor with
-        | Error reason -> CacheIngestBeginResult.Rejected reason
-        | Ok () ->
-            withBusyRetry (fun () ->
-                use connection = openConnection sharedStore.DatabasePath
-                use transaction = connection.BeginTransaction()
-
-                match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
-                | Some valid when
-                    descriptorMatches descriptor valid
-                    && isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId
-                    ->
-                    transaction.Commit()
-                    CacheIngestBeginResult.AlreadyValid
-                | Some valid when descriptorMatches descriptor valid ->
-                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                    | Some pending when descriptorMatches descriptor pending ->
+                    match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
+                    | Some valid when
+                        descriptorMatches descriptor valid
+                        && isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId
+                        ->
                         transaction.Commit()
-                        CacheIngestBeginResult.Pending
+                        CacheIngestBeginResult.AlreadyValid
+                    | Some valid when descriptorMatches descriptor valid ->
+                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                        | Some pending when descriptorMatches descriptor pending ->
+                            transaction.Commit()
+                            CacheIngestBeginResult.Pending
+                        | Some _ ->
+                            transaction.Rollback()
+                            CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
+                        | None ->
+                            insertPendingIngest connection (Some transaction) descriptor
+                            transaction.Commit()
+                            CacheIngestBeginResult.Pending
                     | Some _ ->
                         transaction.Rollback()
-                        CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
-                    | None ->
-                        insertPendingIngest connection (Some transaction) descriptor
-                        transaction.Commit()
-                        CacheIngestBeginResult.Pending
-                | Some _ ->
-                    transaction.Rollback()
-                    CacheIngestBeginResult.Rejected "Artifact id already belongs to a different valid immutable descriptor."
-                | None when hasPendingArtifactIdentityConflict connection (Some transaction) descriptor ->
-                    transaction.Rollback()
-                    CacheIngestBeginResult.Rejected "Artifact id already has a cross-root pending ingest with a different immutable identity."
-                | None ->
-                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                    | Some pending when descriptorMatches descriptor pending ->
-                        transaction.Commit()
-                        CacheIngestBeginResult.Pending
-                    | Some _ ->
+                        CacheIngestBeginResult.Rejected "Artifact id already belongs to a different valid immutable descriptor."
+                    | None when hasPendingArtifactIdentityConflict connection (Some transaction) descriptor ->
                         transaction.Rollback()
-                        CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
+                        CacheIngestBeginResult.Rejected "Artifact id already has a cross-root pending ingest with a different immutable identity."
                     | None ->
-                        insertPendingIngest connection (Some transaction) descriptor
-                        transaction.Commit()
-                        CacheIngestBeginResult.Pending)
+                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                        | Some pending when descriptorMatches descriptor pending ->
+                            transaction.Commit()
+                            CacheIngestBeginResult.Pending
+                        | Some _ ->
+                            transaction.Rollback()
+                            CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
+                        | None ->
+                            insertPendingIngest connection (Some transaction) descriptor
+                            transaction.Commit()
+                            CacheIngestBeginResult.Pending))
 
     /// Atomically publishes one confirmed artifact and its complete recursive metadata only while the original pending identity remains current.
     let commitPromotedIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) : CacheIngestCommitResult =
-        let sharedStore = requireLiveStore store
+        withStoreOperation store (fun sharedStore ->
+            match validateDescriptor descriptor, validateMetadata descriptor metadata with
+            | Error reason, _
+            | _, Error reason -> CacheIngestCommitResult.Rejected reason
+            | Ok (), Ok () ->
+                withBusyRetry (fun () ->
+                    use connection = openConnection sharedStore.DatabasePath
+                    use transaction = connection.BeginTransaction()
 
-        match validateDescriptor descriptor, validateMetadata descriptor metadata with
-        | Error reason, _
-        | _, Error reason -> CacheIngestCommitResult.Rejected reason
-        | Ok (), Ok () ->
-            withBusyRetry (fun () ->
-                use connection = openConnection sharedStore.DatabasePath
-                use transaction = connection.BeginTransaction()
+                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                    | None ->
+                        match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
+                        | Some valid when descriptorMatches descriptor valid ->
+                            match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
+                            | Error reason ->
+                                transaction.Rollback()
+                                CacheIngestCommitResult.Rejected reason
+                            | Ok () ->
+                                insertMetadata connection (Some transaction) descriptor metadata
 
-                match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                | None ->
-                    match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
-                    | Some valid when descriptorMatches descriptor valid ->
+                                if isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId then
+                                    transaction.Commit()
+                                    CacheIngestCommitResult.AlreadyPublished
+                                else
+                                    transaction.Rollback()
+                                    CacheIngestCommitResult.Rejected "Existing artifact publication could not establish the requested root membership."
+                        | _ ->
+                            transaction.Rollback()
+                            CacheIngestCommitResult.Rejected "No current pending ingest exists for the promoted artifact."
+                    | Some pending when not (descriptorMatches descriptor pending) ->
+                        transaction.Rollback()
+                        CacheIngestCommitResult.Rejected "Pending ingest identity changed before promoted publication."
+                    | Some _ ->
                         match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
                         | Error reason ->
                             transaction.Rollback()
@@ -861,68 +928,59 @@ module CacheStore =
                         | Ok () ->
                             insertMetadata connection (Some transaction) descriptor metadata
 
-                            if isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId then
+                            match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                            | Some current when descriptorMatches descriptor current ->
+                                executeNonQuery
+                                    connection
+                                    (Some transaction)
+                                    "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
+                                    (fun parameters ->
+                                        parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                                        |> ignore
+
+                                        parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                                        |> ignore)
+
                                 transaction.Commit()
-                                CacheIngestCommitResult.AlreadyPublished
-                            else
+                                CacheIngestCommitResult.Published
+                            | _ ->
                                 transaction.Rollback()
-                                CacheIngestCommitResult.Rejected "Existing artifact publication could not establish the requested root membership."
-                    | _ ->
-                        transaction.Rollback()
-                        CacheIngestCommitResult.Rejected "No current pending ingest exists for the promoted artifact."
-                | Some pending when not (descriptorMatches descriptor pending) ->
-                    transaction.Rollback()
-                    CacheIngestCommitResult.Rejected "Pending ingest identity changed before promoted publication."
-                | Some _ ->
-                    match validateCanonicalDirectoryMetadata connection (Some transaction) metadata with
-                    | Error reason ->
-                        transaction.Rollback()
-                        CacheIngestCommitResult.Rejected reason
-                    | Ok () ->
-                        insertMetadata connection (Some transaction) descriptor metadata
-
-                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
-                        | Some current when descriptorMatches descriptor current ->
-                            executeNonQuery
-                                connection
-                                (Some transaction)
-                                "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
-                                (fun parameters ->
-                                    parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
-                                    |> ignore
-
-                                    parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
-                                    |> ignore)
-
-                            transaction.Commit()
-                            CacheIngestCommitResult.Published
-                        | _ ->
-                            transaction.Rollback()
-                            CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication.")
+                                CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication."))
 
     /// Lists only artifact rows committed as valid; pending and rejected state never crosses this query boundary.
     let getValidArtifacts (store: CacheStore) : CacheValidArtifact array =
-        let sharedStore = requireLiveStore store
-        use connection = openConnection sharedStore.DatabasePath
+        withStoreOperation store (fun sharedStore ->
+            use connection = openConnection sharedStore.DatabasePath
 
-        use command =
-            createCommand
-                connection
-                None
-                "SELECT artifacts.artifact_id, artifacts.digest, artifacts.uncompressed_size, roots.root_directory_version_id FROM artifacts INNER JOIN root_artifact_memberships AS roots ON roots.artifact_id = artifacts.artifact_id WHERE artifacts.lifecycle_state = 'Valid' ORDER BY artifacts.artifact_id, roots.root_directory_version_id;"
-                ignore
+            use command =
+                createCommand
+                    connection
+                    None
+                    "SELECT artifacts.artifact_id, artifacts.digest, artifacts.uncompressed_size, roots.root_directory_version_id FROM artifacts INNER JOIN root_artifact_memberships AS roots ON roots.artifact_id = artifacts.artifact_id WHERE artifacts.lifecycle_state = 'Valid' ORDER BY artifacts.artifact_id, roots.root_directory_version_id;"
+                    ignore
 
-        use reader = command.ExecuteReader()
-        let artifacts = List<CacheValidArtifact>()
+            use reader = command.ExecuteReader()
+            let artifacts = List<CacheValidArtifact>()
 
-        while reader.Read() do
-            artifacts.Add(
-                {
-                    ArtifactId = reader.GetString(0)
-                    Digest = reader.GetString(1)
-                    UncompressedSize = reader.GetInt64(2)
-                    RootDirectoryVersionId = reader.GetString(3)
-                }
-            )
+            while reader.Read() do
+                artifacts.Add(
+                    {
+                        ArtifactId = reader.GetString(0)
+                        Digest = reader.GetString(1)
+                        UncompressedSize = reader.GetInt64(2)
+                        RootDirectoryVersionId = reader.GetString(3)
+                    }
+                )
 
-        artifacts.ToArray()
+            artifacts.ToArray())
+
+    /// Holds a deterministic in-flight operation for lifecycle tests without exposing cache persistence internals.
+    let internal runBlockedOperationForTest (store: CacheStore) (entered: ManualResetEventSlim) (release: ManualResetEventSlim) failAfterRelease =
+        withStoreOperation store (fun _ ->
+            entered.Set()
+
+            if not (release.Wait(TimeSpan.FromSeconds(10.0))) then
+                invalidOp "The cache store lifecycle test operation was not released within ten seconds."
+
+            if failAfterRelease then
+                invalidOp "The cache store lifecycle test operation failed after release.")

--- a/src/Grace.Cache/CacheStore.fs
+++ b/src/Grace.Cache/CacheStore.fs
@@ -1,0 +1,672 @@
+namespace Grace.Cache
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.Globalization
+open System.IO
+open System.Threading
+open Microsoft.Data.Sqlite
+open SQLitePCL
+
+/// Identifies immutable promoted content and the root whose metadata will retain it.
+type CacheArtifactDescriptor = { ArtifactId: string; Digest: string; UncompressedSize: int64; RootDirectoryVersionId: string; FillToken: string }
+
+/// Describes one canonical directory version and its recursive relationships in a cache ingest.
+type CacheDirectoryMetadata = { DirectoryVersionId: string; ChildDirectoryVersionIds: string list; ArtifactIds: string list }
+
+/// Carries the complete root-reachable directory graph required for one promoted artifact publication.
+type CacheRecursiveMetadata = { Directories: CacheDirectoryMetadata list }
+
+/// Reports the durable SQLite invariants established for a cache store connection.
+type CacheStoreDiagnostics = { SchemaVersion: int; JournalMode: string; ForeignKeysEnabled: bool; BusyTimeoutMilliseconds: int }
+
+/// Represents the private cache database handle used only by the cache runtime's narrow store API.
+type CacheStore = private { DatabasePath: string; Diagnostics: CacheStoreDiagnostics }
+
+/// Identifies a pending artifact that restart recovery removed and the filesystem owner must clean up.
+type CacheRecoveredIncompleteIngest = { ArtifactId: string; RootDirectoryVersionId: string; Digest: string; UncompressedSize: int64; FillToken: string }
+
+/// Returns a store after startup recovery has removed every incomplete ingest from its SQLite boundary.
+type CacheStoreOpenResult = { Store: CacheStore; RecoveredIncomplete: CacheRecoveredIncompleteIngest array }
+
+/// Distinguishes a new pending ingest from an idempotent valid or rejected source descriptor.
+type CacheIngestBeginResult =
+    | Pending
+    | AlreadyValid
+    | Rejected of reason: string
+
+/// Distinguishes atomic publication from an idempotent repeat or a rejected promotion/metadata attempt.
+type CacheIngestCommitResult =
+    | Published
+    | AlreadyPublished
+    | Rejected of reason: string
+
+/// Exposes only valid, fully committed artifacts to later cache read-through callers.
+type CacheValidArtifact = { ArtifactId: string; Digest: string; UncompressedSize: int64; RootDirectoryVersionId: string }
+
+/// Owns the schema-versioned local SQLite store for cache metadata and immutable artifact validity.
+module CacheStore =
+
+    [<Literal>]
+    let private SchemaVersion = 1
+
+    [<Literal>]
+    let private BusyTimeoutMilliseconds = 5000
+
+    let private sqliteInitialized =
+        lazy
+            (Batteries_V2.Init()
+             true)
+
+    let private initializationLocks = ConcurrentDictionary<string, obj>(StringComparer.OrdinalIgnoreCase)
+
+    let private schemaTables =
+        [|
+            "cache_schema"
+            "directory_versions"
+            "artifacts"
+            "pending_ingests"
+            "root_directory_memberships"
+            "root_artifact_memberships"
+            "directory_child_memberships"
+            "directory_artifact_memberships"
+        |]
+
+    let private schemaStatements =
+        [|
+            "CREATE TABLE IF NOT EXISTS cache_schema (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema_version INTEGER NOT NULL CHECK (schema_version > 0));"
+            "CREATE TABLE IF NOT EXISTS directory_versions (directory_version_id TEXT PRIMARY KEY NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS artifacts (artifact_id TEXT PRIMARY KEY NOT NULL, digest TEXT NOT NULL, uncompressed_size INTEGER NOT NULL CHECK (uncompressed_size >= 0), lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN ('Valid')));"
+            "CREATE TABLE IF NOT EXISTS pending_ingests (artifact_id TEXT NOT NULL, digest TEXT NOT NULL, uncompressed_size INTEGER NOT NULL CHECK (uncompressed_size >= 0), root_directory_version_id TEXT NOT NULL, fill_token TEXT NOT NULL, PRIMARY KEY (artifact_id, root_directory_version_id));"
+            "CREATE TABLE IF NOT EXISTS root_directory_memberships (root_directory_version_id TEXT NOT NULL, directory_version_id TEXT NOT NULL, PRIMARY KEY (root_directory_version_id, directory_version_id), FOREIGN KEY (root_directory_version_id) REFERENCES directory_versions(directory_version_id) ON DELETE RESTRICT, FOREIGN KEY (directory_version_id) REFERENCES directory_versions(directory_version_id) ON DELETE RESTRICT);"
+            "CREATE TABLE IF NOT EXISTS root_artifact_memberships (root_directory_version_id TEXT NOT NULL, artifact_id TEXT NOT NULL, PRIMARY KEY (root_directory_version_id, artifact_id), FOREIGN KEY (root_directory_version_id) REFERENCES directory_versions(directory_version_id) ON DELETE RESTRICT, FOREIGN KEY (artifact_id) REFERENCES artifacts(artifact_id) ON DELETE RESTRICT);"
+            "CREATE TABLE IF NOT EXISTS directory_child_memberships (directory_version_id TEXT NOT NULL, child_directory_version_id TEXT NOT NULL, PRIMARY KEY (directory_version_id, child_directory_version_id), FOREIGN KEY (directory_version_id) REFERENCES directory_versions(directory_version_id) ON DELETE RESTRICT, FOREIGN KEY (child_directory_version_id) REFERENCES directory_versions(directory_version_id) ON DELETE RESTRICT);"
+            "CREATE TABLE IF NOT EXISTS directory_artifact_memberships (directory_version_id TEXT NOT NULL, artifact_id TEXT NOT NULL, PRIMARY KEY (directory_version_id, artifact_id), FOREIGN KEY (directory_version_id) REFERENCES directory_versions(directory_version_id) ON DELETE RESTRICT, FOREIGN KEY (artifact_id) REFERENCES artifacts(artifact_id) ON DELETE RESTRICT);"
+        |]
+
+    /// Creates a parameterized command for private fixed-schema SQLite operations.
+    let private createCommand
+        (connection: SqliteConnection)
+        (transaction: SqliteTransaction option)
+        (sql: string)
+        (configure: SqliteParameterCollection -> unit)
+        =
+        let command = connection.CreateCommand()
+        command.CommandText <- sql
+
+        transaction
+        |> Option.iter (fun value -> command.Transaction <- value)
+
+        configure command.Parameters
+        command
+
+    /// Executes a private fixed-schema command and disposes it before the surrounding transaction advances.
+    let private executeNonQuery connection transaction sql configure =
+        use command = createCommand connection transaction sql configure
+        command.ExecuteNonQuery() |> ignore
+
+    /// Reads one scalar string from a private fixed-schema SQLite query.
+    let private executeScalarString connection transaction sql configure =
+        use command = createCommand connection transaction sql configure
+        let value = command.ExecuteScalar()
+
+        if isNull value || value = Convert.DBNull then
+            None
+        else
+            Some(Convert.ToString(value, CultureInfo.InvariantCulture))
+
+    /// Reads one scalar integer from a private fixed-schema SQLite query.
+    let private executeScalarInt connection transaction sql configure =
+        executeScalarString connection transaction sql configure
+        |> Option.map (fun value -> Int32.Parse(value, CultureInfo.InvariantCulture))
+
+    /// Opens a cache-local connection and verifies every required SQLite setting instead of inheriting process defaults.
+    let private openConnection (databasePath: string) =
+        sqliteInitialized.Value |> ignore
+        let directory = Path.GetDirectoryName(databasePath)
+
+        if not (String.IsNullOrWhiteSpace directory) then
+            Directory.CreateDirectory(directory) |> ignore
+
+        let builder = SqliteConnectionStringBuilder()
+        builder.DataSource <- databasePath
+        builder.Mode <- SqliteOpenMode.ReadWriteCreate
+        builder.Pooling <- true
+        builder.DefaultTimeout <- BusyTimeoutMilliseconds / 1000
+
+        let connection = new SqliteConnection(builder.ToString())
+
+        try
+            connection.Open()
+            executeNonQuery connection None $"PRAGMA busy_timeout = {BusyTimeoutMilliseconds};" ignore
+            executeNonQuery connection None "PRAGMA foreign_keys = ON;" ignore
+
+            let journalMode = executeScalarString connection None "PRAGMA journal_mode = WAL;" ignore
+            let foreignKeysEnabled = executeScalarInt connection None "PRAGMA foreign_keys;" ignore
+            let busyTimeout = executeScalarInt connection None "PRAGMA busy_timeout;" ignore
+
+            if journalMode <> Some "wal" then
+                invalidOp "Cache SQLite connection did not establish WAL journal mode."
+
+            if foreignKeysEnabled <> Some 1 then
+                invalidOp "Cache SQLite connection did not enable foreign keys."
+
+            if busyTimeout <> Some BusyTimeoutMilliseconds then
+                invalidOp "Cache SQLite connection did not establish the declared busy timeout."
+
+            connection
+        with
+        | error ->
+            connection.Dispose()
+            raise error
+
+    /// Detects a named table without querying missing schema objects.
+    let private tableExists connection tableName =
+        let count =
+            executeScalarInt connection None "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = @name;" (fun parameters ->
+                parameters.AddWithValue("@name", tableName)
+                |> ignore)
+
+        count = Some 1
+
+    /// Counts known cache tables before schema creation so a missing version marker cannot be treated as a new database.
+    let private countExistingCacheTables connection =
+        schemaTables
+        |> Array.sumBy (fun tableName -> if tableExists connection tableName then 1 else 0)
+
+    /// Ensures only the deterministic cache schema version is accepted by this store release.
+    let private ensureSchema connection =
+        let schemaExists = tableExists connection "cache_schema"
+        let existingCacheTables = countExistingCacheTables connection
+
+        if not schemaExists && existingCacheTables <> 0 then
+            invalidOp "Cache SQLite database has cache tables without the required schema version marker."
+
+        if schemaExists
+           && existingCacheTables <> schemaTables.Length then
+            invalidOp "Cache SQLite database is missing a required table for its declared schema."
+
+        use transaction = connection.BeginTransaction()
+
+        for statement in schemaStatements do
+            executeNonQuery connection (Some transaction) statement ignore
+
+        if not schemaExists then
+            executeNonQuery connection (Some transaction) "INSERT INTO cache_schema (singleton, schema_version) VALUES (1, @schemaVersion);" (fun parameters ->
+                parameters.AddWithValue("@schemaVersion", SchemaVersion)
+                |> ignore)
+
+        let versions =
+            use command = createCommand connection (Some transaction) "SELECT schema_version FROM cache_schema ORDER BY singleton;" ignore
+            use reader = command.ExecuteReader()
+            let values = List<int>()
+
+            while reader.Read() do
+                values.Add(reader.GetInt32(0))
+
+            values
+
+        if versions.Count <> 1
+           || versions[0] <> SchemaVersion then
+            invalidOp "Cache SQLite database has an unsupported schema version."
+
+        transaction.Commit()
+
+    /// Fails closed when SQLite detects relational or page-level corruption before recovery or valid reads proceed.
+    let private verifyIntegrity connection =
+        let integrity = executeScalarString connection None "PRAGMA integrity_check;" ignore
+
+        if integrity <> Some "ok" then invalidOp "Cache SQLite integrity check failed."
+
+        use command = createCommand connection None "PRAGMA foreign_key_check;" ignore
+        use reader = command.ExecuteReader()
+
+        if reader.Read() then
+            invalidOp "Cache SQLite foreign-key integrity check failed."
+
+    /// Reads a pending or valid descriptor without exposing SQL tables outside the store module.
+    let private tryReadDescriptor connection transaction tableName artifactId rootDirectoryVersionId : CacheArtifactDescriptor option =
+        let sql =
+            if tableName = "pending_ingests" then
+                "SELECT artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
+            else
+                "SELECT artifact_id, digest, uncompressed_size, NULL, NULL FROM artifacts WHERE artifact_id = @artifactId;"
+
+        use command =
+            createCommand connection transaction sql (fun parameters ->
+                parameters.AddWithValue("@artifactId", artifactId)
+                |> ignore
+
+                if tableName = "pending_ingests" then
+                    parameters.AddWithValue("@rootDirectoryVersionId", rootDirectoryVersionId)
+                    |> ignore)
+
+        use reader = command.ExecuteReader()
+
+        if reader.Read() then
+            Some
+                {
+                    ArtifactId = reader.GetString(0)
+                    Digest = reader.GetString(1)
+                    UncompressedSize = reader.GetInt64(2)
+                    RootDirectoryVersionId = if reader.IsDBNull(3) then "" else reader.GetString(3)
+                    FillToken = if reader.IsDBNull(4) then "" else reader.GetString(4)
+                }
+        else
+            None
+
+    /// Compares the complete stale-sensitive identity tuple used for pending and valid publication decisions.
+    let private descriptorMatches (expected: CacheArtifactDescriptor) (actual: CacheArtifactDescriptor) =
+        expected.ArtifactId = actual.ArtifactId
+        && expected.Digest = actual.Digest
+        && expected.UncompressedSize = actual.UncompressedSize
+        && (String.IsNullOrEmpty(actual.RootDirectoryVersionId)
+            || expected.RootDirectoryVersionId = actual.RootDirectoryVersionId)
+        && (String.IsNullOrEmpty(actual.FillToken)
+            || expected.FillToken = actual.FillToken)
+
+    /// Detects whether an already-valid canonical artifact is retained under the descriptor's requested root.
+    let private isArtifactRetainedByRoot connection transaction artifactId rootDirectoryVersionId =
+        let count =
+            executeScalarInt
+                connection
+                transaction
+                "SELECT COUNT(*) FROM root_artifact_memberships WHERE root_directory_version_id = @rootDirectoryVersionId AND artifact_id = @artifactId;"
+                (fun parameters ->
+                    parameters.AddWithValue("@rootDirectoryVersionId", rootDirectoryVersionId)
+                    |> ignore
+
+                    parameters.AddWithValue("@artifactId", artifactId)
+                    |> ignore)
+
+        count |> Option.defaultValue 0 > 0
+
+    /// Validates source identity before it can become either pending state or a valid artifact row.
+    let private validateDescriptor (descriptor: CacheArtifactDescriptor) =
+        let hasSha256Shape (value: string) =
+            value.Length = 64
+            && value
+               |> Seq.forall (fun character -> Uri.IsHexDigit(character))
+
+        if String.IsNullOrWhiteSpace descriptor.ArtifactId then
+            Error "Artifact id is required."
+        elif not (hasSha256Shape descriptor.Digest) then
+            Error "Artifact digest must be a 64-character hexadecimal SHA-256 value."
+        elif descriptor.UncompressedSize < 0L then
+            Error "Artifact uncompressed size cannot be negative."
+        elif String.IsNullOrWhiteSpace descriptor.RootDirectoryVersionId then
+            Error "Root directory version id is required."
+        elif String.IsNullOrWhiteSpace descriptor.FillToken then
+            Error "Fill token is required."
+        else
+            Ok()
+
+    /// Validates that recursive metadata is non-empty, canonical, root-reachable, and tied only to the promoted artifact.
+    let private validateMetadata (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) =
+        if List.isEmpty metadata.Directories then
+            Error "Recursive metadata must contain the promoted root directory."
+        else
+            let directories = Dictionary<string, CacheDirectoryMetadata>(StringComparer.Ordinal)
+            let mutable error = None
+
+            for directory in metadata.Directories do
+                if String.IsNullOrWhiteSpace directory.DirectoryVersionId then
+                    error <- Some "Directory version ids are required."
+                elif directories.ContainsKey(directory.DirectoryVersionId) then
+                    error <- Some "Recursive metadata cannot repeat a directory version id."
+                else
+                    directories.Add(directory.DirectoryVersionId, directory)
+
+            if error.IsSome then
+                Error error.Value
+            elif not (directories.ContainsKey(descriptor.RootDirectoryVersionId)) then
+                Error "Recursive metadata must contain the descriptor root directory version id."
+            else
+                let mutable hasPromotedArtifact = false
+
+                for directory in metadata.Directories do
+                    for childId in directory.ChildDirectoryVersionIds do
+                        if
+                            String.IsNullOrWhiteSpace childId
+                            || not (directories.ContainsKey(childId))
+                        then
+                            error <- Some "Every child directory membership must reference supplied recursive metadata."
+                        elif childId = directory.DirectoryVersionId then
+                            error <- Some "A directory cannot be its own child."
+
+                    for artifactId in directory.ArtifactIds do
+                        if artifactId <> descriptor.ArtifactId then
+                            error <- Some "Recursive metadata cannot reference an artifact that was not confirmed for this ingest."
+                        else
+                            hasPromotedArtifact <- true
+
+                if error.IsSome then
+                    Error error.Value
+                elif not hasPromotedArtifact then
+                    Error "Recursive metadata must retain the confirmed promoted artifact."
+                else
+                    let reachable = HashSet<string>(StringComparer.Ordinal)
+                    let pending = Stack<string>()
+                    pending.Push(descriptor.RootDirectoryVersionId)
+
+                    while pending.Count > 0 do
+                        let directoryId = pending.Pop()
+
+                        if reachable.Add(directoryId) then
+                            for childId in directories[directoryId].ChildDirectoryVersionIds do
+                                pending.Push(childId)
+
+                    if reachable.Count <> directories.Count then
+                        Error "Recursive metadata cannot contain directories unreachable from the descriptor root."
+                    else
+                        Ok()
+
+    /// Executes a write operation again only when SQLite reports a bounded busy or locked condition.
+    let private withBusyRetry operation =
+        let rec execute attempt =
+            try
+                operation ()
+            with
+            | :? SqliteException as error when
+                (error.SqliteErrorCode = 5
+                 || error.SqliteErrorCode = 6)
+                && attempt < 6
+                ->
+                Thread.Sleep(25 * (attempt + 1))
+                execute (attempt + 1)
+
+        execute 0
+
+    /// Inserts a canonical row or retains the prior identical canonical row without exposing an upsert API.
+    let private insertDirectory connection transaction directoryId =
+        executeNonQuery
+            connection
+            transaction
+            "INSERT INTO directory_versions (directory_version_id) VALUES (@directoryId) ON CONFLICT(directory_version_id) DO NOTHING;"
+            (fun parameters ->
+                parameters.AddWithValue("@directoryId", directoryId)
+                |> ignore)
+
+    /// Persists every verified recursive relation inside the publication transaction.
+    let private insertMetadata connection transaction (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) =
+        insertDirectory connection transaction descriptor.RootDirectoryVersionId
+
+        for directory in metadata.Directories do
+            insertDirectory connection transaction directory.DirectoryVersionId
+
+        executeNonQuery
+            connection
+            transaction
+            "INSERT INTO artifacts (artifact_id, digest, uncompressed_size, lifecycle_state) VALUES (@artifactId, @digest, @uncompressedSize, 'Valid') ON CONFLICT(artifact_id) DO NOTHING;"
+            (fun parameters ->
+                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                |> ignore
+
+                parameters.AddWithValue("@digest", descriptor.Digest)
+                |> ignore
+
+                parameters.AddWithValue("@uncompressedSize", descriptor.UncompressedSize)
+                |> ignore)
+
+        executeNonQuery
+            connection
+            transaction
+            "INSERT INTO root_artifact_memberships (root_directory_version_id, artifact_id) VALUES (@rootDirectoryVersionId, @artifactId) ON CONFLICT(root_directory_version_id, artifact_id) DO NOTHING;"
+            (fun parameters ->
+                parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                |> ignore
+
+                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                |> ignore)
+
+        for directory in metadata.Directories do
+            executeNonQuery
+                connection
+                transaction
+                "INSERT INTO root_directory_memberships (root_directory_version_id, directory_version_id) VALUES (@rootDirectoryVersionId, @directoryVersionId) ON CONFLICT(root_directory_version_id, directory_version_id) DO NOTHING;"
+                (fun parameters ->
+                    parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                    |> ignore
+
+                    parameters.AddWithValue("@directoryVersionId", directory.DirectoryVersionId)
+                    |> ignore)
+
+            for childId in directory.ChildDirectoryVersionIds do
+                executeNonQuery
+                    connection
+                    transaction
+                    "INSERT INTO directory_child_memberships (directory_version_id, child_directory_version_id) VALUES (@directoryVersionId, @childDirectoryVersionId) ON CONFLICT(directory_version_id, child_directory_version_id) DO NOTHING;"
+                    (fun parameters ->
+                        parameters.AddWithValue("@directoryVersionId", directory.DirectoryVersionId)
+                        |> ignore
+
+                        parameters.AddWithValue("@childDirectoryVersionId", childId)
+                        |> ignore)
+
+            for artifactId in directory.ArtifactIds do
+                executeNonQuery
+                    connection
+                    transaction
+                    "INSERT INTO directory_artifact_memberships (directory_version_id, artifact_id) VALUES (@directoryVersionId, @artifactId) ON CONFLICT(directory_version_id, artifact_id) DO NOTHING;"
+                    (fun parameters ->
+                        parameters.AddWithValue("@directoryVersionId", directory.DirectoryVersionId)
+                        |> ignore
+
+                        parameters.AddWithValue("@artifactId", artifactId)
+                        |> ignore)
+
+    /// Reads and deletes all pending rows atomically so restart cannot elevate incomplete state to valid.
+    let private recoverIncompleteIngests (connection: SqliteConnection) =
+        use transaction = connection.BeginTransaction()
+
+        use command =
+            createCommand
+                connection
+                (Some transaction)
+                "SELECT artifact_id, root_directory_version_id, digest, uncompressed_size, fill_token FROM pending_ingests ORDER BY artifact_id;"
+                ignore
+
+        use reader = command.ExecuteReader()
+        let recovered = List<CacheRecoveredIncompleteIngest>()
+
+        while reader.Read() do
+            recovered.Add(
+                {
+                    ArtifactId = reader.GetString(0)
+                    RootDirectoryVersionId = reader.GetString(1)
+                    Digest = reader.GetString(2)
+                    UncompressedSize = reader.GetInt64(3)
+                    FillToken = reader.GetString(4)
+                }
+            )
+
+        reader.Close()
+        executeNonQuery connection (Some transaction) "DELETE FROM pending_ingests;" ignore
+        transaction.Commit()
+        recovered.ToArray()
+
+    /// Creates or verifies the cache schema, checks integrity, and recovers incomplete transactions before exposing a store.
+    let openStore databasePath =
+        if String.IsNullOrWhiteSpace databasePath then
+            invalidArg (nameof databasePath) "Cache database path is required."
+
+        let fullPath = Path.GetFullPath(databasePath)
+        let initializationLock = initializationLocks.GetOrAdd(fullPath, (fun _ -> obj ()))
+
+        lock initializationLock (fun () ->
+            use connection = openConnection fullPath
+            ensureSchema connection
+            verifyIntegrity connection
+            let recovered = recoverIncompleteIngests connection
+            verifyIntegrity connection
+
+            {
+                Store =
+                    {
+                        DatabasePath = fullPath
+                        Diagnostics =
+                            { SchemaVersion = SchemaVersion; JournalMode = "wal"; ForeignKeysEnabled = true; BusyTimeoutMilliseconds = BusyTimeoutMilliseconds }
+                    }
+                RecoveredIncomplete = recovered
+            })
+
+    /// Returns the verified connection settings captured while the store was opened.
+    let getDiagnostics (store: CacheStore) = store.Diagnostics
+
+    /// Records a valid source descriptor as pending while rejecting malformed or stale identities before persistence.
+    let beginIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) : CacheIngestBeginResult =
+        match validateDescriptor descriptor with
+        | Error reason -> CacheIngestBeginResult.Rejected reason
+        | Ok () ->
+            withBusyRetry (fun () ->
+                use connection = openConnection store.DatabasePath
+                use transaction = connection.BeginTransaction()
+
+                match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
+                | Some valid when
+                    descriptorMatches descriptor valid
+                    && isArtifactRetainedByRoot connection (Some transaction) descriptor.ArtifactId descriptor.RootDirectoryVersionId
+                    ->
+                    transaction.Commit()
+                    CacheIngestBeginResult.AlreadyValid
+                | Some _ ->
+                    match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
+                    | Some valid when descriptorMatches descriptor valid ->
+                        match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                        | Some pending when descriptorMatches descriptor pending ->
+                            transaction.Commit()
+                            CacheIngestBeginResult.Pending
+                        | Some _ ->
+                            transaction.Rollback()
+                            CacheIngestBeginResult.Rejected "Artifact/root pair already has a pending ingest with a different stale-sensitive identity."
+                        | None ->
+                            executeNonQuery
+                                connection
+                                (Some transaction)
+                                "INSERT INTO pending_ingests (artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token) VALUES (@artifactId, @digest, @uncompressedSize, @rootDirectoryVersionId, @fillToken);"
+                                (fun parameters ->
+                                    parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                                    |> ignore
+
+                                    parameters.AddWithValue("@digest", descriptor.Digest)
+                                    |> ignore
+
+                                    parameters.AddWithValue("@uncompressedSize", descriptor.UncompressedSize)
+                                    |> ignore
+
+                                    parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                                    |> ignore
+
+                                    parameters.AddWithValue("@fillToken", descriptor.FillToken)
+                                    |> ignore)
+
+                            transaction.Commit()
+                            CacheIngestBeginResult.Pending
+                    | Some _ ->
+                        transaction.Rollback()
+                        CacheIngestBeginResult.Rejected "Artifact id already belongs to a different valid immutable descriptor."
+                    | None ->
+                        transaction.Rollback()
+                        CacheIngestBeginResult.Rejected "Artifact state changed before the root-specific pending ingest could be recorded."
+                | None ->
+                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                    | Some pending when descriptorMatches descriptor pending ->
+                        transaction.Commit()
+                        CacheIngestBeginResult.Pending
+                    | Some _ ->
+                        transaction.Rollback()
+                        CacheIngestBeginResult.Rejected "Artifact id already has a pending ingest with a different stale-sensitive identity."
+                    | None ->
+                        executeNonQuery
+                            connection
+                            (Some transaction)
+                            "INSERT INTO pending_ingests (artifact_id, digest, uncompressed_size, root_directory_version_id, fill_token) VALUES (@artifactId, @digest, @uncompressedSize, @rootDirectoryVersionId, @fillToken);"
+                            (fun parameters ->
+                                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                                |> ignore
+
+                                parameters.AddWithValue("@digest", descriptor.Digest)
+                                |> ignore
+
+                                parameters.AddWithValue("@uncompressedSize", descriptor.UncompressedSize)
+                                |> ignore
+
+                                parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                                |> ignore
+
+                                parameters.AddWithValue("@fillToken", descriptor.FillToken)
+                                |> ignore)
+
+                        transaction.Commit()
+                        CacheIngestBeginResult.Pending)
+
+    /// Atomically publishes one confirmed artifact and its complete recursive metadata only while the original pending identity remains current.
+    let commitPromotedIngest (store: CacheStore) (descriptor: CacheArtifactDescriptor) (metadata: CacheRecursiveMetadata) : CacheIngestCommitResult =
+        match validateDescriptor descriptor, validateMetadata descriptor metadata with
+        | Error reason, _
+        | _, Error reason -> CacheIngestCommitResult.Rejected reason
+        | Ok (), Ok () ->
+            withBusyRetry (fun () ->
+                use connection = openConnection store.DatabasePath
+                use transaction = connection.BeginTransaction()
+
+                match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                | None ->
+                    match tryReadDescriptor connection (Some transaction) "artifacts" descriptor.ArtifactId "" with
+                    | Some valid when descriptorMatches descriptor valid ->
+                        transaction.Commit()
+                        CacheIngestCommitResult.AlreadyPublished
+                    | _ ->
+                        transaction.Rollback()
+                        CacheIngestCommitResult.Rejected "No current pending ingest exists for the promoted artifact."
+                | Some pending when not (descriptorMatches descriptor pending) ->
+                    transaction.Rollback()
+                    CacheIngestCommitResult.Rejected "Pending ingest identity changed before promoted publication."
+                | Some _ ->
+                    insertMetadata connection (Some transaction) descriptor metadata
+
+                    match tryReadDescriptor connection (Some transaction) "pending_ingests" descriptor.ArtifactId descriptor.RootDirectoryVersionId with
+                    | Some current when descriptorMatches descriptor current ->
+                        executeNonQuery
+                            connection
+                            (Some transaction)
+                            "DELETE FROM pending_ingests WHERE artifact_id = @artifactId AND root_directory_version_id = @rootDirectoryVersionId;"
+                            (fun parameters ->
+                                parameters.AddWithValue("@artifactId", descriptor.ArtifactId)
+                                |> ignore
+
+                                parameters.AddWithValue("@rootDirectoryVersionId", descriptor.RootDirectoryVersionId)
+                                |> ignore)
+
+                        transaction.Commit()
+                        CacheIngestCommitResult.Published
+                    | _ ->
+                        transaction.Rollback()
+                        CacheIngestCommitResult.Rejected "Pending ingest identity changed before valid publication.")
+
+    /// Lists only artifact rows committed as valid; pending and rejected state never crosses this query boundary.
+    let getValidArtifacts (store: CacheStore) : CacheValidArtifact array =
+        use connection = openConnection store.DatabasePath
+
+        use command =
+            createCommand
+                connection
+                None
+                "SELECT artifacts.artifact_id, artifacts.digest, artifacts.uncompressed_size, roots.root_directory_version_id FROM artifacts INNER JOIN root_artifact_memberships AS roots ON roots.artifact_id = artifacts.artifact_id WHERE artifacts.lifecycle_state = 'Valid' ORDER BY artifacts.artifact_id, roots.root_directory_version_id;"
+                ignore
+
+        use reader = command.ExecuteReader()
+        let artifacts = List<CacheValidArtifact>()
+
+        while reader.Read() do
+            artifacts.Add(
+                {
+                    ArtifactId = reader.GetString(0)
+                    Digest = reader.GetString(1)
+                    UncompressedSize = reader.GetInt64(2)
+                    RootDirectoryVersionId = reader.GetString(3)
+                }
+            )
+
+        artifacts.ToArray()

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -11,10 +11,13 @@
 
   <ItemGroup>
     <Compile Include="CacheHost.fs" />
+    <Compile Include="CacheStore.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.301" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary

- add a deterministic versioned SQLite store for cache metadata and pending ingest state
- enforce WAL, foreign keys, busy timeout, integrity checks, transactional publication, and fail-closed recovery
- preserve canonical directory/artifact rows across overlapping roots through explicit membership tables
- add focused restart, corruption, idempotency, overlap, interruption, and concurrency proof

## Why This Matters

Grace Cache needs a durable local index that can survive process restarts and concurrent fills without publishing incomplete or corrupt metadata. This slice establishes that internal store boundary without introducing CLI state, artifact filesystem behavior, or prefetch workflow state.

## Issue

Related to #623.

Part of #601 and #597.

## Validation

- focused RED: five directly observable ledger tests failed against reviewed head `9ac2e487`, as expected
- targeted Fantomas passed for all touched F# files
- focused Release build passed
- focused `Grace.Cache.Tests` persistence suite passed 23/23
- `git diff --check` passed
- local `pwsh ./scripts/validate.ps1 -Full` passed with only the existing Aspire F# support warning
- [hosted current-head Full](https://github.com/ScottArbeit/Grace/actions/runs/29301252507/job/86985307168) passed

## Review Status

- Current head: `c968744a9a55bab7a494f69a96be010a0903ab1b`
- Codex review: session 4 completed with finding `3576896827`; all earlier findings remain fixed and resolved
- Maintainer decision: the supported deployment has exactly one active `grace cache` instance and one cache store per
  machine
- Finding disposition: `3576896827` is invalid under that supported deployment and requires no #623 code change;
  filesystem case discovery would support an explicitly unsupported multi-store or alternate-path shape
- Propagated obligation: #622 now requires a machine-wide single-instance startup guard before cache-store creation,
  recovery, listener readiness, or server mutation; the guard cannot depend on the database path or filesystem case
  behavior
- #623 contract: retain defensive locking for the one configured database and restart recovery; alternate-path reopening,
  case-only aliases, and multiple database identities on one machine are not supported contracts
- Validation: focused structural proofs passed 4/4; persistence suite passed 31/31; targeted Fantomas and
  `git diff --check` passed; local and hosted current-head Full passed
- Review threads: `3576896827` has the approved no-code reply and is resolved; zero unresolved threads remain
- Substantive review cycles: 3; the stabilization ledger is revised and approved, with no further #623 coding authorized
- Merge readiness: current head is 0 commits behind the epic base, the scoped five-file diff has no unexpected deletions,
  GitHub reports MERGEABLE/CLEAN, and the current-head hosted Full check passed
- Manual review trigger: prohibited; no review was requested as part of this disposition
- Prevention: supported runtime cardinality is now explicit in #623, and #622 carries the machine-singleton startup proof
  so filesystem-specific path equivalence cannot silently return as a cache-store requirement.

## Documentation

No documentation change. This issue adds no public command, route, SDK contract, operator configuration, or supported reset workflow.
