### PR TITLE
Prove manifest accounting after Redis restart

### DIFF
--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -42,6 +42,16 @@ type TestHostState =
         OperationsSqlConnectionString: string
     }
 
+/// Captures the command result and fresh Aspire resource snapshot for one pinned Redis restart.
+type RedisRestartCommandObservation =
+    {
+        PostCommandResourceEventObserved: bool
+        PreCommandStartTimestamp: string
+        PostCommandStartTimestamp: string
+        PostCommandState: string
+        PostCommandHealth: string
+    }
+
 /// Groups shared helpers for aspire test host.
 module AspireTestHost =
     do AppDomain.CurrentDomain.ProcessExit.Add(fun _ -> Environment.ExitCode <- 0)
@@ -1517,6 +1527,92 @@ module AspireTestHost =
                 do! waitForGraceServerHttpReadyAsync state.Client cts.Token
                 logProgress $"Grace.Server HTTP readiness recovered after intentional restart '{normalizedRestartContext}'."
                 Console.WriteLine($"Grace.Server Aspire project resource restart completed for {normalizedRestartContext}.")
+            finally
+                sharedStateLock.Release() |> ignore
+        }
+
+    /// Restarts the pinned Redis resource and requires a post-command event plus a Healthy snapshot before returning.
+    let restartRedisAsync (state: TestHostState) =
+        task {
+            do! sharedStateLock.WaitAsync()
+
+            try
+                let notificationService = state.App.Services.GetRequiredService<ResourceNotificationService>()
+                let mutable preCommandEvent = Unchecked.defaultof<ResourceEvent>
+
+                if not (notificationService.TryGetCurrentState(redisResourceName, &preCommandEvent)) then
+                    invalidOp "The pinned Redis resource did not expose a pre-command Aspire snapshot."
+
+                let preCommandStartTimestamp = box preCommandEvent.Snapshot.StartTimeStamp
+                let commandService = state.App.Services.GetRequiredService<ResourceCommandService>()
+                use cts = new CancellationTokenSource(defaultWaitTimeout)
+                let mutable commandIssued = false
+
+                let postCommandEventTask =
+                    task {
+                        use enumerator =
+                            notificationService
+                                .WatchAsync(cts.Token)
+                                .GetAsyncEnumerator(cts.Token)
+
+                        let mutable observed: ResourceEvent option = None
+
+                        while observed.IsNone do
+                            let! hasNext = enumerator.MoveNextAsync().AsTask()
+
+                            if not hasNext then
+                                invalidOp "The Aspire resource event stream ended before Redis restart evidence was observed."
+
+                            let resourceEvent = enumerator.Current
+
+                            if
+                                commandIssued
+                                && resourceEvent.Resource.Name.Equals(redisResourceName, StringComparison.Ordinal)
+                                && not (Object.Equals(box resourceEvent.Snapshot.StartTimeStamp, preCommandStartTimestamp))
+                            then
+                                observed <- Some resourceEvent
+
+                        return observed.Value
+                    }
+
+                commandIssued <- true
+
+                let! result =
+                    task {
+                        try
+                            return! commandService.ExecuteCommandAsync(redisResourceName, KnownResourceCommands.RestartCommand, cts.Token)
+                        with
+                        | ex ->
+                            cts.Cancel()
+                            return raise ex
+                    }
+
+                if not result.Success then
+                    cts.Cancel()
+
+                    let errorMessage =
+                        if not (String.IsNullOrWhiteSpace result.Message) then result.Message
+                        elif result.Canceled then "Restart command was canceled."
+                        else "Restart command failed without details."
+
+                    invalidOp $"Redis restart command failed: {errorMessage}"
+
+                let! _ = postCommandEventTask
+
+                do! waitForResourceHealthyAsync notificationService state.App redisResourceName cts.Token
+                let mutable postCommandEvent = Unchecked.defaultof<ResourceEvent>
+
+                if not (notificationService.TryGetCurrentState(redisResourceName, &postCommandEvent)) then
+                    invalidOp "The pinned Redis resource did not expose a post-command Aspire snapshot."
+
+                return
+                    {
+                        PostCommandResourceEventObserved = true
+                        PreCommandStartTimestamp = string preCommandEvent.Snapshot.StartTimeStamp
+                        PostCommandStartTimestamp = string postCommandEvent.Snapshot.StartTimeStamp
+                        PostCommandState = string postCommandEvent.Snapshot.State
+                        PostCommandHealth = string postCommandEvent.Snapshot.HealthStatus
+                    }
             finally
                 sharedStateLock.Release() |> ignore
         }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="RestartDurability.Server.Tests.fs" />
     <Compile Include="ManifestContributionAccounting.Server.Tests.fs" />
     <Compile Include="ManifestContributionBaseline.Measurement.Tests.fs" />
+    <Compile Include="ManifestContributionRedisRestart.Measurement.Tests.fs" />
     <Compile Include="RepositoryCounterRecentResult.Integration.Server.Tests.fs" />
     <Compile Include="Policy.Server.Tests.fs" />
     <Compile Include="Queue.Integration.Server.Tests.fs" />

--- a/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
@@ -528,8 +528,8 @@ module internal BaselineRuntime =
             return ()
         }
 
-    /// Creates one child branch with a caller-owned automatic Rebase Reference identity.
-    let createBranchAsync state ownerId organizationId repositoryId (parent: Branch.BranchDto) index rebaseReferenceId =
+    /// Creates one child branch with caller-selected permissions and a caller-owned automatic Rebase Reference identity.
+    let createBranchWithPermissionsAsync state ownerId organizationId repositoryId (parent: Branch.BranchDto) index rebaseReferenceId initialPermissions =
         task {
             let branchId = Guid.NewGuid()
             let parameters = Parameters.Branch.CreateBranchParameters()
@@ -541,11 +541,22 @@ module internal BaselineRuntime =
             parameters.ParentBranchId <- string parent.BranchId
             parameters.ParentBranchName <- string parent.BranchName
             parameters.ReferenceId <- rebaseReferenceId
+            parameters.InitialPermissions <- initialPermissions
             parameters.CorrelationId <- generateCorrelationId ()
             use! response = state.Client.PostAsync("/branch/create", createJsonContent parameters)
             let! _ = requireOkAsync "POST /branch/create" response
             return! getBranchAsync state ownerId organizationId repositoryId branchId
         }
+
+    /// Creates one child branch with the default writable permissions and a caller-owned automatic Rebase Reference identity.
+    let createBranchAsync state ownerId organizationId repositoryId (parent: Branch.BranchDto) index rebaseReferenceId =
+        let defaults =
+            Parameters
+                .Branch
+                .CreateBranchParameters()
+                .InitialPermissions
+
+        createBranchWithPermissionsAsync state ownerId organizationId repositoryId parent index rebaseReferenceId defaults
 
     /// Creates one explicit Save Reference with a caller-owned identity.
     let saveReferenceAsync state ownerId organizationId repositoryId (asset: BaselineAsset) =

--- a/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionBaseline.Measurement.Tests.fs
@@ -34,7 +34,7 @@ open System.Threading
 open System.Threading.Tasks
 
 /// Carries one distinct manifest, root, branch, and explicit Save identity through the Baseline tracer.
-type private BaselineAsset =
+type internal BaselineAsset =
     {
         BlockAddress: ContentBlockAddress
         Manifest: FileManifest
@@ -45,7 +45,7 @@ type private BaselineAsset =
     }
 
 /// Captures each independent durable convergence result without treating one state store as broker evidence.
-type private DurableStatus =
+type internal DurableStatus =
     {
         ReferenceRoots: bool
         ManifestRelationships: bool
@@ -56,7 +56,7 @@ type private DurableStatus =
     }
 
 /// Implements the one explicit fixture-owned Baseline measurement runtime.
-module private BaselineRuntime =
+module internal BaselineRuntime =
 
     [<Literal>]
     let SelectedTopologyCount = 3
@@ -535,7 +535,7 @@ module private BaselineRuntime =
             parameters.ReferenceId <- asset.SaveReferenceId
             parameters.DirectoryVersionId <- asset.Root.DirectoryVersionId
             parameters.Sha256Hash <- asset.Root.Sha256Hash
