### PR TITLE
MCA-08B-R7: prove dead-letter delivery boundary

### DIFF
--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="AspireTestHost.fs" />
     <Compile Include="..\Grace.Server.Unit.Tests\ManifestContributionMeasurement.fs" Link="ManifestContributionMeasurement.fs" />
+    <Compile Include="..\Grace.Server.Unit.Tests\ManifestContributionDeadLetterMeasurement.fs" Link="ManifestContributionDeadLetterMeasurement.fs" />
     <Compile Include="AspireTestHost.Diagnostics.Tests.fs" />
     <Compile Include="OperationalFactsPublisher.AppHost.Tests.fs" />
     <Compile Include="General.Server.Tests.fs" />
@@ -39,6 +40,7 @@
     <Compile Include="RestartDurability.Server.Tests.fs" />
     <Compile Include="ManifestContributionAccounting.Server.Tests.fs" />
     <Compile Include="ManifestContributionBaseline.Measurement.Tests.fs" />
+    <Compile Include="ManifestContributionDeadLetter.Measurement.Tests.fs" />
     <Compile Include="RepositoryCounterRecentResult.Integration.Server.Tests.fs" />
     <Compile Include="Policy.Server.Tests.fs" />
     <Compile Include="Queue.Integration.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
@@ -34,7 +34,7 @@ open System.Threading
 open System.Threading.Tasks
 
 /// Carries one distinct manifest, root, branch, and explicit Save identity through the Baseline tracer.
-type private BaselineAsset =
+type internal BaselineAsset =
     {
         BlockAddress: ContentBlockAddress
         Manifest: FileManifest
@@ -45,7 +45,7 @@ type private BaselineAsset =
     }
 
 /// Captures each independent durable convergence result without treating one state store as broker evidence.
-type private DurableStatus =
+type internal DurableStatus =
     {
         ReferenceRoots: bool
         ManifestRelationships: bool
@@ -56,7 +56,7 @@ type private DurableStatus =
     }
 
 /// Implements the one explicit fixture-owned Baseline measurement runtime.
-module private BaselineRuntime =
+module internal BaselineRuntime =
 
     [<Literal>]
     let SelectedTopologyCount = 3

--- a/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
@@ -9,8 +9,10 @@ open Grace.Types
 open Grace.Types.Common
 open Grace.Types.Events
 open Grace.Types.Owner
+open Grace.Types.Reference
 open NUnit.Framework
 open System
+open System.Collections.Generic
 open System.IO
 open System.Text.Json
 open System.Threading
@@ -50,6 +52,136 @@ module private DeadLetterRuntime =
             use sender = client.CreateSender(state.ServiceBusTopic)
             use cts = new CancellationTokenSource(TimeSpan.FromSeconds(10.0))
             do! sender.SendMessageAsync(message, cts.Token)
+        }
+
+    /// Creates the selected-process fixture repository and returns its persisted default Reference producer identity.
+    let createDefaultReferenceProducerAsync (state: TestHostState) fixtureCorrelationId =
+        task {
+            let ownerId = Guid.NewGuid()
+            let organizationId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let ownerParameters = Parameters.Owner.CreateOwnerParameters()
+            ownerParameters.OwnerId <- string ownerId
+            ownerParameters.OwnerName <- $"McaDeadLetterOwner{ownerId:N}"
+            ownerParameters.CorrelationId <- fixtureCorrelationId
+            use! ownerResponse = state.Client.PostAsync("/owner/create", createJsonContent ownerParameters)
+            let! _ = BaselineRuntime.requireOkAsync "POST /owner/create" ownerResponse
+
+            let organizationParameters = Parameters.Organization.CreateOrganizationParameters()
+            organizationParameters.OwnerId <- string ownerId
+            organizationParameters.OrganizationId <- string organizationId
+            organizationParameters.OrganizationName <- $"McaDeadLetterOrganization{organizationId:N}"
+            organizationParameters.CorrelationId <- fixtureCorrelationId
+            use! organizationResponse = state.Client.PostAsync("/organization/create", createJsonContent organizationParameters)
+            let! _ = BaselineRuntime.requireOkAsync "POST /organization/create" organizationResponse
+
+            let repositoryParameters = Parameters.Repository.CreateRepositoryParameters()
+            repositoryParameters.OwnerId <- string ownerId
+            repositoryParameters.OrganizationId <- string organizationId
+            repositoryParameters.RepositoryId <- string repositoryId
+            repositoryParameters.RepositoryName <- $"mca-dead-letter-{repositoryId:N}"
+            repositoryParameters.CorrelationId <- fixtureCorrelationId
+            use! repositoryResponse = state.Client.PostAsync("/repository/create", createJsonContent repositoryParameters)
+            let! repositoryBody = BaselineRuntime.requireOkAsync "POST /repository/create" repositoryResponse
+            let result = deserialize<GraceReturnValue<string>> repositoryBody
+            let branchId = Grace.Server.Tests.Common.requireGuidProperty (nameof BranchId) result.Properties[nameof BranchId]
+            let referenceId = Grace.Server.Tests.Common.requireGuidProperty (nameof ReferenceId) result.Properties[nameof ReferenceId]
+            let! branch = BaselineRuntime.getBranchAsync state ownerId organizationId repositoryId branchId
+
+            if branch.LatestReference.ReferenceId <> referenceId then
+                invalidOp "The dead-letter fixture repository default Reference did not match its persisted branch."
+
+            return $"Reference/{referenceId}/Created"
+        }
+
+    /// Inventories active selected-process work through PeekLock and settles only the classified fixture/default producers.
+    let inventoryDefaultReferenceProducerAsync (state: TestHostState) fixtureCorrelationId expectedMessageId =
+        task {
+            use client = new ServiceBusClient(state.ServiceBusConnectionString)
+            let options = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
+            use receiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, options)
+            let expectedMessageIds = [| expectedMessageId |]
+            let expected = HashSet<string>(expectedMessageIds, StringComparer.Ordinal)
+            let timeoutAt = DateTime.UtcNow.AddSeconds(30.0)
+            let mutable drain = ProducerInventoryDrain.start
+
+            while ProducerInventoryDrain.status drain = ProducerInventoryDrainStatus.Receiving
+                  && DateTime.UtcNow < timeoutAt do
+                let remaining = timeoutAt - DateTime.UtcNow
+
+                if remaining <= TimeSpan.Zero then
+                    drain <- ProducerInventoryDrain.deadlineExpired drain
+                else
+                    let receiveWindow = min remaining (TimeSpan.FromSeconds(2.0))
+                    let! received = receiver.ReceiveMessagesAsync(50, receiveWindow)
+                    let batch = received |> Seq.toArray
+
+                    if Array.isEmpty batch then
+                        drain <- ProducerInventoryDrain.emptyWindow expectedMessageIds drain
+                    else
+                        let observedReferenceIds = ResizeArray<string>()
+                        let mutable index = 0
+
+                        while index < batch.Length do
+                            let message = batch[index]
+                            let testOwned = String.Equals(message.CorrelationId, fixtureCorrelationId, StringComparison.Ordinal)
+
+                            let parsedEvent =
+                                try
+                                    JsonSerializer.Deserialize<GraceEvent>(message.Body.ToArray(), Constants.JsonSerializerOptions)
+                                    |> Some
+                                with
+                                | :? JsonException -> None
+
+                            let referenceIdentity =
+                                match parsedEvent with
+                                | Some graceEvent ->
+                                    match graceEvent with
+                                    | GraceEvent.ReferenceEvent referenceEvent ->
+                                        match referenceEvent.Event with
+                                        | ReferenceEventType.Created (referenceId, _, _, _, _, _, _, _, _, _, _) ->
+                                            let bodyIdentity = $"Reference/{referenceId}/Created"
+
+                                            if String.Equals(message.MessageId, bodyIdentity, StringComparison.Ordinal) then
+                                                Some bodyIdentity
+                                            else
+                                                Some $"{message.MessageId} (body identity {bodyIdentity})"
+                                        | _ -> None
+                                    | _ -> None
+                                | None -> None
+
+                            match referenceIdentity with
+                            | Some identity -> observedReferenceIds.Add identity
+                            | None -> ()
+
+                            let classifiedTestWork =
+                                match parsedEvent, referenceIdentity with
+                                | Some _, Some identity -> expected.Contains identity
+                                | Some _, None -> true
+                                | None, _ -> false
+
+                            if testOwned && classifiedTestWork then
+                                do! receiver.CompleteMessageAsync(message)
+                            else
+                                do! receiver.AbandonMessageAsync(message)
+
+                                let identity =
+                                    referenceIdentity
+                                    |> Option.defaultValue message.MessageId
+
+                                invalidOp $"Active producer inventory observed unclassified identity '{identity}'."
+
+                            index <- index + 1
+
+                        drain <- ProducerInventoryDrain.receiveBatch expectedMessageIds (observedReferenceIds.ToArray()) drain
+
+            if ProducerInventoryDrain.status drain = ProducerInventoryDrainStatus.Receiving then
+                drain <- ProducerInventoryDrain.deadlineExpired drain
+
+            match ProducerInventoryDrain.status drain with
+            | ProducerInventoryDrainStatus.Complete -> return ProducerInventoryDrain.observedMessageIds drain
+            | ProducerInventoryDrainStatus.Failed -> return invalidOp $"Dead-letter producer inventory failed: {ProducerInventoryDrain.failure drain}"
+            | ProducerInventoryDrainStatus.Receiving -> return invalidOp "Dead-letter producer inventory stopped without terminal evidence."
         }
 
     /// Peeks a bounded broker snapshot without settling or locking any message.
