### PR TITLE
Prove exact shared DirectoryVersion DAG reachability

### DIFF
--- a/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -125,8 +125,13 @@ type ManifestContributionAccountingAspireTests() =
 
             fileVersion.ContentReference <- FileContentReference.FileManifest manifest
 
-            let root = BranchServerTestHelpers.createRootDirectoryVersion repositoryId fileVersion
-            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ root ]
+            let shared = BranchServerTestHelpers.createDirectoryVersionWithFile repositoryId (RelativePath "shared") fileVersion
+            let left = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId (RelativePath "left") [ shared ]
+            let right = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId (RelativePath "right") [ shared ]
+
+            let root = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId Constants.RootDirectoryPath [ left; right ]
+
+            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ shared; left; right; root ]
 
             let! _ = AspireTestHost.drainServiceBusAsync state
             let referenceId = Guid.NewGuid()
@@ -188,8 +193,33 @@ type ManifestContributionAccountingAspireTests() =
                             RepositoryId = Guid.Parse repositoryId
                             StoragePoolId = manifest.StoragePoolId
                             ManifestAddress = manifest.ManifestAddress
-                            DirectoryVersionId = root.DirectoryVersionId
+                            DirectoryVersionId = shared.DirectoryVersionId
                         })
+
+            let expectedEdges =
+                [|
+                    root.DirectoryVersionId, left.DirectoryVersionId
+                    root.DirectoryVersionId, right.DirectoryVersionId
+                    left.DirectoryVersionId, shared.DirectoryVersionId
+                    right.DirectoryVersionId, shared.DirectoryVersionId
+                |]
+
+            let mutable edgeIndex = 0
+
+            while edgeIndex < expectedEdges.Length do
+                let parentDirectoryVersionId, childDirectoryVersionId = expectedEdges[edgeIndex]
+
+                do!
+                    AspireTestHost.waitForExactRelationshipAsync
+                        state
+                        (ExactRelationship.ParentChild
+                            {
+                                RepositoryId = Guid.Parse repositoryId
+                                ParentDirectoryVersionId = parentDirectoryVersionId
+                                ChildDirectoryVersionId = childDirectoryVersionId
+                            })
+
+                edgeIndex <- edgeIndex + 1
 
             parameters.CorrelationId <- generateCorrelationId ()
             let! retryResponse = state.Client.PostAsync("/branch/commit", createJsonContent parameters)

--- a/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -293,21 +293,28 @@ type ManifestContributionAccountingServerTests() =
             Assert.That(manifestWrites[0].ManifestAddress, Is.EqualTo(manifestAddress))
         }
 
-    /// Verifies a Reference retains manifests through exact parent-child edges without attributing them to the root.
+    /// Verifies a diamond DAG retains one shared manifest after traversing each newly retained parent.
     [<Test>]