-            parameters.Message <- "MCA-08B-R1 Baseline explicit Save"
+            parameters.Message <- "MCA selected-process explicit Save measurement"
             parameters.CorrelationId <- generateCorrelationId ()
             use! response = state.Client.PostAsync("/branch/save", createJsonContent parameters)
             let! _ = requireOkAsync "POST /branch/save" response

--- a/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
@@ -272,7 +272,17 @@ type ManifestContributionRedisRestartMeasurementTests() =
                 do! BaselineRuntime.saveRootAsync state ownerId organizationId repositoryId root
                 let seedRebaseReferenceId = Guid.NewGuid()
                 let seedSaveReferenceId = Guid.NewGuid()
-                let! seedBranch = BaselineRuntime.createBranchAsync state ownerId organizationId repositoryId defaultBranch 0 seedRebaseReferenceId
+
+                let! seedBranch =
+                    BaselineRuntime.createBranchWithPermissionsAsync
+                        state
+                        ownerId
+                        organizationId
+                        repositoryId
+                        defaultBranch
+                        0
+                        seedRebaseReferenceId
+                        RedisRestart.promotionEnabledParentPermissions
 
                 let seedAsset =
                     {

--- a/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
@@ -1,0 +1,502 @@
+namespace Grace.Server.Measurements
+
+open Grace.Server.Tests
+open Grace.Server.Tests.Measurement
+open Grace.Shared
+open Grace.Types
+open Grace.Types.Common
+open Grace.Types.ContentBlockMetadata
+open Grace.Types.ManifestContributionAccounting
+open Grace.Types.ManifestContributionWorkflow
+open Grace.Types.Reference
+open Grace.Types.RepositoryContentCounter
+open Microsoft.Azure.Cosmos
+open NUnit.Framework
+open StackExchange.Redis
+open System
+open System.Collections.Generic
+open System.Diagnostics
+open System.Globalization
+open System.IO
+open System.Text
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Captures one hot manifest's independently observable durable state across Redis restart recovery.
+type private RedisRestartDurableState =
+    {
+        ReferenceRootPresent: bool
+        ManifestRelationshipPresent: bool
+        LogicalCount: int64
+        WorkflowFingerprint: string
+        PhysicalActiveCount: int64
+        Detail: string
+    }
+
+/// Implements one selected-process Redis restart recovery measurement over the R1 host and evidence boundary.
+module private RedisRestartRuntime =
+
+    [<Literal>]
+    let MaximumRecordBytes = 65536
+
+    /// Reads the exact counter, workflow snapshot, physical range, and relationship state for one hot manifest.
+    let readDurableStateAsync state repositoryId (asset: BaselineAsset) requiredReferenceId =
+        task {
+            let! counters = BaselineRuntime.readActorSnapshotsAsync<RepositoryContentCounterDto> state "RepoContentCounter"
+            let! workflows = BaselineRuntime.readActorSnapshotsAsync<ManifestContributionWorkflowDto> state "ManifestContributionWorkflow"
+            let! metadataStreams = BaselineRuntime.readActorEventStreamsAsync<ContentBlockMetadataEvent> state "ContentBlockMetadata"
+
+            let matchingCounters =
+                counters
+                |> Array.filter (fun counter ->
+                    counter.RepositoryId = repositoryId
+                    && counter.StoragePoolId = asset.Manifest.StoragePoolId
+                    && counter.ManifestAddress = asset.Manifest.ManifestAddress)
+
+            let logicalCount =
+                if matchingCounters.Length = 1 then
+                    matchingCounters[0].Count
+                else
+                    Int64.MinValue
+
+            let matchingWorkflows =
+                workflows
+                |> Array.filter (fun workflow ->
+                    workflow.RepositoryId = repositoryId
+                    && workflow.StoragePoolId = asset.Manifest.StoragePoolId
+                    && workflow.ManifestAddress = asset.Manifest.ManifestAddress)
+                |> Array.map (fun workflow -> JsonSerializer.Serialize(workflow, Constants.JsonSerializerOptions))
+                |> Array.sort
+
+            let workflowFingerprint = String.Join("|", matchingWorkflows)
+
+            let metadata =
+                metadataStreams
+                |> Array.map (fun events ->
+                    events
+                    |> Array.fold (fun current event -> ContentBlockMetadataDto.UpdateDto event current) ContentBlockMetadataDto.Empty)
+                |> Array.choose (fun dto -> dto.Metadata)
+                |> Array.filter (fun value ->
+                    value.StoragePoolId = asset.Manifest.StoragePoolId
+                    && value.ContentBlockAddress = asset.BlockAddress)
+
+            let physicalActiveCount =
+                if metadata.Length = 1
+                   && metadata[0].Ranges.Length > 0
+                   && metadata[0].Ranges
+                      |> Array.map (fun range -> range.ActiveManifestCount)
+                      |> Array.distinct
+                      |> Array.length
+                      |> (=) 1 then
+                    int64 metadata[0].Ranges[0].ActiveManifestCount
+                else
+                    Int64.MinValue
+
+            let! referenceRootPresent =
+                match requiredReferenceId with
+                | Some referenceId ->
+                    BaselineRuntime.exactRelationshipExistsAsync
+                        state
+                        (ExactRelationship.ReferenceRoot
+                            { RepositoryId = repositoryId; RootDirectoryVersionId = asset.Root.DirectoryVersionId; ReferenceId = referenceId })
+                | None -> Task.FromResult true
+
+            let! manifestRelationshipPresent =
+                BaselineRuntime.exactRelationshipExistsAsync
+                    state
+                    (ExactRelationship.DirectoryVersionManifest
+                        {
+                            RepositoryId = repositoryId
+                            StoragePoolId = asset.Manifest.StoragePoolId
+                            ManifestAddress = asset.Manifest.ManifestAddress
+                            DirectoryVersionId = asset.Root.DirectoryVersionId
+                        })
+
+            return
+                {
+                    ReferenceRootPresent = referenceRootPresent
+                    ManifestRelationshipPresent = manifestRelationshipPresent
+                    LogicalCount = logicalCount
+                    WorkflowFingerprint = workflowFingerprint
+                    PhysicalActiveCount = physicalActiveCount
+                    Detail =
+                        $"referenceRoot={referenceRootPresent}; manifest={manifestRelationshipPresent}; logical={logicalCount}; workflows={matchingWorkflows.Length}; physical={physicalActiveCount}"
+                }
+        }
+
+    /// Waits for one exact durable recovery state without using elapsed quiet time as correctness evidence.
+    let waitForDurableStateAsync state repositoryId asset requiredReferenceId expectedLogicalCount expectedWorkflowFingerprint =
+        task {
+            let timeoutAt = DateTime.UtcNow.AddSeconds(45.0)
+
+            let mutable observed =
+                {
+                    ReferenceRootPresent = false
+                    ManifestRelationshipPresent = false
+                    LogicalCount = Int64.MinValue
+                    WorkflowFingerprint = String.Empty
+                    PhysicalActiveCount = Int64.MinValue
+                    Detail = "not observed"
+                }
+
+            let complete value =
+                value.ReferenceRootPresent
+                && value.ManifestRelationshipPresent
+                && value.LogicalCount = expectedLogicalCount
+                && value.WorkflowFingerprint.Equals(expectedWorkflowFingerprint, StringComparison.Ordinal)
+                && value.PhysicalActiveCount = 1L
+
+            while not (complete observed)
+                  && DateTime.UtcNow < timeoutAt do
+                let! current = readDurableStateAsync state repositoryId asset requiredReferenceId
+                observed <- current
+
+                if not (complete observed) then do! Task.Delay(TimeSpan.FromMilliseconds(250.0))
+
+            return observed
+        }
+
+    /// Performs one bounded Redis PING against the endpoint published after the resource restart.
+    let proveProtocolReadyAsync state =
+        task {
+            let endpoint = AspireTestHost.getRedisEndpoint state
+            let configuration = ConfigurationOptions()
+            configuration.EndPoints.Add(endpoint.Host, endpoint.Port)
+            configuration.AbortOnConnectFail <- false
+            configuration.ConnectTimeout <- 10000
+            configuration.AsyncTimeout <- 10000
+            use cts = new CancellationTokenSource(TimeSpan.FromSeconds(15.0))
+            let timer = Stopwatch.StartNew()
+
+            let! connection =
+                ConnectionMultiplexer
+                    .ConnectAsync(configuration)
+                    .WaitAsync(cts.Token)
+
+            use connection = connection
+
+            let! latency =
+                connection
+                    .GetDatabase()
+                    .PingAsync()
+                    .WaitAsync(cts.Token)
+
+            timer.Stop()
+            let latencyText = latency.TotalMilliseconds.ToString("F3", CultureInfo.InvariantCulture)
+            let elapsedText = timer.Elapsed.TotalMilliseconds.ToString("F3", CultureInfo.InvariantCulture)
+            return latency >= TimeSpan.Zero, $"endpoint={endpoint}; latencyMs={latencyText}; elapsedMs={elapsedText}"
+        }
+
+    /// Adds one typed Redis restart sample using the shared evidence writer.
+    let recordSample (writer: EvidenceWriter) runId sampleId name value labels =
+        writer.Append(MeasurementSample.Create(runId, "redis-restart", sampleId, name, value, labels))
+
+/// Proves one hot-manifest Reference converges exactly once after a real pinned Redis resource restart.
+[<NonParallelizable>]
+type ManifestContributionRedisRestartMeasurementTests() =
+
+    /// Emits truthful restart, readiness, settlement, durable-state, identity, cleanup, and evidence results.
+    [<Test; Explicit("Run only through the focused MCA Redis restart measurement selector.")>]
+    member _.``hot manifest converges one Reference after Redis restart``() =
+        task {
+            let runId = Guid.NewGuid().ToString("N")
+
+            let worktree =
+                BaselineRuntime.requireEnvironment "GRACE_MCA_WORKTREE"
+                |> Path.GetFullPath
+
+            let command = BaselineRuntime.requireEnvironment "GRACE_MCA_HOSTED_COMMAND"
+
+            let evidenceRoot =
+                BaselineRuntime.requireEnvironment "GRACE_MCA_EVIDENCE_ROOT"
+                |> Path.GetFullPath
+
+            let evidenceDirectory = Path.Combine(evidenceRoot, runId)
+            let! commitSha = BaselineRuntime.runGitAsync worktree [| "rev-parse"; "HEAD" |]
+
+            let! status =
+                BaselineRuntime.runGitAsync
+                    worktree
+                    [|
+                        "status"
+                        "--porcelain=v1"
+                        "--untracked-files=all"
+                    |]
+
+            let worktreeState = if String.IsNullOrWhiteSpace status then "clean" else status
+            use writer = new EvidenceWriter(evidenceDirectory, RedisRestartRuntime.MaximumRecordBytes)
+            let plan = [| "redis-restart" |]
+            writer.Append(MeasurementRun.Create(runId, commitSha, worktree, worktreeState, command, evidenceDirectory, plan))
+            let assertions = ResizeArray<MeasurementAssertion>()
+            let failures = ResizeArray<string>()
+            let expectedMessageIds = ResizeArray<string>()
+            let observedMessageIds = ResizeArray<string>()
+            let mutable host: TestHostState option = None
+
+            let recordAssertion assertionId passed detail =
+                let assertion = MeasurementAssertion.Create(runId, "redis-restart", assertionId, passed, detail)
+                assertions.Add assertion
+                writer.Append assertion
+
+            try
+                let bootstrapUserId = Guid.NewGuid().ToString("D")
+                let! state = AspireTestHost.startIsolatedAsync bootstrapUserId
+                host <- Some state
+                state.Client.DefaultRequestHeaders.Add("x-grace-user-id", bootstrapUserId)
+                let! _ = AspireTestHost.drainServiceBusAsync state
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                do! BaselineRuntime.createOwnerAsync state ownerId
+                do! BaselineRuntime.createOrganizationAsync state ownerId organizationId
+                let! defaultBranchId, defaultReferenceId = BaselineRuntime.createRepositoryAsync state ownerId organizationId repositoryId
+                let! defaultBranch = BaselineRuntime.getBranchAsync state ownerId organizationId repositoryId defaultBranchId
+
+                if defaultBranch.LatestReference.ReferenceId
+                   <> defaultReferenceId then
+                    invalidOp "The Redis restart repository default Reference inventory did not match its persisted branch."
+
+                let defaultMessageId = $"Reference/{defaultReferenceId}/Created"
+                expectedMessageIds.Add defaultMessageId
+                let! defaultObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| defaultMessageId |] "repository default"
+                observedMessageIds.AddRange defaultObserved
+                let! initialMetrics = BaselineRuntime.waitForCompletedSettlementSamplesAsync state
+                let! blockAddress, manifest, bytes = BaselineRuntime.createManifestAssetAsync state ownerId organizationId repositoryId 0
+                let root = BaselineRuntime.createRoot ownerId organizationId repositoryId 0 manifest bytes
+                do! BaselineRuntime.saveRootAsync state ownerId organizationId repositoryId root
+                let seedRebaseReferenceId = Guid.NewGuid()
+                let seedSaveReferenceId = Guid.NewGuid()
+                let! seedBranch = BaselineRuntime.createBranchAsync state ownerId organizationId repositoryId defaultBranch 0 seedRebaseReferenceId
+
+                let seedAsset =
+                    {
+                        BlockAddress = blockAddress
+                        Manifest = manifest
+                        Root = root
+                        Branch = seedBranch
+                        RebaseReferenceId = seedRebaseReferenceId
+                        SaveReferenceId = seedSaveReferenceId
+                    }
+
+                let seedRebaseMessageId = $"Reference/{seedRebaseReferenceId}/Created"
+                expectedMessageIds.Add seedRebaseMessageId
+                let! seedRebaseObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| seedRebaseMessageId |] "seed branch Rebase"
+                observedMessageIds.AddRange seedRebaseObserved
+
+                let! seedRebaseMessageDelta, seedRebaseDurationDelta, seedSaveBaseline =
+                    BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L initialMetrics
+
+                let! _ = BaselineRuntime.saveReferenceAsync state ownerId organizationId repositoryId seedAsset
+                let seedSaveMessageId = $"Reference/{seedSaveReferenceId}/Created"
+                expectedMessageIds.Add seedSaveMessageId
+                let! seedSaveObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| seedSaveMessageId |] "seed explicit Save"
+                observedMessageIds.AddRange seedSaveObserved
+                let! seedDurable = BaselineRuntime.waitForDurableStatusAsync state repositoryId [| seedAsset |]
+
+                let! seedSaveMessageDelta, seedSaveDurationDelta, restartMetricsBaseline =
+                    BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L seedSaveBaseline
+
+                let seedDeliveriesComplete =
+                    defaultObserved.Length = 1
+                    && seedRebaseObserved.Length = 1
+                    && seedSaveObserved.Length = 1
+                    && seedRebaseMessageDelta = 1L
+                    && seedRebaseDurationDelta = 1L
+                    && seedSaveMessageDelta = 1L
+                    && seedSaveDurationDelta = 1L
+                    && seedDurable.ReferenceRoots
+                    && seedDurable.ManifestRelationships
+                    && seedDurable.LogicalCounts
+                    && seedDurable.WorkflowCounts
+                    && seedDurable.PhysicalActiveCounts
+
+                recordAssertion
+                    "redis-restart.seed-deliveries-completed"
+                    seedDeliveriesComplete
+                    $"default={defaultObserved.Length}; rebase={seedRebaseObserved.Length}/{seedRebaseMessageDelta}/{seedRebaseDurationDelta}; save={seedSaveObserved.Length}/{seedSaveMessageDelta}/{seedSaveDurationDelta}; durable={seedDurable.Detail}"
+
+                if not seedDeliveriesComplete then
+                    invalidOp "Redis restart was not attempted because the hot-manifest seed deliveries did not settle exactly."
+
+                let! beforeRestart = RedisRestartRuntime.readDurableStateAsync state repositoryId seedAsset (Some seedSaveReferenceId)
+                let! restart = AspireTestHost.restartRedisAsync state
+
+                recordAssertion
+                    "redis-restart.command-completed"
+                    restart.PostCommandResourceEventObserved
+                    $"postCommandEvent={restart.PostCommandResourceEventObserved}; preStart={restart.PreCommandStartTimestamp}; postStart={restart.PostCommandStartTimestamp}; state={restart.PostCommandState}"
+
+                let! protocolSucceeded, protocolDetail = RedisRestartRuntime.proveProtocolReadyAsync state
+
+                let readiness =
+                    RedisRestart.evaluateReadiness
+                        {
+                            PostCommandResourceEventObserved = restart.PostCommandResourceEventObserved
+                            PostCommandHealth = restart.PostCommandHealth
+                            ProtocolOperationSucceeded = protocolSucceeded
+                        }
+
+                recordAssertion
+                    "redis-restart.fresh-health"
+                    (readiness.FreshResourceEvent && readiness.Healthy)
+                    $"postCommandEvent={restart.PostCommandResourceEventObserved}; health={restart.PostCommandHealth}"
+
+                recordAssertion "redis-restart.protocol-ready" readiness.ProtocolReady protocolDetail
+
+                if
+                    not
+                        (
+                            readiness.FreshResourceEvent
+                            && readiness.Healthy
+                            && readiness.ProtocolReady
+                        )
+                then
+                    invalidOp "Post-restart Reference setup was not attempted because fresh Redis readiness was not proven."
+
+                let branchRebaseReferenceId = Guid.NewGuid()
+                let explicitSaveReferenceId = Guid.NewGuid()
+                let! recoveryBranch = BaselineRuntime.createBranchAsync state ownerId organizationId repositoryId seedBranch 1 branchRebaseReferenceId
+                let branchRebaseMessageId = $"Reference/{branchRebaseReferenceId}/Created"
+                expectedMessageIds.Add branchRebaseMessageId
+                let! branchRebaseObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| branchRebaseMessageId |] "post-restart branch Rebase"
+                observedMessageIds.AddRange branchRebaseObserved
+
+                let! branchMessageDelta, branchDurationDelta, explicitMetricsBaseline =
+                    BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L restartMetricsBaseline
+
+                let recoveryAsset =
+                    { seedAsset with Branch = recoveryBranch; RebaseReferenceId = branchRebaseReferenceId; SaveReferenceId = explicitSaveReferenceId }
+
+                let expectedBranchLogicalCount = beforeRestart.LogicalCount + 1L
+
+                let! explicitDurableBaseline =
+                    RedisRestartRuntime.waitForDurableStateAsync
+                        state
+                        repositoryId
+                        recoveryAsset
+                        (Some branchRebaseReferenceId)
+                        expectedBranchLogicalCount
+                        beforeRestart.WorkflowFingerprint
+
+                let branchSetupComplete =
+                    branchRebaseObserved.Length = 1
+                    && branchMessageDelta = 1L
+                    && branchDurationDelta = 1L
+                    && explicitDurableBaseline.LogicalCount = expectedBranchLogicalCount
+                    && explicitDurableBaseline.WorkflowFingerprint.Equals(beforeRestart.WorkflowFingerprint, StringComparison.Ordinal)
+
+                recordAssertion
+                    "redis-restart.branch-setup-delivery-completed"
+                    branchSetupComplete
+                    $"observed={branchRebaseObserved.Length}; messages={branchMessageDelta}; durations={branchDurationDelta}; durable={explicitDurableBaseline.Detail}"
+
+                if not branchSetupComplete then
+                    invalidOp "The explicit Reference was not created because the branch Rebase delivery did not settle before its baseline."
+
+                let! _ = BaselineRuntime.saveReferenceAsync state ownerId organizationId repositoryId recoveryAsset
+                let explicitMessageId = $"Reference/{explicitSaveReferenceId}/Created"
+                expectedMessageIds.Add explicitMessageId
+                let! explicitObserved = BaselineRuntime.observeReferenceEnvelopesAsync state [| explicitMessageId |] "post-restart explicit Save"
+                observedMessageIds.AddRange explicitObserved
+
+                let! finalDurable =
+                    RedisRestartRuntime.waitForDurableStateAsync
+                        state
+                        repositoryId
+                        recoveryAsset
+                        (Some explicitSaveReferenceId)
+                        (explicitDurableBaseline.LogicalCount + 1L)
+                        explicitDurableBaseline.WorkflowFingerprint
+
+                let! stimulusMessageDelta, stimulusDurationDelta, _ = BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L explicitMetricsBaseline
+
+                recordAssertion
+                    "redis-restart.stimulus-message-delta"
+                    (explicitObserved.Length = 1
+                     && stimulusMessageDelta = 1L)
+                    $"observed={explicitObserved.Length}; delta={stimulusMessageDelta}"
+
+                recordAssertion "redis-restart.stimulus-duration-delta" (stimulusDurationDelta = 1L) $"delta={stimulusDurationDelta}"
+                recordAssertion "redis-restart.reference-root-present" finalDurable.ReferenceRootPresent finalDurable.Detail
+                recordAssertion "redis-restart.manifest-relationship-present" finalDurable.ManifestRelationshipPresent finalDurable.Detail
+
+                recordAssertion
+                    "redis-restart.logical-count-plus-one"
+                    (finalDurable.LogicalCount = explicitDurableBaseline.LogicalCount + 1L)
+                    $"baseline={explicitDurableBaseline.LogicalCount}; observed={finalDurable.LogicalCount}"
+
+                recordAssertion
+                    "redis-restart.workflow-unchanged"
+                    (finalDurable.WorkflowFingerprint.Equals(beforeRestart.WorkflowFingerprint, StringComparison.Ordinal)
+                     && finalDurable.WorkflowFingerprint.Equals(explicitDurableBaseline.WorkflowFingerprint, StringComparison.Ordinal))
+                    $"beforeRestartLength={beforeRestart.WorkflowFingerprint.Length}; explicitBaselineLength={explicitDurableBaseline.WorkflowFingerprint.Length}; finalLength={finalDurable.WorkflowFingerprint.Length}"
+
+                recordAssertion "redis-restart.physical-active-count-one" (finalDurable.PhysicalActiveCount = 1L) finalDurable.Detail
+
+                let labels = Dictionary<string, string>()
+                labels["stage"] <- "settle"
+                labels["outcome"] <- "completed"
+
+                RedisRestartRuntime.recordSample writer runId "stimulus-messages" "grace_manifest_contribution_messages_total.delta" stimulusMessageDelta labels
+
+                RedisRestartRuntime.recordSample
+                    writer
+                    runId
+                    "stimulus-durations"
+                    "grace_manifest_contribution_processing_duration_milliseconds_count.delta"
+                    stimulusDurationDelta
+                    labels
+            with
+            | ex -> failures.Add(ex.ToString())
+
+            match host with
+            | Some state ->
+                try
+                    do! AspireTestHost.stopIsolatedAsync state
+                with
+                | ex -> failures.Add($"cleanup: {ex}")
+            | None -> ()
+
+            if
+                not
+                    (
+                        assertions
+                        |> Seq.exists (fun assertion -> assertion.AssertionId = "redis-restart.evidence-integrity")
+                    )
+            then
+                try
+                    let inventoryErrors = ProducerInventory.validate (expectedMessageIds.ToArray()) (observedMessageIds.ToArray())
+                    let fileIntegrity = BaselineRuntime.verifyEvidenceIntegrity writer
+                    let inventoryDetail = String.Join("; ", inventoryErrors)
+
+                    recordAssertion
+                        "redis-restart.evidence-integrity"
+                        (fileIntegrity && inventoryErrors.Length = 0)
+                        $"path={writer.Path}; expected={expectedMessageIds.Count}; observed={observedMessageIds.Count}; inventory={inventoryDetail}"
+                with
+                | ex -> recordAssertion "redis-restart.evidence-integrity" false ex.Message
+
+            RedisRestart.requiredAssertionIds
+            |> Array.iter (fun assertionId ->
+                if
+                    not
+                        (
+                            assertions
+                            |> Seq.exists (fun assertion -> assertion.AssertionId = assertionId)
+                        )
+                then
+                    recordAssertion assertionId false "The runtime failed before this assertion could be evaluated.")
+
+            let summary = ScenarioSummary.derive runId "redis-restart" RedisRestart.requiredAssertionIds (assertions.ToArray()) (failures.ToArray()) false
+
+            writer.Append summary
+            TestContext.Progress.WriteLine($"MCA Redis restart evidence directory: {evidenceDirectory}")
+            TestContext.Progress.Flush()
+
+            Assert.That(
+                summary.Outcome,
+                Is.EqualTo("Passed"),
+                $"Evidence: {evidenceDirectory}{Environment.NewLine}{String.Join(Environment.NewLine, failures)}"
+            )
+        }