@@ -114,7 +246,8 @@ module private DeadLetterRuntime =
             let deadLetterMessageId = deadLetterMessage.MessageId
             let deadLetterDeliveryCount = deadLetterMessage.DeliveryCount
             let deadLetterReason = deadLetterMessage.DeadLetterReason
-            return activeIdentityExact, belowMaximum, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason
+            let deadLetterIdentityExact = DeadLetter.dlqMessageObserved expectedMessageId deadLetterMessageId
+            return activeIdentityExact, belowMaximum, deadLetterIdentityExact, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason
         }
 
     /// Peeks both subqueues after terminal settlement so the exact witness cannot obstruct later scenarios.
@@ -216,28 +349,38 @@ type ManifestContributionDeadLetterMeasurementTests() =
                 let! state = AspireTestHost.startIsolatedAsync bootstrapUserId
                 host <- Some state
                 state.Client.DefaultRequestHeaders.Add("x-grace-user-id", bootstrapUserId)
-                let! _ = AspireTestHost.drainServiceBusAsync state
                 let testSubscriptionIsolated = not (state.ServiceBusTestSubscription.Equals(state.ServiceBusServerSubscription, StringComparison.Ordinal))
-
-                recordAssertion
-                    "dead-letter.test-subscription-isolated"
-                    testSubscriptionIsolated
-                    $"testSubscription={state.ServiceBusTestSubscription}; productionSubscriptionDistinct={testSubscriptionIsolated}"
 
                 if not testSubscriptionIsolated then
                     invalidOp "The selected test subscription resolved to the production server subscription."
 
-                let! baselineMetrics = BaselineRuntime.scrapeMetricsAsync state
+                let fixtureCorrelationId = generateCorrelationId ()
+                let! defaultReferenceMessageId = DeadLetterRuntime.createDefaultReferenceProducerAsync state fixtureCorrelationId
+
+                let! producerInventory = DeadLetterRuntime.inventoryDefaultReferenceProducerAsync state fixtureCorrelationId defaultReferenceMessageId
+
+                let producerInventoryValid =
+                    ProducerInventory.validate [| defaultReferenceMessageId |] producerInventory
+                    |> Array.isEmpty
+
+                let producerInventoryDetail = String.Join(",", producerInventory)
+
+                recordAssertion
+                    "dead-letter.test-subscription-isolated"
+                    (testSubscriptionIsolated && producerInventoryValid)
+                    $"testSubscription={state.ServiceBusTestSubscription}; productionSubscriptionDistinct={testSubscriptionIsolated}; producerInventory={producerInventoryDetail}"
+
+                let! baselineMetrics = BaselineRuntime.waitForCompletedSettlementSamplesAsync state
                 let messageId = $"mca-dead-letter-{runId}"
                 witnessMessageId <- Some messageId
                 do! DeadLetterRuntime.sendUnrelatedGraceEventAsync state messageId
 
-                let! exactActiveIdentity, belowMaximum, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason =
+                let! exactActiveIdentity, belowMaximum, deadLetterIdentityExact, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason =
                     DeadLetterRuntime.transitionAsync state messageId
 
                 recordAssertion "dead-letter.message-identity-exact" exactActiveIdentity $"messageId={messageId}"
                 recordAssertion "dead-letter.below-maximum-remains-active" belowMaximum $"delivery={DeadLetter.MaximumDeliveryCount}"
-                recordAssertion "dead-letter.dlq-message-observed" true $"messageId={deadLetterMessageId}"
+                recordAssertion "dead-letter.dlq-message-observed" deadLetterIdentityExact $"messageId={deadLetterMessageId}"
 
                 recordAssertion
                     "dead-letter.delivery-count-eleven"
@@ -246,10 +389,7 @@ type ManifestContributionDeadLetterMeasurementTests() =
 
                 let boundedReason = DeadLetter.boundedBrokerReason deadLetterReason
 
-                recordAssertion
-                    "dead-letter.reason-bounded-nonempty"
-                    (DeadLetter.deadLetterObservationPasses messageId deadLetterMessageId deadLetterDeliveryCount deadLetterReason)
-                    $"reason={boundedReason}"
+                recordAssertion "dead-letter.reason-bounded-nonempty" (DeadLetter.brokerReasonPasses deadLetterReason) $"reason={boundedReason}"
 
                 let! observedMetrics = BaselineRuntime.scrapeMetricsAsync state
 

