### PR TITLE
MCA-08A: Add typed manifest-accounting settlement and observability

### DIFF
--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="DedupeIndex.Server.Tests.fs" />
     <Compile Include="Eventing.Server.Tests.fs" />
     <Compile Include="OperationalFactsPublisher.Actor.Tests.fs" />
+    <Compile Include="ManifestContributionTelemetry.Server.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="PromotionSet.DirectoryHash.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
@@ -2,14 +2,18 @@ namespace Grace.Server.Tests
 
 open Grace.Server
 open Grace.Server.Notification
+open Grace.Types.Common
 open Grace.Types.Events
 open Grace.Types.ManifestContributionAccounting
+open Grace.Types.Reference
+open Grace.Types.Repository
 open NUnit.Framework
 open System
 open System.Collections.Generic
 open System.Diagnostics
 open System.Diagnostics.Metrics
 open Microsoft.Extensions.Logging
+open Microsoft.Extensions.Logging.Abstractions
 open System.Threading
 open System.Threading.Tasks
 
@@ -24,8 +28,30 @@ type ManifestContributionTelemetryServerTests() =
     /// Supplies stable high-cardinality message context without exposing it as metric dimensions.
     let metadata: Subscriber.GraceEventMessageMetadata = { MessageId = "message-123"; CorrelationId = "correlation-456"; DeliveryCount = 3 }
 
-    /// Represents a parsed event whose concrete case is irrelevant to settlement orchestration.
-    let validEvent = Unchecked.defaultof<GraceEvent>
+    /// Represents a valid Reference-created delivery that enters manifest contribution accounting.
+    let validEvent =
+        GraceEvent.ReferenceEvent
+            {
+                Event =
+                    ReferenceEventType.Created(
+                        Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                        Guid.Parse("22222222-2222-2222-2222-222222222222"),
+                        Guid.Parse("33333333-3333-3333-3333-333333333333"),
+                        Guid.Parse("44444444-4444-4444-4444-444444444444"),
+                        Guid.Parse("55555555-5555-5555-5555-555555555555"),
+                        Guid.Parse("66666666-6666-6666-6666-666666666666"),
+                        Sha256Hash String.Empty,
+                        Blake3Hash String.Empty,
+                        ReferenceType.Commit,
+                        "reference-created",
+                        []
+                    )
+                Metadata = EventMetadata.New "reference-created-correlation" "unit-test"
+            }
+
+    /// Represents a valid general Grace delivery that never enters manifest contribution accounting.
+    let unrelatedEvent =
+        GraceEvent.RepositoryEvent { Event = RepositoryEventType.Initialized; Metadata = EventMetadata.New "repository-initialized-correlation" "unit-test" }
 
     /// Executes one successful delivery and proves handler and completion are each invoked once.
     [<Test>]
@@ -54,14 +80,118 @@ type ManifestContributionTelemetryServerTests() =
             Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "complete" |] :> obj))
         }
 
+    /// Proves valid general Grace deliveries do not inflate manifest-accounting message or duration instruments.
+    [<Test>]
+    member _.UnrelatedGraceEventDoesNotEmitManifestMessageMeasurements() =
+        task {
+            let measurements = ResizeArray<string>()
+            use listener = new MeterListener()
+
+            listener.InstrumentPublished <-
+                fun instrument meterListener ->
+                    if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                       && (instrument.Name = "grace.manifest_contribution.messages"
+                           || instrument.Name = "grace.manifest_contribution.processing.duration") then
+                        meterListener.EnableMeasurementEvents instrument
+
+            listener.SetMeasurementEventCallback<int64>(fun instrument _ _ _ -> measurements.Add instrument.Name)
+            listener.SetMeasurementEventCallback<double>(fun instrument _ _ _ -> measurements.Add instrument.Name)
+            listener.Start()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok unrelatedEvent)
+                    (fun _ _ -> Task.CompletedTask)
+                    (fun _ -> Task.CompletedTask)
+                    (fun _ -> Task.CompletedTask)
+                    (fun _ _ _ -> Task.CompletedTask)
+
+            do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+
+            Assert.That(measurements, Is.Empty)
+        }
+
+    /// Proves Reference-created deliveries emit both manifest message instruments with bounded terminal tags.
+    [<Test>]
+    member _.ReferenceCreatedDeliveryEmitsManifestMessageAndDurationMeasurements() =
+        task {
+            let measurements = ResizeArray<string * string * string>()
+            use listener = new MeterListener()
+
+            listener.InstrumentPublished <-
+                fun instrument meterListener ->
+                    if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                       && (instrument.Name = "grace.manifest_contribution.messages"
+                           || instrument.Name = "grace.manifest_contribution.processing.duration") then
+                        meterListener.EnableMeasurementEvents instrument
+
+            listener.SetMeasurementEventCallback<int64> (fun instrument _ tags _ ->
+                let mutable stage = String.Empty
+                let mutable outcome = String.Empty
+
+                for tag in tags do
+                    if tag.Key = "stage" then stage <- string tag.Value
+                    elif tag.Key = "outcome" then outcome <- string tag.Value
+
+                measurements.Add(instrument.Name, stage, outcome))
+
+            listener.SetMeasurementEventCallback<double> (fun instrument _ tags _ ->
+                let mutable stage = String.Empty
+                let mutable outcome = String.Empty
+
+                for tag in tags do
+                    if tag.Key = "stage" then stage <- string tag.Value
+                    elif tag.Key = "outcome" then outcome <- string tag.Value
+
+                measurements.Add(instrument.Name, stage, outcome))
+
+            listener.Start()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ -> Task.CompletedTask)
+                    (fun _ -> Task.CompletedTask)
+                    (fun _ -> Task.CompletedTask)
+                    (fun _ _ _ -> Task.CompletedTask)
+
+            do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+
+            Assert.That(
+                measurements
+                |> Seq.map (fun (instrumentName, _, _) -> instrumentName),
+                Is.EquivalentTo(
+                    [|
+                        "grace.manifest_contribution.messages"
+                        "grace.manifest_contribution.processing.duration"
+                    |]
+                )
+            )
+
+            Assert.That(measurements, Has.All.Matches<string * string * string>(fun (_, stage, outcome) -> stage = "settle" && outcome = "completed"))
+        }
+
     /// Proves malformed and JSON-null payloads dead-letter once with fixed redacted evidence.
     [<TestCase("{not-json")>]
     [<TestCase("null")>]
     member _.MalformedPayloadDeadLettersOnceWithoutPayloadEvidence(payload: string) =
         task {
             let calls = ResizeArray<string>()
+            let measurements = ResizeArray<string>()
             let mutable reason = String.Empty
             let mutable description = String.Empty
+            use listener = new MeterListener()
+
+            listener.InstrumentPublished <-
+                fun instrument meterListener ->
+                    if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                       && (instrument.Name = "grace.manifest_contribution.messages"
+                           || instrument.Name = "grace.manifest_contribution.processing.duration") then
+                        meterListener.EnableMeasurementEvents instrument
+
+            listener.SetMeasurementEventCallback<int64>(fun instrument _ _ _ -> measurements.Add instrument.Name)
+            listener.SetMeasurementEventCallback<double>(fun instrument _ _ _ -> measurements.Add instrument.Name)
+            listener.Start()
 
             let seam =
                 dependencies
@@ -90,7 +220,8 @@ type ManifestContributionTelemetryServerTests() =
                     Assert.That(description, Is.EqualTo(Subscriber.MalformedGraceEventDescription))
                     Assert.That(description.Length, Is.LessThanOrEqualTo(128))
                     Assert.That(description, Does.Not.Contain(payload))
-                    Assert.That(description, Does.Not.Contain("secret-value")))
+                    Assert.That(description, Does.Not.Contain("secret-value"))
+                    Assert.That(measurements, Is.Empty))
             )
         }
 
@@ -154,6 +285,59 @@ type ManifestContributionTelemetryServerTests() =
             Assert.That(calls.ToArray(), Is.EqualTo([| "handle" |] :> obj))
         }
 
+    /// Proves cancellation observed after handling but before settlement is not relabeled as an unknown settlement.
+    [<Test>]
+    member _.PreSettlementCancellationPropagatesWithoutSettlementFailureOutcome() =
+        task {
+            let calls = ResizeArray<string>()
+            let outcomes = ResizeArray<string>()
+            use cancellation = new CancellationTokenSource()
+            use listener = new MeterListener()
+
+            listener.InstrumentPublished <-
+                fun instrument meterListener ->
+                    if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                       && instrument.Name = "grace.manifest_contribution.messages" then
+                        meterListener.EnableMeasurementEvents instrument
+
+            listener.SetMeasurementEventCallback<int64> (fun _ _ tags _ ->
+                for tag in tags do
+                    if tag.Key = "outcome" then outcomes.Add(string tag.Value))
+
+            listener.Start()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        cancellation.Cancel()
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            let mutable cancellationPropagated = false
+
+            try
+                do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) cancellation.Token
+            with
+            | :? OperationCanceledException -> cancellationPropagated <- true
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(cancellationPropagated, Is.True)
+                    Assert.That(calls.ToArray(), Is.EqualTo([| "handle" |] :> obj))
+                    Assert.That(outcomes, Is.Empty))
+            )
+        }
+
     /// Proves cancellation before parsing propagates without any settlement attempt.
     [<Test>]
     member _.CancellationBeforeParsingPropagatesWithoutSettlement() =