--- a/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
@@ -393,31 +393,51 @@ type ManifestContributionRedisRestartMeasurementTests() =
                 let! branchMessageDelta, branchDurationDelta, explicitMetricsBaseline =
                     BaselineRuntime.waitForCompletedSettlementDeltaAsync state 1L restartMetricsBaseline
 
+                let! recoveryReferences = BaselineRuntime.getBranchReferencesAsync state ownerId organizationId repositoryId recoveryBranch.BranchId
+
+                let rebasePersisted =
+                    recoveryReferences
+                    |> Array.exists (fun reference -> reference.ReferenceId = branchRebaseReferenceId)
+
+                let branchInventoryErrors =
+                    ProducerInventory.validate
+                        [| branchRebaseMessageId |]
+                        (branchRebaseObserved
+                         |> Array.map (fun envelope -> envelope.MessageId))
+
                 let recoveryAsset =
                     { seedAsset with Branch = recoveryBranch; RebaseReferenceId = branchRebaseReferenceId; SaveReferenceId = explicitSaveReferenceId }
-
-                let expectedBranchLogicalCount = beforeRestart.LogicalCount + 1L
 
                 let! explicitDurableBaseline =
                     RedisRestartRuntime.waitForDurableStateAsync
                         state
                         repositoryId
                         recoveryAsset
