### PR TITLE
Implement bounded manifest contribution accounting workflow

### DIFF
--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -257,10 +257,9 @@ module ContentBlockMetadata =
             existing.ActiveManifestCount = 0
             && range.ActiveManifestCount > 0
 
-        /// Folds a finalize contribution into an already covering metadata range when the bytes match.
+        /// Folds finalized physical-range evidence into an already covering metadata range without changing its active count.
         let tryMergeFinalizeContributionIntoCoveringRange (range: ContentBlockMetadataRange) =
-            if not isFinalizeContribution
-               || range.ActiveManifestCount <= 0 then
+            if not isFinalizeContribution then
                 false
             else
                 /// Calculates the exclusive logical ordinal end for a metadata range.

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -31,6 +31,7 @@ module ContentBlockMetadata =
         | ContentBlockMetadataCommand.MergePhysicalRanges _ -> "MergePhysicalRanges"
         | ContentBlockMetadataCommand.CompactPhysicalRanges _ -> "CompactPhysicalRanges"
         | ContentBlockMetadataCommand.SetCompactionChurnState _ -> "SetCompactionChurnState"
+        | ContentBlockMetadataCommand.AdjustActiveManifestCount _ -> "AdjustActiveManifestCount"
 
     /// Extracts the client operation id that lets command retries match previously emitted events.
     let operationId command =
@@ -41,6 +42,8 @@ module ContentBlockMetadata =
         | ContentBlockMetadataCommand.CompactPhysicalRanges compact -> compact.OperationId
         | ContentBlockMetadataCommand.SetCompactionChurnState setChurnState when isNull (box setChurnState) -> String.Empty
         | ContentBlockMetadataCommand.SetCompactionChurnState setChurnState -> setChurnState.OperationId
+        | ContentBlockMetadataCommand.AdjustActiveManifestCount adjust when isNull (box adjust) -> String.Empty
+        | ContentBlockMetadataCommand.AdjustActiveManifestCount adjust -> adjust.OperationId
 
     /// Coordinates event operation id logic for the ContentBlockMetadata actor.
     let private eventOperationId metadataEvent =
@@ -49,11 +52,17 @@ module ContentBlockMetadata =
         | ContentBlockMetadataEventType.PhysicalRangesMerged (operationId, _) -> operationId
         | ContentBlockMetadataEventType.PhysicalRangesCompacted (operationId, _) -> operationId
         | ContentBlockMetadataEventType.CompactionChurnStateSet (operationId, _) -> operationId
+        | ContentBlockMetadataEventType.ActiveManifestCountAdjusted (adjust, _) -> adjust.OperationId
 
     /// Checks whether the operation id has already produced a persisted event.
     let private hasAppliedOperationId (events: seq<ContentBlockMetadataEvent>) operationId =
         events
         |> Seq.exists (fun metadataEvent -> eventOperationId metadataEvent = operationId)
+
+    /// Finds the persisted event for an operation so delta retries can verify their exact payload.
+    let private tryFindAppliedOperation (events: seq<ContentBlockMetadataEvent>) operationId =
+        events
+        |> Seq.tryFind (fun metadataEvent -> eventOperationId metadataEvent = operationId)
 
     /// Replays persisted ContentBlockMetadata events into an in-memory state snapshot.
     let applyEvents (events: ContentBlockMetadataEvent list) (current: ContentBlockMetadataDto) =
@@ -585,6 +594,80 @@ module ContentBlockMetadata =
     /// Coordinates stamp metadata logic for the ContentBlockMetadata actor.
     let private stampMetadata (metadata: ContentBlockMetadata) nextVersion timestamp = { metadata with MetadataVersion = nextVersion; UpdatedAt = timestamp }
 
+    /// Applies a contribution delta to every stored physical range covering the requested logical range.
+    let private adjustActiveManifestCount correlationId (current: ContentBlockMetadataDto) (adjust: AdjustContentBlockActiveManifestCount) timestamp =
+        if isNull (box adjust) then
+            Error(graceError correlationId "AdjustActiveManifestCount payload is required.")
+        elif adjust.Delta <> 1 && adjust.Delta <> -1 then
+            Error(graceError correlationId "AdjustActiveManifestCount Delta must be 1 or -1.")
+        elif adjust.Range.OrdinalStart < 0
+             || adjust.Range.OrdinalCount <= 0 then
+            Error(graceError correlationId "AdjustActiveManifestCount range must have a non-negative start and positive count.")
+        else
+            match current.Metadata with
+            | None -> Error(graceError correlationId "ContentBlockMetadata does not exist; active manifest count cannot be adjusted.")
+            | Some metadata when metadata.StoragePoolId <> adjust.StoragePoolId ->
+                Error(graceError correlationId "AdjustActiveManifestCount StoragePoolId does not match current metadata.")
+            | Some metadata when
+                metadata.ContentBlockAddress
+                <> adjust.ContentBlockAddress
+                ->
+                Error(graceError correlationId "AdjustActiveManifestCount ContentBlockAddress does not match current metadata.")
+            | Some metadata when
+                metadata.MetadataVersion
+                <> adjust.ExpectedMetadataVersion
+                ->
+                Error(
+                    graceError
+                        correlationId
+                        $"Stale ContentBlockMetadata active-count delta rejected. Expected MetadataVersion {adjust.ExpectedMetadataVersion}, current MetadataVersion {metadata.MetadataVersion}."
+                )
+            | Some metadata ->
+                let requestedEnd =
+                    int64 adjust.Range.OrdinalStart
+                    + int64 adjust.Range.OrdinalCount
+
+                let matchingIndexes =
+                    metadata.Ranges
+                    |> Array.mapi (fun index range ->
+                        let rangeEnd =
+                            int64 range.OrdinalStart
+                            + int64 range.OrdinalCount
+
+                        if int64 range.OrdinalStart
+                           <= int64 adjust.Range.OrdinalStart
+                           && rangeEnd >= requestedEnd then
+                            Some index
+                        else
+                            None)
+                    |> Array.choose id
+
+                if Array.isEmpty matchingIndexes then
+                    Error(graceError correlationId "AdjustActiveManifestCount range is absent from current metadata.")
+                elif matchingIndexes
+                     |> Array.exists (fun index ->
+                         let count = metadata.Ranges[index].ActiveManifestCount
+
+                         adjust.Delta < 0 && count = 0
+                         || adjust.Delta > 0 && count = Int32.MaxValue) then
+                    Error(graceError correlationId "AdjustActiveManifestCount would move an active manifest count outside its valid range.")
+                else
+                    let ranges = Array.copy metadata.Ranges
+
+                    matchingIndexes
+                    |> Array.iter (fun index -> ranges[index] <- { ranges[index] with ActiveManifestCount = ranges[index].ActiveManifestCount + adjust.Delta })
+
+                    match activePhysicalBytes correlationId ranges with
+                    | Error error -> Error error
+                    | Ok activeBytes ->
+                        Ok
+                            { metadata with
+                                Ranges = ranges
+                                ActivePhysicalBytes = activeBytes
+                                MetadataVersion = metadata.MetadataVersion + 1L
+                                UpdatedAt = timestamp
+                            }
+
     /// Coordinates ok decision logic for the ContentBlockMetadata actor.
     let private okDecision metadata operationId events wasReplay message =
         Ok { Metadata = metadata; OperationId = operationId; Events = events; WasIdempotentReplay = wasReplay; Message = message }
@@ -600,9 +683,16 @@ module ContentBlockMetadata =
         if String.IsNullOrWhiteSpace operationId then
             Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata command requires a non-empty operation id.")
         elif hasAppliedOperationId events operationId then
-            match current.Metadata with
-            | Some metadata -> okDecision metadata operationId [] true "ContentBlockMetadata command replayed."
-            | None -> Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata operation was replayed but no metadata state is available.")
+            match tryFindAppliedOperation events operationId, command, current.Metadata with
+            | Some { Event = ContentBlockMetadataEventType.ActiveManifestCountAdjusted (recorded, _) },
+              ContentBlockMetadataCommand.AdjustActiveManifestCount requested,
+              Some metadata when recorded = requested -> okDecision metadata operationId [] true "ContentBlockMetadata command replayed."
+            | Some { Event = ContentBlockMetadataEventType.ActiveManifestCountAdjusted _ }, ContentBlockMetadataCommand.AdjustActiveManifestCount _, _ ->
+                Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata operation id was already used with a different active-count payload.")
+            | Some _, ContentBlockMetadataCommand.AdjustActiveManifestCount _, _ ->
+                Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata operation id was already used for a different command.")
+            | _, _, Some metadata -> okDecision metadata operationId [] true "ContentBlockMetadata command replayed."
+            | _ -> Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata operation was replayed but no metadata state is available.")
         else
             match command with
             | ContentBlockMetadataCommand.ReplaceWholeRecord replace ->
@@ -676,6 +766,16 @@ module ContentBlockMetadata =
                             ]
 
                         okDecision metadata operationId events false "ContentBlockMetadata compaction churn state set."
+            | ContentBlockMetadataCommand.AdjustActiveManifestCount adjust ->
+                match adjustActiveManifestCount eventMetadata.CorrelationId current adjust eventMetadata.Timestamp with
+                | Error error -> Error error
+                | Ok metadata ->
+                    let events =
+                        [
+                            { Event = ContentBlockMetadataEventType.ActiveManifestCountAdjusted(adjust, metadata); Metadata = eventMetadata }
+                        ]
+
+                    okDecision metadata operationId events false "ContentBlockMetadata active manifest count adjusted."
 
     /// Implements the Orleans grain for content block metadata actor.
     type ContentBlockMetadataActor

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -64,6 +64,14 @@ module ContentBlockMetadata =
         events
         |> Seq.tryFind (fun metadataEvent -> eventOperationId metadataEvent = operationId)
 
+    /// Compares the durable delta identity while allowing a retry to observe the metadata version produced by its first attempt.
+    let private sameActiveManifestCountDelta (recorded: AdjustContentBlockActiveManifestCount) (requested: AdjustContentBlockActiveManifestCount) =
+        recorded.OperationId = requested.OperationId
+        && recorded.StoragePoolId = requested.StoragePoolId
+        && recorded.ContentBlockAddress = requested.ContentBlockAddress
+        && recorded.Range = requested.Range
+        && recorded.Delta = requested.Delta
+
     /// Replays persisted ContentBlockMetadata events into an in-memory state snapshot.
     let applyEvents (events: ContentBlockMetadataEvent list) (current: ContentBlockMetadataDto) =
         events
@@ -686,7 +694,8 @@ module ContentBlockMetadata =
             match tryFindAppliedOperation events operationId, command, current.Metadata with
             | Some { Event = ContentBlockMetadataEventType.ActiveManifestCountAdjusted (recorded, _) },
               ContentBlockMetadataCommand.AdjustActiveManifestCount requested,
-              Some metadata when recorded = requested -> okDecision metadata operationId [] true "ContentBlockMetadata command replayed."
+              Some metadata when sameActiveManifestCountDelta recorded requested ->
+                okDecision metadata operationId [] true "ContentBlockMetadata command replayed."
             | Some { Event = ContentBlockMetadataEventType.ActiveManifestCountAdjusted _ }, ContentBlockMetadataCommand.AdjustActiveManifestCount _, _ ->
                 Error(graceError eventMetadata.CorrelationId "ContentBlockMetadata operation id was already used with a different active-count payload.")
             | Some _, ContentBlockMetadataCommand.AdjustActiveManifestCount _, _ ->
@@ -879,3 +888,7 @@ module ContentBlockMetadata =
 
             /// Merges physical range metadata for uploaded or reused content-block bytes.
             member this.MergePhysicalRanges merge eventMetadata = this.HandleCommand (ContentBlockMetadataCommand.MergePhysicalRanges merge) eventMetadata
+
+            /// Applies a manifest-retention delta through a stable actor method payload.
+            member this.AdjustActiveManifestCount adjust eventMetadata =
+                this.HandleCommand (ContentBlockMetadataCommand.AdjustActiveManifestCount adjust) eventMetadata

--- a/src/Grace.Actors/ContentBlockMetadata.Actor.fs
+++ b/src/Grace.Actors/ContentBlockMetadata.Actor.fs
@@ -69,7 +69,6 @@ module ContentBlockMetadata =
         recorded.OperationId = requested.OperationId
         && recorded.StoragePoolId = requested.StoragePoolId
         && recorded.ContentBlockAddress = requested.ContentBlockAddress
-        && recorded.Range = requested.Range
         && recorded.Delta = requested.Delta
 
     /// Replays persisted ContentBlockMetadata events into an in-memory state snapshot.
@@ -602,15 +601,12 @@ module ContentBlockMetadata =
     /// Coordinates stamp metadata logic for the ContentBlockMetadata actor.
     let private stampMetadata (metadata: ContentBlockMetadata) nextVersion timestamp = { metadata with MetadataVersion = nextVersion; UpdatedAt = timestamp }
 
-    /// Applies a contribution delta to every stored physical range covering the requested logical range.
+    /// Applies one ContentBlock contribution delta to every authoritative current physical range atomically.
     let private adjustActiveManifestCount correlationId (current: ContentBlockMetadataDto) (adjust: AdjustContentBlockActiveManifestCount) timestamp =
         if isNull (box adjust) then
             Error(graceError correlationId "AdjustActiveManifestCount payload is required.")
         elif adjust.Delta <> 1 && adjust.Delta <> -1 then
             Error(graceError correlationId "AdjustActiveManifestCount Delta must be 1 or -1.")
-        elif adjust.Range.OrdinalStart < 0
-             || adjust.Range.OrdinalCount <= 0 then
-            Error(graceError correlationId "AdjustActiveManifestCount range must have a non-negative start and positive count.")
         else
             match current.Metadata with
             | None -> Error(graceError correlationId "ContentBlockMetadata does not exist; active manifest count cannot be adjusted.")
@@ -630,40 +626,19 @@ module ContentBlockMetadata =
                         correlationId
                         $"Stale ContentBlockMetadata active-count delta rejected. Expected MetadataVersion {adjust.ExpectedMetadataVersion}, current MetadataVersion {metadata.MetadataVersion}."
                 )
+            | Some metadata when Array.isEmpty metadata.Ranges ->
+                Error(graceError correlationId "AdjustActiveManifestCount requires at least one authoritative physical range.")
             | Some metadata ->
-                let requestedEnd =
-                    int64 adjust.Range.OrdinalStart
-                    + int64 adjust.Range.OrdinalCount
-
-                let matchingIndexes =
-                    metadata.Ranges
-                    |> Array.mapi (fun index range ->
-                        let rangeEnd =
-                            int64 range.OrdinalStart
-                            + int64 range.OrdinalCount
-
-                        if int64 range.OrdinalStart
-                           <= int64 adjust.Range.OrdinalStart
-                           && rangeEnd >= requestedEnd then
-                            Some index
-                        else
-                            None)
-                    |> Array.choose id
-
-                if Array.isEmpty matchingIndexes then
-                    Error(graceError correlationId "AdjustActiveManifestCount range is absent from current metadata.")
-                elif matchingIndexes
-                     |> Array.exists (fun index ->
-                         let count = metadata.Ranges[index].ActiveManifestCount
-
-                         adjust.Delta < 0 && count = 0
-                         || adjust.Delta > 0 && count = Int32.MaxValue) then
+                if metadata.Ranges
+                   |> Array.exists (fun range ->
+                       adjust.Delta < 0 && range.ActiveManifestCount = 0
+                       || adjust.Delta > 0
+                          && range.ActiveManifestCount = Int32.MaxValue) then
                     Error(graceError correlationId "AdjustActiveManifestCount would move an active manifest count outside its valid range.")
                 else
-                    let ranges = Array.copy metadata.Ranges
-
-                    matchingIndexes
-                    |> Array.iter (fun index -> ranges[index] <- { ranges[index] with ActiveManifestCount = ranges[index].ActiveManifestCount + adjust.Delta })
+                    let ranges =
+                        metadata.Ranges
+                        |> Array.map (fun range -> { range with ActiveManifestCount = range.ActiveManifestCount + adjust.Delta })
 
                     match activePhysicalBytes correlationId ranges with
                     | Error error -> Error error

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -624,6 +624,10 @@ module Interfaces =
         abstract member MergePhysicalRanges:
             merge: MergeContentBlockPhysicalRanges -> eventMetadata: EventMetadata -> Task<GraceResult<ContentBlockMetadataDecision>>
 
+        /// Applies one deterministic manifest-retention delta without serializing a new command union case across Orleans.
+        abstract member AdjustActiveManifestCount:
+            adjust: AdjustContentBlockActiveManifestCount -> eventMetadata: EventMetadata -> Task<GraceResult<ContentBlockMetadataDecision>>
+
     /// Defines the operations for the cluster-scoped dedupe discovery index actor.
     [<Interface>]
     type IDedupeIndexActor =

--- a/src/Grace.Actors/Interfaces.Actor.fs
+++ b/src/Grace.Actors/Interfaces.Actor.fs
@@ -800,6 +800,7 @@ module Interfaces =
             manifestAddress: ManifestAddress ->
             direction: ManifestContributionDirection ->
             ranges: ManifestContributionWorkflowRange array ->
+            counterRevision: int64 ->
             eventMetadata: EventMetadata ->
                 Task<GraceResult<ManifestContributionWorkflowDecision>>
 

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -22,6 +22,10 @@ module ManifestContributionWorkflow =
     let primaryKey (repositoryId: RepositoryId) (storagePoolId: StoragePoolId) (manifestAddress: ManifestAddress) =
         $"{repositoryId:N}|{storagePoolId}|{manifestAddress}"
 
+    /// Builds the deterministic downstream ContentBlock operation id for one workflow range.
+    let contentBlockOperationId (startOperationId: ManifestContributionWorkflowOperationId) (counterRevision: int64) (rangeIndex: int) =
+        $"{startOperationId}:revision:{counterRevision}:range:{rangeIndex}:active-count"
+
     /// Maps a ManifestContributionWorkflow command case to the operation name used in idempotency and diagnostics.
     let commandName command =
         match command with
@@ -417,8 +421,6 @@ module ManifestContributionWorkflow =
             let grainFactory = this.GrainFactory
 
             task {
-                let operationPrefix = $"{startOperationId}:range:{rangeIndex}"
-
                 let contentBlockActor =
                     grainFactory.GetGrain<IContentBlockMetadataActor>(ContentBlockMetadataActorKey.Create range.StoragePoolId range.ContentBlockAddress)
 
@@ -437,7 +439,7 @@ module ManifestContributionWorkflow =
 
                     let adjust =
                         {
-                            OperationId = $"{operationPrefix}:active-count"
+                            OperationId = contentBlockOperationId startOperationId workflow.CounterRevision rangeIndex
                             ExpectedMetadataVersion = currentMetadata.MetadataVersion
                             StoragePoolId = range.StoragePoolId
                             ContentBlockAddress = range.ContentBlockAddress
@@ -450,7 +452,7 @@ module ManifestContributionWorkflow =
                         match! (this :> IManifestContributionWorkflowActor)
                                    .Handle
                                    (ManifestContributionWorkflowCommand.RecordRangeSucceeded(
-                                       $"{operationPrefix}:completed",
+                                       $"{startOperationId}:revision:{workflow.CounterRevision}:range:{rangeIndex}:completed",
                                        workflow.RepositoryId,
                                        workflow.StoragePoolId,
                                        workflow.ManifestAddress,

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -107,6 +107,44 @@ module ManifestContributionWorkflow =
         events
         |> Seq.tryFind (fun workflowEvent -> eventOperationId workflowEvent = operationId)
 
+    /// Matches an operation against bounded current progress when no lifetime event stream is retained.
+    let private tryMatchCurrentOperation (workflow: ManifestContributionWorkflowDto) command =
+        let commandOperationId = operationId command
+
+        match command with
+        | ManifestContributionWorkflowCommand.Start (_, repositoryId, storagePoolId, manifestAddress, direction, ranges) when
+            workflow.LastOperationId = Some commandOperationId
+            ->
+            Some(
+                workflow.RepositoryId = repositoryId
+                && workflow.StoragePoolId = storagePoolId
+                && workflow.ManifestAddress = manifestAddress
+                && workflow.Direction = direction
+                && rangesEqual workflow.Ranges ranges
+            )
+        | ManifestContributionWorkflowCommand.RecordRangeSucceeded (_, repositoryId, storagePoolId, manifestAddress, range) ->
+            match workflow.CompletedRanges.TryGetValue range with
+            | true, completedOperationId when completedOperationId = commandOperationId ->
+                Some(
+                    workflow.RepositoryId = repositoryId
+                    && workflow.StoragePoolId = storagePoolId
+                    && workflow.ManifestAddress = manifestAddress
+                )
+            | _ when workflow.LastOperationId = Some commandOperationId -> Some false
+            | _ -> None
+        | ManifestContributionWorkflowCommand.RecordRangeFailed (_, repositoryId, storagePoolId, manifestAddress, range, message) ->
+            match workflow.FailedRanges.TryGetValue range with
+            | true, failure when failure.OperationId = commandOperationId ->
+                Some(
+                    workflow.RepositoryId = repositoryId
+                    && workflow.StoragePoolId = storagePoolId
+                    && workflow.ManifestAddress = manifestAddress
+                    && failure.Message = message
+                )
+            | _ when workflow.LastOperationId = Some commandOperationId -> Some false
+            | _ -> None
+        | _ -> None
+
     /// Applies events changes to the ManifestContributionWorkflow actor state.
     let private applyEvents (events: ManifestContributionWorkflowEvent list) (workflow: ManifestContributionWorkflowDto) =
         events
@@ -253,62 +291,68 @@ module ManifestContributionWorkflow =
         if String.IsNullOrWhiteSpace operationId then
             Error(graceError metadata.CorrelationId "ManifestContributionWorkflow command requires a non-empty operation id.")
         else
-            match tryFindAppliedOperation events operationId with
-            | Some workflowEvent when
-                eventCommandName workflowEvent
-                <> commandName command
-                ->
-                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used for a different command.")
-            | Some workflowEvent when not (eventMatchesCommand workflowEvent command) ->
-                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used with a different payload.")
-            | Some _ -> okDecision workflow operationId [] [] true "Manifest contribution workflow command replayed."
+            match tryMatchCurrentOperation workflow command with
+            | Some true -> okDecision workflow operationId [] [] true "Manifest contribution workflow command replayed."
+            | Some false -> Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used with a different payload.")
             | None ->
-                match command with
-                | ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges) ->
-                    let start = startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges
+                match tryFindAppliedOperation events operationId with
+                | Some workflowEvent when
+                    eventCommandName workflowEvent
+                    <> commandName command
+                    ->
+                    Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used for a different command.")
+                | Some workflowEvent when not (eventMatchesCommand workflowEvent command) ->
+                    Error(graceError metadata.CorrelationId "ManifestContributionWorkflow operation id was already used with a different payload.")
+                | Some _ -> okDecision workflow operationId [] [] true "Manifest contribution workflow command replayed."
+                | None ->
+                    match command with
+                    | ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges) ->
+                        let start = startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges
 
-                    match validateStart expectedPrimaryKey workflow start metadata with
-                    | Some error -> Error error
-                    | None ->
-                        let workflowEvent = { Event = ManifestContributionWorkflowEventType.WorkflowStarted start; Metadata = metadata }
-                        okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow started."
-                | ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, repositoryId, storagePoolId, manifestAddress, range) ->
-                    let progress = progressCommandPayload operationId repositoryId storagePoolId manifestAddress range
+                        match validateStart expectedPrimaryKey workflow start metadata with
+                        | Some error -> Error error
+                        | None ->
+                            let workflowEvent = { Event = ManifestContributionWorkflowEventType.WorkflowStarted start; Metadata = metadata }
+                            okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow started."
+                    | ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, repositoryId, storagePoolId, manifestAddress, range) ->
+                        let progress = progressCommandPayload operationId repositoryId storagePoolId manifestAddress range
 
-                    match validateProgressTarget expectedPrimaryKey workflow progress.RepositoryId progress.StoragePoolId progress.ManifestAddress metadata with
-                    | Some error -> Error error
-                    | None ->
-                        if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
-                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
-                        elif not (isKnownRange workflow progress.Range) then
-                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
-                        elif workflow.CompletedRanges.ContainsKey progress.Range then
-                            okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
-                        else
-                            let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeSucceeded progress; Metadata = metadata }
+                        match validateProgressTarget expectedPrimaryKey workflow progress.RepositoryId progress.StoragePoolId progress.ManifestAddress metadata
+                            with
+                        | Some error -> Error error
+                        | None ->
+                            if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
+                                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
+                            elif not (isKnownRange workflow progress.Range) then
+                                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
+                            elif workflow.CompletedRanges.ContainsKey progress.Range then
+                                okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
+                            else
+                                let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeSucceeded progress; Metadata = metadata }
 
-                            let intents =
-                                [
-                                    ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(progress.Range, activeCountDelta workflow.Direction)
-                                ]
+                                let intents =
+                                    [
+                                        ManifestContributionWorkflowIntent.AdjustRangeActiveManifestCount(progress.Range, activeCountDelta workflow.Direction)
+                                    ]
 
-                            okDecision workflow operationId [ workflowEvent ] intents false "Manifest contribution workflow range completed."
-                | ManifestContributionWorkflowCommand.RecordRangeFailed (operationId, repositoryId, storagePoolId, manifestAddress, range, message) ->
-                    let failure = failureCommandPayload operationId repositoryId storagePoolId manifestAddress range message
+                                okDecision workflow operationId [ workflowEvent ] intents false "Manifest contribution workflow range completed."
+                    | ManifestContributionWorkflowCommand.RecordRangeFailed (operationId, repositoryId, storagePoolId, manifestAddress, range, message) ->
+                        let failure = failureCommandPayload operationId repositoryId storagePoolId manifestAddress range message
 
-                    match validateProgressTarget expectedPrimaryKey workflow failure.RepositoryId failure.StoragePoolId failure.ManifestAddress metadata with
-                    | Some error -> Error error
-                    | None ->
-                        if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
-                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
-                        elif not (isKnownRange workflow failure.Range) then
-                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
-                        elif workflow.CompletedRanges.ContainsKey failure.Range then
-                            okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
-                        else
-                            let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeFailed failure; Metadata = metadata }
+                        match validateProgressTarget expectedPrimaryKey workflow failure.RepositoryId failure.StoragePoolId failure.ManifestAddress metadata
+                            with
+                        | Some error -> Error error
+                        | None ->
+                            if workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted then
+                                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
+                            elif not (isKnownRange workflow failure.Range) then
+                                Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
+                            elif workflow.CompletedRanges.ContainsKey failure.Range then
+                                okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
+                            else
+                                let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeFailed failure; Metadata = metadata }
 
-                            okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow range failure recorded."
+                                okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow range failure recorded."
 
     /// Validates a ManifestContributionWorkflow command and derives the events needed for a state transition.
     let decideCommand events workflow command metadata = decideCommandForKey None events workflow command metadata
@@ -316,7 +360,7 @@ module ManifestContributionWorkflow =
     /// Implements the Orleans grain for manifest contribution workflow actor.
     type ManifestContributionWorkflowActor
         (
-            [<PersistentState(StateName.ManifestContributionWorkflow, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<List<ManifestContributionWorkflowEvent>>
+            [<PersistentState(StateName.ManifestContributionWorkflow, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<ManifestContributionWorkflowDto>
         ) =
         inherit Grain()
 
@@ -330,17 +374,19 @@ module ManifestContributionWorkflow =
             logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
 
             workflow <-
-                state.State
-                |> Seq.fold (fun dto event -> ManifestContributionWorkflowDto.UpdateDto event dto) ManifestContributionWorkflowDto.Default
+                if state.RecordExists then
+                    state.State
+                else
+                    ManifestContributionWorkflowDto.Default
 
             Task.CompletedTask
 
-        /// Replays persisted ManifestContributionWorkflow events into an in-memory state snapshot.
-        member private this.ApplyEvents(events: ManifestContributionWorkflowEvent list) =
+        /// Overwrites the bounded current workflow snapshot after one progress transition.
+        member private this.ApplySnapshot(snapshot: ManifestContributionWorkflowDto) =
             task {
-                state.State.AddRange(events)
+                state.State <- snapshot
                 do! state.WriteStateAsync()
-                workflow <- applyEvents events workflow
+                workflow <- snapshot
             }
 
         interface IHasRepositoryId with
@@ -378,7 +424,7 @@ module ManifestContributionWorkflow =
             member this.GetEvents correlationId =
                 this.correlationId <- correlationId
 
-                (state.State :> IReadOnlyList<ManifestContributionWorkflowEvent>)
+                (Array.empty<ManifestContributionWorkflowEvent> :> IReadOnlyList<ManifestContributionWorkflowEvent>)
                 |> returnTask
 
             /// Coordinates start logic for the ManifestContributionWorkflow actor.
@@ -397,9 +443,9 @@ module ManifestContributionWorkflow =
                     this.correlationId <- metadata.CorrelationId
                     RequestContext.Set(Grace.Shared.Constants.CurrentCommandProperty, commandName command)
 
-                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) state.State workflow command metadata with
+                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) Seq.empty workflow command metadata with
                     | Ok decision ->
-                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+                        if not decision.Events.IsEmpty then do! this.ApplySnapshot decision.Workflow
 
                         let returnValue =
                             (GraceReturnValue.Create decision metadata.CorrelationId)

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -5,6 +5,7 @@ open Grace.Actors.Context
 open Grace.Actors.Interfaces
 open Grace.Actors.Services
 open Grace.Shared.Utilities
+open Grace.Types.ContentBlockMetadata
 open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.Common
 open Microsoft.Extensions.Logging
@@ -113,7 +114,7 @@ module ManifestContributionWorkflow =
 
         match command with
         | ManifestContributionWorkflowCommand.Start (_, repositoryId, storagePoolId, manifestAddress, direction, ranges) when
-            workflow.LastOperationId = Some commandOperationId
+            workflow.StartOperationId = Some commandOperationId
             ->
             Some(
                 workflow.RepositoryId = repositoryId
@@ -389,6 +390,104 @@ module ManifestContributionWorkflow =
                 workflow <- snapshot
             }
 
+        /// Executes one deterministic ContentBlock delta and records bounded workflow progress.
+        member private this.ApplyRange
+            (
+                startOperationId: ManifestContributionWorkflowOperationId,
+                rangeIndex: int,
+                range: ManifestContributionWorkflowRange,
+                metadata: EventMetadata
+            ) =
+            let grainFactory = this.GrainFactory
+
+            task {
+                let operationPrefix = $"{startOperationId}:range:{rangeIndex}"
+
+                let contentBlockActor =
+                    grainFactory.GetGrain<IContentBlockMetadataActor>(ContentBlockMetadataActorKey.Create range.StoragePoolId range.ContentBlockAddress)
+
+                let! currentMetadata = contentBlockActor.Get metadata.CorrelationId
+
+                match currentMetadata with
+                | None ->
+                    return
+                        Error(
+                            GraceError.Create
+                                $"ContentBlockMetadata does not exist for workflow range {range.StoragePoolId}/{range.ContentBlockAddress}."
+                                metadata.CorrelationId
+                        )
+                | Some currentMetadata ->
+                    let delta = activeCountDelta workflow.Direction
+
+                    let adjust =
+                        {
+                            OperationId = $"{operationPrefix}:active-count"
+                            ExpectedMetadataVersion = currentMetadata.MetadataVersion
+                            StoragePoolId = range.StoragePoolId
+                            ContentBlockAddress = range.ContentBlockAddress
+                            Range = { OrdinalStart = range.OrdinalStart; OrdinalCount = range.OrdinalCount }
+                            Delta = delta
+                        }
+
+                    match! contentBlockActor.AdjustActiveManifestCount adjust metadata with
+                    | Error error -> return Error error
+                    | Ok _ ->
+                        match! (this :> IManifestContributionWorkflowActor)
+                                   .Handle
+                                   (ManifestContributionWorkflowCommand.RecordRangeSucceeded(
+                                       $"{operationPrefix}:completed",
+                                       workflow.RepositoryId,
+                                       workflow.StoragePoolId,
+                                       workflow.ManifestAddress,
+                                       range
+                                   ))
+                                   metadata
+                            with
+                        | Error error -> return Error error
+                        | Ok _ -> return Ok()
+            }
+
+        /// Resumes every pending range from the bounded workflow snapshot.
+        member private this.ApplyPendingRanges(startOperationId: ManifestContributionWorkflowOperationId, metadata: EventMetadata) =
+            task {
+                let ranges = workflow.Ranges
+                let mutable rangeIndex = 0
+                let mutable error: GraceError option = None
+
+                while rangeIndex < ranges.Length && error.IsNone do
+                    let range = ranges[rangeIndex]
+
+                    if not (workflow.CompletedRanges.ContainsKey range) then
+                        match! this.ApplyRange(startOperationId, rangeIndex, range, metadata) with
+                        | Ok _ -> ()
+                        | Error rangeError ->
+                            let failureOperationId = $"{startOperationId}:range:{rangeIndex}:failed"
+
+                            let! failureResult =
+                                (this :> IManifestContributionWorkflowActor)
+                                    .Handle
+                                    (ManifestContributionWorkflowCommand.RecordRangeFailed(
+                                        failureOperationId,
+                                        workflow.RepositoryId,
+                                        workflow.StoragePoolId,
+                                        workflow.ManifestAddress,
+                                        range,
+                                        rangeError.Error
+                                    ))
+                                    metadata
+
+                            match failureResult with
+                            | Ok _ -> error <- Some rangeError
+                            | Error failureError -> error <- Some failureError
+
+                    rangeIndex <- rangeIndex + 1
+
+                return
+                    match error with
+                    | Some rangeError -> Error rangeError
+                    | None -> Ok()
+            }
+
         interface IHasRepositoryId with
             /// Returns the repository id recorded in this ManifestContributionWorkflow actor state.
             member this.GetRepositoryId correlationId =
@@ -430,11 +529,16 @@ module ManifestContributionWorkflow =
             /// Coordinates start logic for the ManifestContributionWorkflow actor.
             member this.Start operationId repositoryId storagePoolId manifestAddress direction ranges metadata =
                 task {
-                    return!
-                        (this :> IManifestContributionWorkflowActor)
-                            .Handle
-                            (ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges))
-                            metadata
+                    match! (this :> IManifestContributionWorkflowActor)
+                               .Handle
+                               (ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges))
+                               metadata
+                        with
+                    | Error error -> return Error error
+                    | Ok startResult ->
+                        match! this.ApplyPendingRanges(operationId, metadata) with
+                        | Error error -> return Error error
+                        | Ok _ -> return Ok startResult
                 }
 
             /// Routes a public actor command to the domain operation that validates and persists it.

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -216,10 +216,6 @@ module ManifestContributionWorkflow =
             Some(graceError correlationId "ManifestContributionWorkflow range requires a non-empty StoragePoolId.")
         elif String.IsNullOrWhiteSpace range.ContentBlockAddress then
             Some(graceError correlationId "ManifestContributionWorkflow range requires a non-empty ContentBlockAddress.")