--- a/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
@@ -1,0 +1,314 @@
+namespace Grace.Server.Measurements
+
+open Azure.Messaging.ServiceBus
+open Grace.Server.Tests
+open Grace.Server.Tests.Measurement
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.Events
+open Grace.Types.Owner
+open NUnit.Framework
+open System
+open System.IO
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Implements the broker-only operations for one isolated dead-letter measurement.
+module private DeadLetterRuntime =
+
+    let private receiveWindow = TimeSpan.FromSeconds(2.0)
+
+    /// Reports missing selected-process inputs before any host, broker, or evidence side effect begins.
+    let missingPrerequisites () =
+        [|
+            "GRACE_MCA_WORKTREE"
+            "GRACE_MCA_HOSTED_COMMAND"
+            "GRACE_MCA_EVIDENCE_ROOT"
+        |]
+        |> Array.filter (fun name -> String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable name))
+
+    /// Sends one valid unrelated Grace event with a caller-owned exact broker identity.
+    let sendUnrelatedGraceEventAsync (state: TestHostState) messageId =
+        task {
+            let correlationId = generateCorrelationId ()
+            let metadata = EventMetadata.New (CorrelationId correlationId) "mca-dead-letter-witness"
+
+            let graceEvent = GraceEvent.OwnerEvent { Event = OwnerEventType.Created(Guid.NewGuid(), $"McaDeadLetter{Guid.NewGuid():N}"); Metadata = metadata }
+
+            let payload = JsonSerializer.SerializeToUtf8Bytes(graceEvent, Constants.JsonSerializerOptions)
+            let message = ServiceBusMessage(payload)
+            message.ContentType <- "application/json"
+            message.Subject <- "GraceEvent"
+            message.CorrelationId <- correlationId
+            message.MessageId <- messageId
+            message.ApplicationProperties[ "graceEventType" ] <- getDiscriminatedUnionFullName graceEvent
+
+            use client = new ServiceBusClient(state.ServiceBusConnectionString)
+            use sender = client.CreateSender(state.ServiceBusTopic)
+            use cts = new CancellationTokenSource(TimeSpan.FromSeconds(10.0))
+            do! sender.SendMessageAsync(message, cts.Token)
+        }
+
+    /// Peeks a bounded broker snapshot without settling or locking any message.
+    let peekMessageIdsAsync (receiver: ServiceBusReceiver) =
+        task {
+            let! messages = receiver.PeekMessagesAsync(100)
+
+            return
+                messages
+                |> Seq.map (fun message -> message.MessageId)
+                |> Seq.toArray
+        }
+
+    /// Receives one exact test-owned message before a bounded deadline and rejects any wrong identity.
+    let receiveExactAsync (receiver: ServiceBusReceiver) expectedMessageId description =
+        task {
+            let timeoutAt = DateTime.UtcNow.AddSeconds(30.0)
+            let mutable observed: ServiceBusReceivedMessage option = None
+
+            while observed.IsNone && DateTime.UtcNow < timeoutAt do
+                let! message = receiver.ReceiveMessageAsync(receiveWindow)
+
+                if not (isNull message) then
+                    if not (DeadLetter.identityMatches expectedMessageId message.MessageId) then
+                        invalidOp $"{description} observed wrong message identity '{message.MessageId}'."
+
+                    observed <- Some message
+
+            return
+                observed
+                |> Option.defaultWith (fun () -> invalidOp $"Timed out waiting for exact {description} identity '{expectedMessageId}'.")
+        }
+
+    /// Completes the delivery-limit transition and returns exact active-boundary plus DLQ observations.
+    let transitionAsync (state: TestHostState) expectedMessageId =
+        task {
+            use client = new ServiceBusClient(state.ServiceBusConnectionString)
+            let activeOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
+            let deadLetterOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock, SubQueue = SubQueue.DeadLetter)
+            use activeReceiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, activeOptions)
+            use deadLetterReceiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, deadLetterOptions)
+            let mutable activeIdentityExact = true
+            let mutable belowMaximum = false
+            let mutable delivery = 1
+
+            while delivery <= DeadLetter.MaximumDeliveryCount do
+                let! message = receiveExactAsync activeReceiver expectedMessageId $"active delivery {delivery}"
+
+                activeIdentityExact <-
+                    activeIdentityExact
+                    && message.DeliveryCount = delivery
+
+                if delivery = DeadLetter.MaximumDeliveryCount then
+                    let! deadLetterIds = peekMessageIdsAsync deadLetterReceiver
+
+                    belowMaximum <- DeadLetter.belowMaximumRemainsActive expectedMessageId message.MessageId message.DeliveryCount deadLetterIds
+
+                do! activeReceiver.AbandonMessageAsync(message)
+                delivery <- delivery + 1
+
+            let! deadLetterMessage = receiveExactAsync deadLetterReceiver expectedMessageId "dead-letter delivery"
+            let deadLetterMessageId = deadLetterMessage.MessageId
+            let deadLetterDeliveryCount = deadLetterMessage.DeliveryCount
+            let deadLetterReason = deadLetterMessage.DeadLetterReason
+            do! deadLetterReceiver.CompleteMessageAsync(deadLetterMessage)
+            return activeIdentityExact, belowMaximum, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason
+        }
+
+    /// Peeks both subqueues after terminal settlement so the exact witness cannot obstruct later scenarios.
+    let verifyCleanupAsync (state: TestHostState) expectedMessageId =
+        task {
+            use client = new ServiceBusClient(state.ServiceBusConnectionString)
+            let activeOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
+            let deadLetterOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock, SubQueue = SubQueue.DeadLetter)
+            use activeReceiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, activeOptions)
+            use deadLetterReceiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, deadLetterOptions)
+            let! activeIds = peekMessageIdsAsync activeReceiver
+            let! deadLetterIds = peekMessageIdsAsync deadLetterReceiver
+            return DeadLetter.cleanupComplete expectedMessageId activeIds deadLetterIds
+        }
+
+    /// Settles an exact witness still present after a failed runtime phase without consuming unrelated identities.
+    let cleanupWitnessAsync (state: TestHostState) expectedMessageId =
+        task {
+            use client = new ServiceBusClient(state.ServiceBusConnectionString)
+
+            let cleanupReceiver subQueue =
+                task {
+                    let options = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock, SubQueue = subQueue)
+                    use receiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, options)
+                    let timeoutAt = DateTime.UtcNow.AddSeconds(10.0)
+                    let mutable settled = false
+
+                    while not settled && DateTime.UtcNow < timeoutAt do
+                        let! message = receiver.ReceiveMessageAsync(receiveWindow)
+
+                        if isNull message then
+                            settled <- true
+                        elif DeadLetter.identityMatches expectedMessageId message.MessageId then
+                            do! receiver.CompleteMessageAsync(message)
+                            settled <- true
+                        else
+                            do! receiver.AbandonMessageAsync(message)
+                            invalidOp $"Cleanup observed wrong isolated-subscription identity '{message.MessageId}'."
+                }
+
+            do! cleanupReceiver SubQueue.None
+            do! cleanupReceiver SubQueue.DeadLetter
+        }
+
+/// Proves the isolated test-subscription maximum-delivery transition in one explicitly selected Aspire process.
+[<NonParallelizable>]
+type ManifestContributionDeadLetterMeasurementTests() =
+
+    /// Emits truthful exact-identity, boundary, DLQ, telemetry, cleanup, and evidence results for one unrelated event.
+    [<Test; Explicit("Run only through the focused MCA dead-letter measurement selector.")>]
+    member _.``isolated broker witness reaches dead-letter delivery eleven``() =
+        task {
+            let missingPrerequisites = DeadLetterRuntime.missingPrerequisites ()
+
+            if not (Array.isEmpty missingPrerequisites) then
+                let missingText = String.Join(", ", missingPrerequisites)
+                Assert.Ignore($"Skipped before side effects because selected-process prerequisites are missing: {missingText}")
+
+            let runId = Guid.NewGuid().ToString("N")
+
+            let worktree =
+                BaselineRuntime.requireEnvironment "GRACE_MCA_WORKTREE"
+                |> Path.GetFullPath
+
+            let command = BaselineRuntime.requireEnvironment "GRACE_MCA_HOSTED_COMMAND"
+
+            let evidenceRoot =
+                BaselineRuntime.requireEnvironment "GRACE_MCA_EVIDENCE_ROOT"
+                |> Path.GetFullPath
+
+            let evidenceDirectory = Path.Combine(evidenceRoot, runId)
+            let! commitSha = BaselineRuntime.runGitAsync worktree [| "rev-parse"; "HEAD" |]
+
+            let! status =
+                BaselineRuntime.runGitAsync
+                    worktree
+                    [|
+                        "status"
+                        "--porcelain=v1"
+                        "--untracked-files=all"
+                    |]
+
+            let worktreeState = if String.IsNullOrWhiteSpace status then "clean" else status
+            use writer = new EvidenceWriter(evidenceDirectory, BaselineRuntime.MaximumRecordBytes)
+            let plan = [| "dead-letter" |]
+            writer.Append(MeasurementRun.Create(runId, commitSha, worktree, worktreeState, command, evidenceDirectory, plan))
+            let assertions = ResizeArray<MeasurementAssertion>()
+            let failures = ResizeArray<string>()
+            let mutable host: TestHostState option = None
+            let mutable witnessMessageId: string option = None
+
+            let recordAssertion assertionId passed detail =
+                let assertion = MeasurementAssertion.Create(runId, "dead-letter", assertionId, passed, detail)
+                assertions.Add assertion
+                writer.Append assertion
+
+            try
+                let bootstrapUserId = Guid.NewGuid().ToString("D")
+                let! state = AspireTestHost.startIsolatedAsync bootstrapUserId
+                host <- Some state
+                state.Client.DefaultRequestHeaders.Add("x-grace-user-id", bootstrapUserId)
+                let! _ = AspireTestHost.drainServiceBusAsync state
+                let testSubscriptionIsolated = not (state.ServiceBusTestSubscription.Equals(state.ServiceBusServerSubscription, StringComparison.Ordinal))
+
+                recordAssertion
+                    "dead-letter.test-subscription-isolated"
+                    testSubscriptionIsolated
+                    $"testSubscription={state.ServiceBusTestSubscription}; productionSubscriptionDistinct={testSubscriptionIsolated}"
+
+                if not testSubscriptionIsolated then
+                    invalidOp "The selected test subscription resolved to the production server subscription."
+
+                let! baselineMetrics = BaselineRuntime.scrapeMetricsAsync state
+                let messageId = $"mca-dead-letter-{runId}"
+                witnessMessageId <- Some messageId
+                do! DeadLetterRuntime.sendUnrelatedGraceEventAsync state messageId
+
+                let! exactActiveIdentity, belowMaximum, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason =
+                    DeadLetterRuntime.transitionAsync state messageId
+
+                recordAssertion "dead-letter.message-identity-exact" exactActiveIdentity $"messageId={messageId}"
+                recordAssertion "dead-letter.below-maximum-remains-active" belowMaximum $"delivery={DeadLetter.MaximumDeliveryCount}"
+                recordAssertion "dead-letter.dlq-message-observed" true $"messageId={deadLetterMessageId}"
+
+                recordAssertion
+                    "dead-letter.delivery-count-eleven"
+                    (deadLetterDeliveryCount = DeadLetter.DeadLetterDeliveryCount)
+                    $"deliveryCount={deadLetterDeliveryCount}"
+
+                let boundedReason = DeadLetter.boundedBrokerReason deadLetterReason
+
+                recordAssertion
+                    "dead-letter.reason-bounded-nonempty"
+                    (DeadLetter.deadLetterObservationPasses messageId deadLetterMessageId deadLetterDeliveryCount deadLetterReason)
+                    $"reason={boundedReason}"
+
+                let! observedMetrics = BaselineRuntime.scrapeMetricsAsync state
+
+                let telemetryUnchanged, telemetryDetail =
+                    match OpenMetrics.evaluateCompletedSettlementUnchanged baselineMetrics observedMetrics with
+                    | UnchangedEvaluation.Unchanged (messages, durations) -> true, $"messages={messages}; durations={durations}"
+                    | UnchangedEvaluation.Changed reason
+                    | UnchangedEvaluation.UnchangedInvalid reason -> false, reason
+
+                recordAssertion "dead-letter.production-manifest-telemetry-unchanged" telemetryUnchanged telemetryDetail
+            with
+            | ex -> failures.Add(ex.ToString())
+
+            match host, witnessMessageId with
+            | Some state, Some messageId ->
+                try
+                    do! DeadLetterRuntime.cleanupWitnessAsync state messageId
+                    let! cleanupComplete = DeadLetterRuntime.verifyCleanupAsync state messageId
+                    recordAssertion "dead-letter.cleanup-complete" cleanupComplete $"messageId={messageId}; absent={cleanupComplete}"
+                with
+                | ex ->
+                    failures.Add($"cleanup-witness: {ex}")
+                    recordAssertion "dead-letter.cleanup-complete" false ex.Message
+            | _ -> ()
+
+            match host with
+            | Some state ->
+                try
+                    do! AspireTestHost.stopIsolatedAsync state
+                with
+                | ex -> failures.Add($"cleanup: {ex}")
+            | None -> ()
+
+            if assertions
+               |> Seq.exists (fun assertion -> assertion.AssertionId = "dead-letter.evidence-integrity")
+               |> not then
+                try
+                    let valid = BaselineRuntime.verifyEvidenceIntegrity writer
+                    recordAssertion "dead-letter.evidence-integrity" valid $"path={writer.Path}"
+                with
+                | ex -> recordAssertion "dead-letter.evidence-integrity" false ex.Message
+
+            DeadLetter.requiredAssertionIds
+            |> Array.iter (fun assertionId ->
+                if assertions
+                   |> Seq.exists (fun assertion -> assertion.AssertionId = assertionId)
+                   |> not then
+                    recordAssertion assertionId false "The runtime failed before this assertion could be evaluated.")
+
+            let summary = ScenarioSummary.derive runId "dead-letter" DeadLetter.requiredAssertionIds (assertions.ToArray()) (failures.ToArray()) false
+
+            writer.Append summary
+            TestContext.Progress.WriteLine($"MCA dead-letter evidence directory: {evidenceDirectory}")
+            TestContext.Progress.Flush()
+
+            Assert.That(
+                summary.Outcome,
+                Is.EqualTo("Passed"),
+                $"Evidence: {evidenceDirectory}{Environment.NewLine}{String.Join(Environment.NewLine, failures)}"
+            )
+        }

