### PR TITLE
Make DirectoryVersion deletion restart-safe

### DIFF
--- a/docs/Data types in Grace.md
+++ b/docs/Data types in Grace.md
@@ -157,9 +157,13 @@ References and DirectoryVersions are where the action happens. New References an
 
 The ratio of new-DirectoryVersions-to-new-References is directly proportional to how deep in the directory tree the updated files are. For every directory level, a new DirectoryVersion will be created. For example, if I update a file called `src/web/js/lib/blah.js` and hit save, that will create one Save Reference, and five new DirectoryVersions - one for the root, and one each for each directory in the path.
 
-Saves have short lifetimes, and checkpoints (by default) have longer, but finite, lifetimes, and they both get deleted at some point. Any DirectoryVersions that are unique to those references, and any FileVersions in object storage that only appear in those references, get deleted when the Reference is deleted.
+References can have different lifetimes, but every `ReferenceType` follows the same deletion rules. Removing a Reference
+removes only its relationship to the root DirectoryVersion. Background relationship accounting later identifies
+DirectoryVersions with no current incoming relationship. Physical DirectoryVersion deletion releases its direct manifest
+relationships and child relationships before the DirectoryVersion state is removed.
 
-Also, of course, every time a Branch is deleted, all References in that Branch get deleted. And all DirectoryVersions unique to those References get deleted. Etc.
+Deleting a Branch therefore removes its References first. DirectoryVersions and stored file content are reclaimed
+separately when their relationship evidence shows that they are no longer in use.
 
 It's completely normal in Grace for References to be deleted. Happens all the time.
 

--- a/docs/adr/0001-content-addressed-storage-contentblocks.md
+++ b/docs/adr/0001-content-addressed-storage-contentblocks.md
@@ -349,7 +349,8 @@ accepted `FileManifest` records, `ContentBlock` payloads, `ContentBlockMetadata`
 Grace keeps repository fan-in separate from StoragePool-level content lifecycle.
 
 `RepositoryContentCounter` is repository-scoped state for one StoragePool-shared CAS target. For manifest-backed