-        elif range.OrdinalStart < 0 then
-            Some(graceError correlationId "ManifestContributionWorkflow range OrdinalStart must be zero or greater.")
-        elif range.OrdinalCount <= 0 then
-            Some(graceError correlationId "ManifestContributionWorkflow range OrdinalCount must be greater than zero.")
         else
             None
 
@@ -445,7 +441,6 @@ module ManifestContributionWorkflow =
                             ExpectedMetadataVersion = currentMetadata.MetadataVersion
                             StoragePoolId = range.StoragePoolId
                             ContentBlockAddress = range.ContentBlockAddress
-                            Range = { OrdinalStart = range.OrdinalStart; OrdinalCount = range.OrdinalCount }
                             Delta = delta
                         }
 

--- a/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
+++ b/src/Grace.Actors/ManifestContributionWorkflow.Actor.fs
@@ -32,12 +32,12 @@ module ManifestContributionWorkflow =
     /// Extracts the client operation id that lets command retries match previously emitted events.
     let operationId command =
         match command with
-        | ManifestContributionWorkflowCommand.Start (operationId, _, _, _, _, _) -> operationId
+        | ManifestContributionWorkflowCommand.Start (operationId, _, _, _, _, _, _) -> operationId
         | ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, _, _, _, _) -> operationId
         | ManifestContributionWorkflowCommand.RecordRangeFailed (operationId, _, _, _, _, _) -> operationId
 
     /// Coordinates start command payload logic for the ManifestContributionWorkflow actor.
-    let private startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges =
+    let private startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges counterRevision =
         {
             OperationId = operationId
             RepositoryId = repositoryId
@@ -45,6 +45,7 @@ module ManifestContributionWorkflow =
             ManifestAddress = manifestAddress
             Direction = direction
             Ranges = ranges
+            CounterRevision = counterRevision
         }
 
     /// Coordinates progress command payload logic for the ManifestContributionWorkflow actor.
@@ -88,13 +89,14 @@ module ManifestContributionWorkflow =
         && existing.ManifestAddress = candidate.ManifestAddress
         && existing.Direction = candidate.Direction
         && rangesEqual existing.Ranges candidate.Ranges
+        && existing.CounterRevision = candidate.CounterRevision
 
     /// Coordinates event matches command logic for the ManifestContributionWorkflow actor.
     let private eventMatchesCommand workflowEvent command =
         match workflowEvent.Event, command with
         | ManifestContributionWorkflowEventType.WorkflowStarted existing,
-          ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges) ->
-            startMatches existing (startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges)
+          ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges, counterRevision) ->
+            startMatches existing (startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges counterRevision)
         | ManifestContributionWorkflowEventType.RangeSucceeded existing,
           ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, repositoryId, storagePoolId, manifestAddress, range) ->
             existing = progressCommandPayload operationId repositoryId storagePoolId manifestAddress range
@@ -113,7 +115,7 @@ module ManifestContributionWorkflow =
         let commandOperationId = operationId command
 
         match command with
-        | ManifestContributionWorkflowCommand.Start (_, repositoryId, storagePoolId, manifestAddress, direction, ranges) when
+        | ManifestContributionWorkflowCommand.Start (_, repositoryId, storagePoolId, manifestAddress, direction, ranges, counterRevision) when
             workflow.StartOperationId = Some commandOperationId
             ->
             Some(
@@ -122,10 +124,13 @@ module ManifestContributionWorkflow =
                 && workflow.ManifestAddress = manifestAddress
                 && workflow.Direction = direction
                 && rangesEqual workflow.Ranges ranges
+                && workflow.CounterRevision = counterRevision
             )
         | ManifestContributionWorkflowCommand.RecordRangeSucceeded (_, repositoryId, storagePoolId, manifestAddress, range) ->
-            match workflow.CompletedRanges.TryGetValue range with
-            | true, completedOperationId when completedOperationId = commandOperationId ->
+            match workflow.CompletedRanges
+                  |> Array.tryFind (fun completed -> completed.Range = range)
+                with
+            | Some completed when completed.OperationId = commandOperationId ->
                 Some(
                     workflow.RepositoryId = repositoryId
                     && workflow.StoragePoolId = storagePoolId
@@ -134,8 +139,10 @@ module ManifestContributionWorkflow =
             | _ when workflow.LastOperationId = Some commandOperationId -> Some false
             | _ -> None
         | ManifestContributionWorkflowCommand.RecordRangeFailed (_, repositoryId, storagePoolId, manifestAddress, range, message) ->
-            match workflow.FailedRanges.TryGetValue range with
-            | true, failure when failure.OperationId = commandOperationId ->
+            match workflow.FailedRanges
+                  |> Array.tryFind (fun failure -> failure.Range = range)
+                with
+            | Some failure when failure.OperationId = commandOperationId ->
                 Some(
                     workflow.RepositoryId = repositoryId
                     && workflow.StoragePoolId = storagePoolId
@@ -154,7 +161,10 @@ module ManifestContributionWorkflow =
     /// Coordinates pending ranges logic for the ManifestContributionWorkflow actor.
     let pendingRanges (workflow: ManifestContributionWorkflowDto) =
         workflow.Ranges
-        |> Array.filter (fun range -> not (workflow.CompletedRanges.ContainsKey range))
+        |> Array.filter (fun range ->
+            workflow.CompletedRanges
+            |> Array.exists (fun completed -> completed.Range = range)
+            |> not)
 
     /// Checks whether blocks unsafe deletion is true for the ManifestContributionWorkflow actor state.
     let blocksUnsafeDeletion (workflow: ManifestContributionWorkflowDto) range =
@@ -250,6 +260,8 @@ module ManifestContributionWorkflow =
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow command target does not match the initialized workflow.")
         elif workflow.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress then
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow has already been started.")
+        elif start.CounterRevision <= 0L then
+            Some(graceError metadata.CorrelationId "ManifestContributionWorkflow counter revision must be greater than zero.")
         elif Array.isEmpty start.Ranges then
             Some(graceError metadata.CorrelationId "ManifestContributionWorkflow requires at least one range.")
         elif hasDuplicateRanges start.Ranges then
@@ -307,14 +319,20 @@ module ManifestContributionWorkflow =
                 | Some _ -> okDecision workflow operationId [] [] true "Manifest contribution workflow command replayed."
                 | None ->
                     match command with
-                    | ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges) ->
-                        let start = startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges
+                    | ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges, counterRevision) ->
+                        let start = startCommandPayload operationId repositoryId storagePoolId manifestAddress direction ranges counterRevision
 
-                        match validateStart expectedPrimaryKey workflow start metadata with
-                        | Some error -> Error error
-                        | None ->
-                            let workflowEvent = { Event = ManifestContributionWorkflowEventType.WorkflowStarted start; Metadata = metadata }
-                            okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow started."
+                        if counterRevision < workflow.CounterRevision then
+                            okDecision workflow operationId [] [] true "Manifest contribution workflow start was superseded."
+                        elif counterRevision = workflow.CounterRevision
+                             && workflow.StartOperationId.IsSome then
+                            Error(graceError metadata.CorrelationId "ManifestContributionWorkflow counter revision was already used by a different operation.")
+                        else
+                            match validateStart expectedPrimaryKey workflow start metadata with
+                            | Some error -> Error error
+                            | None ->
+                                let workflowEvent = { Event = ManifestContributionWorkflowEventType.WorkflowStarted start; Metadata = metadata }
+                                okDecision workflow operationId [ workflowEvent ] [] false "Manifest contribution workflow started."
                     | ManifestContributionWorkflowCommand.RecordRangeSucceeded (operationId, repositoryId, storagePoolId, manifestAddress, range) ->
                         let progress = progressCommandPayload operationId repositoryId storagePoolId manifestAddress range
 
@@ -326,7 +344,8 @@ module ManifestContributionWorkflow =
                                 Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
                             elif not (isKnownRange workflow progress.Range) then
                                 Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
-                            elif workflow.CompletedRanges.ContainsKey progress.Range then
+                            elif workflow.CompletedRanges
+                                 |> Array.exists (fun completed -> completed.Range = progress.Range) then
                                 okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
                             else
                                 let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeSucceeded progress; Metadata = metadata }
@@ -348,7 +367,8 @@ module ManifestContributionWorkflow =
                                 Error(graceError metadata.CorrelationId "ManifestContributionWorkflow must be started before recording range progress.")
                             elif not (isKnownRange workflow failure.Range) then
                                 Error(graceError metadata.CorrelationId "ManifestContributionWorkflow range is not part of this workflow.")
-                            elif workflow.CompletedRanges.ContainsKey failure.Range then
+                            elif workflow.CompletedRanges
+                                 |> Array.exists (fun completed -> completed.Range = failure.Range) then
                                 okDecision workflow operationId [] [] true "Manifest contribution workflow range was already completed."
                             else
                                 let workflowEvent = { Event = ManifestContributionWorkflowEventType.RangeFailed failure; Metadata = metadata }
@@ -457,7 +477,9 @@ module ManifestContributionWorkflow =
                 while rangeIndex < ranges.Length && error.IsNone do
                     let range = ranges[rangeIndex]
 
-                    if not (workflow.CompletedRanges.ContainsKey range) then
+                    if workflow.CompletedRanges
+                       |> Array.exists (fun completed -> completed.Range = range)
+                       |> not then
                         match! this.ApplyRange(startOperationId, rangeIndex, range, metadata) with
                         | Ok _ -> ()
                         | Error rangeError ->
@@ -527,18 +549,27 @@ module ManifestContributionWorkflow =
                 |> returnTask
 
             /// Coordinates start logic for the ManifestContributionWorkflow actor.
-            member this.Start operationId repositoryId storagePoolId manifestAddress direction ranges metadata =
+            member this.Start operationId repositoryId storagePoolId manifestAddress direction ranges counterRevision metadata =
                 task {
                     match! (this :> IManifestContributionWorkflowActor)
                                .Handle
-                               (ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges))
+                               (ManifestContributionWorkflowCommand.Start(
+                                   operationId,
+                                   repositoryId,
+                                   storagePoolId,
+                                   manifestAddress,
+                                   direction,
+                                   ranges,
+                                   counterRevision
+                               ))
                                metadata
                         with
                     | Error error -> return Error error
-                    | Ok startResult ->
+                    | Ok startResult when startResult.ReturnValue.Workflow.StartOperationId = Some operationId ->
                         match! this.ApplyPendingRanges(operationId, metadata) with
                         | Error error -> return Error error
                         | Ok _ -> return Ok startResult
+                    | Ok startResult -> return Ok startResult
                 }
 
             /// Routes a public actor command to the domain operation that validates and persists it.

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -181,7 +181,7 @@ module Reference =
             let block = manifest.Blocks[index]
 
             if seenContentBlocks.Add block.Address then
-                ranges.Add({ StoragePoolId = storagePoolId; ContentBlockAddress = block.Address; OrdinalStart = 0; OrdinalCount = 1 })
+                ranges.Add({ StoragePoolId = storagePoolId; ContentBlockAddress = block.Address })
 
             index <- index + 1
 

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -188,7 +188,7 @@ module Reference =
         ranges.ToArray()
 
     /// Coordinates workflow start command for plan logic for the Reference actor.
-    let private workflowStartCommandForPlan plan =
+    let private workflowStartCommandForPlan plan counterRevision =
         let direction = counterCommandDirection plan.CounterCommand
 
         ManifestContributionWorkflowCommand.Start(
@@ -197,7 +197,8 @@ module Reference =
             plan.Manifest.StoragePoolId,
             plan.Manifest.ManifestAddress,
             direction,
-            plan.WorkflowRanges
+            plan.WorkflowRanges,
+            counterRevision
         )
 
     let private planManifestReferences
@@ -391,66 +392,26 @@ module Reference =
     /// Attempts to create manifest contribution start and returns no value when the required invariant is not met.
     let tryCreateManifestContributionStart plan intent =
         match intent with
-        | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, storagePoolId, manifestAddress) when
+        | RepositoryContentCounterIntent.IncrementManifestReferenceCount (repositoryId, storagePoolId, manifestAddress, counterRevision) when
             repositoryId = plan.RepositoryId
             && storagePoolId = plan.Manifest.StoragePoolId
             && manifestAddress = plan.Manifest.ManifestAddress
             && counterCommandDirection plan.CounterCommand = ManifestContributionDirection.Increment
             ->
-            Some(workflowStartCommandForPlan plan)
-        | RepositoryContentCounterIntent.DecrementManifestReferenceCount (repositoryId, storagePoolId, manifestAddress) when
+            Some(workflowStartCommandForPlan plan counterRevision)
+        | RepositoryContentCounterIntent.DecrementManifestReferenceCount (repositoryId, storagePoolId, manifestAddress, counterRevision) when
             repositoryId = plan.RepositoryId
             && storagePoolId = plan.Manifest.StoragePoolId
             && manifestAddress = plan.Manifest.ManifestAddress
             && counterCommandDirection plan.CounterCommand = ManifestContributionDirection.Decrement
             ->
-            Some(workflowStartCommandForPlan plan)
+            Some(workflowStartCommandForPlan plan counterRevision)
         | _ -> None
 
-    /// Coordinates counter command operation id logic for the Reference actor.
-    let private counterCommandOperationId command =
-        match command with
-        | RepositoryContentCounterCommand.AddReference (operationId, _, _, _)
-        | RepositoryContentCounterCommand.RemoveReference (operationId, _, _, _) -> Some operationId
-
-    /// Coordinates command crossed zero logic for the Reference actor.
-    let private commandCrossedZero operationId command events =
-        let mutable referenceCount = 0L
-        let mutable crossedZero = false
-
-        for counterEvent in events do
-            match counterEvent.Event with
-            | RepositoryContentCounterEventType.ReferenceAdded (eventOperationId, _, _, _) ->
-                if eventOperationId = operationId
-                   && referenceCount = 0L
-                   && counterCommandDirection command = ManifestContributionDirection.Increment then
-                    crossedZero <- true
-
-                referenceCount <- referenceCount + 1L
-            | RepositoryContentCounterEventType.ReferenceRemoved eventOperationId ->
-                if eventOperationId = operationId
-                   && referenceCount = 1L
-                   && counterCommandDirection command = ManifestContributionDirection.Decrement then
-                    crossedZero <- true
-
-                referenceCount <- max 0L (referenceCount - 1L)
-
-        crossedZero
-
-    /// Attempts to create manifest contribution start for counter decision and returns no value when the required invariant is not met.
-    let tryCreateManifestContributionStartForCounterDecision plan (decision: RepositoryContentCounterDecision) events =
-        let startFromIntent =
-            decision.Intents
-            |> List.tryPick (tryCreateManifestContributionStart plan)
-
-        match startFromIntent with
-        | Some startCommand -> Some startCommand
-        | None when decision.WasIdempotentReplay ->
-            match counterCommandOperationId plan.CounterCommand with
-            | Some operationId when commandCrossedZero operationId plan.CounterCommand events -> Some(workflowStartCommandForPlan plan)
-            | None
-            | Some _ -> None
-        | None -> None
+    /// Creates workflow work only from the counter decision's revision-bearing zero-crossing intent.
+    let tryCreateManifestContributionStartForCounterDecision plan (decision: RepositoryContentCounterDecision) _events =
+        decision.Intents
+        |> List.tryPick (tryCreateManifestContributionStart plan)
 
     /// Builds repository content counter actor data needed by the Reference actor.
     let private createRepositoryContentCounterActor repositoryId storagePoolId manifestAddress correlationId =
@@ -511,8 +472,14 @@ module Reference =
                                 metadata.CorrelationId
 
                         match startCommand with
-                        | ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges) ->
-                            match! workflowActor.Start operationId repositoryId storagePoolId manifestAddress direction ranges metadata with
+                        | ManifestContributionWorkflowCommand.Start (operationId,
+                                                                     repositoryId,
+                                                                     storagePoolId,
+                                                                     manifestAddress,
+                                                                     direction,
+                                                                     ranges,
+                                                                     counterRevision) ->
+                            match! workflowActor.Start operationId repositoryId storagePoolId manifestAddress direction ranges counterRevision metadata with
                             | Ok _ -> ()
                             | Error graceError -> error <- Some graceError
                         | _ -> error <- Some(GraceError.Create "Manifest contribution save boundary expected a workflow start command." metadata.CorrelationId)

--- a/src/Grace.Actors/RepositoryContentCounter.Actor.fs
+++ b/src/Grace.Actors/RepositoryContentCounter.Actor.fs
@@ -79,11 +79,11 @@ module RepositoryContentCounter =
         match change.Operation, change.PreviousCount, change.CurrentCount with
         | RepositoryContentCounterChangeOperation.Added, 0L, 1L ->
             [
-                RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress)
+                RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress, change.Revision)
             ]
         | RepositoryContentCounterChangeOperation.Removed, 1L, 0L ->
             [
-                RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress)
+                RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress, change.Revision)
             ]
         | _ -> []
 
@@ -185,7 +185,12 @@ module RepositoryContentCounter =
                     let intents =
                         if counter.ReferenceCount = 0L then
                             [
-                                RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress)
+                                RepositoryContentCounterIntent.IncrementManifestReferenceCount(
+                                    repositoryId,
+                                    storagePoolId,
+                                    manifestAddress,
+                                    counter.Revision + 1L
+                                )
                             ]
                         else
                             []
@@ -200,7 +205,12 @@ module RepositoryContentCounter =
                         let intents =
                             if counter.ReferenceCount = 1L then
                                 [
-                                    RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress)
+                                    RepositoryContentCounterIntent.DecrementManifestReferenceCount(
+                                        repositoryId,
+                                        storagePoolId,
+                                        manifestAddress,
+                                        counter.Revision + 1L
+                                    )
                                 ]
                             else
                                 []

--- a/src/Grace.Actors/RepositoryContentCounter.Actor.fs
+++ b/src/Grace.Actors/RepositoryContentCounter.Actor.fs
@@ -13,7 +13,29 @@ open Orleans
 open Orleans.Runtime
 open System
 open System.Collections.Generic
+open System.Threading
 open System.Threading.Tasks
+
+/// Provides short-lived replay results without making Redis part of repository manifest membership.
+type IRepositoryCounterRecentResult =
+
+    /// Returns a cached result or `None` when the operation is unknown, expired, malformed, or unavailable.
+    abstract member TryGetAsync:
+        repositoryId: RepositoryId *
+        storagePoolId: StoragePoolId *
+        manifestAddress: ManifestAddress *
+        operationId: RepositoryContentCounterOperationId *
+        cancellationToken: CancellationToken ->
+            Task<RepositoryContentCounterCompletedChange option>
+
+    /// Attempts to cache one completed result for ten minutes and reports whether Redis accepted the write.
+    abstract member TrySetAsync:
+        repositoryId: RepositoryId *
+        storagePoolId: StoragePoolId *
+        manifestAddress: ManifestAddress *
+        change: RepositoryContentCounterCompletedChange *
+        cancellationToken: CancellationToken ->
+            Task<bool>
 
 /// Groups Orleans actor helpers for repository content counter keys, proxies, state, or workflow transitions.
 module RepositoryContentCounter =
@@ -40,37 +62,30 @@ module RepositoryContentCounter =
         | RepositoryContentCounterCommand.AddReference (_, repositoryId, storagePoolId, manifestAddress)
         | RepositoryContentCounterCommand.RemoveReference (_, repositoryId, storagePoolId, manifestAddress) -> repositoryId, storagePoolId, manifestAddress
 
-    /// Coordinates event operation id logic for the RepositoryContentCounter actor.
-    let private eventOperationId counterEvent =
-        match counterEvent.Event with
-        | RepositoryContentCounterEventType.ReferenceAdded (operationId, _, _, _) -> operationId
-        | RepositoryContentCounterEventType.ReferenceRemoved operationId -> operationId
-
-    /// Coordinates event command name logic for the RepositoryContentCounter actor.
-    let private eventCommandName counterEvent =
-        match counterEvent.Event with
-        | RepositoryContentCounterEventType.ReferenceAdded _ -> "AddReference"
-        | RepositoryContentCounterEventType.ReferenceRemoved _ -> "RemoveReference"
-
-    /// Attempts to find applied operation and returns no value when the required invariant is not met.
-    let private tryFindAppliedOperation (counter: RepositoryContentCounterDto) operationId =
+    /// Attempts to find the bounded completed change for one operation.
+    let private tryFindCompletedChange (counter: RepositoryContentCounterDto) operationId =
         counter.LastCompletedChange
-        |> Option.bind (fun change ->
-            if change.OperationId <> operationId then
-                None
-            else
-                let eventType =
-                    match change.Operation with
-                    | RepositoryContentCounterChangeOperation.Added ->
-                        RepositoryContentCounterEventType.ReferenceAdded(
-                            change.OperationId,
-                            counter.RepositoryId,
-                            counter.StoragePoolId,
-                            counter.ManifestAddress
-                        )
-                    | RepositoryContentCounterChangeOperation.Removed -> RepositoryContentCounterEventType.ReferenceRemoved change.OperationId
+        |> Option.filter (fun change -> change.OperationId = operationId)
 
-                Some { Event = eventType; Metadata = Unchecked.defaultof<EventMetadata> })
+    /// Returns whether the completed change matches the requested counter direction.
+    let private changeMatchesCommand change command =
+        match change.Operation, command with
+        | RepositoryContentCounterChangeOperation.Added, RepositoryContentCounterCommand.AddReference _
+        | RepositoryContentCounterChangeOperation.Removed, RepositoryContentCounterCommand.RemoveReference _ -> true
+        | _ -> false
+
+    /// Recreates only the zero-transition intent carried by an original completed result.
+    let private intentsForCompletedChange repositoryId storagePoolId manifestAddress change =
+        match change.Operation, change.PreviousCount, change.CurrentCount with
+        | RepositoryContentCounterChangeOperation.Added, 0L, 1L ->
+            [
+                RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress)
+            ]
+        | RepositoryContentCounterChangeOperation.Removed, 1L, 0L ->
+            [
+                RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress)
+            ]
+        | _ -> []
 
     /// Applies events changes to the RepositoryContentCounter actor state.
     let private applyEvents (events: RepositoryContentCounterEvent list) (counter: RepositoryContentCounterDto) =
@@ -107,6 +122,31 @@ module RepositoryContentCounter =
         | Some expectedPrimaryKey -> not (String.Equals(expectedPrimaryKey, primaryKey repositoryId storagePoolId manifestAddress, StringComparison.Ordinal))
         | None -> false
 