@@ -191,11 +375,25 @@ type ManifestContributionTelemetryServerTests() =
             Assert.That(calls, Is.Empty)
         }
 
-    /// Proves an unknown complete result propagates without abandon or dead-letter fallback.
+    /// Proves an unknown complete result surfaces one typed failure without abandon or dead-letter fallback.
     [<Test>]
     member _.CompleteFailureDoesNotAttemptFallbackSettlement() =
         task {
             let calls = ResizeArray<string>()
+            let outcomes = ResizeArray<string>()
+            use listener = new MeterListener()
+
+            listener.InstrumentPublished <-
+                fun instrument meterListener ->
+                    if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                       && instrument.Name = "grace.manifest_contribution.messages" then
+                        meterListener.EnableMeasurementEvents instrument
+
+            listener.SetMeasurementEventCallback<int64> (fun _ _ tags _ ->
+                for tag in tags do
+                    if tag.Key = "outcome" then outcomes.Add(string tag.Value))
+
+            listener.Start()
 
             let seam =
                 dependencies
@@ -218,10 +416,29 @@ type ManifestContributionTelemetryServerTests() =
             try
                 do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
             with
-            | :? InvalidOperationException -> failed <- true
+            | :? Subscriber.GraceEventSettlementFailureException -> failed <- true
 
             Assert.That(failed, Is.True)
             Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "complete" |] :> obj))
+            Assert.That(outcomes.ToArray(), Is.EqualTo([| "settlement_failed" |] :> obj))
+        }
+
+    /// Proves the production processor boundary suppresses only typed settlement failures, not cancellation.
+    [<Test>]
+    member _.ProcessorBoundaryPreventsAutomaticAbandonmentAndPreservesCancellation() =
+        task {
+            let settlementFailure = Subscriber.GraceEventSettlementFailureException("complete", InvalidOperationException("complete outcome unknown"))
+
+            do! Subscriber.runProcessorMessageCallbackWith NullLogger.Instance metadata (fun () -> Task.FromException(settlementFailure))
+
+            let mutable cancellationPropagated = false
+
+            try
+                do! Subscriber.runProcessorMessageCallbackWith NullLogger.Instance metadata (fun () -> Task.FromCanceled(CancellationToken(true)))
+            with
+            | :? OperationCanceledException -> cancellationPropagated <- true
+
+            Assert.That(cancellationPropagated, Is.True)
         }
 
     /// Proves an unknown abandon result propagates without complete or dead-letter fallback.
@@ -251,7 +468,7 @@ type ManifestContributionTelemetryServerTests() =
             try
                 do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
             with
-            | :? InvalidOperationException -> failed <- true
+            | :? Subscriber.GraceEventSettlementFailureException -> failed <- true
 
             Assert.That(failed, Is.True)
             Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "abandon" |] :> obj))
@@ -284,7 +501,7 @@ type ManifestContributionTelemetryServerTests() =
             try
                 do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("bad")) CancellationToken.None
             with
-            | :? InvalidOperationException -> failed <- true
+            | :? Subscriber.GraceEventSettlementFailureException -> failed <- true
 
             Assert.That(failed, Is.True)
             Assert.That(calls.ToArray(), Is.EqualTo([| "dead-letter" |] :> obj))

