### PR TITLE
Prove Grace.Server restart replay

### DIFF
--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -42,6 +42,16 @@ type TestHostState =
         OperationsSqlConnectionString: string
     }
 
+/// Captures the ordered resource and HTTP observations produced by one deliberate Grace.Server restart.
+type GraceServerRestartEvidence =
+    {
+        CommandStartedAt: DateTimeOffset
+        CommandCompletedAt: DateTimeOffset
+        ResourceEventObservedAt: DateTimeOffset
+        ResourceState: string
+        HttpReadyObservedAt: DateTimeOffset
+    }
+
 /// Groups shared helpers for aspire test host.
 module AspireTestHost =
     do AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> Environment.ExitCode <- 0)
@@ -1483,8 +1493,8 @@ module AspireTestHost =
                 Console.WriteLine("Aspire host shutdown skipped to avoid test host teardown crashes.")
         }
 
-    /// Restarts Grace.Server with a scenario label for deliberate restart diagnostics.
-    let restartGraceServerAsync (state: TestHostState) (restartContext: string) =
+    /// Restarts Grace.Server and returns fresh post-command resource-event and HTTP-readiness evidence.
+    let restartGraceServerWithEvidenceAsync (state: TestHostState) (restartContext: string) =
         task {
             do! sharedStateLock.WaitAsync()
 
@@ -1492,33 +1502,85 @@ module AspireTestHost =
                 let normalizedRestartContext = normalizeRestartContext restartContext
                 Console.WriteLine($"Restarting Grace.Server Aspire project resource for {normalizedRestartContext}...")
                 let commandService = state.App.Services.GetRequiredService<ResourceCommandService>()
+                let notificationService = state.App.Services.GetRequiredService<ResourceNotificationService>()
                 use cts = new CancellationTokenSource(defaultWaitTimeout)
 
-                let! result = commandService.ExecuteCommandAsync(graceServerResourceName, KnownResourceCommands.RestartCommand, cts.Token)
+                let events =
+                    notificationService
+                        .WatchAsync(cts.Token)
+                        .GetAsyncEnumerator(cts.Token)
 
-                if not result.Success then
-                    let errorMessage =
-                        if not (String.IsNullOrWhiteSpace result.Message) then result.Message
-                        elif result.Canceled then "Restart command was canceled."
-                        else "Restart command failed without details."
+                try
+                    let commandStartedAt = DateTimeOffset.UtcNow
+                    let mutable nextResourceEvent = events.MoveNextAsync().AsTask()
+                    let! result = commandService.ExecuteCommandAsync(graceServerResourceName, KnownResourceCommands.RestartCommand, cts.Token)
 
-                    raise (InvalidOperationException($"Grace.Server restart failed during {normalizedRestartContext}: {errorMessage}"))
+                    if not result.Success then
+                        let errorMessage =
+                            if not (String.IsNullOrWhiteSpace result.Message) then result.Message
+                            elif result.Canceled then "Restart command was canceled."
+                            else "Restart command failed without details."
 
-                let notificationService = state.App.Services.GetRequiredService<ResourceNotificationService>()
+                        raise (InvalidOperationException($"Grace.Server restart failed during {normalizedRestartContext}: {errorMessage}"))
 
-                do!
-                    waitForResourceHealthyWithProgressContextAsync
-                        notificationService
-                        state.App
-                        graceServerResourceName
-                        cts.Token
-                        (Some normalizedRestartContext)
+                    let commandCompletedAt = DateTimeOffset.UtcNow
+                    let mutable healthyEvent: ResourceEvent option = None
+                    let mutable restartTransitionObserved = false
 
-                do! waitForGraceServerHttpReadyAsync state.Client cts.Token
-                logProgress $"Grace.Server HTTP readiness recovered after intentional restart '{normalizedRestartContext}'."
-                Console.WriteLine($"Grace.Server Aspire project resource restart completed for {normalizedRestartContext}.")
+                    while healthyEvent.IsNone do
+                        let! hasEvent = nextResourceEvent
+
+                        if not hasEvent then
+                            invalidOp "Grace.Server resource event observation ended before fresh Healthy evidence."
+
+                        let resourceEvent = events.Current
+
+                        if resourceEvent.Resource.Name.Equals(graceServerResourceName, StringComparison.OrdinalIgnoreCase) then
+                            let isHealthy =
+                                resourceEvent.Snapshot.HealthStatus.HasValue
+                                && resourceEvent.Snapshot.HealthStatus.Value = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy
+
+                            if
+                                not isHealthy
+                                || not (String.Equals(resourceEvent.Snapshot.State.Text, KnownResourceStates.Running, StringComparison.Ordinal))
+                            then
+                                restartTransitionObserved <- true
+                            elif restartTransitionObserved then
+                                healthyEvent <- Some resourceEvent
+
+                        if healthyEvent.IsNone then nextResourceEvent <- events.MoveNextAsync().AsTask()
+
+                    let resourceEventObservedAt = DateTimeOffset.UtcNow
+                    let resourceState = healthyEvent.Value.Snapshot.HealthStatus.Value.ToString()
+                    logProgress (formatResourceHealthWaitHealthyProgress graceServerResourceName (Some normalizedRestartContext))
+                    do! waitForGraceServerHttpReadyAsync state.Client cts.Token
+                    let httpReadyObservedAt = DateTimeOffset.UtcNow
+                    logProgress $"Grace.Server HTTP readiness recovered after intentional restart '{normalizedRestartContext}'."
+                    Console.WriteLine($"Grace.Server Aspire project resource restart completed for {normalizedRestartContext}.")
+
+                    return
+                        {
+                            CommandStartedAt = commandStartedAt
+                            CommandCompletedAt = commandCompletedAt
+                            ResourceEventObservedAt = resourceEventObservedAt
+                            ResourceState = resourceState
+                            HttpReadyObservedAt = httpReadyObservedAt
+                        }
+                finally
+                    events
+                        .DisposeAsync()
+                        .AsTask()
+                        .GetAwaiter()
+                        .GetResult()
             finally
                 sharedStateLock.Release() |> ignore
+        }
+
+    /// Restarts Grace.Server with a scenario label for deliberate restart diagnostics.
+    let restartGraceServerAsync (state: TestHostState) (restartContext: string) =
+        task {
+            let! _ = restartGraceServerWithEvidenceAsync state restartContext
+            return ()
         }
 
     /// Builds a deterministic service bus receiver for integration setup fixture for the server integration aspire Test Host assertions.

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -1539,17 +1539,29 @@ module AspireTestHost =
                         let resourceEvent = events.Current
 
                         if resourceEvent.Resource.Name.Equals(graceServerResourceName, StringComparison.OrdinalIgnoreCase) then
+                            let resourceState = resourceEvent.Snapshot.State.Text
+
                             let isHealthy =
                                 resourceEvent.Snapshot.HealthStatus.HasValue
                                 && resourceEvent.Snapshot.HealthStatus.Value = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy
 
-                            if
-                                not isHealthy
-                                || not (String.Equals(resourceEvent.Snapshot.State.Text, KnownResourceStates.Running, StringComparison.Ordinal))
-                            then
+                            let hasNamedNonRunningState =
+                                not (String.IsNullOrWhiteSpace resourceState)
+                                && not (String.Equals(resourceState, "Unknown", StringComparison.OrdinalIgnoreCase))
+                                && not (String.Equals(resourceState, KnownResourceStates.Running, StringComparison.Ordinal))
+
+                            let hasKnownNonHealthyStatus =
+                                resourceEvent.Snapshot.HealthStatus.HasValue
+                                && not isHealthy
+
+                            if hasNamedNonRunningState
+                               || hasKnownNonHealthyStatus then
                                 if nonReadyEvent.IsNone then
                                     nonReadyEvent <- Some(DateTimeOffset.UtcNow, resourceEvent)