+    /// Validates a counter command before either Redis replay or durable mutation.
+    let private validateCommandTarget
+        (expectedPrimaryKey: string option)
+        (counter: RepositoryContentCounterDto)
+        (command: RepositoryContentCounterCommand)
+        (metadata: EventMetadata)
+        =
+        let operationId = operationId command
+        let repositoryId, storagePoolId, manifestAddress = commandTarget command
+
+        if String.IsNullOrWhiteSpace operationId then
+            Some(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty operation id.")
+        elif repositoryId = RepositoryId.Empty then
+            Some(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty RepositoryId.")
+        elif String.IsNullOrWhiteSpace storagePoolId then
+            Some(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty StoragePoolId.")
+        elif String.IsNullOrWhiteSpace manifestAddress then
+            Some(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty ManifestAddress.")
+        elif expectedPrimaryKeyMismatch expectedPrimaryKey repositoryId storagePoolId manifestAddress then
+            Some(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the grain key.")
+        elif targetMismatch counter repositoryId storagePoolId manifestAddress then
+            Some(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the initialized counter.")
+        else
+            None
+
     let decideCommandForKey
         (expectedPrimaryKey: string option)
         (_events: seq<RepositoryContentCounterEvent>)
@@ -119,26 +159,20 @@ module RepositoryContentCounter =
         /// Coordinates repository id logic for the RepositoryContentCounter actor.
         let repositoryId, storagePoolId, manifestAddress = commandTarget command
 
-        if String.IsNullOrWhiteSpace operationId then
-            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty operation id.")
-        elif repositoryId = RepositoryId.Empty then
-            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty RepositoryId.")
-        elif String.IsNullOrWhiteSpace storagePoolId then
-            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty StoragePoolId.")
-        elif String.IsNullOrWhiteSpace manifestAddress then
-            Error(graceError metadata.CorrelationId "RepositoryContentCounter command requires a non-empty ManifestAddress.")
-        elif expectedPrimaryKeyMismatch expectedPrimaryKey repositoryId storagePoolId manifestAddress then
-            Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the grain key.")
-        elif targetMismatch counter repositoryId storagePoolId manifestAddress then
-            Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the initialized counter.")
-        else
-            match tryFindAppliedOperation counter operationId with
-            | Some counterEvent when
-                eventCommandName counterEvent
-                <> commandName command
-                ->
+        match validateCommandTarget expectedPrimaryKey counter command metadata with
+        | Some error -> Error error
+        | None ->
+            match tryFindCompletedChange counter operationId with
+            | Some change when not (changeMatchesCommand change command) ->
                 Error(graceError metadata.CorrelationId "RepositoryContentCounter operation id was already used for a different command.")
-            | Some _ -> okDecision counter operationId [] [] true "Repository content counter command replayed."
+            | Some change ->
+                okDecision
+                    counter
+                    operationId
+                    []
+                    (intentsForCompletedChange repositoryId storagePoolId manifestAddress change)
+                    true
+                    "Repository content counter command replayed."
             | None ->
                 match command with
                 | RepositoryContentCounterCommand.AddReference _ ->
@@ -176,10 +210,87 @@ module RepositoryContentCounter =
     /// Validates a RepositoryContentCounter command and derives the events needed for a state transition.
     let decideCommand events counter command metadata = decideCommandForKey None events counter command metadata
 
+    /// Resolves Redis replay, bounded persistence, and safe removal gating for one counter command.
+    let handleWithRecentResult
+        (recentResult: IRepositoryCounterRecentResult)
+        (persistSnapshot: RepositoryContentCounterDto -> Task)
+        expectedPrimaryKey
+        counter
+        command
+        metadata
+        cancellationToken
+        =
+        task {
+            match validateCommandTarget expectedPrimaryKey counter command metadata with
+            | Some error -> return Error error
+            | None ->
+                let repositoryId, storagePoolId, manifestAddress = commandTarget command
+                let operationId = operationId command
+
+                match! recentResult.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, cancellationToken) with
+                | Some cachedChange when cachedChange.OperationId <> operationId ->
+                    return
+                        Error(graceError metadata.CorrelationId "RepositoryContentCounter recent result operation id does not match the requested operation.")
+                | Some cachedChange when not (changeMatchesCommand cachedChange command) ->
+                    return Error(graceError metadata.CorrelationId "RepositoryContentCounter operation id was already used for a different command.")
+                | Some cachedChange ->
+                    return
+                        okDecision
+                            counter
+                            operationId
+                            []
+                            (intentsForCompletedChange repositoryId storagePoolId manifestAddress cachedChange)
+                            true
+                            "Repository content counter command replayed from recent result."
+                | None ->
+                    match decideCommandForKey expectedPrimaryKey Seq.empty counter command metadata with
+                    | Error error -> return Error error
+                    | Ok localDecision ->
+                        let isRemoval =
+                            match command with
+                            | RepositoryContentCounterCommand.RemoveReference _ -> true
+                            | RepositoryContentCounterCommand.AddReference _ -> false
+
+                        let! previousResultCached =
+                            match counter.LastCompletedChange with
+                            | Some previousChange when previousChange.OperationId <> operationId ->
+                                recentResult.TrySetAsync(repositoryId, storagePoolId, manifestAddress, previousChange, cancellationToken)
+                            | Some _
+                            | None -> Task.FromResult true
+
+                        if isRemoval && not previousResultCached then
+                            return
+                                Error(
+                                    graceError
+                                        metadata.CorrelationId
+                                        "RepositoryContentCounter removal paused because Redis could not preserve the previous completed result."
+                                )
+                        else
+                            if not localDecision.Events.IsEmpty then
+                                do! persistSnapshot localDecision.Counter
+
+                            match localDecision.Counter.LastCompletedChange with
+                            | None -> return Error(graceError metadata.CorrelationId "RepositoryContentCounter completed without a bounded result.")
+                            | Some completedChange ->
+                                let! completedResultCached =
+                                    recentResult.TrySetAsync(repositoryId, storagePoolId, manifestAddress, completedChange, cancellationToken)
+
+                                if isRemoval && not completedResultCached then
+                                    return
+                                        Error(
+                                            graceError
+                                                metadata.CorrelationId
+                                                "RepositoryContentCounter removal was retained safely because Redis did not confirm the completed result."
+                                        )
+                                else
+                                    return Ok localDecision
+        }
+
     /// Implements the Orleans grain for repository content counter actor.
     type RepositoryContentCounterActor
         (
-            [<PersistentState(StateName.RepositoryContentCounter, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<RepositoryContentCounterDto>
+            [<PersistentState(StateName.RepositoryContentCounter, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<RepositoryContentCounterDto>,
+            recentResult: IRepositoryCounterRecentResult
         ) =
         inherit Grain()
 
@@ -197,12 +308,13 @@ module RepositoryContentCounter =
             Task.CompletedTask
 
         /// Overwrites the bounded RepositoryContentCounter snapshot after one completed transition.
-        member private this.ApplySnapshot(snapshot: RepositoryContentCounterDto) =
-            task {
+        member private this.ApplySnapshot(snapshot: RepositoryContentCounterDto) : Task =
+            (task {
                 state.State <- snapshot
                 do! state.WriteStateAsync()
                 counter <- snapshot
             }
+            :> Task)
 
         interface IRepositoryContentCounterActor with
             /// Reports whether this RepositoryContentCounter actor has persisted state.
@@ -232,10 +344,17 @@ module RepositoryContentCounter =
                     this.correlationId <- metadata.CorrelationId
                     RequestContext.Set(Grace.Shared.Constants.CurrentCommandProperty, commandName command)
 
-                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) Seq.empty counter command metadata with
+                    match!
+                        handleWithRecentResult
+                            recentResult
+                            this.ApplySnapshot
+                            (Some(this.GetPrimaryKeyString()))
+                            counter
+                            command
+                            metadata
+                            CancellationToken.None
+                        with
                     | Ok decision ->
-                        if not decision.Events.IsEmpty then do! this.ApplySnapshot decision.Counter
-
                         let returnValue =
                             (GraceReturnValue.Create decision metadata.CorrelationId)
                                 .enhance(nameof RepositoryId, decision.Counter.RepositoryId)

--- a/src/Grace.Actors/RepositoryContentCounter.Actor.fs
+++ b/src/Grace.Actors/RepositoryContentCounter.Actor.fs
@@ -53,9 +53,24 @@ module RepositoryContentCounter =
         | RepositoryContentCounterEventType.ReferenceRemoved _ -> "RemoveReference"
 
     /// Attempts to find applied operation and returns no value when the required invariant is not met.
-    let private tryFindAppliedOperation (events: seq<RepositoryContentCounterEvent>) operationId =
-        events
-        |> Seq.tryFind (fun counterEvent -> eventOperationId counterEvent = operationId)
+    let private tryFindAppliedOperation (counter: RepositoryContentCounterDto) operationId =
+        counter.LastCompletedChange
+        |> Option.bind (fun change ->
+            if change.OperationId <> operationId then
+                None
+            else
+                let eventType =
+                    match change.Operation with
+                    | RepositoryContentCounterChangeOperation.Added ->
+                        RepositoryContentCounterEventType.ReferenceAdded(
+                            change.OperationId,
+                            counter.RepositoryId,
+                            counter.StoragePoolId,
+                            counter.ManifestAddress
+                        )
+                    | RepositoryContentCounterChangeOperation.Removed -> RepositoryContentCounterEventType.ReferenceRemoved change.OperationId
+
+                Some { Event = eventType; Metadata = Unchecked.defaultof<EventMetadata> })
 
     /// Applies events changes to the RepositoryContentCounter actor state.
     let private applyEvents (events: RepositoryContentCounterEvent list) (counter: RepositoryContentCounterDto) =
@@ -94,7 +109,7 @@ module RepositoryContentCounter =
 
     let decideCommandForKey
         (expectedPrimaryKey: string option)
-        (events: seq<RepositoryContentCounterEvent>)
+        (_events: seq<RepositoryContentCounterEvent>)
         (counter: RepositoryContentCounterDto)
         (command: RepositoryContentCounterCommand)
         (metadata: EventMetadata)
@@ -117,7 +132,7 @@ module RepositoryContentCounter =
         elif targetMismatch counter repositoryId storagePoolId manifestAddress then
             Error(graceError metadata.CorrelationId "RepositoryContentCounter command target does not match the initialized counter.")
         else
-            match tryFindAppliedOperation events operationId with
+            match tryFindAppliedOperation counter operationId with
             | Some counterEvent when
                 eventCommandName counterEvent
                 <> commandName command
@@ -164,7 +179,7 @@ module RepositoryContentCounter =
     /// Implements the Orleans grain for repository content counter actor.
     type RepositoryContentCounterActor
         (
-            [<PersistentState(StateName.RepositoryContentCounter, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<List<RepositoryContentCounterEvent>>
+            [<PersistentState(StateName.RepositoryContentCounter, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<RepositoryContentCounterDto>
         ) =
         inherit Grain()
 
@@ -177,18 +192,16 @@ module RepositoryContentCounter =
             let activateStartTime = getCurrentInstant ()
             logActorActivation log this.IdentityString activateStartTime (getActorActivationMessage state.RecordExists)
 
-            counter <-
-                state.State
-                |> Seq.fold (fun dto event -> RepositoryContentCounterDto.UpdateDto event dto) RepositoryContentCounterDto.Default
+            counter <- if state.RecordExists then state.State else RepositoryContentCounterDto.Default
 
             Task.CompletedTask
 
-        /// Replays persisted RepositoryContentCounter events into an in-memory state snapshot.
-        member private this.ApplyEvents(events: RepositoryContentCounterEvent list) =
+        /// Overwrites the bounded RepositoryContentCounter snapshot after one completed transition.
+        member private this.ApplySnapshot(snapshot: RepositoryContentCounterDto) =
             task {
-                state.State.AddRange(events)
+                state.State <- snapshot
                 do! state.WriteStateAsync()
-                counter <- applyEvents events counter
+                counter <- snapshot
             }
 
         interface IRepositoryContentCounterActor with
@@ -206,11 +219,11 @@ module RepositoryContentCounter =
                 this.correlationId <- correlationId
                 counter |> returnTask
 
-            /// Returns the persisted RepositoryContentCounter event stream for replay or audit.
+            /// Returns no lifetime events because the actor persists only its bounded current snapshot.
             member this.GetEvents correlationId =
                 this.correlationId <- correlationId
 
-                (state.State :> IReadOnlyList<RepositoryContentCounterEvent>)
+                (Array.empty<RepositoryContentCounterEvent> :> IReadOnlyList<RepositoryContentCounterEvent>)
                 |> returnTask
 
             /// Routes a public actor command to the domain operation that validates and persists it.
@@ -219,9 +232,9 @@ module RepositoryContentCounter =
                     this.correlationId <- metadata.CorrelationId
                     RequestContext.Set(Grace.Shared.Constants.CurrentCommandProperty, commandName command)
 
-                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) state.State counter command metadata with
+                    match decideCommandForKey (Some(this.GetPrimaryKeyString())) Seq.empty counter command metadata with
                     | Ok decision ->
-                        if not decision.Events.IsEmpty then do! this.ApplyEvents decision.Events
+                        if not decision.Events.IsEmpty then do! this.ApplySnapshot decision.Counter
 
                         let returnValue =
                             (GraceReturnValue.Create decision metadata.CorrelationId)

--- a/src/Grace.Actors/UploadSession.Actor.fs
+++ b/src/Grace.Actors/UploadSession.Actor.fs
@@ -410,10 +410,10 @@ module UploadSession =
         finalizedManifestContentBlockAddresses manifest
         |> HashSet<ContentBlockAddress>
 
-    /// Coordinates finalized manifest contribution ranges logic for the UploadSession actor.
-    let finalizedManifestContributionRanges (ranges: ContentBlockMetadataRange array) =
+    /// Keeps finalized physical ranges reclaimable until repository contribution accounting activates them.
+    let finalizedManifestPhysicalRanges (ranges: ContentBlockMetadataRange array) =
         ranges
-        |> Array.map (fun range -> { range with ActiveManifestCount = 1 })
+        |> Array.map (fun range -> { range with ActiveManifestCount = 0 })
 
     /// Coordinates block was uploaded logic for the UploadSession actor.
     let private blockWasUploaded (session: UploadSessionDto) (block: ContentBlock) =
@@ -876,7 +876,7 @@ module UploadSession =
                                             ContentBlockAddress = firstClaimedRange.ContentBlockAddress
                                             BlockFormatVersion = authoritativeMetadata.BlockFormatVersion
                                             StoragePlacement = authoritativeMetadata.StoragePlacement
-                                            Ranges = finalizedManifestContributionRanges (physicalRanges.ToArray())
+                                            Ranges = finalizedManifestPhysicalRanges (physicalRanges.ToArray())
                                             ExpectedMetadataVersion = None
                                             RequireMissingMetadata = false
                                             ExpectedRanges = expectedRanges.ToArray()
@@ -903,7 +903,7 @@ module UploadSession =
                             ContentBlockAddress = confirmedBlock.ContentBlockAddress
                             BlockFormatVersion = 1s
                             StoragePlacement = confirmedBlock.StoragePlacement
-                            Ranges = finalizedManifestContributionRanges confirmedBlock.Ranges
+                            Ranges = finalizedManifestPhysicalRanges confirmedBlock.Ranges
                             ExpectedMetadataVersion = None
                             RequireMissingMetadata = false
                             ExpectedRanges = Array.empty
@@ -968,7 +968,7 @@ module UploadSession =
                 { merge with
                     BlockFormatVersion = authoritativeMetadata.BlockFormatVersion
                     StoragePlacement = authoritativeMetadata.StoragePlacement
-                    Ranges = finalizedManifestContributionRanges activeCurrentRanges
+                    Ranges = finalizedManifestPhysicalRanges activeCurrentRanges
                     ExpectedRanges = Array.empty
                 }
 
@@ -1060,7 +1060,7 @@ module UploadSession =
                                         ContentBlockAddress = firstClaimedRange.ContentBlockAddress
                                         BlockFormatVersion = authoritativeMetadata.BlockFormatVersion
                                         StoragePlacement = authoritativeMetadata.StoragePlacement
-                                        Ranges = finalizedManifestContributionRanges (physicalRanges.ToArray())
+                                        Ranges = finalizedManifestPhysicalRanges (physicalRanges.ToArray())
                                         ExpectedMetadataVersion = None
                                         RequireMissingMetadata = false
                                         ExpectedRanges = expectedRanges.ToArray()

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -82,7 +82,7 @@ public partial class Program
 
             // Redis: keep local container for both run modes (Local + Azure debug), and even in publish mode if you like.
             var redisContainerName = runSuffix is null ? "redis" : $"redis-{runSuffix}";
-            var redis = builder.AddContainer("redis", "redis", "latest")
+            var redis = builder.AddContainer("redis", "redis", "8.6.3")
                 .WithContainerName(redisContainerName)
                 //.WithLifetime(ContainerLifetime.Session)
                 .WithEnvironment("ACCEPT_EULA", "Y")

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -48,6 +48,7 @@ module AspireTestHost =
     let private graceServerResourceName = "grace-server"
     let private operationsWorkerResourceName = "grace-operations-worker"
     let private azuriteResourceName = "azurite"
+    let private redisResourceName = "redis"
     let private sharedStateLock = new SemaphoreSlim(1, 1)
     let mutable private sharedState: TestHostState option = None
     let mutable private sharedBootstrapUserId: string option = None
@@ -1099,6 +1100,12 @@ module AspireTestHost =
                 Console.WriteLine($"Azurite resource detected: {azuriteResourceName}")
                 do! waitForResourceHealthyAsync notificationService app azuriteResourceName cts.Token
             | None -> Console.WriteLine("Azurite resource not found in model.")
+
+            match tryFindResourceByName app redisResourceName with
+            | Some _ ->
+                Console.WriteLine($"Redis resource detected: {redisResourceName}")
+                do! waitForResourceHealthyAsync notificationService app redisResourceName cts.Token
+            | None -> Console.WriteLine("Redis resource not found in model.")
 
             let serviceBusSqlResourceName = getServiceBusSqlResourceName ()
             let serviceBusEmulatorResourceName = getServiceBusEmulatorResourceName ()

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -22,6 +22,7 @@ open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
 open Grace.Types
+open Grace.Types.ManifestContributionAccounting
 open Grace.Shared.Utilities
 
 /// Captures test host state values used by the test suite.
@@ -1752,4 +1753,35 @@ module AspireTestHost =
                 |> String.concat Environment.NewLine
 
             return $"Active:{Environment.NewLine}{describe active}{Environment.NewLine}DeadLetter:{Environment.NewLine}{describe deadLetter}"
+        }
+
+    /// Waits until manifest contribution accounting records one canonical exact relationship.
+    let waitForExactRelationshipAsync (state: TestHostState) relationship =
+        task {
+            let key =
+                match ExactRelationshipKey.create relationship with
+                | Ok key -> key
+                | Error error -> failwith error
+
+            use client = createCosmosClient state
+            let container = client.GetContainer(state.CosmosDatabaseName, state.CosmosContainerName)
+            let timeoutAt = DateTime.UtcNow.AddSeconds(30.0)
+            let mutable found = false
+
+            while not found && DateTime.UtcNow < timeoutAt do
+                try
+                    let! _ = container.ReadItemAsync<JsonElement>(key.ItemId, PartitionKey key.PartitionKey, cancellationToken = CancellationToken.None)
+
+                    found <- true
+                with
+                | :? CosmosException as ex when ex.StatusCode = System.Net.HttpStatusCode.NotFound -> do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            if not found then
+                let! logs = getGraceServerLogsAsync state
+                let! fileLog = getGraceServerFileLogAsync state
+                let! subscription = describeGraceServerSubscriptionAsync state
+
+                Assert.Fail(
+                    $"Timed out waiting for exact relationship {key.PartitionKey}/{key.ItemId}.{Environment.NewLine}Grace.Server logs:{Environment.NewLine}{logs}{Environment.NewLine}Grace.Server file log:{Environment.NewLine}{fileLog}{Environment.NewLine}{subscription}"
+                )
         }

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -1699,6 +1699,14 @@ module AspireTestHost =
     /// Returns current Grace.Server resource logs for focused Aspire failure diagnostics.
     let getGraceServerLogsAsync (state: TestHostState) = getResourceLogsAsync state.App graceServerResourceName
 
+    /// Returns the Redis endpoint published by the running Aspire application model.
+    let getRedisEndpoint (state: TestHostState) =
+        let endpointName =
+            tryGetEndpointNameForTargetPort state.App redisResourceName 6379
+            |> Option.defaultWith (fun () -> getEndpointName state.App redisResourceName)
+
+        state.App.GetEndpoint(redisResourceName, endpointName)
+
     /// Returns the latest Grace.Server file-log tail for focused Aspire failure diagnostics.
     let getGraceServerFileLogAsync (state: TestHostState) =
         task {

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="WorkItem.Integration.Server.Tests.fs" />
     <Compile Include="RestartDurability.Server.Tests.fs" />
     <Compile Include="ManifestContributionAccounting.Server.Tests.fs" />
+    <Compile Include="RepositoryCounterRecentResult.Integration.Server.Tests.fs" />
     <Compile Include="Policy.Server.Tests.fs" />
     <Compile Include="Queue.Integration.Server.Tests.fs" />
     <Compile Include="PromotionSet.Integration.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -55,6 +55,36 @@ module private ManifestContributionAccountingAspireTestHelpers =
             return actorEventStreams
         }
 
+    /// Reads bounded actor snapshots of one grain type from the shared Aspire Cosmos container.
+    let readActorSnapshotsAsync<'T> (state: TestHostState) (grainType: string) =
+        task {
+            use client = AspireTestHost.createCosmosClient state
+            let container = client.GetContainer(state.CosmosDatabaseName, state.CosmosContainerName)
+            use iterator = container.GetItemQueryIterator<Dictionary<string, obj>>(QueryDefinition("SELECT * FROM c"))
+            let actorSnapshots = ResizeArray<'T>()
+
+            while iterator.HasMoreResults do
+                let! page = iterator.ReadNextAsync()
+
+                for document in page do
+                    let tryGetJsonElement name =
+                        match document.TryGetValue name with
+                        | true, (:? JsonElement as value) -> Some value
+                        | _ -> None
+
+                    let documentGrainType =
+                        tryGetJsonElement "GrainType"
+                        |> Option.bind (fun value -> if value.ValueKind = JsonValueKind.String then Some(value.GetString()) else None)
+                        |> Option.defaultValue String.Empty
+
+                    if documentGrainType.Equals(grainType, StringComparison.Ordinal) then
+                        match tryGetJsonElement "State" with
+                        | Some stateValue -> actorSnapshots.Add(JsonSerializer.Deserialize<'T>(stateValue.GetRawText(), Constants.JsonSerializerOptions))
+                        | None -> ()
+
+            return actorSnapshots
+        }
+
 /// Proves the public Commit tracer across the real Aspire Service Bus and Cosmos resources.
 [<NonParallelizable>]
 type ManifestContributionAccountingAspireTests() =
@@ -231,14 +261,11 @@ type ManifestContributionAccountingAspireTests() =
             Assert.That(validationResult.ValidationName, Is.EqualTo("quick-scan"))
             Assert.That(validationResult.ValidationVersion, Is.EqualTo("1.0"))
 
-            let! counterEventStreams =
-                ManifestContributionAccountingAspireTestHelpers.readActorEventStreamsAsync<RepositoryContentCounterEvent> state "RepoContentCounter"
+            let! counterSnapshots =
+                ManifestContributionAccountingAspireTestHelpers.readActorSnapshotsAsync<RepositoryContentCounterDto> state "RepoContentCounter"
 
             let counter =
-                counterEventStreams
-                |> Seq.map (fun counterEvents ->
-                    counterEvents
-                    |> Seq.fold (fun current counterEvent -> RepositoryContentCounterDto.UpdateDto counterEvent current) RepositoryContentCounterDto.Default)
+                counterSnapshots
                 |> Seq.tryFind (fun candidate ->
                     candidate.RepositoryId = Guid.Parse(repositoryId)
                     && candidate.StoragePoolId = manifest.StoragePoolId

--- a/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -294,12 +294,13 @@ type ManifestContributionAccountingAspireTests() =
                 |> Option.defaultWith (fun () -> failwith "ContentBlock metadata was not retained.")
 
             Assert.That(retainedMetadata.ContentBlockAddress, Is.EqualTo(block.Address))
+            Assert.That(retainedMetadata.Ranges, Is.Not.Empty, "The retained ContentBlock must contain authoritative physical ranges.")
 
             Assert.That(
                 retainedMetadata.Ranges
-                |> Array.exists (fun range -> range.ActiveManifestCount = 1),
+                |> Array.forall (fun range -> range.ActiveManifestCount = 1),
                 Is.True,
-                "The retained ContentBlock range must be active for the first manifest contribution."
+                "Every retained ContentBlock physical range must be active exactly once for the first repository manifest contribution."
             )
 
             let! subscription = AspireTestHost.describeGraceServerSubscriptionAsync state

--- a/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -17,7 +17,6 @@ open System
 open System.Collections.Generic
 open System.Net
 open System.Text.Json
-open System.Threading
 open System.Threading.Tasks
 
 /// Provides typed access to raw actor persistence for the focused Aspire tracer.
@@ -88,37 +87,6 @@ module private ManifestContributionAccountingAspireTestHelpers =
 /// Proves the public Commit tracer across the real Aspire Service Bus and Cosmos resources.
 [<NonParallelizable>]
 type ManifestContributionAccountingAspireTests() =
-
-    /// Waits for one canonical exact relationship item in the Aspire Cosmos container.
-    let waitForExactRelationshipAsync (state: TestHostState) relationship =
-        task {
-            let key =
-                match ExactRelationshipKey.create relationship with
-                | Ok key -> key
-                | Error error -> failwith error
-
-            use client = AspireTestHost.createCosmosClient state
-            let container = client.GetContainer(state.CosmosDatabaseName, state.CosmosContainerName)
-            let timeoutAt = DateTime.UtcNow.AddSeconds(30.0)
-            let mutable found = false
-
-            while not found && DateTime.UtcNow < timeoutAt do
-                try
-                    let! _ = container.ReadItemAsync<JsonElement>(key.ItemId, PartitionKey key.PartitionKey, cancellationToken = CancellationToken.None)
-
-                    found <- true
-                with
-                | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.NotFound -> do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
-
-            if not found then
-                let! logs = AspireTestHost.getGraceServerLogsAsync state
-                let! fileLog = AspireTestHost.getGraceServerFileLogAsync state
-                let! subscription = AspireTestHost.describeGraceServerSubscriptionAsync state
-
-                Assert.Fail(
-                    $"Timed out waiting for exact relationship {key.PartitionKey}/{key.ItemId}.{Environment.NewLine}Grace.Server logs:{Environment.NewLine}{logs}{Environment.NewLine}Grace.Server file log:{Environment.NewLine}{fileLog}{Environment.NewLine}{subscription}"
-                )
-        }
 
     /// Verifies Commit returns after durable save plus broker acceptance while the existing subscriber converges retained content.
     [<Test>]
@@ -207,13 +175,13 @@ type ManifestContributionAccountingAspireTests() =
                     Constants.DefaultTimestamp
 
             do!
-                waitForExactRelationshipAsync
+                AspireTestHost.waitForExactRelationshipAsync
                     state
                     (ExactRelationship.ReferenceRoot
                         { RepositoryId = Guid.Parse repositoryId; RootDirectoryVersionId = root.DirectoryVersionId; ReferenceId = referenceId })
 
             do!
-                waitForExactRelationshipAsync
+                AspireTestHost.waitForExactRelationshipAsync
                     state
                     (ExactRelationship.DirectoryVersionManifest
                         {

--- a/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
@@ -16,6 +16,34 @@ open System.Diagnostics
 open System.Threading
 open System.Threading.Tasks
 
+/// Captures Redis boundary failures in the NUnit witness without changing nonthrowing production behavior.
+type private RedisWitnessLogger() =
+    let entries = ResizeArray<string>()
+
+    let emptyScope =
+        { new IDisposable with
+            member _.Dispose() = ()
+        }
+
+    /// Returns the structured messages captured from Redis boundary calls.
+    member _.Entries = entries |> Seq.toArray
+
+    interface ILogger with
+        member _.IsEnabled _ = true
+        member _.BeginScope<'TState>(_state: 'TState) = emptyScope
+
+        member _.Log<'TState>(level: LogLevel, eventId: EventId, state: 'TState, error: exn, formatter: Func<'TState, exn, string>) =
+            let message = formatter.Invoke(state, error)
+
+            let entry =
+                if isNull error then
+                    $"{level} {eventId.Id}: {message}"
+                else
+                    $"{level} {eventId.Id}: {message}{Environment.NewLine}{error}"
+
+            entries.Add entry
+            TestContext.Progress.WriteLine entry
+
 /// Proves the bounded Redis accelerator against the Redis version and lifecycle supplied by Grace Aspire.
 [<NonParallelizable>]
 type RepositoryCounterRecentResultIntegrationTests() =
@@ -29,25 +57,27 @@ type RepositoryCounterRecentResultIntegrationTests() =
             let storagePoolId = StoragePoolId "integration"
             let manifestAddress = ManifestAddress(String.replicate 64 "a")
             let operationId = RepositoryContentCounterOperationId $"redis-witness:{Guid.NewGuid():N}"
+            let redisEndpoint = AspireTestHost.getRedisEndpoint state
 
             let change =
                 { OperationId = operationId; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L; Revision = 1L }
 
-            let redisLog =
-                state
-                    .App
-                    .Services
-                    .GetRequiredService<ILoggerFactory>()
-                    .CreateLogger("RepositoryCounterRecentResult.Integration")
+            let redisLog = RedisWitnessLogger()
 
-            use redisRecentResult = new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult("127.0.0.1", 6379, redisLog)
+            use redisRecentResult = new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisEndpoint.Host, redisEndpoint.Port, redisLog)
+
             let recentResult = redisRecentResult :> IRepositoryCounterRecentResult
 
             let! stored = recentResult.TrySetAsync(repositoryId, storagePoolId, manifestAddress, change, CancellationToken.None)
 
-            Assert.That(stored, Is.True, "The Aspire Redis instance must accept the recent result.")
+            Assert.That(
+                stored,
+                Is.True,
+                $"The Aspire Redis instance at {redisEndpoint} must accept the recent result.{Environment.NewLine}{String.Join(Environment.NewLine, redisLog.Entries)}"
+            )
 
-            let! rawConnection = ConnectionMultiplexer.ConnectAsync("127.0.0.1:6379,abortConnect=false")
+            let rawConfiguration = RepositoryCounterRecentResult.configurationForEndpoint redisEndpoint.Host redisEndpoint.Port
+            let! rawConnection = ConnectionMultiplexer.ConnectAsync(rawConfiguration)
             use rawConnection = rawConnection
             let database = rawConnection.GetDatabase()
             let redisKey = RepositoryCounterRecentResult.key repositoryId storagePoolId manifestAddress operationId

--- a/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
@@ -1,0 +1,111 @@
+namespace Grace.Server.Tests
+
+open Aspire.Hosting
+open Aspire.Hosting.ApplicationModel
+open Grace.Actors
+open Grace.Server
+open Grace.Server.Tests.Services
+open Grace.Types.Common
+open Grace.Types.RepositoryContentCounter
+open Microsoft.Extensions.DependencyInjection
+open NUnit.Framework
+open StackExchange.Redis
+open System
+open System.Diagnostics
+open System.Threading
+open System.Threading.Tasks
+
+/// Proves the bounded Redis accelerator against the Redis version and lifecycle supplied by Grace Aspire.
+[<NonParallelizable>]
+type RepositoryCounterRecentResultIntegrationTests() =
+
+    /// Verifies the exact TTL, cache-loss behavior, and native reconnect path without making Redis authoritative.
+    [<Test>]
+    member _.``Redis recent result expires in ten minutes and reconnects after loss``() =
+        task {
+            let! state = AspireTestHost.startAsync testUserId
+            let repositoryId = Guid.NewGuid()
+            let storagePoolId = StoragePoolId "integration"
+            let manifestAddress = ManifestAddress(String.replicate 64 "a")
+            let operationId = RepositoryContentCounterOperationId $"redis-witness:{Guid.NewGuid():N}"
+
+            let change = { OperationId = operationId; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L }
+
+            let recentResult = RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult("127.0.0.1", 6379) :> IRepositoryCounterRecentResult
+
+            let! stored = recentResult.TrySetAsync(repositoryId, storagePoolId, manifestAddress, change, CancellationToken.None)
+
+            Assert.That(stored, Is.True, "The Aspire Redis instance must accept the recent result.")
+
+            let! rawConnection = ConnectionMultiplexer.ConnectAsync("127.0.0.1:6379,abortConnect=false")
+            use rawConnection = rawConnection
+            let database = rawConnection.GetDatabase()
+            let redisKey = RepositoryCounterRecentResult.key repositoryId storagePoolId manifestAddress operationId
+            let! ttl = database.KeyTimeToLiveAsync redisKey
+
+            let ttlValue =
+                ttl
+                |> Option.ofNullable
+                |> Option.defaultWith (fun () -> failwith "Redis did not report a TTL for the recent result.")
+
+            Assert.That(ttlValue, Is.LessThanOrEqualTo(RepositoryCounterRecentResult.expiry))
+
+            Assert.That(
+                ttlValue,
+                Is.GreaterThan(
+                    RepositoryCounterRecentResult.expiry
+                    - TimeSpan.FromSeconds(10.0)
+                )
+            )
+
+            let redisVersion =
+                rawConnection.GetServers()
+                |> Seq.tryHead
+                |> Option.map (fun server -> string server.Version)
+                |> Option.defaultValue "unavailable"
+
+            Assert.That(redisVersion, Does.StartWith("8.6.3"))
+
+            let! deleted = database.KeyDeleteAsync redisKey
+            Assert.That(deleted, Is.True, "Deleting the accelerator entry must simulate Redis result loss.")
+
+            let! lostResult = recentResult.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, CancellationToken.None)
+
+            Assert.That(lostResult.IsNone, Is.True, "A lost Redis entry must remain a nonauthoritative miss.")
+
+            let commandService = state.App.Services.GetRequiredService<ResourceCommandService>()
+            use commandCancellation = new CancellationTokenSource(TimeSpan.FromMinutes(2.0))
+            let! stopResult = commandService.ExecuteCommandAsync("redis", KnownResourceCommands.StopCommand, commandCancellation.Token)
+            Assert.That(stopResult.Success, Is.True, stopResult.Message)
+
+            let! unavailableResult = recentResult.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, CancellationToken.None)
+
+            Assert.That(unavailableResult.IsNone, Is.True, "Redis unavailability must be observed as a bounded cache miss.")
+
+            let! startResult = commandService.ExecuteCommandAsync("redis", KnownResourceCommands.StartCommand, commandCancellation.Token)
+            Assert.That(startResult.Success, Is.True, startResult.Message)
+
+            let reconnectTimer = Stopwatch.StartNew()
+            let mutable recovered = false
+
+            while not recovered
+                  && reconnectTimer.Elapsed < TimeSpan.FromSeconds(30.0) do
+                let! recoveredWrite = recentResult.TrySetAsync(repositoryId, storagePoolId, manifestAddress, change, CancellationToken.None)
+
+                if recoveredWrite then
+                    let! recoveredResult = recentResult.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, CancellationToken.None)
+
+                    recovered <- recoveredResult = Some change
+
+                if not recovered then do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            reconnectTimer.Stop()
+            Assert.That(recovered, Is.True, "The existing Redis client must reconnect after the Aspire resource restarts.")
+
+            let! cleaned = database.KeyDeleteAsync redisKey
+
+            TestContext.Progress.WriteLine(
+                $"RedisVersion={redisVersion}; InitialTtl={ttlValue.TotalSeconds:F3}s; LossObserved={lostResult.IsNone}; "
+                + $"UnavailableObserved={unavailableResult.IsNone}; ReconnectElapsed={reconnectTimer.Elapsed.TotalSeconds:F3}s; CleanupDeleted={cleaned}"
+            )
+        }

--- a/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
@@ -8,6 +8,7 @@ open Grace.Server.Tests.Services
 open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
 open NUnit.Framework
 open StackExchange.Redis
 open System
@@ -32,7 +33,15 @@ type RepositoryCounterRecentResultIntegrationTests() =
             let change =
                 { OperationId = operationId; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L; Revision = 1L }
 
-            let recentResult = RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult("127.0.0.1", 6379) :> IRepositoryCounterRecentResult
+            let redisLog =
+                state
+                    .App
+                    .Services
+                    .GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("RepositoryCounterRecentResult.Integration")
+
+            use redisRecentResult = new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult("127.0.0.1", 6379, redisLog)
+            let recentResult = redisRecentResult :> IRepositoryCounterRecentResult
 
             let! stored = recentResult.TrySetAsync(repositoryId, storagePoolId, manifestAddress, change, CancellationToken.None)
 

--- a/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RepositoryCounterRecentResult.Integration.Server.Tests.fs
@@ -29,7 +29,8 @@ type RepositoryCounterRecentResultIntegrationTests() =
             let manifestAddress = ManifestAddress(String.replicate 64 "a")
             let operationId = RepositoryContentCounterOperationId $"redis-witness:{Guid.NewGuid():N}"
 
-            let change = { OperationId = operationId; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L }
+            let change =
+                { OperationId = operationId; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L; Revision = 1L }
 
             let recentResult = RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult("127.0.0.1", 6379) :> IRepositoryCounterRecentResult
 

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -2068,7 +2068,7 @@ type StorageManifestUploadSessionRoutes() =
                             RepositoryId = Guid.Parse repositoryId
                             StoragePoolId = manifest.StoragePoolId
                             ManifestAddress = manifest.ManifestAddress
-                            DirectoryVersionId = root.DirectoryVersionId
+                            DirectoryVersionId = child.DirectoryVersionId
                         })
 
             let! savedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"

--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -7,6 +7,7 @@ open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.ContentBlockMetadata
+open Grace.Types.ManifestContributionAccounting
 open Grace.Types.UploadSession
 open Grace.Types.Common
 open NUnit.Framework
@@ -1697,6 +1698,7 @@ type StorageManifestUploadSessionRoutes() =
     [<Test>]
     member _.RepositoriesInSameStoragePoolReuseDurableContentBlockPlacementAcrossManifests() =
         task {
+            let! state = AspireTestHost.startAsync testUserId
             let firstRepositoryId = repositoryIds[0]
             let secondRepositoryId = repositoryIds[1]
             let firstCorrelationId = generateCorrelationId ()
@@ -1753,6 +1755,30 @@ type StorageManifestUploadSessionRoutes() =
 
             Assert.That(firstFinalize.ReturnValue.Session.FinalizedManifestAddress, Is.EqualTo(Some firstManifest.ManifestAddress))
             Assert.That(firstFinalize.ReturnValue.Session.StoragePoolId, Is.EqualTo(sharedStoragePoolId))
+
+            let firstManifestFileVersion = manifestBackedFileVersion (RelativePath firstScope) payload firstManifest
+            let firstRoot = BranchServerTestHelpers.createRootDirectoryVersion firstRepositoryId firstManifestFileVersion
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync firstRepositoryId [ firstRoot ]
+
+            let! firstParentBranch = BranchServerTestHelpers.getBranchAsync firstRepositoryId repositoryDefaultBranchIds[0]
+            let! firstBranch = BranchServerTestHelpers.createBranchAsync firstRepositoryId firstParentBranch $"CrossRepositoryReuse{Guid.NewGuid():N}"
+
+            let! firstSaveResponse =
+                BranchServerTestHelpers.saveReferenceResponseAsync firstRepositoryId firstBranch firstRoot.DirectoryVersionId firstRoot.Sha256Hash
+
+            let! firstSaveBody = firstSaveResponse.Content.ReadAsStringAsync()
+            Assert.That(firstSaveResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstSaveBody)
+
+            do!
+                AspireTestHost.waitForExactRelationshipAsync
+                    state
+                    (ExactRelationship.DirectoryVersionManifest
+                        {
+                            RepositoryId = Guid.Parse firstRepositoryId
+                            StoragePoolId = firstManifest.StoragePoolId
+                            ManifestAddress = firstManifest.ManifestAddress
+                            DirectoryVersionId = firstRoot.DirectoryVersionId
+                        })
 
             let! discovery = discoverContentBlocks secondRepositoryId block
             let candidates = discovery.ReturnValue.CandidateContentBlocks
@@ -1914,6 +1940,7 @@ type StorageManifestUploadSessionRoutes() =
     [<Test>]
     member _.LargeBinarySaveLifecycleRequiresFinalizedManifestAndDownloadsAfterRouteChange() =
         task {
+            let! state = AspireTestHost.startAsync testUserId
             let repositoryId = repositoryIds[0]
             let branchId = repositoryDefaultBranchIds[0]
             let correlationId = generateCorrelationId ()
@@ -2032,6 +2059,17 @@ type StorageManifestUploadSessionRoutes() =
             let! saveResponse = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch root.DirectoryVersionId root.Sha256Hash
             let! saveBody = saveResponse.Content.ReadAsStringAsync()
             Assert.That(saveResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), saveBody)
+
+            do!
+                AspireTestHost.waitForExactRelationshipAsync
+                    state
+                    (ExactRelationship.DirectoryVersionManifest
+                        {
+                            RepositoryId = Guid.Parse repositoryId
+                            StoragePoolId = manifest.StoragePoolId
+                            ManifestAddress = manifest.ManifestAddress
+                            DirectoryVersionId = root.DirectoryVersionId
+                        })
 
             let! savedBranch = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
             Assert.That(savedBranch.LatestSave.DirectoryId, Is.EqualTo(root.DirectoryVersionId))

--- a/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -121,10 +121,97 @@ type ContentBlockMetadataActorTests() =
 
     let setChurnState operationId churnState = ContentBlockMetadataCommand.SetCompactionChurnState { OperationId = operationId; ChurnState = churnState }
 
+    /// Builds a deterministic active-manifest-count delta command for one logical range.
+    let adjust operationId expectedVersion delta range =
+        ContentBlockMetadataCommand.AdjustActiveManifestCount
+            {
+                OperationId = operationId
+                ExpectedMetadataVersion = expectedVersion
+                StoragePoolId = storagePoolId
+                ContentBlockAddress = contentBlockAddress
+                Range = range
+                Delta = delta
+            }
+
     /// Applies all inputs to drive the server unit content Block Metadata Actor state transition under test.
     let applyAll events current =
         events
         |> List.fold (fun state event -> ContentBlockMetadataDto.UpdateDto event state) current
+
+    /// Verifies deterministic contribution deltas mutate authoritative ContentBlock counts and replay once.
+    [<Test>]
+    member _.ActiveManifestCountDeltaMutatesMetadataAndReplayDoesNotApplyTwice() =
+        let currentMetadata = recordWithTotals [| activeRange |] activeRange.PhysicalLength activeRange.PhysicalLength timestamp 7L
+        let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
+        let command = adjust "workflow-range-1" 7L 1 { OrdinalStart = 0; OrdinalCount = 1 }
+        let first = ContentBlockMetadataActor.decideCommand [] current command (metadata "corr-delta")
+
+        match first with
+        | Error error -> Assert.Fail($"Expected active-count delta to succeed, got {error.Error}.")
+        | Ok decision ->
+            Assert.That(decision.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(3))
+            Assert.That(decision.Metadata.MetadataVersion, Is.EqualTo(8L))
+
+            let replayed = ContentBlockMetadataActor.decideCommand decision.Events (applyAll decision.Events current) command (metadata "corr-delta-replay")
+
+            match replayed with
+            | Error error -> Assert.Fail($"Expected active-count delta replay to succeed, got {error.Error}.")
+            | Ok replay ->
+                Assert.That(replay.WasIdempotentReplay, Is.True)
+                Assert.That(replay.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(3))
+
+    /// Verifies decrement deltas fail closed instead of making a reclaimable range negative.
+    [<Test>]
+    member _.ActiveManifestCountDeltaRejectsUnderflow() =
+        let currentMetadata = recordWithTotals [| reclaimableRange |] reclaimableRange.PhysicalLength 0L timestamp 4L
+        let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
+
+        let result =
+            ContentBlockMetadataActor.decideCommand
+                []
+                current
+                (adjust "workflow-underflow" 4L -1 { OrdinalStart = reclaimableRange.OrdinalStart; OrdinalCount = 1 })
+                (metadata "corr-underflow")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected active-count underflow to reject.")
+        | Error error -> Assert.That(error.Error, Does.Contain("outside its valid range"))
+
+    /// Verifies a stale workflow delta cannot overwrite a newer ContentBlock metadata revision.
+    [<Test>]
+    member _.ActiveManifestCountDeltaRejectsStaleMetadataVersion() =
+        let currentMetadata = recordWithTotals [| activeRange |] activeRange.PhysicalLength activeRange.PhysicalLength timestamp 7L
+        let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
+
+        let result =
+            ContentBlockMetadataActor.decideCommand
+                []
+                current
+                (adjust "workflow-stale" 6L 1 { OrdinalStart = 0; OrdinalCount = 1 })
+                (metadata "corr-stale-delta")
+
+        match result with
+        | Ok _ -> Assert.Fail("Expected stale active-count delta to reject.")
+        | Error error -> Assert.That(error.Error, Does.Contain("Stale ContentBlockMetadata active-count delta"))
+
+    /// Verifies operation reuse cannot replay a different delta payload.
+    [<Test>]
+    member _.ActiveManifestCountDeltaRejectsOperationReuseWithDifferentPayload() =
+        let currentMetadata = recordWithTotals [| activeRange |] activeRange.PhysicalLength activeRange.PhysicalLength timestamp 7L
+        let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
+        let firstCommand = adjust "workflow-reused" 7L 1 { OrdinalStart = 0; OrdinalCount = 1 }
+        let first = ContentBlockMetadataActor.decideCommand [] current firstCommand (metadata "corr-reused-first")
+
+        match first with
+        | Error error -> Assert.Fail($"Expected first active-count delta to succeed, got {error.Error}.")
+        | Ok decision ->
+            let afterFirst = applyAll decision.Events current
+            let differentPayload = adjust "workflow-reused" 8L -1 { OrdinalStart = 0; OrdinalCount = 1 }
+            let replay = ContentBlockMetadataActor.decideCommand decision.Events afterFirst differentPayload (metadata "corr-reused-second")
+
+            match replay with
+            | Ok _ -> Assert.Fail("Expected operation reuse with a different active-count payload to reject.")
+            | Error error -> Assert.That(error.Error, Does.Contain("different active-count payload"))
 
     /// Verifies that create Whole Record Stamps Version And Reports Active Presence.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -121,15 +121,14 @@ type ContentBlockMetadataActorTests() =
 
     let setChurnState operationId churnState = ContentBlockMetadataCommand.SetCompactionChurnState { OperationId = operationId; ChurnState = churnState }
 
-    /// Builds a deterministic active-manifest-count delta command for one logical range.
-    let adjust operationId expectedVersion delta range =
+    /// Builds a deterministic active-manifest-count delta command for every physical range in one ContentBlock.
+    let adjust operationId expectedVersion delta =
         ContentBlockMetadataCommand.AdjustActiveManifestCount
             {
                 OperationId = operationId
                 ExpectedMetadataVersion = expectedVersion
                 StoragePoolId = storagePoolId
                 ContentBlockAddress = contentBlockAddress
-                Range = range
                 Delta = delta
             }
 
@@ -143,7 +142,7 @@ type ContentBlockMetadataActorTests() =
     member _.ActiveManifestCountDeltaMutatesMetadataAndReplayDoesNotApplyTwice() =
         let currentMetadata = recordWithTotals [| activeRange |] activeRange.PhysicalLength activeRange.PhysicalLength timestamp 7L
         let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
-        let command = adjust "workflow-range-1" 7L 1 { OrdinalStart = 0; OrdinalCount = 1 }
+        let command = adjust "workflow-range-1" 7L 1
         let first = ContentBlockMetadataActor.decideCommand [] current command (metadata "corr-delta")
 
         match first with
@@ -164,7 +163,7 @@ type ContentBlockMetadataActorTests() =
                 ContentBlockMetadataActor.decideCommand
                     decision.Events
                     (applyAll decision.Events current)
-                    (adjust "workflow-range-1" 8L 1 { OrdinalStart = 0; OrdinalCount = 1 })
+                    (adjust "workflow-range-1" 8L 1)
                     (metadata "corr-delta-unknown-outcome")
 
             match replayAfterUnknownOutcome with
@@ -173,18 +172,72 @@ type ContentBlockMetadataActorTests() =
                 Assert.That(replay.WasIdempotentReplay, Is.True)
                 Assert.That(replay.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(3))
 
+    /// Verifies one ContentBlock contribution changes every authoritative physical range exactly once through replay and reversal.
+    [<Test>]
+    member _.ActiveManifestCountDeltaCoversEveryPhysicalRangeExactlyOnce() =
+        let firstRange = { activeRange with ActiveManifestCount = 1 }
+        let secondRange = { reclaimableRange with ActiveManifestCount = 1 }
+
+        let currentMetadata =
+            recordWithTotals
+                [| firstRange; secondRange |]
+                (firstRange.PhysicalLength
+                 + secondRange.PhysicalLength)
+                (firstRange.PhysicalLength
+                 + secondRange.PhysicalLength)
+                timestamp
+                7L
+
+        let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
+        let increment = adjust "workflow-all-ranges-increment" 7L 1
+
+        let incremented =
+            match ContentBlockMetadataActor.decideCommand [] current increment (metadata "corr-all-ranges-increment") with
+            | Ok decision -> decision
+            | Error error -> failwith $"Expected every-range increment to succeed, got {error.Error}."
+
+        Assert.That(incremented.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(2))
+        Assert.That(incremented.Metadata.Ranges[1].ActiveManifestCount, Is.EqualTo(2))
+
+        let afterIncrement = applyAll incremented.Events current
+
+        let replayed =
+            match
+                ContentBlockMetadataActor.decideCommand
+                    incremented.Events
+                    afterIncrement
+                    (adjust "workflow-all-ranges-increment" 8L 1)
+                    (metadata "corr-all-ranges-replay")
+                with
+            | Ok decision -> decision
+            | Error error -> failwith $"Expected every-range replay to succeed, got {error.Error}."
+
+        Assert.That(replayed.WasIdempotentReplay, Is.True)
+
+        Assert.That(replayed.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(2))
+        Assert.That(replayed.Metadata.Ranges[1].ActiveManifestCount, Is.EqualTo(2))
+
+        let decrement =
+            match
+                ContentBlockMetadataActor.decideCommand
+                    incremented.Events
+                    afterIncrement
+                    (adjust "workflow-all-ranges-decrement" 8L -1)
+                    (metadata "corr-all-ranges-decrement")
+                with
+            | Ok decision -> decision
+            | Error error -> failwith $"Expected every-range decrement to succeed, got {error.Error}."
+
+        Assert.That(decrement.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+        Assert.That(decrement.Metadata.Ranges[1].ActiveManifestCount, Is.EqualTo(1))
+
     /// Verifies decrement deltas fail closed instead of making a reclaimable range negative.
     [<Test>]
     member _.ActiveManifestCountDeltaRejectsUnderflow() =
         let currentMetadata = recordWithTotals [| reclaimableRange |] reclaimableRange.PhysicalLength 0L timestamp 4L
         let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
 
-        let result =
-            ContentBlockMetadataActor.decideCommand
-                []
-                current
-                (adjust "workflow-underflow" 4L -1 { OrdinalStart = reclaimableRange.OrdinalStart; OrdinalCount = 1 })
-                (metadata "corr-underflow")
+        let result = ContentBlockMetadataActor.decideCommand [] current (adjust "workflow-underflow" 4L -1) (metadata "corr-underflow")
 
         match result with
         | Ok _ -> Assert.Fail("Expected active-count underflow to reject.")
@@ -196,12 +249,7 @@ type ContentBlockMetadataActorTests() =
         let currentMetadata = recordWithTotals [| activeRange |] activeRange.PhysicalLength activeRange.PhysicalLength timestamp 7L
         let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
 
-        let result =
-            ContentBlockMetadataActor.decideCommand
-                []
-                current
-                (adjust "workflow-stale" 6L 1 { OrdinalStart = 0; OrdinalCount = 1 })
-                (metadata "corr-stale-delta")
+        let result = ContentBlockMetadataActor.decideCommand [] current (adjust "workflow-stale" 6L 1) (metadata "corr-stale-delta")
 
         match result with
         | Ok _ -> Assert.Fail("Expected stale active-count delta to reject.")
@@ -212,14 +260,14 @@ type ContentBlockMetadataActorTests() =
     member _.ActiveManifestCountDeltaRejectsOperationReuseWithDifferentPayload() =
         let currentMetadata = recordWithTotals [| activeRange |] activeRange.PhysicalLength activeRange.PhysicalLength timestamp 7L
         let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
-        let firstCommand = adjust "workflow-reused" 7L 1 { OrdinalStart = 0; OrdinalCount = 1 }
+        let firstCommand = adjust "workflow-reused" 7L 1
         let first = ContentBlockMetadataActor.decideCommand [] current firstCommand (metadata "corr-reused-first")
 
         match first with
         | Error error -> Assert.Fail($"Expected first active-count delta to succeed, got {error.Error}.")
         | Ok decision ->
             let afterFirst = applyAll decision.Events current
-            let differentPayload = adjust "workflow-reused" 8L -1 { OrdinalStart = 0; OrdinalCount = 1 }
+            let differentPayload = adjust "workflow-reused" 8L -1
             let replay = ContentBlockMetadataActor.decideCommand decision.Events afterFirst differentPayload (metadata "corr-reused-second")
 
             match replay with

--- a/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -160,6 +160,19 @@ type ContentBlockMetadataActorTests() =
                 Assert.That(replay.WasIdempotentReplay, Is.True)
                 Assert.That(replay.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(3))
 
+            let replayAfterUnknownOutcome =
+                ContentBlockMetadataActor.decideCommand
+                    decision.Events
+                    (applyAll decision.Events current)
+                    (adjust "workflow-range-1" 8L 1 { OrdinalStart = 0; OrdinalCount = 1 })
+                    (metadata "corr-delta-unknown-outcome")
+
+            match replayAfterUnknownOutcome with
+            | Error error -> Assert.Fail($"Expected active-count delta unknown-outcome replay to succeed, got {error.Error}.")
+            | Ok replay ->
+                Assert.That(replay.WasIdempotentReplay, Is.True)
+                Assert.That(replay.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(3))
+
     /// Verifies decrement deltas fail closed instead of making a reclaimable range negative.
     [<Test>]
     member _.ActiveManifestCountDeltaRejectsUnderflow() =

--- a/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ContentBlockMetadata.Actor.Tests.fs
@@ -14,6 +14,8 @@ module ContentBlockMetadataActor = Grace.Actors.ContentBlockMetadata
 
 module ContentBlockMetadataTypes = Grace.Types.ContentBlockMetadata
 
+module ManifestContributionWorkflowActor = Grace.Actors.ManifestContributionWorkflow
+
 /// Covers content Block Metadata Actor behavior in no-Aspire server unit tests.
 [<Parallelizable(ParallelScope.All)>]
 type ContentBlockMetadataActorTests() =
@@ -230,6 +232,67 @@ type ContentBlockMetadataActorTests() =
 
         Assert.That(decrement.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
         Assert.That(decrement.Metadata.Ranges[1].ActiveManifestCount, Is.EqualTo(1))
+
+    /// Verifies a later add after removal and Redis loss remains distinct and reactivates every physical range once.
+    [<Test>]
+    member _.CounterRevisionReactivatesEveryRangeAfterRemovalAndRedisLoss() =
+        let firstRange = { activeRange with ActiveManifestCount = 0 }
+        let secondRange = { reclaimableRange with ActiveManifestCount = 0 }
+
+        let currentMetadata =
+            recordWithTotals
+                [| firstRange; secondRange |]
+                (firstRange.PhysicalLength
+                 + secondRange.PhysicalLength)
+                0L
+                timestamp
+                7L
+
+        let current = { ContentBlockMetadataDto.Empty with Metadata = Some currentMetadata }
+        let workflowOperationId = "stable-workflow"
+        let addV1OperationId = ManifestContributionWorkflowActor.contentBlockOperationId workflowOperationId 1L 0
+        let removeV2OperationId = ManifestContributionWorkflowActor.contentBlockOperationId workflowOperationId 2L 0
+        let addV3OperationId = ManifestContributionWorkflowActor.contentBlockOperationId workflowOperationId 3L 0
+
+        let addV1 =
+            ContentBlockMetadataActor.decideCommand [] current (adjust addV1OperationId 7L 1) (metadata "corr-add-v1")
+            |> Result.defaultWith (fun error -> failwith $"Expected revision-1 add to succeed, got {error.Error}.")
+
+        let afterAddV1 = applyAll addV1.Events current
+
+        let removeV2 =
+            ContentBlockMetadataActor.decideCommand addV1.Events afterAddV1 (adjust removeV2OperationId 8L -1) (metadata "corr-remove-v2")
+            |> Result.defaultWith (fun error -> failwith $"Expected revision-2 removal to succeed, got {error.Error}.")
+
+        let throughRemovalEvents = addV1.Events @ removeV2.Events
+        let afterRemoveV2 = applyAll removeV2.Events afterAddV1
+
+        let addV3AfterRedisLoss =
+            ContentBlockMetadataActor.decideCommand throughRemovalEvents afterRemoveV2 (adjust addV3OperationId 9L 1) (metadata "corr-add-v3")
+            |> Result.defaultWith (fun error -> failwith $"Expected revision-3 add after Redis loss to succeed, got {error.Error}.")
+
+        Assert.That(addV3AfterRedisLoss.WasIdempotentReplay, Is.False)
+
+        Assert.That(
+            addV3AfterRedisLoss.Metadata.Ranges
+            |> Array.forall (fun range -> range.ActiveManifestCount = 1),
+            Is.True
+        )
+
+        let allEvents = throughRemovalEvents @ addV3AfterRedisLoss.Events
+        let afterAddV3 = applyAll addV3AfterRedisLoss.Events afterRemoveV2
+
+        let replayedAddV3 =
+            ContentBlockMetadataActor.decideCommand allEvents afterAddV3 (adjust addV3OperationId 10L 1) (metadata "corr-add-v3-replay")
+            |> Result.defaultWith (fun error -> failwith $"Expected revision-3 replay to succeed, got {error.Error}.")
+
+        Assert.That(replayedAddV3.WasIdempotentReplay, Is.True)
+
+        Assert.That(
+            replayedAddV3.Metadata.Ranges
+            |> Array.forall (fun range -> range.ActiveManifestCount = 1),
+            Is.True
+        )
 
     /// Verifies decrement deltas fail closed instead of making a reclaimable range negative.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
     <Compile Include="Reminder.Actor.Tests.fs" />
     <Compile Include="ManifestContributionAccounting.Server.Tests.fs" />
+    <Compile Include="RepositoryCounterRecentResult.Server.Tests.fs" />
     <Compile Include="Reference.Actor.Tests.fs" />
     <Compile Include="SaveBoundary.Actor.Tests.fs" />
     <Compile Include="Services.VersionHashPrefixResolution.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -207,7 +207,7 @@ type ManifestContributionAccountingServerTests() =
                 do! handleReferenceCreatedWith dependencies CancellationToken.None delivery
                 do! handleReferenceCreatedWith dependencies CancellationToken.None delivery
 
-                Assert.That(lifecycleCount, Is.EqualTo(1), $"Expected {referenceType} lifecycle preparation to converge.")
+                Assert.That(lifecycleCount, Is.EqualTo(2), $"Expected {referenceType} lifecycle convergence on each idempotent delivery.")
                 Assert.That(contributionCount, Is.EqualTo(1), $"Expected {referenceType} contribution work to converge.")
                 Assert.That(storedRelationships.Count, Is.EqualTo(2), $"Expected {referenceType} to retain one root and one manifest relationship.")
         }
@@ -258,7 +258,7 @@ type ManifestContributionAccountingServerTests() =
             Assert.That(referenceReads, Is.EqualTo(1))
             Assert.That(directoryReads, Is.EqualTo(2), "The current root is read to discover candidates and reread immediately before the manifest mutation.")
             Assert.That(exactWrites.Count, Is.EqualTo(1))
-            Assert.That(effectOrder |> Seq.toArray, Is.EqualTo<string array>([| "lifecycle"; "exact-root" |]))
+            Assert.That(effectOrder |> Seq.toArray, Is.EqualTo<string array>([| "exact-root"; "lifecycle" |]))
 
             match exactWrites[0] with
             | ExactRelationship.ReferenceRoot relationship ->
@@ -272,9 +272,73 @@ type ManifestContributionAccountingServerTests() =
             Assert.That(manifestWrites[0].ManifestAddress, Is.EqualTo(manifestAddress))
         }
 
-    /// Verifies a failed lifecycle effect leaves the Reference-root exact item absent so a retry cannot skip repair.
+    /// Verifies a pending Save lifecycle write cannot delay Reference-wide manifest accounting.
     [<Test>]
-    member _.ReferenceLifecycleFailurePreventsExactRootWrite() =
+    member _.PendingReferenceLifecycleDoesNotBlockManifestAccounting() =
+        task {
+            let exactWrites = ResizeArray<ExactRelationship>()
+            let manifestWrites = ResizeArray<DirectoryVersionManifestRelationship>()
+            let effectOrder = ResizeArray<string>()
+            let lifecycleStarted = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let releaseLifecycle = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let dependencies: ManifestContributionAccountingDependencies =
+                {
+                    GetReference =
+                        fun _ _ _ ->
+                            Task.FromResult
+                                { ReferenceDto.Default with
+                                    ReferenceId = referenceId
+                                    RepositoryId = repositoryId
+                                    DirectoryId = currentDirectoryVersionId
+                                    ReferenceType = ReferenceType.Save
+                                    UpdatedAt = Some(getCurrentInstant ())
+                                }
+                    GetDirectoryVersion = fun _ _ _ -> Task.FromResult(currentDirectoryVersionDto ())
+                    ExactRelationships = recordingStore exactWrites effectOrder
+                    EnsureAutomaticPhysicalDeletionReminder =
+                        fun _ _ _ _ ->
+                            task {
+                                effectOrder.Add("lifecycle")
+                                lifecycleStarted.SetResult()
+                                do! releaseLifecycle.Task
+                            }
+                            :> Task
+                    EnsureDirectoryVersionManifest =
+                        fun relationship _ _ _ ->
+                            effectOrder.Add("manifest")
+                            manifestWrites.Add(relationship)
+                            Task.CompletedTask
+                }
+
+            let operation = handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Save)
+            do! lifecycleStarted.Task.WaitAsync(TimeSpan.FromSeconds(1.0))
+
+            let exactWritesBeforeLifecycleCompleted = exactWrites.Count
+            let manifestWritesBeforeLifecycleCompleted = manifestWrites.Count
+            let effectOrderBeforeLifecycleCompleted = effectOrder |> Seq.toArray
+
+            releaseLifecycle.SetResult()
+            do! operation
+
+            Assert.That(exactWritesBeforeLifecycleCompleted, Is.EqualTo(1))
+            Assert.That(manifestWritesBeforeLifecycleCompleted, Is.EqualTo(1))
+
+            Assert.That(
+                effectOrderBeforeLifecycleCompleted,
+                Is.EqualTo<string array>(
+                    [|
+                        "exact-root"
+                        "manifest"
+                        "lifecycle"
+                    |]
+                )
+            )
+        }
+
+    /// Verifies a failed lifecycle effect does not roll back already-converged Reference accounting.
+    [<Test>]
+    member _.ReferenceLifecycleFailurePreservesExactRootWrite() =
         task {
             let exactWrites = ResizeArray<ExactRelationship>()
             let effectOrder = ResizeArray<string>()
@@ -297,19 +361,32 @@ type ManifestContributionAccountingServerTests() =
                         fun _ _ _ _ ->
                             effectOrder.Add("lifecycle")
                             Task.FromException(InvalidOperationException("reminder scheduling failed"))
-                    EnsureDirectoryVersionManifest = fun _ _ _ _ -> Task.CompletedTask
+                    EnsureDirectoryVersionManifest =
+                        fun _ _ _ _ ->
+                            effectOrder.Add("manifest")
+                            Task.CompletedTask
                 }
 
             let operation = handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Commit)
             let _ = Assert.ThrowsAsync<InvalidOperationException>(Func<Task>(fun () -> operation))
 
-            Assert.That(effectOrder |> Seq.toArray, Is.EqualTo<string array>([| "lifecycle" |]))
-            Assert.That(exactWrites, Is.Empty)
+            Assert.That(
+                effectOrder |> Seq.toArray,
+                Is.EqualTo<string array>(
+                    [|
+                        "exact-root"
+                        "manifest"
+                        "lifecycle"
+                    |]
+                )
+            )
+
+            Assert.That(exactWrites.Count, Is.EqualTo(1))
         }
 
-    /// Verifies a conflicting stable reminder target fails delivery before the exact Reference root is recorded.
+    /// Verifies a conflicting stable reminder target fails delivery after independent Reference accounting converges.
     [<Test>]
-    member _.ReferenceLifecycleConflictPreventsExactRootWrite() =
+    member _.ReferenceLifecycleConflictPreservesExactRootWrite() =
         task {
             let exactWrites = ResizeArray<ExactRelationship>()
             let effectOrder = ResizeArray<string>()
@@ -332,15 +409,29 @@ type ManifestContributionAccountingServerTests() =
                         fun _ _ _ _ ->
                             effectOrder.Add("lifecycle-conflict")
                             Task.FromException(InvalidOperationException("stable reminder targets different Reference data"))
-                    EnsureDirectoryVersionManifest = fun _ _ _ _ -> Task.CompletedTask
+                    EnsureDirectoryVersionManifest =
+                        fun _ _ _ _ ->
+                            effectOrder.Add("manifest")
+                            Task.CompletedTask
                 }
 
             let operation = handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Checkpoint)
             let error = Assert.ThrowsAsync<InvalidOperationException>(Func<Task>(fun () -> operation))
 
             Assert.That(error.Message, Does.Contain("different Reference data"))
-            Assert.That(effectOrder |> Seq.toArray, Is.EqualTo<string array>([| "lifecycle-conflict" |]))
-            Assert.That(exactWrites, Is.Empty)
+
+            Assert.That(
+                effectOrder |> Seq.toArray,
+                Is.EqualTo<string array>(
+                    [|
+                        "exact-root"
+                        "manifest"
+                        "lifecycle-conflict"
+                    |]
+                )
+            )
+
+            Assert.That(exactWrites.Count, Is.EqualTo(1))
         }
 
     /// Verifies response loss after stable lifecycle persistence retries once and records one Reference root.

--- a/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -79,6 +79,27 @@ type ManifestContributionAccountingServerTests() =
             HashesValidated = true
         }
 
+    /// Builds one current DirectoryVersion actor snapshot for a nested traversal witness.
+    let nestedDirectoryVersionDto directoryVersionId relativePath directories files =
+        {
+            DirectoryVersion =
+                DirectoryVersion.CreateWithHashes
+                    directoryVersionId
+                    ownerId
+                    organizationId
+                    repositoryId
+                    relativePath
+                    (Sha256Hash $"sha-{directoryVersionId:N}")
+                    (Blake3Hash $"b3-{directoryVersionId:N}")
+                    directories
+                    files
+                    4L
+            RecursiveSize = 4L
+            DeletedAt = None
+            DeleteReason = String.Empty
+            HashesValidated = true
+        }
+
     /// Builds a stale delivery whose DirectoryVersionId differs from the durable Reference actor state.
     let staleCreatedEvent referenceType =
         {
@@ -255,7 +276,7 @@ type ManifestContributionAccountingServerTests() =
 
             do! handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Commit)
 
-            Assert.That(referenceReads, Is.EqualTo(1))
+            Assert.That(referenceReads, Is.EqualTo(4), "The Reference is reread before the root write, manifest mutation, and lifecycle convergence.")
             Assert.That(directoryReads, Is.EqualTo(2), "The current root is read to discover candidates and reread immediately before the manifest mutation.")
             Assert.That(exactWrites.Count, Is.EqualTo(1))
             Assert.That(effectOrder |> Seq.toArray, Is.EqualTo<string array>([| "exact-root"; "lifecycle" |]))
@@ -270,6 +291,298 @@ type ManifestContributionAccountingServerTests() =
             Assert.That(manifestWrites[0].DirectoryVersionId, Is.EqualTo(currentDirectoryVersionId))
             Assert.That(manifestWrites[0].StoragePoolId, Is.EqualTo(storagePoolId))
             Assert.That(manifestWrites[0].ManifestAddress, Is.EqualTo(manifestAddress))
+        }
+
+    /// Verifies a Reference retains manifests through exact parent-child edges without attributing them to the root.
+    [<Test>]
+    member _.ReferenceCreatedTraversesNestedDirectoryVersionsAndAttributesDirectManifestOwner() =
+        task {
+            let childDirectoryVersionId = Guid.Parse("88888888-7290-4000-8000-888888888888")
+            let childDirectories = List<DirectoryVersionId>()
+            let rootDirectories = List<DirectoryVersionId>()
+            rootDirectories.Add(childDirectoryVersionId)
+            let childFiles = List<FileVersion>()
+            let file, manifest = manifestBackedFile ()
+            childFiles.Add(file)
+
+            let root = nestedDirectoryVersionDto currentDirectoryVersionId (RelativePath ".") rootDirectories (List<FileVersion>())
+
+            let child = nestedDirectoryVersionDto childDirectoryVersionId (RelativePath "nested") childDirectories childFiles
+
+            let storedRelationships = HashSet<ExactRelationship>()
+            let manifestWrites = ResizeArray<DirectoryVersionManifestRelationship>()
+            let effectOrder = ResizeArray<string>()
+
+            let store =
+                { new IExactRelationshipStore with
+                    member _.EnsurePresentAsync(relationship, _) =
+                        let outcome =
+                            if storedRelationships.Add relationship then
+                                effectOrder.Add(
+                                    match relationship with
+                                    | ExactRelationship.ReferenceRoot _ -> "reference-root"
+                                    | ExactRelationship.ParentChild _ -> "parent-child"
+                                    | ExactRelationship.DirectoryVersionManifest _ -> "directory-version-manifest"
+                                )
+
+                                ExactRelationshipWriteOutcome.Changed
+                            else
+                                ExactRelationshipWriteOutcome.AlreadyConverged
+
+                        Task.FromResult outcome
+
+                    member _.EnsureAbsentAsync(_, _) = Task.FromResult ExactRelationshipWriteOutcome.AlreadyConverged
+
+                    member _.EnumerateAsync(partition, bound, _, _) =
+                        let maximumCount = ExactRelationshipReadBound.value bound
+
+                        Task.FromResult
+                            {
+                                Relationships =
+                                    storedRelationships
+                                    |> Seq.filter (fun relationship -> ExactRelationshipKey.partition relationship = Ok partition)
+                                    |> Seq.truncate maximumCount
+                                    |> Seq.toArray
+                                ContinuationToken = None
+                            }
+
+                    member _.VerifyAsync(relationship, _) =
+                        Task.FromResult(
+                            if storedRelationships.Contains relationship then
+                                ExactRelationshipPresence.Present
+                            else
+                                ExactRelationshipPresence.Absent
+                        )
+                }
+
+            let dependencies: ManifestContributionAccountingDependencies =
+                {
+                    GetReference =
+                        fun _ _ _ ->
+                            Task.FromResult
+                                { ReferenceDto.Default with
+                                    ReferenceId = referenceId
+                                    RepositoryId = repositoryId
+                                    DirectoryId = currentDirectoryVersionId
+                                    ReferenceType = ReferenceType.Save
+                                    UpdatedAt = Some(getCurrentInstant ())
+                                }
+                    GetDirectoryVersion =
+                        fun _ directoryVersionId _ ->
+                            Task.FromResult(
+                                if directoryVersionId = currentDirectoryVersionId then root
+                                elif directoryVersionId = childDirectoryVersionId then child
+                                else DirectoryVersionDto.Default
+                            )
+                    ExactRelationships = store
+                    EnsureAutomaticPhysicalDeletionReminder = fun _ _ _ _ -> Task.CompletedTask
+                    EnsureDirectoryVersionManifest =
+                        fun relationship currentManifest _ cancellationToken ->
+                            task {
+                                Assert.That(currentManifest, Is.EqualTo(manifest))
+                                manifestWrites.Add(relationship)
+                                effectOrder.Add("manifest-effect")
+
+                                let! _ = store.EnsurePresentAsync(ExactRelationship.DirectoryVersionManifest relationship, cancellationToken)
+
+                                return ()
+                            }
+                            :> Task
+                }
+
+            do! handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Save)
+
+            Assert.That(
+                storedRelationships,
+                Does.Contain(
+                    ExactRelationship.ParentChild
+                        { RepositoryId = repositoryId; ParentDirectoryVersionId = currentDirectoryVersionId; ChildDirectoryVersionId = childDirectoryVersionId }
+                )
+            )
+
+            Assert.That(manifestWrites.Count, Is.EqualTo(1))
+            Assert.That(manifestWrites[0].DirectoryVersionId, Is.EqualTo(childDirectoryVersionId))
+            Assert.That(manifestWrites[0].StoragePoolId, Is.EqualTo(storagePoolId))
+            Assert.That(manifestWrites[0].ManifestAddress, Is.EqualTo(manifestAddress))
+
+            Assert.That(
+                effectOrder,
+                Is.EqualTo<string array>(
+                    [|
+                        "reference-root"
+                        "manifest-effect"
+                        "directory-version-manifest"
+                        "parent-child"
+                    |]
+                ),
+                "Child contents must converge before the parent-child edge makes retries stop at that retained child."
+            )
+        }
+
+    /// Verifies an already-retained shared child gains the new edge without walking its subtree again.
+    [<Test>]
+    member _.ReferenceCreatedStopsAtSharedChildWithExistingIncomingRelationship() =
+        task {
+            let childDirectoryVersionId = Guid.Parse("aaaaaaaa-7290-4000-8000-aaaaaaaaaaaa")
+            let existingReferenceId = Guid.Parse("bbbbbbbb-7290-4000-8000-bbbbbbbbbbbb")
+            let rootDirectories = List<DirectoryVersionId>()
+            rootDirectories.Add(childDirectoryVersionId)
+
+            let root = nestedDirectoryVersionDto currentDirectoryVersionId (RelativePath ".") rootDirectories (List<FileVersion>())
+
+            let child =
+                let childFiles = List<FileVersion>()
+                let file, _ = manifestBackedFile ()
+                childFiles.Add(file)
+
+                nestedDirectoryVersionDto childDirectoryVersionId (RelativePath "shared") (List<DirectoryVersionId>()) childFiles
+
+            let storedRelationships =
+                HashSet<ExactRelationship>(
+                    [
+                        ExactRelationship.ReferenceRoot
+                            { RepositoryId = repositoryId; RootDirectoryVersionId = childDirectoryVersionId; ReferenceId = existingReferenceId }
+                    ]
+                )
+
+            let mutable childReads = 0
+            let mutable manifestWrites = 0
+
+            let store =
+                { new IExactRelationshipStore with
+                    member _.EnsurePresentAsync(relationship, _) =
+                        Task.FromResult(
+                            if storedRelationships.Add relationship then
+                                ExactRelationshipWriteOutcome.Changed
+                            else
+                                ExactRelationshipWriteOutcome.AlreadyConverged
+                        )
+
+                    member _.EnsureAbsentAsync(_, _) = Task.FromResult ExactRelationshipWriteOutcome.AlreadyConverged
+
+                    member _.EnumerateAsync(partition, bound, _, _) =
+                        let maximumCount = ExactRelationshipReadBound.value bound
+
+                        Task.FromResult
+                            {
+                                Relationships =
+                                    storedRelationships
+                                    |> Seq.filter (fun relationship -> ExactRelationshipKey.partition relationship = Ok partition)
+                                    |> Seq.truncate maximumCount
+                                    |> Seq.toArray
+                                ContinuationToken = None
+                            }
+
+                    member _.VerifyAsync(relationship, _) =
+                        Task.FromResult(
+                            if storedRelationships.Contains relationship then
+                                ExactRelationshipPresence.Present
+                            else
+                                ExactRelationshipPresence.Absent
+                        )
+                }
+
+            let dependencies: ManifestContributionAccountingDependencies =
+                {
+                    GetReference =
+                        fun _ _ _ ->
+                            Task.FromResult
+                                { ReferenceDto.Default with
+                                    ReferenceId = referenceId
+                                    RepositoryId = repositoryId
+                                    DirectoryId = currentDirectoryVersionId
+                                    ReferenceType = ReferenceType.Tag
+                                    UpdatedAt = Some(getCurrentInstant ())
+                                }
+                    GetDirectoryVersion =
+                        fun _ directoryVersionId _ ->
+                            if directoryVersionId = currentDirectoryVersionId then
+                                Task.FromResult root
+                            else
+                                childReads <- childReads + 1
+                                Task.FromResult child
+                    ExactRelationships = store
+                    EnsureAutomaticPhysicalDeletionReminder = fun _ _ _ _ -> Task.CompletedTask
+                    EnsureDirectoryVersionManifest =
+                        fun _ _ _ _ ->
+                            manifestWrites <- manifestWrites + 1
+                            Task.CompletedTask
+                }
+
+            do! handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Tag)
+
+            Assert.That(
+                storedRelationships,
+                Does.Contain(
+                    ExactRelationship.ParentChild
+                        { RepositoryId = repositoryId; ParentDirectoryVersionId = currentDirectoryVersionId; ChildDirectoryVersionId = childDirectoryVersionId }
+                )
+            )
+
+            Assert.That(childReads, Is.EqualTo(1), "The child is reread only to validate the exact edge before mutation.")
+            Assert.That(manifestWrites, Is.Zero, "An existing incoming edge proves the shared child's contents were already converged.")
+        }
+
+    /// Verifies a child removed from current parent state cannot create stale child or manifest relationships.
+    [<Test>]
+    member _.ReferenceCreatedRevalidatesNestedDirectoryVersionBeforeRelationshipMutations() =
+        task {
+            let childDirectoryVersionId = Guid.Parse("99999999-7290-4000-8000-999999999999")
+            let candidateRootDirectories = List<DirectoryVersionId>()
+            candidateRootDirectories.Add(childDirectoryVersionId)
+            let currentRootDirectories = List<DirectoryVersionId>()
+            let childFiles = List<FileVersion>()
+            let file, _ = manifestBackedFile ()
+            childFiles.Add(file)
+
+            let candidateRoot = nestedDirectoryVersionDto currentDirectoryVersionId (RelativePath ".") candidateRootDirectories (List<FileVersion>())
+
+            let currentRoot = nestedDirectoryVersionDto currentDirectoryVersionId (RelativePath ".") currentRootDirectories (List<FileVersion>())
+
+            let child = nestedDirectoryVersionDto childDirectoryVersionId (RelativePath "nested") (List<DirectoryVersionId>()) childFiles
+
+            let exactWrites = ResizeArray<ExactRelationship>()
+            let manifestWrites = ResizeArray<DirectoryVersionManifestRelationship>()
+            let mutable rootReads = 0
+
+            let dependencies: ManifestContributionAccountingDependencies =
+                {
+                    GetReference =
+                        fun _ _ _ ->
+                            Task.FromResult
+                                { ReferenceDto.Default with
+                                    ReferenceId = referenceId
+                                    RepositoryId = repositoryId
+                                    DirectoryId = currentDirectoryVersionId
+                                    ReferenceType = ReferenceType.Commit
+                                    UpdatedAt = Some(getCurrentInstant ())
+                                }
+                    GetDirectoryVersion =
+                        fun _ directoryVersionId _ ->
+                            if directoryVersionId = currentDirectoryVersionId then
+                                rootReads <- rootReads + 1
+                                Task.FromResult(if rootReads = 1 then candidateRoot else currentRoot)
+                            else
+                                Task.FromResult child
+                    ExactRelationships = recordingStore exactWrites (ResizeArray<string>())
+                    EnsureAutomaticPhysicalDeletionReminder = fun _ _ _ _ -> Task.CompletedTask
+                    EnsureDirectoryVersionManifest =
+                        fun relationship _ _ _ ->
+                            manifestWrites.Add(relationship)
+                            Task.CompletedTask
+                }
+
+            do! handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Commit)
+
+            Assert.That(
+                exactWrites
+                |> Seq.exists (function
+                    | ExactRelationship.ParentChild _ -> true
+                    | _ -> false),
+                Is.False
+            )
+
+            Assert.That(manifestWrites, Is.Empty)
         }
 
     /// Verifies a pending Save lifecycle write cannot delay Reference-wide manifest accounting.