--- a/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
@@ -1,0 +1,427 @@
+namespace Grace.Server.Tests
+
+open Grace.Server
+open Grace.Server.Notification
+open Grace.Types.Events
+open Grace.Types.ManifestContributionAccounting
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Diagnostics
+open System.Diagnostics.Metrics
+open Microsoft.Extensions.Logging
+open System.Threading
+open System.Threading.Tasks
+
+/// Proves bounded manifest-accounting telemetry and single-intent Service Bus settlement behavior.
+[<NonParallelizable>]
+type ManifestContributionTelemetryServerTests() =
+
+    /// Creates settlement dependencies whose calls are retained for exact-path assertions.
+    let dependencies parse handle complete abandon deadLetter : Subscriber.GraceEventSettlementDependencies =
+        { Parse = parse; Handle = handle; Complete = complete; Abandon = abandon; DeadLetter = deadLetter }
+
+    /// Supplies stable high-cardinality message context without exposing it as metric dimensions.
+    let metadata: Subscriber.GraceEventMessageMetadata = { MessageId = "message-123"; CorrelationId = "correlation-456"; DeliveryCount = 3 }
+
+    /// Represents a parsed event whose concrete case is irrelevant to settlement orchestration.
+    let validEvent = Unchecked.defaultof<GraceEvent>
+
+    /// Executes one successful delivery and proves handler and completion are each invoked once.
+    [<Test>]
+    member _.ValidMessageHandlesAndCompletesExactlyOnce() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+
+            Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "complete" |] :> obj))
+        }
+
+    /// Proves malformed and JSON-null payloads dead-letter once with fixed redacted evidence.
+    [<TestCase("{not-json")>]
+    [<TestCase("null")>]
+    member _.MalformedPayloadDeadLettersOnceWithoutPayloadEvidence(payload: string) =
+        task {
+            let calls = ResizeArray<string>()
+            let mutable reason = String.Empty
+            let mutable description = String.Empty
+
+            let seam =
+                dependencies
+                    (fun _ -> Error "parser detail containing payload: secret-value")
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun actualReason actualDescription _ ->
+                        calls.Add "dead-letter"
+                        reason <- actualReason
+                        description <- actualDescription
+                        Task.CompletedTask)
+
+            do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString(payload)) CancellationToken.None
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(calls.ToArray(), Is.EqualTo([| "dead-letter" |] :> obj))
+                    Assert.That(reason, Is.EqualTo("MalformedGraceEvent"))
+                    Assert.That(description, Is.EqualTo(Subscriber.MalformedGraceEventDescription))
+                    Assert.That(description.Length, Is.LessThanOrEqualTo(128))
+                    Assert.That(description, Does.Not.Contain(payload))
+                    Assert.That(description, Does.Not.Contain("secret-value")))
+            )
+        }
+
+    /// Proves handler failure abandons exactly once and never attempts another settlement.
+    [<Test>]
+    member _.HandlerFailureAbandonsExactlyOnce() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.FromException(InvalidOperationException("handler failed")))
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+
+            Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "abandon" |] :> obj))
+        }
+
+    /// Proves cancellation during handling propagates without a replacement settlement.
+    [<Test>]
+    member _.CancellationDuringHandlingPropagatesWithoutSettlement() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.FromCanceled(CancellationToken(true)))
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            let mutable cancelled = false
+
+            try
+                do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+            with
+            | :? OperationCanceledException -> cancelled <- true
+
+            Assert.That(cancelled, Is.True)
+            Assert.That(calls.ToArray(), Is.EqualTo([| "handle" |] :> obj))
+        }
+
+    /// Proves cancellation before parsing propagates without any settlement attempt.
+    [<Test>]
+    member _.CancellationBeforeParsingPropagatesWithoutSettlement() =
+        task {
+            let calls = ResizeArray<string>()
+            use cancellation = new CancellationTokenSource()
+            cancellation.Cancel()
+
+            let seam =
+                dependencies
+                    (fun _ ->
+                        calls.Add "parse"
+                        Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            let mutable cancelled = false
+
+            try
+                do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) cancellation.Token
+            with
+            | :? OperationCanceledException -> cancelled <- true
+
+            Assert.That(cancelled, Is.True)
+            Assert.That(calls, Is.Empty)
+        }
+
+    /// Proves an unknown complete result propagates without abandon or dead-letter fallback.
+    [<Test>]
+    member _.CompleteFailureDoesNotAttemptFallbackSettlement() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.FromException(InvalidOperationException("complete unknown")))
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            let mutable failed = false
+
+            try
+                do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+            with
+            | :? InvalidOperationException -> failed <- true
+
+            Assert.That(failed, Is.True)
+            Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "complete" |] :> obj))
+        }
+
+    /// Proves an unknown abandon result propagates without complete or dead-letter fallback.
+    [<Test>]
+    member _.AbandonFailureDoesNotAttemptFallbackSettlement() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.FromException(InvalidOperationException("handler failed")))
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.FromException(InvalidOperationException("abandon unknown")))
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            let mutable failed = false
+
+            try
+                do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+            with
+            | :? InvalidOperationException -> failed <- true
+
+            Assert.That(failed, Is.True)
+            Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "abandon" |] :> obj))
+        }
+
+    /// Proves an unknown dead-letter result propagates without complete or abandon fallback.
+    [<Test>]
+    member _.DeadLetterFailureDoesNotAttemptFallbackSettlement() =
+        task {
+            let calls = ResizeArray<string>()
+
+            let seam =
+                dependencies
+                    (fun _ -> Error "malformed")
+                    (fun _ _ ->
+                        calls.Add "handle"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.FromException(InvalidOperationException("dead-letter unknown")))
+
+            let mutable failed = false
+
+            try
+                do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("bad")) CancellationToken.None
+            with
+            | :? InvalidOperationException -> failed <- true
+
+            Assert.That(failed, Is.True)
+            Assert.That(calls.ToArray(), Is.EqualTo([| "dead-letter" |] :> obj))
+        }
+
+    /// Proves emitted metrics use only the issue-approved bounded tag keys.
+    [<Test>]
+    member _.MetricTagKeysAreBounded() =
+        let observed = ResizeArray<string>()
+        use listener = new MeterListener()
+
+        listener.InstrumentPublished <-
+            fun instrument meterListener ->
+                if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName then
+                    meterListener.EnableMeasurementEvents instrument
+
+        listener.SetMeasurementEventCallback<int64> (fun _ _ tags _ ->
+            for tag in tags do
+                observed.Add tag.Key)
+
+        listener.SetMeasurementEventCallback<double> (fun _ _ tags _ ->
+            for tag in tags do
+                observed.Add tag.Key)
+
+        listener.Start()
+
+        ManifestContributionTelemetry.recordMessage ManifestContributionProcessingStage.Parse ManifestContributionMessageOutcome.Completed 1.0
+
+        let relationship =
+            ExactRelationship.ReferenceRoot
+                {
+                    RepositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                    RootDirectoryVersionId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    ReferenceId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+                }
+
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsurePresent relationship "changed"
+        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get "hit"
+        ManifestContributionTelemetry.recordRepairActions [| "GetOrAddExactRelationship" |] "verified_complete"
+
+        Assert.That(observed, Is.Not.Empty)
+        Assert.That(observed, Has.All.Matches<string>(fun key -> ManifestContributionTelemetry.AllowedMetricTagKeys.Contains key))
+
+    /// Proves high-cardinality identifiers are carried by activities, not metric tags.
+    [<Test>]
+    member _.MessageActivityCarriesIdentifiers() =
+        let observed = ResizeArray<Activity>()
+        use listener = new ActivityListener()
+        listener.ShouldListenTo <- fun source -> source.Name = ManifestContributionTelemetry.InstrumentationName
+        listener.Sample <- fun _ -> ActivitySamplingResult.AllDataAndRecorded
+        listener.ActivityStopped <- fun activity -> observed.Add activity
+        ActivitySource.AddActivityListener listener
+
+        use activity = ManifestContributionTelemetry.startMessageActivity metadata.MessageId metadata.CorrelationId metadata.DeliveryCount
+
+        Assert.That(activity, Is.Not.Null)
+        ManifestContributionTelemetry.enrichReferenceActivity "reference-789" "repository-012" "directory-version-345" "Commit"
+        activity.Dispose()
+
+        let completed = observed |> Seq.exactlyOne
+
+        let tags =
+            completed.TagObjects
+            |> Seq.map (fun tag -> tag.Key, tag.Value)
+            |> dict
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(tags["messaging.message.id"], Is.EqualTo(metadata.MessageId))
+                Assert.That(tags["grace.correlation_id"], Is.EqualTo(metadata.CorrelationId))
+                Assert.That(tags["messaging.servicebus.delivery_count"], Is.EqualTo(metadata.DeliveryCount))
+                Assert.That(tags["grace.reference.id"], Is.EqualTo("reference-789"))
+                Assert.That(tags["grace.repository.id"], Is.EqualTo("repository-012"))
+                Assert.That(tags["grace.directory_version.id"], Is.EqualTo("directory-version-345"))
+                Assert.That(tags["grace.reference.type"], Is.EqualTo("Commit")))
+        )
+
+    /// Proves all required bounded instruments are published by the exact application meter.
+    [<Test>]
+    member _.RequiredInstrumentNamesArePublished() =
+        Assert.That(ManifestContributionTelemetry.InstrumentationName, Is.EqualTo("Grace.ManifestContributionAccounting"))
+
+        let observed = HashSet<string>(StringComparer.Ordinal)
+        use listener = new MeterListener()
+
+        listener.InstrumentPublished <-
+            fun instrument _ ->
+                if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName then
+                    observed.Add instrument.Name |> ignore
+
+        listener.Start()
+
+        Assert.That(
+            observed,
+            Is.SupersetOf(
+                [|
+                    "grace.manifest_contribution.messages"
+                    "grace.manifest_contribution.processing.duration"
+                    "grace.manifest_contribution.relationship.writes"
+                    "grace.manifest_contribution.redis.operations"
+                    "grace.manifest_contribution.repair.actions"
+                |]
+            )
+        )
+
+    /// Proves processor SDK errors log structured broker fields and complete without a custom delay.
+    [<Test>]
+    member _.ProcessorErrorCallbackIsStructuredAndImmediate() =
+        let observed = Dictionary<string, obj>(StringComparer.Ordinal)
+
+        let logger =
+            { new ILogger with
+                member _.BeginScope<'TState>(_: 'TState) = null
+                member _.IsEnabled _ = true
+
+                member _.Log<'TState>(_, _, state: 'TState, _, _) =
+                    match box state with
+                    | :? IEnumerable<KeyValuePair<string, obj>> as fields ->
+                        for field in fields do
+                            observed[field.Key] <- field.Value
+                    | _ -> ()
+            }
+
+        let callback =
+            Subscriber.handleProcessorErrorWith
+                logger
+                (InvalidOperationException("processor failed"))
+                "Receive"
+                "grace-events/subscriptions/server"
+                "servicebus.example"
+                "processor-1"
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(callback.IsCompletedSuccessfully, Is.True)
+                Assert.That(observed["ErrorSource"], Is.EqualTo("Receive"))
+                Assert.That(observed["EntityPath"], Is.EqualTo("grace-events/subscriptions/server"))
+                Assert.That(observed["FullyQualifiedNamespace"], Is.EqualTo("servicebus.example"))
+                Assert.That(observed["Identifier"], Is.EqualTo("processor-1")))
+        )

--- a/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
@@ -252,6 +252,50 @@ type ManifestContributionTelemetryServerTests() =
             Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "abandon" |] :> obj))
         }
 
+    /// Proves Reference-created activity identity is available at the point where handling fails.
+    [<Test>]
+    member _.ReferenceCreatedActivityIsEnrichedBeforeHandlerFailure() =
+        task {
+            let calls = ResizeArray<string>()
+            let observedTags = Dictionary<string, obj>(StringComparer.Ordinal)
+            use listener = new ActivityListener()
+            listener.ShouldListenTo <- fun source -> source.Name = ManifestContributionTelemetry.InstrumentationName
+            listener.Sample <- fun _ -> ActivitySamplingResult.AllDataAndRecorded
+            ActivitySource.AddActivityListener listener
+
+            let seam =
+                dependencies
+                    (fun _ -> Ok validEvent)
+                    (fun _ _ ->
+                        calls.Add "handle"
+
+                        if not (isNull Activity.Current) then
+                            for tag in Activity.Current.TagObjects do
+                                observedTags[tag.Key] <- tag.Value
+
+                        Task.FromException(InvalidOperationException("handler failed")))
+                    (fun _ ->
+                        calls.Add "complete"
+                        Task.CompletedTask)
+                    (fun _ ->
+                        calls.Add "abandon"
+                        Task.CompletedTask)
+                    (fun _ _ _ ->
+                        calls.Add "dead-letter"
+                        Task.CompletedTask)
+
+            do! Subscriber.processGraceEventWith seam metadata (BinaryData.FromString("{}")) CancellationToken.None
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(calls.ToArray(), Is.EqualTo([| "handle"; "abandon" |] :> obj))
+                    Assert.That(observedTags["grace.reference.id"], Is.EqualTo("11111111-1111-1111-1111-111111111111"))
+                    Assert.That(observedTags["grace.repository.id"], Is.EqualTo("44444444-4444-4444-4444-444444444444"))
+                    Assert.That(observedTags["grace.directory_version.id"], Is.EqualTo("66666666-6666-6666-6666-666666666666"))
+                    Assert.That(observedTags["grace.reference.type"], Is.EqualTo("ReferenceType.Commit")))
+            )
+        }
+
     /// Proves cancellation during handling propagates without a replacement settlement.
     [<Test>]
     member _.CancellationDuringHandlingPropagatesWithoutSettlement() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionTelemetry.Server.Tests.fs
@@ -171,6 +171,145 @@ type ManifestContributionTelemetryServerTests() =
             Assert.That(measurements, Has.All.Matches<string * string * string>(fun (_, stage, outcome) -> stage = "settle" && outcome = "completed"))
         }
 