-                        (Some branchRebaseReferenceId)
-                        expectedBranchLogicalCount
+                        None
+                        beforeRestart.LogicalCount
                         beforeRestart.WorkflowFingerprint
 
                 let branchSetupComplete =
-                    branchRebaseObserved.Length = 1
-                    && branchMessageDelta = 1L
-                    && branchDurationDelta = 1L
-                    && explicitDurableBaseline.LogicalCount = expectedBranchLogicalCount
-                    && explicitDurableBaseline.WorkflowFingerprint.Equals(beforeRestart.WorkflowFingerprint, StringComparison.Ordinal)
+                    RedisRestart.branchSetupComplete
+                        {
+                            RebasePersisted = rebasePersisted
+                            ObservedEnvelopeCount = branchRebaseObserved.Length
+                            MessageDelta = branchMessageDelta
+                            DurationDelta = branchDurationDelta
+                            IdentityInventoryClean = branchInventoryErrors.Length = 0
+                            BeforeLogicalCount = beforeRestart.LogicalCount
+                            BaselineLogicalCount = explicitDurableBaseline.LogicalCount
+                            WorkflowUnchanged = explicitDurableBaseline.WorkflowFingerprint.Equals(beforeRestart.WorkflowFingerprint, StringComparison.Ordinal)
+                            ManifestRelationshipPresent = explicitDurableBaseline.ManifestRelationshipPresent
+                            PhysicalActiveCount = explicitDurableBaseline.PhysicalActiveCount
+                        }
+
+                let branchInventoryDetail = String.Join("; ", branchInventoryErrors)
 
                 recordAssertion
                     "redis-restart.branch-setup-delivery-completed"
                     branchSetupComplete