--- a/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -71,6 +71,17 @@ type ManifestContributionWorkflowActorTests() =
             Assert.Fail($"Expected command to succeed, got {error.Error}.")
             Unchecked.defaultof<ManifestContributionWorkflowDecision>
 
+    /// Verifies add/remove/add cycles cannot reuse the original downstream ContentBlock operation identity.
+    [<Test>]
+    member _.CounterRevisionDistinguishesDownstreamContentBlockOperationIdentity() =
+        let originalAdd = ManifestContributionWorkflowActor.contentBlockOperationId "workflow-cycle" 1L 0
+        let removal = ManifestContributionWorkflowActor.contentBlockOperationId "workflow-cycle" 2L 0
+        let laterAddAfterRedisLoss = ManifestContributionWorkflowActor.contentBlockOperationId "workflow-cycle" 3L 0
+
+        Assert.That(removal, Is.Not.EqualTo(originalAdd))
+        Assert.That(laterAddAfterRedisLoss, Is.Not.EqualTo(originalAdd))
+        Assert.That(laterAddAfterRedisLoss, Is.Not.EqualTo(removal))
+
     /// Verifies a completed cycle is overwritten by the next bounded workflow snapshot.
     [<Test>]
     member _.NextCycleOverwritesPriorRangeProgress() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -66,6 +66,102 @@ type ManifestContributionWorkflowActorTests() =
             Assert.Fail($"Expected command to succeed, got {error.Error}.")
             Unchecked.defaultof<ManifestContributionWorkflowDecision>
 