+    /// Proves VerifyAsync read observations never enter the relationship-writes counter while both write operations retain bounded outcomes.
+    [<Test>]
+    member _.VerifyAsyncReadDoesNotEmitRelationshipWritesAndEnsureOperationsDo() =
+        let measurements = ResizeArray<string * string>()
+        use listener = new MeterListener()
+
+        listener.InstrumentPublished <-
+            fun instrument meterListener ->
+                if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                   && instrument.Name = "grace.manifest_contribution.relationship.writes" then
+                    meterListener.EnableMeasurementEvents instrument
+
+        listener.SetMeasurementEventCallback<int64> (fun _ _ tags _ ->
+            let mutable operation = String.Empty
+            let mutable outcome = String.Empty
+
+            for tag in tags do
+                if tag.Key = "operation" then operation <- string tag.Value
+                elif tag.Key = "outcome" then outcome <- string tag.Value
+
+            measurements.Add(operation, outcome))
+
+        listener.Start()
+
+        let relationship =
+            ExactRelationship.ReferenceRoot
+                {
+                    RepositoryId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                    RootDirectoryVersionId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+                    ReferenceId = Guid.Parse("33333333-3333-3333-3333-333333333333")
+                }
+
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.Verify relationship "present"
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.Verify relationship "absent"
+
+        Assert.That(measurements, Is.Empty, "VerifyAsync maps to Verify at the typed telemetry seam and must remain read-only.")
+
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsurePresent relationship "changed"
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsurePresent relationship "already_converged"
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsureAbsent relationship "changed"
+        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsureAbsent relationship "already_converged"
+
+        Assert.That(
+            measurements,
+            Is.EquivalentTo(
+                [|
+                    "ensure_present", "changed"
+                    "ensure_present", "already_converged"
+                    "ensure_absent", "changed"
+                    "ensure_absent", "already_converged"
+                |]
+            )
+        )
+
+    /// Proves the Redis instrument publishes only the typed Get and Set operation outcomes.
+    [<Test>]
+    member _.RedisOperationsEmitTypedGetAndSetOutcomes() =
+        let measurements = ResizeArray<string * string>()
+        use listener = new MeterListener()
+
+        listener.InstrumentPublished <-
+            fun instrument meterListener ->
+                if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                   && instrument.Name = "grace.manifest_contribution.redis.operations" then
+                    meterListener.EnableMeasurementEvents instrument
+
+        listener.SetMeasurementEventCallback<int64> (fun _ _ tags _ ->
+            let mutable operation = String.Empty
+            let mutable outcome = String.Empty
+
+            for tag in tags do
+                if tag.Key = "operation" then operation <- string tag.Value
+                elif tag.Key = "outcome" then outcome <- string tag.Value
+
+            measurements.Add(operation, outcome))
+
+        listener.Start()
+
+        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get "hit"
+        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get "miss"
+        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Set "confirmed"
+        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Set "unconfirmed"
+
+        Assert.That(
+            measurements,
+            Is.EquivalentTo(
+                [|
+                    "get", "hit"
+                    "get", "miss"
+                    "set", "confirmed"
+                    "set", "unconfirmed"
+                |]
+            )
+        )
+
+    /// Proves repair telemetry counts each applied action observation and emits nothing for an empty applied prefix.
+    [<Test>]
+    member _.RepairActionsCountAppliedObservationsAndIgnoreEmptyPrefixes() =
+        let measurements = ResizeArray<string * string>()
+        use listener = new MeterListener()
+
+        listener.InstrumentPublished <-
+            fun instrument meterListener ->
+                if instrument.Meter.Name = ManifestContributionTelemetry.InstrumentationName
+                   && instrument.Name = "grace.manifest_contribution.repair.actions" then
+                    meterListener.EnableMeasurementEvents instrument
+
+        listener.SetMeasurementEventCallback<int64> (fun _ _ tags _ ->
+            let mutable operation = String.Empty
+            let mutable outcome = String.Empty
+
+            for tag in tags do
+                if tag.Key = "operation" then operation <- string tag.Value
+                elif tag.Key = "outcome" then outcome <- string tag.Value
+
+            measurements.Add(operation, outcome))
+
+        listener.Start()
+
+        ManifestContributionTelemetry.recordRepairActions Array.empty "verified_complete"
+        Assert.That(measurements, Is.Empty)
+
+        ManifestContributionTelemetry.recordRepairActions
+            [|
+                "GetOrAddExactRelationship"
+                "ReconcileRepositoryContentCount"
+            |]
+            "verified_complete"
+
+        Assert.That(
+            measurements,
+            Is.EquivalentTo(
+                [|
+                    "GetOrAddExactRelationship", "verified_complete"
+                    "ReconcileRepositoryContentCount", "verified_complete"
+                |]
+            )
+        )
+
     /// Proves malformed and JSON-null payloads dead-letter once with fixed redacted evidence.
     [<TestCase("{not-json")>]
     [<TestCase("null")>]

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -101,6 +101,7 @@
                 <Compile Include="Artifact.Server.fs" />
                 <Compile Include="ReviewAnalysis.Server.fs" />
                 <Compile Include="Eventing.Server.fs" />
+                <Compile Include="ManifestContributionTelemetry.Server.fs" />
                 <Compile Include="RepositoryCounterRecentResult.Server.fs" />
                 <Compile Include="ManifestContributionAccounting.Server.fs" />
                 <Compile Include="ManifestContributionDiagnosis.Server.fs" />

--- a/src/Grace.Server/ManifestContributionAccounting.Server.fs
+++ b/src/Grace.Server/ManifestContributionAccounting.Server.fs
@@ -56,9 +56,17 @@ module ManifestContributionAccounting =
                     try
                         let! _ = container.CreateItemAsync(document, PartitionKey key.PartitionKey, cancellationToken = cancellationToken)
 
+                        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsurePresent relationship "changed"
+
                         return ExactRelationshipWriteOutcome.Changed
                     with
-                    | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.Conflict -> return ExactRelationshipWriteOutcome.AlreadyConverged
+                    | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.Conflict ->
+                        ManifestContributionTelemetry.recordRelationship
+                            ManifestContributionRelationshipOperation.EnsurePresent
+                            relationship
+                            "already_converged"
+
+                        return ExactRelationshipWriteOutcome.AlreadyConverged
                 }
 
             member _.EnsureAbsentAsync(relationship, cancellationToken) =
@@ -73,9 +81,14 @@ module ManifestContributionAccounting =
                                 cancellationToken = cancellationToken
                             )
 
+                        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsureAbsent relationship "changed"
+
                         return ExactRelationshipWriteOutcome.Changed
                     with
-                    | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.NotFound -> return ExactRelationshipWriteOutcome.AlreadyConverged
+                    | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.NotFound ->
+                        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.EnsureAbsent relationship "already_converged"
+
+                        return ExactRelationshipWriteOutcome.AlreadyConverged
                 }
 
             member _.EnumerateAsync(partition, bound, continuationToken, cancellationToken) =
@@ -128,9 +141,14 @@ module ManifestContributionAccounting =
                         let! _ =
                             container.ReadItemAsync<ExactRelationshipDocument>(key.ItemId, PartitionKey key.PartitionKey, cancellationToken = cancellationToken)
 
+                        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.Verify relationship "present"
+
                         return ExactRelationshipPresence.Present
                     with
-                    | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.NotFound -> return ExactRelationshipPresence.Absent
+                    | :? CosmosException as ex when ex.StatusCode = HttpStatusCode.NotFound ->
+                        ManifestContributionTelemetry.recordRelationship ManifestContributionRelationshipOperation.Verify relationship "absent"
+
+                        return ExactRelationshipPresence.Absent
                 }
 
     /// Provides current actor reads and exact mutation effects to the provider-neutral convergence loop.

--- a/src/Grace.Server/ManifestContributionRepair.Server.fs
+++ b/src/Grace.Server/ManifestContributionRepair.Server.fs
@@ -893,7 +893,19 @@ module ManifestContributionRepair =
                                 $"Repair failed after preserving the confirmed applied prefix; run a fresh diagnosis: {ex.Message}"
                         )
 
-                return terminal.Value
+                let completed = terminal.Value
+
+                let terminalOutcome =
+                    match completed.Outcome with
+                    | RepairOutcome.VerifiedComplete -> "verified_complete"
+                    | RepairOutcome.IncompleteRetain -> "incomplete_retain"
+                    | RepairOutcome.FailedRetain -> "failed_retain"
+
+                completed.AppliedActions
+                |> Array.map (fun action -> action.Kind)
+                |> fun actionKinds -> ManifestContributionTelemetry.recordRepairActions actionKinds terminalOutcome
+
+                return completed
         }
 
     /// Creates the production bounded reads and the five approved repair-only mutations.

--- a/src/Grace.Server/ManifestContributionTelemetry.Server.fs
+++ b/src/Grace.Server/ManifestContributionTelemetry.Server.fs
@@ -144,16 +144,20 @@ module ManifestContributionTelemetry =
         messages.Add(1L, tags)
         processingDuration.Record(durationMilliseconds, tags)
 
-    /// Records one exact-relationship storage observation without relationship identifiers.
+    /// Records one exact-relationship write without relationship identifiers and excludes verification reads.
     let internal recordRelationship operation relationship outcome =
-        let tags =
-            [|
-                KeyValuePair<string, obj>("relationship_kind", relationshipKind relationship)
-                KeyValuePair<string, obj>("operation", relationshipOperationName operation)
-                KeyValuePair<string, obj>("outcome", outcome)
-            |]
+        match operation with
+        | ManifestContributionRelationshipOperation.Verify -> ()
+        | ManifestContributionRelationshipOperation.EnsurePresent
+        | ManifestContributionRelationshipOperation.EnsureAbsent ->
+            let tags =
+                [|
+                    KeyValuePair<string, obj>("relationship_kind", relationshipKind relationship)
+                    KeyValuePair<string, obj>("operation", relationshipOperationName operation)
+                    KeyValuePair<string, obj>("outcome", outcome)
+                |]
 