-                    $"observed={branchRebaseObserved.Length}; messages={branchMessageDelta}; durations={branchDurationDelta}; durable={explicitDurableBaseline.Detail}"
+                    $"persisted={rebasePersisted}; observed={branchRebaseObserved.Length}; messages={branchMessageDelta}; durations={branchDurationDelta}; inventory={branchInventoryDetail}; durable={explicitDurableBaseline.Detail}"
 
                 if not branchSetupComplete then
                     invalidOp "The explicit Reference was not created because the branch Rebase delivery did not settle before its baseline."

--- a/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
+++ b/src/Grace.Server.Tests/ManifestContributionRedisRestart.Measurement.Tests.fs
@@ -405,17 +405,46 @@ type ManifestContributionRedisRestartMeasurementTests() =
                         (branchRebaseObserved
                          |> Array.map (fun envelope -> envelope.MessageId))
 
+                let stimulusRoot = BaselineRuntime.createRoot ownerId organizationId repositoryId 0 manifest bytes
+                do! BaselineRuntime.saveRootAsync state ownerId organizationId repositoryId stimulusRoot
+
                 let recoveryAsset =
-                    { seedAsset with Branch = recoveryBranch; RebaseReferenceId = branchRebaseReferenceId; SaveReferenceId = explicitSaveReferenceId }
+                    { seedAsset with
+                        Root = stimulusRoot
+                        Branch = recoveryBranch
+                        RebaseReferenceId = branchRebaseReferenceId
+                        SaveReferenceId = explicitSaveReferenceId
+                    }
+
+                let fixtureIdentityErrors =
+                    RedisRestart.validateFixtureIdentity
+                        {
+                            SeedRootId = string seedAsset.Root.DirectoryVersionId
+                            RebaseRootId = string recoveryBranch.LatestReference.DirectoryId
+                            StimulusRootId = string stimulusRoot.DirectoryVersionId
+                            SeedStoragePoolId = string seedAsset.Manifest.StoragePoolId
+                            StimulusStoragePoolId = string recoveryAsset.Manifest.StoragePoolId
+                            SeedManifestAddress = string seedAsset.Manifest.ManifestAddress
+                            StimulusManifestAddress = string recoveryAsset.Manifest.ManifestAddress
+                            SeedContentBlockIdentity = string seedAsset.BlockAddress
+                            StimulusContentBlockIdentity = string recoveryAsset.BlockAddress
+                            SeedBytes = bytes
+                            StimulusBytes = Array.copy bytes
+                        }
+
+                let! stimulusManifestRelationshipBeforeSave =
+                    BaselineRuntime.exactRelationshipExistsAsync
+                        state
+                        (ExactRelationship.DirectoryVersionManifest
+                            {
+                                RepositoryId = repositoryId
+                                StoragePoolId = recoveryAsset.Manifest.StoragePoolId
+                                ManifestAddress = recoveryAsset.Manifest.ManifestAddress
+                                DirectoryVersionId = recoveryAsset.Root.DirectoryVersionId
+                            })
 
                 let! explicitDurableBaseline =
-                    RedisRestartRuntime.waitForDurableStateAsync
-                        state
-                        repositoryId
-                        recoveryAsset
-                        None
-                        beforeRestart.LogicalCount
-                        beforeRestart.WorkflowFingerprint
+                    RedisRestartRuntime.waitForDurableStateAsync state repositoryId seedAsset None beforeRestart.LogicalCount beforeRestart.WorkflowFingerprint
 
                 let branchSetupComplete =
                     RedisRestart.branchSetupComplete
@@ -431,13 +460,16 @@ type ManifestContributionRedisRestartMeasurementTests() =
                             ManifestRelationshipPresent = explicitDurableBaseline.ManifestRelationshipPresent
                             PhysicalActiveCount = explicitDurableBaseline.PhysicalActiveCount
                         }
+                    && fixtureIdentityErrors.Length = 0
+                    && not stimulusManifestRelationshipBeforeSave
 
                 let branchInventoryDetail = String.Join("; ", branchInventoryErrors)
+                let fixtureIdentityDetail = String.Join("; ", fixtureIdentityErrors)
 
                 recordAssertion
                     "redis-restart.branch-setup-delivery-completed"
                     branchSetupComplete