+    /// Verifies a completed cycle is overwritten by the next bounded workflow snapshot.
+    [<Test>]
+    member _.NextCycleOverwritesPriorRangeProgress() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-bounded-start")
+            |> expectOk
+
+        let afterStart = applyAll started.Events ManifestContributionWorkflowDto.Default
+
+        let firstRange =
+            ManifestContributionWorkflowActor.decideCommand started.Events afterStart (succeeded "bounded-range-0" range0) (metadata "corr-bounded-range-0")
+            |> expectOk
+
+        let afterFirst = applyAll firstRange.Events afterStart
+
+        let secondRange =
+            ManifestContributionWorkflowActor.decideCommand
+                (started.Events @ firstRange.Events)
+                afterFirst
+                (succeeded "bounded-range-1" range1)
+                (metadata "corr-bounded-range-1")
+            |> expectOk
+
+        let restarted =
+            ManifestContributionWorkflowActor.decideCommand
+                (started.Events
+                 @ firstRange.Events @ secondRange.Events)
+                secondRange.Workflow
+                (startWithOperation "bounded-next-cycle" ManifestContributionDirection.Decrement [| range0 |])
+                (metadata "corr-bounded-next-cycle")
+            |> expectOk
+
+        Assert.That(restarted.Workflow.Revision, Is.EqualTo(4L))
+        Assert.That(restarted.Workflow.Ranges, Is.EquivalentTo([| range0 |]))
+        Assert.That(restarted.Workflow.CompletedRanges, Is.Empty)
+        Assert.That(restarted.Workflow.FailedRanges, Is.Empty)
+
+    /// Verifies snapshot-only restart recovery replays start and range completion without persisted lifetime events.
+    [<Test>]
+    member _.SnapshotOnlyRecoveryReplaysCurrentProgress() =
+        let startCommand = start ManifestContributionDirection.Increment
+
+        let started =
+            ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default startCommand (metadata "corr-snapshot-start")
+            |> expectOk
+
+        let replayedStart =
+            ManifestContributionWorkflowActor.decideCommand [] started.Workflow startCommand (metadata "corr-snapshot-start-replay")
+            |> expectOk
+
+        Assert.That(replayedStart.WasIdempotentReplay, Is.True)
+        Assert.That(replayedStart.Events, Is.Empty)
+
+        let rangeCommand = succeeded "snapshot-range" range0
+
+        let completed =
+            ManifestContributionWorkflowActor.decideCommand [] started.Workflow rangeCommand (metadata "corr-snapshot-range")
+            |> expectOk
+
+        let replayedRange =
+            ManifestContributionWorkflowActor.decideCommand [] completed.Workflow rangeCommand (metadata "corr-snapshot-range-replay")
+            |> expectOk
+
+        Assert.That(replayedRange.WasIdempotentReplay, Is.True)
+        Assert.That(replayedRange.Events, Is.Empty)
+        Assert.That(replayedRange.Intents, Is.Empty)
+
+    /// Verifies bounded failed-range progress retains enough identity for snapshot-only retries.
+    [<Test>]
+    member _.SnapshotOnlyRecoveryReplaysFailedRange() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-failure-start")
+            |> expectOk
+
+        let failureCommand = failed "snapshot-failure" range0 "transient"
+
+        let failedRange =
+            ManifestContributionWorkflowActor.decideCommand [] started.Workflow failureCommand (metadata "corr-failure")
+            |> expectOk
+
+        let replay =
+            ManifestContributionWorkflowActor.decideCommand [] failedRange.Workflow failureCommand (metadata "corr-failure-replay")
+            |> expectOk
+
+        Assert.That(replay.WasIdempotentReplay, Is.True)
+        Assert.That(replay.Events, Is.Empty)
+        Assert.That(replay.Workflow.Revision, Is.EqualTo(failedRange.Workflow.Revision))
+
     /// Verifies that workflow Primary Key Combines Repository Id Storage Pool Id And Manifest Address.
     [<Test>]
     member _.WorkflowPrimaryKeyCombinesRepositoryIdStoragePoolIdAndManifestAddress() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -6,6 +6,7 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Text.Json
 
 module ManifestContributionWorkflowActor = Grace.Actors.ManifestContributionWorkflow
 
@@ -35,11 +36,15 @@ type ManifestContributionWorkflowActorTests() =
 
     /// Builds start With Ranges test data for the server unit manifest Contribution Workflow Actor scenarios in this file.
     let startWithRanges direction ranges =
-        ManifestContributionWorkflowCommand.Start("workflow-start", repositoryId, storagePoolId, manifestAddress, direction, ranges)
+        ManifestContributionWorkflowCommand.Start("workflow-start", repositoryId, storagePoolId, manifestAddress, direction, ranges, 1L)
 
     /// Builds start With Operation test data for the server unit manifest Contribution Workflow Actor scenarios in this file.
     let startWithOperation operationId direction ranges =
-        ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges)
+        ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges, 1L)
+
+    /// Builds a start command carrying the counter revision that orders contribution cycles.
+    let startWithOperationAtRevision operationId direction ranges counterRevision =
+        ManifestContributionWorkflowCommand.Start(operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges, counterRevision)
 
     let start direction = startWithRanges direction [| range0; range1 |]
 
@@ -98,7 +103,7 @@ type ManifestContributionWorkflowActorTests() =
                 (started.Events
                  @ firstRange.Events @ secondRange.Events)
                 secondRange.Workflow
-                (startWithOperation "bounded-next-cycle" ManifestContributionDirection.Decrement [| range0 |])
+                (startWithOperationAtRevision "bounded-next-cycle" ManifestContributionDirection.Decrement [| range0 |] 2L)
                 (metadata "corr-bounded-next-cycle")
             |> expectOk
 
@@ -136,6 +141,31 @@ type ManifestContributionWorkflowActorTests() =
         Assert.That(replayedRange.WasIdempotentReplay, Is.True)
         Assert.That(replayedRange.Events, Is.Empty)
         Assert.That(replayedRange.Intents, Is.Empty)
+
+    /// Verifies bounded workflow progress uses a Cosmos-compatible JSON array shape.
+    [<Test>]
+    member _.BoundedProgressSerializesWithoutDictionaryKeys() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-json-start")
+            |> expectOk
+
+        let progressed =
+            ManifestContributionWorkflowActor.decideCommand [] started.Workflow (succeeded "json-range" range0) (metadata "corr-json-range")
+            |> expectOk
+
+        let json = JsonSerializer.Serialize(progressed.Workflow, Grace.Shared.Constants.JsonSerializerOptions)
+        use document = JsonDocument.Parse json
+        let completedRanges = document.RootElement.GetProperty("CompletedRanges")
+        let failedRanges = document.RootElement.GetProperty("FailedRanges")
+
+        Assert.That(completedRanges.ValueKind, Is.EqualTo(JsonValueKind.Array))
+        Assert.That(completedRanges.GetArrayLength(), Is.EqualTo(1))
+        Assert.That(completedRanges[0].GetProperty("Range").ValueKind, Is.EqualTo(JsonValueKind.Object))
+        Assert.That(failedRanges.ValueKind, Is.EqualTo(JsonValueKind.Array))
 
     /// Verifies bounded failed-range progress retains enough identity for snapshot-only retries.
     [<Test>]
@@ -238,7 +268,13 @@ type ManifestContributionWorkflowActorTests() =
 
         Assert.That(replay.WasIdempotentReplay, Is.True)
         Assert.That(replay.Events, Is.Empty)
-        Assert.That(replay.Workflow.CompletedRanges.ContainsKey(range0), Is.True)
+
+        Assert.That(
+            replay.Workflow.CompletedRanges
+            |> Array.exists (fun completed -> completed.Range = range0),
+            Is.True
+        )
+
         let pending = ManifestContributionWorkflowActor.pendingRanges replay.Workflow
         Assert.That(pending, Has.Length.EqualTo(1))
         Assert.That(pending[0], Is.EqualTo(range1))
@@ -304,7 +340,7 @@ type ManifestContributionWorkflowActorTests() =
             ManifestContributionWorkflowActor.decideCommand
                 completedEvents
                 range1Done.Workflow
-                (startWithOperation "workflow-restart" ManifestContributionDirection.Decrement [| range0 |])
+                (startWithOperationAtRevision "workflow-restart" ManifestContributionDirection.Decrement [| range0 |] 2L)
                 (metadata "corr-restart")
             |> expectOk
 
@@ -313,6 +349,73 @@ type ManifestContributionWorkflowActorTests() =
         let restartedPending = ManifestContributionWorkflowActor.pendingRanges restarted.Workflow
         Assert.That(restartedPending.Length, Is.EqualTo(1))
         Assert.That(restartedPending[0], Is.EqualTo(range0))
+
+    /// Verifies that a superseded completed start cannot reopen an older contribution cycle.
+    [<Test>]
+    member _.SupersededCompletedStartDoesNotReapplyContentBlockDelta() =
+        let olderStart = startWithOperationAtRevision "workflow-older" ManifestContributionDirection.Increment [| range0 |] 1L
+
+        let olderStarted =
+            ManifestContributionWorkflowActor.decideCommand [] ManifestContributionWorkflowDto.Default olderStart (metadata "corr-older-start")
+            |> expectOk
+
+        let olderCompleted =
+            ManifestContributionWorkflowActor.decideCommand [] olderStarted.Workflow (succeeded "workflow-older-range" range0) (metadata "corr-older-range")
+            |> expectOk
+
+        Assert.That(olderCompleted.Intents.Length, Is.EqualTo(1))
+
+        let newerStart = startWithOperationAtRevision "workflow-newer" ManifestContributionDirection.Decrement [| range0 |] 2L
+
+        let newerStarted =
+            ManifestContributionWorkflowActor.decideCommand [] olderCompleted.Workflow newerStart (metadata "corr-newer-start")
+            |> expectOk
+
+        let newerCompleted =
+            ManifestContributionWorkflowActor.decideCommand [] newerStarted.Workflow (succeeded "workflow-newer-range" range0) (metadata "corr-newer-range")
+            |> expectOk
+
+        Assert.That(newerCompleted.Intents.Length, Is.EqualTo(1))
+
+        let supersededReplay =
+            ManifestContributionWorkflowActor.decideCommand [] newerCompleted.Workflow olderStart (metadata "corr-older-replay")
+            |> expectOk
+
+        Assert.That(supersededReplay.WasIdempotentReplay, Is.True)
+        Assert.That(supersededReplay.Events, Is.Empty)
+        Assert.That(supersededReplay.Intents, Is.Empty)
+        Assert.That(supersededReplay.Workflow.StartOperationId, Is.EqualTo(newerCompleted.Workflow.StartOperationId))
+        Assert.That(supersededReplay.Workflow.Direction, Is.EqualTo(ManifestContributionDirection.Decrement))
+
+    /// Verifies that one counter revision cannot identify two different contribution operations.
+    [<Test>]
+    member _.SameCounterRevisionWithDifferentOperationRejects() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (startWithOperationAtRevision "workflow-revision-owner" ManifestContributionDirection.Increment [| range0 |] 7L)
+                (metadata "corr-revision-owner")
+            |> expectOk
+
+        let completed =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                started.Workflow
+                (succeeded "workflow-revision-owner-range" range0)
+                (metadata "corr-revision-owner-range")
+            |> expectOk
+
+        let conflicting =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                completed.Workflow
+                (startWithOperationAtRevision "workflow-revision-conflict" ManifestContributionDirection.Decrement [| range0 |] 7L)
+                (metadata "corr-revision-conflict")
+
+        match conflicting with
+        | Ok _ -> Assert.Fail("Expected a different operation at the current counter revision to reject.")
+        | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow counter revision was already used by a different operation."))
 
     /// Verifies that range Progress Rejects When Actor Key Does Not Match Workflow Target.
     [<Test>]
@@ -383,7 +486,8 @@ type ManifestContributionWorkflowActorTests() =
                 otherStoragePoolId,
                 manifestAddress,
                 ManifestContributionDirection.Increment,
-                [| archiveRange |]
+                [| archiveRange |],
+                1L
             )
 
         let result =
@@ -456,7 +560,12 @@ type ManifestContributionWorkflowActorTests() =
         let pendingAfterFailure = ManifestContributionWorkflowActor.pendingRanges afterFailure
         Assert.That(pendingAfterFailure.Length, Is.EqualTo(1))
         Assert.That(pendingAfterFailure[0], Is.EqualTo(range1))
-        Assert.That(afterFailure.FailedRanges.ContainsKey(range1), Is.True)
+
+        Assert.That(
+            afterFailure.FailedRanges
+            |> Array.exists (fun failure -> failure.Range = range1),
+            Is.True
+        )
 
         let retrySucceeded =
             ManifestContributionWorkflowActor.decideCommand

--- a/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -217,6 +217,32 @@ type ManifestContributionWorkflowActorTests() =
         | Ok _ -> Assert.Fail("Expected reused start operation id with different payload to reject.")
         | Error error -> Assert.That(error.Error, Is.EqualTo("ManifestContributionWorkflow operation id was already used with a different payload."))
 
+    /// Verifies a workflow start can resume after bounded range progress replaced LastOperationId.
+    [<Test>]
+    member _.StartReplayAfterRangeProgressResumesCurrentWorkflow() =
+        let started =
+            ManifestContributionWorkflowActor.decideCommand
+                []
+                ManifestContributionWorkflowDto.Default
+                (start ManifestContributionDirection.Increment)
+                (metadata "corr-start-resume")
+            |> expectOk
+
+        let progressed =
+            ManifestContributionWorkflowActor.decideCommand [] started.Workflow (succeeded "range-resume" range0) (metadata "corr-range-resume")
+            |> expectOk
+
+        let replay =
+            ManifestContributionWorkflowActor.decideCommand [] progressed.Workflow (start ManifestContributionDirection.Increment) (metadata "corr-start-retry")
+            |> expectOk
+
+        Assert.That(replay.WasIdempotentReplay, Is.True)
+        Assert.That(replay.Events, Is.Empty)
+        Assert.That(replay.Workflow.CompletedRanges.ContainsKey(range0), Is.True)
+        let pending = ManifestContributionWorkflowActor.pendingRanges replay.Workflow
+        Assert.That(pending, Has.Length.EqualTo(1))
+        Assert.That(pending[0], Is.EqualTo(range1))
+
     /// Verifies that reused Range Success Operation Id With Different Range Rejects Instead Of Replaying.
     [<Test>]
     member _.ReusedRangeSuccessOperationIdWithDifferentRangeRejectsInsteadOfReplaying() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionWorkflow.Actor.Tests.fs
@@ -20,9 +20,9 @@ type ManifestContributionWorkflowActorTests() =
     let otherStoragePoolId = StoragePoolId "pool-archive"
     let manifestAddress = "manifest:blake3:alpha"
 
-    let range0 = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress "block-a"; OrdinalStart = 0; OrdinalCount = 8 }
+    let range0 = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress "block-a" }
 
-    let range1 = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress "block-b"; OrdinalStart = 8; OrdinalCount = 4 }
+    let range1 = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress "block-b" }
 
     /// Constructs metadata fixtures used by the server unit manifest Contribution Workflow Actor assertions.
     let metadata correlationId =
@@ -164,7 +164,26 @@ type ManifestContributionWorkflowActorTests() =
 
         Assert.That(completedRanges.ValueKind, Is.EqualTo(JsonValueKind.Array))
         Assert.That(completedRanges.GetArrayLength(), Is.EqualTo(1))
-        Assert.That(completedRanges[0].GetProperty("Range").ValueKind, Is.EqualTo(JsonValueKind.Object))
+        let completedRange = completedRanges[ 0 ].GetProperty("Range")
+        Assert.That(completedRange.ValueKind, Is.EqualTo(JsonValueKind.Object))
+
+        Assert.That(
+            completedRange
+                .GetProperty("StoragePoolId")
+                .GetString(),
+            Is.EqualTo(storagePoolId)
+        )
+
+        Assert.That(
+            completedRange
+                .GetProperty("ContentBlockAddress")
+                .GetString(),
+            Is.EqualTo(string range0.ContentBlockAddress)
+        )
+
+        let mutable ignoredProperty = Unchecked.defaultof<JsonElement>
+        Assert.That(completedRange.TryGetProperty("OrdinalStart", &ignoredProperty), Is.False)
+        Assert.That(completedRange.TryGetProperty("OrdinalCount", &ignoredProperty), Is.False)
         Assert.That(failedRanges.ValueKind, Is.EqualTo(JsonValueKind.Array))
 
     /// Verifies bounded failed-range progress retains enough identity for snapshot-only retries.

--- a/src/Grace.Server.Unit.Tests/RepositoryContentCounter.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryContentCounter.Actor.Tests.fs
@@ -6,6 +6,8 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Collections.Generic
+open System.Threading
+open System.Threading.Tasks
 
 module RepositoryContentCounterActor = Grace.Actors.RepositoryContentCounter
 
@@ -34,6 +36,14 @@ type RepositoryContentCounterActorTests() =
     let add operationId = RepositoryContentCounterCommand.AddReference(operationId, repositoryId, storagePoolId, manifestAddress)
 
     let remove operationId = RepositoryContentCounterCommand.RemoveReference(operationId, repositoryId, storagePoolId, manifestAddress)
+
+    /// Unwraps a counter decision while preserving a useful assertion failure.
+    let expectDecision result =
+        match result with
+        | Ok decision -> decision
+        | Error error ->
+            Assert.Fail($"Expected counter decision, got {error.Error}.")
+            Unchecked.defaultof<RepositoryContentCounterDecision>
 
     /// Applies all inputs to drive the server unit repository Content Counter Actor state transition under test.
     let applyAll events dto =
@@ -90,7 +100,7 @@ type RepositoryContentCounterActorTests() =
             | Ok replayDecision ->
                 Assert.That(replayDecision.WasIdempotentReplay, Is.True)
                 Assert.That(replayDecision.Events, Is.Empty)
-                Assert.That(replayDecision.Intents, Is.Empty)
+                Assert.That(replayDecision.Intents.Length, Is.EqualTo(1))
                 Assert.That(replayDecision.Counter.ReferenceCount, Is.EqualTo(1L))
             | Error error -> Assert.Fail($"Expected add replay to be idempotent, got {error.Error}.")
         | Error error -> Assert.Fail($"Expected add to succeed, got {error.Error}.")
@@ -173,7 +183,7 @@ type RepositoryContentCounterActorTests() =
         | Ok decision ->
             Assert.That(decision.WasIdempotentReplay, Is.True)
             Assert.That(decision.Events, Is.Empty)
-            Assert.That(decision.Intents, Is.Empty)
+            Assert.That(decision.Intents.Length, Is.EqualTo(1))
             Assert.That(decision.Counter.ReferenceCount, Is.EqualTo(0L))
             Assert.That(decision.Counter.LifecycleState, Is.EqualTo(RepositoryContentCounterLifecycleState.NotReferenced))
         | Error error -> Assert.Fail($"Expected remove replay to be idempotent, got {error.Error}.")
@@ -243,3 +253,198 @@ type RepositoryContentCounterActorTests() =
         match result with
         | Ok _ -> Assert.Fail("Expected cross-pool command on same manifest address to reject against the wrong grain key.")
         | Error error -> Assert.That(error.Error, Is.EqualTo("RepositoryContentCounter command target does not match the grain key."))
+
+    /// Verifies a superseded operation can replay its original zero transition from Redis without another count write.
+    [<Test>]
+    member _.SupersededOperationReplaysFromRecentResult() =
+        task {
+            let first =
+                RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-first") (metadata "corr-add-first")
+                |> expectDecision
+
+            let second =
+                RepositoryContentCounterActor.decideCommand [] first.Counter (add "op-add-second") (metadata "corr-add-second")
+                |> expectDecision
+
+            let recent =
+                { new Grace.Actors.IRepositoryCounterRecentResult with
+                    member _.TryGetAsync(_, _, _, operationId, _) =
+                        Task.FromResult(if operationId = "op-add-first" then first.Counter.LastCompletedChange else None)
+
+                    member _.TrySetAsync(_, _, _, _, _) = Task.FromResult true
+                }
+
+            let mutable persisted = false
+
+            let! result =
+                RepositoryContentCounterActor.handleWithRecentResult
+                    recent
+                    (fun _ ->
+                        persisted <- true
+                        Task.CompletedTask)
+                    None
+                    second.Counter
+                    (add "op-add-first")
+                    (metadata "corr-replay-first")
+                    CancellationToken.None
+
+            match result with
+            | Error error -> Assert.Fail($"Expected recent-result replay, got {error.Error}.")
+            | Ok decision ->
+                Assert.That(decision.WasIdempotentReplay, Is.True)
+                Assert.That(decision.Intents.Length, Is.EqualTo(1))
+                Assert.That(decision.Counter.Count, Is.EqualTo(2L))
+                Assert.That(persisted, Is.False)
+        }
+
+    /// Verifies a cached removal replay is resolved before the current zero count can reject it as a new removal.
+    [<Test>]
+    member _.SupersededRemovalReplaysFromRecentResultAtCurrentZero() =
+        task {
+            let addedFirst =
+                RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-first") (metadata "corr-add-first")
+                |> expectDecision
+
+            let removedFirst =
+                RepositoryContentCounterActor.decideCommand [] addedFirst.Counter (remove "op-remove-first") (metadata "corr-remove-first")
+                |> expectDecision
+
+            let addedSecond =
+                RepositoryContentCounterActor.decideCommand [] removedFirst.Counter (add "op-add-second") (metadata "corr-add-second")
+                |> expectDecision
+
+            let removedSecond =
+                RepositoryContentCounterActor.decideCommand [] addedSecond.Counter (remove "op-remove-second") (metadata "corr-remove-second")
+                |> expectDecision
+
+            let recent =
+                { new Grace.Actors.IRepositoryCounterRecentResult with
+                    member _.TryGetAsync(_, _, _, operationId, _) =
+                        Task.FromResult(
+                            if operationId = "op-remove-first" then
+                                removedFirst.Counter.LastCompletedChange
+                            else
+                                None
+                        )
+
+                    member _.TrySetAsync(_, _, _, _, _) = Task.FromResult true
+                }
+
+            let mutable persisted = false
+
+            let! result =
+                RepositoryContentCounterActor.handleWithRecentResult
+                    recent
+                    (fun _ ->
+                        persisted <- true
+                        Task.CompletedTask)
+                    None
+                    removedSecond.Counter
+                    (remove "op-remove-first")
+                    (metadata "corr-replay-remove-first")
+                    CancellationToken.None
+
+            match result with
+            | Error error -> Assert.Fail($"Expected recent removal replay, got {error.Error}.")
+            | Ok decision ->
+                Assert.That(decision.WasIdempotentReplay, Is.True)
+                Assert.That(decision.Intents.Length, Is.EqualTo(1))
+                Assert.That(decision.Counter.Count, Is.EqualTo(0L))
+                Assert.That(persisted, Is.False)
+        }
+
+    /// Verifies Redis loss pauses a removal before the bounded count is changed.
+    [<Test>]
+    member _.RedisLossPausesRemovalBeforeCountChange() =
+        task {
+            let added =
+                RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add") (metadata "corr-add")
+                |> expectDecision
+
+            let recent =
+                { new Grace.Actors.IRepositoryCounterRecentResult with
+                    member _.TryGetAsync(_, _, _, _, _) = Task.FromResult(None)
+                    member _.TrySetAsync(_, _, _, _, _) = Task.FromResult false
+                }
+
+            let mutable persisted = false
+
+            let! result =
+                RepositoryContentCounterActor.handleWithRecentResult
+                    recent
+                    (fun _ ->
+                        persisted <- true
+                        Task.CompletedTask)
+                    None
+                    added.Counter
+                    (remove "op-remove")
+                    (metadata "corr-remove")
+                    CancellationToken.None
+
+            match result with
+            | Ok _ -> Assert.Fail("Expected removal to pause while Redis cannot preserve the previous result.")
+            | Error error -> Assert.That(error.Error, Does.Contain("removal paused"))
+
+            Assert.That(persisted, Is.False)
+            Assert.That(added.Counter.Count, Is.EqualTo(1L))
+        }
+
+    /// Verifies a removal whose Redis reply is lost remains recoverable from LastCompletedChange.
+    [<Test>]
+    member _.RemovalRecoversAfterCompletedResultWriteReturnsUnknown() =
+        task {
+            let added =
+                RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add") (metadata "corr-add")
+                |> expectDecision
+
+            let firstRecent =
+                { new Grace.Actors.IRepositoryCounterRecentResult with
+                    member _.TryGetAsync(_, _, _, _, _) = Task.FromResult(None)
+
+                    member _.TrySetAsync(_, _, _, change, _) = Task.FromResult(change.Operation = RepositoryContentCounterChangeOperation.Added)
+                }
+
+            let mutable persisted = RepositoryContentCounterDto.Default
+
+            let! first =
+                RepositoryContentCounterActor.handleWithRecentResult
+                    firstRecent
+                    (fun snapshot ->
+                        persisted <- snapshot
+                        Task.CompletedTask)
+                    None
+                    added.Counter
+                    (remove "op-remove")
+                    (metadata "corr-remove")
+                    CancellationToken.None
+
+            match first with
+            | Ok _ -> Assert.Fail("Expected the unconfirmed completed-result write to withhold removal intent.")
+            | Error error -> Assert.That(error.Error, Does.Contain("retained safely"))
+
+            Assert.That(persisted.Count, Is.EqualTo(0L))
+            Assert.That(persisted.LastCompletedChange.Value.OperationId, Is.EqualTo("op-remove"))
+
+            let recoveredRecent =
+                { new Grace.Actors.IRepositoryCounterRecentResult with
+                    member _.TryGetAsync(_, _, _, _, _) = Task.FromResult(None)
+                    member _.TrySetAsync(_, _, _, _, _) = Task.FromResult true
+                }
+
+            let! recovered =
+                RepositoryContentCounterActor.handleWithRecentResult
+                    recoveredRecent
+                    (fun _ -> Task.CompletedTask)
+                    None
+                    persisted
+                    (remove "op-remove")
+                    (metadata "corr-remove-retry")
+                    CancellationToken.None
+
+            match recovered with
+            | Error error -> Assert.Fail($"Expected removal recovery, got {error.Error}.")
+            | Ok decision ->
+                Assert.That(decision.WasIdempotentReplay, Is.True)
+                Assert.That(decision.Intents.Length, Is.EqualTo(1))
+                Assert.That(decision.Counter.Count, Is.EqualTo(0L))
+        }

--- a/src/Grace.Server.Unit.Tests/RepositoryContentCounter.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryContentCounter.Actor.Tests.fs
@@ -40,6 +40,31 @@ type RepositoryContentCounterActorTests() =
         events
         |> List.fold (fun current event -> RepositoryContentCounterDto.UpdateDto event current) dto
 