-        relationshipWrites.Add(1L, tags)
+            relationshipWrites.Add(1L, tags)
 
     /// Records one Redis accelerator result without its key or manifest identity.
     let internal recordRedisOperation operation outcome =

--- a/src/Grace.Server/ManifestContributionTelemetry.Server.fs
+++ b/src/Grace.Server/ManifestContributionTelemetry.Server.fs
@@ -1,0 +1,178 @@
+namespace Grace.Server
+
+open Grace.Types.ManifestContributionAccounting
+open System
+open System.Collections.Generic
+open System.Diagnostics
+open System.Diagnostics.Metrics
+
+/// Names the processing boundary that produced one manifest-accounting message outcome.
+type ManifestContributionProcessingStage =
+    | Parse
+    | Handle
+    | Settle
+
+/// Names the truthful terminal observation for one Service Bus delivery.
+type ManifestContributionMessageOutcome =
+    | Completed
+    | Abandoned
+    | DeadLettered
+    | SettlementFailed
+
+/// Names one exact-relationship storage operation without exposing relationship identities.
+type ManifestContributionRelationshipOperation =
+    | EnsurePresent
+    | EnsureAbsent
+    | Verify
+
+/// Names one bounded Redis accelerator operation.
+type ManifestContributionRedisOperation =
+    | Get
+    | Set
+
+/// Emits bounded metrics and high-cardinality activity context for manifest contribution accounting.
+module ManifestContributionTelemetry =
+
+    /// Identifies the one meter and activity source registered by Grace Server.
+    [<Literal>]
+    let InstrumentationName = "Grace.ManifestContributionAccounting"
+
+    /// Lists every metric dimension permitted by the manifest-accounting telemetry contract.
+    let internal AllowedMetricTagKeys =
+        HashSet<string>(
+            [|
+                "stage"
+                "outcome"
+                "reference_type"
+                "relationship_kind"
+                "operation"
+                "direction"
+                "is_replay"
+            |],
+            StringComparer.Ordinal
+        )
+
+    let private meter = new Meter(InstrumentationName)
+    let private activitySource = new ActivitySource(InstrumentationName)
+
+    let private messages = meter.CreateCounter<int64>("grace.manifest_contribution.messages")
+
+    let private processingDuration = meter.CreateHistogram<double>("grace.manifest_contribution.processing.duration", "ms")
+
+    let private relationshipWrites = meter.CreateCounter<int64>("grace.manifest_contribution.relationship.writes")
+
+    let private redisOperations = meter.CreateCounter<int64>("grace.manifest_contribution.redis.operations")
+
+    let private repairActions = meter.CreateCounter<int64>("grace.manifest_contribution.repair.actions")
+
+    /// Converts a processing stage to its stable bounded telemetry value.
+    let private stageName =
+        function
+        | ManifestContributionProcessingStage.Parse -> "parse"
+        | ManifestContributionProcessingStage.Handle -> "handle"
+        | ManifestContributionProcessingStage.Settle -> "settle"
+
+    /// Converts a message outcome to its stable bounded telemetry value.
+    let private messageOutcomeName =
+        function
+        | ManifestContributionMessageOutcome.Completed -> "completed"
+        | ManifestContributionMessageOutcome.Abandoned -> "abandoned"
+        | ManifestContributionMessageOutcome.DeadLettered -> "dead_lettered"
+        | ManifestContributionMessageOutcome.SettlementFailed -> "settlement_failed"
+
+    /// Converts an exact relationship case to its stable bounded telemetry value.
+    let private relationshipKind =
+        function
+        | ExactRelationship.ReferenceRoot _ -> "reference_root"
+        | ExactRelationship.ParentChild _ -> "parent_child"
+        | ExactRelationship.DirectoryVersionManifest _ -> "directory_version_manifest"
+
+    /// Converts an exact relationship operation to its stable bounded telemetry value.
+    let private relationshipOperationName =
+        function
+        | ManifestContributionRelationshipOperation.EnsurePresent -> "ensure_present"
+        | ManifestContributionRelationshipOperation.EnsureAbsent -> "ensure_absent"
+        | ManifestContributionRelationshipOperation.Verify -> "verify"
+
+    /// Converts a Redis operation to its stable bounded telemetry value.
+    let private redisOperationName =
+        function
+        | ManifestContributionRedisOperation.Get -> "get"
+        | ManifestContributionRedisOperation.Set -> "set"
+
+    /// Starts one delivery activity carrying identifiers that are forbidden from metric dimensions.
+    let internal startMessageActivity messageId correlationId deliveryCount =
+        let activity = activitySource.StartActivity("manifest-contribution.process-message", ActivityKind.Consumer)
+
+        if not (isNull activity) then
+            activity.SetTag("messaging.message.id", messageId)
+            |> ignore
+
+            activity.SetTag("grace.correlation_id", correlationId)
+            |> ignore
+
+            activity.SetTag("messaging.servicebus.delivery_count", deliveryCount)
+            |> ignore
+
+        activity
+
+    /// Adds Reference accounting identities to the current activity without creating metric dimensions.
+    let internal enrichReferenceActivity referenceId repositoryId directoryVersionId referenceType =
+        let activity = Activity.Current
+
+        if not (isNull activity) then
+            activity.SetTag("grace.reference.id", referenceId)
+            |> ignore
+
+            activity.SetTag("grace.repository.id", repositoryId)
+            |> ignore
+
+            activity.SetTag("grace.directory_version.id", directoryVersionId)
+            |> ignore
+
+            activity.SetTag("grace.reference.type", referenceType)
+            |> ignore
+
+    /// Records the single truthful message outcome and its bounded processing duration.
+    let internal recordMessage stage outcome durationMilliseconds =
+        let tags =
+            [|
+                KeyValuePair<string, obj>("stage", stageName stage)
+                KeyValuePair<string, obj>("outcome", messageOutcomeName outcome)
+            |]
+
+        messages.Add(1L, tags)
+        processingDuration.Record(durationMilliseconds, tags)
+
+    /// Records one exact-relationship storage observation without relationship identifiers.
+    let internal recordRelationship operation relationship outcome =
+        let tags =
+            [|
+                KeyValuePair<string, obj>("relationship_kind", relationshipKind relationship)
+                KeyValuePair<string, obj>("operation", relationshipOperationName operation)
+                KeyValuePair<string, obj>("outcome", outcome)
+            |]
+
+        relationshipWrites.Add(1L, tags)
+
+    /// Records one Redis accelerator result without its key or manifest identity.
+    let internal recordRedisOperation operation outcome =
+        let tags =
+            [|
+                KeyValuePair<string, obj>("operation", redisOperationName operation)
+                KeyValuePair<string, obj>("outcome", outcome)
+            |]
+
+        redisOperations.Add(1L, tags)
+
+    /// Records each confirmed repair action with the bounded terminal repair outcome.
+    let internal recordRepairActions (actionKinds: string array) terminalOutcome =
+        actionKinds
+        |> Array.iter (fun actionKind ->
+            let tags =
+                [|
+                    KeyValuePair<string, obj>("operation", actionKind)
+                    KeyValuePair<string, obj>("outcome", terminalOutcome)
+                |]
+
+            repairActions.Add(1L, tags))

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -31,6 +31,7 @@ open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
 open System
 open System.Collections.Generic
+open System.Diagnostics
 open System.Linq
 open System.Text.Json
 open System.Text.RegularExpressions
@@ -429,6 +430,131 @@ module Notification =
 
     /// Contains Grace Server subscriber behavior and supporting helpers.
     module Subscriber =