-content, the target is the `ManifestAddress`. The counter absorbs repeated live references inside one repository:
+content, the target is the `ManifestAddress`. The counter absorbs repeated current `DirectoryVersion` relationships
+inside one repository:
 
 ```text
 (RepositoryId, ManifestAddress).ReferenceCount
@@ -368,12 +369,22 @@ and not an upload-session child. The workflow actor owns:
 - Retry state for range liveness updates.
 - The ability to resume after activation, crash, or timeout.
 
-A save that introduces a manifest-backed `FileVersion` is complete only after the increment intent for
-`(RepositoryId, ManifestAddress)` is durably recorded. The full block-range fan-out may complete asynchronously with
-retry. Garbage collection and compaction must treat a pending contribution workflow as live enough to prevent deleting
-the manifest or ranges it is in the process of making active.
+A `DirectoryVersion` creation request returns after the `DirectoryVersion` is stored. Background accounting records its
+exact manifest relationships, updates the repository counter, and runs any required block-range fan-out. Garbage
+collection and compaction must treat a pending contribution workflow as live enough to prevent deleting the manifest or
+ranges it is in the process of making active.
 
-This keeps user-facing saves responsive without letting accepted manifests outrun content retention.
+Logical deletion does not change those relationships. Physical deletion first checks for a current incoming
+relationship. If none exists, it completes each manifest decrement before removing the matching exact relationship,
+removes its parent-child relationships, verifies that all outgoing evidence is absent, and only then clears actor state.
+Retries reconstruct this work from the immutable `DirectoryVersion` and current exact relationships; no deletion ledger
+or Reference-type-specific behavior is required.
+
+Grace performs the incoming check once. A new relationship created after physical cleanup begins does not cancel the
+deletion; this narrow race is accepted in the current design.
+
+Reference physical deletion removes only that Reference's root relationship. Manifest retention remains owned by the
+referenced `DirectoryVersion`, regardless of `ReferenceType`.
 
 ## Dedupe Index Maintenance
 

--- a/src/Grace.Actors/DirectoryVersion.Actor.fs
+++ b/src/Grace.Actors/DirectoryVersion.Actor.fs
@@ -16,8 +16,11 @@ open Grace.Shared.Services
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.Events
+open Grace.Types.ManifestContributionAccounting
+open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.Reminder
 open Grace.Types.Repository
+open Grace.Types.RepositoryContentCounter
 open Grace.Types.DirectoryVersion
 open Grace.Types.Common
 open Grace.Types.ContentBlockMetadata
@@ -547,10 +550,142 @@ module DirectoryVersion =
 
         validateManifestReferencesForSaveBoundaryWithResolver getScopedRangePresence repositoryId correlationId manifestReferences
 
+    /// Reports whether physical deletion must wait or may clear the DirectoryVersion actor state.
+    type PhysicalDeletionDisposition =
+        | BlockedByIncomingRelationship
+        | OutgoingRelationshipStillPresent
+        | ReadyToClear
+
+    /// Supplies exact relationship and manifest-release effects to the restart-safe deletion loop.
+    type PhysicalDeletionDependencies =
+        {
+            EnumerateIncoming: RepositoryId -> DirectoryVersionId -> CancellationToken -> Task<ExactRelationship array>
+            Verify: ExactRelationship -> CancellationToken -> Task<ExactRelationshipPresence>
+            EnsureAbsent: ExactRelationship -> CancellationToken -> Task<ExactRelationshipWriteOutcome>
+            ReleaseManifest: DirectoryVersionManifestRelationship -> FileManifest -> EventMetadata -> CancellationToken -> Task
+        }
+
+    /// Caps the physical-deletion incoming probe at the first relationship that blocks deletion.
+    let private oneIncomingRelationshipBound =
+        match ExactRelationshipReadBound.create 1 with
+        | Ok bound -> bound
+        | Error error -> invalidOp error
+
+    /// Builds the shared repository, storage-pool, and manifest actor key.
+    let private manifestAccountingPrimaryKey (repositoryId: RepositoryId) (storagePoolId: StoragePoolId) (manifestAddress: ManifestAddress) =
+        $"{repositoryId:N}|{storagePoolId}|{manifestAddress}"
+
+    /// Reconstructs exact outgoing evidence from immutable DirectoryVersion actor state.
+    let private outgoingPhysicalDeletionEvidence (directoryVersionDto: DirectoryVersionDto) correlationId =
+        let directoryVersion = directoryVersionDto.DirectoryVersion
+
+        let manifestEvidence =
+            match getManifestReferencesForSaveBoundary directoryVersion correlationId with
+            | Error graceError -> invalidOp graceError.Error
+            | Ok manifestReferences ->
+                manifestReferences
+                |> Seq.map (fun manifestReference -> manifestReference.Manifest)
+                |> Seq.distinctBy (fun manifest -> manifest.StoragePoolId, manifest.ManifestAddress)
+                |> Seq.map (fun manifest ->
+                    ExactRelationship.DirectoryVersionManifest
+                        {
+                            RepositoryId = directoryVersion.RepositoryId
+                            StoragePoolId = manifest.StoragePoolId
+                            ManifestAddress = manifest.ManifestAddress
+                            DirectoryVersionId = directoryVersion.DirectoryVersionId
+                        },
+                    manifest)
+                |> Seq.toArray
+
+        let childEvidence =
+            directoryVersion.Directories
+            |> Seq.distinct
+            |> Seq.map (fun childDirectoryVersionId ->
+                ExactRelationship.ParentChild
+                    {
+                        RepositoryId = directoryVersion.RepositoryId
+                        ParentDirectoryVersionId = directoryVersion.DirectoryVersionId
+                        ChildDirectoryVersionId = childDirectoryVersionId
+                    })
+            |> Seq.toArray
+
+        manifestEvidence, childEvidence
+
+    /// Converges physical deletion from current exact evidence without recording deletion progress.
+    let convergePhysicalDeletionWith
+        (dependencies: PhysicalDeletionDependencies)
+        (directoryVersionDto: DirectoryVersionDto)
+        (metadata: EventMetadata)
+        cancellationToken
+        =
+        task {
+            let directoryVersion = directoryVersionDto.DirectoryVersion
+
+            let! incoming = dependencies.EnumerateIncoming directoryVersion.RepositoryId directoryVersion.DirectoryVersionId cancellationToken
+
+            if incoming.Length > 0 then
+                return BlockedByIncomingRelationship
+            else
+                let manifestEvidence, childEvidence = outgoingPhysicalDeletionEvidence directoryVersionDto metadata.CorrelationId
+                let mutable manifestIndex = 0
+
+                while manifestIndex < manifestEvidence.Length do
+                    cancellationToken.ThrowIfCancellationRequested()
+                    let relationship, manifest = manifestEvidence[manifestIndex]
+
+                    match! dependencies.Verify relationship cancellationToken with
+                    | ExactRelationshipPresence.Absent -> ()
+                    | ExactRelationshipPresence.Present ->
+                        let manifestRelationship =
+                            match relationship with
+                            | ExactRelationship.DirectoryVersionManifest manifestRelationship -> manifestRelationship
+                            | _ -> invalidOp "DirectoryVersion physical deletion expected manifest evidence."
+
+                        do! dependencies.ReleaseManifest manifestRelationship manifest metadata cancellationToken
+                        let! _ = dependencies.EnsureAbsent relationship cancellationToken
+                        ()
+
+                    manifestIndex <- manifestIndex + 1
+
+                let mutable childIndex = 0
+
+                while childIndex < childEvidence.Length do
+                    cancellationToken.ThrowIfCancellationRequested()
+                    let! _ = dependencies.EnsureAbsent childEvidence[childIndex] cancellationToken
+                    childIndex <- childIndex + 1
+
+                let finalManifestEvidence, finalChildEvidence = outgoingPhysicalDeletionEvidence directoryVersionDto metadata.CorrelationId
+                let mutable allAbsent = true
+                let mutable finalManifestIndex = 0
+
+                while finalManifestIndex < finalManifestEvidence.Length
+                      && allAbsent do
+                    let relationship, _ = finalManifestEvidence[finalManifestIndex]
+
+                    match! dependencies.Verify relationship cancellationToken with
+                    | ExactRelationshipPresence.Absent -> ()
+                    | ExactRelationshipPresence.Present -> allAbsent <- false
+
+                    finalManifestIndex <- finalManifestIndex + 1
+
+                let mutable finalChildIndex = 0
+
+                while finalChildIndex < finalChildEvidence.Length
+                      && allAbsent do
+                    match! dependencies.Verify finalChildEvidence[finalChildIndex] cancellationToken with
+                    | ExactRelationshipPresence.Absent -> ()
+                    | ExactRelationshipPresence.Present -> allAbsent <- false
+
+                    finalChildIndex <- finalChildIndex + 1
+
+                return if allAbsent then ReadyToClear else OutgoingRelationshipStillPresent
+        }
+
     /// Implements the Orleans grain for directory version actor.
     type DirectoryVersionActor
         (
-            [<PersistentState(StateName.DirectoryVersion, Constants.GraceActorStorage)>] state: IPersistentState<List<DirectoryVersionEvent>>
+            [<PersistentState(StateName.DirectoryVersion, Constants.GraceActorStorage)>] state: IPersistentState<List<DirectoryVersionEvent>>,
+            exactRelationships: IExactRelationshipStore
         ) =
         inherit Grain()
 
@@ -569,6 +704,121 @@ module DirectoryVersion =
 
         /// Stores the correlation id used by this actor while reporting timings and errors.
         member val private correlationId: CorrelationId = String.Empty with get, set
+
+        /// Releases one direct manifest contribution before removing its exact relationship evidence.
+        member private this.ReleaseManifestContribution
+            (
+                relationship: DirectoryVersionManifestRelationship,
+                manifest: FileManifest,
+                metadata: EventMetadata,
+                cancellationToken: CancellationToken
+            ) =
+            let grainFactory = this.GrainFactory
+
+            task {
+                cancellationToken.ThrowIfCancellationRequested()
+
+                let counterActor =
+                    grainFactory.GetGrain<IRepositoryContentCounterActor>(
+                        manifestAccountingPrimaryKey relationship.RepositoryId relationship.StoragePoolId relationship.ManifestAddress
+                    )
+
+                let operationId =
+                    RepositoryContentCounterOperationId
+                        $"directory-version:{relationship.DirectoryVersionId:N}:{relationship.StoragePoolId}:{relationship.ManifestAddress}:remove"
+
+                let counterCommand =
+                    RepositoryContentCounterCommand.RemoveReference(
+                        operationId,
+                        relationship.RepositoryId,
+                        relationship.StoragePoolId,
+                        relationship.ManifestAddress
+                    )
+
+                match! counterActor.Handle counterCommand metadata with
+                | Error graceError -> invalidOp graceError.Error
+                | Ok counterReturnValue ->
+                    let decrementRevision =
+                        counterReturnValue.ReturnValue.Intents
+                        |> List.tryPick (function
+                            | RepositoryContentCounterIntent.DecrementManifestReferenceCount (repositoryId, storagePoolId, manifestAddress, counterRevision) when
+                                repositoryId = relationship.RepositoryId
+                                && storagePoolId = relationship.StoragePoolId
+                                && manifestAddress = relationship.ManifestAddress
+                                ->
+                                Some counterRevision
+                            | _ -> None)
+
+                    match decrementRevision with
+                    | None -> ()
+                    | Some counterRevision ->
+                        let ranges =
+                            manifest.Blocks
+                            |> Seq.distinctBy (fun block -> block.Address)
+                            |> Seq.map (fun block -> { StoragePoolId = manifest.StoragePoolId; ContentBlockAddress = block.Address })
+                            |> Seq.toArray
+
+                        let workflowActor =
+                            grainFactory.GetGrain<IManifestContributionWorkflowActor>(
+                                manifestAccountingPrimaryKey relationship.RepositoryId relationship.StoragePoolId relationship.ManifestAddress
+                            )
+
+                        let workflowOperationId =
+                            ManifestContributionWorkflowOperationId
+                                $"directory-version:{relationship.DirectoryVersionId:N}:{relationship.StoragePoolId}:{relationship.ManifestAddress}:release"
+
+                        match!
+                            workflowActor.Start
+                                workflowOperationId
+                                relationship.RepositoryId
+                                relationship.StoragePoolId
+                                relationship.ManifestAddress
+                                ManifestContributionDirection.Decrement
+                                ranges
+                                counterRevision
+                                metadata
+                            with
+                        | Ok _ -> ()
+                        | Error graceError -> invalidOp graceError.Error
+            }
+            :> Task
+
+        /// Runs the one-shot incoming check and restart-safe outgoing convergence for physical deletion.
+        member private this.ConvergePhysicalDeletion(metadata: EventMetadata, cancellationToken: CancellationToken) =
+            let dependencies =
+                {
+                    EnumerateIncoming =
+                        fun repositoryId directoryVersionId cancellationToken ->
+                            task {
+                                let! page =
+                                    exactRelationships.EnumerateAsync(
+                                        ExactRelationshipPartition.IncomingDirectoryVersion(repositoryId, directoryVersionId),
+                                        oneIncomingRelationshipBound,
+                                        None,
+                                        cancellationToken
+                                    )
+
+                                return page.Relationships
+                            }
+                    Verify = fun relationship cancellationToken -> exactRelationships.VerifyAsync(relationship, cancellationToken)
+                    EnsureAbsent = fun relationship cancellationToken -> exactRelationships.EnsureAbsentAsync(relationship, cancellationToken)
+                    ReleaseManifest =
+                        fun relationship manifest metadata cancellationToken ->
+                            this.ReleaseManifestContribution(relationship, manifest, metadata, cancellationToken)
+                }
+
+            convergePhysicalDeletionWith dependencies directoryVersionDto metadata cancellationToken
+
+        /// Converts a retained physical-deletion disposition into a retryable actor error.
+        member private this.PhysicalDeletionError(disposition, correlationId) =
+            let message =
+                match disposition with
+                | BlockedByIncomingRelationship -> "DirectoryVersion physical deletion is blocked by a current incoming relationship."
+                | OutgoingRelationshipStillPresent -> "DirectoryVersion physical deletion retained state because outgoing exact evidence is still present."
+                | ReadyToClear -> invalidArg (nameof disposition) "Ready-to-clear physical deletion is not an error."
+
+            (GraceError.Create message correlationId)
+                .enhance ("IsRetryable", "true")
 
         override this.OnActivateAsync(ct) =
             let activateStartTime = getCurrentInstant ()
@@ -694,21 +944,25 @@ module DirectoryVersion =
                     | ReminderTypes.PhysicalDeletion, ReminderState.DirectoryVersionPhysicalDeletion reminderState ->
                         this.correlationId <- reminderState.CorrelationId
 
-                        // Delete saved state for this actor.
-                        do! state.ClearStateAsync()
+                        let metadata = EventMetadata.New reminderState.CorrelationId "DirectoryVersionPhysicalDeletionReminder"
 
-                        log.LogInformation(
-                            "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Deleted state for directory version; RepositoryId: {RepositoryId}; DirectoryVersionId: {DirectoryVersionId}; deleteReason: {deleteReason}.",
-                            getCurrentInstantExtended (),
-                            getMachineName,
-                            reminderState.CorrelationId,
-                            directoryVersionDto.DirectoryVersion.RepositoryId,
-                            directoryVersionDto.DirectoryVersion.DirectoryVersionId,
-                            reminderState.DeleteReason
-                        )
+                        match! this.ConvergePhysicalDeletion(metadata, CancellationToken.None) with
+                        | ReadyToClear ->
+                            do! state.ClearStateAsync()
 
-                        this.DeactivateOnIdle()
-                        return Ok()
+                            log.LogInformation(
+                                "{CurrentInstant}: Node: {HostName}; CorrelationId: {correlationId}; Deleted state for directory version; RepositoryId: {RepositoryId}; DirectoryVersionId: {DirectoryVersionId}; deleteReason: {deleteReason}.",
+                                getCurrentInstantExtended (),
+                                getMachineName,
+                                reminderState.CorrelationId,
+                                directoryVersionDto.DirectoryVersion.RepositoryId,
+                                directoryVersionDto.DirectoryVersion.DirectoryVersionId,
+                                reminderState.DeleteReason
+                            )
+
+                            this.DeactivateOnIdle()
+                            return Ok()
+                        | disposition -> return Error(this.PhysicalDeletionError(disposition, reminderState.CorrelationId))
                     | reminderType, state ->
                         return
                             Error(
@@ -1368,13 +1622,28 @@ module DirectoryVersion =
 
                                         return Ok(LogicalDeleted deleteReason)
                                     | DeletePhysical ->
-                                        do! state.ClearStateAsync()
-                                        this.DeactivateOnIdle()
-                                        return Ok(PhysicalDeleted)
+                                        match! this.ConvergePhysicalDeletion(metadata, CancellationToken.None) with
+                                        | ReadyToClear -> return Ok PhysicalDeleted
+                                        | disposition -> return Error(this.PhysicalDeletionError(disposition, metadata.CorrelationId))
                                     | Undelete -> return Ok(Undeleted)
                                 }
 
                             match event with
+                            | Ok PhysicalDeleted ->
+                                let directoryVersion = directoryVersionDto.DirectoryVersion
+                                let directoryVersionEvent: DirectoryVersionEvent = { Event = PhysicalDeleted; Metadata = metadata }
+                                do! publishGraceEvent (GraceEvent.DirectoryVersionEvent directoryVersionEvent) metadata
+                                do! state.ClearStateAsync()
+                                this.DeactivateOnIdle()
+
+                                return
+                                    Ok(
+                                        (GraceReturnValue.Create "Directory version command succeeded." metadata.CorrelationId)
+                                            .enhance(nameof RepositoryId, directoryVersion.RepositoryId)
+                                            .enhance(nameof DirectoryVersionId, directoryVersion.DirectoryVersionId)
+                                            .enhance(nameof Sha256Hash, directoryVersion.Sha256Hash)
+                                            .enhance (nameof DirectoryVersionEventType, getDiscriminatedUnionFullName PhysicalDeleted)
+                                    )
                             | Ok event -> return! this.ApplyEvent { Event = event; Metadata = metadata }
                             | Error error -> return Error error
                         with

--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -38,6 +38,7 @@
         <Compile Include="Organization.Actor.fs" />
         <Compile Include="OrganizationName.Actor.fs" />
         <Compile Include="NamedSection.Actor.fs" />
+        <Compile Include="ManifestContributionAccounting.Actor.fs" />
         <Compile Include="DirectoryVersion.Actor.fs" />
         <Compile Include="Reference.Actor.fs" />
         <Compile Include="Branch.Actor.fs" />
@@ -56,7 +57,6 @@
         <Compile Include="DedupeIndex.Actor.fs" />
         <Compile Include="ContentBlockMetadata.Actor.fs" />
         <Compile Include="UploadSession.Actor.fs" />
-        <Compile Include="ManifestContributionAccounting.Actor.fs" />
         <Compile Include="RepositoryContentCounter.Actor.fs" />
         <Compile Include="ManifestContributionWorkflow.Actor.fs" />
         <Compile Include="PromotionQueue.Actor.fs" />

--- a/src/Grace.Actors/Reference.Actor.fs
+++ b/src/Grace.Actors/Reference.Actor.fs
@@ -15,6 +15,7 @@ open Grace.Shared.Constants
 open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.Events
+open Grace.Types.ManifestContributionAccounting
 open Grace.Types.ManifestContributionWorkflow
 open Grace.Types.Reference
 open Grace.Types.Reminder
@@ -30,6 +31,7 @@ open System.Globalization
 open System.Security.Cryptography
 open System.Text
 open System.Text.Json
+open System.Threading
 open System.Threading.Tasks
 
 /// Groups Orleans actor helpers for reference keys, proxies, state, or workflow transitions.
@@ -284,10 +286,11 @@ module Reference =
     let planManifestSaveBoundary repositoryId referenceId (directoryVersion: DirectoryVersion) correlationId =
         planManifestSaveBoundaryForDirectoryVersions repositoryId referenceId [ directoryVersion ] correlationId
 
-    /// Completes Reference physical deletion without changing DirectoryVersion-owned manifest retention.
-    let internal completeReferencePhysicalDeletion (markBranchForRecompute: unit -> Task) (clearReferenceState: unit -> Task) =
+    /// Completes ordered Reference physical-deletion effects without changing DirectoryVersion-owned manifest retention.
+    let internal completeReferencePhysicalDeletion (removeReferenceRoot: unit -> Task) (afterRootRemoval: unit -> Task) (clearReferenceState: unit -> Task) =
         task {
-            do! markBranchForRecompute ()
+            do! removeReferenceRoot ()
+            do! afterRootRemoval ()
             do! clearReferenceState ()
         }
 
@@ -492,7 +495,11 @@ module Reference =
         }
 
     /// Implements the Orleans grain for reference actor.
-    type ReferenceActor([<PersistentState(StateName.Reference, Constants.GraceActorStorage)>] state: IPersistentState<List<ReferenceEvent>>) =
+    type ReferenceActor
+        (
+            [<PersistentState(StateName.Reference, Constants.GraceActorStorage)>] state: IPersistentState<List<ReferenceEvent>>,
+            exactRelationships: IExactRelationshipStore
+        ) =
         inherit Grain()
 
         static let actorName = ActorName.Reference
@@ -556,6 +563,23 @@ module Reference =
 
                         do!
                             completeReferencePhysicalDeletion
+                                (fun () ->
+                                    task {
+                                        let relationship =
+                                            ExactRelationship.ReferenceRoot
+                                                {
+                                                    RepositoryId = physicalDeletionReminderState.RepositoryId
+                                                    RootDirectoryVersionId = physicalDeletionReminderState.DirectoryVersionId
+                                                    ReferenceId = referenceId
+                                                }
+
+                                        let! _ = exactRelationships.EnsureAbsentAsync(relationship, CancellationToken.None)
+
+                                        match! exactRelationships.VerifyAsync(relationship, CancellationToken.None) with
+                                        | ExactRelationshipPresence.Absent -> ()
+                                        | ExactRelationshipPresence.Present ->
+                                            invalidOp $"Reference-root relationship remained present for Reference {referenceId}."
+                                    })
                                 (fun () ->
                                     // Mark the branch as needing to update its latest references.
                                     let branchActorProxy =
@@ -772,32 +796,33 @@ module Reference =
 
                 /// Runs Reference command decisions, applies emitted events, and persists the result.
                 let processCommand (command: ReferenceCommand) (metadata: EventMetadata) =
-                    /// Coordinates existing reference return value logic for the Reference actor.
-                    let existingReferenceReturnValue () =
+                    /// Builds the stable Reference response metadata for one persisted or completed event.
+                    let referenceReturnValue referenceEventType =
                         (GraceReturnValue.Create referenceDto metadata.CorrelationId)
                             .enhance(nameof RepositoryId, referenceDto.RepositoryId)
                             .enhance(nameof BranchId, referenceDto.BranchId)
                             .enhance(nameof ReferenceId, referenceDto.ReferenceId)
                             .enhance(nameof DirectoryVersionId, referenceDto.DirectoryId)
                             .enhance(nameof ReferenceType, getDiscriminatedUnionCaseName referenceDto.ReferenceType)
-                            .enhance (
-                                nameof ReferenceEventType,
-                                getDiscriminatedUnionFullName (
-                                    Created(
-                                        referenceDto.ReferenceId,
-                                        referenceDto.OwnerId,
-                                        referenceDto.OrganizationId,
-                                        referenceDto.RepositoryId,
-                                        referenceDto.BranchId,
-                                        referenceDto.DirectoryId,
-                                        referenceDto.Sha256Hash,
-                                        referenceDto.Blake3Hash,
-                                        referenceDto.ReferenceType,
-                                        referenceDto.ReferenceText,
-                                        referenceDto.Links
-                                    )
-                                )
+                            .enhance (nameof ReferenceEventType, getDiscriminatedUnionFullName referenceEventType)
+
+                    /// Coordinates existing reference return value logic for the Reference actor.
+                    let existingReferenceReturnValue () =
+                        referenceReturnValue (
+                            Created(
+                                referenceDto.ReferenceId,
+                                referenceDto.OwnerId,
+                                referenceDto.OrganizationId,
+                                referenceDto.RepositoryId,
+                                referenceDto.BranchId,
+                                referenceDto.DirectoryId,
+                                referenceDto.Sha256Hash,
+                                referenceDto.Blake3Hash,
+                                referenceDto.ReferenceType,
+                                referenceDto.ReferenceText,
+                                referenceDto.Links
                             )
+                        )
 
                     /// Reconstructs and republishes the persisted Created event for an exact matching identity retry.
                     let republishSavedCreatedEvent () =
@@ -933,7 +958,28 @@ module Reference =
 
                                         return Ok(LogicalDeleted(force, deleteReason))
                                     | DeletePhysical ->
-                                        do! completeReferencePhysicalDeletion (fun () -> Task.CompletedTask) (fun () -> state.ClearStateAsync())
+                                        let relationship =
+                                            ExactRelationship.ReferenceRoot
+                                                {
+                                                    RepositoryId = referenceDto.RepositoryId
+                                                    RootDirectoryVersionId = referenceDto.DirectoryId
+                                                    ReferenceId = referenceDto.ReferenceId
+                                                }
+
+                                        do!
+                                            completeReferencePhysicalDeletion
+                                                (fun () ->
+                                                    task {
+                                                        let! _ = exactRelationships.EnsureAbsentAsync(relationship, CancellationToken.None)
+
+                                                        match! exactRelationships.VerifyAsync(relationship, CancellationToken.None) with
+                                                        | ExactRelationshipPresence.Absent -> ()
+                                                        | ExactRelationshipPresence.Present ->
+                                                            invalidOp $"Reference-root relationship remained present for Reference {referenceDto.ReferenceId}."
+                                                    })
+                                                (fun () ->
+                                                    publishGraceEvent (GraceEvent.ReferenceEvent { Event = PhysicalDeleted; Metadata = metadata }) metadata)
+                                                (fun () -> state.ClearStateAsync())
 
                                         this.DeactivateOnIdle()
                                         return Ok PhysicalDeleted
@@ -941,6 +987,7 @@ module Reference =
                                 }
 
                             match referenceEventTypeResult with
+                            | Ok ReferenceEventType.PhysicalDeleted -> return Ok(referenceReturnValue PhysicalDeleted)
                             | Ok referenceEventType ->
                                 let referenceEvent: ReferenceEvent = { Event = referenceEventType; Metadata = metadata }
                                 return! this.ApplyEvent referenceEvent

--- a/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionAccounting.Server.Tests.fs
@@ -943,3 +943,232 @@ type ManifestContributionAccountingServerTests() =
             Assert.That(durableCount, Is.EqualTo(1))
             Assert.That(relationshipPresent, Is.True)
         }
+
+    /// Verifies a current incoming relationship blocks physical deletion before any outgoing mutation.
+    [<Test>]
+    member _.DirectoryVersionPhysicalDeletionStopsBeforeMutationWhenIncomingRelationshipExists() =
+        task {
+            let dto = currentDirectoryVersionDto ()
+
+            let incoming =
+                ExactRelationship.ReferenceRoot { RepositoryId = repositoryId; RootDirectoryVersionId = currentDirectoryVersionId; ReferenceId = referenceId }
+
+            let mutable releaseCalls = 0
+            let mutable removeCalls = 0
+
+            let dependencies: Grace.Actors.DirectoryVersion.PhysicalDeletionDependencies =
+                {
+                    EnumerateIncoming = fun _ _ _ -> Task.FromResult [| incoming |]
+                    Verify = fun _ _ -> Task.FromResult ExactRelationshipPresence.Present
+                    EnsureAbsent =
+                        fun _ _ ->
+                            removeCalls <- removeCalls + 1
+                            Task.FromResult ExactRelationshipWriteOutcome.Changed
+                    ReleaseManifest =
+                        fun _ _ _ _ ->
+                            releaseCalls <- releaseCalls + 1
+                            Task.CompletedTask
+                }
+
+            let! disposition =
+                Grace.Actors.DirectoryVersion.convergePhysicalDeletionWith
+                    dependencies
+                    dto
+                    (EventMetadata.New "directory-delete-blocked" "unit-test")
+                    CancellationToken.None
+
+            Assert.That(disposition, Is.EqualTo(Grace.Actors.DirectoryVersion.PhysicalDeletionDisposition.BlockedByIncomingRelationship))
+            Assert.That(releaseCalls, Is.Zero)
+            Assert.That(removeCalls, Is.Zero)
+        }
+
+    /// Verifies restart resumes from exact outgoing evidence after manifest release returns unknown.
+    [<Test>]
+    member _.DirectoryVersionPhysicalDeletionRetainsExactEvidenceUntilReleaseCompletes() =
+        task {
+            let dto = currentDirectoryVersionDto ()
+            let childDirectoryVersionId = Guid.Parse("88888888-7290-4000-8000-888888888888")
+            dto.DirectoryVersion.Directories.Add(childDirectoryVersionId)
+
+            let manifestRelationship =
+                ExactRelationship.DirectoryVersionManifest
+                    {
+                        RepositoryId = repositoryId
+                        StoragePoolId = storagePoolId
+                        ManifestAddress = manifestAddress
+                        DirectoryVersionId = currentDirectoryVersionId
+                    }
+
+            let childRelationship =
+                ExactRelationship.ParentChild
+                    { RepositoryId = repositoryId; ParentDirectoryVersionId = currentDirectoryVersionId; ChildDirectoryVersionId = childDirectoryVersionId }
+
+            let present =
+                HashSet<ExactRelationship>(
+                    [|
+                        manifestRelationship
+                        childRelationship
+                    |]
+                )
+
+            let calls = ResizeArray<string>()
+            let mutable releaseAttempts = 0
+
+            let dependencies: Grace.Actors.DirectoryVersion.PhysicalDeletionDependencies =
+                {
+                    EnumerateIncoming = fun _ _ _ -> Task.FromResult Array.empty
+                    Verify =
+                        fun relationship _ ->
+                            Task.FromResult(
+                                if present.Contains relationship then
+                                    ExactRelationshipPresence.Present
+                                else
+                                    ExactRelationshipPresence.Absent
+                            )
+                    EnsureAbsent =
+                        fun relationship _ ->
+                            calls.Add($"remove:{relationship}")
+                            let changed = present.Remove relationship
+
+                            Task.FromResult(
+                                if changed then
+                                    ExactRelationshipWriteOutcome.Changed
+                                else
+                                    ExactRelationshipWriteOutcome.AlreadyConverged
+                            )
+                    ReleaseManifest =
+                        fun relationship _ _ _ ->
+                            releaseAttempts <- releaseAttempts + 1
+                            calls.Add($"release:{relationship.ManifestAddress}")
+
+                            if releaseAttempts = 1 then
+                                Task.FromException(TimeoutException("counter response lost"))
+                            else
+                                Task.CompletedTask
+                }
+
+            let metadata = EventMetadata.New "directory-delete-restart" "unit-test"
+            let first = Grace.Actors.DirectoryVersion.convergePhysicalDeletionWith dependencies dto metadata CancellationToken.None
+            let _ = Assert.ThrowsAsync<TimeoutException>(Func<Task>(fun () -> first :> Task))
+
+            Assert.That(present.Contains manifestRelationship, Is.True)
+            Assert.That(present.Contains childRelationship, Is.True)
+            Assert.That(calls, Is.EqualTo<string array>([| $"release:{manifestAddress}" |]))
+
+            let! disposition = Grace.Actors.DirectoryVersion.convergePhysicalDeletionWith dependencies dto metadata CancellationToken.None
+
+            Assert.That(disposition, Is.EqualTo(Grace.Actors.DirectoryVersion.PhysicalDeletionDisposition.ReadyToClear))
+            Assert.That(present, Is.Empty)
+            Assert.That(releaseAttempts, Is.EqualTo(2))
+            Assert.That(calls[1], Is.EqualTo($"release:{manifestAddress}"))
+            Assert.That(calls[2], Does.StartWith("remove:DirectoryVersionManifest"))
+            Assert.That(calls[3], Does.StartWith("remove:ParentChild"))
+        }
+
+    /// Verifies final exact verification prevents actor-state clear when a removal has not converged.
+    [<Test>]
+    member _.DirectoryVersionPhysicalDeletionRequiresFinalOutgoingAbsence() =
+        task {
+            let dto = currentDirectoryVersionDto ()
+            let mutable verifyCalls = 0
+
+            let dependencies: Grace.Actors.DirectoryVersion.PhysicalDeletionDependencies =
+                {
+                    EnumerateIncoming = fun _ _ _ -> Task.FromResult Array.empty
+                    Verify =
+                        fun _ _ ->
+                            verifyCalls <- verifyCalls + 1
+                            Task.FromResult ExactRelationshipPresence.Present
+                    EnsureAbsent = fun _ _ -> Task.FromResult ExactRelationshipWriteOutcome.Changed
+                    ReleaseManifest = fun _ _ _ _ -> Task.CompletedTask
+                }
+
+            let! disposition =
+                Grace.Actors.DirectoryVersion.convergePhysicalDeletionWith
+                    dependencies
+                    dto
+                    (EventMetadata.New "directory-delete-final-verify" "unit-test")
+                    CancellationToken.None
+
+            Assert.That(disposition, Is.EqualTo(Grace.Actors.DirectoryVersion.PhysicalDeletionDisposition.OutgoingRelationshipStillPresent))
+            Assert.That(verifyCalls, Is.EqualTo(2))
+        }
+
+    /// Verifies an unknown exact-removal outcome stops deletion before later outgoing evidence is removed.
+    [<Test>]
+    member _.DirectoryVersionPhysicalDeletionStopsAfterUnknownExactRemoval() =
+        task {
+            let dto = currentDirectoryVersionDto ()
+            let childDirectoryVersionId = Guid.Parse("99999999-7290-4000-8000-999999999999")
+            dto.DirectoryVersion.Directories.Add(childDirectoryVersionId)
+
+            let mutable releaseCalls = 0
+            let mutable removeCalls = 0
+
+            let dependencies: Grace.Actors.DirectoryVersion.PhysicalDeletionDependencies =
+                {
+                    EnumerateIncoming = fun _ _ _ -> Task.FromResult Array.empty
+                    Verify = fun _ _ -> Task.FromResult ExactRelationshipPresence.Present
+                    EnsureAbsent =
+                        fun _ _ ->
+                            removeCalls <- removeCalls + 1
+                            Task.FromException<ExactRelationshipWriteOutcome>(TimeoutException("exact removal response lost"))
+                    ReleaseManifest =
+                        fun _ _ _ _ ->
+                            releaseCalls <- releaseCalls + 1
+                            Task.CompletedTask
+                }
+
+            let deletion =
+                Grace.Actors.DirectoryVersion.convergePhysicalDeletionWith
+                    dependencies
+                    dto
+                    (EventMetadata.New "directory-delete-exact-unknown" "unit-test")
+                    CancellationToken.None
+
+            let _ = Assert.ThrowsAsync<TimeoutException>(Func<Task>(fun () -> deletion :> Task))
+
+            Assert.That(releaseCalls, Is.EqualTo(1))
+            Assert.That(removeCalls, Is.EqualTo(1), "The child relationship must remain untouched after the manifest removal is unknown.")
+        }
+
+    /// Verifies a DirectoryVersion with no outgoing evidence clears after exactly one incoming check.
+    [<Test>]
+    member _.DirectoryVersionPhysicalDeletionConvergesWithoutOutgoingEvidence() =
+        task {
+            let dto = currentDirectoryVersionDto ()
+            dto.DirectoryVersion.Files.Clear()
+            let mutable incomingChecks = 0
+            let mutable outgoingCalls = 0
+
+            let dependencies: Grace.Actors.DirectoryVersion.PhysicalDeletionDependencies =
+                {
+                    EnumerateIncoming =
+                        fun _ _ _ ->
+                            incomingChecks <- incomingChecks + 1
+                            Task.FromResult Array.empty
+                    Verify =
+                        fun _ _ ->
+                            outgoingCalls <- outgoingCalls + 1
+                            Task.FromResult ExactRelationshipPresence.Absent
+                    EnsureAbsent =
+                        fun _ _ ->
+                            outgoingCalls <- outgoingCalls + 1
+                            Task.FromResult ExactRelationshipWriteOutcome.AlreadyConverged
+                    ReleaseManifest =
+                        fun _ _ _ _ ->
+                            outgoingCalls <- outgoingCalls + 1
+                            Task.CompletedTask
+                }
+
+            let! disposition =
+                Grace.Actors.DirectoryVersion.convergePhysicalDeletionWith
+                    dependencies
+                    dto
+                    (EventMetadata.New "directory-delete-no-outgoing" "unit-test")
+                    CancellationToken.None
+
+            Assert.That(disposition, Is.EqualTo(Grace.Actors.DirectoryVersion.PhysicalDeletionDisposition.ReadyToClear))
+            Assert.That(incomingChecks, Is.EqualTo(1))
+            Assert.That(outgoingCalls, Is.Zero)
+        }

--- a/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Reference.Actor.Tests.fs
@@ -490,6 +490,9 @@ type ReferenceActorHashValidationTests() =
                 do!
                     completeReferencePhysicalDeletion
                         (fun () ->
+                            calls.Add($"remove-root:{getDiscriminatedUnionCaseName referenceType}")
+                            Task.CompletedTask)
+                        (fun () ->
                             calls.Add($"mark:{getDiscriminatedUnionCaseName referenceType}")
                             Task.CompletedTask)
                         (fun () ->
@@ -500,9 +503,32 @@ type ReferenceActorHashValidationTests() =
                     calls,
                     Is.EqualTo<string array>(
                         [|
+                            $"remove-root:{getDiscriminatedUnionCaseName referenceType}"
                             $"mark:{getDiscriminatedUnionCaseName referenceType}"
                             $"clear:{getDiscriminatedUnionCaseName referenceType}"
                         |]
                     )
                 )
+        }
+
+    /// Verifies an unknown Reference-root removal prevents later physical-deletion effects.
+    [<Test>]
+    member _.ReferencePhysicalDeletionStopsWhenRootRemovalIsUnknown() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let deletion =
+                completeReferencePhysicalDeletion
+                    (fun () ->
+                        calls.Add("remove-root")
+                        Task.FromException(TimeoutException("exact removal response lost")))
+                    (fun () ->
+                        calls.Add("mark")
+                        Task.CompletedTask)
+                    (fun () ->
+                        calls.Add("clear")
+                        Task.CompletedTask)
+
+            let _ = Assert.ThrowsAsync<TimeoutException>(Func<Task>(fun () -> deletion :> Task))
+            Assert.That(calls, Is.EqualTo<string array>([| "remove-root" |]))
         }

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -2083,6 +2083,10 @@ module Application =
                     new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort, redisLog) :> IRepositoryCounterRecentResult)
             |> ignore
 
+            services.AddSingleton<IExactRelationshipStore> (fun _ ->
+                ManifestContributionAccounting.CosmosExactRelationshipStore(ApplicationContext.cosmosContainer) :> IExactRelationshipStore)
+            |> ignore
+
             let apiVersioningBuilder =
                 services.AddApiVersioning (fun options ->
                     options.ReportApiVersions <- true


### PR DESCRIPTION
# DirectoryVersion deletion

## Purpose

Make DirectoryVersion physical deletion retain-first and restart-safe while preserving the small asynchronous Reference
success path and avoiding new durable coordination state.

Relates to #733. Parent epic: #727.

## Changes

- Check current exact incoming relationships once before physical DirectoryVersion deletion.
- Keep exact outgoing evidence until matching repository-count and 1-to-0 release work is known complete.
- Remove and verify direct manifest and parent-child evidence before clearing actor state.
- Make direct and reminder deletion use the same no-ledger convergence path.
- Remove and verify a Reference's exact root relationship before Reference physical state clear, uniformly across every
  `ReferenceType`, without changing DirectoryVersion-owned manifest retention.
- Preserve existing `PhysicalDeleted` publication and response metadata without re-persisting cleared state.
- Update nearby lifecycle documentation.

No new durable deletion state, Redis dependency, migration behavior, public contract, or `ReferenceType` specialization
was added.

## Validation

- RED Release build proved the missing deletion dependencies and callbacks: expected semantic failure in 44.61 seconds.
- Final Release build: passed with 0 warnings/errors.
- Manifest contribution accounting fixture: 17/17 passed in 154 ms.
- Reference actor fixture: 16/16 passed in 217 ms.
- Fantomas: passed.
- MarkdownLint: passed with 0 errors.
- `git diff --check`: passed.
- Bot-prevention self-review caught and fixed direct `PhysicalDeleted` publication/response preservation before push.
- Aspire: not started; hosted Cosmos/Orleans interruption and activation proof remains the current proof gap.

## Review Status

- Implementation/fix-worker starts: 1/4.
- Aspire starts: 0/3.
- Codex review sessions: 1/3.
- Current head: `52aae653a11170dbf159ce5e09564240dc53ede7`.
- GitHub Validate: Full passed on run `30313307691`.
- Codex Code Review Bot: session 1/3 completed; two owner-contract findings received no-code dispositions, and both
  threads are resolved.
- Hosted mid-deletion witness: skipped. Full covers real DI/Cosmos activation and restart smoke. A truthful
  mid-deletion interruption would require brittle persisted-state fabrication or a new production fault seam.
  Deterministic partial-state unit proof remains the selected evidence.