-                            elif nonReadyEvent.IsSome then
+                            elif
+                                nonReadyEvent.IsSome && isHealthy
+                                && String.Equals(resourceState, KnownResourceStates.Running, StringComparison.Ordinal)
+                            then
                                 healthyEvent <- Some resourceEvent
 
                         if healthyEvent.IsNone then nextResourceEvent <- events.MoveNextAsync().AsTask()

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -47,6 +47,9 @@ type GraceServerRestartEvidence =
     {
         CommandStartedAt: DateTimeOffset
         CommandCompletedAt: DateTimeOffset
+        NonReadyEventObservedAt: DateTimeOffset
+        NonReadyResourceState: string
+        NonReadyHealthStatus: string
         ResourceEventObservedAt: DateTimeOffset
         ResourceState: string
         HttpReadyObservedAt: DateTimeOffset
@@ -1525,7 +1528,7 @@ module AspireTestHost =
 
                     let commandCompletedAt = DateTimeOffset.UtcNow
                     let mutable healthyEvent: ResourceEvent option = None
-                    let mutable restartTransitionObserved = false
+                    let mutable nonReadyEvent: (DateTimeOffset * ResourceEvent) option = None
 
                     while healthyEvent.IsNone do
                         let! hasEvent = nextResourceEvent
@@ -1544,14 +1547,24 @@ module AspireTestHost =
                                 not isHealthy
                                 || not (String.Equals(resourceEvent.Snapshot.State.Text, KnownResourceStates.Running, StringComparison.Ordinal))
                             then
-                                restartTransitionObserved <- true
-                            elif restartTransitionObserved then
+                                if nonReadyEvent.IsNone then
+                                    nonReadyEvent <- Some(DateTimeOffset.UtcNow, resourceEvent)
+                            elif nonReadyEvent.IsSome then
                                 healthyEvent <- Some resourceEvent
 
                         if healthyEvent.IsNone then nextResourceEvent <- events.MoveNextAsync().AsTask()
 
                     let resourceEventObservedAt = DateTimeOffset.UtcNow
                     let resourceState = healthyEvent.Value.Snapshot.HealthStatus.Value.ToString()
+                    let nonReadyEventObservedAt, observedNonReadyEvent = nonReadyEvent.Value
+                    let nonReadyResourceState = observedNonReadyEvent.Snapshot.State.Text
+
+                    let nonReadyHealthStatus =
+                        if observedNonReadyEvent.Snapshot.HealthStatus.HasValue then
+                            observedNonReadyEvent.Snapshot.HealthStatus.Value.ToString()
+                        else
+                            "Unknown"
+
                     logProgress (formatResourceHealthWaitHealthyProgress graceServerResourceName (Some normalizedRestartContext))
                     do! waitForGraceServerHttpReadyAsync state.Client cts.Token
                     let httpReadyObservedAt = DateTimeOffset.UtcNow
@@ -1562,6 +1575,9 @@ module AspireTestHost =
                         {
                             CommandStartedAt = commandStartedAt
                             CommandCompletedAt = commandCompletedAt
+                            NonReadyEventObservedAt = nonReadyEventObservedAt
+                            NonReadyResourceState = nonReadyResourceState
+                            NonReadyHealthStatus = nonReadyHealthStatus
                             ResourceEventObservedAt = resourceEventObservedAt
                             ResourceState = resourceState
                             HttpReadyObservedAt = httpReadyObservedAt

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="RestartDurability.Server.Tests.fs" />
     <Compile Include="ManifestContributionAccounting.Server.Tests.fs" />
     <Compile Include="ManifestContributionBaseline.Measurement.Tests.fs" />
+    <Compile Include="ManifestContributionServerRestart.Measurement.Tests.fs" />
     <Compile Include="RepositoryCounterRecentResult.Integration.Server.Tests.fs" />
     <Compile Include="Policy.Server.Tests.fs" />
     <Compile Include="Queue.Integration.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
@@ -34,7 +34,7 @@ open System.Threading
 open System.Threading.Tasks
 
 /// Carries one distinct manifest, root, branch, and explicit Save identity through the Baseline tracer.
-type private BaselineAsset =
+type internal BaselineAsset =
     {
         BlockAddress: ContentBlockAddress
         Manifest: FileManifest
@@ -45,7 +45,7 @@ type private BaselineAsset =
     }
 
 /// Captures each independent durable convergence result without treating one state store as broker evidence.
-type private DurableStatus =
+type internal DurableStatus =
     {
         ReferenceRoots: bool
         ManifestRelationships: bool
@@ -55,8 +55,19 @@ type private DurableStatus =
         Detail: string
     }
 
+/// Retains the persisted Reference-created broker envelope needed by later replay witnesses.
+type internal CapturedReferenceEnvelope =
+    {
+        Body: byte array
+        MessageId: string
+        CorrelationId: string
+        Subject: string
+        ContentType: string
+        ApplicationProperties: Dictionary<string, obj>
+    }
+
 /// Implements the one explicit fixture-owned Baseline measurement runtime.
-module private BaselineRuntime =
+module internal BaselineRuntime =
 
     [<Literal>]
     let SelectedTopologyCount = 3
@@ -248,6 +259,7 @@ module private BaselineRuntime =
             use receiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, options)
             let timeoutAt = DateTime.UtcNow.AddSeconds(30.0)
             let mutable drain = ProducerInventoryDrain.start
+            let captured = ResizeArray<CapturedReferenceEnvelope>()
 
             while ProducerInventoryDrain.status drain = ProducerInventoryDrainStatus.Receiving
                   && DateTime.UtcNow < timeoutAt do
@@ -286,6 +298,17 @@ module private BaselineRuntime =
                                                 observedInBatch.Add($"{message.MessageId} (body identity {expectedMessageId})")
                                             else
                                                 observedInBatch.Add message.MessageId
+
+                                                captured.Add(
+                                                    {
+                                                        Body = message.Body.ToArray()
+                                                        MessageId = message.MessageId
+                                                        CorrelationId = message.CorrelationId
+                                                        Subject = message.Subject
+                                                        ContentType = message.ContentType
+                                                        ApplicationProperties = Dictionary<string, obj>(message.ApplicationProperties, StringComparer.Ordinal)
+                                                    }
+                                                )
                                         | _ -> ()
                                     | _ -> ()
                                 with
@@ -302,7 +325,7 @@ module private BaselineRuntime =
                 drain <- ProducerInventoryDrain.deadlineExpired drain
 
             match ProducerInventoryDrain.status drain with
-            | ProducerInventoryDrainStatus.Complete -> return ProducerInventoryDrain.observedMessageIds drain
+            | ProducerInventoryDrainStatus.Complete -> return captured.ToArray()
             | ProducerInventoryDrainStatus.Failed -> return invalidOp $"{description} producer inventory failed: {ProducerInventoryDrain.failure drain}"
             | ProducerInventoryDrainStatus.Receiving -> return invalidOp $"{description} producer inventory stopped without terminal evidence."
         }
@@ -979,6 +1002,7 @@ type ManifestContributionBaselineMeasurementTests() =
                     Array.concat [| defaultObserved
                                     setupObserved
                                     saveObserved |]
+                    |> Array.map (fun envelope -> envelope.MessageId)
 
                 let identityErrors = ProducerInventory.validate allExpected allObserved
                 recordAssertion "baseline.identity-isolation" (identityErrors.Length = 0) (String.Join("; ", identityErrors))