+    /// Verifies repeated counter changes retain only the latest bounded completion snapshot.
+    [<Test>]
+    member _.RepeatedChangesRetainOnlyLatestCompletedSnapshot() =
+        let addDecision =
+            match RepositoryContentCounterActor.decideCommand [] RepositoryContentCounterDto.Default (add "op-add-bounded") (metadata "corr-add-bounded") with
+            | Ok decision -> decision
+            | Error error ->
+                Assert.Fail($"Expected bounded add to succeed, got {error.Error}.")
+                Unchecked.defaultof<RepositoryContentCounterDecision>
+
+        let removeDecision =
+            match
+                RepositoryContentCounterActor.decideCommand addDecision.Events addDecision.Counter (remove "op-remove-bounded") (metadata "corr-remove-bounded")
+                with
+            | Ok decision -> decision
+            | Error error ->
+                Assert.Fail($"Expected bounded remove to succeed, got {error.Error}.")
+                Unchecked.defaultof<RepositoryContentCounterDecision>
+
+        Assert.That(removeDecision.Counter.Count, Is.EqualTo(0L))
+        Assert.That(removeDecision.Counter.Revision, Is.EqualTo(2L))
+        Assert.That(removeDecision.Counter.LastCompletedChange.Value.OperationId, Is.EqualTo("op-remove-bounded"))
+        Assert.That(removeDecision.Counter.LastCompletedChange.Value.PreviousCount, Is.EqualTo(1L))
+        Assert.That(removeDecision.Counter.LastCompletedChange.Value.CurrentCount, Is.EqualTo(0L))
+
     /// Verifies that zero To One Emits Increment Intent And Retry Is Idempotent.
     [<Test>]
     member _.ZeroToOneEmitsIncrementIntentAndRetryIsIdempotent() =

--- a/src/Grace.Server.Unit.Tests/RepositoryContentCounter.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryContentCounter.Actor.Tests.fs
@@ -90,7 +90,7 @@ type RepositoryContentCounterActorTests() =
 
             Assert.That(
                 decision.Intents[0],
-                Is.EqualTo(RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress))
+                Is.EqualTo(RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress, 1L))
             )
 
             let dto = applyAll decision.Events RepositoryContentCounterDto.Default
@@ -152,7 +152,7 @@ type RepositoryContentCounterActorTests() =
 
             Assert.That(
                 decision.Intents[0],
-                Is.EqualTo(RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress))
+                Is.EqualTo(RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifestAddress, 4L))
             )
         | Error error -> Assert.Fail($"Expected final remove to succeed, got {error.Error}.")
 

--- a/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
@@ -21,6 +21,17 @@ type RepositoryCounterRecentResultTests() =
     [<Test>]
     member _.InitialRedisConnectionAllowsBoundedContainerHandshake() = Assert.That(connectionTimeout, Is.EqualTo(TimeSpan.FromSeconds 10.0))
 
+    /// Verifies a disconnected lazy multiplexer receives the full readiness window observed missing in CI before bounded commands begin.
+    [<Test>]
+    member _.DisconnectedInitialMultiplexerUsesReadinessProbeConfiguration() =
+        let configuration = configurationForEndpoint "127.0.0.1" 6379
+
+        Assert.That(configuration.AbortOnConnectFail, Is.False)
+        Assert.That(configuration.ConnectTimeout, Is.EqualTo(int connectionTimeout.TotalMilliseconds))
+        Assert.That(configuration.AsyncTimeout, Is.EqualTo(int connectionTimeout.TotalMilliseconds))
+        Assert.That(requiresReadinessProbe false, Is.True)
+        Assert.That(requiresReadinessProbe true, Is.False)
+
     /// Verifies cached changes round-trip without inventing a zero for missing or malformed values.
     [<Test>]
     member _.RecentResultRoundTripsAndMalformedValueIsMiss() =

--- a/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
@@ -1,0 +1,58 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.RepositoryCounterRecentResult
+open Grace.Shared
+open Grace.Types.Common
+open Grace.Types.RepositoryContentCounter
+open NUnit.Framework
+open System
+open System.Threading
+
+/// Covers the provider-neutral Redis recent-result wire contract without starting Redis.
+[<Parallelizable(ParallelScope.All)>]
+type RepositoryCounterRecentResultTests() =
+
+    /// Verifies recent results use the accepted exact ten-minute expiry.
+    [<Test>]
+    member _.RecentResultExpiryIsExactlyTenMinutes() = Assert.That(expiry, Is.EqualTo(TimeSpan.FromMinutes 10.0))
+
+    /// Verifies cached changes round-trip without inventing a zero for missing or malformed values.
+    [<Test>]
+    member _.RecentResultRoundTripsAndMalformedValueIsMiss() =
+        let change =
+            { OperationId = "directory-version:1:add"; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L }
+
+        Assert.That(tryDeserialize (serialize change), Is.EqualTo(Some change))
+        Assert.That(tryDeserialize "not-a-result", Is.EqualTo(None))
+        Assert.That(tryDeserialize String.Empty, Is.EqualTo(None))
+
+    /// Verifies cache keys partition identical manifest text by repository and StoragePool.
+    [<Test>]
+    member _.RecentResultKeyUsesExactRepositoryManifestDimensions() =
+        let repositoryId = Guid.Parse("75ce5e36-25f6-4da0-afdd-ad4ad56540d5")
+        let otherRepositoryId = Guid.Parse("41ff01d0-8f4c-41e7-875d-1c4f7b519c11")
+        let operationId = "directory-version:1:add"
+        let main = key repositoryId (StoragePoolId "pool-main") "manifest:alpha" operationId
+        let otherPool = key repositoryId (StoragePoolId "pool-archive") "manifest:alpha" operationId
+        let otherRepository = key otherRepositoryId (StoragePoolId "pool-main") "manifest:alpha" operationId
+
+        Assert.That(otherPool, Is.Not.EqualTo(main))
+        Assert.That(otherRepository, Is.Not.EqualTo(main))
+
+    /// Verifies missing Redis is represented as unknown rather than a synthetic zero result.
+    [<Test>]
+    member _.UnavailableRedisReturnsMiss() =
+        task {
+            let recent = UnavailableRepositoryCounterRecentResult() :> IRepositoryCounterRecentResult
+
+            let! result =
+                recent.TryGetAsync(
+                    Guid.Parse("75ce5e36-25f6-4da0-afdd-ad4ad56540d5"),
+                    StoragePoolId "pool-main",
+                    "manifest:alpha",
+                    "directory-version:1:add",
+                    CancellationToken.None
+                )
+
+            Assert.That(result, Is.EqualTo(None))
+        }

--- a/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
@@ -1,5 +1,6 @@
 namespace Grace.Server.Tests
 
+open Grace.Actors
 open Grace.Server.RepositoryCounterRecentResult
 open Grace.Shared
 open Grace.Types.Common
@@ -55,4 +56,30 @@ type RepositoryCounterRecentResultTests() =
                 )
 
             Assert.That(result, Is.EqualTo(None))
+        }
+
+    /// Verifies absent Redis reports an unconfirmed write so removal work can pause safely.
+    [<Test>]
+    member _.UnavailableRedisDoesNotConfirmWrite() =
+        task {
+            let recent = UnavailableRepositoryCounterRecentResult() :> IRepositoryCounterRecentResult
+
+            let change =
+                {
+                    OperationId = "directory-version:1:remove"
+                    Operation = RepositoryContentCounterChangeOperation.Removed
+                    PreviousCount = 1L
+                    CurrentCount = 0L
+                }
+
+            let! confirmed =
+                recent.TrySetAsync(
+                    Guid.Parse("75ce5e36-25f6-4da0-afdd-ad4ad56540d5"),
+                    StoragePoolId "pool-main",
+                    "manifest:alpha",
+                    change,
+                    CancellationToken.None
+                )
+
+            Assert.That(confirmed, Is.False)
         }

--- a/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
@@ -17,11 +17,21 @@ type RepositoryCounterRecentResultTests() =
     [<Test>]
     member _.RecentResultExpiryIsExactlyTenMinutes() = Assert.That(expiry, Is.EqualTo(TimeSpan.FromMinutes 10.0))
 
+    /// Verifies the one-time Redis handshake remains bounded but is not limited to a command-sized CI window.
+    [<Test>]
+    member _.InitialRedisConnectionAllowsBoundedContainerHandshake() = Assert.That(connectionTimeout, Is.EqualTo(TimeSpan.FromSeconds 10.0))
+
     /// Verifies cached changes round-trip without inventing a zero for missing or malformed values.
     [<Test>]
     member _.RecentResultRoundTripsAndMalformedValueIsMiss() =
         let change =
-            { OperationId = "directory-version:1:add"; Operation = RepositoryContentCounterChangeOperation.Added; PreviousCount = 0L; CurrentCount = 1L }
+            {
+                OperationId = "directory-version:1:add"
+                Operation = RepositoryContentCounterChangeOperation.Added
+                PreviousCount = 0L
+                CurrentCount = 1L
+                Revision = 1L
+            }
 
         Assert.That(tryDeserialize (serialize change), Is.EqualTo(Some change))
         Assert.That(tryDeserialize "not-a-result", Is.EqualTo(None))
@@ -70,6 +80,7 @@ type RepositoryCounterRecentResultTests() =
                     Operation = RepositoryContentCounterChangeOperation.Removed
                     PreviousCount = 1L
                     CurrentCount = 0L
+                    Revision = 2L
                 }
 
             let! confirmed =

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -874,8 +874,7 @@ type SaveBoundaryActorTests() =
             plan.WorkflowRanges
             |> Seq.forall (fun range ->
                 range.StoragePoolId = expectedStoragePoolId
-                && range.OrdinalStart = 0
-                && range.OrdinalCount = 1),
+                && range.ContentBlockAddress = manifest.Blocks[0].Address),
             Is.True
         )
 

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -681,7 +681,12 @@ type SaveBoundaryActorTests() =
                 Unchecked.defaultof<RepositoryContentCounterDecision>
 
         Assert.That(replayDecision.WasIdempotentReplay, Is.True)
-        Assert.That(replayDecision.Intents, Is.Empty)
+        Assert.That(replayDecision.Intents, Has.Length.EqualTo(1))
+
+        match replayDecision.Intents[0] with
+        | RepositoryContentCounterIntent.IncrementManifestReferenceCount (_, _, replayManifestAddress) ->
+            Assert.That(replayManifestAddress, Is.EqualTo(manifest.ManifestAddress))
+        | intent -> Assert.Fail($"Expected increment workflow intent on replay, got {intent}.")
 
         match ReferenceActor.tryCreateManifestContributionStartForCounterDecision plan replayDecision firstCounterDecision.Events with
         | Some startCommand ->
@@ -1031,7 +1036,12 @@ type SaveBoundaryActorTests() =
         | Ok decision ->
             Assert.That(decision.WasIdempotentReplay, Is.True)
             Assert.That(decision.Events, Is.Empty)
-            Assert.That(decision.Intents, Is.Empty)
+            Assert.That(decision.Intents, Has.Length.EqualTo(1))
+
+            match decision.Intents[0] with
+            | RepositoryContentCounterIntent.DecrementManifestReferenceCount (_, _, replayManifestAddress) ->
+                Assert.That(replayManifestAddress, Is.EqualTo(manifest.ManifestAddress))
+            | intent -> Assert.Fail($"Expected decrement workflow intent on replay, got {intent}.")
 
             match ReferenceActor.tryCreateManifestContributionStartForCounterDecision decrementPlan decision allEvents with
             | Some startCommand ->

--- a/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/SaveBoundary.Actor.Tests.fs
@@ -646,7 +646,7 @@ type SaveBoundaryActorTests() =
 
             Assert.That(
                 decision.Intents[0],
-                Is.EqualTo(RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress))
+                Is.EqualTo(RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 1L))
             )
         | Error error -> Assert.Fail($"Expected repository content counter increment to succeed, got {error.Error}.")
 
@@ -684,7 +684,7 @@ type SaveBoundaryActorTests() =
         Assert.That(replayDecision.Intents, Has.Length.EqualTo(1))
 
         match replayDecision.Intents[0] with
-        | RepositoryContentCounterIntent.IncrementManifestReferenceCount (_, _, replayManifestAddress) ->
+        | RepositoryContentCounterIntent.IncrementManifestReferenceCount (_, _, replayManifestAddress, _) ->
             Assert.That(replayManifestAddress, Is.EqualTo(manifest.ManifestAddress))
         | intent -> Assert.Fail($"Expected increment workflow intent on replay, got {intent}.")
 
@@ -708,7 +708,7 @@ type SaveBoundaryActorTests() =
             ReferenceActor.planManifestSaveBoundary repositoryId referenceId directoryVersion "corr-fanout"
             |> expectPlan
 
-        let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress)
+        let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 1L)
 
         match ReferenceActor.tryCreateManifestContributionStart plan intent with
         | Some startCommand ->
@@ -879,7 +879,7 @@ type SaveBoundaryActorTests() =
             Is.True
         )
 
-        let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress)
+        let intent = RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 1L)
 
         match ReferenceActor.tryCreateManifestContributionStart plan intent with
         | Some startCommand ->
@@ -912,7 +912,7 @@ type SaveBoundaryActorTests() =
                     )
             }
 
-        let intent = RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress)
+        let intent = RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 1L)
 
         match ReferenceActor.tryCreateManifestContributionStart decrementPlan intent with
         | Some startCommand ->
@@ -940,7 +940,7 @@ type SaveBoundaryActorTests() =
             match
                 ReferenceActor.tryCreateManifestContributionStart
                     savePlan
-                    (RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress))
+                    (RepositoryContentCounterIntent.IncrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 1L))
                 with
             | Some command -> command
             | None ->
@@ -970,7 +970,7 @@ type SaveBoundaryActorTests() =
             match
                 ReferenceActor.tryCreateManifestContributionStart
                     decrementPlan
-                    (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress))
+                    (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 2L))
                 with
             | Some command -> command
             | None ->
@@ -1039,7 +1039,7 @@ type SaveBoundaryActorTests() =
             Assert.That(decision.Intents, Has.Length.EqualTo(1))
 
             match decision.Intents[0] with
-            | RepositoryContentCounterIntent.DecrementManifestReferenceCount (_, _, replayManifestAddress) ->
+            | RepositoryContentCounterIntent.DecrementManifestReferenceCount (_, _, replayManifestAddress, _) ->
                 Assert.That(replayManifestAddress, Is.EqualTo(manifest.ManifestAddress))
             | intent -> Assert.Fail($"Expected decrement workflow intent on replay, got {intent}.")
 
@@ -1083,7 +1083,7 @@ type SaveBoundaryActorTests() =
             match
                 ReferenceActor.tryCreateManifestContributionStart
                     decrementPlan
-                    (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress))
+                    (RepositoryContentCounterIntent.DecrementManifestReferenceCount(repositoryId, storagePoolId, manifest.ManifestAddress, 1L))
                 with
             | Some command -> command
             | None ->

--- a/src/Grace.Server.Unit.Tests/UploadSession.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/UploadSession.Actor.Tests.fs
@@ -918,7 +918,7 @@ type UploadSessionActorTests() =
                 Assert.That(merge.Ranges, Has.Length.EqualTo(1))
                 Assert.That(merge.Ranges[0].OrdinalStart, Is.EqualTo(0))
                 Assert.That(merge.Ranges[0].OrdinalCount, Is.EqualTo(1))
-                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.Zero)
                 Assert.That(merge.ExpectedMetadataVersion, Is.EqualTo(None))
                 Assert.That(merge.RequireMissingMetadata, Is.False)
                 Assert.That(merge.ExpectedRanges, Is.Empty)
@@ -986,7 +986,7 @@ type UploadSessionActorTests() =
             Assert.That(merge.Ranges[0].OrdinalCount, Is.EqualTo(metadataRange.OrdinalCount))
             Assert.That(merge.Ranges[0].PhysicalOffset, Is.EqualTo(metadataRange.PhysicalOffset))
             Assert.That(merge.Ranges[0].PhysicalLength, Is.EqualTo(metadataRange.PhysicalLength))
-            Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+            Assert.That(merge.Ranges[0].ActiveManifestCount, Is.Zero)
             Assert.That(merge.ExpectedMetadataVersion, Is.EqualTo(None))
             Assert.That(merge.RequireMissingMetadata, Is.False)
             Assert.That(merge.ExpectedRanges, Is.EquivalentTo([| metadataRange |]))
@@ -1005,7 +1005,7 @@ type UploadSessionActorTests() =
             Assert.That(
                 mergeDecision.Metadata.Ranges[0]
                     .ActiveManifestCount,
-                Is.EqualTo(3)
+                Is.EqualTo(metadataRange.ActiveManifestCount)
             )
         | _ -> Assert.Fail("Expected claimed reuse finalization to create a ContentBlockMetadata MergePhysicalRanges command.")
 
@@ -1079,7 +1079,7 @@ type UploadSessionActorTests() =
 
             Assert.That(subwindowContribution.PhysicalOffset, Is.EqualTo(subwindowClaim.PhysicalOffset))
             Assert.That(subwindowContribution.PhysicalLength, Is.EqualTo(subwindowClaim.PhysicalLength))
-            Assert.That(subwindowContribution.ActiveManifestCount, Is.EqualTo(1))
+            Assert.That(subwindowContribution.ActiveManifestCount, Is.Zero)
             Assert.That(merge.ExpectedRanges, Is.EquivalentTo([| coveringRange; coveringRange |]))
 
             let mergeDecision =
@@ -1098,7 +1098,7 @@ type UploadSessionActorTests() =
 
             Assert.That(subwindowRange.PhysicalOffset, Is.EqualTo(subwindowClaim.PhysicalOffset))
             Assert.That(subwindowRange.PhysicalLength, Is.EqualTo(subwindowClaim.PhysicalLength))
-            Assert.That(subwindowRange.ActiveManifestCount, Is.EqualTo(coveringRange.ActiveManifestCount + 1))
+            Assert.That(subwindowRange.ActiveManifestCount, Is.EqualTo(coveringRange.ActiveManifestCount))
         | _ -> Assert.Fail("Expected claimed reuse subwindow finalization to create a ContentBlockMetadata MergePhysicalRanges command.")
 
     /// Verifies that finalize Manifest Accepts Claimed Reuse Range Cover For Multi Chunk Block.
@@ -1188,7 +1188,7 @@ type UploadSessionActorTests() =
             Assert.That(
                 merge.Ranges
                 |> Array.map (fun range -> range.ActiveManifestCount),
-                Is.All.EqualTo(1)
+                Is.All.Zero
             )
 
             Assert.That(merge.ExpectedRanges, Is.EquivalentTo([| firstRange; secondRange |]))
@@ -1486,7 +1486,7 @@ type UploadSessionActorTests() =
             | ContentBlockMetadataCommand.MergePhysicalRanges merge ->
                 Assert.That(merge.ContentBlockAddress, Is.EqualTo(block.Address))
                 Assert.That(merge.StoragePlacement.ObjectKey, Is.EqualTo(StorageKeys.contentBlockObjectKey block.Address))
-                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.Zero)
                 Assert.That(merge.ExpectedMetadataVersion, Is.EqualTo(None))
                 Assert.That(merge.RequireMissingMetadata, Is.False)
                 Assert.That(merge.ExpectedRanges, Is.Empty)
@@ -1561,7 +1561,7 @@ type UploadSessionActorTests() =
                 Assert.That(merge.StoragePlacement, Is.EqualTo(freshMetadata.StoragePlacement))
                 Assert.That(merge.Ranges, Has.Length.EqualTo(1))
                 Assert.That(merge.Ranges[0].PhysicalLength, Is.EqualTo(int64 fileBytes.Length))
-                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.Zero)
                 Assert.That(merge.ExpectedMetadataVersion, Is.EqualTo(None))
                 Assert.That(merge.ExpectedRanges, Is.EquivalentTo([| freshRange |]))
                 Assert.That(merge.IsFinalizeContribution, Is.True)
@@ -1634,7 +1634,7 @@ type UploadSessionActorTests() =
                 Assert.That(merge.Ranges, Has.Length.EqualTo(1))
                 Assert.That(merge.Ranges[0].PhysicalOffset, Is.EqualTo(activeCurrentRange.PhysicalOffset))
                 Assert.That(merge.Ranges[0].PhysicalLength, Is.EqualTo(activeCurrentRange.PhysicalLength))
-                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+                Assert.That(merge.Ranges[0].ActiveManifestCount, Is.Zero)
                 Assert.That(merge.ExpectedRanges, Is.EquivalentTo([| activeCurrentRange |]))
                 Assert.That(merge.IsFinalizeContribution, Is.True)
             | _ -> Assert.Fail("Expected the matching active exact claimed range to provide the metadata merge command.")
@@ -1891,7 +1891,7 @@ type UploadSessionActorTests() =
 
         let secondDecision =
             ContentBlockMetadataActor.decideCommand firstDecision.Events currentMetadataDto revalidatedSecondCommand (metadata "corr-metadata-second")
-            |> decisionOrFail "Expected second metadata merge to be a distinct contribution"
+            |> decisionOrFail "Expected second metadata merge to remain a distinct upload-session operation"
 
         Assert.That(secondDecision.WasIdempotentReplay, Is.False)
         Assert.That(secondDecision.Metadata.Ranges, Has.Length.EqualTo(1))
@@ -1899,7 +1899,7 @@ type UploadSessionActorTests() =
         Assert.That(
             secondDecision.Metadata.Ranges[0]
                 .ActiveManifestCount,
-            Is.EqualTo(2)
+            Is.Zero
         )
 
     /// Verifies that finalize Metadata Merge Operation Ids Include Repository Scope For Shared Pool Sessions.
@@ -2034,7 +2034,7 @@ type UploadSessionActorTests() =
             |> decisionOrFail "Expected first metadata merge to succeed"
 
         Assert.That(firstResult.Metadata.Ranges, Has.Length.EqualTo(1))