--- a/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
@@ -6,10 +6,15 @@ open Grace.Server.Tests.Measurement
 open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types
+open Grace.Types.Branch
 open Grace.Types.Common
+open Grace.Types.DirectoryVersion
 open Grace.Types.Events
+open Grace.Types.Organization
 open Grace.Types.Owner
 open Grace.Types.Reference
+open Grace.Types.Repository
+open Grace.Types.Validation
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -22,6 +27,20 @@ open System.Threading.Tasks
 module private DeadLetterRuntime =
 
     let private receiveWindow = TimeSpan.FromSeconds(2.0)
+
+    /// Identifies every durable entity created by the finite selected-process default-Reference fixture.
+    type FixtureProducerInventory =
+        {
+            OwnerId: Guid
+            OrganizationId: Guid
+            RepositoryId: Guid
+            BranchId: Guid
+            ReferenceId: Guid
+            DirectoryVersionId: Guid
+        }
+
+        /// Gets the deterministic Reference-created broker identity owned by this fixture.
+        member this.ReferenceMessageId = $"Reference/{this.ReferenceId}/Created"
 
     /// Reports missing selected-process inputs before any host, broker, or evidence side effect begins.
     let missingPrerequisites () =
@@ -91,16 +110,78 @@ module private DeadLetterRuntime =
             if branch.LatestReference.ReferenceId <> referenceId then
                 invalidOp "The dead-letter fixture repository default Reference did not match its persisted branch."
 
-            return $"Reference/{referenceId}/Created"
+            return
+                {
+                    OwnerId = ownerId
+                    OrganizationId = organizationId
+                    RepositoryId = repositoryId
+                    BranchId = branchId
+                    ReferenceId = referenceId
+                    DirectoryVersionId = branch.LatestReference.DirectoryId
+                }
         }
 
