### PR TITLE
Add bounded manifest contribution diagnosis

### DIFF
--- a/docs/Manifest contribution diagnosis.md
+++ b/docs/Manifest contribution diagnosis.md
@@ -142,8 +142,6 @@ The diagnostic can emit the following repair target prefixes:
 - `RemoveStaleExactRelationship:` identifies an exact relationship whose source DirectoryVersion no longer supports
   it.
 - `ReconcileCounter:` identifies a repository manifest counter that differs from a complete actor rebuild.
-- `ResumeManifestContributionWorkflow:` identifies unfinished or failed ContentBlock fan-out for one repository
-  manifest.
 - `DiagnoseReadableSourceRequired:` means the selector cannot identify a complete missing set. Supply a readable
   Reference or DirectoryVersion before attempting repair.
 

--- a/docs/Manifest contribution diagnosis.md
+++ b/docs/Manifest contribution diagnosis.md
@@ -119,8 +119,8 @@ itself.
 Start with these fields:
 
 - `Outcome` gives the terminal result.
-- `ReclamationPermitted` is `true` only when source-backed evidence is complete and all relevant stored and rebuilt
-  counts are zero.
+- No diagnosis report field positively authorizes reclamation. The supported selectors cannot prove global absence;
+  `Outcome` classifies bounded evidence for investigation and repair only.
 - `EvidenceGaps` explains what Grace could not prove.
 - `UnknownFields` names report facts that cannot be complete for this selector.
 - `MissingRelationships` lists actor-supported relationships absent from the exact projection.
@@ -153,6 +153,9 @@ belong to the manifest contribution repair workflow tracked by Grace issue #735.
 `MaxRelationships` applies cumulatively to distinct exact relationships verified or enumerated by the request. If the
 diagnostic encounters another relationship after reaching the limit, the route rejects the request rather than
 returning a report that looks complete.
+
+If source discovery consumes the full allowance before exact enumeration starts, Grace does not issue an unbudgeted
+probe. The report remains `IncompleteRetain` and records the missing enumeration evidence.
 
 Increase the bound only when the selected target is understood and remains operationally safe. The maximum is 5000.
 The diagnostic has no repository-wide default scan.

--- a/docs/Manifest contribution diagnosis.md
+++ b/docs/Manifest contribution diagnosis.md
@@ -1,0 +1,182 @@
+# Manifest contribution diagnosis
+
+Grace provides a bounded, read-only diagnostic for manifest contribution accounting. Use it when a repository manifest
+counter, exact relationship, or background contribution workflow appears inconsistent.
+
+The diagnostic does not repair or delete anything. It reads current actor state, exact relationships, counters,
+workflows, and optional short-lived Redis evidence. It then writes a self-verifying JSON report for the operator.
+
+## Requirements
+
+- A running Grace Server
+- A bearer token with `SystemAdmin`
+- PowerShell 7
+- One target selector
+- An explicit relationship limit from 1 through 5000
+- An existing output directory
+
+Set the server and token before running the script.
+
+PowerShell:
+
+```powershell
+$env:GRACE_SERVER_URI = "http://localhost:5000"
+$env:GRACE_TOKEN = "<system-admin-token>"
+```
+
+bash / zsh:
+
+```bash
+export GRACE_SERVER_URI="http://localhost:5000"
+export GRACE_TOKEN="<system-admin-token>"
+```
+
+The script never prints the token or writes it into the report.
+
+## Diagnose one target
+
+Choose exactly one of the following selector forms.
+
+### Reference
+
+Use a Reference when you want Grace to rebuild expected relationships from the Reference's current root
+DirectoryVersion and its reachable DirectoryVersions.
+
+```powershell
+pwsh ./scripts/diagnose-manifest-contribution.ps1 `
+  -RepositoryId 11111111-1111-1111-1111-111111111111 `
+  -ReferenceId 22222222-2222-2222-2222-222222222222 `
+  -MaxRelationships 5000 `
+  -OutputPath ./artifacts/manifest-contribution-reference.json
+```
+
+`RepositoryId` is an optional qualifier for a Reference. When supplied, the current Reference actor must belong to that
+Repository.
+
+### DirectoryVersion
+
+Use a DirectoryVersion when you want Grace to rebuild expected relationships from that current DirectoryVersion and
+its reachable subtree.
+
+```powershell
+pwsh ./scripts/diagnose-manifest-contribution.ps1 `
+  -RepositoryId 11111111-1111-1111-1111-111111111111 `
+  -DirectoryVersionId 33333333-3333-3333-3333-333333333333 `
+  -MaxRelationships 5000 `
+  -OutputPath ./artifacts/manifest-contribution-directory-version.json
+```
+
+`RepositoryId` is an optional qualifier for a DirectoryVersion.
+
+### Repository manifest counter
+
+Use the complete counter tuple when the suspicious item is already known.
+
+```powershell
+pwsh ./scripts/diagnose-manifest-contribution.ps1 `
+  -RepositoryId 11111111-1111-1111-1111-111111111111 `
+  -StoragePoolId default `
+  -ManifestAddress 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef `
+  -MaxRelationships 5000 `
+  -OutputPath ./artifacts/manifest-contribution-counter.json
+```
+
+A counter tuple has no source actor from which Grace can discover relationships that are missing from the exact
+projection. Grace therefore reports all bounded facts it can read but returns `IncompleteRetain`.
+
+### Counter operation
+
+Use a deterministic repository counter operation identity when it is the only known starting point.
+
+```powershell
+pwsh ./scripts/diagnose-manifest-contribution.ps1 `
+  -RepositoryContentCounterOperationId `
+    "directory-version:33333333333333333333333333333333:default:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef:add" `
+  -MaxRelationships 5000 `
+  -OutputPath ./artifacts/manifest-contribution-operation.json
+```
+
+The operation must use Grace's current `directory-version:<id>:<pool>:<manifest>:add|remove` form. Grace reads the
+named DirectoryVersion and uses current actor state to check the operation identity. One operation still cannot prove
+that every possible source actor is known, so its terminal result remains conservative.
+
+## Exit codes
+
+The script writes the complete JSON report atomically and verifies its SHA-256 before returning codes 0, 2, or 3.
+
+| Code | Outcome | Meaning |
+| ---: | --- | --- |
+| 0 | `VerifiedComplete` | Bounded source-backed reads were complete and the observed evidence agrees. |
+| 2 | `IncompleteRetain` | Useful evidence was collected, but Grace cannot safely claim completeness. Retain data. |
+| 3 | `FailedRetain` | The selected source could not produce a usable current diagnosis. Retain data. |
+| 4 | No trusted report | Input, authorization, transport, bound, response, SHA-256, or file writing failed. |
+
+Treat every nonzero result as a reason to retain the manifest and investigate. The route never authorizes deletion by
+itself.
+
+## Read the report
+
+Start with these fields:
+
+- `Outcome` gives the terminal result.
+- `ReclamationPermitted` is `true` only when source-backed evidence is complete and all relevant stored and rebuilt
+  counts are zero.
+- `EvidenceGaps` explains what Grace could not prove.
+- `UnknownFields` names report facts that cannot be complete for this selector.
+- `MissingRelationships` lists actor-supported relationships absent from the exact projection.
+- `StaleRelationships` lists projected relationships no longer supported by the source DirectoryVersion actor.
+- `CountEvidence` compares each durable counter with a complete actor rebuild when one is possible.
+- `ActorFacts` contains every actor snapshot read by the diagnostic.
+- `RedisEvidence` reports the optional recent operation result. `AbsentOrUnavailable` does not hide durable evidence.
+- `RepairTargets` identifies the exact follow-up operation without executing it.
+- `ReportSha256` protects the complete report content. The script verifies it before replacing `OutputPath`.
+
+Actor snapshots are observations made during the bounded diagnostic. They are not a transaction or a durable audit
+record.
+
+## Interpret repair targets
+
+The diagnostic can emit the following repair target prefixes:
+
+- `GetOrAddExactRelationship:` identifies an actor-supported exact relationship that is missing.
+- `RemoveStaleExactRelationship:` identifies an exact relationship whose source DirectoryVersion no longer supports
+  it.
+- `ReconcileCounter:` identifies a repository manifest counter that differs from a complete actor rebuild.
+- `ResumeManifestContributionWorkflow:` identifies unfinished or failed ContentBlock fan-out for one repository
+  manifest.
+- `DiagnoseReadableSourceRequired:` means the selector cannot identify a complete missing set. Supply a readable
+  Reference or DirectoryVersion before attempting repair.
+
+Do not translate an `IncompleteRetain` report into a guessed repair. The repair commands and their verification steps
+belong to the manifest contribution repair workflow tracked by Grace issue #735.
+
+## Bound failures
+
+`MaxRelationships` applies cumulatively to distinct exact relationships verified or enumerated by the request. If the
+diagnostic encounters another relationship after reaching the limit, the route rejects the request rather than
+returning a report that looks complete.
+
+Increase the bound only when the selected target is understood and remains operationally safe. The maximum is 5000.
+The diagnostic has no repository-wide default scan.
+
+## Troubleshooting
+
+### HTTP 401 or 403
+
+Confirm `GRACE_TOKEN` is current and grants `SystemAdmin` on `System`. The route is intentionally absent from public
+OpenAPI and generated Grace clients.
+
+### Exit code 3 for Reference or DirectoryVersion
+
+Confirm the identifier and optional Repository qualifier. A cleared, deleted, empty, or mismatched source cannot
+support a complete rebuild.
+
+### Redis says `AbsentOrUnavailable`
+
+Continue with the durable actor, exact relationship, counter, and workflow evidence in the report. Redis only holds a
+short-lived recent-operation result and is not a source of manifest membership.
+
+### The output file did not change
+
+The script replaces the requested file only after receiving a successful response, verifying its SHA-256, and mapping
+the outcome. Invocation failures return exit code 4 and preserve the prior report.

--- a/scripts/diagnose-manifest-contribution.ps1
+++ b/scripts/diagnose-manifest-contribution.ps1
@@ -92,7 +92,7 @@ function Test-ReportSha256 {
         $document.AsObject().Remove('ReportSha256') | Out-Null
         $unsignedJson = $document.ToJsonString()
         $bytes = [Text.Encoding]::UTF8.GetBytes($unsignedJson)
-        $computedHash = [Convert]::ToHexStringLower([Security.Cryptography.SHA256]::HashData($bytes))
+        $computedHash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
 
         return [string]::Equals($reportedHash, $computedHash, [StringComparison]::OrdinalIgnoreCase)
     }

--- a/scripts/diagnose-manifest-contribution.ps1
+++ b/scripts/diagnose-manifest-contribution.ps1
@@ -223,7 +223,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         exit $result
     }
     catch {
-        Write-Error $_.Exception.Message
+        [Console]::Error.WriteLine($_.Exception.Message)
         exit 4
     }
 }

--- a/scripts/diagnose-manifest-contribution.ps1
+++ b/scripts/diagnose-manifest-contribution.ps1
@@ -1,0 +1,229 @@
+[CmdletBinding(DefaultParameterSetName = 'Reference')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Reference')]
+    [ValidateNotNullOrEmpty()]
+    [string] $ReferenceId,
+
+    [Parameter(Mandatory, ParameterSetName = 'DirectoryVersion')]
+    [ValidateNotNullOrEmpty()]
+    [string] $DirectoryVersionId,
+
+    [Parameter(ParameterSetName = 'Reference')]
+    [Parameter(ParameterSetName = 'DirectoryVersion')]
+    [Parameter(Mandatory, ParameterSetName = 'Counter')]
+    [ValidateNotNullOrEmpty()]
+    [string] $RepositoryId,
+
+    [Parameter(Mandatory, ParameterSetName = 'Counter')]
+    [ValidateNotNullOrEmpty()]
+    [string] $StoragePoolId,
+
+    [Parameter(Mandatory, ParameterSetName = 'Counter')]
+    [ValidateNotNullOrEmpty()]
+    [string] $ManifestAddress,
+
+    [Parameter(Mandatory, ParameterSetName = 'Operation')]
+    [ValidateNotNullOrEmpty()]
+    [string] $RepositoryContentCounterOperationId,
+
+    [Parameter(Mandatory)]
+    [ValidateRange(1, 5000)]
+    [int] $MaxRelationships,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $OutputPath
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Test-NonEmptyGuid {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [string] $Value
+    )
+
+    $parsed = [guid]::Empty
+
+    if (-not [guid]::TryParse($Value, [ref] $parsed) -or $parsed -eq [guid]::Empty) {
+        throw "$Name must be a non-empty GUID."
+    }
+}
+
+function Get-ValidatedOutputPath {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    $fullPath = [IO.Path]::GetFullPath($Path)
+
+    if (Test-Path -LiteralPath $fullPath -PathType Container) {
+        throw "OutputPath must name a JSON file, not a directory: $fullPath"
+    }
+
+    $parent = Split-Path -Parent $fullPath
+
+    if ([string]::IsNullOrWhiteSpace($parent) -or -not (Test-Path -LiteralPath $parent -PathType Container)) {
+        throw "OutputPath parent directory does not exist: $parent"
+    }
+
+    return $fullPath
+}
+
+function Test-ReportSha256 {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Json
+    )
+
+    try {
+        $document = [Text.Json.Nodes.JsonNode]::Parse($Json)
+        $reportedHash = $document['ReportSha256'].GetValue[string]()
+
+        if ([string]::IsNullOrWhiteSpace($reportedHash) -or $reportedHash.Length -ne 64) {
+            return $false
+        }
+
+        $document.AsObject().Remove('ReportSha256') | Out-Null
+        $unsignedJson = $document.ToJsonString()
+        $bytes = [Text.Encoding]::UTF8.GetBytes($unsignedJson)
+        $computedHash = [Convert]::ToHexStringLower([Security.Cryptography.SHA256]::HashData($bytes))
+
+        return [string]::Equals($reportedHash, $computedHash, [StringComparison]::OrdinalIgnoreCase)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Get-DiagnosisExitCode {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Outcome
+    )
+
+    switch ($Outcome.ToLowerInvariant()) {
+        'verifiedcomplete' { return 0 }
+        'incompleteretain' { return 2 }
+        'failedretain' { return 3 }
+        default { throw "The server returned an unknown diagnosis outcome: $Outcome" }
+    }
+}
+
+function Invoke-ManifestContributionDiagnosis {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $BoundParameters,
+
+        [Parameter(Mandatory)]
+        [string] $ParameterSetName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($env:GRACE_SERVER_URI)) {
+        throw 'GRACE_SERVER_URI must contain the Grace Server base URI.'
+    }
+
+    $serverUri = $null
+
+    if (-not [uri]::TryCreate($env:GRACE_SERVER_URI, [UriKind]::Absolute, [ref] $serverUri) -or
+        $serverUri.Scheme -notin @('http', 'https')) {
+        throw 'GRACE_SERVER_URI must be an absolute HTTP or HTTPS URI.'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:GRACE_TOKEN)) {
+        throw 'GRACE_TOKEN must contain a SystemAdmin bearer token.'
+    }
+
+    switch ($ParameterSetName) {
+        'Reference' {
+            Test-NonEmptyGuid -Name 'ReferenceId' -Value $BoundParameters.ReferenceId
+
+            if ($BoundParameters.ContainsKey('RepositoryId')) {
+                Test-NonEmptyGuid -Name 'RepositoryId' -Value $BoundParameters.RepositoryId
+            }
+        }
+        'DirectoryVersion' {
+            Test-NonEmptyGuid -Name 'DirectoryVersionId' -Value $BoundParameters.DirectoryVersionId
+
+            if ($BoundParameters.ContainsKey('RepositoryId')) {
+                Test-NonEmptyGuid -Name 'RepositoryId' -Value $BoundParameters.RepositoryId
+            }
+        }
+        'Counter' {
+            Test-NonEmptyGuid -Name 'RepositoryId' -Value $BoundParameters.RepositoryId
+        }
+        'Operation' {
+            if ([string]::IsNullOrWhiteSpace($BoundParameters.RepositoryContentCounterOperationId)) {
+                throw 'RepositoryContentCounterOperationId must not be empty.'
+            }
+        }
+        default {
+            throw "Unsupported selector parameter set: $ParameterSetName"
+        }
+    }
+
+    $validatedOutputPath = Get-ValidatedOutputPath -Path $BoundParameters.OutputPath
+
+    $body = @{
+        ReferenceId = if ($BoundParameters.ContainsKey('ReferenceId')) { $BoundParameters.ReferenceId } else { '' }
+        DirectoryVersionId = if ($BoundParameters.ContainsKey('DirectoryVersionId')) { $BoundParameters.DirectoryVersionId } else { '' }
+        RepositoryId = if ($BoundParameters.ContainsKey('RepositoryId')) { $BoundParameters.RepositoryId } else { '' }
+        StoragePoolId = if ($BoundParameters.ContainsKey('StoragePoolId')) { $BoundParameters.StoragePoolId } else { '' }
+        ManifestAddress = if ($BoundParameters.ContainsKey('ManifestAddress')) { $BoundParameters.ManifestAddress } else { '' }
+        RepositoryContentCounterOperationId =
+            if ($BoundParameters.ContainsKey('RepositoryContentCounterOperationId')) {
+                $BoundParameters.RepositoryContentCounterOperationId
+            }
+            else {
+                ''
+            }
+        MaxRelationships = $BoundParameters.MaxRelationships
+    } | ConvertTo-Json -Compress
+
+    $routeUri = [uri]::new($serverUri, '/admin/manifest-contribution/diagnose')
+    $headers = @{ Authorization = "Bearer $($env:GRACE_TOKEN)" }
+    $response = Invoke-WebRequest -Uri $routeUri -Method Post -Headers $headers -ContentType 'application/json' -Body $body -SkipHttpErrorCheck
+
+    if ($response.StatusCode -lt 200 -or $response.StatusCode -ge 300) {
+        throw "Grace Server returned HTTP $($response.StatusCode) for manifest contribution diagnosis."
+    }
+
+    $json = $response.Content
+
+    if (-not (Test-ReportSha256 -Json $json)) {
+        throw 'The diagnosis report SHA-256 is missing or does not match the complete response.'
+    }
+
+    $report = $json | ConvertFrom-Json
+    $exitCode = Get-DiagnosisExitCode -Outcome ([string] $report.Outcome)
+    $temporaryPath = Join-Path (Split-Path -Parent $validatedOutputPath) ".$([IO.Path]::GetFileName($validatedOutputPath)).$([guid]::NewGuid().ToString('N')).tmp"
+
+    try {
+        [IO.File]::WriteAllText($temporaryPath, $json, [Text.UTF8Encoding]::new($false))
+        Move-Item -LiteralPath $temporaryPath -Destination $validatedOutputPath -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporaryPath) {
+            Remove-Item -LiteralPath $temporaryPath -Force
+        }
+    }
+
+    Write-Host "Manifest contribution diagnosis wrote a verified report to '$validatedOutputPath'."
+    return $exitCode
+}
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        $result = Invoke-ManifestContributionDiagnosis -BoundParameters $PSBoundParameters -ParameterSetName $PSCmdlet.ParameterSetName
+        exit $result
+    }
+    catch {
+        Write-Error $_.Exception.Message
+        exit 4
+    }
+}

--- a/scripts/tests/diagnose-manifest-contribution.Tests.ps1
+++ b/scripts/tests/diagnose-manifest-contribution.Tests.ps1
@@ -21,6 +21,45 @@ function Assert-True {
 $scriptPath = Join-Path $PSScriptRoot '..\diagnose-manifest-contribution.ps1'
 $outputPath = Join-Path ([IO.Path]::GetTempPath()) 'manifest-contribution-diagnosis-test.json'
 
+function Invoke-DiagnosisChildProcess {
+    param(
+        [Parameter(Mandatory)]
+        [string] $FilePath,
+
+        [Parameter(Mandatory)]
+        [string[]] $ArgumentList
+    )
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = (Get-Process -Id $PID).Path
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.Environment['GRACE_SERVER_URI'] = 'https://diagnosis.invalid'
+    $startInfo.Environment['GRACE_TOKEN'] = 'focused-system-admin-token'
+    $startInfo.ArgumentList.Add('-NoProfile')
+    $startInfo.ArgumentList.Add('-NonInteractive')
+    $startInfo.ArgumentList.Add('-File')
+    $startInfo.ArgumentList.Add($FilePath)
+
+    foreach ($argument in $ArgumentList) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $process.Start() | Out-Null
+    $standardOutput = $process.StandardOutput.ReadToEnd()
+    $standardError = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+
+    return [pscustomobject] @{
+        ExitCode = $process.ExitCode
+        Output = $standardOutput
+        Error = $standardError
+    }
+}
+
 . $scriptPath `
     -ReferenceId '11111111-1111-1111-1111-111111111111' `
     -MaxRelationships 1 `