-        Assert.That(firstResult.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+        Assert.That(firstResult.Metadata.Ranges[0].ActiveManifestCount, Is.Zero)
 
         let finalizedSession =
             apply { Event = UploadSessionEventType.Finalized("op-finalize", manifest.ManifestAddress); Metadata = metadata "corr-finalized" } session
@@ -2053,7 +2053,7 @@ type UploadSessionActorTests() =
         match advancedSecondResult with
         | Ok decision ->
             Assert.That(decision.WasIdempotentReplay, Is.False)
-            Assert.That(decision.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+            Assert.That(decision.Metadata.Ranges[0].ActiveManifestCount, Is.Zero)
         | Error error -> Assert.Fail($"Expected versionless finalized merge to tolerate advanced metadata, got {error.Error}.")
 
         let firstMetadataDto =
@@ -2070,7 +2070,7 @@ type UploadSessionActorTests() =
 
         Assert.That(firstRetry.WasIdempotentReplay, Is.True)
         Assert.That(firstRetry.Events, Is.Empty)
-        Assert.That(firstRetry.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+        Assert.That(firstRetry.Metadata.Ranges[0].ActiveManifestCount, Is.Zero)
 
         let secondRetryMerge = UploadSessionActor.withFinalizeMergePrecondition (mergeAt 1)
 
@@ -2084,19 +2084,19 @@ type UploadSessionActorTests() =
 
         Assert.That(secondRetry.WasIdempotentReplay, Is.False)
         Assert.That(secondRetry.Metadata.Ranges, Has.Length.EqualTo(1))
-        Assert.That(secondRetry.Metadata.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+        Assert.That(secondRetry.Metadata.Ranges[0].ActiveManifestCount, Is.Zero)
 
-    /// Verifies that finalized Manifest Ranges Emit Single Reference Contribution Delta.
+    /// Verifies finalized physical ranges remain reclaimable until a repository contributes the manifest.
     [<Test>]
-    member _.FinalizedManifestRangesEmitSingleReferenceContributionDelta() =
+    member _.FinalizedManifestRangesDoNotPreemptRepositoryContribution() =
         let ranges =
             [|
                 { OrdinalStart = 0; OrdinalCount = 1; ActiveManifestCount = 2; PhysicalOffset = 0L; PhysicalLength = 11L }
             |]
 
-        let activeRanges = UploadSessionActor.finalizedManifestContributionRanges ranges
+        let finalizedRanges = UploadSessionActor.finalizedManifestPhysicalRanges ranges
 
-        Assert.That(activeRanges[0].ActiveManifestCount, Is.EqualTo(1))
+        Assert.That(finalizedRanges[0].ActiveManifestCount, Is.Zero)
         Assert.That(ranges[0].ActiveManifestCount, Is.EqualTo(2))
 
     /// Verifies that finalize Manifest Replay Repairs Metadata Before Dedupe Registration.
@@ -2376,7 +2376,7 @@ type UploadSessionActorTests() =
         Assert.That(rebasedMerge.Ranges[0].OrdinalCount, Is.EqualTo(activeCurrentRange.OrdinalCount))
         Assert.That(rebasedMerge.Ranges[0].PhysicalOffset, Is.EqualTo(activeCurrentRange.PhysicalOffset))
         Assert.That(rebasedMerge.Ranges[0].PhysicalLength, Is.EqualTo(activeCurrentRange.PhysicalLength))
-        Assert.That(rebasedMerge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+        Assert.That(rebasedMerge.Ranges[0].ActiveManifestCount, Is.Zero)
 
         Assert.That(
             rebasedMerge.Ranges
@@ -2450,7 +2450,7 @@ type UploadSessionActorTests() =
         | Ok (Some (ContentBlockMetadataCommand.MergePhysicalRanges merge)) ->
             Assert.That(merge.Ranges, Has.Length.EqualTo(1))
             Assert.That(merge.Ranges[0].PhysicalOffset, Is.EqualTo(activeRelocatedRange.PhysicalOffset))
-            Assert.That(merge.Ranges[0].ActiveManifestCount, Is.EqualTo(1))
+            Assert.That(merge.Ranges[0].ActiveManifestCount, Is.Zero)
             Assert.That(merge.ExpectedMetadataVersion, Is.EqualTo(None))
             Assert.That(merge.ExpectedRanges, Is.EquivalentTo([| activeRelocatedRange |]))
         | Ok _ -> Assert.Fail("Expected active relocated metadata to produce a claimed merge command.")

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -101,6 +101,7 @@
                 <Compile Include="Artifact.Server.fs" />
                 <Compile Include="ReviewAnalysis.Server.fs" />
                 <Compile Include="Eventing.Server.fs" />
+                <Compile Include="RepositoryCounterRecentResult.Server.fs" />
                 <Compile Include="ManifestContributionAccounting.Server.fs" />
 		<Compile Include="DirectoryVersion.Server.fs" />
 		<Compile Include="Diff.Server.fs" />
@@ -169,6 +170,7 @@
 		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+		<PackageReference Include="StackExchange.Redis" Version="2.11.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Update="FSharp.Core" Version="10.1.301" />

--- a/src/Grace.Server/ManifestContributionAccounting.Server.fs
+++ b/src/Grace.Server/ManifestContributionAccounting.Server.fs
@@ -169,6 +169,46 @@ module ManifestContributionAccounting =
             |> Seq.toArray
         | Error graceError -> invalidOp graceError.Error
 
+    /// Represents one bounded iterative step while converging a retained DirectoryVersion DAG.
+    type private DirectoryTraversalStep =
+        | VisitDirectory of directoryVersionId: DirectoryVersionId
+        | VisitChild of parentDirectoryVersionId: DirectoryVersionId * childDirectoryVersionId: DirectoryVersionId
+        | ConvergeParentChild of parentDirectoryVersionId: DirectoryVersionId * childDirectoryVersionId: DirectoryVersionId
+
+    /// Caps the retained-child probe at the first exact incoming relationship.
+    let private oneIncomingRelationshipBound =
+        match ExactRelationshipReadBound.create 1 with
+        | Ok bound -> bound
+        | Error error -> invalidOp error
+
+    /// Confirms the Reference actor still retains the same root named by this delivery.
+    let private isCurrentLiveReference
+        (dependencies: ManifestContributionAccountingDependencies)
+        repositoryId
+        referenceId
+        rootDirectoryVersionId
+        correlationId
+        =
+        task {
+            let! currentReference = dependencies.GetReference repositoryId referenceId correlationId
+
+            return
+                currentReference.ReferenceId = referenceId
+                && currentReference.RepositoryId = repositoryId
+                && currentReference.DirectoryId = rootDirectoryVersionId
+                && currentReference.DeletedAt.IsNone
+        }
+
+    /// Confirms a DirectoryVersion actor read belongs to the requested immutable repository node.
+    let private isCurrentDirectoryVersion repositoryId directoryVersionId (directoryVersionDto: DirectoryVersionDto) =
+        directoryVersionDto.DirectoryVersion.RepositoryId = repositoryId
+        && directoryVersionDto.DirectoryVersion.DirectoryVersionId = directoryVersionId
+
+    /// Confirms the current immutable parent still directly names the candidate child.
+    let private isCurrentDirectChild repositoryId parentDirectoryVersionId childDirectoryVersionId (parentDto: DirectoryVersionDto) =
+        isCurrentDirectoryVersion repositoryId parentDirectoryVersionId parentDto
+        && parentDto.DirectoryVersion.Directories.Contains childDirectoryVersionId
+
     /// Reconciles one Reference Created event from fresh actor state before converging its independent lifecycle effect.
     let handleReferenceCreatedWith (dependencies: ManifestContributionAccountingDependencies) cancellationToken (referenceEvent: ReferenceEvent) =
         task {
@@ -193,43 +233,178 @@ module ManifestContributionAccounting =
                     match! dependencies.ExactRelationships.VerifyAsync(referenceRoot, cancellationToken) with
                     | ExactRelationshipPresence.Present -> ()
                     | ExactRelationshipPresence.Absent ->
-                        let! _ = dependencies.ExactRelationships.EnsurePresentAsync(referenceRoot, cancellationToken)
-                        ()
+                        let! stillLive =
+                            isCurrentLiveReference
+                                dependencies
+                                currentReference.RepositoryId
+                                currentReference.ReferenceId
+                                currentReference.DirectoryId
+                                correlationId
 
-                    let! candidateState = dependencies.GetDirectoryVersion currentReference.RepositoryId currentReference.DirectoryId correlationId
+                        if stillLive then
+                            let! _ = dependencies.ExactRelationships.EnsurePresentAsync(referenceRoot, cancellationToken)
+                            ()
 
-                    let candidates = directManifests correlationId candidateState
+                    let pending = Stack<DirectoryTraversalStep>()
+                    pending.Push(VisitDirectory currentReference.DirectoryId)
 
-                    for candidate in candidates do
+                    while pending.Count > 0 do
                         cancellationToken.ThrowIfCancellationRequested()
 
-                        let! currentDirectoryVersion = dependencies.GetDirectoryVersion currentReference.RepositoryId currentReference.DirectoryId correlationId
+                        match pending.Pop() with
+                        | VisitDirectory directoryVersionId ->
+                            let! candidateState = dependencies.GetDirectoryVersion currentReference.RepositoryId directoryVersionId correlationId
 
-                        let currentManifest =
-                            directManifests correlationId currentDirectoryVersion
-                            |> Array.tryFind (fun manifest ->
-                                manifest.StoragePoolId = candidate.StoragePoolId
-                                && manifest.ManifestAddress = candidate.ManifestAddress)
+                            if isCurrentDirectoryVersion currentReference.RepositoryId directoryVersionId candidateState then
+                                let manifestCandidates = directManifests correlationId candidateState
+                                let mutable manifestIndex = 0
 
-                        match currentManifest with
-                        | None -> ()
-                        | Some manifest ->
-                            let relationship =
-                                {
-                                    RepositoryId = currentReference.RepositoryId
-                                    StoragePoolId = manifest.StoragePoolId
-                                    ManifestAddress = manifest.ManifestAddress
-                                    DirectoryVersionId = currentDirectoryVersion.DirectoryVersion.DirectoryVersionId
-                                }
+                                while manifestIndex < manifestCandidates.Length do
+                                    cancellationToken.ThrowIfCancellationRequested()
+                                    let candidate = manifestCandidates[manifestIndex]
 
-                            do! dependencies.EnsureDirectoryVersionManifest relationship manifest referenceEvent.Metadata cancellationToken
+                                    let! referenceStillLive =
+                                        isCurrentLiveReference
+                                            dependencies
+                                            currentReference.RepositoryId
+                                            currentReference.ReferenceId
+                                            currentReference.DirectoryId
+                                            correlationId
 
-                    do!
-                        dependencies.EnsureAutomaticPhysicalDeletionReminder
+                                    let! currentDirectoryVersion =
+                                        dependencies.GetDirectoryVersion currentReference.RepositoryId directoryVersionId correlationId
+
+                                    let currentManifest =
+                                        if referenceStillLive
+                                           && isCurrentDirectoryVersion currentReference.RepositoryId directoryVersionId currentDirectoryVersion then
+                                            directManifests correlationId currentDirectoryVersion
+                                            |> Array.tryFind (fun manifest ->
+                                                manifest.StoragePoolId = candidate.StoragePoolId
+                                                && manifest.ManifestAddress = candidate.ManifestAddress)
+                                        else
+                                            None
+
+                                    match currentManifest with
+                                    | None -> ()
+                                    | Some manifest ->
+                                        let relationship =
+                                            {
+                                                RepositoryId = currentReference.RepositoryId
+                                                StoragePoolId = manifest.StoragePoolId
+                                                ManifestAddress = manifest.ManifestAddress
+                                                DirectoryVersionId = directoryVersionId
+                                            }
+
+                                        do! dependencies.EnsureDirectoryVersionManifest relationship manifest referenceEvent.Metadata cancellationToken
+
+                                    manifestIndex <- manifestIndex + 1
+
+                                let childCandidates =
+                                    candidateState.DirectoryVersion.Directories
+                                    |> Seq.distinct
+                                    |> Seq.toArray
+
+                                let mutable childIndex = childCandidates.Length - 1
+
+                                while childIndex >= 0 do
+                                    pending.Push(VisitChild(directoryVersionId, childCandidates[childIndex]))
+                                    childIndex <- childIndex - 1
+                        | VisitChild (parentDirectoryVersionId, childDirectoryVersionId) ->
+                            let! referenceStillLive =
+                                isCurrentLiveReference
+                                    dependencies
+                                    currentReference.RepositoryId
+                                    currentReference.ReferenceId
+                                    currentReference.DirectoryId
+                                    correlationId
+
+                            let! currentParent = dependencies.GetDirectoryVersion currentReference.RepositoryId parentDirectoryVersionId correlationId
+
+                            if referenceStillLive
+                               && isCurrentDirectChild currentReference.RepositoryId parentDirectoryVersionId childDirectoryVersionId currentParent then
+                                let relationship =
+                                    ExactRelationship.ParentChild
+                                        {
+                                            RepositoryId = currentReference.RepositoryId
+                                            ParentDirectoryVersionId = parentDirectoryVersionId
+                                            ChildDirectoryVersionId = childDirectoryVersionId
+                                        }
+
+                                match! dependencies.ExactRelationships.VerifyAsync(relationship, cancellationToken) with
+                                | ExactRelationshipPresence.Present -> ()
+                                | ExactRelationshipPresence.Absent ->
+                                    let! incoming =
+                                        dependencies.ExactRelationships.EnumerateAsync(
+                                            ExactRelationshipPartition.IncomingDirectoryVersion(currentReference.RepositoryId, childDirectoryVersionId),
+                                            oneIncomingRelationshipBound,
+                                            None,
+                                            cancellationToken
+                                        )
+
+                                    if incoming.Relationships.Length > 0 then
+                                        let! latestReferenceStillLive =
+                                            isCurrentLiveReference
+                                                dependencies
+                                                currentReference.RepositoryId
+                                                currentReference.ReferenceId
+                                                currentReference.DirectoryId
+                                                correlationId
+
+                                        let! latestParent =
+                                            dependencies.GetDirectoryVersion currentReference.RepositoryId parentDirectoryVersionId correlationId
+
+                                        let! latestChild = dependencies.GetDirectoryVersion currentReference.RepositoryId childDirectoryVersionId correlationId
+
+                                        if latestReferenceStillLive
+                                           && isCurrentDirectChild currentReference.RepositoryId parentDirectoryVersionId childDirectoryVersionId latestParent
+                                           && isCurrentDirectoryVersion currentReference.RepositoryId childDirectoryVersionId latestChild then
+                                            let! _ = dependencies.ExactRelationships.EnsurePresentAsync(relationship, cancellationToken)
+                                            ()
+                                    else
+                                        pending.Push(ConvergeParentChild(parentDirectoryVersionId, childDirectoryVersionId))
+                                        pending.Push(VisitDirectory childDirectoryVersionId)
+                        | ConvergeParentChild (parentDirectoryVersionId, childDirectoryVersionId) ->
+                            let! referenceStillLive =
+                                isCurrentLiveReference
+                                    dependencies
+                                    currentReference.RepositoryId
+                                    currentReference.ReferenceId
+                                    currentReference.DirectoryId
+                                    correlationId
+
+                            let! currentParent = dependencies.GetDirectoryVersion currentReference.RepositoryId parentDirectoryVersionId correlationId
+
+                            let! currentChild = dependencies.GetDirectoryVersion currentReference.RepositoryId childDirectoryVersionId correlationId
+
+                            if referenceStillLive
+                               && isCurrentDirectChild currentReference.RepositoryId parentDirectoryVersionId childDirectoryVersionId currentParent
+                               && isCurrentDirectoryVersion currentReference.RepositoryId childDirectoryVersionId currentChild then
+                                let relationship =
+                                    ExactRelationship.ParentChild
+                                        {
+                                            RepositoryId = currentReference.RepositoryId
+                                            ParentDirectoryVersionId = parentDirectoryVersionId
+                                            ChildDirectoryVersionId = childDirectoryVersionId
+                                        }
+
+                                let! _ = dependencies.ExactRelationships.EnsurePresentAsync(relationship, cancellationToken)
+                                ()
+
+                    let! referenceStillLive =
+                        isCurrentLiveReference
+                            dependencies
                             currentReference.RepositoryId
                             currentReference.ReferenceId
+                            currentReference.DirectoryId
                             correlationId
-                            cancellationToken
+
+                    if referenceStillLive then
+                        do!
+                            dependencies.EnsureAutomaticPhysicalDeletionReminder
+                                currentReference.RepositoryId
+                                currentReference.ReferenceId
+                                correlationId
+                                cancellationToken
             | _ -> ()
         }
         :> Task

--- a/src/Grace.Server/ManifestContributionAccounting.Server.fs
+++ b/src/Grace.Server/ManifestContributionAccounting.Server.fs
@@ -275,8 +275,7 @@ module ManifestContributionAccounting =
                         WorkflowRanges =
                             manifest.Blocks
                             |> Seq.distinctBy (fun block -> block.Address)
-                            |> Seq.map (fun block ->
-                                { StoragePoolId = manifest.StoragePoolId; ContentBlockAddress = block.Address; OrdinalStart = 0; OrdinalCount = 1 })
+                            |> Seq.map (fun block -> { StoragePoolId = manifest.StoragePoolId; ContentBlockAddress = block.Address })
                             |> Seq.toArray
                     }
 

--- a/src/Grace.Server/ManifestContributionAccounting.Server.fs
+++ b/src/Grace.Server/ManifestContributionAccounting.Server.fs
@@ -282,25 +282,19 @@ module ManifestContributionAccounting =
 
                 match Reference.tryCreateManifestContributionStartForCounterDecision plan counterReturnValue.ReturnValue counterEvents with
                 | None -> ()
-                | Some _ ->
+                | Some startCommand ->
                     let workflowActor =
                         grainFactory.CreateActorProxyWithCorrelationId<IManifestContributionWorkflowActor>(
                             ManifestContributionWorkflow.primaryKey relationship.RepositoryId relationship.StoragePoolId relationship.ManifestAddress,
                             metadata.CorrelationId
                         )
 
-                    match!
-                        workflowActor.Start
-                            (directoryVersionManifestWorkflowOperationId relationship)
-                            relationship.RepositoryId
-                            relationship.StoragePoolId
-                            relationship.ManifestAddress
-                            ManifestContributionDirection.Increment
-                            plan.WorkflowRanges
-                            metadata
-                        with
-                    | Ok _ -> ()
-                    | Error graceError -> invalidOp graceError.Error
+                    match startCommand with
+                    | ManifestContributionWorkflowCommand.Start (operationId, repositoryId, storagePoolId, manifestAddress, direction, ranges, counterRevision) ->
+                        match! workflowActor.Start operationId repositoryId storagePoolId manifestAddress direction ranges counterRevision metadata with
+                        | Ok _ -> ()
+                        | Error graceError -> invalidOp graceError.Error
+                    | _ -> invalidOp "Manifest contribution accounting expected a workflow start command."
         }
         :> Task
 

--- a/src/Grace.Server/ManifestContributionAccounting.Server.fs
+++ b/src/Grace.Server/ManifestContributionAccounting.Server.fs
@@ -169,7 +169,7 @@ module ManifestContributionAccounting =
             |> Seq.toArray
         | Error graceError -> invalidOp graceError.Error
 
-    /// Reconciles one Reference Created event from fresh ReferenceActor and DirectoryVersionActor state.
+    /// Reconciles one Reference Created event from fresh actor state before converging its independent lifecycle effect.
     let handleReferenceCreatedWith (dependencies: ManifestContributionAccountingDependencies) cancellationToken (referenceEvent: ReferenceEvent) =
         task {
             match referenceEvent.Event with
@@ -193,13 +193,6 @@ module ManifestContributionAccounting =
                     match! dependencies.ExactRelationships.VerifyAsync(referenceRoot, cancellationToken) with
                     | ExactRelationshipPresence.Present -> ()
                     | ExactRelationshipPresence.Absent ->
-                        do!
-                            dependencies.EnsureAutomaticPhysicalDeletionReminder
-                                currentReference.RepositoryId
-                                currentReference.ReferenceId
-                                correlationId
-                                cancellationToken
-
                         let! _ = dependencies.ExactRelationships.EnsurePresentAsync(referenceRoot, cancellationToken)
                         ()
 
@@ -230,6 +223,13 @@ module ManifestContributionAccounting =
                                 }
 
                             do! dependencies.EnsureDirectoryVersionManifest relationship manifest referenceEvent.Metadata cancellationToken
+
+                    do!
+                        dependencies.EnsureAutomaticPhysicalDeletionReminder
+                            currentReference.RepositoryId
+                            currentReference.ReferenceId
+                            correlationId
+                            cancellationToken
             | _ -> ()
         }
         :> Task

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -20,6 +20,9 @@ module RepositoryCounterRecentResult =
     /// Bounds individual Redis connection and command waits without adding an outer retry policy.
     let private commandTimeout = TimeSpan.FromSeconds 2.0
 
+    /// Gives the lazy first connection enough bounded time for a healthy CI container to finish its handshake.
+    let connectionTimeout = TimeSpan.FromSeconds 10.0
+
     /// Creates the opaque direct-lookup key for one repository-manifest operation.
     let key repositoryId storagePoolId manifestAddress operationId =
         let identity = $"{repositoryId:N}|{storagePoolId}|{manifestAddress}|{operationId}"
@@ -34,7 +37,7 @@ module RepositoryCounterRecentResult =
             | RepositoryContentCounterChangeOperation.Removed -> "remove"
 
         let encodedOperationId = Convert.ToBase64String(Encoding.UTF8.GetBytes(string change.OperationId))
-        String.Join("|", encodedOperationId, operation, change.PreviousCount, change.CurrentCount)
+        String.Join("|", encodedOperationId, operation, change.PreviousCount, change.CurrentCount, change.Revision)
 
     /// Parses a bounded recent result and rejects malformed or inconsistent cache data as a miss.
     let tryDeserialize value =
@@ -42,7 +45,7 @@ module RepositoryCounterRecentResult =
             None
         else
             match value.Split('|') with
-            | [| operationId; operation; previousCount; currentCount |] ->
+            | [| operationId; operation; previousCount; currentCount; revision |] ->
                 try
                     let operationId =
                         Convert.FromBase64String operationId
@@ -57,10 +60,22 @@ module RepositoryCounterRecentResult =
 
                     match operation,
                           Int64.TryParse(previousCount, NumberStyles.None, CultureInfo.InvariantCulture),
-                          Int64.TryParse(currentCount, NumberStyles.None, CultureInfo.InvariantCulture)
+                          Int64.TryParse(currentCount, NumberStyles.None, CultureInfo.InvariantCulture),
+                          Int64.TryParse(revision, NumberStyles.None, CultureInfo.InvariantCulture)
                         with
-                    | Some operation, (true, previousCount), (true, currentCount) when previousCount >= 0L && currentCount >= 0L ->
-                        Some { OperationId = operationId; Operation = operation; PreviousCount = previousCount; CurrentCount = currentCount }
+                    | Some operation, (true, previousCount), (true, currentCount), (true, revision) when
+                        previousCount >= 0L
+                        && currentCount >= 0L
+                        && revision > 0L
+                        ->
+                        Some
+                            {
+                                OperationId = operationId
+                                Operation = operation
+                                PreviousCount = previousCount
+                                CurrentCount = currentCount
+                                Revision = revision
+                            }
                     | _ -> None
                 with
                 | :? FormatException
@@ -80,7 +95,7 @@ module RepositoryCounterRecentResult =
         let configuration =
             ConfigurationOptions(
                 AbortOnConnectFail = false,
-                ConnectTimeout = int commandTimeout.TotalMilliseconds,
+                ConnectTimeout = int connectionTimeout.TotalMilliseconds,
                 SyncTimeout = int commandTimeout.TotalMilliseconds,
                 AsyncTimeout = int commandTimeout.TotalMilliseconds
             )
@@ -91,7 +106,7 @@ module RepositoryCounterRecentResult =
 
         let database (cancellationToken: CancellationToken) : Task<IDatabase> =
             task {
-                let! multiplexer = connection.Value.WaitAsync(commandTimeout, cancellationToken)
+                let! multiplexer = connection.Value.WaitAsync(connectionTimeout, cancellationToken)
                 return multiplexer.GetDatabase()
             }
 

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -1,0 +1,149 @@
+namespace Grace.Server
+
+open Grace.Shared
+open Grace.Types.Common
+open Grace.Types.RepositoryContentCounter
+open StackExchange.Redis
+open System
+open System.Globalization
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+/// Provides a nonauthoritative Redis accelerator for recently completed repository counter operations.
+module RepositoryCounterRecentResult =
+
+    /// Defines the exact ten-minute lifetime required for recent counter results.
+    let expiry = TimeSpan.FromMinutes 10.0
+
+    /// Bounds individual Redis connection and command waits without adding an outer retry policy.
+    let private commandTimeout = TimeSpan.FromSeconds 2.0
+
+    /// Creates the opaque direct-lookup key for one repository-manifest operation.
+    let key repositoryId storagePoolId manifestAddress operationId =
+        let identity = $"{repositoryId:N}|{storagePoolId}|{manifestAddress}|{operationId}"
+        let digest = Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes identity)
+        $"grace:repository-counter:recent:v1:{Convert.ToHexStringLower digest}"
+
+    /// Serializes the bounded change without treating Redis as a membership ledger.
+    let serialize (change: RepositoryContentCounterCompletedChange) =
+        let operation =
+            match change.Operation with
+            | RepositoryContentCounterChangeOperation.Added -> "add"
+            | RepositoryContentCounterChangeOperation.Removed -> "remove"
+
+        let encodedOperationId = Convert.ToBase64String(Encoding.UTF8.GetBytes(string change.OperationId))
+        String.Join("|", encodedOperationId, operation, change.PreviousCount, change.CurrentCount)
+
+    /// Parses a bounded recent result and rejects malformed or inconsistent cache data as a miss.
+    let tryDeserialize value =
+        if String.IsNullOrWhiteSpace value then
+            None
+        else
+            match value.Split('|') with
+            | [| operationId; operation; previousCount; currentCount |] ->
+                try
+                    let operationId =
+                        Convert.FromBase64String operationId
+                        |> Encoding.UTF8.GetString
+                        |> RepositoryContentCounterOperationId
+
+                    let operation =
+                        match operation with
+                        | "add" -> Some RepositoryContentCounterChangeOperation.Added
+                        | "remove" -> Some RepositoryContentCounterChangeOperation.Removed
+                        | _ -> None
+
+                    match operation,
+                          Int64.TryParse(previousCount, NumberStyles.None, CultureInfo.InvariantCulture),
+                          Int64.TryParse(currentCount, NumberStyles.None, CultureInfo.InvariantCulture)
+                        with
+                    | Some operation, (true, previousCount), (true, currentCount) when previousCount >= 0L && currentCount >= 0L ->
+                        Some { OperationId = operationId; Operation = operation; PreviousCount = previousCount; CurrentCount = currentCount }
+                    | _ -> None
+                with
+                | :? FormatException
+                | :? DecoderFallbackException -> None
+            | _ -> None
+
+    /// Exposes direct recent-result reads and best-effort writes without making Redis authoritative.
+    type IRepositoryCounterRecentResult =
+
+        /// Returns a cached result or `None` when Redis is missing, unavailable, expired, or malformed.
+        abstract member TryGetAsync:
+            repositoryId: RepositoryId *
+            storagePoolId: StoragePoolId *
+            manifestAddress: ManifestAddress *
+            operationId: RepositoryContentCounterOperationId *
+            cancellationToken: CancellationToken ->
+                Task<RepositoryContentCounterCompletedChange option>
+
+        /// Stores one recent result for exactly ten minutes; Redis failure never changes the durable outcome.
+        abstract member SetAsync:
+            repositoryId: RepositoryId *
+            storagePoolId: StoragePoolId *
+            manifestAddress: ManifestAddress *
+            change: RepositoryContentCounterCompletedChange *
+            cancellationToken: CancellationToken ->
+                Task
+
+    /// Represents an intentionally absent Redis configuration as cache misses and ignored best-effort writes.
+    type UnavailableRepositoryCounterRecentResult() =
+        interface IRepositoryCounterRecentResult with
+            member _.TryGetAsync(_, _, _, _, _) = Task.FromResult<RepositoryContentCounterCompletedChange option>(None)
+
+            member _.SetAsync(_, _, _, _, _) = Task.CompletedTask
+
+    /// Uses one lazy StackExchange.Redis connection with native reconnect and bounded direct GET/SET calls.
+    type RedisRepositoryCounterRecentResult(host: string, port: int) =
+
+        let configuration =
+            ConfigurationOptions(
+                AbortOnConnectFail = false,
+                ConnectTimeout = int commandTimeout.TotalMilliseconds,
+                SyncTimeout = int commandTimeout.TotalMilliseconds,
+                AsyncTimeout = int commandTimeout.TotalMilliseconds
+            )
+
+        do configuration.EndPoints.Add(host, port)
+
+        let connection = lazy (task { return! ConnectionMultiplexer.ConnectAsync configuration })
+
+        let database (cancellationToken: CancellationToken) : Task<IDatabase> =
+            task {
+                let! multiplexer = connection.Value.WaitAsync(commandTimeout, cancellationToken)
+                return multiplexer.GetDatabase()
+            }
+
+        interface IRepositoryCounterRecentResult with
+            member _.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, (cancellationToken: CancellationToken)) =
+                task {
+                    try
+                        let! database = database cancellationToken
+
+                        let! value =
+                            database
+                                .StringGetAsync(key repositoryId storagePoolId manifestAddress operationId)
+                                .WaitAsync(commandTimeout, cancellationToken)
+
+                        return if value.IsNullOrEmpty then None else tryDeserialize (string value)
+                    with
+                    | :? RedisException
+                    | :? TimeoutException -> return None
+                }
+
+            member _.SetAsync(repositoryId, storagePoolId, manifestAddress, change, (cancellationToken: CancellationToken)) =
+                task {
+                    try
+                        let! database = database cancellationToken
+
+                        let! _ =
+                            database
+                                .StringSetAsync(key repositoryId storagePoolId manifestAddress change.OperationId, serialize change, expiry)
+                                .WaitAsync(commandTimeout, cancellationToken)
+
+                        ()
+                    with
+                    | :? RedisException
+                    | :? TimeoutException -> ()
+                }

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -4,6 +4,8 @@ open Grace.Shared
 open Grace.Actors
 open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
+open Microsoft.Extensions.Logging
+open Microsoft.Extensions.Logging.Abstractions
 open StackExchange.Redis
 open System
 open System.Globalization
@@ -22,6 +24,22 @@ module RepositoryCounterRecentResult =
 
     /// Gives the lazy first connection enough bounded time for a healthy CI container to finish its handshake.
     let connectionTimeout = TimeSpan.FromSeconds 10.0
+
+    /// Builds the StackExchange.Redis configuration whose native reconnect lifecycle is bounded by Grace at each call boundary.
+    let configurationForEndpoint (host: string) (port: int) =
+        let configuration =
+            ConfigurationOptions(
+                AbortOnConnectFail = false,
+                ConnectTimeout = int connectionTimeout.TotalMilliseconds,
+                SyncTimeout = int commandTimeout.TotalMilliseconds,
+                AsyncTimeout = int connectionTimeout.TotalMilliseconds
+            )
+
+        configuration.EndPoints.Add(host, port)
+        configuration
+
+    /// Requires an explicit readiness probe when StackExchange.Redis returns its reconnecting multiplexer before a socket is connected.
+    let requiresReadinessProbe isConnected = not isConnected
 
     /// Creates the opaque direct-lookup key for one repository-manifest operation.
     let key repositoryId storagePoolId manifestAddress operationId =
@@ -89,54 +107,87 @@ module RepositoryCounterRecentResult =
 
             member _.TrySetAsync(_, _, _, _, _) = Task.FromResult false
 
-    /// Uses one lazy StackExchange.Redis connection with native reconnect and bounded direct GET/SET calls.
-    type RedisRepositoryCounterRecentResult(host: string, port: int) =
+    /// Uses one lazy StackExchange.Redis connection with native reconnect, readiness proof, bounded commands, and structured failure evidence.
+    type RedisRepositoryCounterRecentResult(host: string, port: int, log: ILogger) =
 
-        let configuration =
-            ConfigurationOptions(
-                AbortOnConnectFail = false,
-                ConnectTimeout = int connectionTimeout.TotalMilliseconds,
-                SyncTimeout = int commandTimeout.TotalMilliseconds,
-                AsyncTimeout = int commandTimeout.TotalMilliseconds
-            )
-
-        do configuration.EndPoints.Add(host, port)
+        let configuration = configurationForEndpoint host port
 
         let connection = lazy (task { return! ConnectionMultiplexer.ConnectAsync configuration })
 
         let database (cancellationToken: CancellationToken) : Task<IDatabase> =
             task {
                 let! multiplexer = connection.Value.WaitAsync(connectionTimeout, cancellationToken)
-                return multiplexer.GetDatabase()
+                let database = multiplexer.GetDatabase()
+
+                if requiresReadinessProbe multiplexer.IsConnected then
+                    let! _ =
+                        database
+                            .PingAsync()
+                            .WaitAsync(connectionTimeout, cancellationToken)
+
+                    ()
+
+                return database
             }
+
+        let logBoundaryFailure operation cacheKey fallback (error: Exception) =
+            log.LogWarning(
+                error,
+                "Redis repository counter recent-result {Operation} failed for cache key {CacheKey}; using nonauthoritative fallback {Fallback}.",
+                operation,
+                cacheKey,
+                fallback
+            )
+
+        /// Creates the Redis accelerator with a no-op logger for focused callers that intentionally omit structured diagnostics.
+        new(host: string, port: int) = new RedisRepositoryCounterRecentResult(host, port, NullLogger.Instance)
 
         interface IRepositoryCounterRecentResult with
             member _.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, (cancellationToken: CancellationToken)) =
                 task {
+                    let cacheKey = key repositoryId storagePoolId manifestAddress operationId
+
                     try
                         let! database = database cancellationToken
 
                         let! value =
                             database
-                                .StringGetAsync(key repositoryId storagePoolId manifestAddress operationId)
+                                .StringGetAsync(cacheKey)
                                 .WaitAsync(commandTimeout, cancellationToken)
 
                         return if value.IsNullOrEmpty then None else tryDeserialize (string value)
                     with
-                    | :? RedisException
-                    | :? TimeoutException -> return None
+                    | :? RedisException as error ->
+                        logBoundaryFailure "GET" cacheKey "cache-miss" error
+                        return None
+                    | :? TimeoutException as error ->
+                        logBoundaryFailure "GET" cacheKey "cache-miss" error
+                        return None
                 }
 
             member _.TrySetAsync(repositoryId, storagePoolId, manifestAddress, change, (cancellationToken: CancellationToken)) =
                 task {
+                    let cacheKey = key repositoryId storagePoolId manifestAddress change.OperationId
+
                     try
                         let! database = database cancellationToken
 
                         return!
                             database
-                                .StringSetAsync(key repositoryId storagePoolId manifestAddress change.OperationId, serialize change, expiry)
+                                .StringSetAsync(cacheKey, serialize change, expiry)
                                 .WaitAsync(commandTimeout, cancellationToken)
                     with
-                    | :? RedisException
-                    | :? TimeoutException -> return false
+                    | :? RedisException as error ->
+                        logBoundaryFailure "SET" cacheKey "unconfirmed-write" error
+                        return false
+                    | :? TimeoutException as error ->
+                        logBoundaryFailure "SET" cacheKey "unconfirmed-write" error
+                        return false
                 }
+
+        interface IDisposable with
+            /// Releases the singleton multiplexer when application shutdown follows a completed connection attempt.
+            member _.Dispose() =
+                if connection.IsValueCreated
+                   && connection.Value.IsCompletedSuccessfully then
+                    connection.Value.Result.Dispose()

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server
 
 open Grace.Shared
+open Grace.Actors
 open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
 open StackExchange.Redis
@@ -66,33 +67,12 @@ module RepositoryCounterRecentResult =
                 | :? DecoderFallbackException -> None
             | _ -> None
 
-    /// Exposes direct recent-result reads and best-effort writes without making Redis authoritative.
-    type IRepositoryCounterRecentResult =
-
-        /// Returns a cached result or `None` when Redis is missing, unavailable, expired, or malformed.
-        abstract member TryGetAsync:
-            repositoryId: RepositoryId *
-            storagePoolId: StoragePoolId *
-            manifestAddress: ManifestAddress *
-            operationId: RepositoryContentCounterOperationId *
-            cancellationToken: CancellationToken ->
-                Task<RepositoryContentCounterCompletedChange option>
-
-        /// Stores one recent result for exactly ten minutes; Redis failure never changes the durable outcome.
-        abstract member SetAsync:
-            repositoryId: RepositoryId *
-            storagePoolId: StoragePoolId *
-            manifestAddress: ManifestAddress *
-            change: RepositoryContentCounterCompletedChange *
-            cancellationToken: CancellationToken ->
-                Task
-
     /// Represents an intentionally absent Redis configuration as cache misses and ignored best-effort writes.
     type UnavailableRepositoryCounterRecentResult() =
         interface IRepositoryCounterRecentResult with
             member _.TryGetAsync(_, _, _, _, _) = Task.FromResult<RepositoryContentCounterCompletedChange option>(None)
 
-            member _.SetAsync(_, _, _, _, _) = Task.CompletedTask
+            member _.TrySetAsync(_, _, _, _, _) = Task.FromResult false
 
     /// Uses one lazy StackExchange.Redis connection with native reconnect and bounded direct GET/SET calls.
     type RedisRepositoryCounterRecentResult(host: string, port: int) =
@@ -132,18 +112,16 @@ module RepositoryCounterRecentResult =
                     | :? TimeoutException -> return None
                 }
 
-            member _.SetAsync(repositoryId, storagePoolId, manifestAddress, change, (cancellationToken: CancellationToken)) =
+            member _.TrySetAsync(repositoryId, storagePoolId, manifestAddress, change, (cancellationToken: CancellationToken)) =
                 task {
                     try
                         let! database = database cancellationToken
 
-                        let! _ =
+                        return!
                             database
                                 .StringSetAsync(key repositoryId storagePoolId manifestAddress change.OperationId, serialize change, expiry)
                                 .WaitAsync(commandTimeout, cancellationToken)
-
-                        ()
                     with
                     | :? RedisException
-                    | :? TimeoutException -> ()
+                    | :? TimeoutException -> return false
                 }

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -2065,6 +2065,20 @@ module Application =
                     new CosmosClient(cosmosConnectionString, options))
             |> ignore
 
+            services.AddSingleton<RepositoryCounterRecentResult.IRepositoryCounterRecentResult> (fun _ ->
+                let redisHost = configuration.GetValue<string>(getConfigKey Constants.EnvironmentVariables.RedisHost)
+
+                let redisPort = configuration.GetValue<int>(getConfigKey Constants.EnvironmentVariables.RedisPort)
+
+                if String.IsNullOrWhiteSpace redisHost then
+                    RepositoryCounterRecentResult.UnavailableRepositoryCounterRecentResult() :> RepositoryCounterRecentResult.IRepositoryCounterRecentResult
+                else
+                    let effectivePort = if redisPort > 0 then redisPort else 6379
+
+                    RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort)
+                    :> RepositoryCounterRecentResult.IRepositoryCounterRecentResult)
+            |> ignore
+
             let apiVersioningBuilder =
                 services.AddApiVersioning (fun options ->
                     options.ReportApiVersions <- true

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -2065,7 +2065,7 @@ module Application =
                     new CosmosClient(cosmosConnectionString, options))
             |> ignore
 
-            services.AddSingleton<IRepositoryCounterRecentResult> (fun _ ->
+            services.AddSingleton<IRepositoryCounterRecentResult> (fun serviceProvider ->
                 let redisHost = configuration.GetValue<string>(getConfigKey Constants.EnvironmentVariables.RedisHost)
 
                 let redisPort = configuration.GetValue<int>(getConfigKey Constants.EnvironmentVariables.RedisPort)
@@ -2075,7 +2075,12 @@ module Application =
                 else
                     let effectivePort = if redisPort > 0 then redisPort else 6379
 
-                    RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort) :> IRepositoryCounterRecentResult)
+                    let redisLog =
+                        serviceProvider
+                            .GetRequiredService<ILoggerFactory>()
+                            .CreateLogger("RepositoryCounterRecentResult.Server")
+
+                    new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort, redisLog) :> IRepositoryCounterRecentResult)
             |> ignore
 
             let apiVersioningBuilder =

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -2065,18 +2065,17 @@ module Application =
                     new CosmosClient(cosmosConnectionString, options))
             |> ignore
 
-            services.AddSingleton<RepositoryCounterRecentResult.IRepositoryCounterRecentResult> (fun _ ->
+            services.AddSingleton<IRepositoryCounterRecentResult> (fun _ ->
                 let redisHost = configuration.GetValue<string>(getConfigKey Constants.EnvironmentVariables.RedisHost)
 
                 let redisPort = configuration.GetValue<int>(getConfigKey Constants.EnvironmentVariables.RedisPort)
 
                 if String.IsNullOrWhiteSpace redisHost then
-                    RepositoryCounterRecentResult.UnavailableRepositoryCounterRecentResult() :> RepositoryCounterRecentResult.IRepositoryCounterRecentResult
+                    RepositoryCounterRecentResult.UnavailableRepositoryCounterRecentResult() :> IRepositoryCounterRecentResult
                 else
                     let effectivePort = if redisPort > 0 then redisPort else 6379
 
-                    RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort)
-                    :> RepositoryCounterRecentResult.IRepositoryCounterRecentResult)
+                    RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort) :> IRepositoryCounterRecentResult)
             |> ignore
 
             let apiVersioningBuilder =

--- a/src/Grace.Types.Tests/ContentBlockMetadata.Types.Tests.fs
+++ b/src/Grace.Types.Tests/ContentBlockMetadata.Types.Tests.fs
@@ -65,6 +65,7 @@ type ContentBlockMetadataTypesTests() =
                     "MergePhysicalRanges", 1u
                     "CompactPhysicalRanges", 2u
                     "SetCompactionChurnState", 3u
+                    "AdjustActiveManifestCount", 4u
                 |]
             )
         )

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -242,6 +242,24 @@ module ContentBlockMetadata =
             ChurnState: ContentBlockCompactionChurnState
         }
 
+    /// Applies one deterministic manifest contribution delta to an authoritative logical range.
+    [<GenerateSerializer>]
+    type AdjustContentBlockActiveManifestCount =
+        {
+            [<Id(0u)>]
+            OperationId: string
+            [<Id(1u)>]
+            ExpectedMetadataVersion: MetadataVersion
+            [<Id(2u)>]
+            StoragePoolId: StoragePoolId
+            [<Id(3u)>]
+            ContentBlockAddress: ContentBlockAddress
+            [<Id(4u)>]
+            Range: ContentBlockRangeQuery
+            [<Id(5u)>]
+            Delta: int
+        }
+
     /// Represents content block metadata command.
     [<KnownType("GetKnownTypes"); GenerateSerializer>]
     type ContentBlockMetadataCommand =
@@ -249,6 +267,7 @@ module ContentBlockMetadata =
         | [<Id(1u)>] MergePhysicalRanges of merge: MergeContentBlockPhysicalRanges
         | [<Id(2u)>] CompactPhysicalRanges of compact: CompactContentBlockPhysicalRanges
         | [<Id(3u)>] SetCompactionChurnState of setChurnState: SetContentBlockCompactionChurnState
+        | [<Id(4u)>] AdjustActiveManifestCount of adjust: AdjustContentBlockActiveManifestCount
 
         /// Returns known nested union types for serializers.
         static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataCommand>()
@@ -260,6 +279,7 @@ module ContentBlockMetadata =
         | PhysicalRangesMerged of operationId: string * metadata: ContentBlockMetadata
         | PhysicalRangesCompacted of operationId: string * metadata: ContentBlockMetadata
         | CompactionChurnStateSet of operationId: string * churnState: ContentBlockCompactionChurnState
+        | ActiveManifestCountAdjusted of adjust: AdjustContentBlockActiveManifestCount * metadata: ContentBlockMetadata
 
         /// Returns known nested union types for serializers.
         static member GetKnownTypes() = GetKnownTypes<ContentBlockMetadataEventType>()
@@ -291,6 +311,8 @@ module ContentBlockMetadata =
                 { _current with Metadata = Some metadata; LastOperationId = Some operationId }
             | ContentBlockMetadataEventType.CompactionChurnStateSet (operationId, churnState) ->
                 { _current with CompactionChurnState = churnState; LastOperationId = Some operationId }
+            | ContentBlockMetadataEventType.ActiveManifestCountAdjusted (adjust, metadata) ->
+                { _current with Metadata = Some metadata; LastOperationId = Some adjust.OperationId }
 
     /// Represents content block metadata decision.
     [<GenerateSerializer>]

--- a/src/Grace.Types/ContentBlockMetadata.Types.fs
+++ b/src/Grace.Types/ContentBlockMetadata.Types.fs
@@ -242,7 +242,7 @@ module ContentBlockMetadata =
             ChurnState: ContentBlockCompactionChurnState
         }
 
-    /// Applies one deterministic manifest contribution delta to an authoritative logical range.
+    /// Applies one deterministic manifest contribution delta to every authoritative physical range in a ContentBlock.
     [<GenerateSerializer>]
     type AdjustContentBlockActiveManifestCount =
         {
@@ -255,8 +255,6 @@ module ContentBlockMetadata =
             [<Id(3u)>]
             ContentBlockAddress: ContentBlockAddress
             [<Id(4u)>]
-            Range: ContentBlockRangeQuery
-            [<Id(5u)>]
             Delta: int
         }
 