+    /// Classifies only Grace events whose body identities belong to the selected fixture entity tuple.
+    let fixtureOwnsEvent (fixture: FixtureProducerInventory) graceEvent =
+        match graceEvent with
+        | GraceEvent.OwnerEvent ownerEvent ->
+            match ownerEvent.Event with
+            | OwnerEventType.Created (ownerId, _) -> ownerId = fixture.OwnerId
+            | _ -> false
+        | GraceEvent.OrganizationEvent organizationEvent ->
+            match organizationEvent.Event with
+            | OrganizationEventType.Created (organizationId, _, ownerId) ->
+                organizationId = fixture.OrganizationId
+                && ownerId = fixture.OwnerId
+            | _ -> false
+        | GraceEvent.RepositoryEvent repositoryEvent ->
+            match repositoryEvent.Event with
+            | RepositoryEventType.Created (_, repositoryId, ownerId, organizationId, _) ->
+                repositoryId = fixture.RepositoryId
+                && ownerId = fixture.OwnerId
+                && organizationId = fixture.OrganizationId
+            | _ -> false
+        | GraceEvent.BranchEvent branchEvent ->
+            match branchEvent.Event with
+            | BranchEventType.Created (branchId, _, _, _, ownerId, organizationId, repositoryId, _) ->
+                branchId = fixture.BranchId
+                && ownerId = fixture.OwnerId
+                && organizationId = fixture.OrganizationId
+                && repositoryId = fixture.RepositoryId
+            | _ -> false
+        | GraceEvent.DirectoryVersionEvent directoryVersionEvent ->
+            match directoryVersionEvent.Event with
+            | DirectoryVersionEventType.Created directoryVersion ->
+                directoryVersion.DirectoryVersionId = fixture.DirectoryVersionId
+                && directoryVersion.OwnerId = fixture.OwnerId
+                && directoryVersion.OrganizationId = fixture.OrganizationId
+                && directoryVersion.RepositoryId = fixture.RepositoryId
+            | _ -> false
+        | GraceEvent.ReferenceEvent referenceEvent ->
+            match referenceEvent.Event with
+            | ReferenceEventType.Created (referenceId, ownerId, organizationId, repositoryId, branchId, directoryVersionId, _, _, _, _, _) ->
+                referenceId = fixture.ReferenceId
+                && ownerId = fixture.OwnerId
+                && organizationId = fixture.OrganizationId
+                && repositoryId = fixture.RepositoryId
+                && branchId = fixture.BranchId
+                && directoryVersionId = fixture.DirectoryVersionId
+            | _ -> false
+        | GraceEvent.ValidationResultEvent validationResultEvent ->
+            match validationResultEvent.Event with
+            | ValidationResultEventType.Recorded validationResult ->
+                validationResult.OwnerId = fixture.OwnerId
+                && validationResult.OrganizationId = fixture.OrganizationId
+                && validationResult.RepositoryId = fixture.RepositoryId
+        | _ -> false
+
     /// Inventories active selected-process work through PeekLock and settles only the classified fixture/default producers.
-    let inventoryDefaultReferenceProducerAsync (state: TestHostState) fixtureCorrelationId expectedMessageId =
+    let inventoryDefaultReferenceProducerAsync (state: TestHostState) (fixture: FixtureProducerInventory) =
         task {
             use client = new ServiceBusClient(state.ServiceBusConnectionString)
             let options = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
             use receiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, options)
-            let expectedMessageIds = [| expectedMessageId |]
+            let expectedMessageIds = [| fixture.ReferenceMessageId |]
             let expected = HashSet<string>(expectedMessageIds, StringComparer.Ordinal)
             let timeoutAt = DateTime.UtcNow.AddSeconds(30.0)
             let mutable drain = ProducerInventoryDrain.start
@@ -124,7 +205,6 @@ module private DeadLetterRuntime =
 
                         while index < batch.Length do
                             let message = batch[index]
-                            let testOwned = String.Equals(message.CorrelationId, fixtureCorrelationId, StringComparison.Ordinal)
 
                             let parsedEvent =
                                 try
@@ -156,11 +236,13 @@ module private DeadLetterRuntime =
 
                             let classifiedTestWork =
                                 match parsedEvent, referenceIdentity with
-                                | Some _, Some identity -> expected.Contains identity
-                                | Some _, None -> true
+                                | Some graceEvent, Some identity ->
+                                    fixtureOwnsEvent fixture graceEvent
+                                    && expected.Contains identity
+                                | Some graceEvent, None -> fixtureOwnsEvent fixture graceEvent
                                 | None, _ -> false
 
-                            if testOwned && classifiedTestWork then
+                            if classifiedTestWork then
                                 do! receiver.CompleteMessageAsync(message)
                             else
                                 do! receiver.AbandonMessageAsync(message)
@@ -355,12 +437,16 @@ type ManifestContributionDeadLetterMeasurementTests() =
                     invalidOp "The selected test subscription resolved to the production server subscription."
 
                 let fixtureCorrelationId = generateCorrelationId ()
-                let! defaultReferenceMessageId = DeadLetterRuntime.createDefaultReferenceProducerAsync state fixtureCorrelationId
+                let! fixtureInventory = DeadLetterRuntime.createDefaultReferenceProducerAsync state fixtureCorrelationId
 
-                let! producerInventory = DeadLetterRuntime.inventoryDefaultReferenceProducerAsync state fixtureCorrelationId defaultReferenceMessageId
+                let! producerInventory = DeadLetterRuntime.inventoryDefaultReferenceProducerAsync state fixtureInventory
 
                 let producerInventoryValid =
-                    ProducerInventory.validate [| defaultReferenceMessageId |] producerInventory
+                    ProducerInventory.validate
+                        [|
+                            fixtureInventory.ReferenceMessageId
+                        |]
+                        producerInventory
                     |> Array.isEmpty
 
                 let producerInventoryDetail = String.Join(",", producerInventory)

--- a/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionDeadLetter.Measurement.Tests.fs
@@ -83,12 +83,12 @@ module private DeadLetterRuntime =
                 |> Option.defaultWith (fun () -> invalidOp $"Timed out waiting for exact {description} identity '{expectedMessageId}'.")
         }
 
-    /// Completes the delivery-limit transition and returns exact active-boundary plus DLQ observations.
+    /// Completes the delivery-limit transition and terminally removes the observed DLQ witness through ReceiveAndDelete.
     let transitionAsync (state: TestHostState) expectedMessageId =
         task {
             use client = new ServiceBusClient(state.ServiceBusConnectionString)
             let activeOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
-            let deadLetterOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock, SubQueue = SubQueue.DeadLetter)
+            let deadLetterOptions = ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete, SubQueue = SubQueue.DeadLetter)
             use activeReceiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, activeOptions)
             use deadLetterReceiver = client.CreateReceiver(state.ServiceBusTopic, state.ServiceBusTestSubscription, deadLetterOptions)
             let mutable activeIdentityExact = true
@@ -114,7 +114,6 @@ module private DeadLetterRuntime =
             let deadLetterMessageId = deadLetterMessage.MessageId
             let deadLetterDeliveryCount = deadLetterMessage.DeliveryCount
             let deadLetterReason = deadLetterMessage.DeadLetterReason
-            do! deadLetterReceiver.CompleteMessageAsync(deadLetterMessage)
             return activeIdentityExact, belowMaximum, deadLetterMessageId, deadLetterDeliveryCount, deadLetterReason
         }
 

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -38,7 +38,9 @@
     <Compile Include="OperationalFactsPublisher.Actor.Tests.fs" />
     <Compile Include="ManifestContributionTelemetry.Server.Tests.fs" />
     <Compile Include="ManifestContributionMeasurement.fs" />
+    <Compile Include="ManifestContributionDeadLetterMeasurement.fs" />
     <Compile Include="ManifestContributionMeasurement.Tests.fs" />
+    <Compile Include="ManifestContributionDeadLetterMeasurement.Tests.fs" />
     <Compile Include="Notification.Server.Tests.fs" />
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="PromotionSet.DirectoryHash.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.Tests.fs
@@ -32,9 +32,28 @@ type ManifestContributionDeadLetterMeasurementTests() =
         let wrong = "mca-dead-letter-wrong"
 
         Assert.That(DeadLetter.identityMatches expected wrong, Is.False)