+
+        /// Carries only delivery metadata needed for structured diagnostics and activity correlation.
+        type GraceEventMessageMetadata = { MessageId: string; CorrelationId: string; DeliveryCount: int }
+
+        /// Supplies the parse, handler, and broker settlement effects for one testable delivery.
+        type GraceEventSettlementDependencies =
+            {
+                Parse: BinaryData -> Result<GraceEvent, string>
+                Handle: GraceEvent -> CancellationToken -> Task
+                Complete: CancellationToken -> Task
+                Abandon: CancellationToken -> Task
+                DeadLetter: string -> string -> CancellationToken -> Task
+            }
+
+        /// Provides fixed bounded dead-letter evidence without retaining message payload or parser details.
+        [<Literal>]
+        let internal MalformedGraceEventDescription = "The Service Bus message body is not a supported GraceEvent."
+
+        /// Records one processor SDK callback with structured broker context and no custom delay or retry.
+        let internal handleProcessorErrorWith (logger: ILogger) (error: Exception) errorSource entityPath fullyQualifiedNamespace identifier =
+            logger.LogError(
+                error,
+                "Grace pub-sub processor fault. ErrorSource: {ErrorSource}; EntityPath: {EntityPath}; FullyQualifiedNamespace: {FullyQualifiedNamespace}; Identifier: {Identifier}.",
+                errorSource,
+                entityPath,
+                fullyQualifiedNamespace,
+                identifier
+            )
+
+            Task.CompletedTask
+
+        /// Processes one Service Bus delivery through exactly one truthful settlement intent.
+        let internal processGraceEventWith
+            (dependencies: GraceEventSettlementDependencies)
+            (metadata: GraceEventMessageMetadata)
+            (body: BinaryData)
+            (cancellationToken: CancellationToken)
+            =
+            task {
+                cancellationToken.ThrowIfCancellationRequested()
+                use activity = ManifestContributionTelemetry.startMessageActivity metadata.MessageId metadata.CorrelationId metadata.DeliveryCount
+
+                let stopwatch = Stopwatch.StartNew()
+
+                match dependencies.Parse body with
+                | Error _ ->
+                    try
+                        do! dependencies.DeadLetter "MalformedGraceEvent" MalformedGraceEventDescription cancellationToken
+                        stopwatch.Stop()
+
+                        ManifestContributionTelemetry.recordMessage
+                            ManifestContributionProcessingStage.Parse
+                            ManifestContributionMessageOutcome.DeadLettered
+                            stopwatch.Elapsed.TotalMilliseconds
+                    with
+                    | ex ->
+                        stopwatch.Stop()
+
+                        ManifestContributionTelemetry.recordMessage
+                            ManifestContributionProcessingStage.Settle
+                            ManifestContributionMessageOutcome.SettlementFailed
+                            stopwatch.Elapsed.TotalMilliseconds
+
+                        return raise ex
+                | Ok graceEvent ->
+                    let! handlerError =
+                        task {
+                            try
+                                do! dependencies.Handle graceEvent cancellationToken
+                                cancellationToken.ThrowIfCancellationRequested()
+                                return None
+                            with
+                            | :? OperationCanceledException as ex ->
+                                stopwatch.Stop()
+
+                                ManifestContributionTelemetry.recordMessage
+                                    ManifestContributionProcessingStage.Handle
+                                    ManifestContributionMessageOutcome.SettlementFailed
+                                    stopwatch.Elapsed.TotalMilliseconds
+
+                                return raise ex
+                            | ex -> return Some ex
+                        }
+
+                    match handlerError with
+                    | None ->
+                        try
+                            do! dependencies.Complete cancellationToken
+                            stopwatch.Stop()
+
+                            ManifestContributionTelemetry.recordMessage
+                                ManifestContributionProcessingStage.Settle
+                                ManifestContributionMessageOutcome.Completed
+                                stopwatch.Elapsed.TotalMilliseconds
+                        with
+                        | ex ->
+                            stopwatch.Stop()
+
+                            ManifestContributionTelemetry.recordMessage
+                                ManifestContributionProcessingStage.Settle
+                                ManifestContributionMessageOutcome.SettlementFailed
+                                stopwatch.Elapsed.TotalMilliseconds
+
+                            return raise ex
+                    | Some _ ->
+                        try
+                            do! dependencies.Abandon cancellationToken
+                            stopwatch.Stop()
+
+                            ManifestContributionTelemetry.recordMessage
+                                ManifestContributionProcessingStage.Handle
+                                ManifestContributionMessageOutcome.Abandoned
+                                stopwatch.Elapsed.TotalMilliseconds
+                        with
+                        | ex ->
+                            stopwatch.Stop()
+
+                            ManifestContributionTelemetry.recordMessage
+                                ManifestContributionProcessingStage.Settle
+                                ManifestContributionMessageOutcome.SettlementFailed
+                                stopwatch.Elapsed.TotalMilliseconds
+
+                            return raise ex
+            }
+
         /// Gets the ReferenceDto for the given ReferenceId.
         let getReferenceDto referenceId repositoryId correlationId =
             task {
@@ -910,6 +1036,8 @@ module Notification =
                                                   referenceType,
                                                   referenceText,
                                                   links) ->
+                        ManifestContributionTelemetry.enrichReferenceActivity $"{referenceId:D}" $"{repositoryId:D}" $"{directoryId:D}" $"{referenceType}"
+
                         /// Emits the same-branch notification after Reference replay and branch recomputation complete.
                         let emitCurrentBranchReference branchName =
                             task {
@@ -1271,38 +1399,68 @@ module Notification =
 
             /// Coordinates handle processor error processing for Grace Server.
             let handleProcessorError (args: ProcessErrorEventArgs) =
-                task {
-                    //subscriptionLog.LogError(
-                    //    args.Exception,
-                    //    "Grace pub-sub processor fault. ErrorSource: {ErrorSource}; EntityPath: {EntityPath}.",
-                    //    args.ErrorSource,
-                    //    args.EntityPath
-                    //)
-
-                    subscriptionLog.LogWarning("Azure Service Bus not ready; pausing for five seconds to retry.")
-                    do! Task.Delay(TimeSpan.FromSeconds(5.0))
-                }
-                :> Task
+                handleProcessorErrorWith subscriptionLog args.Exception args.ErrorSource args.EntityPath args.FullyQualifiedNamespace args.Identifier
 
             /// Coordinates process grace event processing for Grace Server.
             let processGraceEvent (args: ProcessMessageEventArgs) =
                 task {
-                    try
-                        use bodyStream = args.Message.Body.ToStream()
-                        let graceEvent = JsonSerializer.Deserialize<GraceEvent>(bodyStream, options = Constants.JsonSerializerOptions)
+                    /// Parses one body without exposing payload or serializer diagnostics to settlement evidence.
+                    let parse (body: BinaryData) =
+                        try
+                            use bodyStream = body.ToStream()
+                            let graceEvent = JsonSerializer.Deserialize<GraceEvent>(bodyStream, options = Constants.JsonSerializerOptions)
 
-                        do! handleEvent graceEvent
-                        do! args.CompleteMessageAsync(args.Message, args.CancellationToken)
+                            if isNull (box graceEvent) then
+                                Error "GraceEvent JSON must not be null."
+                            else
+                                Ok graceEvent
+                        with
+                        | :? JsonException -> Error "The message body is not valid GraceEvent JSON."
+                        | :? NotSupportedException -> Error "The message body is not a supported GraceEvent."
+
+                    let dependencies =
+                        {
+                            Parse = parse
+                            Handle =
+                                fun graceEvent cancellationToken ->
+                                    task {
+                                        try
+                                            cancellationToken.ThrowIfCancellationRequested()
+                                            do! handleEvent graceEvent
+                                        with
+                                        | :? OperationCanceledException as ex -> return raise ex
+                                        | ex ->
+                                            subscriptionLog.LogError(
+                                                ex,
+                                                "GraceEvent handler failed for message {MessageId} (CorrelationId: {CorrelationId}); abandoning for broker retry.",
+                                                args.Message.MessageId,
+                                                args.Message.CorrelationId
+                                            )
+
+                                            return raise ex
+                                    }
+                                    :> Task
+                            Complete = fun cancellationToken -> args.CompleteMessageAsync(args.Message, cancellationToken)
+                            Abandon = fun cancellationToken -> args.AbandonMessageAsync(args.Message, cancellationToken = cancellationToken)
+                            DeadLetter =
+                                fun reason description cancellationToken -> args.DeadLetterMessageAsync(args.Message, reason, description, cancellationToken)
+                        }
+
+                    let metadata =
+                        { MessageId = args.Message.MessageId; CorrelationId = args.Message.CorrelationId; DeliveryCount = args.Message.DeliveryCount }
+
+                    try
+                        do! processGraceEventWith dependencies metadata args.Message.Body args.CancellationToken
                     with
                     | ex ->
                         subscriptionLog.LogError(
                             ex,
-                            "Failed to process GraceEvent message {MessageId} (CorrelationId: {CorrelationId}).",
+                            "GraceEvent settlement failed or was cancelled for message {MessageId} (CorrelationId: {CorrelationId}); no replacement settlement was attempted.",
                             args.Message.MessageId,
                             args.Message.CorrelationId
                         )
 
-                        do! args.AbandonMessageAsync(args.Message, cancellationToken = args.CancellationToken)
+                        return raise ex
                 }
 
             /// Implements start azure service bus processor for the server request pipeline.

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -444,6 +444,13 @@ module Notification =
                 DeadLetter: string -> string -> CancellationToken -> Task
             }
 
+        /// Distinguishes an unknown explicit settlement outcome from failures that occurred before settlement began.
+        type internal GraceEventSettlementFailureException(operation: string, innerException: Exception) =
+            inherit Exception($"GraceEvent {operation} settlement outcome is unknown.", innerException)
+
+            /// Names the one bounded settlement operation whose result is unknown.
+            member _.Operation = operation
+
         /// Provides fixed bounded dead-letter evidence without retaining message payload or parser details.
         [<Literal>]
         let internal MalformedGraceEventDescription = "The Service Bus message body is not a supported GraceEvent."
@@ -461,6 +468,28 @@ module Notification =
 
             Task.CompletedTask
 