--- a/src/Grace.Types/ManifestContributionWorkflow.Types.fs
+++ b/src/Grace.Types/ManifestContributionWorkflow.Types.fs
@@ -31,7 +31,7 @@ module ManifestContributionWorkflow =
         /// Returns known nested union types for serializers.
         static member GetKnownTypes() = GetKnownTypes<ManifestContributionWorkflowLifecycleState>()
 
-    /// Represents manifest contribution workflow range.
+    /// Identifies one ContentBlock whose authoritative current physical ranges receive a manifest contribution.
     [<CLIMutable; GenerateSerializer; CustomComparison; CustomEquality>]
     type ManifestContributionWorkflowRange =
         {
@@ -40,12 +40,6 @@ module ManifestContributionWorkflow =
 
             [<Id(1u)>]
             ContentBlockAddress: ContentBlockAddress
-
-            [<Id(2u)>]
-            OrdinalStart: int
-
-            [<Id(3u)>]
-            OrdinalCount: int
         }
 
         interface IComparable with
@@ -53,9 +47,7 @@ module ManifestContributionWorkflow =
             member this.CompareTo other =
                 match other with
                 | :? ManifestContributionWorkflowRange as otherRange ->
-                    compare
-                        (this.StoragePoolId, this.ContentBlockAddress, this.OrdinalStart, this.OrdinalCount)
-                        (otherRange.StoragePoolId, otherRange.ContentBlockAddress, otherRange.OrdinalStart, otherRange.OrdinalCount)
+                    compare (this.StoragePoolId, this.ContentBlockAddress) (otherRange.StoragePoolId, otherRange.ContentBlockAddress)
                 | _ -> invalidArg (nameof other) "Cannot compare ManifestContributionWorkflowRange with a different type."
 
         /// Compares the domain identity fields that define whether two values refer to the same Grace object.
@@ -64,12 +56,10 @@ module ManifestContributionWorkflow =
             | :? ManifestContributionWorkflowRange as otherRange ->
                 this.StoragePoolId = otherRange.StoragePoolId
                 && this.ContentBlockAddress = otherRange.ContentBlockAddress
-                && this.OrdinalStart = otherRange.OrdinalStart
-                && this.OrdinalCount = otherRange.OrdinalCount
             | _ -> false
 
         /// Computes a hash code from the same domain identity fields used by equality.
-        override this.GetHashCode() = HashCode.Combine(this.StoragePoolId, this.ContentBlockAddress, this.OrdinalStart, this.OrdinalCount)
+        override this.GetHashCode() = HashCode.Combine(this.StoragePoolId, this.ContentBlockAddress)
 
     /// Represents start manifest contribution workflow.
     [<GenerateSerializer>]

--- a/src/Grace.Types/ManifestContributionWorkflow.Types.fs
+++ b/src/Grace.Types/ManifestContributionWorkflow.Types.fs
@@ -203,6 +203,7 @@ module ManifestContributionWorkflow =
             CompletedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>
             FailedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>
             LifecycleState: ManifestContributionWorkflowLifecycleState
+            StartOperationId: ManifestContributionWorkflowOperationId option
             LastOperationId: ManifestContributionWorkflowOperationId option
             Revision: int64
         }
@@ -219,6 +220,7 @@ module ManifestContributionWorkflow =
                 CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
                 FailedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>()
                 LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted
+                StartOperationId = None
                 LastOperationId = None
                 Revision = 0L
             }
@@ -259,6 +261,7 @@ module ManifestContributionWorkflow =
                     CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
                     FailedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>()
                     LifecycleState = lifecycle
+                    StartOperationId = Some start.OperationId
                     LastOperationId = Some start.OperationId
                     Revision = current.Revision + 1L
                 }

--- a/src/Grace.Types/ManifestContributionWorkflow.Types.fs
+++ b/src/Grace.Types/ManifestContributionWorkflow.Types.fs
@@ -92,6 +92,9 @@ module ManifestContributionWorkflow =
 
             [<Id(5u)>]
             Ranges: ManifestContributionWorkflowRange array
+
+            [<Id(6u)>]
+            CounterRevision: int64
         }
 
     /// Represents manifest contribution workflow range progress.
@@ -146,7 +149,8 @@ module ManifestContributionWorkflow =
             storagePoolId: StoragePoolId *
             manifestAddress: ManifestAddress *
             direction: ManifestContributionDirection *
-            ranges: ManifestContributionWorkflowRange array
+            ranges: ManifestContributionWorkflowRange array *
+            counterRevision: int64
         | RecordRangeSucceeded of
             operationId: ManifestContributionWorkflowOperationId *
             repositoryId: RepositoryId *
@@ -186,10 +190,6 @@ module ManifestContributionWorkflow =
     [<GenerateSerializer>]
     type ManifestContributionWorkflowEvent = { Event: ManifestContributionWorkflowEventType; Metadata: EventMetadata }
 
-    /// Records the latest failed attempt for one bounded current workflow range.
-    [<GenerateSerializer>]
-    type ManifestContributionWorkflowFailure = { OperationId: ManifestContributionWorkflowOperationId; Message: string }
-
     /// Represents manifest contribution workflow dto.
     [<GenerateSerializer>]
     type ManifestContributionWorkflowDto =
@@ -200,11 +200,12 @@ module ManifestContributionWorkflow =
             ManifestAddress: ManifestAddress
             Direction: ManifestContributionDirection
             Ranges: ManifestContributionWorkflowRange array
-            CompletedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>
-            FailedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>
+            CompletedRanges: ManifestContributionWorkflowRangeProgress array
+            FailedRanges: ManifestContributionWorkflowRangeFailure array
             LifecycleState: ManifestContributionWorkflowLifecycleState
             StartOperationId: ManifestContributionWorkflowOperationId option
             LastOperationId: ManifestContributionWorkflowOperationId option
+            CounterRevision: int64
             Revision: int64
         }
 
@@ -217,11 +218,12 @@ module ManifestContributionWorkflow =
                 ManifestAddress = String.Empty
                 Direction = ManifestContributionDirection.Increment
                 Ranges = Array.empty
-                CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
-                FailedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>()
+                CompletedRanges = Array.empty
+                FailedRanges = Array.empty
                 LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted
                 StartOperationId = None
                 LastOperationId = None
+                CounterRevision = 0L
                 Revision = 0L
             }
 
@@ -233,14 +235,6 @@ module ManifestContributionWorkflow =
                 ManifestContributionWorkflowLifecycleState.Completed
             else
                 ManifestContributionWorkflowLifecycleState.InProgress
-
-        /// Marks the workflow clone phase as completed with its completion timestamp.
-        static member private CloneCompleted(completedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>) =
-            Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>(completedRanges)
-
-        /// Marks the workflow clone phase as failed while retaining the failure reason.
-        static member private CloneFailed(failedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>) =
-            Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>(failedRanges)
 
         /// Creates the DTO shape used to carry partial updates without mutating the persisted aggregate directly.
         static member UpdateDto workflowEvent current =
@@ -258,34 +252,40 @@ module ManifestContributionWorkflow =
                     ManifestAddress = start.ManifestAddress
                     Direction = start.Direction
                     Ranges = Array.copy start.Ranges
-                    CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
-                    FailedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>()
+                    CompletedRanges = Array.empty
+                    FailedRanges = Array.empty
                     LifecycleState = lifecycle
                     StartOperationId = Some start.OperationId
                     LastOperationId = Some start.OperationId
+                    CounterRevision = start.CounterRevision
                     Revision = current.Revision + 1L
                 }
             | ManifestContributionWorkflowEventType.RangeSucceeded progress ->
-                let completed = ManifestContributionWorkflowDto.CloneCompleted current.CompletedRanges
-                completed[progress.Range] <- progress.OperationId
+                let completed =
+                    current.CompletedRanges
+                    |> Array.filter (fun existing -> existing.Range <> progress.Range)
+                    |> Array.append [| progress |]
 
-                let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
-                failed.Remove(progress.Range) |> ignore
+                let failed =
+                    current.FailedRanges
+                    |> Array.filter (fun existing -> existing.Range <> progress.Range)
 
                 { current with
                     CompletedRanges = completed
                     FailedRanges = failed
-                    LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges completed.Count
+                    LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges completed.Length
                     LastOperationId = Some progress.OperationId
                     Revision = current.Revision + 1L
                 }
             | ManifestContributionWorkflowEventType.RangeFailed failure ->
-                let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
-                failed[failure.Range] <- { OperationId = failure.OperationId; Message = failure.Message }
+                let failed =
+                    current.FailedRanges
+                    |> Array.filter (fun existing -> existing.Range <> failure.Range)
+                    |> Array.append [| failure |]
 
                 { current with
                     FailedRanges = failed
-                    LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges current.CompletedRanges.Count
+                    LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges current.CompletedRanges.Length
                     LastOperationId = Some failure.OperationId
                     Revision = current.Revision + 1L
                 }

--- a/src/Grace.Types/ManifestContributionWorkflow.Types.fs
+++ b/src/Grace.Types/ManifestContributionWorkflow.Types.fs
@@ -186,6 +186,10 @@ module ManifestContributionWorkflow =
     [<GenerateSerializer>]
     type ManifestContributionWorkflowEvent = { Event: ManifestContributionWorkflowEventType; Metadata: EventMetadata }
 
+    /// Records the latest failed attempt for one bounded current workflow range.
+    [<GenerateSerializer>]
+    type ManifestContributionWorkflowFailure = { OperationId: ManifestContributionWorkflowOperationId; Message: string }
+
     /// Represents manifest contribution workflow dto.
     [<GenerateSerializer>]
     type ManifestContributionWorkflowDto =
@@ -197,9 +201,10 @@ module ManifestContributionWorkflow =
             Direction: ManifestContributionDirection
             Ranges: ManifestContributionWorkflowRange array
             CompletedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>
-            FailedRanges: Dictionary<ManifestContributionWorkflowRange, string>
+            FailedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>
             LifecycleState: ManifestContributionWorkflowLifecycleState
             LastOperationId: ManifestContributionWorkflowOperationId option
+            Revision: int64
         }
 
         /// Represents the deterministic default instance used when callers need an initialized contract value.
@@ -212,9 +217,10 @@ module ManifestContributionWorkflow =
                 Direction = ManifestContributionDirection.Increment
                 Ranges = Array.empty
                 CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
-                FailedRanges = Dictionary<ManifestContributionWorkflowRange, string>()
+                FailedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>()
                 LifecycleState = ManifestContributionWorkflowLifecycleState.NotStarted
                 LastOperationId = None
+                Revision = 0L
             }
 
         /// Summarizes the workflow timestamps that describe clone and promotion progress.
@@ -231,8 +237,8 @@ module ManifestContributionWorkflow =
             Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>(completedRanges)
 
         /// Marks the workflow clone phase as failed while retaining the failure reason.
-        static member private CloneFailed(failedRanges: Dictionary<ManifestContributionWorkflowRange, string>) =
-            Dictionary<ManifestContributionWorkflowRange, string>(failedRanges)
+        static member private CloneFailed(failedRanges: Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>) =
+            Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>(failedRanges)
 
         /// Creates the DTO shape used to carry partial updates without mutating the persisted aggregate directly.
         static member UpdateDto workflowEvent current =
@@ -251,9 +257,10 @@ module ManifestContributionWorkflow =
                     Direction = start.Direction
                     Ranges = Array.copy start.Ranges
                     CompletedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowOperationId>()
-                    FailedRanges = Dictionary<ManifestContributionWorkflowRange, string>()
+                    FailedRanges = Dictionary<ManifestContributionWorkflowRange, ManifestContributionWorkflowFailure>()
                     LifecycleState = lifecycle
                     LastOperationId = Some start.OperationId
+                    Revision = current.Revision + 1L
                 }
             | ManifestContributionWorkflowEventType.RangeSucceeded progress ->
                 let completed = ManifestContributionWorkflowDto.CloneCompleted current.CompletedRanges
@@ -267,15 +274,17 @@ module ManifestContributionWorkflow =
                     FailedRanges = failed
                     LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges completed.Count
                     LastOperationId = Some progress.OperationId
+                    Revision = current.Revision + 1L
                 }
             | ManifestContributionWorkflowEventType.RangeFailed failure ->
                 let failed = ManifestContributionWorkflowDto.CloneFailed current.FailedRanges
-                failed[failure.Range] <- failure.Message
+                failed[failure.Range] <- { OperationId = failure.OperationId; Message = failure.Message }
 
                 { current with
                     FailedRanges = failed
                     LifecycleState = ManifestContributionWorkflowDto.Lifecycle current.Ranges current.CompletedRanges.Count
                     LastOperationId = Some failure.OperationId
+                    Revision = current.Revision + 1L
                 }
 
     /// Represents manifest contribution workflow decision.

--- a/src/Grace.Types/RepositoryContentCounter.Types.fs
+++ b/src/Grace.Types/RepositoryContentCounter.Types.fs
@@ -19,6 +19,25 @@ module RepositoryContentCounter =
         /// Returns known nested union types for serializers.
         static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterLifecycleState>()
 
+    /// Identifies the bounded counter operation recorded by the latest completed change.
+    [<KnownType("GetKnownTypes"); GenerateSerializer>]
+    type RepositoryContentCounterChangeOperation =
+        | Added
+        | Removed
+
+        /// Returns known nested union types for serializers.
+        static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterChangeOperation>()
+
+    /// Records the latest completed count transition without retaining a lifetime operation history.
+    [<GenerateSerializer>]
+    type RepositoryContentCounterCompletedChange =
+        {
+            OperationId: RepositoryContentCounterOperationId
+            Operation: RepositoryContentCounterChangeOperation
+            PreviousCount: ReferenceCount
+            CurrentCount: ReferenceCount
+        }
+
     /// Represents repository content counter command.
     [<KnownType("GetKnownTypes")>]
     type RepositoryContentCounterCommand =
@@ -69,10 +88,25 @@ module RepositoryContentCounter =
             RepositoryId: RepositoryId
             StoragePoolId: StoragePoolId
             ManifestAddress: ManifestAddress
-            ReferenceCount: ReferenceCount
-            LifecycleState: RepositoryContentCounterLifecycleState
-            LastOperationId: RepositoryContentCounterOperationId option
+            Count: ReferenceCount
+            Revision: int64
+            LastCompletedChange: RepositoryContentCounterCompletedChange option
         }
+
+        /// Preserves the established read name while the durable snapshot stores the contract's `Count` field.
+        member this.ReferenceCount = this.Count
+
+        /// Derives lifecycle from the bounded current count instead of persisting duplicate state.
+        member this.LifecycleState =
+            if this.Count = 0L then
+                RepositoryContentCounterLifecycleState.NotReferenced
+            else
+                RepositoryContentCounterLifecycleState.Referenced
+
+        /// Projects the latest operation identity for existing callers without persisting another field.
+        member this.LastOperationId =
+            this.LastCompletedChange
+            |> Option.map (fun change -> change.OperationId)
 
         /// Represents the deterministic default instance used when callers need an initialized contract value.
         static member Default =
@@ -81,15 +115,17 @@ module RepositoryContentCounter =
                 RepositoryId = RepositoryId.Empty
                 StoragePoolId = String.Empty
                 ManifestAddress = String.Empty
-                ReferenceCount = 0L
-                LifecycleState = RepositoryContentCounterLifecycleState.NotReferenced
-                LastOperationId = None
+                Count = 0L
+                Revision = 0L
+                LastCompletedChange = None
             }
 
         /// Creates the DTO shape used to carry partial updates without mutating the persisted aggregate directly.
         static member UpdateDto counterEvent current =
             match counterEvent.Event with
             | RepositoryContentCounterEventType.ReferenceAdded (operationId, repositoryId, storagePoolId, manifestAddress) ->
+                let nextCount = current.Count + 1L
+
                 { current with
                     RepositoryId =
                         if current.RepositoryId = RepositoryId.Empty then
@@ -106,21 +142,31 @@ module RepositoryContentCounter =
                             manifestAddress
                         else
                             current.ManifestAddress
-                    ReferenceCount = current.ReferenceCount + 1L
-                    LifecycleState = RepositoryContentCounterLifecycleState.Referenced
-                    LastOperationId = Some operationId
+                    Count = nextCount
+                    Revision = current.Revision + 1L
+                    LastCompletedChange =
+                        Some
+                            {
+                                OperationId = operationId
+                                Operation = RepositoryContentCounterChangeOperation.Added
+                                PreviousCount = current.Count
+                                CurrentCount = nextCount
+                            }
                 }
             | RepositoryContentCounterEventType.ReferenceRemoved operationId ->
-                let nextReferenceCount = max 0L (current.ReferenceCount - 1L)
+                let nextReferenceCount = max 0L (current.Count - 1L)
 
                 { current with
-                    ReferenceCount = nextReferenceCount
-                    LifecycleState =
-                        if nextReferenceCount = 0L then
-                            RepositoryContentCounterLifecycleState.NotReferenced
-                        else
-                            RepositoryContentCounterLifecycleState.Referenced
-                    LastOperationId = Some operationId
+                    Count = nextReferenceCount
+                    Revision = current.Revision + 1L
+                    LastCompletedChange =
+                        Some
+                            {
+                                OperationId = operationId
+                                Operation = RepositoryContentCounterChangeOperation.Removed
+                                PreviousCount = current.Count
+                                CurrentCount = nextReferenceCount
+                            }
                 }
 
     /// Represents repository content counter decision.

--- a/src/Grace.Types/RepositoryContentCounter.Types.fs
+++ b/src/Grace.Types/RepositoryContentCounter.Types.fs
@@ -36,6 +36,7 @@ module RepositoryContentCounter =
             Operation: RepositoryContentCounterChangeOperation
             PreviousCount: ReferenceCount
             CurrentCount: ReferenceCount
+            Revision: int64
         }
 
     /// Represents repository content counter command.
@@ -71,8 +72,16 @@ module RepositoryContentCounter =
     /// Represents repository content counter intent.
     [<KnownType("GetKnownTypes")>]
     type RepositoryContentCounterIntent =
-        | IncrementManifestReferenceCount of repositoryId: RepositoryId * storagePoolId: StoragePoolId * manifestAddress: ManifestAddress
-        | DecrementManifestReferenceCount of repositoryId: RepositoryId * storagePoolId: StoragePoolId * manifestAddress: ManifestAddress
+        | IncrementManifestReferenceCount of
+            repositoryId: RepositoryId *
+            storagePoolId: StoragePoolId *
+            manifestAddress: ManifestAddress *
+            counterRevision: int64
+        | DecrementManifestReferenceCount of
+            repositoryId: RepositoryId *
+            storagePoolId: StoragePoolId *
+            manifestAddress: ManifestAddress *
+            counterRevision: int64
 
         /// Returns known nested union types for serializers.
         static member GetKnownTypes() = GetKnownTypes<RepositoryContentCounterIntent>()
@@ -151,6 +160,7 @@ module RepositoryContentCounter =
                                 Operation = RepositoryContentCounterChangeOperation.Added
                                 PreviousCount = current.Count
                                 CurrentCount = nextCount
+                                Revision = current.Revision + 1L
                             }
                 }
             | RepositoryContentCounterEventType.ReferenceRemoved operationId ->
@@ -166,6 +176,7 @@ module RepositoryContentCounter =
                                 Operation = RepositoryContentCounterChangeOperation.Removed
                                 PreviousCount = current.Count
                                 CurrentCount = nextReferenceCount
+                                Revision = current.Revision + 1L
                             }
                 }
 

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -61,7 +61,7 @@ Open `http://localhost:18888` and confirm the following resources show
 `Running`:
 
 - `azurite` – Azure Storage emulator (blob/queue/table) on ports `10000-10002`
-- `redis` – Redis cache on port `6379`
+- `redis` – Redis 8.6.3 recent-result cache on port `6379`
 - `cosmos` – Cosmos DB emulator on port `8081`
 - `servicebus-sql` – SQL Server container required by the Service Bus emulator
   and used locally for the `GraceOperations` SQL database
@@ -73,9 +73,16 @@ Open `http://localhost:18888` and confirm the following resources show
   subscription
 
 Redis is provisioned by AppHost and its host/port are forwarded to
-`Grace.Server`. Current startup code does not enable Redis-backed SignalR, so
-Redis remains an explicit AppHost dependency pending a follow-up runtime
-decision rather than a prerequisite proven by the integration tests.
+`Grace.Server`. Repository manifest accounting uses direct Redis `GET` and
+`SET` calls only to accelerate recently completed counter operations. Results
+expire after exactly ten minutes. Redis is not a membership ledger or source
+of truth: missing, expired, malformed, or unavailable results are cache misses,
+never a zero count. The client connects lazily, uses native reconnect, and
+bounds each connection and command wait without an outer Polly policy.
+
+Repository manifest counters persist only `Count`, `Revision`, and the latest
+completed change. Manifest contribution workflows overwrite their bounded
+current range progress instead of retaining lifetime event histories.
 
 The local operations worker creates the `ops` SQL schema and usage fact tables
 inside a `GraceOperations` database on the local SQL Server container before it

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -77,8 +77,11 @@ Redis is provisioned by AppHost and its host/port are forwarded to
 `SET` calls only to accelerate recently completed counter operations. Results
 expire after exactly ten minutes. Redis is not a membership ledger or source
 of truth: missing, expired, malformed, or unavailable results are cache misses,
-never a zero count. The client connects lazily, uses native reconnect, and
-bounds each connection and command wait without an outer Polly policy.
+never a zero count. Additions can continue under cache loss because extra
+retention is safe; removals pause or withhold their decrement workflow until
+Redis confirms the bounded completed result. The client connects lazily, uses
+native reconnect, and bounds each connection and command wait without an outer
+Polly policy.
 
 Repository manifest counters persist only `Count`, `Revision`, and the latest
 completed change. Manifest contribution workflows overwrite their bounded

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -215,7 +215,9 @@ Messages are completed only after SQL processing succeeds or the durable usage f
 - `grace__redis__port`: Redis port; defaults to `6379` when a host is set.
 
 When Redis is not configured or cannot be reached, recent-result reads return
-unknown and writes are ignored. Durable exact relationships and bounded
+unknown. Addition processing may continue because retaining content is safe.
+Removal processing pauses, or withholds its decrement workflow, until Redis
+confirms the bounded completed result. Durable exact relationships and bounded
 counter/workflow snapshots remain responsible for correctness.
 
 ### Orleans

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -210,8 +210,13 @@ Messages are completed only after SQL processing succeeds or the durable usage f
 
 ### Redis
 
-- `grace__redis__host`: Redis host.
-- `grace__redis__port`: Redis port.
+- `grace__redis__host`: optional Redis host for ten-minute repository-counter
+  recent results.
+- `grace__redis__port`: Redis port; defaults to `6379` when a host is set.
+
+When Redis is not configured or cannot be reached, recent-result reads return
+unknown and writes are ignored. Durable exact relationships and bounded
+counter/workflow snapshots remain responsible for correctness.
 
 ### Orleans
 


### PR DESCRIPTION
# Issue #732: Bounded manifest contribution accounting workflow

## Why this matters

Grace should acknowledge a `Reference` quickly and move manifest contribution accounting into a bounded,
restart-safe background workflow. The workflow must converge across duplicate delivery and unknown outcomes without
adding another durable summary or treating one `ReferenceType` differently from another.

Relates to #732.

## What changed

- Added bounded repository contribution counter state with deterministic replay facts.
- Added Redis-backed recent-result lookup as a nonauthoritative replay aid with safe removal gating.
- Executed and resumed deterministic manifest contribution workflow ranges.
- Applied `ContentBlock` active-manifest deltas through a typed Orleans method.
- Made unknown-outcome replay compare stable delta identity without reapplying the one-shot expected-version
  precondition.
- Added Redis readiness to the Aspire test host and a focused Redis loss/reconnect witness.
- Added focused unit, regression, integration, and tracer coverage.

## Explicit boundaries

- No new durable summary state.
- No `ReferenceType`-specific accounting behavior.
- No foreground manifest traversal.
- No default Polly retry policy.
- Producer identity propagation remains in #730.
- The invalid physical-deletion Branch projection premise from #740 is not implemented here.

## Validation

- Release unit-test build: passed with 0 warnings and 0 errors.
- Focused tests: 197/197 passed.
- Release integration-test build: passed with 0 warnings and 0 errors.
- Markdown lint: 0 errors.
- Diff checks: clean.

The final grouped Aspire witness passed both manifest and Redis scenarios in one process and one shared host. All local
Aspire starts are exhausted. GitHub Validate is the required broad current-head gate.

## Stabilization ledger

- Upload finalization leaves physical ranges at zero repository contributions; repository 0-to-1 is the sole owner of
  the first `ActiveManifestCount` increment.
- Downstream ContentBlock operation identity includes the counter revision; add/remove/add cycles must never collide
  after Redis expiry or loss.
- Workflow execution derives and atomically updates every current physical range from bounded ContentBlock identity.
- Redis remains nonauthoritative and nonthrowing to callers, but its initial-connect and command failures remain visible
  to tests and structured logs.
- Required proof: revisions 1/2/3 add-remove-add across Redis loss, every-range convergence, ten-minute TTL, deletion
  miss, stopped-resource miss, and native reconnect.
- No new durable state, permanent receipt, `ReferenceType` branch, foreground traversal, or default Polly is allowed.

## Review Status

Presentation subagents are excluded from the implementation/fix-worker count.

- Implementation/fix-worker starts: 6/6; the final runtime-fix worker completed and pushed.
- Aspire starts: 3/3 cumulative; the final grouped focused witness passed 2/2.
- Codex review sessions: 4/4; current-head review completed and its final finding is resolved as an owner-accepted
  residual risk with no code change.
- Current head: `417341a55b91699673d85009743749065772ff13`.
- Review sessions 1 and 2 findings are fixed; both exact conversations are answered and resolved.
- Validate run 30257806857 failed: the retained ContentBlock range remained inactive and Redis returned
  `TrySet = false` after ten seconds.
- Review session 3 P1 was fixed in `417341a5`.
  [Fix evidence](https://github.com/ScottArbeit/Grace/pull/745#discussion_r3659689396); conversation resolved.
- Owner-approved scope: add the counter revision to downstream ContentBlock operation identities, diagnose and fix Redis
  `TrySet = false` with visible diagnostics, and provide directly required current-head proof. No new durable state,
  permanent receipt, `ReferenceType`-specific behavior, foreground traversal, or default Polly is authorized.

## Final stabilization stop

- Worker start 5/5 stopped without commit or push; PR head remains `54b41cfac7906ca57da898cd375b47235b9c5163`.
- The uncommitted five-file candidate passed both Release builds, 127/127 focused tests, Fantomas, and
  `git diff --check`.
- Aspire start 2/2 passed Redis 8.6.3 with a 599.984-second TTL, visible outage exceptions, deletion/loss behavior,
  and native reconnect in 2.303 seconds.
- The same fresh-container witness still failed the manifest invariant: the exact relationship existed and repository
  count reached 1, but no physical ContentBlock range reached `ActiveManifestCount = 1`.
- Disabled Cosmos persistence and a fresh container disprove cross-run fixture reuse. This remains an unresolved
  product or test-runtime defect, not a justified proof-isolation change.
- No current-head review was requested. Another worker or Aspire start requires a new explicit numbered owner limit.

## Owner-approved runtime continuation

- Limits: 6 cumulative implementation/fix-worker starts, 3 cumulative Aspire starts, and 4 cumulative Codex review sessions.
- One fresh GPT-5.6-Sol Medium worker must preserve and evaluate the uncommitted five-file candidate.
- Scope: diagnose and fix why a fresh 0-to-1 contribution creates the exact relationship and reaches repository count 1
  without activating every physical ContentBlock range; remove the directly obsolete `operationPrefix` local; add only
  directly required proof.
- At most one grouped focused Aspire start and one resulting current-head review are authorized.
- No new durable state, permanent receipt, `ReferenceType`-specific behavior, foreground traversal, default Polly, or
  weaker retention assertion is authorized. Stop if the witness or review finds another problem.

## Current-head runtime result

- Commit `417341a55b91699673d85009743749065772ff13` is pushed; the branch is clean and 0 behind the Epic base.
- Upload finalization now leaves new physical ranges at zero repository contributions; repository 0-to-1 owns the first
  `ActiveManifestCount` increment.
- Counter revision is included in downstream adjustment and completion identities.
- Both Release builds passed, 197/197 focused tests passed, Fantomas was clean, and `git diff --check` passed.
- Grouped Aspire start 3/3 passed 2/2: all nonempty manifest ranges equaled 1; Redis 8.6.3 reported a 599.982-second
  TTL, visible outage diagnostics, native reconnect in 4.842 seconds, and successful cleanup.
- No Fast or Full run was selected; GitHub Validate is the required broad current-head gate.
- [Validate 30291428409](https://github.com/ScottArbeit/Grace/actions/runs/30291428409) failed two storage tests.
- Review session 4/4 completed. Its removal-replay finding is resolved with no code change because Redis is deliberately
  ephemeral and the owner accepts the narrow compound interruption risk. No further review is authorized.

## Review session 4 stop

- Codex reviewed `417341a55b91699673d85009743749065772ff13` and opened
  [a P1 removal-replay finding](https://github.com/ScottArbeit/Grace/pull/745#discussion_r3659693816).
- Candidate producer: Redis loses a cached removal result, a newer add replaces `LastCompletedChange`, and a delayed
  duplicate of the older removal reaches the counter after the cache miss.
- If that sequence is reachable, the old removal can drive 1-to-0 and make still-referenced content reclaimable.
- The supported application does not yet construct removal commands outside focused tests. The future deletion path
  normally closes the brief interval by converging the exact relationship after the counter change.
- The owner accepts the residual compound interruption window in which Redis loses the short-lived result, processing
  stops before exact convergence, a newer add replaces `LastCompletedChange`, and the older removal is delivered again.
  Redis must remain ephemeral: additions do not wait for it, and Grace adds no permanent receipt or stronger Redis
  correctness dependency. The conversation is resolved with no code change.

## Current-head Validate failure

[Validate 30291428409](https://github.com/ScottArbeit/Grace/actions/runs/30291428409) failed 2 of 253
`Grace.Server.Tests` while all other reported test assemblies passed:

- `LargeBinarySaveLifecycleRequiresFinalizedManifestAndDownloadsAfterRouteChange` returned `BadRequest` because active
  ContentBlock ranges no longer covered a finalized manifest block.
- `RepositoriesInSameStoragePoolReuseDurableContentBlockPlacementAcrossManifests` found zero reusable durable ranges.

Both failures follow from changing upload finalization from one active contribution to zero. Existing storage behavior
therefore assigns real placement/download meaning to that contribution. The current head cannot merge, and the correct
relationship between finalized-manifest retention and repository-manifest retention is not yet implementation-ready.

In this issue, a retained `DirectoryVersion` is one that remains reachable from a live `Reference` or a retained parent
`DirectoryVersion`. The client creates and saves `DirectoryVersion` values in a Repository; retained does not mean
merely saved in the database.

## Stabilization ledger revision 2

PR #745 has completed four Codex review sessions. Do not request another review or apply another one-off patch until
these invariants form one coherent model.

### Accepted invariants

1. A finalized FileManifest remains downloadable and reusable before any Repository retains it; its physical
   ContentBlock ranges therefore remain active after upload finalization.
1. Each Repository contributes at most once for one ManifestAddress, regardless of how many retained
   DirectoryVersions use it.
1. Removing the last retained repository use must eventually let every range reach zero when no other current use keeps
   it active.
1. Redis remains a nonauthoritative, short-lived replay aid and additions do not wait for it. Product V1 accepts the
   narrow compound interruption risk recorded in the review-session disposition; no permanent receipt or stronger
   Redis dependency is added.

### Source-proven contract stop

The canonical specification requires repository zero crossings to reach StoragePool-level manifest and `ContentBlock`
accounting. Existing Grace design also names a StoragePool-level `RepositoryReferenceCount`. The current branch contains
no StoragePool-level manifest count or retained-state snapshot and instead drives `ContentBlock.ActiveManifestCount`
directly from each repository.

Upload finalization already makes accepted physical ranges active once. Setting that value to zero caused the current
`Validate` failures. Restoring one without a StoragePool-level manifest transition would double-count the first
repository and leave no sound final-release rule.

The owner must choose between:

- **A - bounded StoragePool manifest retention snapshot (recommended):** retain finalized download and reuse behavior,
  add only the smallest current snapshot for `(StoragePoolId, ManifestAddress)`, and let repository transitions take over,
  release, or later reactivate that manifest's one `ContentBlock` contribution.
- **B - zero-count finalized ranges:** avoid that snapshot by treating zero-count ranges as usable until physically
  reclaimed, while accepting that delayed background accounting can race reclamation and weaken retain-first behavior.

No implementation continues until this choice is approved. The direct per-repository fan-out with an unexplained upload
baseline is not a valid third model.

### Required proof before another review

- cross-Repository placement discovery and reuse immediately after the first manifest is finalized, before the second
  client creates a DirectoryVersion or Reference for that content;
- download immediately after the client saves the DirectoryVersions and creates the Reference, without assuming the
  background contribution has already converged;
- first Repository use without a duplicate physical-range contribution;
- two Repositories adding and removing the same manifest;
- final Repository removal reaching zero when no other current use remains;
- the normal remove-to-exact-relationship convergence path, with the accepted compound interruption window named
  explicitly rather than hidden behind durable Redis assumptions;
- a status map naming the code and proof seam for every invariant.

No new durable state, permanent receipt, `ReferenceType` specialization, foreground traversal, default Polly, or weaker
retention assertion is authorized.