### PR TITLE
Use focused local proof and authoritative PR Validate

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -171,9 +171,10 @@ body:
     attributes:
       label: Expected validation
       placeholder: |
-        - focused test command
-        - fast validation expectation
-        - full validation expectation, if needed
+        - required focused local proof
+        - required formatting, linting, generated-file, or syntax checks
+        - required GitHub Validate expectation for the current pull-request revision
+        - exceptional local Fast or Full requirement with reason, or N/A
         - manual validation, if any
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,7 +47,7 @@ Details:
 - [ ] Owned paths and forbidden paths reviewed against the issue.
 - [ ] Sensitive surfaces reviewed and marked below.
 - [ ] README, CONTRIBUTING, AGENTS, and docs drift checked.
-- [ ] Skipped validation is explicitly listed with a reason.
+- [ ] Any genuinely required validation that was not run is explicitly listed with a reason.
 
 ## Risk surfaces
 
@@ -69,15 +69,28 @@ Choose one:
 - [ ] Docs impact: None - reason
 - [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.
 
-## Validation run
+## Local focused evidence
 
-- [ ] `pwsh ./scripts/validate.ps1 -Fast`
-- [ ] `pwsh ./scripts/validate.ps1 -Full`
-- [ ] Focused tests: command
-- [ ] Formatting/linting: command
-- [ ] Manual validation: command or steps
+- [ ] Focused proof: command and result
+- [ ] Formatting/linting: command and result
+- [ ] Generated-file/freshness or syntax checks: command and result
+- [ ] Manual validation: command, steps, or N/A
+
+## Optional local broad preflight
+
+- [ ] Fast, Full, or neither: result and reason when run
+
+## Required CI evidence
+
+- Current head SHA:
+- GitHub `Validate` state:
+- GitHub Actions run link:
+- [ ] The result was triggered by and remains associated with the latest PR revision.
 
 ## Validation not run
+
+List only required proof that was omitted. Normal omission of local Fast or Full after focused proof is not skipped
+validation.
 
 ## Residual risks
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
           exit "${pull_failed}"
-      - name: Test
+      - name: Test every solution project through the shared Full profile
         env:
           GRACE_TEST_SERVER_CLEANUP: "0"
-        run: dotnet test "src/Grace.slnx" --configuration Release --no-build --no-restore
+        run: pwsh ./scripts/validate.ps1 -Full -SkipFormat -SkipBuild -Configuration Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,12 @@ Prerequisites:
 Commands:
 
 - `pwsh ./scripts/bootstrap.ps1`
-- `pwsh ./scripts/validate.ps1 -Fast`
+- Run the smallest meaningful focused proof for the changed slice.
 
-Use `pwsh ./scripts/validate.ps1 -Full` for Aspire integration coverage.
-Optional: `pwsh ./scripts/install-githooks.ps1` to add a pre-commit `validate -Fast` hook.
+Use `pwsh ./scripts/validate.ps1 -Fast` as an optional broad local preflight and `-Full` for local integration
+reproduction or diagnosis. GitHub `Validate` is the required broad gate for the current pull-request revision.
+Optional: `pwsh ./scripts/install-githooks.ps1` adds a lightweight pre-commit staged-diff check; focused tests and
+formatting remain explicit responsibilities.
 
 More context:
 
@@ -113,31 +115,22 @@ so links stay traceable without relying on epic-branch auto-close behavior.
   issues, or current `origin/epic/...` for sub-issues under the required epic integration branch.
 - When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
   absolute path under the assigned worktree. After the first patch, verify git status in both locations.
-- Prefer vertical slices with focused tests and `pwsh ./scripts/validate.ps1 -Fast` as the normal validation gate.
-- Use `pwsh ./scripts/validate.ps1 -Full` when Aspire, emulators, storage, Service Bus, Cosmos DB, Redis,
-  deployment/runtime behavior, or cross-service integration is affected.
-- Order validation to avoid duplicate builds. Run targeted Fantomas formatting or checks before validation for touched
-  F# files, then choose exactly one final build/test gate. If the slice will run
-  `pwsh ./scripts/validate.ps1 -Fast` or `pwsh ./scripts/validate.ps1 -Full`, do not also ask workers to routinely run
-  project-specific `dotnet build` plus `dotnet test --no-build`; `validate` is the final build/test gate.
-- Focused project build/test is appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
-  outside the selected validate profile, or issues that explicitly require a focused-only gate. When a focused test
-  command uses `--no-build`, run the matching Release build for that project after formatting and before the
-  `--no-build` test command.
-- Freshness or generated-file update workers follow the same validation ladder: formatting or freshness checks first,
-  then exactly one final build/test gate. If `validate -Fast` or `validate -Full` runs, do not also run routine focused
-  build/test commands.
+- Prefer vertical slices with focused local proof: RED where applicable, formatting, the smallest relevant test or
+  parser/lint/rendered-artifact check, required freshness checks, and `git diff --check` before each commit.
+- Do not routinely run local Fast or Full and then repeat the same broad proof in required CI. Fast is an optional
+  broad preflight; Full is for local integration reproduction or diagnosis. Use either only for concrete escalation,
+  such as unavailable CI, broad compile fan-out, a requested gate, or local investigation.
+- When a focused `dotnet test` command uses `--no-build`, run the matching Release build first. If Fast or Full is
+  intentionally selected, it replaces—not supplements—the routine focused build/test gate for that checkpoint.
 - Treat parallel work as two separate decisions: product/DAG independence and merge/write-set independence. Run
   branches in parallel only when their write sets are disjoint enough to avoid predictable churn. Serialize or
   merge-queue branches that touch shared project files such as `*.fsproj`, `Startup.Server.fs`, or the same test/helper
   files. For broad waves, consider a preparatory compile-item or file-scaffold slice before later branches edit
   separate files.
-- Before the Grace completion review gate, update the branch against current `origin/main`, verify ahead/behind,
-  verify the scoped diff and that no unexpected deletions are present, run the chosen validation gate, then wait for
-  Codex Code Review Bot to review the refreshed PR head. A bot signal on a stale commit does not satisfy the completion
-  gate. For sub-issue PRs targeting an epic integration branch, run that freshness gate against the current epic branch;
-  for the final epic-to-`main` PR, run it against current `origin/main`.
-- Commit after each completed slice and keep pull requests focused and reviewable.
+- Before the completion review gate, update against the required base, inspect ahead/behind, the scoped diff, unexpected
+  deletions, and relevant conflict resolutions, then rerun focused proof if they affect the slice. Push and require
+  current GitHub `Validate` plus Codex Code Review Bot state for that revision.
+- Commit after each completed slice; push one or more completed local commits as a coherent, reviewable checkpoint.
 - When acting as the main implementation orchestrator, delegate each coding task and each fix task to a fresh worker
   subagent. The main orchestrator must not implement, repair, inspect or validate code fixes as a substitute for the
   worker, or commit code changes locally. If an earlier worker thread is lost, compacted away, leaves uncommitted work,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This repo is primarily **F#** and targets **.NET 10**.
 4. Test:
 
    - `dotnet test ./src/Grace.slnx` (optionally add `-c Release`)
-   - Or run the repo validator: `pwsh ./scripts/validate.ps1 -Full`
+   - Run the smallest focused proof for your change; GitHub `Validate` is the broad pull-request gate.
 
 5. Format F#:
 
@@ -67,8 +67,12 @@ From the repo root:
 
 This repo also includes a validation script:
 
-- Fast loop: `pwsh ./scripts/validate.ps1 -Fast`
-- Full validation (includes Aspire integration coverage): `pwsh ./scripts/validate.ps1 -Full`
+- Optional broad local preflight: `pwsh ./scripts/validate.ps1 -Fast`
+- Local integration reproduction or diagnosis: `pwsh ./scripts/validate.ps1 -Full`
+
+Before each commit, run focused proof, formatting or syntax checks, required freshness checks, and `git diff --check`.
+Commit completed slices, then push a coherent reviewable checkpoint. GitHub `Validate` is the required broad proof for
+the current pull-request revision; omitting redundant local Fast or Full is normal, not skipped validation.
 
 ## Formatting (required)
 
@@ -327,11 +331,10 @@ Prometheus:
 
 ## Pull request checklist
 
-- [ ] Builds: `dotnet build ./src/Grace.slnx`
-- [ ] Tests: `dotnet test ./src/Grace.slnx`
 - [ ] Formatting: run `dotnet tool run fantomas --recurse .` from `./src`
 - [ ] Focused validation for the touched behavior is listed in the PR
+- [ ] Required GitHub `Validate` passed for the current PR revision
 - [ ] Local review-only subagent loop completed with no remaining issues
-- [ ] Skipped validation is listed with a reason
+- [ ] Any genuinely required validation not run is listed with a reason
 - [ ] Documentation updated (if behavior changed)
 - [ ] Docs impact, residual risk, and rollback or recovery notes are recorded when relevant

--- a/GraceDevelopmentProcess.html
+++ b/GraceDevelopmentProcess.html
@@ -349,7 +349,7 @@
         <span>GitHub issue first</span>
         <span>Owned paths</span>
         <span>Vertical slices</span>
-        <span>Fast validation</span>
+        <span>Focused local proof</span>
         <span>Checkpoint commits</span>
         <span>Promotion-ready review</span>
       </div>
@@ -378,8 +378,8 @@
           <h3>Keep Grace-Native</h3>
           <ul>
             <li>Use GitHub issues as the active task record for implementation work.</li>
-            <li>Use <code>pwsh ./scripts/validate.ps1 -Fast</code> as the normal validation gate.</li>
-            <li>Use <code>-Full</code> when Aspire, integration, emulators, or cross-service behavior changes.</li>
+            <li>Use focused local proof before each commit; GitHub <code>Validate</code> is the broad PR gate.</li>
+            <li>Use <code>-Fast</code> as an optional preflight and <code>-Full</code> for local diagnosis or reproduction.</li>
             <li>Keep the fork and PR contribution path for outside contributors.</li>
             <li>Use epic integration branches when the whole epic is the production-safe unit for <code>main</code>.</li>
             <li>Map final integration language to Grace's promotion model: candidates, gates, attestations, and review reports.</li>
@@ -531,16 +531,16 @@ Definition of done:</code></pre>
         </article>
 
         <article class="step" data-step="8">
-          <h3>Run the fastest meaningful validation first</h3>
+          <h3>Prove the slice locally, certify it broadly in CI</h3>
           <p>
-            Start with the impacted test project, then promote to the repo validator when the change crosses project,
-            fixture, build, or integration boundaries. The normal repo gates are:
+            Start with the impacted test project, parser, linter, or rendered artifact, then run freshness checks and
+            <code>git diff --check</code>. GitHub <code>Validate</code> certifies the current PR revision broadly:
           </p>
           <pre><code>pwsh ./scripts/validate.ps1 -Fast
 pwsh ./scripts/validate.ps1 -Full</code></pre>
           <p>
-            Use <code>-Full</code> when Aspire integration, emulators, storage, Service Bus, Cosmos, Redis, deployment,
-            or cross-service behavior matters.
+            Use <code>-Fast</code> only for a justified local broad preflight. Use <code>-Full</code> for local
+            integration diagnosis or reproduction. Commit each completed slice and push coherent checkpoints.
           </p>
         </article>
 
@@ -668,7 +668,7 @@ Definition of done:
           <h3>CLI Or Server Boundary</h3>
           <p>
             Commands, endpoints, SDK calls, or actor-backed workflows. Prefer focused command/API/server-surface tests
-            before broader validation.
+            before optional broader local validation.
           </p>
         </div>
         <div class="panel">
@@ -681,8 +681,8 @@ Definition of done:
         <div class="panel">
           <h3>Deployment Runtime</h3>
           <p>
-            Aspire, emulators, Azure settings, Docker, or scripts. Pair parser/script checks with
-            <code>validate.ps1 -Full</code> or live evidence when runtime behavior is affected.
+            Aspire, emulators, Azure settings, Docker, or scripts. Pair parser/script checks with focused live evidence;
+            use <code>validate.ps1 -Full</code> for local diagnosis and GitHub <code>Validate</code> for broad CI proof.
           </p>
         </div>
         <div class="panel">

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ Grace development uses a task-record-first process that keeps human and agent wo
 4. Claim the issue with a comment, assign it to the authenticated GitHub user, and create an issue-owned worktree from
    the latest `origin/main`.
 5. Work in vertical slices that prove one public behavior at a time.
-6. Validate with the fastest meaningful focused command, then run `pwsh ./scripts/validate.ps1 -Fast` for the normal
-   repo gate.
-7. Use `pwsh ./scripts/validate.ps1 -Full` when Aspire integration, emulators, storage, Cosmos DB, Service Bus, Redis,
-   deployment/runtime behavior, or cross-service behavior changes.
-8. Commit after each completed slice and keep pull requests focused.
+6. Validate with the fastest meaningful focused command, formatting or syntax checks, and `git diff --check`.
+7. Use `pwsh ./scripts/validate.ps1 -Fast` only as an optional broad local preflight and `-Full` for local integration
+   reproduction or diagnosis. GitHub `Validate` is the required broad gate for the current pull-request revision.
+8. Commit after each completed slice and push one or more completed commits as a coherent, reviewable checkpoint.
 9. Update docs and nearby `AGENTS.md` files when behavior, commands, APIs, dependencies, or workflow changes.
 
 When a maintainer says `Plan <work item>`, plan the work in chat. Create a GitHub issue only when they explicitly ask

--- a/docs/Development process.md
+++ b/docs/Development process.md
@@ -19,8 +19,8 @@ For small typo fixes or tiny docs corrections, keep the spirit of the process bu
   paths.
 - Prefer vertical slices over broad horizontal phases.
 - Add or update focused tests for behavior changes.
-- Run the fastest meaningful validation first, then broader validation when risk or shared surfaces justify it.
-- Commit after each completed slice so review scope stays clear.
+- Run the smallest meaningful focused proof locally; use broader local validation only as an explicit escalation.
+- Commit after each completed slice, then push one or more completed commits as a coherent reviewable checkpoint.
 - Keep docs, README guidance, and nearby `AGENTS.md` files aligned with behavior and workflow changes.
 - Include the purpose behind each feature or implementation change. Plans, issue bodies, and pull request bodies should
   explain why the work benefits Grace and its users so implementation agents can make better decisions when details are
@@ -274,8 +274,6 @@ not a new required section.
 If review finds a missing class of acceptance criterion, adversarial case, contract propagation, or validation evidence,
 update active and future sibling issues before assigning more workers. Preserve issue history by appending an addendum
 unless replacing stale text is clearer and safe.
-
-
 
 ### Decision Closure And Contract Propagation
 
@@ -676,8 +674,6 @@ true:
 
 After every review-fix push, wait for Codex Code Review Bot to finish on the new head before assigning more fix work.
 
-
-
 ### Repeated Review Cycle Learning Loop
 
 A PR crosses the stabilization threshold when it has three substantive Codex review cycles, two cycles on the same
@@ -789,8 +785,8 @@ The review loop is blocking:
    validation evidence, repeated trap, or issue-template gap that could affect active or future workers, amend the
    active and future sibling issues before spawning more workers. Update the issue template or agent docs when the trap
    is structural. Preserve issue history by appending an addendum unless replacing stale text is clearer and safe.
-6. The implementation subagent re-runs focused validation for the changed behavior or docs, plus broader validation when
-   the fix touches shared or risky surfaces.
+6. The implementation subagent adds focused regression proof for the changed behavior or docs, then uses GitHub
+   `Validate` as the current-revision broad result. Local Fast or Full is required only for a documented escalation.
 7. The implementation subagent commits and pushes the review fix, then returns a new Ready For Review handoff.
 8. The orchestrator replies to each Codex Code Review Bot top-level or inline review comment with the outcome, fix
    commit, and validation evidence using the [Review/Fix comment template](#reviewfix-comment-template). The comment
@@ -976,9 +972,24 @@ Not every review finding requires a docs change. Ordinary implementation mistake
 changing templates or process docs. Repeated or structural traps should update active/future sibling issues before more
 workers are assigned, and should update the issue template or agent docs when the missing guard belongs in future tasks.
 
-## Validation Commands
+## Validation
 
-Use the local scripts for repository validation:
+Focused local proof establishes that a coherent commit or implementation slice is correct. GitHub `Validate` certifies
+the current pull-request revision across the repository. Local Fast and Full are escalation, reproduction, and
+diagnostic tools, not routine pre-commit or pre-push requirements.
+
+| Stage | Default proof |
+| ----- | ------------- |
+| RED | Smallest test proving missing or incorrect behavior |
+| GREEN/refactor | Same focused test or fixture |
+| Before commit | Format/check, focused proof, freshness checks, `git diff --check` |
+| Before push | Confirm local evidence is current; no routine broad local gate |
+| PR current revision | GitHub `Validate`, authoritative broad gate |
+| Review fix | Focused regression proof, then GitHub `Validate` |
+| CI failure | Inspect CI evidence and reproduce narrowly; escalate to Fast or Full as needed |
+| Merge | Current CI green, current review satisfied, residual risks recorded |
+
+Use the local scripts only when their escalation role is justified:
 
 ```powershell
 pwsh ./scripts/bootstrap.ps1
@@ -986,33 +997,47 @@ pwsh ./scripts/validate.ps1 -Fast
 pwsh ./scripts/validate.ps1 -Full
 ```
 
-Use `-Fast` for the normal development loop. Use `-Full` when the change touches Aspire integration coverage, emulators,
-storage, Cosmos DB, Service Bus, Redis, cross-service behavior, or deployment/runtime behavior.
+Fast is an optional broad local preflight for unavailable or delayed CI, unusually broad compile fan-out, an explicit
+task or maintainer request, handoff without an immediate PR, or broader failure reproduction. Full is for local
+Aspire-backed integration reproduction or diagnosis, emulator/storage/runtime investigation, unavailable CI integration
+proof, an explicit request, or a defined release-candidate procedure. Do not infer a routine Full requirement merely
+from touching an integration-related path.
 
-Avoid duplicate builds. The validation ladder is:
+Focused local proof is the normal path. For F# behavior changes, use RED where applicable, format touched files, build
+the focused project before a `--no-build` test, run the smallest relevant fixture, namespace, category, or project, then
+run freshness checks and `git diff --check`. Docs-only proof can be MarkdownLint, YAML or PowerShell parsing, rendered
+HTML inspection, and `git diff --check`.
+
+Some repetition is intentional: focused tests provide rapid local feedback and run again as independent CI
+certification. Avoid routine local near-full or full validation immediately before the same broad repository proof in
+CI. The validation ladder is:
 
 1. Run Fantomas formatting or targeted Fantomas checks for touched F# files.
 2. Run any required freshness or generated-file checks.
 3. Choose exactly one final build/test gate.
 4. Run `git diff --check`.
 
-`validate.ps1 -Fast` and `validate.ps1 -Full` already restore, build the solution, and run the selected test projects.
-If a worker is going to run `validate -Fast` or `validate -Full`, do not also prompt it to routinely run a
-project-specific `dotnet build` plus `dotnet test --no-build`. The selected `validate` command is the final build/test
-gate.
+Fast keeps its selected non-Aspire filter. Full runs one unfiltered solution-level test command, including every current
+and future test project in `src/Grace.slnx`. GitHub `Validate` restores and builds once, then invokes the shared Full
+implementation without rebuilding. Do not add per-project test-process fan-out.
+
+When Fast or Full is intentionally selected, do not also duplicate its build/test work with routine focused commands
+for that checkpoint. Otherwise, local broad validation is normally omitted. That omission is not skipped validation
+when focused proof is complete, the PR is pushed, and current GitHub `Validate` is required and available. Record
+"skipped validation" only for omitted required focused proof, syntax/lint/freshness checks, required CI, or task-specific
+manual validation.
 
 Focused project build/test is still appropriate when it is the right evidence for the slice:
 
 - RED evidence before a code change.
 - Failure diagnosis or faster defect localization after a failing broad gate.
-- A skipped-validate workflow where the task record explicitly accepts the narrower gate.
+- Normal slice proof before current-revision GitHub `Validate`.
 - Tests outside the selected validate profile.
 - Issues that explicitly require focused-only validation.
 
 When a focused command uses `--no-build`, first run the matching
 `dotnet build --configuration Release <project>` command so the test assembly exists and reflects the current source.
-Use separate broad `dotnet build` or broad `dotnet test` commands only when diagnosing a failure or when `validate` is
-being intentionally skipped.
+Use separate broad `dotnet build` or broad `dotnet test` commands only when diagnosing a failure.
 
 If running commands manually, the high-level fallback is:
 
@@ -1028,16 +1053,15 @@ npx --yes markdownlint-cli2 "**/*.md"
 git diff --check
 ```
 
-If validation is skipped, record exactly what was skipped and why in the task record or pull request.
+If required validation is skipped, record exactly what was skipped and why in the task record or pull request.
 
 For F# changes, run Fantomas formatting or targeted Fantomas checks before build and test validation. The intended
 order is:
 
 1. Apply the code change.
 2. Run Fantomas on the touched files, or run the repo-standard recursive Fantomas command when the edit is broad.
-3. Run focused project build/test only when it is needed for RED evidence, failure diagnosis, tests outside the selected
-   validate profile, skipped-validate workflows, or explicitly focused-only issues.
-4. Run exactly one final build/test gate, normally `validate -Fast` or `validate -Full`.
+3. Run focused project build/test for the changed behavior.
+4. Use Fast or Full only when their documented escalation condition applies.
 5. Run `git diff --check`.
 
 Avoid running the full test suite before formatting, then discovering Fantomas rewrote files and forcing another
@@ -1074,8 +1098,10 @@ comments as the review loop continues:
 - why the change benefits Grace and its users
 - summary of changed behavior
 - touched paths and any write-set expansion
-- focused validation run
-- broader validation run, or skipped-validation reason
+- focused local proof, formatting/linting, freshness/syntax, and manual evidence as applicable
+- optional Fast or Full evidence and the reason when one was run
+- current head SHA, GitHub `Validate` conclusion, run link, and confirmation that it is associated with the latest PR
+  revision; successful logs need not be summarized unless CI fails or warns
 - implementation and review path used, including the implementation subagent and Codex Code Review Bot state observed
 - final no-issues bot review result for the latest commit
 - replies to each Codex Code Review Bot comment that required a fix, including the issue, fix, fix commit, validation,
@@ -1098,10 +1124,11 @@ Then verify:
 - ahead/behind status shows the branch is current enough for a blocking review decision
 - the scoped diff still contains only the intended write set
 - no unexpected deletions were introduced during the update
-- the chosen validation gate has passed on the refreshed branch
+- focused proof was rerun when conflict resolution or relevant base changes could affect the slice
 
-Only then wait for Codex Code Review Bot to review the refreshed head commit. A bot reaction or comment on an older head
-commit is useful history, but it does not satisfy the completion review gate.
+Push the refreshed revision, require a new GitHub `Validate` result associated with that revision, and wait for Codex
+Code Review Bot. CI and code review can run in parallel. A bot reaction, comment, or CI result on an older revision is
+useful history, but it does not satisfy the completion review gate.
 
 Open normal ready-for-review pull requests for Grace implementation work. Do not open draft pull requests unless the
 maintainer explicitly asks for a draft.
@@ -1120,8 +1147,9 @@ The agent should:
 2. Evaluate whether the feedback is correct and identify the smallest appropriate fix, or state why no code change is
    needed.
 3. Make the fix in the issue-owned branch/worktree and keep the change traceable to the review thread.
-4. Run focused validation for the changed behavior or docs, and broader validation when the feedback touches shared or
-   risky surfaces.
+4. Add or strengthen focused regression proof, then run formatting, relevant syntax/freshness checks, and
+   `git diff --check`. Use local Fast or Full only for an explicit escalation condition; GitHub `Validate` provides the
+   new broad current-revision result.
 5. Commit the fix and push the branch.
 6. Reply to the GitHub review comment with the outcome, changed commit, validation evidence, and a short prevention
    line.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -73,8 +73,10 @@ try {
     Invoke-External "dotnet restore" { dotnet restore "src/Grace.slnx" }
 
     Write-Section "Next Steps"
-    Write-Host "Run: pwsh ./scripts/validate.ps1 -Fast"
-    Write-Host "Use -Full for Aspire integration coverage."
+    Write-Host "Run the focused proof appropriate to your change before committing."
+    Write-Host "Use validate.ps1 -Fast for an optional broad local preflight."
+    Write-Host "Use validate.ps1 -Full for local integration reproduction or diagnosis."
+    Write-Host "GitHub Validate is the broad gate for pull requests."
 } catch {
     $exitCode = 1
     Write-Error $_

--- a/scripts/install-githooks.ps1
+++ b/scripts/install-githooks.ps1
@@ -8,13 +8,19 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
-$gitDir = Join-Path $repoRoot ".git"
-
-if (-not (Test-Path $gitDir)) {
-    throw "No .git directory found at $gitDir. Run from inside a Git clone."
+$hookDirRelative = (& git -C $repoRoot rev-parse --git-path hooks).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($hookDirRelative)) {
+    throw "Unable to locate Git hooks. Run from inside a Git clone."
 }
 
-$hookDir = Join-Path $gitDir "hooks"
+$hookDir =
+    if ([System.IO.Path]::IsPathRooted($hookDirRelative)) {
+        $hookDirRelative
+    } else {
+        Join-Path $repoRoot $hookDirRelative
+    }
+
+New-Item -ItemType Directory -Force -Path $hookDir | Out-Null
 $hookPath = Join-Path $hookDir "pre-commit"
 $backupPath = Join-Path $hookDir "pre-commit.grace.bak"
 $marker = "Grace Validate Hook"
@@ -28,29 +34,29 @@ function Get-FileContent([string]$Path) {
 }
 
 function Write-Hook([string]$Path) {
-    $hook = @"
-#!/usr/bin/env sh
+    $hook = @'
+#!/bin/sh
 # Grace Validate Hook (installed by scripts/install-githooks.ps1)
-# Runs validate -Fast after any existing hook logic.
+# Runs a lightweight staged-diff check after any existing hook logic.
+# Focused tests and formatting remain explicit developer responsibilities.
 
-HOOK_DIR=$(cd "$(dirname "$0")" && pwd)
+HOOK_DIR=$(cd "${0%/*}" && pwd)
 BACKUP="$HOOK_DIR/pre-commit.grace.bak"
 
 if [ -x "$BACKUP" ]; then
   "$BACKUP" "$@" || exit $?
 fi
 
-if command -v pwsh >/dev/null 2>&1; then
-  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-  if [ -n "$REPO_ROOT" ]; then
-    pwsh -NoProfile -ExecutionPolicy Bypass -File "$REPO_ROOT/scripts/validate.ps1" -Fast || exit $?
-  else
-    echo "Grace hook: unable to locate repo root; skipping validate." >&2
-  fi
-else
-  echo "Grace hook: pwsh not found; skipping validate." >&2
-fi
-"@
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Grace hook: unable to locate repository root." >&2
+  exit 1
+}
+
+git -C "$REPO_ROOT" diff --cached --check || {
+  echo "Grace hook: staged whitespace or conflict-marker errors must be fixed before committing." >&2
+  exit 1
+}
+'@
 
     Set-Content -Path $Path -Value $hook -Encoding ASCII
 }
@@ -89,5 +95,6 @@ if (Test-Path $hookPath) {
 }
 
 Write-Hook $hookPath
-Write-Host "Installed Grace pre-commit hook (validate -Fast)."
+Write-Host "Installed Grace pre-commit hook (staged-diff check only; no build, tests, or network operations)."
+Write-Host "Focused tests and formatting remain explicit developer responsibilities."
 Write-Host "Run with -Uninstall to restore the previous hook."

--- a/scripts/validate.ps1
+++ b/scripts/validate.ps1
@@ -221,28 +221,24 @@ function Get-FastTestFilterTerms {
     [string[]]($terms + (Get-ServerUnitTestFilterTerms))
 }
 
-function Get-TestFilter([bool]$IncludeFullTests) {
-    $terms = Get-FastTestFilterTerms
-
-    if ($IncludeFullTests) {
-        $terms += "FullyQualifiedName~Grace.Server.Tests"
-    }
-
-    Join-TestFilter $terms
+function Get-FastTestFilter {
+    Join-TestFilter (Get-FastTestFilterTerms)
 }
 
-function Invoke-SolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
-    $testFilter = Get-TestFilter $IncludeFullTests
+function Invoke-SolutionTests([string]$Configuration, [bool]$UseFastFilter) {
+    $testFilter = if ($UseFastFilter) { Get-FastTestFilter } else { $null }
 
     Write-Host "Test target: src/Grace.slnx"
-    Write-Host ("Test filter: {0}" -f $testFilter)
-    if ($IncludeFullTests) {
-        Write-Host "Progress note: -Full includes Grace.Server.Tests; the Aspire-backed test assembly generally runs for 3-4 minutes after the faster assemblies finish."
+    if ($UseFastFilter) {
+        Write-Host ("Test filter: {0}" -f $testFilter)
+    } else {
+        Write-Host "Test filter: none (-Full runs every test project in src/Grace.slnx)."
+        Write-Host "Progress note: the Aspire-backed test assembly generally runs for 3-4 minutes after the faster assemblies finish."
         Write-Host "Progress note: VSTest may buffer test-host progress output; wait for the Grace.Server.Tests summary before treating quiet output as a hang."
     }
 
     $previousServerCleanup = $env:GRACE_TEST_SERVER_CLEANUP
-    $setServerCleanupForRun = $IncludeFullTests -and [string]::IsNullOrWhiteSpace($env:GRACE_TEST_SERVER_CLEANUP)
+    $setServerCleanupForRun = -not $UseFastFilter -and [string]::IsNullOrWhiteSpace($env:GRACE_TEST_SERVER_CLEANUP)
 
     if ($setServerCleanupForRun) {
         $env:GRACE_TEST_SERVER_CLEANUP = "0"
@@ -250,10 +246,16 @@ function Invoke-SolutionTests([string]$Configuration, [bool]$IncludeFullTests) {
     }
 
     try {
-        Write-Host ("Running: dotnet test `"src/Grace.slnx`" -c {0} --no-build --filter `"{1}`"" -f $Configuration, $testFilter)
-
-        Invoke-External "Grace solution tests" {
-            dotnet test "src/Grace.slnx" -c $Configuration --no-build --filter $testFilter
+        if ($UseFastFilter) {
+            Write-Host ("Running: dotnet test `"src/Grace.slnx`" -c {0} --no-build --no-restore --filter `"{1}`"" -f $Configuration, $testFilter)
+            Invoke-External "Grace solution tests" {
+                dotnet test "src/Grace.slnx" -c $Configuration --no-build --no-restore --filter $testFilter
+            }
+        } else {
+            Write-Host ("Running: dotnet test `"src/Grace.slnx`" -c {0} --no-build --no-restore" -f $Configuration)
+            Invoke-External "Grace solution tests" {
+                dotnet test "src/Grace.slnx" -c $Configuration --no-build --no-restore
+            }
         }
     } finally {
         if ($setServerCleanupForRun) {
@@ -332,7 +334,7 @@ try {
 
     if (-not $SkipTests) {
         Write-Section "Test"
-        Invoke-SolutionTests $Configuration $Full
+        Invoke-SolutionTests $Configuration $Fast
     } else {
         Write-Section "Test"
         Write-Host "Skipped (-SkipTests)."

--- a/skills/code-review-stabilizer/SKILL.md
+++ b/skills/code-review-stabilizer/SKILL.md
@@ -1,4 +1,3 @@
-
 ---
 name: code-review-stabilizer
 description: >-
@@ -26,8 +25,9 @@ Count a **substantive review cycle** as:
 1. A worker pushes a fix commit or fix series.
 1. The next review reports another substantive finding on the new head.
 
-Do not count purely administrative comments, duplicate comments, formatting-only nits, CI flakes, stale review threads,
-maintainer-accepted future-leaf deferrals, or reviewer comments that the orchestrator explicitly classifies as invalid.
+Do not count purely administrative comments, duplicate comments, formatting-only nits, CI flakes, stale review threads
+from previous review passes whether resolved or unresolved, maintainer-accepted future-leaf deferrals, or reviewer
+comments that the orchestrator explicitly classifies as invalid.
 
 ### Default threshold
 

--- a/skills/grace/SKILL.md
+++ b/skills/grace/SKILL.md
@@ -60,8 +60,11 @@ Use these sibling skills when the task needs a specialized workflow:
   `references/workflow.md`. Route sub-issue pull requests to that epic branch; do not use direct-to-`main` epic slices.
 - Coordinate across `Grace.Types`, `Grace.Shared`, `Grace.Server`, `Grace.Actors`, `Grace.SDK`, `Grace.CLI`, and tests
   when one surface changes another.
-- Prefer `pwsh ./scripts/validate.ps1 -Fast`; use `-Full` when Aspire, emulators, Service Bus, storage, Redis,
-  deployment/runtime behavior, or cross-service integration is affected.
+- Require focused local proof first. Use `pwsh ./scripts/validate.ps1 -Fast` only as an optional broad preflight and
+  `-Full` for local integration reproduction or diagnosis. GitHub `Validate` certifies the current PR revision across
+  the repository; successful CI logs need not be ingested unless a failure or warning requires diagnosis.
+- Push one or more completed local commits as a coherent checkpoint. Review fixes use focused regression proof, then
+  the current-revision GitHub `Validate` result.
 - Use PowerShell examples before bash / zsh in docs.
 
 ## PowerShell Text Editing and Quoting

--- a/skills/grace/references/docs-and-contributing.md
+++ b/skills/grace/references/docs-and-contributing.md
@@ -68,6 +68,10 @@ pwsh ./scripts/validate.ps1 -Fast
 pwsh ./scripts/validate.ps1 -Full
 ```
 
+Explain focused proof, formatting or syntax checks, and `git diff --check` as the normal local path. Describe Fast as
+an optional broad preflight and Full as local integration reproduction or diagnosis. GitHub `Validate` is the required
+broad gate for the current pull-request revision; omission of redundant local Fast or Full is not skipped validation.
+
 From `./src` for formatting:
 
 ```powershell

--- a/skills/grace/references/tests.md
+++ b/skills/grace/references/tests.md
@@ -78,8 +78,9 @@ Add canned regressions for:
 
 ## Validation Commands
 
-Use focused tests first. Then run the selected profile. Build the matching project in Release before any
-project-specific `dotnet test --no-build` command.
+Use focused tests first. Build the matching project in Release before any project-specific `dotnet test --no-build`
+command. Fast is an optional broad preflight and Full is for local integration reproduction or diagnosis; GitHub
+`Validate` is the required broad current-revision proof.
 
 ```powershell
 dotnet build --configuration Release src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -96,9 +97,9 @@ pwsh ./scripts/validate.ps1 -Fast
 pwsh ./scripts/validate.ps1 -Full
 ```
 
-`validate.ps1` uses one solution-level `dotnet test "src/Grace.slnx"` invocation with Fast or Full selection filters,
-not custom per-project process fan-out. Fast selects Authorization, CLI, Types, and Server.Unit tests. Full adds Server
-integration tests.
+`validate.ps1` uses one solution-level `dotnet test "src/Grace.slnx"` invocation, not custom per-project process
+fan-out. Fast uses the selected non-Aspire filter; Full is unfiltered and therefore includes every current and future
+test project in the solution. GitHub `Validate` invokes the shared Full implementation.
 
 Run `dotnet tool run fantomas --recurse .` from `./src` after F# changes when formatting is needed.
 

--- a/skills/grace/references/workflow.md
+++ b/skills/grace/references/workflow.md
@@ -148,7 +148,10 @@ Use the profile from `docs/Development process.md`:
 | `sdk-client` | SDK surface or client contract changes |
 | `deployment-runtime` | Aspire, emulators, Docker, Azure resources, scripts, runtime config |
 
-Default commands:
+Focused proof comes first. The broad commands below are optional local escalation tools; GitHub `Validate` is the
+authoritative broad gate for the current pull-request revision.
+
+Commands:
 
 ```powershell
 pwsh ./scripts/bootstrap.ps1
@@ -158,23 +161,17 @@ npx --yes markdownlint-cli2 "**/*.md"
 git diff --check
 ```
 
-Run `-Full` for Aspire integration, emulators, storage, Cosmos DB, Service Bus, Redis, runtime delivery, or
-cross-service behavior.
-
-Use the validation ladder from `docs/Development process.md`: run targeted Fantomas formatting or checks before
-validation for touched F# files, run freshness checks when needed, then choose exactly one final build/test gate. If
-`validate -Fast` or `validate -Full` will run, do not also ask workers to routinely run project-specific
-`dotnet build` plus `dotnet test --no-build`; `validate` is the final build/test gate.
-
-Focused project build/test remains appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
-outside the selected validate profile, or explicitly focused-only issues. Freshness/update workers follow the same
-rule: formatting or freshness checks first, then one final build/test gate.
+Use Fast for a concrete optional broad preflight, such as unavailable CI or unusually broad compile fan-out. Use Full
+for local integration reproduction or diagnosis, not merely because an integration-related path was touched. Avoid
+routine local broad validation immediately followed by required CI. Focused project build/test, formatting, freshness
+checks, and `git diff --check` are required before commit; build the focused project before `--no-build` tests.
 
 Before the Grace completion review gate, update the branch against its required base: current `origin/main` for
 standalone non-epic issue branches, current `origin/epic/...` for sub-issue branches targeting an epic integration
 branch, and current `origin/main` for the final epic-to-`main` PR. Verify ahead/behind, verify the scoped diff and that
-no unexpected deletions are present, run the chosen validation gate, then wait for Codex Code Review Bot on the
-refreshed PR head. A bot reaction or comment on a stale commit does not satisfy completion.
+no unexpected deletions are present, and rerun focused proof when relevant changes affect the slice. Push the refreshed
+head, then require current GitHub `Validate` and Codex Code Review Bot state. A bot reaction or CI result on a stale
+revision does not satisfy completion.
 
 ## Merge Cleanup
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -7,9 +7,9 @@ Treat this file as the canonical high-level brief; each project folder contains 
 ## Local Commands
 
 - `pwsh ./scripts/bootstrap.ps1`
-- `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration tests)
+- Focused project proof for the changed behavior; use Fast or Full only as optional broad local escalation.
 
-Optional: `pwsh ./scripts/install-githooks.ps1` to add a pre-commit `validate -Fast` hook.
+Optional: `pwsh ./scripts/install-githooks.ps1` adds a staged-diff check only; focused tests and formatting stay explicit.
 
 ## Work Tracking
 
@@ -57,27 +57,19 @@ update the issue before editing the new paths.
 - When a task assigns a worktree different from the thread workspace root, every `apply_patch` filename must be an
   absolute path under the assigned worktree. After the first patch, verify git status in both locations.
 - Prefer vertical slices that prove one public behavior at a time through the closest stable boundary.
-- Validate changes with `pwsh ./scripts/validate.ps1 -Fast` (use `-Full` for Aspire integration coverage).
-- Order validation to avoid duplicate builds. Run targeted Fantomas formatting or checks before validation for touched
-  F# files, then choose exactly one final build/test gate. If `validate -Fast` or `validate -Full` will run, do not also
-  ask workers to routinely run project-specific `dotnet build` plus `dotnet test --no-build`; `validate` is the final
-  build/test gate.
-- Focused project build/test is appropriate for RED evidence, failure diagnosis, skipped-validate workflows, tests
-  outside the selected validate profile, or explicitly focused-only issues. If running commands manually instead of
-  `validate`, use `dotnet build --configuration Release` and `dotnet test --no-build`; build the focused project before
-  any project-specific `--no-build` test command.
-- Freshness or generated-file update workers follow the same validation ladder: formatting or freshness checks first,
-  then exactly one final build/test gate. If `validate -Fast` or `validate -Full` runs, do not also run routine focused
-  build/test commands.
+- Validate the changed behavior locally with the smallest focused proof. Format touched F# files first, build the
+  focused project before a `--no-build` test, run required freshness checks, and finish with `git diff --check`.
+- GitHub `Validate` is the required broad gate for the current pull-request revision. Local Fast is an optional broad
+  preflight; Full is for local integration reproduction or diagnosis, not a routine consequence of touching a runtime
+  surface. If either broad command is intentionally selected, do not duplicate its build/test work with routine focused
+  build/test commands for that checkpoint.
 - Product/DAG independence is not the same as merge/write-set independence. Parallelize branches only when their write
   sets are disjoint enough to avoid predictable churn. Serialize or merge-queue branches that touch shared project
   files such as `*.fsproj`, `Startup.Server.fs`, or the same test/helper files. For broad waves, consider a
   preparatory compile-item or file-scaffold slice before later branches edit separate files.
-- Before the Grace completion review gate, update the branch against current `origin/main`, verify ahead/behind,
-  verify the scoped diff and that no unexpected deletions are present, run the chosen validation gate, then wait for
-  Codex Code Review Bot to review the refreshed PR head. A bot signal on a stale commit does not satisfy the completion
-  gate. For sub-issue PRs targeting an epic integration branch, run that freshness gate against the current epic branch;
-  for the final epic-to-`main` PR, run it against current `origin/main`.
+- Before the Grace completion review gate, update against the required base, inspect ahead/behind, scoped diff,
+  unexpected deletions, and relevant conflict resolutions, then rerun focused proof if needed. Push and require
+  current GitHub `Validate` and Codex Code Review Bot state for the refreshed revision.
 - Never sleep or poll for more than 120 seconds in one command. This applies to `Start-Sleep`, `wait_agent`,
   long-polling commands, watch loops, and tool waits; use repeated shorter checks instead, with status updates between
   checks during long workflows.
@@ -158,8 +150,10 @@ update the issue before editing the new paths.
 
 ## Test Parallelization And Validation
 
-- `pwsh ./scripts/validate.ps1 -Fast` and `-Full` run one solution-level `dotnet test "src/Grace.slnx"` command with
-  selection filters. Fast selects Authorization, CLI, Types, and Server.Unit tests. Full adds Server integration tests.
+- `pwsh ./scripts/validate.ps1 -Fast` uses one solution-level `dotnet test "src/Grace.slnx"` command with the selected
+  non-Aspire filter: Authorization, CLI, Operations, Types, and Server.Unit tests. `-Full` uses one unfiltered
+  solution-level command, so every current and future test project in `src/Grace.slnx` runs. GitHub `Validate` reuses
+  this Full selection implementation rather than maintaining its own test list.
 - Do not reintroduce custom per-project process fan-out into validation unless a future issue owns that runner change.
 - Assembly-level NUnit parallel defaults are intentionally limited. `Grace.Authorization.Tests` and `Grace.Types.Tests`
   have bounded defaults. `Grace.Server.Unit.Tests` is deferred while process-static approval-store mutation remains in

--- a/src/Grace.Authorization.Tests/AGENTS.md
+++ b/src/Grace.Authorization.Tests/AGENTS.md
@@ -22,4 +22,5 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
 - Run targeted Fantomas formatting or checks before build/test validation after F# changes.
 - Build `src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj` in Release before project-specific
   `--no-build` tests.
-- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate.
+- Run the smallest focused authorization proof first. Fast is an optional broad preflight; GitHub `Validate` certifies
+  the current pull-request revision across the repository.

--- a/src/Grace.CLI.Tests/AGENTS.md
+++ b/src/Grace.CLI.Tests/AGENTS.md
@@ -36,5 +36,6 @@ Read `../AGENTS.md` for global expectations before updating CLI tests.
 - Run the matching Release build before any project-specific `dotnet test --no-build` command.
 - Run `dotnet test --configuration Release --no-build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` only after that build
   context exists.
-- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate. The script uses one solution-level `dotnet test`
-  invocation with filters rather than custom per-project process fan-out.
+- Run the smallest focused CLI proof first. Fast is an optional broad preflight; GitHub `Validate` certifies the current
+  pull-request revision. Fast remains one solution-level `dotnet test` invocation with a filter rather than custom
+  per-project process fan-out.

--- a/src/Grace.Server.Tests/AGENTS.md
+++ b/src/Grace.Server.Tests/AGENTS.md
@@ -43,6 +43,7 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
 - Run the matching Release build before any project-specific `dotnet test --no-build` command.
 - Run `dotnet test --configuration Release --no-build src/Grace.Server.Tests/Grace.Server.Tests.fsproj` only after that
   build context exists.
-- Run `pwsh ./scripts/validate.ps1 -Full` for the integration gate. The script uses one solution-level `dotnet test`
-  invocation with filters rather than custom per-project process fan-out.
+- Run the smallest focused integration proof first. Use `pwsh ./scripts/validate.ps1 -Full` only for local integration
+  reproduction or diagnosis; GitHub `Validate` is the broad integration gate for the current pull-request revision.
+  Full uses one unfiltered solution-level `dotnet test` invocation rather than custom per-project process fan-out.
 - Run `dotnet tool run fantomas --recurse .` from `./src` after F# changes.

--- a/src/Grace.Server.Unit.Tests/AGENTS.md
+++ b/src/Grace.Server.Unit.Tests/AGENTS.md
@@ -25,6 +25,7 @@ Global policies live in `../AGENTS.md`; follow them before touching tests here.
   `--no-build` tests.
 - Run `dotnet test --configuration Release --no-build src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`
   only after that build context exists.
-- Run `pwsh ./scripts/validate.ps1 -Fast` for the normal fast gate. The script runs solution-level `dotnet test` with
-  selection filters; because several moved files keep historical `Grace.Server.Tests` namespaces, the Server.Unit
-  filter currently derives fixture/type selectors from project compile items and source declarations.
+- Run the smallest focused unit proof first. Fast is an optional broad preflight; GitHub `Validate` certifies the
+  current pull-request revision. Fast uses a solution-level `dotnet test` filter; because several moved files keep
+  historical `Grace.Server.Tests` namespaces, the Server.Unit selectors derive from project compile items and source
+  declarations.


### PR DESCRIPTION
Closes #725

## Why this matters

Grace currently repeats near-repository-wide validation locally and in GitHub Actions. This change keeps the fast feedback
and correctness value of focused local proof while making the required GitHub `Validate` workflow the authoritative broad
certification for the current pull-request revision. It also lets multiple coherent local commits share one reviewable
checkpoint push instead of triggering avoidable sequential CI runs.

## Summary

- Require the smallest meaningful focused local proof before each coherent commit.
- Treat local Fast and Full as bounded escalation, reproduction, and diagnostic tools rather than routine gates.
- Require GitHub `Validate` as the broad gate associated with the latest PR revision for `main` and `epic/**` targets.
- Reuse `scripts/validate.ps1 -Full` as the single Full test-selection implementation in local and GitHub validation.
- Replace the build/test pre-commit hook with a staged-diff-only hook that preserves the prior-hook lifecycle.
- Separate focused local, optional broad local, and required CI evidence in issue and PR templates.
- Align contributor docs, agent guidance, test-project guidance, the maintained HTML guide, Grace skills, and the
  code-review stabilizer clarification.

## Scope and contract impact

Changed paths are limited to process guidance, templates, validation/bootstrap/hook scripts, GitHub Actions, the maintained
process HTML guide, and repository skills. No Grace application behavior, domain contract, API, actor, persistence, CLI,
SDK, OpenAPI, or product test behavior changed. No ADR was created because this is a reversible development-process policy,
not a durable architectural decision.

## Local focused evidence

- PowerShell parser over every changed `.ps1`: passed.
- `pwsh ./scripts/validate.ps1 -Full -SkipFormat -SkipBuild -SkipTests`: passed; exercised control flow without tests.
- Fast/Full selection source proof: Fast retains the intended filter; Full constructs no test-selection filter.
- Ruby YAML parse of `.github/workflows/validate.yml` and `.github/ISSUE_TEMPLATE/agent-task.yml`: passed.
- MarkdownLint with `.markdownlint.jsonc`: passed; repository MD013 policy preserved.
- `GraceDevelopmentProcess.html` structural/rendered-equivalent and stale-language inspection: passed.
- Disposable Git hook lifecycle: install, idempotent reinstall, previous-hook invocation, staged-whitespace rejection,
  clean staged commit, no PowerShell/build/test dependency, uninstall restoration: passed.
- `git diff --check`: passed.
- Current normative stale-language audit: passed; no obsolete policy statements remain.

Generated-file/freshness checks: N/A; no generated contract changed.

Manual validation: maintained HTML structure, headings, overflow-sensitive layout, malformed markup, and stale validation
language inspected with no issue found.

## Optional local broad preflight

Neither Fast nor Full test execution was run. This is the intended normal path for this process/tooling slice: focused
proof is complete and GitHub `Validate` will supply the required broad current-revision certification.

## Required CI evidence

- Current head SHA: `e581fb005ea2bccd409ad10762c11eb90a101110`
- GitHub `Validate`: success
- Run link: [Validate run 29662402099](https://github.com/ScottArbeit/Grace/actions/runs/29662402099)
- Latest-revision association: confirmed; the pull-request run reports head SHA
  `e581fb005ea2bccd409ad10762c11eb90a101110`

Successful CI logs will not be ingested unless the run fails or reports a warning needing diagnosis.

## External skill archive

No writable task-supplied `SKILLS.zip`, `SKILLS(1).zip`, or extracted external skills tree was present in the supplied
workspace. Repository Grace skills were updated; no external archive was invented.

## Review Status

- Current head: `e581fb005ea2bccd409ad10762c11eb90a101110`
- Codex Code Review Bot: current-head no-issues 👍; no top-level or inline findings
- Substantive cycle count: 0
- Completed review sessions: 1
- Manual trigger: not attempted
- Manual trigger lock: do not trigger while current-head acknowledgement or review is present; use the documented
  missed-ack guard only if the current head receives no acknowledgement, no review, no finding, and no no-issues signal.
- First-pass bot-prevention self-review: completed by the implementation worker; no residual implementation finding found.

## Residual risk

No known residual risk remains. GitHub `Validate` passed and Codex Code Review Bot reported no issues for the current PR
revision.