--- a/src/Grace.Server.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -1,0 +1,497 @@
+namespace Grace.Server.Measurements
+
+open Azure.Messaging.ServiceBus
+open Grace.Server.Tests
+open Grace.Server.Tests.Measurement
+open Grace.Shared
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.ContentBlockMetadata
+open Grace.Types.Events
+open Grace.Types.ManifestContributionAccounting
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.RepositoryContentCounter
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+open System.Text
+open System.Text.Json
+open System.Threading.Tasks
+
+/// Captures the five independently authoritative durable projections compared across restart replay.
+type private ServerRestartSnapshot =
+    {
+        ReferenceRoots: string array
+        ManifestRelationships: string array
+        LogicalState: string array
+        WorkflowState: string array
+        PhysicalState: string array
+        IsConverged: bool
+    }
+
+/// Implements one persisted-envelope replay after a real Grace.Server restart on the R1 measurement boundary.
+module private ServerRestartRuntime =
+
+    [<Literal>]
+    let ScenarioId = "server-restart"
+
+    /// Serializes a durable projection with the stable Grace JSON contract used for exact comparison.
+    let private serialize value = JsonSerializer.Serialize(value, Constants.JsonSerializerOptions)
+
+    /// Returns whether every selected projection contains one converged entry.
+    let snapshotComplete snapshot =
+        snapshot.ReferenceRoots.Length = 1
+        && snapshot.ManifestRelationships.Length = 1
+        && snapshot.LogicalState.Length = 1
+        && snapshot.WorkflowState.Length = 1
+        && snapshot.PhysicalState.Length = 1
+        && snapshot.IsConverged
+        && snapshot.ReferenceRoots
+           |> Array.forall (fun value -> not (value.StartsWith("missing:", StringComparison.Ordinal)))
+        && snapshot.ManifestRelationships
+           |> Array.forall (fun value -> not (value.StartsWith("missing:", StringComparison.Ordinal)))
+
+    /// Reads every selected durable projection directly from Cosmos without consulting Redis or a pre-restart actor.
+    let readSnapshotAsync state repositoryId (asset: BaselineAsset) =
+        task {
+            let referenceRoot =
+                ExactRelationship.ReferenceRoot
+                    { RepositoryId = repositoryId; RootDirectoryVersionId = asset.Root.DirectoryVersionId; ReferenceId = asset.SaveReferenceId }
+
+            let manifestRelationship =
+                ExactRelationship.DirectoryVersionManifest
+                    {
+                        RepositoryId = repositoryId
+                        StoragePoolId = asset.Manifest.StoragePoolId
+                        ManifestAddress = asset.Manifest.ManifestAddress
+                        DirectoryVersionId = asset.Root.DirectoryVersionId
+                    }
+
+            let! referenceRootExists = BaselineRuntime.exactRelationshipExistsAsync state referenceRoot
+            let! manifestRelationshipExists = BaselineRuntime.exactRelationshipExistsAsync state manifestRelationship
+            let! counters = BaselineRuntime.readActorSnapshotsAsync<RepositoryContentCounterDto> state "RepoContentCounter"
+            let! workflows = BaselineRuntime.readActorSnapshotsAsync<ManifestContributionWorkflowDto> state "ManifestContributionWorkflow"
+            let! metadataStreams = BaselineRuntime.readActorEventStreamsAsync<ContentBlockMetadataEvent> state "ContentBlockMetadata"
+
+            let metadata =
+                metadataStreams
+                |> Array.map (fun events ->
+                    events
+                    |> Array.fold (fun current event -> ContentBlockMetadataDto.UpdateDto event current) ContentBlockMetadataDto.Empty)
+
+            let selectedCounters =
+                counters
+                |> Array.filter (fun counter ->
+                    counter.RepositoryId = repositoryId
+                    && counter.StoragePoolId = asset.Manifest.StoragePoolId
+                    && counter.ManifestAddress = asset.Manifest.ManifestAddress)
+
+            let selectedWorkflows =
+                workflows
+                |> Array.filter (fun workflow ->
+                    workflow.RepositoryId = repositoryId
+                    && workflow.StoragePoolId = asset.Manifest.StoragePoolId
+                    && workflow.ManifestAddress = asset.Manifest.ManifestAddress)
+
+            let selectedMetadata =
+                metadata
+                |> Array.filter (fun dto ->
+                    dto.Metadata
+                    |> Option.exists (fun value ->
+                        value.StoragePoolId = asset.Manifest.StoragePoolId
+                        && value.ContentBlockAddress = asset.BlockAddress))
+
+            let logicalConverged =
+                selectedCounters.Length = 1
+                && selectedCounters[0].Count = 1L
+
+            let workflowConverged =
+                selectedWorkflows.Length = 1
+                && selectedWorkflows[0].Direction = ManifestContributionDirection.Increment
+                && selectedWorkflows[0].CounterRevision = 1L
+                && selectedWorkflows[0].LifecycleState = ManifestContributionWorkflowLifecycleState.Completed
+                && selectedWorkflows[0].Ranges.Length = 1
+                && selectedWorkflows[0].CompletedRanges.Length = 1
+                && selectedWorkflows[0].FailedRanges.Length = 0
+
+            let physicalConverged =
+                selectedMetadata.Length = 1
+                && selectedMetadata[0].Metadata
+                   |> Option.exists (fun value ->
+                       value.Ranges.Length > 0
+                       && value.Ranges
+                          |> Array.forall (fun range -> range.ActiveManifestCount = 1))
+
+            return
+                {
+                    ReferenceRoots =
+                        [|
+                            if referenceRootExists then
+                                serialize referenceRoot
+                            else
+                                $"missing:{serialize referenceRoot}"
+                        |]
+                    ManifestRelationships =
+                        [|
+                            if manifestRelationshipExists then
+                                serialize manifestRelationship
+                            else
+                                $"missing:{serialize manifestRelationship}"
+                        |]
+                    LogicalState =
+                        selectedCounters
+                        |> Array.map serialize
+                        |> Array.sort
+                    WorkflowState =
+                        selectedWorkflows
+                        |> Array.map serialize
+                        |> Array.sort
+                    PhysicalState =
+                        selectedMetadata
+                        |> Array.map serialize
+                        |> Array.sort
+                    IsConverged =
+                        logicalConverged
+                        && workflowConverged
+                        && physicalConverged
+                }
+        }
+
+    /// Waits for the one selected manifest to converge across all five durable projection layers.
+    let waitForSnapshotAsync state repositoryId asset =
+        task {
+            let timeoutAt = DateTime.UtcNow.AddSeconds(45.0)
+
+            let mutable snapshot =
+                {
+                    ReferenceRoots = Array.empty
+                    ManifestRelationships = Array.empty
+                    LogicalState = Array.empty
+                    WorkflowState = Array.empty
+                    PhysicalState = Array.empty
+                    IsConverged = false
+                }
+
+            while not (snapshotComplete snapshot)
+                  && DateTime.UtcNow < timeoutAt do
+                let! current = readSnapshotAsync state repositoryId asset
+                snapshot <- current
+
+                if not (snapshotComplete snapshot) then
+                    do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            return snapshot
+        }
+
+    /// Publishes exactly one captured Reference envelope to the production topic.
+    let publishCapturedEnvelopeAsync (state: TestHostState) (envelope: CapturedReferenceEnvelope) =
+        task {
+            use client = new ServiceBusClient(state.ServiceBusConnectionString)
+            let sender = client.CreateSender(state.ServiceBusTopic)
+
+            try
+                let message = ServiceBusMessage(BinaryData(envelope.Body))
+                message.MessageId <- envelope.MessageId
+                message.CorrelationId <- envelope.CorrelationId
+                message.Subject <- envelope.Subject
+                message.ContentType <- envelope.ContentType
+                let properties = envelope.ApplicationProperties |> Seq.toArray
+                let mutable index = 0
+
+                while index < properties.Length do
+                    let property = properties[index]
+                    message.ApplicationProperties[ property.Key ] <- property.Value
+                    index <- index + 1
+
+                do! sender.SendMessageAsync message
+            finally
+                sender
+                    .DisposeAsync()
+                    .AsTask()
+                    .GetAwaiter()
+                    .GetResult()
+        }
+
+    /// Adds one typed restart-replay sample with stable completed-settlement labels.
+    let recordSample (writer: EvidenceWriter) runId sampleId name value =
+        let labels = Dictionary<string, string>()
+        labels["stage"] <- "settle"
+        labels["outcome"] <- "completed"
+        writer.Append(MeasurementSample.Create(runId, ScenarioId, sampleId, name, value, labels))
+
+/// Proves one persisted Reference envelope completes idempotently after a real Grace.Server restart.
+[<NonParallelizable>]
+type ManifestContributionServerRestartMeasurementTests() =
+
+    /// Emits truthful restart, readiness, replay settlement, durable equality, and evidence results.
+    [<Test; Explicit("Run only through the focused MCA server-restart measurement selector.")>]
+    member _.``isolated persisted envelope completes after Grace Server restart``() =
+        task {
+            let runId = Guid.NewGuid().ToString("N")
+
+            let worktree =
+                BaselineRuntime.requireEnvironment "GRACE_MCA_WORKTREE"
+                |> Path.GetFullPath
+
+            let command = BaselineRuntime.requireEnvironment "GRACE_MCA_HOSTED_COMMAND"
+
+            let evidenceRoot =
+                BaselineRuntime.requireEnvironment "GRACE_MCA_EVIDENCE_ROOT"
+                |> Path.GetFullPath
+
+            let evidenceDirectory = Path.Combine(evidenceRoot, runId)
+            let! commitSha = BaselineRuntime.runGitAsync worktree [| "rev-parse"; "HEAD" |]
+
+            let! status =
+                BaselineRuntime.runGitAsync
+                    worktree
+                    [|
+                        "status"
+                        "--porcelain=v1"
+                        "--untracked-files=all"
+                    |]
+
+            let worktreeState = if String.IsNullOrWhiteSpace status then "clean" else status
+            use writer = new EvidenceWriter(evidenceDirectory, BaselineRuntime.MaximumRecordBytes)
+            let plan = [| ServerRestartRuntime.ScenarioId |]
+            writer.Append(MeasurementRun.Create(runId, commitSha, worktree, worktreeState, command, evidenceDirectory, plan))
+            let assertions = ResizeArray<MeasurementAssertion>()
+            let failures = ResizeArray<string>()
+            let mutable host: TestHostState option = None
+
+            let recordAssertion assertionId passed detail =
+                let assertion = MeasurementAssertion.Create(runId, ServerRestartRuntime.ScenarioId, assertionId, passed, detail)
+                assertions.Add assertion
+                writer.Append assertion
+
+            try
+                let bootstrapUserId = Guid.NewGuid().ToString("D")
+                let! state = AspireTestHost.startIsolatedAsync bootstrapUserId
+                host <- Some state
+                state.Client.DefaultRequestHeaders.Add("x-grace-user-id", bootstrapUserId)
+                let! _ = AspireTestHost.drainServiceBusAsync state
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                do! BaselineRuntime.createOwnerAsync state ownerId
+                do! BaselineRuntime.createOrganizationAsync state ownerId organizationId
+                let! defaultBranchId, defaultReferenceId = BaselineRuntime.createRepositoryAsync state ownerId organizationId repositoryId
+                let! defaultBranch = BaselineRuntime.getBranchAsync state ownerId organizationId repositoryId defaultBranchId
+
+                if defaultBranch.LatestReference.ReferenceId
+                   <> defaultReferenceId then
+                    invalidOp "The repository default Reference inventory did not match its persisted branch."
+
+                let defaultMessageId = $"Reference/{defaultReferenceId}/Created"
+                let! defaultObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| defaultMessageId |] "repository default"
+                let! _ = BaselineRuntime.waitForCompletedSettlementSamplesAsync state
+                let! blockAddress, manifest, bytes = BaselineRuntime.createManifestAssetAsync state ownerId organizationId repositoryId 0
+                let root = BaselineRuntime.createRoot ownerId organizationId repositoryId 0 manifest bytes
+                do! BaselineRuntime.saveRootAsync state ownerId organizationId repositoryId root
+                let rebaseReferenceId = Guid.NewGuid()
+                let saveReferenceId = Guid.NewGuid()
+                let! rebaseBaseline = BaselineRuntime.scrapeMetricsAsync state
+                let! branch = BaselineRuntime.createBranchAsync state ownerId organizationId repositoryId defaultBranch 0 rebaseReferenceId
+
+                let asset =
+                    {
+                        BlockAddress = blockAddress
+                        Manifest = manifest
+                        Root = root
+                        Branch = branch
+                        RebaseReferenceId = rebaseReferenceId
+                        SaveReferenceId = saveReferenceId
+                    }
+
+                let rebaseMessageId = $"Reference/{rebaseReferenceId}/Created"
+                let! rebaseObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| rebaseMessageId |] "branch Rebase"
+
+                let! rebaseMessageDelta, rebaseDurationDelta, saveBaseline = BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L rebaseBaseline
+
+                let! persistedSave = BaselineRuntime.saveReferenceAsync state ownerId organizationId repositoryId asset
+                let saveMessageId = $"Reference/{saveReferenceId}/Created"
+                let! saveObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| saveMessageId |] "explicit Save"
+
+                if saveObserved.Length <> 1 then
+                    invalidOp $"Expected one captured explicit Save envelope but observed {saveObserved.Length}."
+
+                let! beforeRestart = ServerRestartRuntime.waitForSnapshotAsync state repositoryId asset
+
+                if not (ServerRestartRuntime.snapshotComplete beforeRestart) then
+                    invalidOp "The selected manifest did not converge before Grace.Server restart."
+
+                let! saveMessageDelta, saveDurationDelta, _ = BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L saveBaseline
+
+                let seedExpected =
+                    [|
+                        defaultMessageId
+                        rebaseMessageId
+                        saveMessageId
+                    |]
+
+                let seedObserved =
+                    Array.concat [| defaultObserved
+                                    rebaseObserved
+                                    saveObserved |]
+                    |> Array.map (fun envelope -> envelope.MessageId)
+
+                let seedErrors = ProducerInventory.validate seedExpected seedObserved
+                let seedErrorDetail = String.Join("; ", seedErrors)
+
+                let seedCompleted =
+                    seedErrors.Length = 0
+                    && persistedSave.ReferenceId = saveReferenceId
+                    && rebaseMessageDelta = 1L
+                    && rebaseDurationDelta = 1L
+                    && saveMessageDelta = 1L
+                    && saveDurationDelta = 1L
+
+                recordAssertion
+                    "server-restart.seed-deliveries-completed"
+                    seedCompleted
+                    $"inventory={seedErrorDetail}; rebaseMessages={rebaseMessageDelta}; rebaseDurations={rebaseDurationDelta}; saveMessages={saveMessageDelta}; saveDurations={saveDurationDelta}"
+
+                let! restart = AspireTestHost.restartGraceServerWithEvidenceAsync state "ManifestContributionServerRestart.persisted-envelope-replay"
+
+                let readinessErrors =
+                    ServerRestart.validateFreshReadiness
+                        true
+                        restart.CommandStartedAt
+                        restart.ResourceEventObservedAt
+                        restart.ResourceState
+                        restart.HttpReadyObservedAt
+                        true
+
+                let readinessErrorDetail = String.Join("; ", readinessErrors)
+
+                recordAssertion
+                    "server-restart.command-completed"
+                    (restart.CommandCompletedAt
+                     >= restart.CommandStartedAt)
+                    $"started={restart.CommandStartedAt:O}; completed={restart.CommandCompletedAt:O}"
+
+                recordAssertion
+                    "server-restart.fresh-health"
+                    (restart.ResourceEventObservedAt > restart.CommandStartedAt
+                     && restart.ResourceState = "Healthy")
+                    $"state={restart.ResourceState}; observed={restart.ResourceEventObservedAt:O}; errors={readinessErrorDetail}"
+
+                recordAssertion
+                    "server-restart.http-ready"
+                    (restart.HttpReadyObservedAt > restart.ResourceEventObservedAt
+                     && readinessErrors.Length = 0)
+                    $"ready={restart.HttpReadyObservedAt:O}; errors={readinessErrorDetail}"
+
+                let! replayBaseline = BaselineRuntime.scrapeMetricsAsync state
+                let replayEnvelope = saveObserved[0]
+                do! ServerRestartRuntime.publishCapturedEnvelopeAsync state replayEnvelope
+                let! replayObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| saveMessageId |] "server-restart replay"
+
+                let! replayMessageDelta, replayDurationDelta, _ = BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L replayBaseline
+
+                let replayObservedIds =
+                    replayObserved
+                    |> Array.map (fun envelope -> envelope.MessageId)
+
+                let replayErrors = ServerRestart.validateReplayCompletion saveMessageId replayObservedIds replayMessageDelta replayDurationDelta true
+
+                let replayErrorDetail = String.Join("; ", replayErrors)
+
+                recordAssertion
+                    "server-restart.replay-message-delta"
+                    (replayMessageDelta = 1L && replayErrors.Length = 0)
+                    $"delta={replayMessageDelta}; errors={replayErrorDetail}"
+
+                recordAssertion
+                    "server-restart.replay-duration-delta"
+                    (replayDurationDelta = 1L
+                     && replayErrors.Length = 0)
+                    $"delta={replayDurationDelta}; errors={replayErrorDetail}"
+
+                let! afterRestart = ServerRestartRuntime.readSnapshotAsync state repositoryId asset
+
+                recordAssertion
+                    "server-restart.reference-root-state-unchanged"
+                    (afterRestart.ReferenceRoots = beforeRestart.ReferenceRoots)
+                    "exact Reference-root state compared"
+
+                recordAssertion
+                    "server-restart.manifest-state-unchanged"
+                    (afterRestart.ManifestRelationships = beforeRestart.ManifestRelationships)
+                    "exact DirectoryVersion-manifest state compared"
+
+                recordAssertion
+                    "server-restart.logical-state-unchanged"
+                    (afterRestart.LogicalState = beforeRestart.LogicalState)
+                    "logical counter state compared"
+
+                recordAssertion "server-restart.workflow-state-unchanged" (afterRestart.WorkflowState = beforeRestart.WorkflowState) "workflow state compared"
+
+                recordAssertion
+                    "server-restart.physical-state-unchanged"
+                    (afterRestart.PhysicalState = beforeRestart.PhysicalState)
+                    "physical active-range state compared"
+
+                ServerRestartRuntime.recordSample writer runId "replay-messages" "grace_manifest_contribution_messages_total.delta" replayMessageDelta
+
+                ServerRestartRuntime.recordSample
+                    writer
+                    runId
+                    "replay-durations"
+                    "grace_manifest_contribution_processing_duration_milliseconds_count.delta"
+                    replayDurationDelta
+            with
+            | ex -> failures.Add(ex.ToString())
+
+            match host with
+            | Some state ->
+                try
+                    do! AspireTestHost.stopIsolatedAsync state
+                with
+                | ex -> failures.Add($"cleanup: {ex}")
+            | None -> ()
+
+            if
+                not
+                    (
+                        assertions
+                        |> Seq.exists (fun assertion -> assertion.AssertionId = "server-restart.evidence-integrity")
+                    )
+            then
+                try
+                    let valid = BaselineRuntime.verifyEvidenceIntegrity writer
+                    recordAssertion "server-restart.evidence-integrity" valid $"path={writer.Path}"
+                with
+                | ex -> recordAssertion "server-restart.evidence-integrity" false ex.Message
+
+            ServerRestart.requiredAssertionIds
+            |> Array.iter (fun assertionId ->
+                if
+                    not
+                        (
+                            assertions
+                            |> Seq.exists (fun assertion -> assertion.AssertionId = assertionId)
+                        )
+                then
+                    recordAssertion assertionId false "The runtime failed before this assertion could be evaluated.")
+
+            let summary =
+                ScenarioSummary.derive
+                    runId
+                    ServerRestartRuntime.ScenarioId
+                    ServerRestart.requiredAssertionIds
+                    (assertions.ToArray())
+                    (failures.ToArray())
+                    false
+
+            writer.Append summary
+            TestContext.Progress.WriteLine($"MCA server-restart evidence directory: {evidenceDirectory}")
+            TestContext.Progress.Flush()
+
+            Assert.That(
+                summary.Outcome,
+                Is.EqualTo("Passed"),
+                $"Evidence: {evidenceDirectory}{Environment.NewLine}{String.Join(Environment.NewLine, failures)}"
+            )
+        }