+        Assert.That(DeadLetter.dlqMessageObserved expected wrong, Is.False)
         Assert.That(DeadLetter.belowMaximumRemainsActive expected wrong DeadLetter.MaximumDeliveryCount Array.empty, Is.False)
         Assert.That(DeadLetter.deadLetterObservationPasses expected wrong DeadLetter.DeadLetterDeliveryCount "MaxDeliveryCountExceeded", Is.False)
         Assert.That(DeadLetter.cleanupComplete expected [| wrong |] [| wrong |], Is.True)
+
+    /// Verifies the selected fixture/default producer inventory rejects any unexpected active Reference identity.
+    [<Test>]
+    member _.``selected fixture producer inventory requires only the declared default Reference``() =
+        let expected = [| "Reference/default/Created" |]
+
+        Assert.That(ProducerInventory.validate expected expected, Is.Empty)
+
+        let unexpected =
+            ProducerInventory.validate
+                expected
+                [|
+                    expected[0]
+                    "Reference/unexpected/Created"
+                |]
+
+        Assert.That(unexpected, Has.One.Items)
+        Assert.That(unexpected[0], Does.Contain("Unclassified Reference-created envelope"))
 
     /// Verifies delivery ten remains active and absent from the DLQ, while nearby false boundaries fail.
     [<Test>]
@@ -68,12 +87,12 @@ type ManifestContributionDeadLetterMeasurementTests() =
         Assert.That(DeadLetter.cleanupComplete expected [| expected |] Array.empty, Is.False)
         Assert.That(DeadLetter.cleanupComplete expected Array.empty [| expected |], Is.False)
 
-    /// Verifies unchanged production settlement telemetry accepts equal exact samples or their absence on both fresh-host scrapes.
+    /// Verifies unchanged production settlement telemetry requires one exact sample of each family on both scrapes.
     [<Test>]
-    member _.``unchanged telemetry rejects mutation and one-sided absence``() =
+    member _.``unchanged telemetry rejects absent malformed and changed samples``() =
         match OpenMetrics.evaluateCompletedSettlementUnchanged String.Empty String.Empty with
-        | UnchangedEvaluation.Unchanged (0L, 0L) -> ()
-        | result -> Assert.Fail($"Expected absent fresh-host samples to remain unchanged, got {result}.")
+        | UnchangedEvaluation.UnchangedInvalid _ -> ()
+        | result -> Assert.Fail($"Expected two absent scrapes to be invalid, got {result}.")
 
         match OpenMetrics.evaluateCompletedSettlementUnchanged (completed 4 4) (completed 4 4) with
         | UnchangedEvaluation.Unchanged (4L, 4L) -> ()
@@ -87,8 +106,37 @@ type ManifestContributionDeadLetterMeasurementTests() =
         | UnchangedEvaluation.UnchangedInvalid _ -> ()
         | result -> Assert.Fail($"Expected one-sided absence to be invalid, got {result}.")
 
-        let suffixOnly = "grace_manifest_contribution_messages_total_suffix 0\n"
+        let invalidScrapes =
+            [|
+                "missing",
+                "grace_manifest_contribution_messages_total{otel_scope_name=\"Grace.ManifestContributionAccounting\",stage=\"settle\",outcome=\"completed\"} 4"
+                "duplicate",
+                completed 4 4
+                + Environment.NewLine
+                + completed 4 4
+                "suffix",
+                """
+grace_manifest_contribution_messages_total_suffix{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 4
+grace_manifest_contribution_processing_duration_milliseconds_count_suffix{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 4
+"""
+                "other-label",
+                """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed",reference_type="Save"} 4
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"} 4
+"""
+                "settlement-failed",
+                """
+grace_manifest_contribution_messages_total{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="settlement_failed"} 4
+grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="settlement_failed"} 4
+"""
+            |]
 