+        /// Completes the production processor callback after an unknown explicit settlement so the SDK cannot auto-abandon it.
+        let internal runProcessorMessageCallbackWith (logger: ILogger) (metadata: GraceEventMessageMetadata) (processDelivery: unit -> Task) =
+            task {
+                try
+                    do! processDelivery ()
+                with
+                | :? GraceEventSettlementFailureException as ex ->
+                    logger.LogError(
+                        ex,
+                        "GraceEvent {SettlementOperation} settlement failed for message {MessageId} (CorrelationId: {CorrelationId}); the processor callback completed without throwing so the SDK cannot attempt automatic abandonment.",
+                        ex.Operation,
+                        metadata.MessageId,
+                        metadata.CorrelationId
+                    )
+            }
+
+        /// Identifies deliveries whose valid Reference-created event enters manifest contribution accounting.
+        let internal isManifestContributionAccountingDelivery =
+            function
+            | GraceEvent.ReferenceEvent { Event = ReferenceEventType.Created _ } -> true
+            | _ -> false
+
         /// Processes one Service Bus delivery through exactly one truthful settlement intent.
         let internal processGraceEventWith
             (dependencies: GraceEventSettlementDependencies)
@@ -470,31 +499,30 @@ module Notification =
             =
             task {
                 cancellationToken.ThrowIfCancellationRequested()
-                use activity = ManifestContributionTelemetry.startMessageActivity metadata.MessageId metadata.CorrelationId metadata.DeliveryCount
-
                 let stopwatch = Stopwatch.StartNew()
 
                 match dependencies.Parse body with
                 | Error _ ->
+                    cancellationToken.ThrowIfCancellationRequested()
+
                     try
                         do! dependencies.DeadLetter "MalformedGraceEvent" MalformedGraceEventDescription cancellationToken
-                        stopwatch.Stop()
-
-                        ManifestContributionTelemetry.recordMessage
-                            ManifestContributionProcessingStage.Parse
-                            ManifestContributionMessageOutcome.DeadLettered
-                            stopwatch.Elapsed.TotalMilliseconds
                     with
-                    | ex ->
-                        stopwatch.Stop()
-
-                        ManifestContributionTelemetry.recordMessage
-                            ManifestContributionProcessingStage.Settle
-                            ManifestContributionMessageOutcome.SettlementFailed
-                            stopwatch.Elapsed.TotalMilliseconds
-
-                        return raise ex
+                    | ex -> return raise (GraceEventSettlementFailureException("dead-letter", ex))
                 | Ok graceEvent ->
+                    let isManifestAccountingDelivery = isManifestContributionAccountingDelivery graceEvent
+
+                    use activity =
+                        if isManifestAccountingDelivery then
+                            ManifestContributionTelemetry.startMessageActivity metadata.MessageId metadata.CorrelationId metadata.DeliveryCount
+                        else
+                            null
+
+                    let recordMessage stage outcome =
+                        if isManifestAccountingDelivery then
+                            stopwatch.Stop()
+                            ManifestContributionTelemetry.recordMessage stage outcome stopwatch.Elapsed.TotalMilliseconds
+
                     let! handlerError =
                         task {
                             try
@@ -502,57 +530,33 @@ module Notification =
                                 cancellationToken.ThrowIfCancellationRequested()
                                 return None
                             with
-                            | :? OperationCanceledException as ex ->
-                                stopwatch.Stop()
-
-                                ManifestContributionTelemetry.recordMessage
-                                    ManifestContributionProcessingStage.Handle
-                                    ManifestContributionMessageOutcome.SettlementFailed
-                                    stopwatch.Elapsed.TotalMilliseconds
-
-                                return raise ex
+                            | :? OperationCanceledException as ex -> return raise ex
                             | ex -> return Some ex
                         }
 
                     match handlerError with
                     | None ->
+                        cancellationToken.ThrowIfCancellationRequested()
+
                         try
                             do! dependencies.Complete cancellationToken
-                            stopwatch.Stop()
-
-                            ManifestContributionTelemetry.recordMessage
-                                ManifestContributionProcessingStage.Settle
-                                ManifestContributionMessageOutcome.Completed
-                                stopwatch.Elapsed.TotalMilliseconds
                         with
                         | ex ->
-                            stopwatch.Stop()
+                            recordMessage ManifestContributionProcessingStage.Settle ManifestContributionMessageOutcome.SettlementFailed
+                            return raise (GraceEventSettlementFailureException("complete", ex))
 
-                            ManifestContributionTelemetry.recordMessage
-                                ManifestContributionProcessingStage.Settle
-                                ManifestContributionMessageOutcome.SettlementFailed
-                                stopwatch.Elapsed.TotalMilliseconds
-
-                            return raise ex
+                        recordMessage ManifestContributionProcessingStage.Settle ManifestContributionMessageOutcome.Completed
                     | Some _ ->
+                        cancellationToken.ThrowIfCancellationRequested()
+
                         try
                             do! dependencies.Abandon cancellationToken
-                            stopwatch.Stop()
-
-                            ManifestContributionTelemetry.recordMessage
-                                ManifestContributionProcessingStage.Handle
-                                ManifestContributionMessageOutcome.Abandoned
-                                stopwatch.Elapsed.TotalMilliseconds
                         with
                         | ex ->
-                            stopwatch.Stop()
+                            recordMessage ManifestContributionProcessingStage.Settle ManifestContributionMessageOutcome.SettlementFailed
+                            return raise (GraceEventSettlementFailureException("abandon", ex))
 
-                            ManifestContributionTelemetry.recordMessage
-                                ManifestContributionProcessingStage.Settle
-                                ManifestContributionMessageOutcome.SettlementFailed
-                                stopwatch.Elapsed.TotalMilliseconds
-
-                            return raise ex
+                        recordMessage ManifestContributionProcessingStage.Handle ManifestContributionMessageOutcome.Abandoned
             }
 
         /// Gets the ReferenceDto for the given ReferenceId.
@@ -1449,18 +1453,9 @@ module Notification =
                     let metadata =
                         { MessageId = args.Message.MessageId; CorrelationId = args.Message.CorrelationId; DeliveryCount = args.Message.DeliveryCount }
 
-                    try
-                        do! processGraceEventWith dependencies metadata args.Message.Body args.CancellationToken
-                    with
-                    | ex ->
-                        subscriptionLog.LogError(
-                            ex,
-                            "GraceEvent settlement failed or was cancelled for message {MessageId} (CorrelationId: {CorrelationId}); no replacement settlement was attempted.",
-                            args.Message.MessageId,
-                            args.Message.CorrelationId
-                        )
-
-                        return raise ex
+                    do!
+                        runProcessorMessageCallbackWith subscriptionLog metadata (fun () ->
+                            processGraceEventWith dependencies metadata args.Message.Body args.CancellationToken)
                 }
 
             /// Implements start azure service bus processor for the server request pipeline.

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -490,6 +490,16 @@ module Notification =
             | GraceEvent.ReferenceEvent { Event = ReferenceEventType.Created _ } -> true
             | _ -> false
 
+        /// Adds parsed Reference-created identity to the current manifest-accounting activity before handling begins.
+        let private enrichManifestContributionActivity graceEvent =
+            match graceEvent with
+            | GraceEvent.ReferenceEvent referenceEvent ->
+                match referenceEvent.Event with
+                | ReferenceEventType.Created (referenceId, _, _, repositoryId, _, directoryVersionId, _, _, referenceType, _, _) ->
+                    ManifestContributionTelemetry.enrichReferenceActivity $"{referenceId:D}" $"{repositoryId:D}" $"{directoryVersionId:D}" $"{referenceType}"
+                | _ -> ()
+            | _ -> ()
+
         /// Processes one Service Bus delivery through exactly one truthful settlement intent.
         let internal processGraceEventWith
             (dependencies: GraceEventSettlementDependencies)
@@ -517,6 +527,8 @@ module Notification =
                             ManifestContributionTelemetry.startMessageActivity metadata.MessageId metadata.CorrelationId metadata.DeliveryCount
                         else
                             null
+
+                    enrichManifestContributionActivity graceEvent
 
                     let recordMessage stage outcome =
                         if isManifestAccountingDelivery then
@@ -1040,8 +1052,6 @@ module Notification =
                                                   referenceType,
                                                   referenceText,
                                                   links) ->
-                        ManifestContributionTelemetry.enrichReferenceActivity $"{referenceId:D}" $"{repositoryId:D}" $"{directoryId:D}" $"{referenceType}"
-
                         /// Emits the same-branch notification after Reference replay and branch recomputation complete.
                         let emitCurrentBranchReference branchName =
                             task {

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -103,9 +103,13 @@ module RepositoryCounterRecentResult =
     /// Represents an intentionally absent Redis configuration as cache misses and ignored best-effort writes.
     type UnavailableRepositoryCounterRecentResult() =
         interface IRepositoryCounterRecentResult with
-            member _.TryGetAsync(_, _, _, _, _) = Task.FromResult<RepositoryContentCounterCompletedChange option>(None)
+            member _.TryGetAsync(_, _, _, _, _) =
+                ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get "miss"
+                Task.FromResult<RepositoryContentCounterCompletedChange option>(None)
 
-            member _.TrySetAsync(_, _, _, _, _) = Task.FromResult false
+            member _.TrySetAsync(_, _, _, _, _) =
+                ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Set "unconfirmed"
+                Task.FromResult false
 
     /// Uses one lazy StackExchange.Redis connection with native reconnect, readiness proof, bounded commands, and structured failure evidence.
     type RedisRepositoryCounterRecentResult(host: string, port: int, log: ILogger) =
@@ -130,14 +134,8 @@ module RepositoryCounterRecentResult =
                 return database
             }
 