--- a/src/Grace.Server.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -383,7 +383,12 @@ type ManifestContributionServerRestartMeasurementTests() =
                      && readinessErrors.Length = 0)
                     $"ready={restart.HttpReadyObservedAt:O}; errors={readinessErrorDetail}"
 
-                let! replayBaseline = BaselineRuntime.scrapeMetricsAsync state
+                let! rawReplayBaseline = BaselineRuntime.scrapeMetricsAsync state
+
+                let replayBaseline =
+                    OpenMetrics.captureFreshProcessCompletedSettlementBaseline rawReplayBaseline
+                    |> Result.defaultWith (fun error -> invalidOp $"Invalid fresh-process replay baseline: {error}")
+
                 let replayEnvelope = saveObserved[0]
                 do! ServerRestartRuntime.publishCapturedEnvelopeAsync state replayEnvelope
                 let! replayObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| saveMessageId |] "server-restart replay"

--- a/src/Grace.Server.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -358,6 +358,10 @@ type ManifestContributionServerRestartMeasurementTests() =
                     ServerRestart.validateFreshReadiness
                         true
                         restart.CommandStartedAt
+                        restart.CommandCompletedAt
+                        restart.NonReadyEventObservedAt
+                        restart.NonReadyResourceState
+                        restart.NonReadyHealthStatus
                         restart.ResourceEventObservedAt
                         restart.ResourceState
                         restart.HttpReadyObservedAt