-    member _.ReferenceCreatedTraversesNestedDirectoryVersionsAndAttributesDirectManifestOwner() =
+    member _.ReferenceCreatedTraversesDiamondAndAttributesSharedManifestToDirectOwnerOnce() =
         task {
-            let childDirectoryVersionId = Guid.Parse("88888888-7290-4000-8000-888888888888")
-            let childDirectories = List<DirectoryVersionId>()
+            let leftDirectoryVersionId = Guid.Parse("88888888-7290-4000-8000-888888888888")
+            let rightDirectoryVersionId = Guid.Parse("89898989-7290-4000-8000-898989898989")
+            let sharedDirectoryVersionId = Guid.Parse("90909090-7290-4000-8000-909090909090")
             let rootDirectories = List<DirectoryVersionId>()
-            rootDirectories.Add(childDirectoryVersionId)
-            let childFiles = List<FileVersion>()
+            rootDirectories.Add(leftDirectoryVersionId)
+            rootDirectories.Add(rightDirectoryVersionId)
+            let sharedDirectories = List<DirectoryVersionId>()
+            sharedDirectories.Add(sharedDirectoryVersionId)
+            let sharedFiles = List<FileVersion>()
             let file, manifest = manifestBackedFile ()
-            childFiles.Add(file)
+            sharedFiles.Add(file)
 
             let root = nestedDirectoryVersionDto currentDirectoryVersionId (RelativePath ".") rootDirectories (List<FileVersion>())
 
-            let child = nestedDirectoryVersionDto childDirectoryVersionId (RelativePath "nested") childDirectories childFiles
+            let left = nestedDirectoryVersionDto leftDirectoryVersionId (RelativePath "left") sharedDirectories (List<FileVersion>())
+            let right = nestedDirectoryVersionDto rightDirectoryVersionId (RelativePath "right") sharedDirectories (List<FileVersion>())
+
+            let shared = nestedDirectoryVersionDto sharedDirectoryVersionId (RelativePath "shared") (List<DirectoryVersionId>()) sharedFiles
 
             let storedRelationships = HashSet<ExactRelationship>()
             let manifestWrites = ResizeArray<DirectoryVersionManifestRelationship>()
@@ -371,7 +378,9 @@ type ManifestContributionAccountingServerTests() =
                         fun _ directoryVersionId _ ->
                             Task.FromResult(
                                 if directoryVersionId = currentDirectoryVersionId then root
-                                elif directoryVersionId = childDirectoryVersionId then child
+                                elif directoryVersionId = leftDirectoryVersionId then left
+                                elif directoryVersionId = rightDirectoryVersionId then right
+                                elif directoryVersionId = sharedDirectoryVersionId then shared
                                 else DirectoryVersionDto.Default
                             )
                     ExactRelationships = store
@@ -392,30 +401,43 @@ type ManifestContributionAccountingServerTests() =
 
             do! handleReferenceCreatedWith dependencies CancellationToken.None (staleCreatedEvent ReferenceType.Save)
 
-            Assert.That(
-                storedRelationships,
-                Does.Contain(
-                    ExactRelationship.ParentChild
-                        { RepositoryId = repositoryId; ParentDirectoryVersionId = currentDirectoryVersionId; ChildDirectoryVersionId = childDirectoryVersionId }
-                )
-            )
+            let expectedEdges =
+                [|
+                    currentDirectoryVersionId, leftDirectoryVersionId
+                    currentDirectoryVersionId, rightDirectoryVersionId
+                    leftDirectoryVersionId, sharedDirectoryVersionId
+                    rightDirectoryVersionId, sharedDirectoryVersionId
+                |]
+
+            expectedEdges
+            |> Array.iter (fun (parentDirectoryVersionId, childDirectoryVersionId) ->
+                Assert.That(
+                    storedRelationships,
+                    Does.Contain(
+                        ExactRelationship.ParentChild
+                            {
+                                RepositoryId = repositoryId
+                                ParentDirectoryVersionId = parentDirectoryVersionId
+                                ChildDirectoryVersionId = childDirectoryVersionId
+                            }
+                    )
+                ))
 
             Assert.That(manifestWrites.Count, Is.EqualTo(1))
-            Assert.That(manifestWrites[0].DirectoryVersionId, Is.EqualTo(childDirectoryVersionId))
+            Assert.That(manifestWrites[0].DirectoryVersionId, Is.EqualTo(sharedDirectoryVersionId))
             Assert.That(manifestWrites[0].StoragePoolId, Is.EqualTo(storagePoolId))
             Assert.That(manifestWrites[0].ManifestAddress, Is.EqualTo(manifestAddress))
 
+            Assert.That(effectOrder[0], Is.EqualTo("reference-root"))
+            Assert.That(effectOrder[1], Is.EqualTo("manifest-effect"))
+            Assert.That(effectOrder[2], Is.EqualTo("directory-version-manifest"))
+            Assert.That(effectOrder[3], Is.EqualTo("parent-child"), "Shared child contents must converge before its first incoming edge.")
+
             Assert.That(
-                effectOrder,
-                Is.EqualTo<string array>(
-                    [|
-                        "reference-root"
-                        "manifest-effect"
-                        "directory-version-manifest"
-                        "parent-child"
-                    |]
-                ),
-                "Child contents must converge before the parent-child edge makes retries stop at that retained child."
+                effectOrder
+                |> Seq.filter ((=) "parent-child")
+                |> Seq.length,
+                Is.EqualTo(4)
             )
         }
 


### PR DESCRIPTION
## Purpose

Prove that background manifest contribution accounting converges exactly for a nested DirectoryVersion diamond with a shared child, without adding synchronous work or new durable state.

Relates to #731. Parent epic: #727.

## Changes

- Add a focused unit test for `root -> left/right -> shared leaf`.
- Prove all four exact parent-child relationships, child-before-edge ordering, direct manifest ownership by the shared leaf, and one manifest traversal.
- Upgrade the public Commit Aspire tracer to the same shared-DAG shape and verify exact accounting convergence.

No production code, public contract, project file, or documentation behavior changes.

## Validation

- Fantomas 4.7.9: passed.
- `Grace.Server.Unit.Tests` Release build: passed, 0 warnings, 0 errors.
- Manifest accounting unit fixture: 12/12 passed.
- Final shared-DAG focused subset: 2/2 passed.
- `Grace.Server.Tests` Release build: passed, 0 warnings, 0 errors.
- Focused Aspire tracer: 1/1 passed in 12 seconds; grouped command about 42 seconds.
- `git diff --check`: passed.
- Worker bot-prevention self-review: clean.

## Review Status

- Implementation/fix-worker starts: 1/4.
- Aspire starts: 1/3.
- Codex review sessions: 1/3.
- Current head: `ae77a958a9ca7d68924f9cf6d617f3afd3e4a4c8`.
- GitHub Validate: passed Full on run `30310310132`.
- Codex Code Review Bot: current-head review completed with no findings.
- Reference removal, 1 -> 0 accounting, logical deletion, and recovery remain owned by #733.