-                    $"persisted={rebasePersisted}; observed={branchRebaseObserved.Length}; messages={branchMessageDelta}; durations={branchDurationDelta}; inventory={branchInventoryDetail}; durable={explicitDurableBaseline.Detail}"
+                    $"persisted={rebasePersisted}; observed={branchRebaseObserved.Length}; messages={branchMessageDelta}; durations={branchDurationDelta}; inventory={branchInventoryDetail}; fixtureIdentity={fixtureIdentityDetail}; stimulusManifestBeforeSave={stimulusManifestRelationshipBeforeSave}; durable={explicitDurableBaseline.Detail}"
 
                 if not branchSetupComplete then
                     invalidOp "The explicit Reference was not created because the branch Rebase delivery did not settle before its baseline."

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
@@ -36,6 +36,23 @@ grace_manifest_contribution_messages_total{{otel_scope_name="Grace.ManifestContr
 grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_name="Grace.ManifestContributionAccounting",stage="settle",outcome="completed"}} {durations}
 """
 
+    let redisRestartAssertionIds =
+        [|
+            "redis-restart.seed-deliveries-completed"
+            "redis-restart.command-completed"
+            "redis-restart.fresh-health"
+            "redis-restart.protocol-ready"
+            "redis-restart.branch-setup-delivery-completed"
+            "redis-restart.stimulus-message-delta"
+            "redis-restart.stimulus-duration-delta"
+            "redis-restart.reference-root-present"
+            "redis-restart.manifest-relationship-present"
+            "redis-restart.logical-count-plus-one"
+            "redis-restart.workflow-unchanged"
+            "redis-restart.physical-active-count-one"
+            "redis-restart.evidence-integrity"
+        |]
+
     /// Creates one passing assertion with the supplied identifier.
     let passingAssertion assertionId = MeasurementAssertion.Create("run-1", "baseline", assertionId, true, "proved")
 
@@ -48,6 +65,94 @@ grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_n
     /// Verifies the Baseline assertion contract is an exact stable set.
     [<Test>]
     member _.RequiredAssertionIdentifiersAreExact() = Assert.That(Baseline.requiredAssertionIds = requiredAssertionIds, Is.True)
+
+    /// Verifies the Redis restart assertion contract is the exact owner-accepted set.
+    [<Test>]
+    member _.RedisRestartAssertionIdentifiersAreExact() = Assert.That(RedisRestart.requiredAssertionIds = redisRestartAssertionIds, Is.True)
+
+    /// Verifies a newer Healthy event and successful protocol operation satisfy three independent readiness gates.
+    [<Test>]
+    member _.RedisRestartRequiresFreshHealthyProtocolEvidence() =
+        let evaluation =
+            RedisRestart.evaluateReadiness { PostCommandResourceEventObserved = true; PostCommandHealth = "Healthy"; ProtocolOperationSucceeded = true }
+
+        Assert.That(evaluation.FreshResourceEvent, Is.True)
+        Assert.That(evaluation.Healthy, Is.True)
+        Assert.That(evaluation.ProtocolReady, Is.True)
+
+    /// Verifies a cached pre-command Healthy snapshot cannot satisfy fresh restart readiness.
+    [<Test>]
+    member _.RedisRestartRejectsStaleHealthySnapshot() =
+        let evaluation =
+            RedisRestart.evaluateReadiness { PostCommandResourceEventObserved = false; PostCommandHealth = "Healthy"; ProtocolOperationSucceeded = true }
+
+        Assert.That(evaluation.FreshResourceEvent, Is.False)
+        Assert.That(evaluation.Healthy, Is.True)
+        Assert.That(evaluation.ProtocolReady, Is.True)
+
+    /// Verifies a post-command resource event cannot substitute for Healthy and Redis protocol readiness.
+    [<TestCase("Unhealthy", true)>]
+    [<TestCase("Healthy", false)>]
+    member _.RedisRestartKeepsHealthAndProtocolReadinessIndependent(health, protocolSucceeded) =
+        let evaluation =
+            RedisRestart.evaluateReadiness
+                { PostCommandResourceEventObserved = true; PostCommandHealth = health; ProtocolOperationSucceeded = protocolSucceeded }
+
+        Assert.That(evaluation.FreshResourceEvent, Is.True)
+        Assert.That(evaluation.Healthy && evaluation.ProtocolReady, Is.False)
+
+    /// Verifies a branch setup delivery inside the explicit baseline overshoots the one-delivery stimulus contract.
+    [<Test>]
+    member _.RedisRestartRejectsBranchSetupCrossingExplicitBaseline() =
+        let beforeBranchSetup = completedMetrics 7 7
+        let afterBranchSetupAndStimulus = completedMetrics 9 9
+
+        match OpenMetrics.evaluateCompletedSettlementDelta 1L beforeBranchSetup afterBranchSetupAndStimulus with
+        | DeltaEvaluation.Invalid reason -> Assert.That(reason, Does.Contain("overshot"))
+        | result -> Assert.Fail($"Branch setup unexpectedly produced {result}.")
+
+    /// Verifies one exact post-restart delivery is the accepted settlement boundary.
+    [<Test>]
+    member _.RedisRestartAcceptsExactlyOneStimulusDelivery() =
+        let baseline = completedMetrics 7 7
+        let observed = completedMetrics 8 8
+
+        Assert.That(OpenMetrics.evaluateCompletedSettlementDelta 1L baseline observed, Is.EqualTo(DeltaEvaluation.Complete(1L, 1L)))
+
+    /// Verifies Redis exceptions and bounded timeouts remain terminal runtime failures in the shared summary seam.
+    [<TestCase("StackExchange.Redis.RedisConnectionException: connection unavailable")>]
+    [<TestCase("System.TimeoutException: Redis protocol readiness timed out")>]
+    member _.RedisRestartInfrastructureFailuresCannotProducePassingSummary(runtimeFailure) =
+        let assertions =
+            redisRestartAssertionIds
+            |> Array.map (fun assertionId -> MeasurementAssertion.Create("run-1", "redis-restart", assertionId, true, "proved"))
+
+        let summary = ScenarioSummary.derive "run-1" "redis-restart" redisRestartAssertionIds assertions [| runtimeFailure |] false
+
+        Assert.That(summary.Outcome, Is.EqualTo("Failed"))
+        Assert.That(summary.RuntimeFailures, Is.Not.Empty)
+
+    /// Verifies passing derives from exactly 13 unique Redis restart assertions and no caller-supplied count.
+    [<Test>]
+    member _.RedisRestartSummaryDerivesExactAssertionCount() =
+        let assertions =
+            redisRestartAssertionIds
+            |> Array.map (fun assertionId -> MeasurementAssertion.Create("run-1", "redis-restart", assertionId, true, "proved"))
+
+        let summary = ScenarioSummary.derive "run-1" "redis-restart" redisRestartAssertionIds assertions Array.empty false
+
+        Assert.That(summary.Outcome, Is.EqualTo("Passed"))
+        Assert.That(summary.RequiredAssertionCount, Is.EqualTo(13))
+        Assert.That(summary.PassedAssertionCount, Is.EqualTo(13))
+
+    /// Verifies a failed Redis restart prerequisite is Skipped with no assertion evidence or side-effect claim.
+    [<Test>]
+    member _.RedisRestartFailedPrerequisiteIsCleanSkip() =
+        let summary = ScenarioSummary.derive "run-1" "redis-restart" redisRestartAssertionIds Array.empty Array.empty true
+
+        Assert.That(summary.Outcome, Is.EqualTo("Skipped"))
+        Assert.That(summary.PassedAssertionCount, Is.Zero)
+        Assert.That(summary.RuntimeFailures, Is.Empty)
 
     /// Verifies exact production settlement samples complete only at the requested cumulative deltas.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
@@ -105,6 +105,63 @@ grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_n
     [<Test>]
     member _.RedisRestartAssertionIdentifiersAreExact() = Assert.That(RedisRestart.requiredAssertionIds = redisRestartAssertionIds, Is.True)
 
+    /// Verifies the +1 fixture requires one distinct stimulus root while retaining the exact seed manifest content identity.
+    [<Test>]
+    member _.RedisRestartFixtureIdentityRequiresDistinctRootWithSameManifestContent() =
+        let sharedBytes = [| 0uy; 1uy; 2uy; 255uy |]
+
+        let valid =
+            {
+                SeedRootId = "seed-root"
+                RebaseRootId = "rebase-root"
+                StimulusRootId = "stimulus-root"
+                SeedStoragePoolId = "pool"
+                StimulusStoragePoolId = "pool"
+                SeedManifestAddress = "manifest"
+                StimulusManifestAddress = "manifest"
+                SeedContentBlockIdentity = "block"
+                StimulusContentBlockIdentity = "block"
+                SeedBytes = sharedBytes
+                StimulusBytes = Array.copy sharedBytes
+            }
+
+        Assert.That(RedisRestart.validateFixtureIdentity valid, Is.Empty)
+
+        let sameRootErrors = RedisRestart.validateFixtureIdentity { valid with StimulusRootId = valid.SeedRootId }
+
+        Assert.That(sameRootErrors, Has.Some.Contains("distinct from the seed root"))
+
+    /// Verifies every retained manifest-content identity dimension participates in the +1 fixture gate.
+    [<TestCase("storage-pool")>]
+    [<TestCase("manifest")>]
+    [<TestCase("content-block")>]
+    [<TestCase("bytes")>]
+    member _.RedisRestartFixtureIdentityRejectsChangedManifestContent(dimension) =
+        let valid =
+            {
+                SeedRootId = "seed-root"
+                RebaseRootId = "rebase-root"
+                StimulusRootId = "stimulus-root"
+                SeedStoragePoolId = "pool"
+                StimulusStoragePoolId = "pool"
+                SeedManifestAddress = "manifest"
+                StimulusManifestAddress = "manifest"
+                SeedContentBlockIdentity = "block"
+                StimulusContentBlockIdentity = "block"
+                SeedBytes = [| 1uy; 2uy; 3uy |]
+                StimulusBytes = [| 1uy; 2uy; 3uy |]
+            }
+
+        let changed =
+            match dimension with
+            | "storage-pool" -> { valid with StimulusStoragePoolId = "different-pool" }
+            | "manifest" -> { valid with StimulusManifestAddress = "different-manifest" }
+            | "content-block" -> { valid with StimulusContentBlockIdentity = "different-block" }
+            | "bytes" -> { valid with StimulusBytes = [| 1uy; 2uy; 4uy |] }
+            | value -> invalidArg (nameof dimension) value
+
+        Assert.That(RedisRestart.validateFixtureIdentity changed, Is.Not.Empty)
+
     /// Verifies the seed branch can both accept its setup Save and parent the post-restart recovery branch.
     [<Test>]
     member _.RedisRestartSeedBranchPermissionsSupportSetupAndRecovery() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
@@ -105,6 +105,45 @@ grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_n
             )
         )
 
+    /// Verifies branch setup settles independently while the explicit-Reference hot-manifest baseline remains unchanged.
+    [<Test>]
+    member _.RedisRestartBranchSetupAcceptsPersistedRebaseAndUnchangedHotManifest() =
+        let observation =
+            {
+                RebasePersisted = true
+                ObservedEnvelopeCount = 1
+                MessageDelta = 1L
+                DurationDelta = 1L
+                IdentityInventoryClean = true
+                BeforeLogicalCount = 1L
+                BaselineLogicalCount = 1L
+                WorkflowUnchanged = true
+                ManifestRelationshipPresent = true
+                PhysicalActiveCount = 1L
+            }
+
+        Assert.That(RedisRestart.branchSetupComplete observation, Is.True)
+
+    /// Verifies setup cannot pass by mutating the hot-manifest count or observing an unpersisted Rebase identity.
+    [<TestCase(false, 1L)>]
+    [<TestCase(true, 2L)>]
+    member _.RedisRestartBranchSetupRejectsMissingRebaseOrHotManifestMutation(rebasePersisted, baselineLogicalCount) =
+        let observation =
+            {
+                RebasePersisted = rebasePersisted
+                ObservedEnvelopeCount = 1
+                MessageDelta = 1L
+                DurationDelta = 1L
+                IdentityInventoryClean = true
+                BeforeLogicalCount = 1L
+                BaselineLogicalCount = baselineLogicalCount
+                WorkflowUnchanged = true
+                ManifestRelationshipPresent = true
+                PhysicalActiveCount = 1L
+            }
+
+        Assert.That(RedisRestart.branchSetupComplete observation, Is.False)
+
     /// Verifies a newer Healthy event and successful protocol operation satisfy three independent readiness gates.
     [<Test>]
     member _.RedisRestartRequiresFreshHealthyProtocolEvidence() =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Unit.Tests
 
 open Grace.Server.Tests.Measurement
+open Grace.Types.Common
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -87,6 +88,22 @@ grace_manifest_contribution_processing_duration_milliseconds_count{{otel_scope_n
     /// Verifies the Redis restart assertion contract is the exact owner-accepted set.
     [<Test>]
     member _.RedisRestartAssertionIdentifiersAreExact() = Assert.That(RedisRestart.requiredAssertionIds = redisRestartAssertionIds, Is.True)
+
+    /// Verifies the seed branch can both accept its setup Save and parent the post-restart recovery branch.
+    [<Test>]
+    member _.RedisRestartSeedBranchPermissionsSupportSetupAndRecovery() =
+        Assert.That(
+            RedisRestart.promotionEnabledParentPermissions,
+            Is.EquivalentTo(
+                [|
+                    ReferenceType.Commit
+                    ReferenceType.Checkpoint
+                    ReferenceType.Save
+                    ReferenceType.Tag
+                    ReferenceType.Promotion
+                |]
+            )
+        )
 
     /// Verifies a newer Healthy event and successful protocol operation satisfy three independent readiness gates.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -279,6 +279,41 @@ module Baseline =
             "baseline.evidence-integrity"
         |]
 
+/// Captures the three independent signals required before a post-restart Reference may be created.
+type RedisRestartReadinessObservation = { PostCommandResourceEventObserved: bool; PostCommandHealth: string; ProtocolOperationSucceeded: bool }
+
+/// Reports each Redis readiness gate separately so stale health cannot be mistaken for recovery.
+type RedisRestartReadinessEvaluation = { FreshResourceEvent: bool; Healthy: bool; ProtocolReady: bool }
+
+/// Defines the exact assertion and readiness contracts for the Redis restart measurement.
+module RedisRestart =
+
+    /// Lists the only assertion identities permitted to produce a passing Redis restart summary.
+    let requiredAssertionIds =
+        [|
+            "redis-restart.seed-deliveries-completed"
+            "redis-restart.command-completed"
+            "redis-restart.fresh-health"
+            "redis-restart.protocol-ready"
+            "redis-restart.branch-setup-delivery-completed"
+            "redis-restart.stimulus-message-delta"
+            "redis-restart.stimulus-duration-delta"
+            "redis-restart.reference-root-present"
+            "redis-restart.manifest-relationship-present"
+            "redis-restart.logical-count-plus-one"
+            "redis-restart.workflow-unchanged"
+            "redis-restart.physical-active-count-one"
+            "redis-restart.evidence-integrity"
+        |]
+
+    /// Evaluates a post-command event, Healthy snapshot, and bounded Redis protocol result as independent gates.
+    let evaluateReadiness observation =
+        {
+            FreshResourceEvent = observation.PostCommandResourceEventObserved
+            Healthy = observation.PostCommandHealth.Equals("Healthy", StringComparison.Ordinal)
+            ProtocolReady = observation.ProtocolOperationSucceeded
+        }
+
 /// Derives a scenario outcome from exact assertion identities and the runtime-failure ledger.
 module ScenarioSummary =
 

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -302,6 +302,22 @@ type RedisRestartBranchSetupObservation =
         PhysicalActiveCount: int64
     }
 
+/// Captures the root and manifest-content identities that distinguish the Redis-restart +1 stimulus from same-root reuse.
+type RedisRestartFixtureIdentityObservation =
+    {
+        SeedRootId: string
+        RebaseRootId: string
+        StimulusRootId: string
+        SeedStoragePoolId: string
+        StimulusStoragePoolId: string
+        SeedManifestAddress: string
+        StimulusManifestAddress: string
+        SeedContentBlockIdentity: string
+        StimulusContentBlockIdentity: string
+        SeedBytes: byte array
+        StimulusBytes: byte array
+    }
+
 /// Defines the exact assertion and readiness contracts for the Redis restart measurement.
 module RedisRestart =
 
@@ -352,6 +368,32 @@ module RedisRestart =
         && observation.WorkflowUnchanged
         && observation.ManifestRelationshipPresent
         && observation.PhysicalActiveCount = 1L
+
+    /// Rejects a same-root no-op and any fixture drift away from the already-hot manifest's exact content identity.
+    let validateFixtureIdentity (observation: RedisRestartFixtureIdentityObservation) =
+        let errors = ResizeArray<string>()
+
+        if String.Equals(observation.StimulusRootId, observation.SeedRootId, StringComparison.Ordinal) then
+            errors.Add("The stimulus root must be distinct from the seed root.")
+
+        if String.Equals(observation.StimulusRootId, observation.RebaseRootId, StringComparison.Ordinal) then
+            errors.Add("The stimulus root must be distinct from the branch Rebase root.")
+
+        if not (String.Equals(observation.StimulusStoragePoolId, observation.SeedStoragePoolId, StringComparison.Ordinal)) then
+            errors.Add("The stimulus root must retain the seed StoragePool identity.")
+
+        if not (String.Equals(observation.StimulusManifestAddress, observation.SeedManifestAddress, StringComparison.Ordinal)) then
+            errors.Add("The stimulus root must retain the seed ManifestAddress.")
+
+        if not (String.Equals(observation.StimulusContentBlockIdentity, observation.SeedContentBlockIdentity, StringComparison.Ordinal)) then
+            errors.Add("The stimulus root must retain the seed ContentBlock identity.")
+
+        if isNull observation.SeedBytes
+           || isNull observation.StimulusBytes
+           || observation.StimulusBytes <> observation.SeedBytes then
+            errors.Add("The stimulus root must retain the seed manifest bytes.")
+
+        errors.ToArray()
 
 /// Captures structured diagnosis evidence and the action support derived by the production repair planner.
 type RepairDiagnosisEvidence =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -286,6 +286,21 @@ type RedisRestartReadinessObservation = { PostCommandResourceEventObserved: bool
 /// Reports each Redis readiness gate separately so stale health cannot be mistaken for recovery.
 type RedisRestartReadinessEvaluation = { FreshResourceEvent: bool; Healthy: bool; ProtocolReady: bool }
 
+/// Captures the independent persistence, delivery, and unchanged hot-manifest gates for post-restart branch setup.
+type RedisRestartBranchSetupObservation =
+    {
+        RebasePersisted: bool
+        ObservedEnvelopeCount: int
+        MessageDelta: int64
+        DurationDelta: int64
+        IdentityInventoryClean: bool
+        BeforeLogicalCount: int64
+        BaselineLogicalCount: int64
+        WorkflowUnchanged: bool
+        ManifestRelationshipPresent: bool
+        PhysicalActiveCount: int64
+    }
+
 /// Defines the exact assertion and readiness contracts for the Redis restart measurement.
 module RedisRestart =
 
@@ -324,6 +339,18 @@ module RedisRestart =
             Healthy = observation.PostCommandHealth.Equals("Healthy", StringComparison.Ordinal)
             ProtocolReady = observation.ProtocolOperationSucceeded
         }
+
+    /// Requires the automatic Rebase to settle independently without pretending it contributes the later hot-manifest stimulus.
+    let branchSetupComplete observation =
+        observation.RebasePersisted
+        && observation.ObservedEnvelopeCount = 1
+        && observation.MessageDelta = 1L
+        && observation.DurationDelta = 1L
+        && observation.IdentityInventoryClean
+        && observation.BaselineLogicalCount = observation.BeforeLogicalCount
+        && observation.WorkflowUnchanged
+        && observation.ManifestRelationshipPresent
+        && observation.PhysicalActiveCount = 1L
 
 /// Defines the only HotManifest assertion identities permitted to produce a passing summary.
 module HotManifest =

--- a/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
+++ b/src/Grace.Server.Unit.Tests/ManifestContributionMeasurement.fs
@@ -8,6 +8,7 @@ open System.Security.Cryptography
 open System.Text
 open System.Text.Json
 open System.Text.RegularExpressions
+open Grace.Types.Common
 
 /// Projects unbounded diagnostic sources into deterministic, inspectable evidence fields.
 module BoundedEvidence =
@@ -287,6 +288,16 @@ type RedisRestartReadinessEvaluation = { FreshResourceEvent: bool; Healthy: bool
 
 /// Defines the exact assertion and readiness contracts for the Redis restart measurement.
 module RedisRestart =
+
+    /// Grants the seed branch its normal writable References plus Promotion so it can parent the post-restart branch.
+    let promotionEnabledParentPermissions =
+        [|
+            ReferenceType.Commit
+            ReferenceType.Checkpoint
+            ReferenceType.Save
+            ReferenceType.Tag
+            ReferenceType.Promotion
+        |]
 
     /// Lists the only assertion identities permitted to produce a passing Redis restart summary.
     let requiredAssertionIds =


### PR DESCRIPTION
## Why this matters

Redis is a nonauthoritative replay accelerator. Grace needs reproducible evidence that losing and restarting it does not
block a genuinely new manifest contribution or replay the manifest's physical contribution.

## Summary

- restart the pinned Redis resource and require a fresh resource event, healthy state, and bounded protocol readiness;
- settle branch-created Rebase setup before the explicit stimulus baseline;
- create a distinct root DirectoryVersion that reuses the already-hot manifest, ContentBlock, and bytes;
- prove one new exact DirectoryVersion-manifest relationship advances the logical count `1 -> 2` while workflow history
  stays unchanged and physical active count remains `1`;
- reject accidental same-root reuse and identity drift through a pure test-only fixture seam;
- retain exact typed evidence for all 13 required assertions.

## Scope

The three-dot diff contains six declared test/support paths. There are no production actor, server, type, Redis,
workflow, retry, durable, public, SDK, CLI, OpenAPI, generated-contract, documentation, or topology changes.

## Validation

- TDD RED: Release build failed meaningfully with `FS0039` for the missing fixture-identity record and seam.
- `Grace.Server.Unit.Tests` Release build: passed with 0 warnings/errors.
- Manifest-contribution measurement tests: 60/60 passed.
- Present-relationship and HotManifest/HighlyShared regressions: 9/9 passed.
- `Grace.Server.Tests` Release build: passed with 0 warnings/errors.
- Hosted discovery: exactly one selected Redis-restart test.
- Runtime start 4: passed 1/1 at `3a09fe210aaf41022f1bbeca732c6f7caaddf669`.
- Runtime evidence: exact 13/13 unique assertions, logical `1 -> 2`, unchanged workflow, physical count `1`, completed
  message/duration deltas `1/1`, clean inventory, zero runtime failures, and clean Aspire/Docker teardown.
- Evidence directory:
  `C:\Users\scott\AppData\Local\Temp\grace-mca-evidence\759\d5fe6fe3b2214676912cc8fee8d475a5`.
- `git diff --check`: passed.
- Fast/Full were intentionally not stacked on the focused and hosted proof; GitHub Validate is the broad current-head
  gate.

## Review Status

- Current head: `3a09fe210aaf41022f1bbeca732c6f7caaddf669`.
- Required base: `ef0deffebe91d48369a0974841cfa48ac6bfc281`.
- Worker starts: 2/4.
- Runtime starts: 4, uncapped and serialized.
- Worker actual-diff self-review: no likely fix-now finding.
- Fresh review session 1: approved with no substantive findings using `gpt-5.6-terra`, High, `fork_turns: none`.
- GitHub Validate: run [30637737107](https://github.com/ScottArbeit/Grace/actions/runs/30637737107) passed for the current head.

## Docs and residual risk

No docs change is needed; #752 owns the final exact-SHA evidence packet and runbook. This proves the pinned local Redis
restart path and does not claim Azure availability, failover, compound-interruption recovery, or production SLOs.

Related to #759.
Part of #736 and #727.