@@ -373,9 +377,10 @@ type ManifestContributionServerRestartMeasurementTests() =
 
                 recordAssertion
                     "server-restart.fresh-health"
-                    (restart.ResourceEventObservedAt > restart.CommandStartedAt
+                    (restart.NonReadyEventObservedAt > restart.CommandCompletedAt
+                     && restart.ResourceEventObservedAt > restart.NonReadyEventObservedAt
                      && restart.ResourceState = "Healthy")
-                    $"state={restart.ResourceState}; observed={restart.ResourceEventObservedAt:O}; errors={readinessErrorDetail}"
+                    $"commandCompleted={restart.CommandCompletedAt:O}; nonReadyState={restart.NonReadyResourceState}; nonReadyHealth={restart.NonReadyHealthStatus}; nonReadyObserved={restart.NonReadyEventObservedAt:O}; healthyState={restart.ResourceState}; healthyObserved={restart.ResourceEventObservedAt:O}; errors={readinessErrorDetail}"
 
                 recordAssertion
                     "server-restart.http-ready"

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="ManifestContributionTelemetry.Server.Tests.fs" />
     <Compile Include="ManifestContributionMeasurement.fs" />
     <Compile Include="ManifestContributionMeasurement.Tests.fs" />
+    <Compile Include="ManifestContributionServerRestart.Measurement.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="PromotionSet.DirectoryHash.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -852,10 +852,14 @@ module ServerRestart =
             "server-restart.evidence-integrity"
         |]
 
-    /// Requires successful restart command execution followed by a fresh Healthy event and bounded HTTP readiness.
+    /// Requires a completed restart command, retained non-ready transition, fresh Healthy event, and bounded HTTP readiness in strict order.
     let validateFreshReadiness
         commandCompleted
         (commandStartedAt: DateTimeOffset)
+        (commandCompletedAt: DateTimeOffset)
+        (nonReadyEventObservedAt: DateTimeOffset)
+        nonReadyResourceState
+        nonReadyHealthStatus
         (resourceEventObservedAt: DateTimeOffset)
         resourceState
         (httpReadyObservedAt: DateTimeOffset)
@@ -866,8 +870,20 @@ module ServerRestart =
         if not commandCompleted then
             errors.Add("The Grace.Server restart command did not complete successfully.")
 
-        if resourceEventObservedAt <= commandStartedAt then
-            errors.Add("Grace.Server health was not observed after the restart command began.")
+        if commandCompletedAt < commandStartedAt then
+            errors.Add("Grace.Server restart command completion preceded its start.")
+
+        if nonReadyEventObservedAt <= commandCompletedAt then
+            errors.Add("The Grace.Server non-ready transition was not observed after restart command completion.")
+
+        if
+            String.Equals(nonReadyResourceState, "Running", StringComparison.Ordinal)
+            && String.Equals(nonReadyHealthStatus, "Healthy", StringComparison.Ordinal)
+        then
+            errors.Add("The retained Grace.Server transition did not demonstrate a non-ready state.")
+
+        if resourceEventObservedAt <= nonReadyEventObservedAt then
+            errors.Add("The fresh Grace.Server Healthy event did not follow the retained non-ready transition.")
 
         if not (String.Equals(resourceState, "Healthy", StringComparison.Ordinal)) then
             errors.Add($"The fresh Grace.Server resource event was not Healthy: {resourceState}.")

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -835,6 +835,21 @@ module ProducerInventory =
 /// Defines the deterministic proof contract for one replay after a real Grace.Server restart.
 module ServerRestart =
 