-        let logBoundaryFailure operation cacheKey fallback (error: Exception) =
-            log.LogWarning(
-                error,
-                "Redis repository counter recent-result {Operation} failed for cache key {CacheKey}; using nonauthoritative fallback {Fallback}.",
-                operation,
-                cacheKey,
-                fallback
-            )
+        let logBoundaryFailure operation fallback (error: Exception) =
+            log.LogWarning(error, "Redis repository counter recent-result {Operation} failed; using nonauthoritative fallback {Fallback}.", operation, fallback)
 
         /// Creates the Redis accelerator with a no-op logger for focused callers that intentionally omit structured diagnostics.
         new(host: string, port: int) = new RedisRepositoryCounterRecentResult(host, port, NullLogger.Instance)
@@ -155,13 +153,17 @@ module RepositoryCounterRecentResult =
                                 .StringGetAsync(cacheKey)
                                 .WaitAsync(commandTimeout, cancellationToken)
 
-                        return if value.IsNullOrEmpty then None else tryDeserialize (string value)
+                        let result = if value.IsNullOrEmpty then None else tryDeserialize (string value)
+                        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get (if result.IsSome then "hit" else "miss")
+                        return result
                     with
                     | :? RedisException as error ->
-                        logBoundaryFailure "GET" cacheKey "cache-miss" error
+                        logBoundaryFailure "GET" "cache-miss" error
+                        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get "miss"
                         return None
                     | :? TimeoutException as error ->
-                        logBoundaryFailure "GET" cacheKey "cache-miss" error
+                        logBoundaryFailure "GET" "cache-miss" error
+                        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Get "miss"
                         return None
                 }
 
@@ -172,16 +174,24 @@ module RepositoryCounterRecentResult =
                     try
                         let! database = database cancellationToken
 
-                        return!
+                        let! confirmed =
                             database
                                 .StringSetAsync(cacheKey, serialize change, expiry)
                                 .WaitAsync(commandTimeout, cancellationToken)
+
+                        ManifestContributionTelemetry.recordRedisOperation
+                            ManifestContributionRedisOperation.Set
+                            (if confirmed then "confirmed" else "unconfirmed")
+
+                        return confirmed
                     with
                     | :? RedisException as error ->
-                        logBoundaryFailure "SET" cacheKey "unconfirmed-write" error
+                        logBoundaryFailure "SET" "unconfirmed-write" error
+                        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Set "unconfirmed"
                         return false
                     | :? TimeoutException as error ->
-                        logBoundaryFailure "SET" cacheKey "unconfirmed-write" error
+                        logBoundaryFailure "SET" "unconfirmed-write" error
+                        ManifestContributionTelemetry.recordRedisOperation ManifestContributionRedisOperation.Set "unconfirmed"
                         return false
                 }
 

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -1885,6 +1885,7 @@ module Application =
                         .AddAspNetCoreInstrumentation()
                         .AddMeter("Microsoft.AspNetCore.Hosting")
                         .AddMeter("Microsoft.AspNetCore.Server.Kestrel")
+                        .AddMeter(ManifestContributionTelemetry.InstrumentationName)
                         .AddPrometheusExporter(fun prometheusOptions -> prometheusOptions.ScrapeEndpointPath <- "/metrics")
                     |> ignore
 
@@ -1901,6 +1902,7 @@ module Application =
                         .AddAspNetCoreInstrumentation()
                         .AddHttpClientInstrumentation()
                         .AddSource(graceServerAppId)
+                        .AddSource(ManifestContributionTelemetry.InstrumentationName)
                     |> ignore
 
                     if


### PR DESCRIPTION
## Why this matters

Manifest-accounting deliveries now expose one truthful settlement result and bounded operational evidence. Grace can distinguish successful handling, retryable handler failures, malformed terminal messages, and unknown settlement outcomes without adding durable coordination state or changing the Reference success contract.

Related to #750. Part of #736 and #727.

## Summary

- adds a typed settlement seam that completes, abandons, or dead-letters exactly once per delivery intent;
- propagates cancellation and settlement failures without attempting a contradictory fallback settlement;
- dead-letters malformed or null events with fixed, bounded, payload-free evidence;
- removes the custom delay from the Service Bus processor error callback;
- registers `Grace.ManifestContributionAccounting` as both the meter and activity source;
- instruments bounded message, relationship, Redis, and repair outcomes while keeping identifiers off metric tags; and
- removes Redis cache keys from boundary warning logs.

## Scope

Changed only the Issue #750 server, compile-order, and focused no-Aspire test paths. No public HTTP, CLI, SDK, OpenAPI, generated, or persisted contract changed. No new queue, subscription, dispatcher, receipt, retry loop, Polly policy, durable state, production fault seam, or `ReferenceType`-specific behavior was added.

## Validation

- RED Release build confirmed the missing settlement seam and telemetry symbols.
- Targeted Fantomas passed on every touched F# file.
- `dotnet build --configuration Release src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj`: passed with 0 warnings and 0 errors.
- Focused settlement, telemetry, accounting, Redis, and repair fixtures: passed 58/58.
- `git diff --check origin/epic/727-manifest-contribution-accounting...HEAD`: passed.
- Unexpected-deletion audit: none.
- Branch refresh: 0 behind and 1 ahead of the current Epic base at handoff.
- Aspire, Fast, and Full were not run. The issue selects typed no-Aspire proof; GitHub `Validate` is the required broad current-head gate.

## Docs and contract impact

No documentation or public/generated contract update is required for this internal transport and telemetry seam. The runtime runbook and exact-SHA evidence packet remain owned by #752.

## Residual risk and recovery

No live broker was started in this slice. The typed seam proves settlement intent and excludes fallback settlement; #751 owns deterministic hosted broker and restart scenarios. Reverting this single leaf commit restores the prior subscriber and telemetry behavior without migrating data.

## Review Status

- Current head: `632702089c299ea902eb70089167997fdcd43cb6`
- Implementation/fix-worker starts: **4/4 used; stabilization worker complete**
- Aspire starts: **0/1; no Aspire start used or authorized for this pass**
- Codex review sessions: **4/4 complete; current-head review returned 👍 with no findings**
- Substantive review cycles: **2; the approved stabilization ledger is implemented and proven**
- GitHub `Validate`: **passed** on current head in run [30424232650](https://github.com/ScottArbeit/Grace/actions/runs/30424232650)
- Session 3 finding: fixed in `632702089c299ea902eb70089167997fdcd43cb6`; review thread resolved after focused proof
- Open findings and unresolved review threads: **0**
- Stabilization ledger: [PR ledger](https://github.com/ScottArbeit/Grace/pull/753#issuecomment-5113358846) and [Issue #750 ledger](https://github.com/ScottArbeit/Grace/issues/750#issuecomment-5113358683)
- Owner approval: [PR record](https://github.com/ScottArbeit/Grace/pull/753#issuecomment-5113408119) and [Issue #750 record](https://github.com/ScottArbeit/Grace/issues/750#issuecomment-5113408001)
- Focused proof: Release build passed with 0 warnings/errors; affected no-Aspire fixtures passed **66/66**; Fantomas, diff, scope, and deletion audits passed
- Manual trigger decision: not attempted; automatic current-head review completed
- Stop condition: not triggered; session 4 found no new issue and no fifth worker or review was started
- Prevention: acceptance-criteria / negative-proof gap; each approved instrument now has explicit semantics and positive plus negative/N/A proof.

### Stabilization status map

| Invariant | Status | Code seam | Test/proof seam | Residual risk |
| --- | --- | --- | --- | --- |
| One truthful settlement path | implemented and proven | `Notification.Subscriber.processGraceEventWith` and `runProcessorMessageCallbackWith` | Settlement-failure, cancellation, handler-failure, malformed, and processor-boundary tests | No live broker was started; #751 owns hosted broker/restart proof. |
| Only manifest-accounting deliveries enter message telemetry | implemented and proven | `isManifestContributionAccountingDelivery` and guarded `recordMessage` | Reference-created positive test, unrelated-event zero test, and malformed tests | None within the #750 typed seam. |
| Failed Reference-created activities contain context before handling | implemented and proven | `enrichManifestContributionActivity` before `dependencies.Handle` | Failed-handler activity-context test and bounded-tag test | Identifiers remain activity/log fields and never metric tags. |
| Every instrument name tells the truth | implemented and proven | `recordMessage`, `recordRelationship`, `recordRedisOperation`, `recordRepairActions`, and audited call sites | Message/duration positive and negative proof; Verify-zero/write-positive relationship proof; Redis Get/Set proof; repair applied/empty proof | Redis negative-operation proof is N/A because its operation is a closed Get/Set union. |
| Telemetry stays bounded and redacted | implemented and proven | Allowed tag set, activity-only identity helpers, fixed malformed evidence, Redis boundary logging, and finite repair action plan | Bounded-tag, identity, malformed-redaction, processor callback, and complete call-site/diff audits | Existing structured exception logging remains; this change exposes no payloads, credentials, connection strings, Redis keys, diagnosis reports, or repair reports. |