-        match OpenMetrics.evaluateCompletedSettlementUnchanged suffixOnly suffixOnly with
-        | UnchangedEvaluation.UnchangedInvalid _ -> ()
-        | result -> Assert.Fail($"Expected a suffix-only metric family to be invalid, got {result}.")
+        invalidScrapes
+        |> Array.iter (fun (name, scrape) ->
+            match OpenMetrics.evaluateCompletedSettlementUnchanged (completed 4 4) scrape with
+            | UnchangedEvaluation.UnchangedInvalid _ -> ()
+            | result -> Assert.Fail($"Expected {name} samples to be invalid, got {result}."))
+
+        match OpenMetrics.evaluateCompletedSettlementUnchanged (completed 4 4) (completed 3 4) with
+        | UnchangedEvaluation.Changed _ -> ()
+        | result -> Assert.Fail($"Expected reset samples to fail, got {result}.")

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.Tests.fs
@@ -1,0 +1,94 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Tests.Measurement
+open NUnit.Framework
+open System
+
+/// Proves the pure identity, boundary, reason, cleanup, and derived-outcome contract used by the hosted DLQ witness.
+[<TestFixture>]
+type ManifestContributionDeadLetterMeasurementTests() =
+
+    let completed messages durations =
+        $"grace_manifest_contribution_messages_total{{otel_scope_name=\"Grace.ManifestContributionAccounting\",stage=\"settle\",outcome=\"completed\"}} {messages}\n"
+        + $"grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_name=\"Grace.ManifestContributionAccounting\",stage=\"settle\",outcome=\"completed\"}} {durations}\n"
+
+    /// Verifies the exact nine assertion identities are the only successful dead-letter summary shape.
+    [<Test>]
+    member _.``dead-letter summary requires the exact derived assertion set``() =
+        let assertions =
+            DeadLetter.requiredAssertionIds
+            |> Array.map (fun assertionId -> MeasurementAssertion.Create("run", "dead-letter", assertionId, true, "proved"))
+
+        let summary = ScenarioSummary.derive "run" "dead-letter" DeadLetter.requiredAssertionIds assertions Array.empty false
+
+        Assert.That(summary.Outcome, Is.EqualTo("Passed"))
+        Assert.That(summary.RequiredAssertionCount, Is.EqualTo(9))
+        Assert.That(summary.PassedAssertionCount, Is.EqualTo(9))
+
+    /// Verifies a wrong broker identity cannot satisfy active, DLQ, or cleanup evidence.
+    [<Test>]
+    member _.``wrong identity cannot pass the broker witness``() =
+        let expected = "mca-dead-letter-expected"
+        let wrong = "mca-dead-letter-wrong"
+
+        Assert.That(DeadLetter.identityMatches expected wrong, Is.False)
+        Assert.That(DeadLetter.belowMaximumRemainsActive expected wrong DeadLetter.MaximumDeliveryCount Array.empty, Is.False)
+        Assert.That(DeadLetter.deadLetterObservationPasses expected wrong DeadLetter.DeadLetterDeliveryCount "MaxDeliveryCountExceeded", Is.False)
+        Assert.That(DeadLetter.cleanupComplete expected [| wrong |] [| wrong |], Is.True)
+
+    /// Verifies delivery ten remains active and absent from the DLQ, while nearby false boundaries fail.
+    [<Test>]
+    member _.``delivery boundary requires active ten and no matching DLQ identity``() =
+        let expected = "mca-dead-letter-boundary"
+
+        Assert.That(DeadLetter.belowMaximumRemainsActive expected expected 10 Array.empty, Is.True)
+        Assert.That(DeadLetter.belowMaximumRemainsActive expected expected 9 Array.empty, Is.False)
+        Assert.That(DeadLetter.belowMaximumRemainsActive expected expected 10 [| expected |], Is.False)
+
+    /// Verifies delivery eleven and a nonempty bounded redacted broker reason are mandatory.
+    [<Test>]
+    member _.``DLQ observation requires delivery eleven and bounded redacted reason``() =
+        let expected = "mca-dead-letter-terminal"
+
+        Assert.That(DeadLetter.deadLetterObservationPasses expected expected 11 "MaxDeliveryCountExceeded", Is.True)
+        Assert.That(DeadLetter.deadLetterObservationPasses expected expected 10 "MaxDeliveryCountExceeded", Is.False)
+        Assert.That(DeadLetter.deadLetterObservationPasses expected expected 11 String.Empty, Is.False)
+
+        let projected = DeadLetter.boundedBrokerReason ($"MaxDeliveryCountExceeded SharedAccessKey={String('s', 512)}")
+        Assert.That(projected, Does.Contain("SharedAccessKey=***"))
+        Assert.That(projected, Does.Not.Contain(String('s', 32)))
+        Assert.That(projected.Length, Is.LessThanOrEqualTo(256))
+
+    /// Verifies cleanup fails while the exact witness remains in either subqueue.
+    [<Test>]
+    member _.``cleanup requires exact witness absence from active and DLQ``() =
+        let expected = "mca-dead-letter-cleanup"
+
+        Assert.That(DeadLetter.cleanupComplete expected Array.empty Array.empty, Is.True)
+        Assert.That(DeadLetter.cleanupComplete expected [| expected |] Array.empty, Is.False)
+        Assert.That(DeadLetter.cleanupComplete expected Array.empty [| expected |], Is.False)
+
+    /// Verifies unchanged production settlement telemetry accepts equal exact samples or their absence on both fresh-host scrapes.
+    [<Test>]
+    member _.``unchanged telemetry rejects mutation and one-sided absence``() =
+        match OpenMetrics.evaluateCompletedSettlementUnchanged String.Empty String.Empty with
+        | UnchangedEvaluation.Unchanged (0L, 0L) -> ()
+        | result -> Assert.Fail($"Expected absent fresh-host samples to remain unchanged, got {result}.")
+
+        match OpenMetrics.evaluateCompletedSettlementUnchanged (completed 4 4) (completed 4 4) with
+        | UnchangedEvaluation.Unchanged (4L, 4L) -> ()
+        | result -> Assert.Fail($"Expected equal exact samples, got {result}.")
+
+        match OpenMetrics.evaluateCompletedSettlementUnchanged (completed 4 4) (completed 5 4) with
+        | UnchangedEvaluation.Changed _ -> ()
+        | result -> Assert.Fail($"Expected changed samples to fail, got {result}.")
+
+        match OpenMetrics.evaluateCompletedSettlementUnchanged String.Empty (completed 1 1) with
+        | UnchangedEvaluation.UnchangedInvalid _ -> ()
+        | result -> Assert.Fail($"Expected one-sided absence to be invalid, got {result}.")
+
+        let suffixOnly = "grace_manifest_contribution_messages_total_suffix 0\n"
+
+        match OpenMetrics.evaluateCompletedSettlementUnchanged suffixOnly suffixOnly with
+        | UnchangedEvaluation.UnchangedInvalid _ -> ()
+        | result -> Assert.Fail($"Expected a suffix-only metric family to be invalid, got {result}.")

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.fs
@@ -1,0 +1,80 @@
+namespace Grace.Server.Tests.Measurement
+
+open System
+open System.Text
+open System.Text.RegularExpressions
+
+/// Defines the exact evidence contract and broker observations for the isolated dead-letter witness.
+module DeadLetter =
+
+    [<Literal>]
+    let MaximumDeliveryCount = 10
+
+    [<Literal>]
+    let DeadLetterDeliveryCount = 11
+
+    [<Literal>]
+    let private MaximumReasonCharacters = 256
+
+    /// Lists the exact assertion identities required by the isolated dead-letter witness.
+    let requiredAssertionIds =
+        [|
+            "dead-letter.test-subscription-isolated"
+            "dead-letter.message-identity-exact"
+            "dead-letter.below-maximum-remains-active"
+            "dead-letter.dlq-message-observed"
+            "dead-letter.delivery-count-eleven"
+            "dead-letter.reason-bounded-nonempty"
+            "dead-letter.production-manifest-telemetry-unchanged"
+            "dead-letter.cleanup-complete"
+            "dead-letter.evidence-integrity"
+        |]
+
+    /// Requires one exact witness identity instead of accepting a count or another subscription message.
+    let identityMatches expectedMessageId observedMessageId =
+        not (String.IsNullOrWhiteSpace expectedMessageId)
+        && expectedMessageId.Equals(observedMessageId, StringComparison.Ordinal)
+
+    /// Requires the last active delivery to remain outside the DLQ at the configured maximum.
+    let belowMaximumRemainsActive expectedMessageId activeMessageId activeDeliveryCount (deadLetterMessageIds: string array) =
+        identityMatches expectedMessageId activeMessageId
+        && activeDeliveryCount = MaximumDeliveryCount
+        && deadLetterMessageIds
+           |> Array.exists (identityMatches expectedMessageId)
+           |> not
+
+    /// Projects a broker-owned reason into bounded printable diagnostics with credential-shaped values redacted.
+    let boundedBrokerReason (reason: string) =
+        let source = if isNull reason then String.Empty else reason.Trim()
+
+        let redacted =
+            Regex.Replace(source, "(?i)(Endpoint|SharedAccessKey|SharedAccessSignature|Password|Token)=([^;\\s]+)", "$1=***", RegexOptions.CultureInvariant)
+
+        let builder = StringBuilder(min redacted.Length MaximumReasonCharacters)
+        let mutable index = 0
+
+        while index < redacted.Length
+              && builder.Length < MaximumReasonCharacters do
+            let character = redacted[index]
+
+            builder.Append(if character >= ' ' && character <= '~' then character else '?')
+            |> ignore
+
+            index <- index + 1
+
+        builder.ToString()
+
+    /// Requires the exact witness to appear in the DLQ on delivery eleven with inspectable broker diagnostics.
+    let deadLetterObservationPasses expectedMessageId observedMessageId deliveryCount brokerReason =
+        let boundedReason = boundedBrokerReason brokerReason
+
+        identityMatches expectedMessageId observedMessageId
+        && deliveryCount = DeadLetterDeliveryCount
+        && not (String.IsNullOrWhiteSpace boundedReason)
+        && boundedReason.Length <= MaximumReasonCharacters
+
+    /// Requires terminal cleanup to remove the exact witness from both active and dead-letter subqueues.
+    let cleanupComplete expectedMessageId (activeMessageIds: string array) (deadLetterMessageIds: string array) =
+        Array.append activeMessageIds deadLetterMessageIds
+        |> Array.exists (identityMatches expectedMessageId)
+        |> not

--- a/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionDeadLetterMeasurement.fs
@@ -35,6 +35,9 @@ module DeadLetter =
         not (String.IsNullOrWhiteSpace expectedMessageId)
         && expectedMessageId.Equals(observedMessageId, StringComparison.Ordinal)
 
+    /// Derives the DLQ-observed assertion only from the exact identity returned by the broker transition.
+    let dlqMessageObserved expectedMessageId returnedMessageId = identityMatches expectedMessageId returnedMessageId
+
     /// Requires the last active delivery to remain outside the DLQ at the configured maximum.
     let belowMaximumRemainsActive expectedMessageId activeMessageId activeDeliveryCount (deadLetterMessageIds: string array) =
         identityMatches expectedMessageId activeMessageId
@@ -64,14 +67,18 @@ module DeadLetter =
 
         builder.ToString()
 
+    /// Requires broker-owned dead-letter diagnostics to remain nonempty after bounded redaction.
+    let brokerReasonPasses reason =
+        let boundedReason = boundedBrokerReason reason
+
+        not (String.IsNullOrWhiteSpace boundedReason)
+        && boundedReason.Length <= MaximumReasonCharacters
+
     /// Requires the exact witness to appear in the DLQ on delivery eleven with inspectable broker diagnostics.
     let deadLetterObservationPasses expectedMessageId observedMessageId deliveryCount brokerReason =