@@ -54,5 +93,108 @@ catch {
 }
 
 Assert-True -Condition $invalidGuidRejected -Message 'An empty GUID must be rejected before any HTTP request.'
+
+$childTestDirectory = Join-Path ([IO.Path]::GetTempPath()) "grace-diagnosis-process-$([guid]::NewGuid().ToString('N'))"
+[IO.Directory]::CreateDirectory($childTestDirectory) | Out-Null
+
+try {
+    $childOutputPath = Join-Path $childTestDirectory 'report.json'
+    $localValidation = Invoke-DiagnosisChildProcess `
+        -FilePath $scriptPath `
+        -ArgumentList @(
+            '-ReferenceId', 'not-a-guid',
+            '-MaxRelationships', '1',
+            '-OutputPath', $childOutputPath
+        )
+
+    Assert-True -Condition ($localValidation.ExitCode -eq 4) `
+        -Message "Local validation failures must exit 4, got $($localValidation.ExitCode). Error: $($localValidation.Error)"
+    Assert-True -Condition ($localValidation.Error -match 'ReferenceId must be a non-empty GUID') `
+        -Message 'Local validation failures must print useful error text.'
+
+    $wrapperPath = Join-Path $childTestDirectory 'invoke-diagnosis-failure.ps1'
+    $wrapper = @'
+param(
+    [Parameter(Mandatory)]
+    [string] $TargetScript,
+
+    [Parameter(Mandatory)]
+    [ValidateSet('Transport', 'Digest', 'FileWrite')]
+    [string] $Mode,
+
+    [Parameter(Mandatory)]
+    [string] $OutputPath
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function New-SignedReportJson {
+    $unsignedJson = '{"SchemaVersion":"grace.manifest-contribution-diagnosis.v1","Outcome":"IncompleteRetain"}'
+    $bytes = [Text.Encoding]::UTF8.GetBytes($unsignedJson)
+    $hash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+    $signed = [Text.Json.Nodes.JsonNode]::Parse($unsignedJson)
+    $signed['ReportSha256'] = $hash
+    return $signed.ToJsonString()
+}
+
+switch ($Mode) {
+    'Transport' {
+        function global:Invoke-WebRequest {
+            throw 'Focused transport failure.'
+        }
+    }
+    'Digest' {
+        function global:Invoke-WebRequest {
+            return [pscustomobject] @{
+                StatusCode = 200
+                Content = '{"Outcome":"IncompleteRetain","ReportSha256":"invalid"}'
+            }
+        }
+    }
+    'FileWrite' {
+        $script:responseJson = New-SignedReportJson
+
+        function global:Invoke-WebRequest {
+            return [pscustomobject] @{
+                StatusCode = 200
+                Content = $script:responseJson
+            }
+        }
+
+        function global:Move-Item {
+            throw 'Focused file replacement failure.'
+        }
+    }
+}
+
+& $TargetScript `
+    -ReferenceId '11111111-1111-1111-1111-111111111111' `
+    -MaxRelationships 1 `
+    -OutputPath $OutputPath
+
+exit $LASTEXITCODE
+'@
+
+    [IO.File]::WriteAllText($wrapperPath, $wrapper, [Text.UTF8Encoding]::new($false))
+
+    foreach ($mode in @('Transport', 'Digest', 'FileWrite')) {
+        $failure = Invoke-DiagnosisChildProcess `
+            -FilePath $wrapperPath `
+            -ArgumentList @(
+                '-TargetScript', $scriptPath,
+                '-Mode', $mode,
+                '-OutputPath', $childOutputPath
+            )
+
+        Assert-True -Condition ($failure.ExitCode -eq 4) `
+            -Message "$mode failures must exit 4, got $($failure.ExitCode). Error: $($failure.Error)"
+        Assert-True -Condition (-not [string]::IsNullOrWhiteSpace($failure.Error)) `
+            -Message "$mode failures must print useful error text."
+    }
+}
+finally {
+    Remove-Item -LiteralPath $childTestDirectory -Recurse -Force
+}
 
 Write-Output 'diagnose-manifest-contribution.ps1 focused tests passed.'

--- a/scripts/tests/diagnose-manifest-contribution.Tests.ps1
+++ b/scripts/tests/diagnose-manifest-contribution.Tests.ps1
@@ -32,7 +32,7 @@ Assert-True -Condition ((Get-DiagnosisExitCode -Outcome 'failedRetain') -eq 3) -
 
 $unsignedJson = '{"SchemaVersion":"grace.manifest-contribution-diagnosis.v1","Outcome":"incompleteRetain"}'
 $unsignedBytes = [Text.Encoding]::UTF8.GetBytes($unsignedJson)
-$hash = [Convert]::ToHexStringLower([Security.Cryptography.SHA256]::HashData($unsignedBytes))
+$hash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($unsignedBytes)).ToLowerInvariant()
 $signed = [Text.Json.Nodes.JsonNode]::Parse($unsignedJson)
 $signed['ReportSha256'] = $hash
 $signedJson = $signed.ToJsonString()

--- a/scripts/tests/diagnose-manifest-contribution.Tests.ps1
+++ b/scripts/tests/diagnose-manifest-contribution.Tests.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)]
+        [bool] $Condition,
+
+        [Parameter(Mandatory)]
+        [string] $Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+$scriptPath = Join-Path $PSScriptRoot '..\diagnose-manifest-contribution.ps1'
+$outputPath = Join-Path ([IO.Path]::GetTempPath()) 'manifest-contribution-diagnosis-test.json'
+
+. $scriptPath `
+    -ReferenceId '11111111-1111-1111-1111-111111111111' `
+    -MaxRelationships 1 `
+    -OutputPath $outputPath
+
+Assert-True -Condition ((Get-DiagnosisExitCode -Outcome 'verifiedComplete') -eq 0) -Message 'VerifiedComplete must map to exit code 0.'
+Assert-True -Condition ((Get-DiagnosisExitCode -Outcome 'incompleteRetain') -eq 2) -Message 'IncompleteRetain must map to exit code 2.'
+Assert-True -Condition ((Get-DiagnosisExitCode -Outcome 'failedRetain') -eq 3) -Message 'FailedRetain must map to exit code 3.'
+
+$unsignedJson = '{"SchemaVersion":"grace.manifest-contribution-diagnosis.v1","Outcome":"incompleteRetain"}'
+$unsignedBytes = [Text.Encoding]::UTF8.GetBytes($unsignedJson)
+$hash = [Convert]::ToHexStringLower([Security.Cryptography.SHA256]::HashData($unsignedBytes))
+$signed = [Text.Json.Nodes.JsonNode]::Parse($unsignedJson)
+$signed['ReportSha256'] = $hash
+$signedJson = $signed.ToJsonString()
+
+Assert-True -Condition (Test-ReportSha256 -Json $signedJson) -Message 'A matching report SHA-256 must verify.'
+Assert-True -Condition (-not (Test-ReportSha256 -Json ($signedJson.Replace('incompleteRetain', 'failedRetain')))) `
+    -Message 'Changing signed report content must fail SHA-256 verification.'
+
+$validatedPath = Get-ValidatedOutputPath -Path $outputPath
+Assert-True -Condition ([IO.Path]::IsPathFullyQualified($validatedPath)) -Message 'OutputPath validation must produce an absolute path.'
+
+$invalidGuidRejected = $false
+
+try {
+    Test-NonEmptyGuid -Name 'ReferenceId' -Value ([guid]::Empty.ToString())
+}
+catch {
+    $invalidGuidRejected = $true
+}
+
+Assert-True -Condition $invalidGuidRejected -Message 'An empty GUID must be rejected before any HTTP request.'
+
+Write-Output 'diagnose-manifest-contribution.ps1 focused tests passed.'

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -46,6 +46,7 @@
     <Compile Include="ManifestContributionWorkflow.Actor.Tests.fs" />
     <Compile Include="Reminder.Actor.Tests.fs" />
     <Compile Include="ManifestContributionAccounting.Server.Tests.fs" />
+    <Compile Include="ManifestContributionDiagnosis.Server.Tests.fs" />
     <Compile Include="RepositoryCounterRecentResult.Server.Tests.fs" />
     <Compile Include="Reference.Actor.Tests.fs" />
     <Compile Include="SaveBoundary.Actor.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
@@ -26,6 +26,7 @@ type ManifestContributionDiagnosisServerTests() =
     let repositoryId = Guid.Parse("33333333-7340-4000-8000-333333333333")
     let directoryVersionId = Guid.Parse("44444444-7340-4000-8000-444444444444")
     let otherDirectoryVersionId = Guid.Parse("55555555-7340-4000-8000-555555555555")
+    let referenceId = Guid.Parse("77777777-7340-4000-8000-777777777777")
     let storagePoolId = StoragePoolId "diagnosis:pool"
     let fileContentHash = FileContentHash(String.replicate 64 "b")
 
@@ -745,6 +746,165 @@ type ManifestContributionDiagnosisServerTests() =
             Assert.That(report.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
             Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
             Assert.That(report.EvidenceGaps, Has.Some.Contains("repeated a continuation token"))
+        }
+
+    /// Verifies DirectoryVersion discovery charges distinct expected relationships before reading a later child actor.
+    [<Test>]
+    member _.DirectoryVersionDiscoveryStopsBeforeReadingPastTheRelationshipBound() =
+        task {
+            let root = directoryVersionDto directoryVersionId
+            root.DirectoryVersion.Directories.Add otherDirectoryVersionId
+            root.DirectoryVersion.Directories.Add otherDirectoryVersionId
+
+            let child = directoryVersionDto otherDirectoryVersionId
+            child.DirectoryVersion.Files.Clear()
+
+            let directoryVersions =
+                Map.ofList [ directoryVersionId, root
+                             otherDirectoryVersionId, child ]
+
+            let createDependencies (reads: ResizeArray<DirectoryVersionId>) =
+                let baseDependencies =
+                    dependencies
+                        directoryVersions
+                        (fun () ->
+                            {
+                                Relationships =
+                                    [|
+                                        manifestRelationship directoryVersionId
+                                    |]
+                                ContinuationToken = None
+                            })
+                        (fun _ -> ExactRelationshipPresence.Present)
+                        None
+                        1L
+
+                { baseDependencies with
+                    GetDirectoryVersion =
+                        fun id _ ->
+                            reads.Add id
+                            Task.FromResult directoryVersions[id]
+                }
+
+            let exactReads = ResizeArray<DirectoryVersionId>()
+
+            let! exactReport =
+                diagnoseWith
+                    (createDependencies exactReads)
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 2)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(exactReport.ExpectedRelationships, Has.Length.EqualTo(2))
+
+            Assert.That(
+                exactReads.ToArray() =
+                    [|
+                        directoryVersionId
+                        otherDirectoryVersionId
+                    |],
+                Is.True
+            )
+
+            let exceededReads = ResizeArray<DirectoryVersionId>()
+
+            Assert.ThrowsAsync<RelationshipBoundExceeded>(
+                Func<Task> (fun () ->
+                    diagnoseWith
+                        (createDependencies exceededReads)
+                        "2026-07-27T00:00:00Z"
+                        "diagnosis-test"
+                        CancellationToken.None
+                        (readBound 1)
+                        (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+                    :> Task)
+            )
+            |> ignore
+
+            Assert.That(exceededReads.ToArray() = [| directoryVersionId |], Is.True)
+        }
+
+    /// Verifies Reference discovery charges its root relationship and stops before reading a child beyond the bound.
+    [<Test>]
+    member _.ReferenceDiscoveryStopsBeforeReadingPastTheRelationshipBound() =
+        task {
+            let root = directoryVersionDto directoryVersionId
+            root.DirectoryVersion.Directories.Add otherDirectoryVersionId
+            root.DirectoryVersion.Directories.Add otherDirectoryVersionId
+
+            let child = directoryVersionDto otherDirectoryVersionId
+            child.DirectoryVersion.Files.Clear()
+
+            let directoryVersions =
+                Map.ofList [ directoryVersionId, root
+                             otherDirectoryVersionId, child ]
+
+            let reference = { ReferenceDto.Default with ReferenceId = referenceId; RepositoryId = repositoryId; DirectoryId = directoryVersionId }
+
+            let createDependencies (reads: ResizeArray<DirectoryVersionId>) =
+                let baseDependencies =
+                    dependencies
+                        directoryVersions
+                        (fun () ->
+                            {
+                                Relationships =
+                                    [|
+                                        manifestRelationship directoryVersionId
+                                    |]
+                                ContinuationToken = None
+                            })
+                        (fun _ -> ExactRelationshipPresence.Present)
+                        None
+                        1L
+
+                { baseDependencies with
+                    GetReference = fun _ _ -> Task.FromResult reference
+                    GetDirectoryVersion =
+                        fun id _ ->
+                            reads.Add id
+                            Task.FromResult directoryVersions[id]
+                }
+
+            let exactReads = ResizeArray<DirectoryVersionId>()
+
+            let! exactReport =
+                diagnoseWith
+                    (createDependencies exactReads)
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 3)
+                    (DiagnosisSelector.ReferenceId(referenceId, Some repositoryId))
+
+            Assert.That(exactReport.ExpectedRelationships, Has.Length.EqualTo(3))
+
+            Assert.That(
+                exactReads.ToArray() =
+                    [|
+                        directoryVersionId
+                        otherDirectoryVersionId
+                    |],
+                Is.True
+            )
+
+            let exceededReads = ResizeArray<DirectoryVersionId>()
+
+            Assert.ThrowsAsync<RelationshipBoundExceeded>(
+                Func<Task> (fun () ->
+                    diagnoseWith
+                        (createDependencies exceededReads)
+                        "2026-07-27T00:00:00Z"
+                        "diagnosis-test"
+                        CancellationToken.None
+                        (readBound 2)
+                        (DiagnosisSelector.ReferenceId(referenceId, Some repositoryId))
+                    :> Task)
+            )
+            |> ignore
+
+            Assert.That(exceededReads.ToArray() = [| directoryVersionId |], Is.True)
         }
 
     /// Verifies the cumulative relationship bound stops a report before it can imply complete evidence.

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
@@ -75,6 +75,25 @@ type ManifestContributionDiagnosisServerTests() =
     /// Creates the shared counter tuple used by focused diagnosis tests.
     let counterTuple () = { RepositoryId = repositoryId; StoragePoolId = storagePoolId; ManifestAddress = manifestAddress }
 
+    /// Creates a completed workflow snapshot that can support complete diagnosis evidence.
+    let completedWorkflow (target: CounterTuple) =
+        let operationId = ManifestContributionWorkflowOperationId "diagnosis-completed"
+
+        { ManifestContributionWorkflowDto.Default with
+            RepositoryId = target.RepositoryId
+            StoragePoolId = target.StoragePoolId
+            ManifestAddress = target.ManifestAddress
+            LifecycleState = ManifestContributionWorkflowLifecycleState.Completed
+            StartOperationId = Some operationId
+            LastOperationId = Some operationId
+            Revision = 8L
+        }
+
+    /// Creates the exact manifest relationship named by the focused DirectoryVersion source.
+    let manifestRelationship id =
+        ExactRelationship.DirectoryVersionManifest
+            { RepositoryId = repositoryId; StoragePoolId = storagePoolId; ManifestAddress = manifestAddress; DirectoryVersionId = id }
+
     /// Creates a valid exact read bound for focused tests.
     let readBound value =
         match ExactRelationshipReadBound.create value with
@@ -109,15 +128,7 @@ type ManifestContributionDiagnosisServerTests() =
                             Count = storedCount
                             Revision = 7L
                         }
-            GetWorkflow =
-                fun target _ ->
-                    Task.FromResult
-                        { ManifestContributionWorkflowDto.Default with
-                            RepositoryId = target.RepositoryId
-                            StoragePoolId = target.StoragePoolId
-                            ManifestAddress = target.ManifestAddress
-                            Revision = 8L
-                        }
+            GetWorkflow = fun target _ -> Task.FromResult(completedWorkflow target)
             GetRecentResult = fun _ _ _ -> Task.FromResult recentResult
         }
 
@@ -251,12 +262,30 @@ type ManifestContributionDiagnosisServerTests() =
                 }
 
             let baseDependencies =
-                dependencies Map.empty (fun () -> { Relationships = Array.empty; ContinuationToken = None }) (fun _ -> ExactRelationshipPresence.Absent) None 0L
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () ->
+                        {
+                            Relationships =
+                                [|
+                                    manifestRelationship directoryVersionId
+                                |]
+                            ContinuationToken = None
+                        })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
 
             let deps = { baseDependencies with GetWorkflow = fun _ _ -> Task.FromResult absentWorkflow }
 
             let! report =
-                diagnoseWith deps "2026-07-27T00:00:00Z" "diagnosis-test" CancellationToken.None (readBound 10) (DiagnosisSelector.CounterTuple target)
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
 
             let workflowFact =
                 report.ActorFacts
@@ -296,6 +325,9 @@ type ManifestContributionDiagnosisServerTests() =
 
             Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
             Assert.That(report.ReclamationPermitted, Is.False)
+            Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+            Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+            Assert.That(report.EvidenceGaps, Has.Some.Contains("absent or unreadable"))
         }
 
     /// Verifies a readable source produces a concrete missing relationship and counter reconciliation target.
@@ -326,6 +358,162 @@ type ManifestContributionDiagnosisServerTests() =
             Assert.That(report.CountEvidence, Has.Length.EqualTo(1))
             Assert.That(report.CountEvidence[0].StoredCount, Is.EqualTo(Some 0L))
             Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(Some 1L))
+        }
+
+    /// Verifies only a readable, target-matching completed workflow can support complete diagnosis evidence.
+    [<Test>]
+    member _.WorkflowEvidenceMustBeReadableTargetMatchingAndCompleted() =
+        task {
+            let target = counterTuple ()
+            let relationship = manifestRelationship directoryVersionId
+            let range = { StoragePoolId = storagePoolId; ContentBlockAddress = finalizedManifest.Blocks[0].Address }
+            let operationId = ManifestContributionWorkflowOperationId "diagnosis-incomplete"
+
+            let unfinishedWorkflow =
+                { completedWorkflow target with
+                    Ranges = [| range |]
+                    CompletedRanges = Array.empty
+                    LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress
+                }
+
+            let failedWorkflow =
+                { completedWorkflow target with
+                    Ranges = [| range |]
+                    CompletedRanges = Array.empty
+                    FailedRanges =
+                        [|
+                            {
+                                OperationId = operationId
+                                RepositoryId = repositoryId
+                                StoragePoolId = storagePoolId
+                                ManifestAddress = manifestAddress
+                                Range = range
+                                Message = "focused failure"
+                            }
+                        |]
+                    LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress
+                }
+
+            let mismatchedWorkflow = { completedWorkflow target with RepositoryId = Guid.Parse("66666666-7340-4000-8000-666666666666") }
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = [| relationship |]; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let! completeReport =
+                diagnoseWith
+                    baseDependencies
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(completeReport.Outcome, Is.EqualTo(DiagnosisOutcome.VerifiedComplete))
+            Assert.That(completeReport.CountEvidence[0].RebuiltCount, Is.EqualTo(Some 1L))
+
+            let verifyIncompleteWorkflow workflow =
+                task {
+                    let deps = { baseDependencies with GetWorkflow = fun _ _ -> Task.FromResult workflow }
+
+                    let! report =
+                        diagnoseWith
+                            deps
+                            "2026-07-27T00:00:00Z"
+                            "diagnosis-test"
+                            CancellationToken.None
+                            (readBound 10)
+                            (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+                    Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+                    Assert.That(report.ReclamationPermitted, Is.False)
+                    Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+                    Assert.That(report.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
+                    Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+                }
+
+            do! verifyIncompleteWorkflow unfinishedWorkflow
+            do! verifyIncompleteWorkflow failedWorkflow
+            do! verifyIncompleteWorkflow mismatchedWorkflow
+        }
+
+    /// Verifies unreadable current source state cannot turn an observed relationship into stale-removal advice.
+    [<Test>]
+    member _.UnreadableObservedRelationshipRemainsUnknownInsteadOfStale() =
+        task {
+            let expectedRelationship = manifestRelationship directoryVersionId
+            let unreadableRelationship = manifestRelationship otherDirectoryVersionId
+
+            let deps =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () ->
+                        {
+                            Relationships =
+                                [|
+                                    expectedRelationship
+                                    unreadableRelationship
+                                |]
+                            ContinuationToken = None
+                        })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let! report =
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.StaleRelationships, Is.Empty)
+            Assert.That(report.RepairTargets, Has.None.StartsWith("RemoveStaleExactRelationship:"))
+            Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+            Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+            Assert.That(report.EvidenceGaps, Has.Some.Contains("did not return readable current state"))
+        }
+
+    /// Verifies an incomplete exact-partition continuation chain cannot support counter reconciliation.
+    [<Test>]
+    member _.RepeatedContinuationKeepsRebuiltCountIncomplete() =
+        task {
+            let relationship = manifestRelationship directoryVersionId
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = [| relationship |]; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    0L
+
+            let deps =
+                { baseDependencies with
+                    EnumerateRelationships = fun _ _ _ _ -> Task.FromResult { Relationships = [| relationship |]; ContinuationToken = Some "repeated-token" }
+                }
+
+            let! report =
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+            Assert.That(report.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
+            Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+            Assert.That(report.EvidenceGaps, Has.Some.Contains("repeated a continuation token"))
         }
 
     /// Verifies the cumulative relationship bound stops a report before it can imply complete evidence.

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
@@ -38,13 +38,20 @@ type ManifestContributionDiagnosisServerTests() =
                 4L,
                 storagePoolId,
                 [
-                    ContentBlock.Create(ContentBlockAddress(String.replicate 64 "c"), 0L, 4L)
+                    ContentBlock.Create(ContentBlockAddress(String.replicate 64 "c"), 0L, 2L)
+                    ContentBlock.Create(ContentBlockAddress(String.replicate 64 "d"), 2L, 2L)
                 ]
             )
 
         { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
 
     let manifestAddress = finalizedManifest.ManifestAddress
+
+    let workflowRanges =
+        finalizedManifest.Blocks
+        |> Seq.distinctBy (fun block -> block.Address)
+        |> Seq.map (fun block -> { StoragePoolId = storagePoolId; ContentBlockAddress = block.Address })
+        |> Seq.toArray
 
     /// Builds current DirectoryVersion state that directly names the test manifest.
     let directoryVersionDto id =
@@ -86,6 +93,18 @@ type ManifestContributionDiagnosisServerTests() =
             LifecycleState = ManifestContributionWorkflowLifecycleState.Completed
             StartOperationId = Some operationId
             LastOperationId = Some operationId
+            Ranges = workflowRanges
+            CompletedRanges =
+                workflowRanges
+                |> Array.map (fun range ->
+                    {
+                        OperationId = operationId
+                        RepositoryId = target.RepositoryId
+                        StoragePoolId = target.StoragePoolId
+                        ManifestAddress = target.ManifestAddress
+                        Range = range
+                    })
+            CounterRevision = 7L
             Revision = 8L
         }
 
@@ -395,6 +414,10 @@ type ManifestContributionDiagnosisServerTests() =
                 }
 
             let mismatchedWorkflow = { completedWorkflow target with RepositoryId = Guid.Parse("66666666-7340-4000-8000-666666666666") }
+            let classIncompatibleWorkflow = { completedWorkflow target with Class = "UnexpectedWorkflow" }
+
+            let directionIncompatibleWorkflow = { completedWorkflow target with Direction = ManifestContributionDirection.Decrement }
+            let revisionIncompatibleWorkflow = { completedWorkflow target with CounterRevision = 0L }
 
             let baseDependencies =
                 dependencies
@@ -434,11 +457,219 @@ type ManifestContributionDiagnosisServerTests() =
                     Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
                     Assert.That(report.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
                     Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+                    Assert.That(report.RepairTargets, Has.None.StartsWith("ResumeManifestContributionWorkflow:"))
                 }
 
             do! verifyIncompleteWorkflow unfinishedWorkflow
             do! verifyIncompleteWorkflow failedWorkflow
             do! verifyIncompleteWorkflow mismatchedWorkflow
+            do! verifyIncompleteWorkflow classIncompatibleWorkflow
+            do! verifyIncompleteWorkflow directionIncompatibleWorkflow
+            do! verifyIncompleteWorkflow revisionIncompatibleWorkflow
+        }
+
+    /// Verifies stale relationship removal is advice only when the selected target's workflow and counter evidence are complete.
+    [<Test>]
+    member _.StaleRelationshipRemovalRequiresCompleteTargetEvidence() =
+        task {
+            let target = counterTuple ()
+            let expectedRelationship = manifestRelationship directoryVersionId
+            let staleRelationship = manifestRelationship otherDirectoryVersionId
+            let staleSource = directoryVersionDto otherDirectoryVersionId
+            staleSource.DirectoryVersion.Files.Clear()
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId
+                                  otherDirectoryVersionId, staleSource ])
+                    (fun () ->
+                        {
+                            Relationships =
+                                [|
+                                    expectedRelationship
+                                    staleRelationship
+                                |]
+                            ContinuationToken = None
+                        })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let diagnose dependencies =
+                diagnoseWith
+                    dependencies
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            let! completeEvidenceReport = diagnose baseDependencies
+            Assert.That(completeEvidenceReport.StaleRelationships, Has.Length.EqualTo(1))
+            Assert.That(completeEvidenceReport.RepairTargets, Has.Some.StartsWith("RemoveStaleExactRelationship:"))
+
+            let incompleteWorkflow = { completedWorkflow target with Ranges = Array.empty; CompletedRanges = Array.empty }
+
+            let invalidCounter =
+                { RepositoryContentCounterDto.Default with
+                    RepositoryId = target.RepositoryId
+                    StoragePoolId = target.StoragePoolId
+                    ManifestAddress = target.ManifestAddress
+                    Count = 1L
+                    Revision = 0L
+                }
+
+            let! incompleteWorkflowReport = diagnose { baseDependencies with GetWorkflow = fun _ _ -> Task.FromResult incompleteWorkflow }
+
+            let! invalidCounterReport = diagnose { baseDependencies with GetCounter = fun _ _ -> Task.FromResult invalidCounter }
+
+            Assert.That(incompleteWorkflowReport.RepairTargets, Has.None.StartsWith("RemoveStaleExactRelationship:"))
+            Assert.That(invalidCounterReport.RepairTargets, Has.None.StartsWith("RemoveStaleExactRelationship:"))
+        }
+
+    /// Verifies completed workflow evidence exactly covers the distinct ContentBlocks in the current source manifest.
+    [<Test>]
+    member _.CompletedWorkflowMustExactlyCoverCurrentSourceManifestRanges() =
+        task {
+            let target = counterTuple ()
+            let relationship = manifestRelationship directoryVersionId
+            let operationId = ManifestContributionWorkflowOperationId "diagnosis-invalid-coverage"
+
+            let progress range =
+                {
+                    OperationId = operationId
+                    RepositoryId = target.RepositoryId
+                    StoragePoolId = target.StoragePoolId
+                    ManifestAddress = target.ManifestAddress
+                    Range = range
+                }
+
+            let unexpectedRange = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress(String.replicate 64 "e") }
+
+            let mismatchedRange = { StoragePoolId = storagePoolId; ContentBlockAddress = ContentBlockAddress(String.replicate 64 "f") }
+
+            let completedWith ranges = { completedWorkflow target with Ranges = ranges; CompletedRanges = ranges |> Array.map progress }
+
+            let nullProgressWorkflow =
+                { completedWorkflow target with
+                    CompletedRanges = Array.create workflowRanges.Length (Unchecked.defaultof<ManifestContributionWorkflowRangeProgress>)
+                }
+
+            let invalidWorkflows =
+                [|
+                    completedWith Array.empty
+                    completedWith [| workflowRanges[0] |]
+                    completedWith [| workflowRanges[0]
+                                     workflowRanges[1]
+                                     unexpectedRange |]
+                    completedWith [| workflowRanges[0]
+                                     mismatchedRange |]
+                    completedWith [| workflowRanges[0]
+                                     workflowRanges[0] |]
+                    nullProgressWorkflow
+                |]
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = [| relationship |]; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let! completeReport =
+                diagnoseWith
+                    baseDependencies
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(completeReport.Outcome, Is.EqualTo(DiagnosisOutcome.VerifiedComplete))
+
+            for invalidWorkflow in invalidWorkflows do
+                let deps = { baseDependencies with GetWorkflow = fun _ _ -> Task.FromResult invalidWorkflow }
+
+                let! report =
+                    diagnoseWith
+                        deps
+                        "2026-07-27T00:00:00Z"
+                        "diagnosis-test"
+                        CancellationToken.None
+                        (readBound 10)
+                        (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+                Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+                Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+                Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+                Assert.That(report.RepairTargets, Has.None.StartsWith("ResumeManifestContributionWorkflow:"))
+        }
+
+    /// Verifies only an initialized, class-correct counter snapshot for the selected tuple contributes stored count evidence.
+    [<Test>]
+    member _.CounterSnapshotMustBeInitializedClassCorrectAndTargetMatching() =
+        task {
+            let target = counterTuple ()
+            let relationship = manifestRelationship directoryVersionId
+
+            let validCounter =
+                { RepositoryContentCounterDto.Default with
+                    RepositoryId = target.RepositoryId
+                    StoragePoolId = target.StoragePoolId
+                    ManifestAddress = target.ManifestAddress
+                    Count = 1L
+                    Revision = 7L
+                }
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = [| relationship |]; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let completeDependencies = { baseDependencies with GetCounter = fun _ _ -> Task.FromResult validCounter }
+
+            let! completeReport =
+                diagnoseWith
+                    completeDependencies
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(completeReport.Outcome, Is.EqualTo(DiagnosisOutcome.VerifiedComplete))
+
+            let invalidCounters =
+                [|
+                    { validCounter with Revision = 0L; Count = 0L }
+                    { validCounter with Class = "UnexpectedCounter"; Count = 0L }
+                    { validCounter with RepositoryId = Guid.Parse("66666666-7340-4000-8000-666666666666"); Count = 0L }
+                    { validCounter with StoragePoolId = StoragePoolId "diagnosis:other"; Count = 0L }
+                    { validCounter with ManifestAddress = ManifestAddress(String.replicate 64 "a"); Count = 0L }
+                |]
+
+            for invalidCounter in invalidCounters do
+                let deps = { baseDependencies with GetCounter = fun _ _ -> Task.FromResult invalidCounter }
+
+                let! report =
+                    diagnoseWith
+                        deps
+                        "2026-07-27T00:00:00Z"
+                        "diagnosis-test"
+                        CancellationToken.None
+                        (readBound 10)
+                        (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+                Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+                Assert.That(report.CountEvidence[0].StoredCount, Is.EqualTo(None))
+                Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(Some 1L))
+                Assert.That(report.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
+                Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+                Assert.That(report.EvidenceGaps, Has.Some.Contains("counter"))
         }
 
     /// Verifies unreadable current source state cannot turn an observed relationship into stale-removal advice.

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
@@ -222,9 +222,16 @@ type ManifestContributionDiagnosisServerTests() =
 
         let signed = signReport unsigned
         let serialized = JsonSerializer.Serialize(signed, Grace.Shared.Constants.JsonSerializerOptions)
+        use document = JsonDocument.Parse serialized
 
         Assert.That(signed.ReportSha256, Has.Length.EqualTo(64))
         Assert.That(verifySerializedReportSha256 serialized, Is.True)
+
+        Assert.That(
+            document.RootElement.TryGetProperty("ReclamationPermitted")
+            |> fst,
+            Is.False
+        )
 
     /// Verifies Decision A preserves bounded evidence but never invents completeness for a source-less tuple.
     [<Test>]
@@ -243,7 +250,6 @@ type ManifestContributionDiagnosisServerTests() =
                     (DiagnosisSelector.CounterTuple(counterTuple ()))
 
             Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
-            Assert.That(report.ReclamationPermitted, Is.False)
             Assert.That(report.UnknownFields, Does.Contain("MissingRelationships"))
             Assert.That(report.UnknownFields, Does.Contain("RebuiltCount"))
 
@@ -344,7 +350,6 @@ type ManifestContributionDiagnosisServerTests() =
             )
 
             Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
-            Assert.That(report.ReclamationPermitted, Is.False)
             Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
             Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
             Assert.That(report.EvidenceGaps, Has.Some.Contains("absent or unreadable"))
@@ -454,7 +459,6 @@ type ManifestContributionDiagnosisServerTests() =
                             (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
 
                     Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
-                    Assert.That(report.ReclamationPermitted, Is.False)
                     Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
                     Assert.That(report.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
                     Assert.That(report.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
@@ -944,6 +948,94 @@ type ManifestContributionDiagnosisServerTests() =
                     :> Task)
             )
             |> ignore
+        }
+
+    /// Verifies each exact-relationship page receives only the distinct allowance left after discovery and earlier pages.
+    [<Test>]
+    member _.EnumerationUsesRemainingRelationshipAllowanceAcrossPages() =
+        task {
+            let expectedRelationship = manifestRelationship directoryVersionId
+            let secondRelationship = manifestRelationship otherDirectoryVersionId
+            let thirdDirectoryVersionId = Guid.Parse("66666666-7340-4000-8000-666666666666")
+            let thirdRelationship = manifestRelationship thirdDirectoryVersionId
+            let requestedBounds = ResizeArray<int>()
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = Array.empty; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let deps =
+                { baseDependencies with
+                    EnumerateRelationships =
+                        fun _ pageBound continuationToken _ ->
+                            requestedBounds.Add(ExactRelationshipReadBound.value pageBound)
+
+                            match continuationToken with
+                            | None ->
+                                Task.FromResult
+                                    {
+                                        Relationships =
+                                            [|
+                                                expectedRelationship
+                                                secondRelationship
+                                            |]
+                                        ContinuationToken = Some "next-page"
+                                    }
+                            | Some _ -> Task.FromResult { Relationships = [| thirdRelationship |]; ContinuationToken = None }
+                }
+
+            let! report =
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 3)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(requestedBounds.ToArray() = [| 2; 1 |], Is.True)
+            Assert.That(report.RelationshipsRead, Is.EqualTo(3))
+        }
+
+    /// Verifies an exact discovery bound is not exceeded by an unbudgeted enumeration probe.
+    [<Test>]
+    member _.EnumerationRetainsWithoutReadingWhenDiscoveryConsumesTheBound() =
+        task {
+            let mutable enumerationCalls = 0
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = Array.empty; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            let deps =
+                { baseDependencies with
+                    EnumerateRelationships =
+                        fun _ _ _ _ ->
+                            enumerationCalls <- enumerationCalls + 1
+                            Task.FromResult { Relationships = Array.empty; ContinuationToken = None }
+                }
+
+            let! report =
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 1)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(enumerationCalls, Is.Zero)
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+            Assert.That(report.EvidenceGaps, Has.Some.Contains("no remaining relationship allowance"))
         }
 
     /// Verifies ephemeral Redis absence is explicit and does not remove durable actor evidence.

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
@@ -1,0 +1,409 @@
+namespace Grace.Server.Unit.Tests
+
+open Grace.Actors
+open Grace.Server.ManifestContributionDiagnosis
+open Grace.Shared
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.DirectoryVersion
+open Grace.Types.ManifestContributionAccounting
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.Reference
+open Grace.Types.RepositoryContentCounter
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Threading
+open System.Threading.Tasks
+open System.Text.Json
+
+/// Proves the bounded diagnosis request and report contracts without starting Grace runtime resources.
+[<Parallelizable(ParallelScope.All)>]
+type ManifestContributionDiagnosisServerTests() =
+
+    let ownerId = Guid.Parse("11111111-7340-4000-8000-111111111111")
+    let organizationId = Guid.Parse("22222222-7340-4000-8000-222222222222")
+    let repositoryId = Guid.Parse("33333333-7340-4000-8000-333333333333")
+    let directoryVersionId = Guid.Parse("44444444-7340-4000-8000-444444444444")
+    let otherDirectoryVersionId = Guid.Parse("55555555-7340-4000-8000-555555555555")
+    let storagePoolId = StoragePoolId "diagnosis:pool"
+    let fileContentHash = FileContentHash(String.replicate 64 "b")
+
+    let finalizedManifest =
+        let manifest =
+            FileManifest.Create(
+                ManifestAddress String.Empty,
+                ChunkingSuiteId "fixed-v1",
+                fileContentHash,
+                4L,
+                storagePoolId,
+                [
+                    ContentBlock.Create(ContentBlockAddress(String.replicate 64 "c"), 0L, 4L)
+                ]
+            )
+
+        { manifest with ManifestAddress = ContentAddress.computeManifestAddressForManifest manifest }
+
+    let manifestAddress = finalizedManifest.ManifestAddress
+
+    /// Builds current DirectoryVersion state that directly names the test manifest.
+    let directoryVersionDto id =
+        let file = FileVersion.CreateWithHashes (RelativePath "diagnose.bin") (Sha256Hash "sha-diagnose") (Blake3Hash fileContentHash) "" true 4L
+        file.ContentReference <- FileContentReference.FileManifest finalizedManifest
+        let files = List<FileVersion>()
+        files.Add file
+
+        {
+            DirectoryVersion =
+                DirectoryVersion.CreateWithHashes
+                    id
+                    ownerId
+                    organizationId
+                    repositoryId
+                    (RelativePath ".")
+                    (Sha256Hash $"sha-{id:N}")
+                    (Blake3Hash $"b3-{id:N}")
+                    (List<DirectoryVersionId>())
+                    files
+                    4L
+            RecursiveSize = 4L
+            DeletedAt = None
+            DeleteReason = String.Empty
+            HashesValidated = true
+        }
+
+    /// Creates the shared counter tuple used by focused diagnosis tests.
+    let counterTuple () = { RepositoryId = repositoryId; StoragePoolId = storagePoolId; ManifestAddress = manifestAddress }
+
+    /// Creates a valid exact read bound for focused tests.
+    let readBound value =
+        match ExactRelationshipReadBound.create value with
+        | Ok bound -> bound
+        | Error error -> invalidOp error
+
+    /// Supplies read-only fakes with per-test relationship behavior.
+    let dependencies directoryVersions enumerate verify recentResult storedCount =
+        {
+            GetReference = fun _ _ -> Task.FromResult ReferenceDto.Default
+            GetDirectoryVersion =
+                fun id _ ->
+                    Task.FromResult(
+                        directoryVersions
+                        |> Map.tryFind id
+                        |> Option.defaultValue DirectoryVersionDto.Default
+                    )
+            EnumerateRelationships =
+                fun _ _ continuationToken _ ->
+                    if continuationToken.IsSome then
+                        Task.FromResult { Relationships = Array.empty; ContinuationToken = None }
+                    else
+                        Task.FromResult(enumerate ())
+            VerifyRelationship = fun relationship _ -> Task.FromResult(verify relationship)
+            GetCounter =
+                fun target _ ->
+                    Task.FromResult
+                        { RepositoryContentCounterDto.Default with
+                            RepositoryId = target.RepositoryId
+                            StoragePoolId = target.StoragePoolId
+                            ManifestAddress = target.ManifestAddress
+                            Count = storedCount
+                            Revision = 7L
+                        }
+            GetWorkflow =
+                fun target _ ->
+                    Task.FromResult
+                        { ManifestContributionWorkflowDto.Default with
+                            RepositoryId = target.RepositoryId
+                            StoragePoolId = target.StoragePoolId
+                            ManifestAddress = target.ManifestAddress
+                            Revision = 8L
+                        }
+            GetRecentResult = fun _ _ _ -> Task.FromResult recentResult
+        }
+
+    /// Builds the smallest valid Reference selector.
+    let referenceParameters () =
+        let parameters = DiagnoseManifestContributionParameters()
+        parameters.ReferenceId <- "11111111-1111-1111-1111-111111111111"
+        parameters.MaxRelationships <- 1
+        parameters
+
+    /// Verifies the selector gate rejects an accidental broad diagnosis.
+    [<Test>]
+    member _.RequiresExactlyOneSelector() =
+        let empty = DiagnoseManifestContributionParameters()
+        empty.MaxRelationships <- 1
+
+        match validateParameters empty with
+        | Error message -> Assert.That(message, Does.Contain("exactly one selector"))
+        | Ok _ -> Assert.Fail("An empty selector must not produce a diagnosis target.")
+
+        let multiple = referenceParameters ()
+        multiple.DirectoryVersionId <- "22222222-2222-2222-2222-222222222222"
+
+        match validateParameters multiple with
+        | Error message -> Assert.That(message, Does.Contain("exactly one selector"))
+        | Ok _ -> Assert.Fail("Multiple selector forms must not produce a diagnosis target.")
+
+    /// Verifies the exact relationship maximum is enforced before any read dependency can run.
+    [<Test>]
+    member _.RejectsRelationshipBoundsOutsideTheSharedLimit() =
+        let parameters = referenceParameters ()
+        parameters.MaxRelationships <- ExactRelationshipReadBound.Maximum + 1
+
+        match validateParameters parameters with
+        | Error message -> Assert.That(message, Does.Contain(string ExactRelationshipReadBound.Maximum))
+        | Ok _ -> Assert.Fail("A relationship bound above the shared maximum must be rejected.")
+
+    /// Verifies a counter tuple is one selector and not three independent selector choices.
+    [<Test>]
+    member _.AcceptsOnlyCompleteCounterTuple() =
+        let parameters = DiagnoseManifestContributionParameters()
+        parameters.RepositoryId <- "33333333-3333-3333-3333-333333333333"
+        parameters.StoragePoolId <- "pool-main"
+        parameters.ManifestAddress <- String.replicate 64 "a"
+        parameters.MaxRelationships <- 10
+
+        match validateParameters parameters with
+        | Ok (DiagnosisSelector.CounterTuple target) ->
+            Assert.That(target.RepositoryId, Is.EqualTo(Guid.Parse parameters.RepositoryId))
+            Assert.That(target.StoragePoolId, Is.EqualTo(parameters.StoragePoolId))
+            Assert.That(target.ManifestAddress, Is.EqualTo(parameters.ManifestAddress))
+        | Ok other -> Assert.Fail($"Expected the counter tuple selector, got {other}.")
+        | Error message -> Assert.Fail(message)
+
+        parameters.ManifestAddress <- String.Empty
+
+        match validateParameters parameters with
+        | Error message -> Assert.That(message, Does.Contain("complete counter tuple"))
+        | Ok _ -> Assert.Fail("A partial counter tuple must be rejected.")
+
+    /// Verifies the report digest covers the compact report with only its digest value blanked.
+    [<Test>]
+    member _.ReportSha256CanBeVerifiedFromTheSerializedReport() =
+        let unsigned =
+            emptyReport
+                "2026-07-27T00:00:00Z"
+                (DiagnosisTarget.Reference "11111111-1111-1111-1111-111111111111")
+                10
+                DiagnosisOutcome.IncompleteRetain
+                [| "RebuiltCount" |]
+
+        let signed = signReport unsigned
+        let serialized = JsonSerializer.Serialize(signed, Grace.Shared.Constants.JsonSerializerOptions)
+
+        Assert.That(signed.ReportSha256, Has.Length.EqualTo(64))
+        Assert.That(verifySerializedReportSha256 serialized, Is.True)
+
+    /// Verifies Decision A preserves bounded evidence but never invents completeness for a source-less tuple.
+    [<Test>]
+    member _.CounterTupleWithoutReadableSourceReturnsIncompleteRetain() =
+        task {
+            let deps =
+                dependencies Map.empty (fun () -> { Relationships = Array.empty; ContinuationToken = None }) (fun _ -> ExactRelationshipPresence.Absent) None 0L
+
+            let! report =
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.CounterTuple(counterTuple ()))
+
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.ReclamationPermitted, Is.False)
+            Assert.That(report.UnknownFields, Does.Contain("MissingRelationships"))
+            Assert.That(report.UnknownFields, Does.Contain("RebuiltCount"))
+
+            Assert.That(
+                report.ActorFacts
+                |> Array.map (fun fact -> fact.ActorType),
+                Does.Contain("RepositoryContentCounter")
+            )
+
+            Assert.That(
+                report.ActorFacts
+                |> Array.map (fun fact -> fact.ActorType),
+                Does.Contain("ManifestContributionWorkflow")
+            )
+
+            Assert.That(report.RedisEvidence, Does.Contain("NotRequested"))
+            Assert.That(verifySerializedReportSha256 (JsonSerializer.Serialize(report, Grace.Shared.Constants.JsonSerializerOptions)), Is.True)
+        }
+
+    /// Verifies an absent workflow actor remains diagnosable when Orleans returns null enum-like union fields.
+    [<Test>]
+    member _.AbsentWorkflowSnapshotUsesExplicitNullEvidence() =
+        task {
+            let target = counterTuple ()
+
+            let absentWorkflow =
+                { ManifestContributionWorkflowDto.Default with
+                    RepositoryId = target.RepositoryId
+                    StoragePoolId = target.StoragePoolId
+                    ManifestAddress = target.ManifestAddress
+                    Direction = Unchecked.defaultof<ManifestContributionDirection>
+                    Ranges = null
+                    CompletedRanges = null
+                    FailedRanges = null
+                    LifecycleState = Unchecked.defaultof<ManifestContributionWorkflowLifecycleState>
+                }
+
+            let baseDependencies =
+                dependencies Map.empty (fun () -> { Relationships = Array.empty; ContinuationToken = None }) (fun _ -> ExactRelationshipPresence.Absent) None 0L
+
+            let deps = { baseDependencies with GetWorkflow = fun _ _ -> Task.FromResult absentWorkflow }
+
+            let! report =
+                diagnoseWith deps "2026-07-27T00:00:00Z" "diagnosis-test" CancellationToken.None (readBound 10) (DiagnosisSelector.CounterTuple target)
+
+            let workflowFact =
+                report.ActorFacts
+                |> Array.find (fun fact -> fact.ActorType = "ManifestContributionWorkflow")
+
+            use snapshot = JsonDocument.Parse(workflowFact.SnapshotJson)
+
+            Assert.That(
+                snapshot
+                    .RootElement
+                    .GetProperty(
+                        "Direction"
+                    )
+                    .ValueKind,
+                Is.EqualTo(JsonValueKind.Null)
+            )
+
+            Assert.That(
+                snapshot
+                    .RootElement
+                    .GetProperty(
+                        "LifecycleState"
+                    )
+                    .ValueKind,
+                Is.EqualTo(JsonValueKind.Null)
+            )
+
+            Assert.That(
+                snapshot
+                    .RootElement
+                    .GetProperty(
+                        "FailedRanges"
+                    )
+                    .ValueKind,
+                Is.EqualTo(JsonValueKind.Null)
+            )
+
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.ReclamationPermitted, Is.False)
+        }
+
+    /// Verifies a readable source produces a concrete missing relationship and counter reconciliation target.
+    [<Test>]
+    member _.DirectoryVersionSourceProducesConcreteMissingRelationshipEvidence() =
+        task {
+            let deps =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = Array.empty; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Absent)
+                    None
+                    0L
+
+            let! report =
+                diagnoseWith
+                    deps
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.MissingRelationships, Has.Length.EqualTo(1))
+            Assert.That(report.RepairTargets, Has.Some.StartsWith("GetOrAddExactRelationship:"))
+            Assert.That(report.RepairTargets, Has.Some.StartsWith("ReconcileCounter:"))
+            Assert.That(report.CountEvidence, Has.Length.EqualTo(1))
+            Assert.That(report.CountEvidence[0].StoredCount, Is.EqualTo(Some 0L))
+            Assert.That(report.CountEvidence[0].RebuiltCount, Is.EqualTo(Some 1L))
+        }
+
+    /// Verifies the cumulative relationship bound stops a report before it can imply complete evidence.
+    [<Test>]
+    member _.RelationshipBoundCountsDistinctEnumeratedIdentities() =
+        task {
+            let first =
+                ExactRelationship.DirectoryVersionManifest
+                    { RepositoryId = repositoryId; StoragePoolId = storagePoolId; ManifestAddress = manifestAddress; DirectoryVersionId = directoryVersionId }
+
+            let second =
+                ExactRelationship.DirectoryVersionManifest
+                    {
+                        RepositoryId = repositoryId
+                        StoragePoolId = storagePoolId
+                        ManifestAddress = manifestAddress
+                        DirectoryVersionId = otherDirectoryVersionId
+                    }
+
+            let deps =
+                dependencies
+                    Map.empty
+                    (fun () -> { Relationships = [| first; second |]; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    2L
+
+            Assert.ThrowsAsync<RelationshipBoundExceeded>(
+                Func<Task> (fun () ->
+                    diagnoseWith
+                        deps
+                        "2026-07-27T00:00:00Z"
+                        "diagnosis-test"
+                        CancellationToken.None
+                        (readBound 1)
+                        (DiagnosisSelector.CounterTuple(counterTuple ()))
+                    :> Task)
+            )
+            |> ignore
+        }
+
+    /// Verifies ephemeral Redis absence is explicit and does not remove durable actor evidence.
+    [<Test>]
+    member _.OperationDiagnosisKeepsDurableEvidenceWhenRedisIsAbsent() =
+        task {
+            let source = directoryVersionDto directoryVersionId
+
+            let operationId = RepositoryContentCounterOperationId $"directory-version:{directoryVersionId:N}:{storagePoolId}:{manifestAddress}:add"
+
+            let deps =
+                dependencies
+                    (Map.ofList [ directoryVersionId, source ])
+                    (fun () -> { Relationships = Array.empty; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Absent)
+                    None
+                    0L
+
+            let! report =
+                diagnoseWith deps "2026-07-27T00:00:00Z" "diagnosis-test" CancellationToken.None (readBound 10) (DiagnosisSelector.OperationId operationId)
+
+            Assert.That(report.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(report.RedisEvidence, Does.Contain("AbsentOrUnavailable"))
+
+            Assert.That(
+                report.ActorFacts
+                |> Array.map (fun fact -> fact.ActorType),
+                Does.Contain("DirectoryVersion")
+            )
+
+            Assert.That(
+                report.ActorFacts
+                |> Array.map (fun fact -> fact.ActorType),
+                Does.Contain("RepositoryContentCounter")
+            )
+
+            Assert.That(
+                report.ActorFacts
+                |> Array.map (fun fact -> fact.ActorType),
+                Does.Contain("ManifestContributionWorkflow")
+            )
+        }

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDiagnosis.Server.Tests.fs
@@ -473,6 +473,51 @@ type ManifestContributionDiagnosisServerTests() =
             do! verifyIncompleteWorkflow revisionIncompatibleWorkflow
         }
 
+    /// Verifies workflow evidence cannot come from a counter revision newer than the counter snapshot read by diagnosis.
+    [<Test>]
+    member _.WorkflowCounterRevisionMustNotExceedCounterSnapshotRevision() =
+        task {
+            let target = counterTuple ()
+            let relationship = manifestRelationship directoryVersionId
+
+            let baseDependencies =
+                dependencies
+                    (Map.ofList [ directoryVersionId, directoryVersionDto directoryVersionId ])
+                    (fun () -> { Relationships = [| relationship |]; ContinuationToken = None })
+                    (fun _ -> ExactRelationshipPresence.Present)
+                    None
+                    1L
+
+            /// Runs the otherwise-complete diagnosis against one selected workflow snapshot.
+            let diagnose workflow =
+                diagnoseWith
+                    { baseDependencies with GetWorkflow = fun _ _ -> Task.FromResult workflow }
+                    "2026-07-27T00:00:00Z"
+                    "diagnosis-test"
+                    CancellationToken.None
+                    (readBound 10)
+                    (DiagnosisSelector.DirectoryVersionId(directoryVersionId, Some repositoryId))
+
+            let! equalRevisionReport = diagnose (completedWorkflow target)
+            Assert.That(equalRevisionReport.Outcome, Is.EqualTo(DiagnosisOutcome.VerifiedComplete))
+
+            let! olderRevisionReport = diagnose { completedWorkflow target with CounterRevision = 6L }
+
+            Assert.That(olderRevisionReport.Outcome, Is.EqualTo(DiagnosisOutcome.VerifiedComplete))
+
+            let! newerRevisionReport = diagnose { completedWorkflow target with CounterRevision = 8L }
+
+            Assert.That(newerRevisionReport.MissingRelationships, Is.Empty)
+            Assert.That(newerRevisionReport.StaleRelationships, Is.Empty)
+            Assert.That(newerRevisionReport.CountEvidence[0].StoredCount, Is.EqualTo(Some 1L))
+            Assert.That(newerRevisionReport.Outcome, Is.EqualTo(DiagnosisOutcome.IncompleteRetain))
+            Assert.That(newerRevisionReport.CountEvidence[0].RebuiltCount, Is.EqualTo(None))
+            Assert.That(newerRevisionReport.CountEvidence[0].Completeness, Is.EqualTo("IncompleteRetain"))
+            Assert.That(newerRevisionReport.RepairTargets, Has.None.StartsWith("ReconcileCounter:"))
+            Assert.That(newerRevisionReport.EvidenceGaps, Has.Length.EqualTo(1))
+            Assert.That(newerRevisionReport.EvidenceGaps, Has.Some.Contains("newer than the counter snapshot revision"))
+        }
+
     /// Verifies stale relationship removal is advice only when the selected target's workflow and counter evidence are complete.
     [<Test>]
     member _.StaleRelationshipRemovalRequiresCompleteTargetEvidence() =

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -103,6 +103,7 @@
                 <Compile Include="Eventing.Server.fs" />
                 <Compile Include="RepositoryCounterRecentResult.Server.fs" />
                 <Compile Include="ManifestContributionAccounting.Server.fs" />
+                <Compile Include="ManifestContributionDiagnosis.Server.fs" />
 		<Compile Include="DirectoryVersion.Server.fs" />
 		<Compile Include="Diff.Server.fs" />
 		<Compile Include="NormalFileMaterialization.Server.fs" />

--- a/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
+++ b/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
@@ -95,7 +95,6 @@ module ManifestContributionDiagnosis =
             RepairTargets: string array
             UnknownFields: string array
             EvidenceGaps: string array
-            ReclamationPermitted: bool
             Outcome: DiagnosisOutcome
             ReportSha256: string
         }
@@ -219,7 +218,6 @@ module ManifestContributionDiagnosis =
             RepairTargets = Array.empty
             UnknownFields = unknownFields
             EvidenceGaps = Array.empty
-            ReclamationPermitted = false
             Outcome = outcome
             ReportSha256 = String.Empty
         }
@@ -618,24 +616,46 @@ module ManifestContributionDiagnosis =
                     let continuationTokens = HashSet<string>(StringComparer.Ordinal)
 
                     while hasMore do
-                        let! page = dependencies.EnumerateRelationships partition bound continuationToken cancellationToken
+                        let remainingRelationships = maximumRelationships - relationshipReads.Count
 
-                        for relationship in page.Relationships do
-                            let identity = noteRelationshipRead relationship
-                            observed.TryAdd(identity, relationship) |> ignore
+                        if remainingRelationships <= 0 then
+                            match continuationToken with
+                            | Some _ ->
+                                raise (
+                                    RelationshipBoundExceeded
+                                        $"Diagnosis exceeded MaxRelationships={maximumRelationships} before the next exact relationship page could be read."
+                                )
+                            | None ->
+                                evidenceGaps.Add(
+                                    "Exact relationship enumeration was not started because no remaining relationship allowance was available after source discovery."
+                                )
 
-                        match page.ContinuationToken with
-                        | Some token when
-                            not (String.IsNullOrWhiteSpace token)
-                            && continuationTokens.Add token
-                            ->
-                            continuationToken <- Some token
-                        | Some _ ->
-                            evidenceGaps.Add("Exact relationship enumeration repeated a continuation token before completing the manifest partition.")
+                                enumerationComplete <- false
+                                hasMore <- false
+                        else
+                            let pageBound =
+                                match ExactRelationshipReadBound.create remainingRelationships with
+                                | Ok remainingBound -> remainingBound
+                                | Error error -> invalidOp error
 
-                            enumerationComplete <- false
-                            hasMore <- false
-                        | None -> hasMore <- false
+                            let! page = dependencies.EnumerateRelationships partition pageBound continuationToken cancellationToken
+
+                            for relationship in page.Relationships do
+                                let identity = noteRelationshipRead relationship
+                                observed.TryAdd(identity, relationship) |> ignore
+
+                            match page.ContinuationToken with
+                            | Some token when
+                                not (String.IsNullOrWhiteSpace token)
+                                && continuationTokens.Add token
+                                ->
+                                continuationToken <- Some token
+                            | Some _ ->
+                                evidenceGaps.Add("Exact relationship enumeration repeated a continuation token before completing the manifest partition.")
+
+                                enumerationComplete <- false
+                                hasMore <- false
+                            | None -> hasMore <- false
 
                     let mutable validObservedCount = 0L
                     let mutable sourceStateComplete = true
@@ -873,14 +893,6 @@ module ManifestContributionDiagnosis =
                     && evidenceGaps.Count = 0
                     && countsMatch
 
-                let reclamationPermitted =
-                    verified
-                    && countEvidence.Count > 0
-                    && (countEvidence
-                        |> Seq.forall (fun evidence ->
-                            evidence.StoredCount = Some 0L
-                            && evidence.RebuiltCount = Some 0L))
-
                 return
                     {
                         SchemaVersion = "grace.manifest-contribution-diagnosis.v1"
@@ -899,7 +911,6 @@ module ManifestContributionDiagnosis =
                         RepairTargets = repairTargets |> Seq.sort |> Seq.toArray
                         UnknownFields = unknownFields |> Seq.sort |> Seq.toArray
                         EvidenceGaps = evidenceGaps.ToArray()
-                        ReclamationPermitted = reclamationPermitted
                         Outcome =
                             if verified then
                                 DiagnosisOutcome.VerifiedComplete

--- a/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
+++ b/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
@@ -327,6 +327,7 @@ module ManifestContributionDiagnosis =
             let unknownFields = HashSet<string>(StringComparer.Ordinal)
             let evidenceGaps = ResizeArray<string>()
             let manifestTargets = Dictionary<string, CounterTuple>(StringComparer.Ordinal)
+            let expectedWorkflowRanges = Dictionary<string, HashSet<ManifestContributionWorkflowRange>>(StringComparer.Ordinal)
             let directoryFacts = Dictionary<DirectoryVersionId, DirectoryVersionDto>()
             let relationshipReads = HashSet<string>(StringComparer.Ordinal)
             let mutable sourceBacked = false
@@ -395,6 +396,28 @@ module ManifestContributionDiagnosis =
                 manifestTargets.TryAdd(key, counterTuple)
                 |> ignore
 
+            /// Records the distinct ContentBlocks that current readable source state requires one manifest workflow to cover.
+            let addManifestSourceTarget repositoryId (manifest: FileManifest) =
+                let counterTuple = { RepositoryId = repositoryId; StoragePoolId = manifest.StoragePoolId; ManifestAddress = manifest.ManifestAddress }
+
+                addManifestTarget counterTuple
+
+                let key = RepositoryContentCounter.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress
+
+                let ranges =
+                    match expectedWorkflowRanges.TryGetValue key with
+                    | true, existing -> existing
+                    | _ ->
+                        let created = HashSet<ManifestContributionWorkflowRange>()
+                        expectedWorkflowRanges[key] <- created
+                        created
+
+                manifest.Blocks
+                |> Seq.distinctBy (fun block -> block.Address)
+                |> Seq.iter (fun block ->
+                    ranges.Add({ StoragePoolId = manifest.StoragePoolId; ContentBlockAddress = block.Address })
+                    |> ignore)
+
             let readDirectoryVersion directoryVersionId =
                 task {
                     match directoryFacts.TryGetValue directoryVersionId with
@@ -441,8 +464,7 @@ module ManifestContributionDiagnosis =
 
                                         addExpected (ExactRelationship.DirectoryVersionManifest relationship)
 
-                                        addManifestTarget
-                                            { RepositoryId = repositoryId; StoragePoolId = manifest.StoragePoolId; ManifestAddress = manifest.ManifestAddress }
+                                        addManifestSourceTarget repositoryId manifest
 
                                 for childDirectoryVersionId in current.Directories |> Seq.distinct do
                                     addExpected (
@@ -527,26 +549,23 @@ module ManifestContributionDiagnosis =
                         | Error error ->
                             rootFailure <- Some $"Operation source DirectoryVersion '{directoryVersionId:D}' manifests could not be interpreted: {error.Error}"
                         | Ok manifests ->
-                            let matchingRelationship =
+                            let matchingManifest =
                                 manifests
-                                |> Array.map (fun manifest ->
-                                    {
-                                        RepositoryId = current.RepositoryId
-                                        StoragePoolId = manifest.StoragePoolId
-                                        ManifestAddress = manifest.ManifestAddress
-                                        DirectoryVersionId = directoryVersionId
-                                    })
-                                |> Array.tryFind (fun relationship -> operationIdentity action relationship = selectedOperationId)
+                                |> Array.tryFind (fun manifest ->
+                                    let relationship =
+                                        {
+                                            RepositoryId = current.RepositoryId
+                                            StoragePoolId = manifest.StoragePoolId
+                                            ManifestAddress = manifest.ManifestAddress
+                                            DirectoryVersionId = directoryVersionId
+                                        }
 
-                            match matchingRelationship with
+                                    operationIdentity action relationship = selectedOperationId)
+
+                            match matchingManifest with
                             | None -> rootFailure <- Some $"Operation id '{selectedOperationId}' cannot be supported by current source actor state."
-                            | Some relationship ->
-                                addManifestTarget
-                                    {
-                                        RepositoryId = relationship.RepositoryId
-                                        StoragePoolId = relationship.StoragePoolId
-                                        ManifestAddress = relationship.ManifestAddress
-                                    }
+                            | Some manifest ->
+                                addManifestSourceTarget current.RepositoryId manifest
 
                                 deterministicIdentities.Add $"{selectedOperationId}"
                                 |> ignore
@@ -650,9 +669,6 @@ module ManifestContributionDiagnosis =
                                         validObservedCount <- validObservedCount + 1L
                                     else
                                         stale.Add identity |> ignore
-
-                                        repairTargets.Add $"RemoveStaleExactRelationship:{identity}"
-                                        |> ignore
                                 | Error error ->
                                     sourceStateComplete <- false
 
@@ -669,6 +685,23 @@ module ManifestContributionDiagnosis =
                         (Some counterDto.Revision)
                         counterDto
 
+                    let counterTargetMatches =
+                        counterDto.RepositoryId = counterTuple.RepositoryId
+                        && counterDto.StoragePoolId = counterTuple.StoragePoolId
+                        && counterDto.ManifestAddress = counterTuple.ManifestAddress
+
+                    let counterReadable =
+                        counterTargetMatches
+                        && String.Equals(counterDto.Class, nameof RepositoryContentCounterDto, StringComparison.Ordinal)
+                        && counterDto.Revision > 0L
+
+                    if not counterReadable then
+                        let targetIdentity = $"{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}"
+
+                        evidenceGaps.Add(
+                            $"Repository content counter for '{targetIdentity}' was uninitialized, class-incompatible, or returned state for a different target."
+                        )
+
                     let! workflowDto = dependencies.GetWorkflow counterTuple correlationId
 
                     addWorkflowActorFact
@@ -684,32 +717,51 @@ module ManifestContributionDiagnosis =
 
                     let workflowReadable =
                         workflowTargetMatches
-                        && not (String.IsNullOrWhiteSpace workflowDto.Class)
+                        && String.Equals(workflowDto.Class, nameof ManifestContributionWorkflowDto, StringComparison.Ordinal)
                         && not (isNull (box workflowDto.Direction))
+                        && workflowDto.Direction = ManifestContributionDirection.Increment
                         && not (isNull workflowDto.Ranges)
                         && not (isNull workflowDto.CompletedRanges)
                         && not (isNull workflowDto.FailedRanges)
                         && not (isNull (box workflowDto.LifecycleState))
                         && workflowDto.StartOperationId.IsSome
                         && workflowDto.LastOperationId.IsSome
+                        && workflowDto.CounterRevision > 0L
                         && workflowDto.Revision > 0L
+
+                    let workflowRangesExact =
+                        match
+                            expectedWorkflowRanges.TryGetValue
+                                (RepositoryContentCounter.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress)
+                            with
+                        | true, expectedRanges when expectedRanges.Count > 0 && workflowReadable ->
+                            let actualRanges = HashSet<ManifestContributionWorkflowRange>(workflowDto.Ranges)
+
+                            workflowDto.Ranges.Length = expectedRanges.Count
+                            && actualRanges.Count = workflowDto.Ranges.Length
+                            && actualRanges.SetEquals expectedRanges
+                        | _ -> false
 
                     let workflowCompleted =
                         workflowReadable
+                        && workflowRangesExact
                         && workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.Completed
                         && workflowDto.FailedRanges.Length = 0
                         && workflowDto.CompletedRanges.Length = workflowDto.Ranges.Length
                         && (workflowDto.CompletedRanges
                             |> Array.forall (fun progress ->
-                                progress.RepositoryId = counterTuple.RepositoryId
+                                not (isNull (box progress))
+                                && not (isNull (box progress.Range))
+                                && progress.RepositoryId = counterTuple.RepositoryId
                                 && progress.StoragePoolId = counterTuple.StoragePoolId
                                 && progress.ManifestAddress = counterTuple.ManifestAddress))
-                        && (workflowDto.Ranges
-                            |> Array.forall (fun range ->
+                        && (let completedRanges =
                                 workflowDto.CompletedRanges
-                                |> Array.filter (fun progress -> progress.Range = range)
-                                |> Array.length
-                                |> (=) 1))
+                                |> Array.map (fun progress -> progress.Range)
+                                |> HashSet<ManifestContributionWorkflowRange>
+
+                            completedRanges.Count = workflowDto.CompletedRanges.Length
+                            && completedRanges.SetEquals workflowDto.Ranges)
 
                     if not workflowCompleted then
                         let targetIdentity = $"{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}"
@@ -719,17 +771,29 @@ module ManifestContributionDiagnosis =
                         elif not workflowReadable then
                             evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' was absent or unreadable.")
                         else
-                            evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' has unfinished, failed, or inconsistent ranges.")
-
-                            if workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress
-                               || workflowDto.FailedRanges.Length > 0 then
-                                repairTargets.Add($"ResumeManifestContributionWorkflow:{targetIdentity}")
-                                |> ignore
+                            evidenceGaps.Add(
+                                $"Manifest contribution workflow for '{targetIdentity}' has unfinished, failed, duplicate, or source-mismatched ranges."
+                            )
 
                     let partitionEvidenceComplete =
                         enumerationComplete
                         && sourceStateComplete
                         && workflowCompleted
+
+                    let completeEvidence = partitionEvidenceComplete && counterReadable
+
+                    if completeEvidence then
+                        for KeyValue (identity, relationship) in observed do
+                            match relationship with
+                            | ExactRelationship.DirectoryVersionManifest manifestRelationship when
+                                manifestRelationship.RepositoryId = counterTuple.RepositoryId
+                                && manifestRelationship.StoragePoolId = counterTuple.StoragePoolId
+                                && manifestRelationship.ManifestAddress = counterTuple.ManifestAddress
+                                && stale.Contains identity
+                                ->
+                                repairTargets.Add $"RemoveStaleExactRelationship:{identity}"
+                                |> ignore
+                            | _ -> ()
 
                     let rebuiltCount =
                         if sourceBacked && partitionEvidenceComplete then
@@ -755,18 +819,14 @@ module ManifestContributionDiagnosis =
                             RepositoryId = $"{counterTuple.RepositoryId:D}"
                             StoragePoolId = $"{counterTuple.StoragePoolId}"
                             ManifestAddress = $"{counterTuple.ManifestAddress}"
-                            StoredCount = Some counterDto.Count
+                            StoredCount = if counterReadable then Some counterDto.Count else None
                             RebuiltCount = rebuiltCount
-                            Completeness =
-                                if sourceBacked && partitionEvidenceComplete then
-                                    "Complete"
-                                else
-                                    "IncompleteRetain"
+                            Completeness = if sourceBacked && completeEvidence then "Complete" else "IncompleteRetain"
                         }
                     )
 
-                    match rebuiltCount with
-                    | Some rebuilt when rebuilt <> counterDto.Count ->
+                    match (if counterReadable then Some counterDto.Count else None), rebuiltCount with
+                    | Some stored, Some rebuilt when rebuilt <> stored ->
                         repairTargets.Add($"ReconcileCounter:{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}")
                         |> ignore
                     | _ -> ()

--- a/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
+++ b/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
@@ -387,8 +387,11 @@ module ManifestContributionDiagnosis =
 
             let addExpected relationship =
                 let identity = relationshipIdentity relationship
-                expected.TryAdd(identity, relationship) |> ignore
-                deterministicIdentities.Add identity |> ignore
+
+                if not (expected.ContainsKey identity) then
+                    noteRelationshipRead relationship |> ignore
+                    expected.Add(identity, relationship)
+                    deterministicIdentities.Add identity |> ignore
 
             let addManifestTarget (counterTuple: CounterTuple) =
                 let key = RepositoryContentCounter.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress

--- a/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
+++ b/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
@@ -1,0 +1,869 @@
+namespace Grace.Server
+
+open Giraffe
+open Grace.Actors
+open Grace.Actors.Extensions.ActorProxy
+open Grace.Actors.Interfaces
+open Grace.Server.ApplicationContext
+open Grace.Server.Services
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.DirectoryVersion
+open Grace.Types.ManifestContributionAccounting
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.Reference
+open Grace.Types.RepositoryContentCounter
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open System
+open System.Collections.Generic
+open System.Security.Cryptography
+open System.Text
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Provides bounded, read-only manifest contribution evidence for Grace operators.
+module ManifestContributionDiagnosis =
+
+    /// Carries the internal operator request without adding a public Grace contract.
+    [<AllowNullLiteral>]
+    type DiagnoseManifestContributionParameters() =
+        member val ReferenceId = String.Empty with get, set
+        member val DirectoryVersionId = String.Empty with get, set
+        member val RepositoryId = String.Empty with get, set
+        member val StoragePoolId = String.Empty with get, set
+        member val ManifestAddress = String.Empty with get, set
+        member val RepositoryContentCounterOperationId = String.Empty with get, set
+        member val MaxRelationships = 0 with get, set
+
+    /// Identifies one repository-manifest counter and workflow pair.
+    type CounterTuple = { RepositoryId: RepositoryId; StoragePoolId: StoragePoolId; ManifestAddress: ManifestAddress }
+
+    /// Represents the one validated diagnosis selector supplied by an operator.
+    type DiagnosisSelector =
+        | ReferenceId of referenceId: ReferenceId * repositoryIdHint: RepositoryId option
+        | DirectoryVersionId of directoryVersionId: DirectoryVersionId * repositoryIdHint: RepositoryId option
+        | CounterTuple of CounterTuple
+        | OperationId of RepositoryContentCounterOperationId
+
+    /// Preserves the selector in the exported report without relying on F# union serialization.
+    type DiagnosisTarget =
+        | Reference of referenceId: string
+        | DirectoryVersion of directoryVersionId: string
+        | Counter of repositoryId: string * storagePoolId: string * manifestAddress: string
+        | Operation of operationId: string
+
+    /// Names the three terminal operator outcomes consumed by the PowerShell script.
+    type DiagnosisOutcome =
+        | VerifiedComplete
+        | IncompleteRetain
+        | FailedRetain
+
+    /// Records one actor snapshot exactly as it was read during this diagnosis.
+    type ActorFact = { ActorType: string; ActorId: string; Revision: int64 option; SnapshotJson: string }
+
+    /// Compares one durable counter value with a bounded actor-derived reconstruction.
+    type ManifestCountEvidence =
+        {
+            RepositoryId: string
+            StoragePoolId: string
+            ManifestAddress: string
+            StoredCount: int64 option
+            RebuiltCount: int64 option
+            Completeness: string
+        }
+
+    /// Is the complete, self-verifying, read-only operator report written by the diagnosis script.
+    type ManifestContributionDiagnosisReport =
+        {
+            SchemaVersion: string
+            GeneratedAt: string
+            Target: DiagnosisTarget
+            MaxRelationships: int
+            RelationshipsRead: int
+            ActorFacts: ActorFact array
+            ExpectedRelationships: string array
+            ObservedRelationships: string array
+            MissingRelationships: string array
+            StaleRelationships: string array
+            CountEvidence: ManifestCountEvidence array
+            DeterministicIdentities: string array
+            RedisEvidence: string array
+            RepairTargets: string array
+            UnknownFields: string array
+            EvidenceGaps: string array
+            ReclamationPermitted: bool
+            Outcome: DiagnosisOutcome
+            ReportSha256: string
+        }
+
+    /// Supplies only read operations to the diagnosis core so tests can prove that diagnosis cannot mutate Grace.
+    type DiagnosisDependencies =
+        {
+            GetReference: ReferenceId -> CorrelationId -> Task<ReferenceDto>
+            GetDirectoryVersion: DirectoryVersionId -> CorrelationId -> Task<DirectoryVersionDto>
+            EnumerateRelationships: ExactRelationshipPartition
+                -> ExactRelationshipReadBound
+                -> string option
+                -> CancellationToken
+                -> Task<ExactRelationshipPage>
+            VerifyRelationship: ExactRelationship -> CancellationToken -> Task<ExactRelationshipPresence>
+            GetCounter: CounterTuple -> CorrelationId -> Task<RepositoryContentCounterDto>
+            GetWorkflow: CounterTuple -> CorrelationId -> Task<ManifestContributionWorkflowDto>
+            GetRecentResult: CounterTuple -> RepositoryContentCounterOperationId -> CancellationToken -> Task<RepositoryContentCounterCompletedChange option>
+        }
+
+    /// Signals that a bounded read found more relationship identities than the operator allowed.
+    exception RelationshipBoundExceeded of string
+
+    /// Validates the optional repository qualifier shared by Reference and DirectoryVersion selectors.
+    let private tryRepositoryIdHint (value: string) =
+        if String.IsNullOrWhiteSpace value then
+            Ok None
+        else
+            match Guid.TryParse value with
+            | true, repositoryId when repositoryId <> Guid.Empty -> Ok(Some(repositoryId: RepositoryId))
+            | _ -> Error "RepositoryId must be a non-empty GUID when supplied."
+
+    /// Validates a required non-empty GUID selector.
+    let private requiredGuid name (value: string) =
+        match Guid.TryParse value with
+        | true, parsed when parsed <> Guid.Empty -> Ok parsed
+        | _ -> Error $"{name} must be a non-empty GUID."
+
+    /// Enforces exactly one bounded selector before any actor or projection read starts.
+    let validateParameters (parameters: DiagnoseManifestContributionParameters) =
+        if isNull parameters then
+            Error "A diagnosis request body is required."
+        else
+            match ExactRelationshipReadBound.create parameters.MaxRelationships with
+            | Error error -> Error error
+            | Ok _ ->
+                let hasReference = not (String.IsNullOrWhiteSpace parameters.ReferenceId)
+                let hasDirectoryVersion = not (String.IsNullOrWhiteSpace parameters.DirectoryVersionId)
+                let hasOperation = not (String.IsNullOrWhiteSpace parameters.RepositoryContentCounterOperationId)
+                let hasRepository = not (String.IsNullOrWhiteSpace parameters.RepositoryId)
+                let hasStoragePool = not (String.IsNullOrWhiteSpace parameters.StoragePoolId)
+                let hasManifest = not (String.IsNullOrWhiteSpace parameters.ManifestAddress)
+                let hasCompleteCounterTuple = hasRepository && hasStoragePool && hasManifest
+
+                let tupleComponentOutsideQualifiedSource =
+                    hasStoragePool
+                    || hasManifest
+                    || (hasRepository
+                        && not hasReference
+                        && not hasDirectoryVersion
+                        && not hasOperation)
+
+                if tupleComponentOutsideQualifiedSource
+                   && not hasCompleteCounterTuple then
+                    Error "RepositoryId, StoragePoolId, and ManifestAddress must form one complete counter tuple."
+                else
+                    let selectorCount =
+                        [
+                            hasReference
+                            hasDirectoryVersion
+                            hasCompleteCounterTuple
+                            hasOperation
+                        ]
+                        |> List.filter id
+                        |> List.length
+
+                    if selectorCount <> 1 then
+                        Error "Specify exactly one selector: ReferenceId, DirectoryVersionId, a complete counter tuple, or RepositoryContentCounterOperationId."
+                    elif hasReference then
+                        match requiredGuid "ReferenceId" parameters.ReferenceId, tryRepositoryIdHint parameters.RepositoryId with
+                        | Ok referenceId, Ok repositoryIdHint -> Ok(DiagnosisSelector.ReferenceId((referenceId: ReferenceId), repositoryIdHint))
+                        | Error error, _
+                        | _, Error error -> Error error
+                    elif hasDirectoryVersion then
+                        match requiredGuid "DirectoryVersionId" parameters.DirectoryVersionId, tryRepositoryIdHint parameters.RepositoryId with
+                        | Ok directoryVersionId, Ok repositoryIdHint ->
+                            Ok(DiagnosisSelector.DirectoryVersionId((directoryVersionId: DirectoryVersionId), repositoryIdHint))
+                        | Error error, _
+                        | _, Error error -> Error error
+                    elif hasCompleteCounterTuple then
+                        match requiredGuid "RepositoryId" parameters.RepositoryId with
+                        | Error error -> Error error
+                        | Ok repositoryId ->
+                            Ok(
+                                DiagnosisSelector.CounterTuple
+                                    {
+                                        RepositoryId = (repositoryId: RepositoryId)
+                                        StoragePoolId = StoragePoolId parameters.StoragePoolId
+                                        ManifestAddress = ManifestAddress parameters.ManifestAddress
+                                    }
+                            )
+                    else
+                        Ok(DiagnosisSelector.OperationId(RepositoryContentCounterOperationId parameters.RepositoryContentCounterOperationId))
+
+    /// Creates a report shell for deterministic tests and terminal failures.
+    let emptyReport generatedAt target maxRelationships outcome unknownFields =
+        {
+            SchemaVersion = "grace.manifest-contribution-diagnosis.v1"
+            GeneratedAt = generatedAt
+            Target = target
+            MaxRelationships = maxRelationships
+            RelationshipsRead = 0
+            ActorFacts = Array.empty
+            ExpectedRelationships = Array.empty
+            ObservedRelationships = Array.empty
+            MissingRelationships = Array.empty
+            StaleRelationships = Array.empty
+            CountEvidence = Array.empty
+            DeterministicIdentities = Array.empty
+            RedisEvidence = Array.empty
+            RepairTargets = Array.empty
+            UnknownFields = unknownFields
+            EvidenceGaps = Array.empty
+            ReclamationPermitted = false
+            Outcome = outcome
+            ReportSha256 = String.Empty
+        }
+
+    let private reportDigestOptions =
+        let options = JsonSerializerOptions(Constants.JsonSerializerOptions)
+        options.WriteIndented <- false
+        options
+
+    /// Computes the report digest over compact JSON with ReportSha256 omitted.
+    let private reportDigest (report: ManifestContributionDiagnosisReport) =
+        let unsigned = JsonSerializer.SerializeToNode(report, reportDigestOptions)
+
+        unsigned
+            .AsObject()
+            .Remove(nameof report.ReportSha256)
+        |> ignore
+
+        let json = unsigned.ToJsonString(reportDigestOptions)
+
+        SHA256.HashData(Encoding.UTF8.GetBytes json)
+        |> Convert.ToHexStringLower
+
+    /// Adds the deterministic SHA-256 that the operator script verifies before writing the report.
+    let signReport report = { report with ReportSha256 = reportDigest report }
+
+    /// Verifies a serialized report using the same omitted-digest canonical form as the server.
+    let verifySerializedReportSha256 (serialized: string) =
+        try
+            let report = JsonSerializer.Deserialize<ManifestContributionDiagnosisReport>(serialized, Constants.JsonSerializerOptions)
+
+            not (isNull (box report))
+            && String.Equals(report.ReportSha256, reportDigest report, StringComparison.OrdinalIgnoreCase)
+        with
+        | :? JsonException -> false
+
+    /// Converts one exact relationship into the provider-neutral identity shown in operator evidence.
+    let relationshipIdentity relationship =
+        match ExactRelationshipKey.create relationship with
+        | Ok key -> $"{key.PartitionKey}|{key.ItemId}"
+        | Error error -> invalidArg (nameof relationship) error
+
+    /// Converts the validated selector into its stable report target.
+    let private selectorTarget selector =
+        match selector with
+        | DiagnosisSelector.ReferenceId (referenceId, _) -> DiagnosisTarget.Reference $"{referenceId:D}"
+        | DiagnosisSelector.DirectoryVersionId (directoryVersionId, _) -> DiagnosisTarget.DirectoryVersion $"{directoryVersionId:D}"
+        | DiagnosisSelector.CounterTuple target -> DiagnosisTarget.Counter($"{target.RepositoryId:D}", $"{target.StoragePoolId}", $"{target.ManifestAddress}")
+        | DiagnosisSelector.OperationId operationId -> DiagnosisTarget.Operation $"{operationId}"
+
+    /// Returns the direct manifests that current DirectoryVersion actor state authoritatively names.
+    let private directManifests directoryVersionDto correlationId =
+        DirectoryVersion.getManifestReferencesForSaveBoundary directoryVersionDto.DirectoryVersion correlationId
+        |> Result.map (fun references ->
+            references
+            |> Seq.map (fun reference -> reference.Manifest)
+            |> Seq.toArray)
+
+    /// Parses the current deterministic DirectoryVersion counter-operation identity.
+    let private tryParseOperationSource (operationId: RepositoryContentCounterOperationId) =
+        let value = $"{operationId}"
+        let prefix = "directory-version:"
+        let sourceStart = prefix.Length
+        let sourceLength = 32
+
+        if value.StartsWith(prefix, StringComparison.Ordinal)
+           && value.Length > sourceStart + sourceLength
+           && value[sourceStart + sourceLength] = ':' then
+            match Guid.TryParseExact(value.Substring(sourceStart, sourceLength), "N") with
+            | true, directoryVersionId when directoryVersionId <> Guid.Empty ->
+                if value.EndsWith(":add", StringComparison.Ordinal) then
+                    Some((directoryVersionId: DirectoryVersionId), "add")
+                elif value.EndsWith(":remove", StringComparison.Ordinal) then
+                    Some((directoryVersionId: DirectoryVersionId), "remove")
+                else
+                    None
+            | _ -> None
+        else
+            None
+
+    /// Builds the deterministic add or remove identity used by current manifest accounting.
+    let private operationIdentity action (relationship: DirectoryVersionManifestRelationship) =
+        RepositoryContentCounterOperationId
+            $"directory-version:{relationship.DirectoryVersionId:N}:{relationship.StoragePoolId}:{relationship.ManifestAddress}:{action}"
+
+    /// Executes one bounded diagnosis entirely through read-only dependencies.
+    let diagnoseWith
+        (dependencies: DiagnosisDependencies)
+        (generatedAt: string)
+        (correlationId: CorrelationId)
+        (cancellationToken: CancellationToken)
+        (bound: ExactRelationshipReadBound)
+        (selector: DiagnosisSelector)
+        =
+        task {
+            let maximumRelationships = ExactRelationshipReadBound.value bound
+            let target = selectorTarget selector
+            let actorFacts = ResizeArray<ActorFact>()
+            let expected = Dictionary<string, ExactRelationship>(StringComparer.Ordinal)
+            let observed = Dictionary<string, ExactRelationship>(StringComparer.Ordinal)
+            let missing = HashSet<string>(StringComparer.Ordinal)
+            let stale = HashSet<string>(StringComparer.Ordinal)
+            let deterministicIdentities = HashSet<string>(StringComparer.Ordinal)
+            let repairTargets = HashSet<string>(StringComparer.Ordinal)
+            let unknownFields = HashSet<string>(StringComparer.Ordinal)
+            let evidenceGaps = ResizeArray<string>()
+            let manifestTargets = Dictionary<string, CounterTuple>(StringComparer.Ordinal)
+            let directoryFacts = Dictionary<DirectoryVersionId, DirectoryVersionDto>()
+            let relationshipReads = HashSet<string>(StringComparer.Ordinal)
+            let mutable sourceBacked = false
+            let mutable rootFailure: string option = None
+            let mutable operationId: RepositoryContentCounterOperationId option = None
+
+            /// Adds one already-normalized actor snapshot to the report evidence.
+            let addActorFactJson actorType actorId revision snapshotJson =
+                actorFacts.Add({ ActorType = actorType; ActorId = actorId; Revision = revision; SnapshotJson = snapshotJson })
+
+            /// Serializes and records one actor snapshot whose contract is safe for the shared JSON options.
+            let addActorFact actorType actorId revision snapshot =
+                addActorFactJson actorType actorId revision (JsonSerializer.Serialize(snapshot, Constants.JsonSerializerOptions))
+
+            /// Preserves every workflow field while representing an uninitialized enum-like union as explicit JSON null.
+            let addWorkflowActorFact actorType actorId revision (snapshot: ManifestContributionWorkflowDto) =
+                let unionName value = if isNull (box value) then null else $"{value}"
+
+                let optionalIdentity value =
+                    match value with
+                    | Some identity -> $"{identity}"
+                    | None -> null
+
+                let snapshotJson =
+                    JsonSerializer.Serialize(
+                        {|
+                            Class = snapshot.Class
+                            RepositoryId = snapshot.RepositoryId
+                            StoragePoolId = snapshot.StoragePoolId
+                            ManifestAddress = snapshot.ManifestAddress
+                            Direction = unionName snapshot.Direction
+                            Ranges = snapshot.Ranges
+                            CompletedRanges = snapshot.CompletedRanges
+                            FailedRanges = snapshot.FailedRanges
+                            LifecycleState = unionName snapshot.LifecycleState
+                            StartOperationId = optionalIdentity snapshot.StartOperationId
+                            LastOperationId = optionalIdentity snapshot.LastOperationId
+                            CounterRevision = snapshot.CounterRevision
+                            Revision = snapshot.Revision
+                        |},
+                        Constants.JsonSerializerOptions
+                    )
+
+                addActorFactJson actorType actorId revision snapshotJson
+
+            let noteRelationshipRead relationship =
+                let identity = relationshipIdentity relationship
+
+                if relationshipReads.Add identity
+                   && relationshipReads.Count > maximumRelationships then
+                    raise (
+                        RelationshipBoundExceeded
+                            $"Diagnosis exceeded MaxRelationships={maximumRelationships} while reading '{identity}'. No complete report can be produced at this bound."
+                    )
+
+                identity
+
+            let addExpected relationship =
+                let identity = relationshipIdentity relationship
+                expected.TryAdd(identity, relationship) |> ignore
+                deterministicIdentities.Add identity |> ignore
+
+            let addManifestTarget (counterTuple: CounterTuple) =
+                let key = RepositoryContentCounter.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress
+
+                manifestTargets.TryAdd(key, counterTuple)
+                |> ignore
+
+            let readDirectoryVersion directoryVersionId =
+                task {
+                    match directoryFacts.TryGetValue directoryVersionId with
+                    | true, dto -> return dto
+                    | _ ->
+                        let! dto = dependencies.GetDirectoryVersion directoryVersionId correlationId
+                        directoryFacts[directoryVersionId] <- dto
+
+                        addActorFact "DirectoryVersion" $"{directoryVersionId:D}" None dto
+
+                        return dto
+                }
+
+            let traverseDirectoryTree repositoryId rootDirectoryVersionId =
+                task {
+                    let pending = Stack<DirectoryVersionId>()
+                    let visited = HashSet<DirectoryVersionId>()
+                    pending.Push rootDirectoryVersionId
+
+                    while pending.Count > 0 do
+                        cancellationToken.ThrowIfCancellationRequested()
+                        let directoryVersionId = pending.Pop()
+
+                        if visited.Add directoryVersionId then
+                            let! dto = readDirectoryVersion directoryVersionId
+                            let current = dto.DirectoryVersion
+
+                            if current.DirectoryVersionId <> directoryVersionId
+                               || current.RepositoryId <> repositoryId then
+                                evidenceGaps.Add($"DirectoryVersion '{directoryVersionId:D}' did not return current state for repository '{repositoryId:D}'.")
+                            else
+                                match directManifests dto correlationId with
+                                | Error error ->
+                                    evidenceGaps.Add($"DirectoryVersion '{directoryVersionId:D}' manifests could not be interpreted: {error.Error}")
+                                | Ok manifests ->
+                                    for manifest in manifests do
+                                        let relationship =
+                                            {
+                                                RepositoryId = repositoryId
+                                                StoragePoolId = manifest.StoragePoolId
+                                                ManifestAddress = manifest.ManifestAddress
+                                                DirectoryVersionId = directoryVersionId
+                                            }
+
+                                        addExpected (ExactRelationship.DirectoryVersionManifest relationship)
+
+                                        addManifestTarget
+                                            { RepositoryId = repositoryId; StoragePoolId = manifest.StoragePoolId; ManifestAddress = manifest.ManifestAddress }
+
+                                for childDirectoryVersionId in current.Directories |> Seq.distinct do
+                                    addExpected (
+                                        ExactRelationship.ParentChild
+                                            {
+                                                RepositoryId = repositoryId
+                                                ParentDirectoryVersionId = directoryVersionId
+                                                ChildDirectoryVersionId = childDirectoryVersionId
+                                            }
+                                    )
+
+                                    pending.Push childDirectoryVersionId
+                }
+
+            match selector with
+            | DiagnosisSelector.ReferenceId (referenceId, repositoryIdHint) ->
+                let! referenceDto = dependencies.GetReference referenceId correlationId
+                addActorFact "Reference" $"{referenceId:D}" None referenceDto
+
+                let repositoryMatches =
+                    repositoryIdHint
+                    |> Option.forall (fun repositoryId -> repositoryId = referenceDto.RepositoryId)
+
+                if referenceDto.ReferenceId <> referenceId
+                   || referenceDto.RepositoryId = RepositoryId.Empty
+                   || referenceDto.DirectoryId = DirectoryVersionId.Empty
+                   || referenceDto.DeletedAt.IsSome
+                   || not repositoryMatches then
+                    rootFailure <- Some $"Reference '{referenceId:D}' has no readable current live root matching the selector."
+                else
+                    sourceBacked <- true
+
+                    addExpected (
+                        ExactRelationship.ReferenceRoot
+                            {
+                                RepositoryId = referenceDto.RepositoryId
+                                RootDirectoryVersionId = referenceDto.DirectoryId
+                                ReferenceId = referenceDto.ReferenceId
+                            }
+                    )
+
+                    do! traverseDirectoryTree referenceDto.RepositoryId referenceDto.DirectoryId
+            | DiagnosisSelector.DirectoryVersionId (directoryVersionId, repositoryIdHint) ->
+                let! directoryVersionDto = readDirectoryVersion directoryVersionId
+                let current = directoryVersionDto.DirectoryVersion
+
+                let repositoryMatches =
+                    repositoryIdHint
+                    |> Option.forall (fun repositoryId -> repositoryId = current.RepositoryId)
+
+                if current.DirectoryVersionId <> directoryVersionId
+                   || current.RepositoryId = RepositoryId.Empty
+                   || not repositoryMatches then
+                    rootFailure <- Some $"DirectoryVersion '{directoryVersionId:D}' has no readable current state matching the selector."
+                else
+                    sourceBacked <- true
+                    do! traverseDirectoryTree current.RepositoryId directoryVersionId
+            | DiagnosisSelector.CounterTuple counterTuple ->
+                addManifestTarget counterTuple
+                unknownFields.Add "MissingRelationships" |> ignore
+                unknownFields.Add "RebuiltCount" |> ignore
+
+                unknownFields.Add "CompleteRepairTargets"
+                |> ignore
+
+                evidenceGaps.Add "A counter tuple has no readable source actor that can prove every expected DirectoryVersion-manifest relationship."
+            | DiagnosisSelector.OperationId selectedOperationId ->
+                operationId <- Some selectedOperationId
+
+                match tryParseOperationSource selectedOperationId with
+                | None ->
+                    rootFailure <- Some $"Operation id '{selectedOperationId}' is not a current deterministic DirectoryVersion manifest operation identity."
+                | Some (directoryVersionId, action) ->
+                    let! directoryVersionDto = readDirectoryVersion directoryVersionId
+                    let current = directoryVersionDto.DirectoryVersion
+
+                    if current.DirectoryVersionId <> directoryVersionId
+                       || current.RepositoryId = RepositoryId.Empty then
+                        rootFailure <- Some $"Operation id '{selectedOperationId}' names a DirectoryVersion whose current actor state is not readable."
+                    else
+                        match directManifests directoryVersionDto correlationId with
+                        | Error error ->
+                            rootFailure <- Some $"Operation source DirectoryVersion '{directoryVersionId:D}' manifests could not be interpreted: {error.Error}"
+                        | Ok manifests ->
+                            let matchingRelationship =
+                                manifests
+                                |> Array.map (fun manifest ->
+                                    {
+                                        RepositoryId = current.RepositoryId
+                                        StoragePoolId = manifest.StoragePoolId
+                                        ManifestAddress = manifest.ManifestAddress
+                                        DirectoryVersionId = directoryVersionId
+                                    })
+                                |> Array.tryFind (fun relationship -> operationIdentity action relationship = selectedOperationId)
+
+                            match matchingRelationship with
+                            | None -> rootFailure <- Some $"Operation id '{selectedOperationId}' cannot be supported by current source actor state."
+                            | Some relationship ->
+                                addManifestTarget
+                                    {
+                                        RepositoryId = relationship.RepositoryId
+                                        StoragePoolId = relationship.StoragePoolId
+                                        ManifestAddress = relationship.ManifestAddress
+                                    }
+
+                                deterministicIdentities.Add $"{selectedOperationId}"
+                                |> ignore
+
+                                unknownFields.Add "MissingRelationships" |> ignore
+                                unknownFields.Add "RebuiltCount" |> ignore
+
+                                unknownFields.Add "CompleteRepairTargets"
+                                |> ignore
+
+                                evidenceGaps.Add "An operation id identifies one source operation, not every actor that may expect this manifest."
+
+            match rootFailure with
+            | Some failure ->
+                return
+                    emptyReport generatedAt target maximumRelationships DiagnosisOutcome.FailedRetain [| "CompleteDiagnosis" |]
+                    |> fun report ->
+                        { report with
+                            ActorFacts = actorFacts.ToArray()
+                            DeterministicIdentities = deterministicIdentities |> Seq.sort |> Seq.toArray
+                            EvidenceGaps = [| failure |]
+                        }
+                    |> signReport
+            | None ->
+                for relationship in expected.Values do
+                    cancellationToken.ThrowIfCancellationRequested()
+                    let identity = noteRelationshipRead relationship
+
+                    match! dependencies.VerifyRelationship relationship cancellationToken with
+                    | ExactRelationshipPresence.Present -> observed.TryAdd(identity, relationship) |> ignore
+                    | ExactRelationshipPresence.Absent ->
+                        missing.Add identity |> ignore
+
+                        repairTargets.Add $"GetOrAddExactRelationship:{identity}"
+                        |> ignore
+
+                let countEvidence = ResizeArray<ManifestCountEvidence>()
+
+                for counterTuple in manifestTargets.Values do
+                    cancellationToken.ThrowIfCancellationRequested()
+
+                    let partition = ExactRelationshipPartition.Manifest(counterTuple.RepositoryId, counterTuple.StoragePoolId, counterTuple.ManifestAddress)
+
+                    let mutable continuationToken = None
+                    let mutable hasMore = true
+                    let continuationTokens = HashSet<string>(StringComparer.Ordinal)
+
+                    while hasMore do
+                        let! page = dependencies.EnumerateRelationships partition bound continuationToken cancellationToken
+
+                        for relationship in page.Relationships do
+                            let identity = noteRelationshipRead relationship
+                            observed.TryAdd(identity, relationship) |> ignore
+
+                        match page.ContinuationToken with
+                        | Some token when continuationTokens.Add token -> continuationToken <- Some token
+                        | Some _ ->
+                            evidenceGaps.Add("Exact relationship enumeration repeated a continuation token before completing the manifest partition.")
+
+                            hasMore <- false
+                        | None -> hasMore <- false
+
+                    let mutable validObservedCount = 0L
+
+                    for KeyValue (identity, relationship) in observed do
+                        match relationship with
+                        | ExactRelationship.DirectoryVersionManifest manifestRelationship when
+                            manifestRelationship.RepositoryId = counterTuple.RepositoryId
+                            && manifestRelationship.StoragePoolId = counterTuple.StoragePoolId
+                            && manifestRelationship.ManifestAddress = counterTuple.ManifestAddress
+                            ->
+                            let! sourceDto = readDirectoryVersion manifestRelationship.DirectoryVersionId
+
+                            let sourceIsCurrent =
+                                sourceDto.DirectoryVersion.DirectoryVersionId = manifestRelationship.DirectoryVersionId
+                                && sourceDto.DirectoryVersion.RepositoryId = manifestRelationship.RepositoryId
+
+                            let sourceNamesManifest =
+                                if sourceIsCurrent then
+                                    match directManifests sourceDto correlationId with
+                                    | Ok manifests ->
+                                        manifests
+                                        |> Array.exists (fun manifest ->
+                                            manifest.StoragePoolId = manifestRelationship.StoragePoolId
+                                            && manifest.ManifestAddress = manifestRelationship.ManifestAddress)
+                                    | Error error ->
+                                        evidenceGaps.Add(
+                                            $"DirectoryVersion '{manifestRelationship.DirectoryVersionId:D}' manifests could not be interpreted: {error.Error}"
+                                        )
+
+                                        false
+                                else
+                                    false
+
+                            if sourceNamesManifest then
+                                validObservedCount <- validObservedCount + 1L
+                            else
+                                stale.Add identity |> ignore
+
+                                repairTargets.Add $"RemoveStaleExactRelationship:{identity}"
+                                |> ignore
+                        | _ -> ()
+
+                    let! counterDto = dependencies.GetCounter counterTuple correlationId
+
+                    addActorFact
+                        "RepositoryContentCounter"
+                        (RepositoryContentCounter.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress)
+                        (Some counterDto.Revision)
+                        counterDto
+
+                    let! workflowDto = dependencies.GetWorkflow counterTuple correlationId
+
+                    addWorkflowActorFact
+                        "ManifestContributionWorkflow"
+                        (ManifestContributionWorkflow.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress)
+                        (Some workflowDto.Revision)
+                        workflowDto
+
+                    if (not (isNull (box workflowDto.LifecycleState))
+                        && workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress)
+                       || (not (isNull workflowDto.FailedRanges)
+                           && workflowDto.FailedRanges.Length > 0) then
+                        evidenceGaps.Add(
+                            $"Manifest contribution workflow for '{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}' has unfinished or failed ranges."
+                        )
+
+                        repairTargets.Add(
+                            $"ResumeManifestContributionWorkflow:{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}"
+                        )
+                        |> ignore
+
+                    let rebuiltCount =
+                        if sourceBacked then
+                            let missingExpectedForTuple =
+                                expected
+                                |> Seq.sumBy (fun (KeyValue (identity, relationship)) ->
+                                    match relationship with
+                                    | ExactRelationship.DirectoryVersionManifest manifestRelationship when
+                                        manifestRelationship.RepositoryId = counterTuple.RepositoryId
+                                        && manifestRelationship.StoragePoolId = counterTuple.StoragePoolId
+                                        && manifestRelationship.ManifestAddress = counterTuple.ManifestAddress
+                                        && missing.Contains identity
+                                        ->
+                                        1L
+                                    | _ -> 0L)
+
+                            Some(validObservedCount + missingExpectedForTuple)
+                        else
+                            None
+
+                    countEvidence.Add(
+                        {
+                            RepositoryId = $"{counterTuple.RepositoryId:D}"
+                            StoragePoolId = $"{counterTuple.StoragePoolId}"
+                            ManifestAddress = $"{counterTuple.ManifestAddress}"
+                            StoredCount = Some counterDto.Count
+                            RebuiltCount = rebuiltCount
+                            Completeness = if sourceBacked then "Complete" else "IncompleteRetain"
+                        }
+                    )
+
+                    match rebuiltCount with
+                    | Some rebuilt when rebuilt <> counterDto.Count ->
+                        repairTargets.Add($"ReconcileCounter:{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}")
+                        |> ignore
+                    | _ -> ()
+
+                let redisEvidence = ResizeArray<string>()
+
+                match operationId with
+                | Some selectedOperationId when manifestTargets.Count = 1 ->
+                    let counterTuple = manifestTargets.Values |> Seq.head
+                    let! recent = dependencies.GetRecentResult counterTuple selectedOperationId cancellationToken
+
+                    match recent with
+                    | Some change ->
+                        redisEvidence.Add(
+                            $"Observed:{change.OperationId}|{change.Operation}|{change.PreviousCount}->{change.CurrentCount}|revision:{change.Revision}"
+                        )
+                    | None ->
+                        redisEvidence.Add "AbsentOrUnavailable"
+                        evidenceGaps.Add "Redis had no recent result; durable actor and exact evidence remain authoritative."
+                | Some _ -> redisEvidence.Add "NotReadableWithoutCounterTuple"
+                | None -> redisEvidence.Add "NotRequested"
+
+                if not sourceBacked then
+                    for counterTuple in manifestTargets.Values do
+                        repairTargets.Add(
+                            $"DiagnoseReadableSourceRequired:{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}"
+                        )
+                        |> ignore
+
+                let countsMatch =
+                    countEvidence
+                    |> Seq.forall (fun evidence ->
+                        match evidence.StoredCount, evidence.RebuiltCount with
+                        | Some stored, Some rebuilt -> stored = rebuilt
+                        | _ -> false)
+
+                let verified =
+                    sourceBacked
+                    && missing.Count = 0
+                    && stale.Count = 0
+                    && evidenceGaps.Count = 0
+                    && countsMatch
+
+                let reclamationPermitted =
+                    verified
+                    && countEvidence.Count > 0
+                    && (countEvidence
+                        |> Seq.forall (fun evidence ->
+                            evidence.StoredCount = Some 0L
+                            && evidence.RebuiltCount = Some 0L))
+
+                return
+                    {
+                        SchemaVersion = "grace.manifest-contribution-diagnosis.v1"
+                        GeneratedAt = generatedAt
+                        Target = target
+                        MaxRelationships = maximumRelationships
+                        RelationshipsRead = relationshipReads.Count
+                        ActorFacts = actorFacts.ToArray()
+                        ExpectedRelationships = expected.Keys |> Seq.sort |> Seq.toArray
+                        ObservedRelationships = observed.Keys |> Seq.sort |> Seq.toArray
+                        MissingRelationships = missing |> Seq.sort |> Seq.toArray
+                        StaleRelationships = stale |> Seq.sort |> Seq.toArray
+                        CountEvidence = countEvidence.ToArray()
+                        DeterministicIdentities = deterministicIdentities |> Seq.sort |> Seq.toArray
+                        RedisEvidence = redisEvidence.ToArray()
+                        RepairTargets = repairTargets |> Seq.sort |> Seq.toArray
+                        UnknownFields = unknownFields |> Seq.sort |> Seq.toArray
+                        EvidenceGaps = evidenceGaps.ToArray()
+                        ReclamationPermitted = reclamationPermitted
+                        Outcome =
+                            if verified then
+                                DiagnosisOutcome.VerifiedComplete
+                            else
+                                DiagnosisOutcome.IncompleteRetain
+                        ReportSha256 = String.Empty
+                    }
+                    |> signReport
+        }
+
+    /// Creates production read dependencies without exposing a mutation-capable service to the diagnosis core.
+    let private productionDependencies (context: HttpContext) =
+        let store = ManifestContributionAccounting.CosmosExactRelationshipStore(cosmosContainer) :> IExactRelationshipStore
+
+        let recentResults = context.RequestServices.GetRequiredService<IRepositoryCounterRecentResult>()
+
+        {
+            GetReference =
+                fun referenceId correlationId ->
+                    let actor = grainFactory.CreateActorProxyWithCorrelationId<IReferenceActor>(referenceId, correlationId)
+
+                    actor.Get correlationId
+            GetDirectoryVersion =
+                fun directoryVersionId correlationId ->
+                    let actor = grainFactory.CreateActorProxyWithCorrelationId<IDirectoryVersionActor>(directoryVersionId, correlationId)
+
+                    actor.Get correlationId
+            EnumerateRelationships =
+                fun partition bound continuationToken cancellationToken -> store.EnumerateAsync(partition, bound, continuationToken, cancellationToken)
+            VerifyRelationship = fun relationship cancellationToken -> store.VerifyAsync(relationship, cancellationToken)
+            GetCounter =
+                fun counterTuple correlationId ->
+                    let actor =
+                        grainFactory.CreateActorProxyWithCorrelationId<IRepositoryContentCounterActor>(
+                            RepositoryContentCounter.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress,
+                            correlationId
+                        )
+
+                    actor.Get correlationId
+            GetWorkflow =
+                fun counterTuple correlationId ->
+                    let actor =
+                        grainFactory.CreateActorProxyWithCorrelationId<IManifestContributionWorkflowActor>(
+                            ManifestContributionWorkflow.primaryKey counterTuple.RepositoryId counterTuple.StoragePoolId counterTuple.ManifestAddress,
+                            correlationId
+                        )
+
+                    actor.Get correlationId
+            GetRecentResult =
+                fun counterTuple operationId cancellationToken ->
+                    recentResults.TryGetAsync(
+                        counterTuple.RepositoryId,
+                        counterTuple.StoragePoolId,
+                        counterTuple.ManifestAddress,
+                        operationId,
+                        cancellationToken
+                    )
+        }
+
+    /// Handles the internal SystemAdmin diagnosis route and returns signed operator evidence without writing Grace state.
+    let Diagnose: HttpHandler =
+        fun next context ->
+            task {
+                try
+                    let! parameters = context.BindJsonAsync<DiagnoseManifestContributionParameters>()
+
+                    match validateParameters parameters with
+                    | Error error -> return! RequestErrors.BAD_REQUEST error next context
+                    | Ok selector ->
+                        match ExactRelationshipReadBound.create parameters.MaxRelationships with
+                        | Error error -> return! RequestErrors.BAD_REQUEST error next context
+                        | Ok bound ->
+                            let! report =
+                                diagnoseWith
+                                    (productionDependencies context)
+                                    (getCurrentInstantExtended ())
+                                    (getCorrelationId context)
+                                    context.RequestAborted
+                                    bound
+                                    selector
+
+                            return! context.WriteJsonAsync report
+                with
+                | RelationshipBoundExceeded error -> return! RequestErrors.BAD_REQUEST error next context
+                | :? JsonException -> return! RequestErrors.BAD_REQUEST "The diagnosis request body must be valid JSON." next context
+            }

--- a/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
+++ b/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
@@ -592,6 +592,7 @@ module ManifestContributionDiagnosis =
 
                     let mutable continuationToken = None
                     let mutable hasMore = true
+                    let mutable enumerationComplete = true
                     let continuationTokens = HashSet<string>(StringComparer.Ordinal)
 
                     while hasMore do
@@ -602,14 +603,20 @@ module ManifestContributionDiagnosis =
                             observed.TryAdd(identity, relationship) |> ignore
 
                         match page.ContinuationToken with
-                        | Some token when continuationTokens.Add token -> continuationToken <- Some token
+                        | Some token when
+                            not (String.IsNullOrWhiteSpace token)
+                            && continuationTokens.Add token
+                            ->
+                            continuationToken <- Some token
                         | Some _ ->
                             evidenceGaps.Add("Exact relationship enumeration repeated a continuation token before completing the manifest partition.")
 
+                            enumerationComplete <- false
                             hasMore <- false
                         | None -> hasMore <- false
 
                     let mutable validObservedCount = 0L
+                    let mutable sourceStateComplete = true
 
                     for KeyValue (identity, relationship) in observed do
                         match relationship with
@@ -620,34 +627,38 @@ module ManifestContributionDiagnosis =
                             ->
                             let! sourceDto = readDirectoryVersion manifestRelationship.DirectoryVersionId
 
-                            let sourceIsCurrent =
+                            let sourceMatchesRelationship =
                                 sourceDto.DirectoryVersion.DirectoryVersionId = manifestRelationship.DirectoryVersionId
                                 && sourceDto.DirectoryVersion.RepositoryId = manifestRelationship.RepositoryId
 
-                            let sourceNamesManifest =
-                                if sourceIsCurrent then
-                                    match directManifests sourceDto correlationId with
-                                    | Ok manifests ->
+                            if not sourceMatchesRelationship then
+                                sourceStateComplete <- false
+
+                                evidenceGaps.Add(
+                                    $"DirectoryVersion '{manifestRelationship.DirectoryVersionId:D}' did not return readable current state for repository '{manifestRelationship.RepositoryId:D}'."
+                                )
+                            else
+                                match directManifests sourceDto correlationId with
+                                | Ok manifests ->
+                                    let sourceNamesManifest =
                                         manifests
                                         |> Array.exists (fun manifest ->
                                             manifest.StoragePoolId = manifestRelationship.StoragePoolId
                                             && manifest.ManifestAddress = manifestRelationship.ManifestAddress)
-                                    | Error error ->
-                                        evidenceGaps.Add(
-                                            $"DirectoryVersion '{manifestRelationship.DirectoryVersionId:D}' manifests could not be interpreted: {error.Error}"
-                                        )
 
-                                        false
-                                else
-                                    false
+                                    if sourceNamesManifest then
+                                        validObservedCount <- validObservedCount + 1L
+                                    else
+                                        stale.Add identity |> ignore
 
-                            if sourceNamesManifest then
-                                validObservedCount <- validObservedCount + 1L
-                            else
-                                stale.Add identity |> ignore
+                                        repairTargets.Add $"RemoveStaleExactRelationship:{identity}"
+                                        |> ignore
+                                | Error error ->
+                                    sourceStateComplete <- false
 
-                                repairTargets.Add $"RemoveStaleExactRelationship:{identity}"
-                                |> ignore
+                                    evidenceGaps.Add(
+                                        $"DirectoryVersion '{manifestRelationship.DirectoryVersionId:D}' manifests could not be interpreted: {error.Error}"
+                                    )
                         | _ -> ()
 
                     let! counterDto = dependencies.GetCounter counterTuple correlationId
@@ -666,21 +677,62 @@ module ManifestContributionDiagnosis =
                         (Some workflowDto.Revision)
                         workflowDto
 
-                    if (not (isNull (box workflowDto.LifecycleState))
-                        && workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress)
-                       || (not (isNull workflowDto.FailedRanges)
-                           && workflowDto.FailedRanges.Length > 0) then
-                        evidenceGaps.Add(
-                            $"Manifest contribution workflow for '{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}' has unfinished or failed ranges."
-                        )
+                    let workflowTargetMatches =
+                        workflowDto.RepositoryId = counterTuple.RepositoryId
+                        && workflowDto.StoragePoolId = counterTuple.StoragePoolId
+                        && workflowDto.ManifestAddress = counterTuple.ManifestAddress
 
-                        repairTargets.Add(
-                            $"ResumeManifestContributionWorkflow:{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}"
-                        )
-                        |> ignore
+                    let workflowReadable =
+                        workflowTargetMatches
+                        && not (String.IsNullOrWhiteSpace workflowDto.Class)
+                        && not (isNull (box workflowDto.Direction))
+                        && not (isNull workflowDto.Ranges)
+                        && not (isNull workflowDto.CompletedRanges)
+                        && not (isNull workflowDto.FailedRanges)
+                        && not (isNull (box workflowDto.LifecycleState))
+                        && workflowDto.StartOperationId.IsSome
+                        && workflowDto.LastOperationId.IsSome
+                        && workflowDto.Revision > 0L
+
+                    let workflowCompleted =
+                        workflowReadable
+                        && workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.Completed
+                        && workflowDto.FailedRanges.Length = 0
+                        && workflowDto.CompletedRanges.Length = workflowDto.Ranges.Length
+                        && (workflowDto.CompletedRanges
+                            |> Array.forall (fun progress ->
+                                progress.RepositoryId = counterTuple.RepositoryId
+                                && progress.StoragePoolId = counterTuple.StoragePoolId
+                                && progress.ManifestAddress = counterTuple.ManifestAddress))
+                        && (workflowDto.Ranges
+                            |> Array.forall (fun range ->
+                                workflowDto.CompletedRanges
+                                |> Array.filter (fun progress -> progress.Range = range)
+                                |> Array.length
+                                |> (=) 1))
+
+                    if not workflowCompleted then
+                        let targetIdentity = $"{counterTuple.RepositoryId:D}|{counterTuple.StoragePoolId}|{counterTuple.ManifestAddress}"
+
+                        if not workflowTargetMatches then
+                            evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' returned state for a different target.")
+                        elif not workflowReadable then
+                            evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' was absent or unreadable.")
+                        else
+                            evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' has unfinished, failed, or inconsistent ranges.")
+
+                            if workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.InProgress
+                               || workflowDto.FailedRanges.Length > 0 then
+                                repairTargets.Add($"ResumeManifestContributionWorkflow:{targetIdentity}")
+                                |> ignore
+
+                    let partitionEvidenceComplete =
+                        enumerationComplete
+                        && sourceStateComplete
+                        && workflowCompleted
 
                     let rebuiltCount =
-                        if sourceBacked then
+                        if sourceBacked && partitionEvidenceComplete then
                             let missingExpectedForTuple =
                                 expected
                                 |> Seq.sumBy (fun (KeyValue (identity, relationship)) ->
@@ -705,7 +757,11 @@ module ManifestContributionDiagnosis =
                             ManifestAddress = $"{counterTuple.ManifestAddress}"
                             StoredCount = Some counterDto.Count
                             RebuiltCount = rebuiltCount
-                            Completeness = if sourceBacked then "Complete" else "IncompleteRetain"
+                            Completeness =
+                                if sourceBacked && partitionEvidenceComplete then
+                                    "Complete"
+                                else
+                                    "IncompleteRetain"
                         }
                     )
 

--- a/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
+++ b/src/Grace.Server/ManifestContributionDiagnosis.Server.fs
@@ -752,6 +752,10 @@ module ManifestContributionDiagnosis =
                         && workflowDto.CounterRevision > 0L
                         && workflowDto.Revision > 0L
 
+                    let workflowCounterSnapshotCoherent =
+                        not counterReadable
+                        || workflowDto.CounterRevision <= counterDto.Revision
+
                     let workflowRangesExact =
                         match
                             expectedWorkflowRanges.TryGetValue
@@ -767,6 +771,7 @@ module ManifestContributionDiagnosis =
 
                     let workflowCompleted =
                         workflowReadable
+                        && workflowCounterSnapshotCoherent
                         && workflowRangesExact
                         && workflowDto.LifecycleState = ManifestContributionWorkflowLifecycleState.Completed
                         && workflowDto.FailedRanges.Length = 0
@@ -793,6 +798,10 @@ module ManifestContributionDiagnosis =
                             evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' returned state for a different target.")
                         elif not workflowReadable then
                             evidenceGaps.Add($"Manifest contribution workflow for '{targetIdentity}' was absent or unreadable.")
+                        elif not workflowCounterSnapshotCoherent then
+                            evidenceGaps.Add(
+                                $"Manifest contribution workflow for '{targetIdentity}' recorded counter revision {workflowDto.CounterRevision}, which is newer than the counter snapshot revision {counterDto.Revision}."
+                            )
                         else
                             evidenceGaps.Add(
                                 $"Manifest contribution workflow for '{targetIdentity}' has unfinished, failed, duplicate, or source-mismatched ranges."

--- a/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
+++ b/src/Grace.Server/Security/EndpointAuthorizationManifest.Server.fs
@@ -42,6 +42,7 @@ module EndpointAuthorizationManifest =
             endpoint "POST" "/authorize/upsert-path-permission" (Authorized(RepositoryAdmin, Repository))
             endpoint "POST" "/admin/deleteAllFromCosmosDB" (Authorized(SystemAdmin, System))
             endpoint "POST" "/admin/deleteAllRemindersFromCosmosDB" (Authorized(SystemAdmin, System))
+            endpoint "POST" "/admin/manifest-contribution/diagnose" (Authorized(SystemAdmin, System))
             endpoint "POST" "/approval/policy/create" (Authorized(ApprovalPolicyManage, Repository))
             endpoint "POST" "/approval/policy/list" (Authorized(ApprovalPolicyManage, Repository))
             endpoint "POST" "/approval/policy/show" (Authorized(ApprovalPolicyManage, Repository))

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1775,7 +1775,7 @@ module Application =
                 subRoute
                     "/admin"
                     [
-                        POST [
+                        POST [ route "/manifest-contribution/diagnose" (composeHandlers requireSystemAdmin ManifestContributionDiagnosis.Diagnose)
 #if DEBUG
                                route "/deleteAllFromCosmosDB" (composeHandlers requireSystemAdmin Storage.DeleteAllFromCosmosDB)
                                route "/deleteAllRemindersFromCosmosDB" (composeHandlers requireSystemAdmin Storage.DeleteAllRemindersFromCosmosDB)

--- a/src/OpenAPI/RouteClassification.json
+++ b/src/OpenAPI/RouteClassification.json
@@ -18,7 +18,8 @@
         { "method": "GET", "path": "/" },
         { "method": "GET", "path": "/healthz" },
         { "method": "GET", "path": "/metrics" },
-        { "method": "GET", "path": "/notifications" }
+        { "method": "GET", "path": "/notifications" },
+        { "method": "POST", "path": "/admin/manifest-contribution/diagnose" }
       ]
     },
     {


### PR DESCRIPTION
# Issue #734: Bounded manifest contribution diagnosis

## Why this matters

Grace operators need to diagnose one manifest contribution target without changing actor state, scanning a Repository,
or introducing another durable source of truth. This slice provides bounded evidence that later repair work can use.

Relates to #734.
Parent epic: #727.

## What changed

- Added the SystemAdmin-only `POST /admin/manifest-contribution/diagnose` route.
- Added bounded `ReferenceId`, `DirectoryVersionId`, counter-tuple, and
  `RepositoryContentCounterOperationId` selectors.
- Reports current actor, exact-relationship, counter, workflow, and optional Redis evidence with conservative
  `IncompleteRetain` or `FailedRetain` outcomes whenever completeness cannot be proven.
- Added a PowerShell operator script that validates inputs, writes reports atomically, verifies the SHA-256 digest,
  and maps terminal outcomes to documented exit codes.
- Added the operator runbook and focused route, authorization, report, script, and regression tests.
- Kept the route out of public OpenAPI and generated clients as an intentionally excluded operational surface.

No diagnosis path mutates Grace. No reverse index, Repository-wide scan, repair execution, durable report, checkpoint,
cursor, scheduler, or `ReferenceType`-specific behavior was added.

## Validation

- Release build, `Grace.Server.Unit.Tests`: passed with 0 warnings and 0 errors.
- `FullyQualifiedName~ManifestContributionDiagnosisServerTests`: 9/9 passed.
- Release build, endpoint authorization tests: passed with 0 warnings and 0 errors.
- `FullyQualifiedName~EndpointAuthorizationManifestTests|FullyQualifiedName~OpenApiRouteCoverageTests`: 25/25 passed.
- PowerShell parser and `scripts/tests/diagnose-manifest-contribution.Tests.ps1`: passed.
- Fantomas on the changed F# files: passed.
- MarkdownLint on `docs/Manifest contribution diagnosis.md`: 0 errors.
- `git diff --check`: passed.

## Aspire witness

All five authorized starts were consumed. Each worker-owned AppHost was stopped and port 5000 was left free.

The fifth, materially different resource-log session acquired a PAT without printing it and proved that bearer
authentication and the new route were reached. It exposed an HTTP 500 when an absent workflow actor produced null
enum-like report fields. The same worker fixed that defect and added a focused regression test, which is included in
the 9/9 result above. The 5/5 budget prohibits another live start, so the current-head fix has automated proof but no
post-fix live-script witness.

No repair or manifest-accounting mutation ran.

## First-pass review readiness

- Bot-prevention self-review: completed over correctness, selector bounds, source-less completeness, authorization,
  zero-write behavior, SHA canonicalization, pagination, null actor state, scripts, and documentation.
- Issues found and fixed before handoff: delimiter-sensitive operation parsing, cross-language SHA canonicalization,
  repeated continuations, unfinished workflow evidence, and the live null-workflow serialization failure.
- Residual risk: no post-fix live-script witness because the authorized Aspire budget is exhausted.

## Review Status

- Current head: `e56c59410209db2c244b80e547d4dcd7c5bdab1a`
- Implementation/fix-worker starts: 7/7; exhausted
- Aspire starts: 5/5; exhausted, with no sixth start authorized
- Codex review sessions: 6/6; complete
- Codex Code Review Bot: review 6/6 completed on `e56c5941`; its two findings were invalid against the accepted bounded/read-only contract and resolved without code changes
- Manual trigger: not attempted
- Manual trigger lock: complete; no manual trigger was used
- Open findings: none; every review conversation is resolved
- Fix commits already pushed: `2215ffc2`, `926337f6`, `71372cdf`, `51ab4085`, `e56c5941`
- Final owner disposition: review 6/6 is complete, both scope findings were invalid, every conversation is resolved, and no further review was triggered
- CI retry: attempt 2 passed unchanged, confirming the unrelated Storage race-test failure was transient; no code-fix worker or product change assigned
- Prevention: acceptance-criteria / negative-proof gap; Issue #734 now has an evidence-trust stabilization ledger covering script runtime compatibility, exact workflow coverage, and counter identity, while sibling Issue #735 rejects repair from incomplete evidence.

## Review stabilization ledger

After two substantive cycles on this high-risk trust surface, review-2 fixes are governed by one invariant: no complete
outcome or repair suggestion may rely on evidence that is uninitialized, target-mismatched, runtime-incompatible, or
incomplete. The frozen action set is PowerShell 7 SHA compatibility, exact workflow coverage of current source
ContentBlocks, and initialized target-matching counter evidence. Full proof obligations and stop conditions are recorded
in Issue #734.
### Review timeline

| Review | Head | Result |
| ------ | ---- | ------ |
| 1/3 | `961dd174` | three findings fixed in `2215ffc2` |
| 2/3 | `2215ffc2` | three findings stabilized in `926337f6` |
| 3/4 | `926337f6` | three valid findings fixed in `71372cdf` |
| 4/5 | `71372cdf` | two findings fixed in `51ab4085` |
| 5/6 | `51ab4085` | one finding fixed and resolved in `e56c5941` |
| 6/6 | `e56c5941` | two findings invalid against accepted bounded/read-only scope; answered and resolved |

GitHub Validate run `30347366583` passed on current head `e56c5941`. Review 6/6 completed; its two bounded/read-only scope findings were answered and resolved without code changes. The unrelated Storage race-test failed once and passed unchanged on retry, so it
is recorded as a CI flake rather than a substantive cycle.
## Documentation impact

Added `docs/Manifest contribution diagnosis.md` with selector examples, bounds, report interpretation, exit codes,
and concrete operator follow-up guidance. Public OpenAPI and generated clients are intentionally N/A because this is
an internal SystemAdmin operational route.