+    /// Returns whether retained state or health text positively identifies a non-ready Grace.Server observation.
+    let isAffirmativeNonReady resourceState healthStatus =
+        let resourceStateIsKnown =
+            not (String.IsNullOrWhiteSpace resourceState)
+            && not (String.Equals(resourceState, "Unknown", StringComparison.OrdinalIgnoreCase))
+
+        let healthStatusIsKnown =
+            not (String.IsNullOrWhiteSpace healthStatus)
+            && not (String.Equals(healthStatus, "Unknown", StringComparison.OrdinalIgnoreCase))
+
+        (resourceStateIsKnown
+         && not (String.Equals(resourceState, "Running", StringComparison.Ordinal)))
+        || (healthStatusIsKnown
+            && not (String.Equals(healthStatus, "Healthy", StringComparison.Ordinal)))
+
     /// Lists the exact assertion identities required by the server-restart replay witness.
     let requiredAssertionIds =
         [|
@@ -876,10 +891,7 @@ module ServerRestart =
         if nonReadyEventObservedAt <= commandCompletedAt then
             errors.Add("The Grace.Server non-ready transition was not observed after restart command completion.")
 
-        if
-            String.Equals(nonReadyResourceState, "Running", StringComparison.Ordinal)
-            && String.Equals(nonReadyHealthStatus, "Healthy", StringComparison.Ordinal)
-        then
+        if not (isAffirmativeNonReady nonReadyResourceState nonReadyHealthStatus) then
             errors.Add("The retained Grace.Server transition did not demonstrate a non-ready state.")
 
         if resourceEventObservedAt <= nonReadyEventObservedAt then

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -468,6 +468,11 @@ module OpenMetrics =
                             else
                                 errors.Add($"{metricName} contained a non-completed-settlement label set.")
                         | _ -> errors.Add($"{metricName} was malformed.")
+                    elif
+                        metricName.StartsWith(messageMetricName, StringComparison.Ordinal)
+                        || metricName.StartsWith(durationMetricName, StringComparison.Ordinal)
+                    then
+                        errors.Add("A completed settlement metric used a forbidden suffixed name.")
                 elif
                     line.StartsWith(messageMetricName, StringComparison.Ordinal)
                     || line.StartsWith(durationMetricName, StringComparison.Ordinal)
@@ -527,6 +532,72 @@ module ProducerInventory =
         observed
         |> Seq.filter (expected.Contains >> not)
         |> Seq.iter (fun messageId -> errors.Add($"Unclassified Reference-created envelope '{messageId}'."))
+
+        errors.ToArray()
+
+/// Defines the deterministic proof contract for one replay after a real Grace.Server restart.
+module ServerRestart =
+
+    /// Lists the exact assertion identities required by the server-restart replay witness.
+    let requiredAssertionIds =
+        [|
+            "server-restart.seed-deliveries-completed"
+            "server-restart.command-completed"
+            "server-restart.fresh-health"
+            "server-restart.http-ready"
+            "server-restart.replay-message-delta"
+            "server-restart.replay-duration-delta"
+            "server-restart.reference-root-state-unchanged"
+            "server-restart.manifest-state-unchanged"
+            "server-restart.logical-state-unchanged"
+            "server-restart.workflow-state-unchanged"
+            "server-restart.physical-state-unchanged"
+            "server-restart.evidence-integrity"
+        |]
+
+    /// Requires successful restart command execution followed by a fresh Healthy event and bounded HTTP readiness.
+    let validateFreshReadiness
+        commandCompleted
+        (commandStartedAt: DateTimeOffset)
+        (resourceEventObservedAt: DateTimeOffset)
+        resourceState
+        (httpReadyObservedAt: DateTimeOffset)
+        httpReady
+        =
+        let errors = ResizeArray<string>()
+
+        if not commandCompleted then
+            errors.Add("The Grace.Server restart command did not complete successfully.")
+
+        if resourceEventObservedAt <= commandStartedAt then
+            errors.Add("Grace.Server health was not observed after the restart command began.")
+
+        if not (String.Equals(resourceState, "Healthy", StringComparison.Ordinal)) then
+            errors.Add($"The fresh Grace.Server resource event was not Healthy: {resourceState}.")
+
+        if httpReadyObservedAt <= resourceEventObservedAt then
+            errors.Add("Grace.Server HTTP readiness did not follow the fresh Healthy resource event.")
+
+        if not httpReady then
+            errors.Add("Grace.Server HTTP readiness failed after the fresh Healthy resource event.")
+
+        errors.ToArray()
+
+    /// Requires one exact observed replay identity plus one completed message and duration settlement observation.
+    let validateReplayCompletion expectedMessageId observedMessageIds messageDelta durationDelta settlementCompleted =
+        let errors = ResizeArray<string>()
+
+        ProducerInventory.validate [| expectedMessageId |] observedMessageIds
+        |> errors.AddRange
+
+        if messageDelta <> 1L then
+            errors.Add($"The replay completed message delta required 1 but observed {messageDelta}.")
+
+        if durationDelta <> 1L then
+            errors.Add($"The replay completed duration delta required 1 but observed {durationDelta}.")
+
+        if not settlementCompleted then
+            errors.Add("The replay settlement failed or did not reach terminal completion.")
 
         errors.ToArray()
 

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -641,6 +641,12 @@ module OpenMetrics =
 
     let private labelPattern = Regex("(?:^|,)\\s*(?<key>[A-Za-z_][A-Za-z0-9_]*)=\"(?<value>(?:\\\\.|[^\"])*)\"\\s*(?=,|$)", RegexOptions.CultureInvariant)
 
+    let private freshProcessZeroBaseline =
+        """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 0
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 0
+"""
+
     /// Unescapes one OpenMetrics label value after the label grammar has bounded it.
     let private unescapeLabelValue (value: string) =
         value
@@ -749,6 +755,35 @@ module OpenMetrics =
             Error($"{durationMetricName} required exactly one sample but found {values[durationMetricName].Count}.")
         else
             Ok(values[messageMetricName][0], values[durationMetricName][0])
+
+    /// Captures a freshly restarted process baseline while normalizing only the uninstantiated paired-zero series shape.
+    let captureFreshProcessCompletedSettlementBaseline (scrape: string) =
+        let hasRelevantSeries =
+            scrape.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.exists (fun rawLine ->
+                let line = rawLine.Trim()
+
+                if line.StartsWith("#", StringComparison.Ordinal) then
+                    false
+                else
+                    let sampleMatch = samplePattern.Match line
+
+                    if sampleMatch.Success then
+                        let metricName = sampleMatch.Groups["name"].Value
+
+                        metricName.StartsWith(messageMetricName, StringComparison.Ordinal)
+                        || metricName.StartsWith(durationMetricName, StringComparison.Ordinal)
+                    else
+                        line.StartsWith(messageMetricName, StringComparison.Ordinal)
+                        || line.StartsWith(durationMetricName, StringComparison.Ordinal))
+
+        if not hasRelevantSeries then
+            Ok freshProcessZeroBaseline
+        else
+            match parseCompletedSettlementSamples scrape with
+            | Ok (0L, 0L) -> Ok scrape
+            | Ok (messages, durations) -> Error($"Fresh-process settlement metrics must both be zero: messages={messages}, durations={durations}.")
+            | Error error -> Error error
 
     /// Evaluates exact cumulative equality while allowing only unchanged or partial deltas to keep waiting.
     let evaluateCompletedSettlementDelta expectedDelta baselineScrape observedScrape =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -114,3 +114,55 @@ grace_manifest_contribution_messages_total_created{otel_scope_name="Grace.Manife
         match OpenMetrics.evaluateCompletedSettlementDelta 1L baseline observed with
         | DeltaEvaluation.Invalid error -> Assert.That(error, Does.Contain("suffixed"))
         | result -> Assert.Fail($"A suffixed settlement series unexpectedly produced {result}.")
+
+    /// Verifies a fresh process with both settlement series absent normalizes to the exact paired-zero baseline.
+    [<Test>]
+    member _.AbsentFreshProcessSeriesNormalizeToPairedZero() =
+        let observed =
+            """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 1
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 1
+"""
+
+        match OpenMetrics.captureFreshProcessCompletedSettlementBaseline "# unrelated metrics only" with
+        | Ok baseline -> Assert.That(OpenMetrics.evaluateCompletedSettlementDelta 1L baseline observed, Is.EqualTo(DeltaEvaluation.Complete(1L, 1L)))
+        | Error error -> Assert.Fail($"Expected an absent fresh-process pair to normalize, got {error}.")
+
+    /// Verifies an exact paired-zero fresh-process scrape remains a valid captured baseline.
+    [<Test>]
+    member _.ExactFreshProcessZeroSeriesRemainValid() =
+        let zero =
+            """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 0
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 0
+"""
+
+        match OpenMetrics.captureFreshProcessCompletedSettlementBaseline zero with
+        | Ok baseline -> Assert.That(baseline, Is.EqualTo(zero))
+        | Error error -> Assert.Fail($"Expected an exact zero baseline to remain valid, got {error}.")
+
+    /// Verifies every ambiguous or nonzero fresh-process settlement shape fails instead of becoming a replay baseline.
+    [<Test>]
+    member _.UnsafeFreshProcessBaselineShapesFail() =
+        let messages value =
+            $"grace_manifest_contribution_messages_total{{otel_scope_name=\"Grace.ManifestContributionAccounting\",stage=\"settle\",outcome=\"completed\"}} {value}"
+
+        let durations value =
+            $"grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_name=\"Grace.ManifestContributionAccounting\",stage=\"settle\",outcome=\"completed\"}} {value}"
+
+        let invalidScrapes =
+            [|
+                "partial", messages 0
+                "nonzero", $"{messages 1}{Environment.NewLine}{durations 1}"
+                "suffix", "grace_manifest_contribution_messages_total_created 0"
+                "other-label", "grace_manifest_contribution_messages_total{outcome=\"completed\"} 0"
+                "settlement-failed", "grace_manifest_contribution_messages_total{outcome=\"settlement_failed\"} 0"
+                "duplicate", $"{messages 0}{Environment.NewLine}{messages 0}{Environment.NewLine}{durations 0}"
+                "malformed", "grace_manifest_contribution_messages_total{ 0"
+            |]
+
+        invalidScrapes
+        |> Array.iter (fun (name, scrape) ->
+            match OpenMetrics.captureFreshProcessCompletedSettlementBaseline scrape with
+            | Error _ -> ()
+            | Ok _ -> Assert.Fail($"{name} unexpectedly normalized to a fresh-process baseline."))

--- a/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -102,6 +102,20 @@ type ManifestContributionServerRestartMeasurementTests() =
         Assert.That(String.Join("; ", errors), Does.Contain("non-ready transition was not observed after"))
         Assert.That(String.Join("; ", errors), Does.Contain("did not demonstrate a non-ready state"))
 
+    /// Verifies blank or Unknown state and health text cannot become affirmative restart-transition evidence.
+    [<TestCase("", "Unknown")>]
+    [<TestCase("Unknown", "")>]
+    [<TestCase("Running", "Unknown")>]
+    [<TestCase("Unknown", "Healthy")>]
+    member _.BlankOrUnknownTransitionDoesNotProveNonReady(resourceState, healthStatus) =
+        Assert.That(ServerRestart.isAffirmativeNonReady resourceState healthStatus, Is.False)
+
+    /// Verifies either a named non-running state or known non-Healthy health value proves the transition.
+    [<TestCase("Starting", "Unknown")>]
+    [<TestCase("Running", "Unhealthy")>]
+    member _.ExplicitNonReadyStateOrHealthProvesTransition(resourceState, healthStatus) =
+        Assert.That(ServerRestart.isAffirmativeNonReady resourceState healthStatus, Is.True)
+
     /// Verifies unchanged durable state cannot replace exact replay identity and settlement completion.
     [<Test>]
     member _.UnsettledReplayFailsEvenWhenDurableStateIsUnchanged() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -1,0 +1,116 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Measurement
+open NUnit.Framework
+open System
+
+/// Proves the deterministic contract used by the Grace.Server restart replay witness.
+[<TestFixture>]
+type ManifestContributionServerRestartMeasurementTests() =
+
+    let requiredAssertionIds =
+        [|
+            "server-restart.seed-deliveries-completed"
+            "server-restart.command-completed"
+            "server-restart.fresh-health"
+            "server-restart.http-ready"
+            "server-restart.replay-message-delta"
+            "server-restart.replay-duration-delta"
+            "server-restart.reference-root-state-unchanged"
+            "server-restart.manifest-state-unchanged"
+            "server-restart.logical-state-unchanged"
+            "server-restart.workflow-state-unchanged"
+            "server-restart.physical-state-unchanged"
+            "server-restart.evidence-integrity"
+        |]
+
+    /// Verifies the scenario can pass only with the exact twelve issue-owned assertion identities.
+    [<Test>]
+    member _.RequiredAssertionIdentifiersAreExact() = Assert.That(ServerRestart.requiredAssertionIds = requiredAssertionIds, Is.True)
+
+    /// Verifies restart readiness requires command success, a fresh Healthy event, and later HTTP success.
+    [<Test>]
+    member _.FreshRestartReadinessPassesInRequiredOrder() =
+        let commandStartedAt = DateTimeOffset.Parse("2026-07-31T10:00:00Z")
+
+        let errors =
+            ServerRestart.validateFreshReadiness true commandStartedAt (commandStartedAt.AddSeconds 1.0) "Healthy" (commandStartedAt.AddSeconds 2.0) true
+
+        Assert.That(errors, Is.Empty)
+
+    /// Verifies a stale health snapshot cannot satisfy a real post-command restart proof.
+    [<Test>]
+    member _.StaleHealthOrMissingReadinessFails() =
+        let commandStartedAt = DateTimeOffset.Parse("2026-07-31T10:00:00Z")
+
+        let errors = ServerRestart.validateFreshReadiness false commandStartedAt commandStartedAt "Running" (commandStartedAt.AddSeconds -1.0) false
+
+        Assert.That(errors, Has.Length.EqualTo(5))
+        Assert.That(String.Join("; ", errors), Does.Contain("command did not complete"))
+        Assert.That(String.Join("; ", errors), Does.Contain("not observed after"))
+        Assert.That(String.Join("; ", errors), Does.Contain("not Healthy"))
+        Assert.That(String.Join("; ", errors), Does.Contain("did not follow"))
+        Assert.That(String.Join("; ", errors), Does.Contain("HTTP readiness failed"))
+
+    /// Verifies unchanged durable state cannot replace exact replay identity and settlement completion.
+    [<Test>]
+    member _.UnsettledReplayFailsEvenWhenDurableStateIsUnchanged() =
+        let expectedMessageId = "Reference/one/Created"
+
+        let errors = ServerRestart.validateReplayCompletion expectedMessageId Array.empty 0L 0L false
+
+        Assert.That(errors, Has.Length.EqualTo(4))
+        Assert.That(String.Join("; ", errors), Does.Contain("Missing expected"))
+        Assert.That(String.Join("; ", errors), Does.Contain("message delta"))
+        Assert.That(String.Join("; ", errors), Does.Contain("duration delta"))
+        Assert.That(String.Join("; ", errors), Does.Contain("settlement failed"))
+
+    /// Verifies exactly one matching replay delivery and both terminal metric observations are required.
+    [<Test>]
+    member _.ExactReplayCompletionPasses() =
+        let expectedMessageId = "Reference/one/Created"
+
+        let errors = ServerRestart.validateReplayCompletion expectedMessageId [| expectedMessageId |] 1L 1L true
+
+        Assert.That(errors, Is.Empty)
+
+    /// Verifies duplicate or unrelated replay identities cannot hide inside an otherwise exact metric delta.
+    [<Test>]
+    member _.DuplicateOrUnclassifiedReplayIdentityFails() =
+        let expectedMessageId = "Reference/one/Created"
+
+        let errors =
+            ServerRestart.validateReplayCompletion
+                expectedMessageId
+                [|
+                    expectedMessageId
+                    expectedMessageId
+                    "Reference/unclassified/Created"
+                |]
+                1L
+                1L
+                true
+
+        Assert.That(errors, Is.Not.Empty)
+        Assert.That(String.Join("; ", errors), Does.Contain("duplicate"))
+        Assert.That(String.Join("; ", errors), Does.Contain("Unclassified"))
+
+    /// Verifies a suffixed settlement series fails even when both required exact samples are also present.
+    [<Test>]
+    member _.SuffixedSettlementSeriesCannotHideBesideExactSamples() =
+        let baseline =
+            """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 7
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 7
+"""
+
+        let observed =
+            """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 8
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 8
+grace_manifest_contribution_messages_total_created{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 8
+"""
+
+        match OpenMetrics.evaluateCompletedSettlementDelta 1L baseline observed with
+        | DeltaEvaluation.Invalid error -> Assert.That(error, Does.Contain("suffixed"))
+        | result -> Assert.Fail($"A suffixed settlement series unexpectedly produced {result}.")

--- a/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionServerRestart.Measurement.Tests.fs
@@ -28,13 +28,26 @@ type ManifestContributionServerRestartMeasurementTests() =
     [<Test>]
     member _.RequiredAssertionIdentifiersAreExact() = Assert.That(ServerRestart.requiredAssertionIds = requiredAssertionIds, Is.True)
 
-    /// Verifies restart readiness requires command success, a fresh Healthy event, and later HTTP success.
+    /// Verifies restart readiness retains the post-command non-ready transition before fresh Healthy and HTTP success.
     [<Test>]
     member _.FreshRestartReadinessPassesInRequiredOrder() =
         let commandStartedAt = DateTimeOffset.Parse("2026-07-31T10:00:00Z")
+        let commandCompletedAt = commandStartedAt.AddSeconds 1.0
+        let nonReadyObservedAt = commandCompletedAt.AddSeconds 1.0
+        let healthyObservedAt = nonReadyObservedAt.AddSeconds 1.0
 
         let errors =
-            ServerRestart.validateFreshReadiness true commandStartedAt (commandStartedAt.AddSeconds 1.0) "Healthy" (commandStartedAt.AddSeconds 2.0) true
+            ServerRestart.validateFreshReadiness
+                true
+                commandStartedAt
+                commandCompletedAt
+                nonReadyObservedAt
+                "Starting"
+                "Unhealthy"
+                healthyObservedAt
+                "Healthy"
+                (healthyObservedAt.AddSeconds 1.0)
+                true
 
         Assert.That(errors, Is.Empty)
 
@@ -43,14 +56,51 @@ type ManifestContributionServerRestartMeasurementTests() =
     member _.StaleHealthOrMissingReadinessFails() =
         let commandStartedAt = DateTimeOffset.Parse("2026-07-31T10:00:00Z")
 
-        let errors = ServerRestart.validateFreshReadiness false commandStartedAt commandStartedAt "Running" (commandStartedAt.AddSeconds -1.0) false
+        let errors =
+            ServerRestart.validateFreshReadiness
+                false
+                commandStartedAt
+                commandStartedAt
+                commandStartedAt
+                "Running"
+                "Healthy"
+                commandStartedAt
+                "Running"
+                (commandStartedAt.AddSeconds -1.0)
+                false
 
-        Assert.That(errors, Has.Length.EqualTo(5))
+        Assert.That(errors, Has.Length.EqualTo(7))
         Assert.That(String.Join("; ", errors), Does.Contain("command did not complete"))
-        Assert.That(String.Join("; ", errors), Does.Contain("not observed after"))
+        Assert.That(String.Join("; ", errors), Does.Contain("non-ready transition was not observed after"))
+        Assert.That(String.Join("; ", errors), Does.Contain("did not demonstrate a non-ready state"))
+        Assert.That(String.Join("; ", errors), Does.Contain("Healthy event did not follow"))
         Assert.That(String.Join("; ", errors), Does.Contain("not Healthy"))
         Assert.That(String.Join("; ", errors), Does.Contain("did not follow"))
         Assert.That(String.Join("; ", errors), Does.Contain("HTTP readiness failed"))
+
+    /// Verifies a Healthy observation cannot hide an omitted or out-of-order non-ready restart transition.
+    [<Test>]
+    member _.MissingOrOutOfOrderNonReadyTransitionFails() =
+        let commandStartedAt = DateTimeOffset.Parse("2026-07-31T10:00:00Z")
+        let commandCompletedAt = commandStartedAt.AddSeconds 1.0
+        let healthyObservedAt = commandCompletedAt.AddSeconds 2.0
+
+        let errors =
+            ServerRestart.validateFreshReadiness
+                true
+                commandStartedAt
+                commandCompletedAt
+                commandStartedAt
+                "Running"
+                "Healthy"
+                healthyObservedAt
+                "Healthy"
+                (healthyObservedAt.AddSeconds 1.0)
+                true
+
+        Assert.That(errors, Has.Length.EqualTo(2))
+        Assert.That(String.Join("; ", errors), Does.Contain("non-ready transition was not observed after"))
+        Assert.That(String.Join("; ", errors), Does.Contain("did not demonstrate a non-ready state"))
 
     /// Verifies unchanged durable state cannot replace exact replay identity and settlement completion.
     [<Test>]


### PR DESCRIPTION
## Why this matters

Grace operators need proof that a real Grace.Server restart does not turn unchanged durable state into a false replay success: the replay itself must settle after fresh readiness while every durable projection remains idempotent.

Part of #760.

## Summary

- adds the selected-process Grace.Server-restart replay witness
- captures and replays one valid persisted Reference envelope only after a real restart and fresh health/HTTP readiness
- requires exact completed replay telemetry and clean producer identity inventory
- re-reads and proves unchanged Reference-root, manifest, logical, workflow, and physical projections
- adds strict fresh-process paired-zero metric-baseline handling and pure negative coverage
- preserves the merged R1, duplicate-backlog, and topology witnesses

## Scope

Test and measurement infrastructure only. No production accounting, actor, transport, Redis, API, generated contract, persistence, repair, counter, workflow, deletion, settlement, restart, retry, or public-contract behavior changed.

## Validation

- final exact-head hosted witness: Passed, 12/12 unique required assertions, 0 failures, 0 runtime failures
- restart sequence: command completed, post-command transition, fresh Healthy, bounded HTTP readiness
- replay samples: exactly 1 completed message and 1 completed duration
- durable projections: Reference-root, manifest, logical, workflow, and physical state unchanged
- producer inventory: clean
- conflict-affected pure suites: 43/43 passed
- `Grace.Server.Unit.Tests` Release build: passed with 0 warnings/errors
- `Grace.Server.Tests` Release build: passed with 0 warnings/errors
- Baseline, duplicate-backlog, topology, and server-restart selectors discovered
- Fantomas and `git diff --check`: passed
- three-dot diff: six declared test/support paths, no production paths/deletions
- cleanup: no run containers or DCP processes

Final evidence: `C:\Users\scott\AppData\Local\Temp\grace-mca-evidence\760-1c0bd629\752b19987e8541ff99face5adacff81b`.

Runtime start 1 retained a truthful failure because a fresh process exposed both completion series as absent. The final commit accepts only the paired absent/paired exact-zero initial state and rejects partial, nonzero, suffix, other-label, settlement-failed, duplicate, and malformed inputs. Runtime start 2 passed on the exact final head.

## Documentation impact

No product/operator documentation changes in this test-only slice. Grouped exact-SHA reconciliation/docs remain owned by #752.

## Review Status

| Gate | Status |
| --- | --- |
| PR head | `45f4a40cc86cc2474d8273baa392aa2d32ac44fb` |
| Epic base | `53f7166ae0b8c08c9b814ccde2834831de077d3b`; branch is 0 behind |
| Implementation/fix workers | 2/4 used |
| Runtime starts | 4 purposeful runs; uncapped policy; all cleaned up |
| GitHub Validate | Run `30627619355` passed on exact head `45f4a40cc86cc2474d8273baa392aa2d32ac44fb` |
| Fresh review subagent | Session 1 completed on `45f4a40cc86cc2474d8273baa392aa2d32ac44fb`: one P2 proof-integrity finding |
| Review findings | Session-1 P2 fixed and verified closed; session 2 found no substantive issues |
| Merge gate | Satisfied: exact-head Validate passed and Terra High session 2 approved |

Accepted limitation: malformed reference-shaped-envelope classification remains deferred harness hardening and is not exercised by this valid captured replay.