-        let boundedReason = boundedBrokerReason brokerReason
-
         identityMatches expectedMessageId observedMessageId
         && deliveryCount = DeadLetterDeliveryCount
-        && not (String.IsNullOrWhiteSpace boundedReason)
-        && boundedReason.Length <= MaximumReasonCharacters
+        && brokerReasonPasses brokerReason
 
     /// Requires terminal cleanup to remove the exact witness from both active and dead-letter subqueues.
     let cleanupComplete expectedMessageId (activeMessageIds: string array) (deadLetterMessageIds: string array) =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -360,6 +360,12 @@ type DeltaEvaluation =
     | Pending
     | Invalid of reason: string
 
+/// Reports whether an exact completed-settlement snapshot stayed unchanged or became invalid.
+type UnchangedEvaluation =
+    | Unchanged of messages: int64 * durations: int64
+    | Changed of reason: string
+    | UnchangedInvalid of reason: string
+
 /// Parses only the two exact production OpenMetrics settlement samples used by the Baseline witness.
 module OpenMetrics =
 
@@ -482,6 +488,34 @@ module OpenMetrics =
             Error($"{durationMetricName} required exactly one sample but found {values[durationMetricName].Count}.")
         else
             Ok(values[messageMetricName][0], values[durationMetricName][0])
+
+    /// Requires the exact completed-settlement samples to remain equal, while accepting their absence on both fresh-host scrapes.
+    let evaluateCompletedSettlementUnchanged baselineScrape observedScrape =
+        let hasTargetMetricFamily (scrape: string) =
+            scrape.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.exists (fun rawLine ->
+                let line = rawLine.Trim()
+
+                not (line.StartsWith("#", StringComparison.Ordinal))
+                && (line.StartsWith(messageMetricName, StringComparison.Ordinal)
+                    || line.StartsWith(durationMetricName, StringComparison.Ordinal)))
+
+        match parseCompletedSettlementSamples baselineScrape, parseCompletedSettlementSamples observedScrape with
+        | Ok (baselineMessages, baselineDurations), Ok (observedMessages, observedDurations) ->
+            if baselineMessages = observedMessages
+               && baselineDurations = observedDurations then
+                Unchanged(observedMessages, observedDurations)
+            else
+                Changed(
+                    $"Completed settlement telemetry changed: messages={baselineMessages}->{observedMessages}; durations={baselineDurations}->{observedDurations}."
+                )
+        | Error _, Error _ when
+            not (hasTargetMetricFamily baselineScrape)
+            && not (hasTargetMetricFamily observedScrape)
+            ->
+            Unchanged(0L, 0L)
+        | Error baselineError, _ -> UnchangedInvalid($"Invalid baseline scrape: {baselineError}")
+        | _, Error observedError -> UnchangedInvalid($"Invalid observed scrape: {observedError}")
 
     /// Evaluates exact cumulative equality while allowing only unchanged or partial deltas to keep waiting.
     let evaluateCompletedSettlementDelta expectedDelta baselineScrape observedScrape =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -1003,17 +1003,8 @@ grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_na
         else
             Ok(values[messageMetricName][0], values[durationMetricName][0])
 
-    /// Requires the exact completed-settlement samples to remain equal, while accepting their absence on both fresh-host scrapes.
+    /// Requires exactly one completed-settlement sample from each metric family on both scrapes before comparing cumulative values.
     let evaluateCompletedSettlementUnchanged baselineScrape observedScrape =
-        let hasTargetMetricFamily (scrape: string) =
-            scrape.Split([| '\r'; '\n' |], StringSplitOptions.RemoveEmptyEntries)
-            |> Array.exists (fun rawLine ->
-                let line = rawLine.Trim()
-
-                not (line.StartsWith("#", StringComparison.Ordinal))
-                && (line.StartsWith(messageMetricName, StringComparison.Ordinal)
-                    || line.StartsWith(durationMetricName, StringComparison.Ordinal)))
-
         match parseCompletedSettlementSamples baselineScrape, parseCompletedSettlementSamples observedScrape with
         | Ok (baselineMessages, baselineDurations), Ok (observedMessages, observedDurations) ->
             if baselineMessages = observedMessages
@@ -1023,11 +1014,6 @@ grace_manifest_contribution_processing_duration_milliseconds_count{otel_scope_na
                 Changed(
                     $"Completed settlement telemetry changed: messages={baselineMessages}->{observedMessages}; durations={baselineDurations}->{observedDurations}."
                 )
-        | Error _, Error _ when
-            not (hasTargetMetricFamily baselineScrape)
-            && not (hasTargetMetricFamily observedScrape)
-            ->
-            Unchanged(0L, 0L)
         | Error baselineError, _ -> UnchangedInvalid($"Invalid baseline scrape: {baselineError}")
         | _, Error observedError -> UnchangedInvalid($"Invalid observed scrape: {observedError}")
 


### PR DESCRIPTION
Part of #762

## Why this matters

The Product V1 evidence packet must prove the broker's real maximum-delivery boundary without introducing a production defect or confusing test-subscription traffic with Grace's production settlement telemetry.

## Summary

- adds one selected hosted DeadLetter measurement scenario on an isolated test subscription
- uses PeekLock and explicit abandon for active deliveries 1–10
- proves delivery 10 remains active and absent from the DLQ
- proves the exact witness reaches the DLQ at delivery 11 with bounded redacted reason evidence
- proves production manifest settlement telemetry remains unchanged
- uses ReceiveAndDelete only for the isolated DLQ observation so successful observation is terminal cleanup
- adds deterministic pure validation for identity, boundary, reason, telemetry, cleanup, outcomes, and exact assertion IDs

## Scope

Six test/project-support paths only, 792 additions, no deletions. No production receiver, subscription, topology, public/generated contract, persistence, retry, or runtime behavior change.

## Focused proof

- Fantomas: passed
- both relevant Release builds: passed, 0 warnings/errors
- affected measurement tests: 47/47, including all session-1 negative regressions
- explicit DeadLetter selector discovery without prerequisites: exactly one side-effect-free `Skipped` test
- final exact-head hosted run 4: 9/9 exact unique assertions, zero runtime failures
- delivery boundary: active delivery 10; exact DLQ identity at delivery 11
- broker reason: `MaxDeliveryCountExceeded`, bounded/printable/credential-redacted
- production manifest telemetry: exact samples present and unchanged, messages `1 → 1`, durations `1 → 1`
- active and DLQ cleanup: witness absent
- `git diff --check` and actual-diff review-prevention self-review: clean

Retained exact-head evidence: `C:\Source\Grace-artifacts\762-dead-letter\f8728ed1cead413b935b66d6c287bb4c`.

Fast/Full were intentionally skipped because focused builds, pure tests, and the selected hosted witness form the local gate. GitHub `Validate` is the required broad current-head gate.

## Review Status

| Gate | Status |
| --- | --- |
| Current head | `22025ef35f07623dd086cdbc6a11ba84efb6a4c6` |
| Implementation workers | 2/4 |
| Runtime starts | 4, uncapped ledger |
| GitHub Validate | Passed: [run 30634828961](https://github.com/ScottArbeit/Grace/actions/runs/30634828961) |
| Review session | Session 2 Terra High approved `22025ef3` with no substantive findings |
| Findings | Session 1 set addressed by `68b96c10` and `22025ef3`; session 2 closed the set |

## Docs impact

Product/operator documentation remains owned by #752 after the grouped exact-SHA proof. No user-facing contract changes in this slice.

## Residual risk

This is local Service Bus emulator evidence for the isolated Product V1 boundary, not an Azure availability, throughput, SLO, or hardened recovery claim.