### PR TITLE
Fix DebugLocal PAT bootstrap persistence readiness

### DIFF
--- a/scripts/start-debuglocal.ps1
+++ b/scripts/start-debuglocal.ps1
@@ -21,8 +21,6 @@ param(
   [string] $TokenName = "local-dev",
   [int]    $TokenDays = 30,
   [int]    $StartupTimeoutSeconds = 240,
-  [int]    $TokenBootstrapMaxAttempts = 4,
-  [int]    $TokenBootstrapInitialBackoffSeconds = 1,
   [int]    $CleanupWaitSeconds = 5,
   [switch] $NoBuild,
   [switch] $NoTokenBootstrap,
@@ -215,7 +213,9 @@ function Get-WebFailureInfo(
   [string] $BootstrapUserId
 ) {
   $message = "Unknown error."
-  if ($null -ne $ErrorRecord -and $null -ne $ErrorRecord.Exception -and -not [string]::IsNullOrWhiteSpace($ErrorRecord.Exception.Message)) {
+  if ($null -ne $ErrorRecord -and $null -ne $ErrorRecord.ErrorDetails -and -not [string]::IsNullOrWhiteSpace($ErrorRecord.ErrorDetails.Message)) {
+    $message = $ErrorRecord.ErrorDetails.Message.Trim()
+  } elseif ($null -ne $ErrorRecord -and $null -ne $ErrorRecord.Exception -and -not [string]::IsNullOrWhiteSpace($ErrorRecord.Exception.Message)) {
     $message = $ErrorRecord.Exception.Message.Trim()
   }
 
@@ -259,6 +259,11 @@ function Get-WebFailureInfo(
     $hint = "$hint You can bypass this preflight with -SkipAuthProbe if intentionally testing without auth probe."
   }
 
+  if ($Stage -eq "token bootstrap" -and $retryable) {
+    $retryable = $false
+    $hint = "The PAT create outcome may be uncertain, so the request was not replayed. Inspect the preserved failure and server logs before retrying with a new token name."
+  }
+
   return New-FailureInfo `
     -Stage $Stage `
     -Classification $classification `
@@ -266,13 +271,6 @@ function Get-WebFailureInfo(
     -Retryable $retryable `
     -Message $message `
     -Hint $hint
-}
-
-function Get-RetryBackoffSeconds([int] $InitialBackoffSeconds, [int] $AttemptNumber) {
-  $safeInitialBackoff = [Math]::Max($InitialBackoffSeconds, 1)
-  $power = [Math]::Max($AttemptNumber - 1, 0)
-  $delay = [Math]::Min($safeInitialBackoff * [Math]::Pow(2, $power), 20)
-  return [int][Math]::Max([Math]::Round($delay), 1)
 }
 
 function Invoke-AuthProbe(
@@ -308,61 +306,43 @@ function Invoke-AuthProbe(
   Write-Detail "Auth readiness probe passed." "Green"
 }
 
-function Invoke-TokenBootstrapWithRetry(
+function Invoke-TokenBootstrap(
   [string] $GraceServerUri,
   [string] $BootstrapUserId,
-  [string] $RequestBodyJson,
-  [int] $MaxAttempts,
-  [int] $InitialBackoffSeconds
+  [string] $RequestBodyJson
 ) {
   $tokenUri = "$GraceServerUri/authenticate/token/create"
   $headers = @{ "x-grace-user-id" = $BootstrapUserId }
-  $safeMaxAttempts = [Math]::Max($MaxAttempts, 1)
-  $safeInitialBackoff = [Math]::Max($InitialBackoffSeconds, 1)
   $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-  for ($attempt = 1; $attempt -le $safeMaxAttempts; $attempt++) {
-    Write-Detail "Token bootstrap attempt $attempt/$safeMaxAttempts -> POST $tokenUri"
+  Write-Detail "Token bootstrap -> POST $tokenUri"
 
-    try {
-      $response = Invoke-RestMethod `
-        -Method Post `
-        -Uri $tokenUri `
-        -Headers $headers `
-        -ContentType "application/json" `
-        -Body $RequestBodyJson `
-        -TimeoutSec 20
+  try {
+    $response = Invoke-RestMethod `
+      -Method Post `
+      -Uri $tokenUri `
+      -Headers $headers `
+      -ContentType "application/json" `
+      -Body $RequestBodyJson `
+      -TimeoutSec 20
 
-      $stopwatch.Stop()
-      return [pscustomobject]@{
-        Response       = $response
-        Attempts       = $attempt
-        ElapsedSeconds = [Math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
-      }
-    } catch {
-      $failure = Get-WebFailureInfo -ErrorRecord $_ -Stage "token bootstrap" -GraceServerUri $GraceServerUri -BootstrapUserId $BootstrapUserId
-      Set-LastFailureInfo -FailureInfo $failure
-
-      $statusSegment = if ($null -eq $failure.StatusCode) { "no-http-status" } else { [string]$failure.StatusCode }
-      Write-Detail "Attempt $attempt failed (classification=$($failure.Classification), status=$statusSegment)." "Yellow"
-
-      $isLastAttempt = $attempt -ge $safeMaxAttempts
-      if (-not $failure.Retryable -or $isLastAttempt) {
-        $stopwatch.Stop()
-        $retrySegment = if ($failure.Retryable) { "retryable" } else { "non-retryable" }
-        throw (
-          "Token bootstrap failed after $attempt attempt(s) in $([Math]::Round($stopwatch.Elapsed.TotalSeconds, 2))s " +
-          "(classification=$($failure.Classification), status=$statusSegment, $retrySegment). $($failure.Hint)"
-        )
-      }
-
-      $delaySeconds = Get-RetryBackoffSeconds -InitialBackoffSeconds $safeInitialBackoff -AttemptNumber $attempt
-      Write-Detail "Transient failure detected. Retrying in $delaySeconds second(s)." "Yellow"
-      Start-Sleep -Seconds $delaySeconds
+    $stopwatch.Stop()
+    return [pscustomobject]@{
+      Response       = $response
+      Attempts       = 1
+      ElapsedSeconds = [Math]::Round($stopwatch.Elapsed.TotalSeconds, 2)
     }
-  }
+  } catch {
+    $failure = Get-WebFailureInfo -ErrorRecord $_ -Stage "token bootstrap" -GraceServerUri $GraceServerUri -BootstrapUserId $BootstrapUserId
+    Set-LastFailureInfo -FailureInfo $failure
+    $stopwatch.Stop()
 
-  throw "Token bootstrap exhausted unexpectedly without a terminal response."
+    $statusSegment = if ($null -eq $failure.StatusCode) { "no-http-status" } else { [string]$failure.StatusCode }
+    throw (
+      "Token bootstrap failed after one non-replayed request in $([Math]::Round($stopwatch.Elapsed.TotalSeconds, 2))s " +
+      "(classification=$($failure.Classification), status=$statusSegment). Failure: $($failure.Message) $($failure.Hint)"
+    )
+  }
 }
 
 function Get-DebugLocalDotnetProcesses([string] $ProjectPath, [string] $LaunchProfile) {
@@ -614,8 +594,6 @@ try {
   Write-Detail "Launch profile: $LaunchProfile"
   Write-Detail "Grace server URI: $GraceServerUri"
   Write-Detail "Startup timeout (seconds): $StartupTimeoutSeconds"
-  Write-Detail "Token max attempts: $TokenBootstrapMaxAttempts"
-  Write-Detail "Token initial backoff (seconds): $TokenBootstrapInitialBackoffSeconds"
   Write-Detail "NoBuild: $NoBuild"
   Write-Detail "NoTokenBootstrap: $NoTokenBootstrap"
   Write-Detail "SkipAuthProbe: $SkipAuthProbe"
@@ -766,12 +744,10 @@ try {
     Write-Detail "Token name: $requestedTokenName"
     Write-Detail "Token lifetime (days): $TokenDays"
 
-    $tokenBootstrapResult = Invoke-TokenBootstrapWithRetry `
+    $tokenBootstrapResult = Invoke-TokenBootstrap `
       -GraceServerUri $GraceServerUri `
       -BootstrapUserId $resolvedBootstrapUserId `
-      -RequestBodyJson $requestBody `
-      -MaxAttempts $TokenBootstrapMaxAttempts `
-      -InitialBackoffSeconds $TokenBootstrapInitialBackoffSeconds
+      -RequestBodyJson $requestBody
 
     Write-Detail "Token bootstrap completed in $($tokenBootstrapResult.Attempts) attempt(s), $($tokenBootstrapResult.ElapsedSeconds)s total." "Green"
 

--- a/src/Grace.Actors/PersonalAccessToken.Actor.fs
+++ b/src/Grace.Actors/PersonalAccessToken.Actor.fs
@@ -1,7 +1,6 @@
 namespace Grace.Actors
 
 open Grace.Actors.Constants
-open Grace.Actors.Context
 open Grace.Actors.Interfaces
 open Grace.Shared
 open Grace.Shared.Constants
@@ -12,6 +11,7 @@ open Microsoft.Extensions.Logging
 open NodaTime
 open Orleans
 open Orleans.Runtime
+open Orleans.Storage
 open System
 open System.Security.Cryptography
 open System.Threading.Tasks
@@ -46,7 +46,8 @@ module PersonalAccessToken =
     /// Implements the Orleans grain for personal access token actor.
     type PersonalAccessTokenActor
         (
-            [<PersistentState(StateName.PersonalAccessToken, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<PersonalAccessTokenState>
+            [<PersistentState(StateName.PersonalAccessToken, Grace.Shared.Constants.GraceActorStorage)>] state: IPersistentState<PersonalAccessTokenState>,
+            loggerFactory: ILoggerFactory
         ) =
         inherit Grain()
 
@@ -58,15 +59,22 @@ module PersonalAccessToken =
             tokenState <- if state.RecordExists then state.State else PersonalAccessTokenState.Empty
             Task.CompletedTask
 
-        /// Persists the updated PersonalAccessToken actor state through the Orleans storage provider.
-        member private this.SaveState() =
+        /// Persists a proposed PAT state before making it visible to later actor calls.
+        member private this.SaveState(proposedState: PersonalAccessTokenState) =
             task {
-                state.State <- tokenState
+                state.State <- proposedState
 
-                if tokenState.Tokens |> List.isEmpty then
-                    do! DefaultAsyncRetryPolicy.ExecuteAsync(fun () -> state.ClearStateAsync())
-                else
-                    do! DefaultAsyncRetryPolicy.ExecuteAsync(fun () -> state.WriteStateAsync())
+                try
+                    if proposedState.Tokens |> List.isEmpty then
+                        do! state.ClearStateAsync()
+                    else
+                        do! state.WriteStateAsync()
+
+                    tokenState <- proposedState
+                with
+                | ex ->
+                    state.State <- tokenState
+                    return raise ex
             }
 
         /// Builds the personal-access-token result returned after token state changes.
@@ -126,23 +134,47 @@ module PersonalAccessToken =
                             GroupIds = groupIds
                         }
 
-                    tokenState <- { tokenState with Tokens = record :: tokenState.Tokens }
-                    do! this.SaveState()
+                    let proposedState = { tokenState with Tokens = record :: tokenState.Tokens }
 
-                    let userId = this.GetPrimaryKeyString()
-                    let token = formatToken userId tokenId secret
-                    let summary = this.Summarize record
-                    let result = { Token = token; Summary = summary }
+                    let! persistenceResult =
+                        task {
+                            try
+                                do! this.SaveState proposedState
+                                return Ok()
+                            with
+                            | :? InconsistentStateException ->
+                                do! state.ReadStateAsync()
+                                tokenState <- if state.RecordExists then state.State else PersonalAccessTokenState.Empty
 
-                    log.LogInformation(
-                        "{CurrentInstant}: Created PAT for user {UserId}. CorrelationId: {CorrelationId}; TokenId: {TokenId}.",
-                        getCurrentInstantExtended (),
-                        userId,
-                        correlationId,
-                        tokenId
-                    )
+                                let persistedDuplicate =
+                                    tokenState.Tokens
+                                    |> List.exists (fun token -> token.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
 
-                    return Ok result
+                                if persistedDuplicate then
+                                    return Error(GraceError.Create "Token name already exists." correlationId)
+                                else
+                                    let refreshedProposal = { tokenState with Tokens = record :: tokenState.Tokens }
+                                    do! this.SaveState refreshedProposal
+                                    return Ok()
+                        }
+
+                    match persistenceResult with
+                    | Error error -> return Error error
+                    | Ok () ->
+                        let userId = this.GetPrimaryKeyString()
+                        let token = formatToken userId tokenId secret
+                        let summary = this.Summarize record
+                        let result = { Token = token; Summary = summary }
+
+                        log.LogInformation(
+                            "{CurrentInstant}: Created PAT for user {UserId}. CorrelationId: {CorrelationId}; TokenId: {TokenId}.",
+                            getCurrentInstantExtended (),
+                            userId,
+                            correlationId,
+                            tokenId
+                        )
+
+                        return Ok result
             }
 
         /// Returns list tokens data from the PersonalAccessToken actor state or related storage.
@@ -180,8 +212,8 @@ module PersonalAccessToken =
                         tokenState.Tokens
                         |> List.filter (fun token -> token.TokenId <> tokenId)
 
-                    tokenState <- { tokenState with Tokens = updated :: remaining }
-                    do! this.SaveState()
+                    let proposedState = { tokenState with Tokens = updated :: remaining }
+                    do! this.SaveState proposedState
                     return Ok(this.Summarize updated)
             }
 
@@ -211,8 +243,8 @@ module PersonalAccessToken =
                                 tokenState.Tokens
                                 |> List.filter (fun token -> token.TokenId <> tokenId)
 
-                            tokenState <- { tokenState with Tokens = updated :: remaining }
-                            do! this.SaveState()
+                            let proposedState = { tokenState with Tokens = updated :: remaining }
+                            do! this.SaveState proposedState
 
                             let result = { TokenId = record.TokenId; UserId = this.GetPrimaryKeyString(); Claims = record.Claims; GroupIds = record.GroupIds }
 

--- a/src/Grace.Server.Tests/Auth.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Auth.Server.Tests.fs
@@ -128,6 +128,30 @@ type AuthEndpoints() =
             Assert.That(meValue.ReturnValue.GraceUserId, Is.EqualTo(testUserId))
         }
 
+    /// Verifies a real case-insensitive duplicate PAT name remains a bad request.
+    [<Test>]
+    member _.AuthTokenDuplicateNameRejected() =
+        task {
+            let parameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
+            parameters.TokenName <- $"pat-{System.Guid.NewGuid():N}"
+            let! createResponse = Client.PostAsync("/authenticate/token/create", createJsonContent parameters)
+            createResponse.EnsureSuccessStatusCode() |> ignore
+            let! createdReturn = deserializeContent<GraceReturnValue<PersonalAccessTokenCreated>> createResponse
+
+            let duplicateParameters = Grace.Shared.Parameters.Auth.CreatePersonalAccessTokenParameters()
+            duplicateParameters.TokenName <- parameters.TokenName.ToUpperInvariant()
+            let! duplicateResponse = Client.PostAsync("/authenticate/token/create", createJsonContent duplicateParameters)
+            let! duplicateBody = duplicateResponse.Content.ReadAsStringAsync()
+
+            Assert.That(duplicateResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+            Assert.That(duplicateBody, Does.Contain("Token name already exists."))
+
+            let revokeParameters = Grace.Shared.Parameters.Auth.RevokePersonalAccessTokenParameters()
+            revokeParameters.TokenId <- createdReturn.ReturnValue.Summary.TokenId
+            let! revokeResponse = Client.PostAsync("/authenticate/token/revoke", createJsonContent revokeParameters)
+            revokeResponse.EnsureSuccessStatusCode() |> ignore
+        }
+
     /// Verifies the auth token revoke blocks access scenario.
     [<Test>]
     member _.AuthTokenRevokeBlocksAccess() =

--- a/src/Grace.Server.Unit.Tests/CosmosWarmup.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/CosmosWarmup.Server.Tests.fs
@@ -1,0 +1,42 @@
+namespace Grace.Server.Tests
+
+open Grace.Server.Application
+open Microsoft.Extensions.Logging.Abstractions
+open NUnit.Framework
+open System
+open System.Threading.Tasks
+
+/// Covers the local Cosmos write-readiness gate without starting Aspire.
+[<Parallelizable(ParallelScope.All)>]
+type CosmosWarmupServerTests() =
+
+    /// Verifies failed sentinel cleanup prevents readiness until that same sentinel is removed.
+    [<Test>]
+    member _.CleanupFailurePreventsReadiness() =
+        task {
+            let mutable writeAttempts = 0
+            let mutable deleteAttempts = 0
+            let mutable delays = 0
+
+            let writeSentinel _ =
+                writeAttempts <- writeAttempts + 1
+                Task.CompletedTask
+
+            let deleteSentinel _ =
+                deleteAttempts <- deleteAttempts + 1
+
+                if deleteAttempts = 1 then
+                    Task.FromException(InvalidOperationException("simulated sentinel cleanup failure"))
+                else
+                    Task.CompletedTask
+
+            let delay _ =
+                delays <- delays + 1
+                Task.CompletedTask
+
+            do! waitForLocalCosmosWriteReadiness 3 writeSentinel deleteSentinel delay NullLogger.Instance TestContext.CurrentContext.CancellationToken
+
+            Assert.That(writeAttempts, Is.EqualTo(1), "Cleanup retry must not create another sentinel.")
+            Assert.That(deleteAttempts, Is.EqualTo(2), "Readiness requires successful cleanup.")
+            Assert.That(delays, Is.EqualTo(1))
+        }

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="TestCommon.fs" />
+    <Compile Include="CosmosWarmup.Server.Tests.fs" />
     <Compile Include="AuthMapping.Unit.Tests.fs" />
     <Compile Include="Authorization.Unit.Tests.fs" />
     <Compile Include="CreatorScopeAdminGrant.Unit.Tests.fs" />
@@ -48,6 +49,7 @@
     <Compile Include="PromotionSet.CommandValidation.Tests.fs" />
     <Compile Include="PromotionSet.DirectoryHash.Tests.fs" />
     <Compile Include="Diff.Actor.Tests.fs" />
+    <Compile Include="PersonalAccessToken.Actor.Tests.fs" />
     <Compile Include="UploadSession.Actor.Tests.fs" />
     <Compile Include="ContentBlockMetadata.Actor.Tests.fs" />
     <Compile Include="RepositoryContentCounter.Actor.Tests.fs" />

--- a/src/Grace.Server.Unit.Tests/PersonalAccessToken.Actor.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/PersonalAccessToken.Actor.Tests.fs
@@ -1,0 +1,70 @@
+namespace Grace.Server.Tests
+
+open Grace.Actors
+open Grace.Actors.Interfaces
+open Grace.Types.PersonalAccessToken
+open Microsoft.Extensions.Logging.Abstractions
+open NodaTime
+open NUnit.Framework
+open Orleans.Runtime
+open System
+open System.Threading.Tasks
+
+/// Records attempted PAT writes while deterministically rejecting persistence.
+type private RejectingPersonalAccessTokenState() =
+    let mutable state = PersonalAccessToken.PersonalAccessTokenState.Empty
+    let mutable writeCount = 0
+
+    member _.WriteCount = writeCount
+
+    interface IPersistentState<PersonalAccessToken.PersonalAccessTokenState> with
+        member _.State
+            with get () = state
+            and set value = state <- value
+
+        member _.Etag = null
+
+        member _.RecordExists = false
+
+        member _.ReadStateAsync() = Task.CompletedTask
+
+        member _.WriteStateAsync() =
+            writeCount <- writeCount + 1
+            Task.FromException(InvalidOperationException("simulated PAT persistence failure"))
+
+        member _.ClearStateAsync() = Task.CompletedTask
+
+/// Covers PAT actor durability behavior without Aspire.
+[<NonParallelizable>]
+type PersonalAccessTokenActorTests() =
+
+    /// Verifies a failed durable write cannot create an in-memory duplicate on retry.
+    [<Test>]
+    member _.CreateFailureDoesNotRetainTokenName() =
+        task {
+            let persistentState = RejectingPersonalAccessTokenState()
+            let actor = PersonalAccessToken.PersonalAccessTokenActor(persistentState, NullLoggerFactory.Instance)
+            let personalAccessTokenActor = actor :> IPersonalAccessTokenActor
+            let now = Instant.FromUtc(2026, 8, 1, 12, 0)
+
+            let invoke attempt =
+                task {
+                    try
+                        let! result = personalAccessTokenActor.CreateToken "local-dev" [] [] None now $"correlation-{attempt}"
+                        return Choice1Of2 result
+                    with
+                    | ex -> return Choice2Of2 ex
+                }
+
+            let! firstFailure = invoke 1
+            let! secondFailure = invoke 2
+            let failures = [ firstFailure; secondFailure ]
+
+            Assert.That(persistentState.WriteCount, Is.EqualTo(2), "Each request should reach durable persistence.")
+
+            for failure in failures do
+                match failure with
+                | Choice1Of2 (Ok _) -> Assert.Fail("A PAT must not be returned after persistence fails.")
+                | Choice1Of2 (Error error) -> Assert.Fail($"Failed persistence became a domain error: {error.Error}")
+                | Choice2Of2 ex -> Assert.That(ex.Message, Is.EqualTo("simulated PAT persistence failure"))
+        }

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -73,32 +73,126 @@ open System.Security.Claims
 /// Contains Grace Server application behavior and supporting helpers.
 module Application =
 
+    /// Waits until a local Cosmos sentinel write and its cleanup have both completed successfully.
+    let internal waitForLocalCosmosWriteReadiness
+        maxAttempts
+        (writeSentinel: CancellationToken -> Task)
+        (deleteSentinel: CancellationToken -> Task)
+        (delay: CancellationToken -> Task)
+        (log: ILogger)
+        (ct: CancellationToken)
+        =
+        task {
+            let mutable attempt = 0
+            let mutable writeConfirmed = false
+            let mutable ready = false
+            let mutable lastFailure: exn = null
+
+            while not ready && attempt < maxAttempts do
+                ct.ThrowIfCancellationRequested()
+                attempt <- attempt + 1
+
+                try
+                    if not writeConfirmed then
+                        do! writeSentinel ct
+                        writeConfirmed <- true
+
+                    do! deleteSentinel ct
+                    writeConfirmed <- false
+                    ready <- true
+                with
+                | ex ->
+                    lastFailure <- ex
+                    log.LogWarning("Cosmos DB container write probe not ready, retry {Try}...", attempt)
+
+                    if attempt < maxAttempts then do! delay ct
+
+            if not ready then
+                return raise (TimeoutException("Cosmos DB container did not become write-ready in time.", lastFailure))
+        }
+
     /// Represents cosmos warmup used by Grace Server APIs and background services.
-    type CosmosWarmup(cosmosClient: CosmosClient, log: ILogger<CosmosWarmup>) =
+    type CosmosWarmup(cosmosClient: CosmosClient, configuration: IConfiguration, log: ILogger<CosmosWarmup>) =
         interface IHostedService with
             /// Starts the host service after configuration bootstrap has completed.
             member _.StartAsync(ct: CancellationToken) : Task =
                 log.LogInformation("Waiting for Cosmos DB emulator to be ready...")
 
-                /// Implements rec for the server request pipeline.
-                let rec loop i =
-                    task {
-                        if i > 120 || ct.IsCancellationRequested then
-                            log.LogError("Cosmos DB emulator was not ready in time.")
+                let debugEnvironment = configuration[getConfigKey Constants.EnvironmentVariables.DebugEnvironment]
+                let isLocal = String.Equals(debugEnvironment, "Local", StringComparison.OrdinalIgnoreCase)
+
+                if isLocal then
+                    let databaseName = configuration[getConfigKey Constants.EnvironmentVariables.AzureCosmosDBDatabaseName]
+                    let containerName = configuration[getConfigKey Constants.EnvironmentVariables.AzureCosmosDBContainerName]
+
+                    if
+                        String.IsNullOrWhiteSpace(databaseName)
+                        || String.IsNullOrWhiteSpace(containerName)
+                    then
+                        invalidOp "Local Cosmos DB database and container names are required for write-readiness probing."
+
+                    let container = cosmosClient.GetContainer(databaseName, containerName)
+                    let sentinelId = $"grace-write-readiness-{Guid.NewGuid():N}"
+                    let sentinelPartitionKey = sentinelId
+                    let sentinel = Dictionary<string, obj>()
+                    sentinel["id"] <- sentinelId
+                    sentinel["PartitionKey"] <- sentinelPartitionKey
+                    sentinel["kind"] <- "grace-cosmos-write-readiness"
+
+                    /// Confirms the configured local Cosmos container accepts a durable item write.
+                    let writeSentinel probeCt =
+                        task {
+                            let! _ = cosmosClient.ReadAccountAsync()
+
+                            let! _ = container.UpsertItemAsync(sentinel, PartitionKey sentinelPartitionKey, cancellationToken = probeCt)
+
                             return ()
-                        else
+                        }
+                        :> Task
+
+                    /// Removes the local readiness sentinel, accepting confirmed absence after an uncertain delete response.
+                    let deleteSentinel probeCt =
+                        task {
                             try
-                                let! _ = cosmosClient.ReadAccountAsync()
-                                log.LogInformation("Cosmos DB emulator ready.")
+                                let! _ =
+                                    container.DeleteItemAsync<Dictionary<string, obj>>(
+                                        sentinelId,
+                                        PartitionKey sentinelPartitionKey,
+                                        cancellationToken = probeCt
+                                    )
+
                                 return ()
                             with
-                            | ex ->
-                                log.LogWarning("Cosmos DB emulator not ready, retry {Try}...", i)
-                                do! Task.Delay(1000, ct)
-                                return! loop (i + 1)
-                    }
+                            | :? CosmosException as ex when ex.StatusCode = System.Net.HttpStatusCode.NotFound ->
+                                // A previous delete may have committed before its response was lost.
+                                // NotFound confirms that cleanup is complete.
+                                return ()
 
-                loop 1 :> Task
+                        }
+                        :> Task
+
+                    waitForLocalCosmosWriteReadiness 120 writeSentinel deleteSentinel (fun probeCt -> Task.Delay(250, probeCt)) log ct :> Task
+                else
+
+                    /// Implements rec for the server request pipeline.
+                    let rec loop i =
+                        task {
+                            if i > 120 || ct.IsCancellationRequested then
+                                log.LogError("Cosmos DB emulator was not ready in time.")
+                                return ()
+                            else
+                                try
+                                    let! _ = cosmosClient.ReadAccountAsync()
+                                    log.LogInformation("Cosmos DB emulator ready.")
+                                    return ()
+                                with
+                                | ex ->
+                                    log.LogWarning("Cosmos DB emulator not ready, retry {Try}...", i)
+                                    do! Task.Delay(1000, ct)
+                                    return! loop (i + 1)
+                        }
+
+                    loop 1 :> Task
 
             /// Stops the host service during graceful server shutdown.
             member _.StopAsync(_ct: CancellationToken) : Task = Task.CompletedTask

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -128,25 +128,27 @@ These are script parameters (not environment variables):
 
 - `-SkipAuthProbe`: skip auth preflight (`/authenticate/oidc/config`, `/authenticate/me`).
 - `-NoTokenBootstrap`: skip PAT creation.
-- `-TokenBootstrapMaxAttempts`: set max token bootstrap attempts.
-- `-TokenBootstrapInitialBackoffSeconds`: set initial retry backoff.
 - `-StartupTimeoutSeconds`: set health wait timeout.
 - `-CleanupWaitSeconds`: set process cleanup wait timeout.
+
+PAT bootstrap sends one create request after the health and auth readiness checks pass. A failed or uncertain create is
+not replayed because token creation is non-idempotent. The failure diagnostics preserve the endpoint error so a storage
+failure is not replaced by a later duplicate-name response.
 
 PowerShell:
 
 ```powershell
 pwsh ./scripts/start-debuglocal.ps1 `
-  -TokenBootstrapMaxAttempts 5 `
-  -TokenBootstrapInitialBackoffSeconds 2
+  -StartupTimeoutSeconds 300 `
+  -CleanupWaitSeconds 10
 ```
 
 bash / zsh:
 
 ```bash
 pwsh ./scripts/start-debuglocal.ps1 \
-  --TokenBootstrapMaxAttempts 5 \
-  --TokenBootstrapInitialBackoffSeconds 2
+  --StartupTimeoutSeconds 300 \
+  --CleanupWaitSeconds 10
 ```
 
 ## DebugLocal Diagnostics Artifacts


### PR DESCRIPTION
# Fix DebugLocal PAT bootstrap persistence readiness

Closes #778.

## Why this matters

Developers need `pwsh ./scripts/dev-local.ps1` to create a usable DebugLocal personal access token only after its
durable actor state can be written. A healthy HTTP endpoint or a successful account read must not be mistaken for
Cosmos write readiness.

## Summary

- Create the DebugLocal bootstrap PAT once, without replaying an uncertain non-idempotent request, and retain the
  endpoint error detail in the terminal output.
- Persist proposed PAT state before publishing it in the actor and reconcile an ETag conflict from authoritative
  persisted state.
- Gate only local Cosmos startup readiness on a private sentinel upsert and confirmed cleanup; this runs for retained,
  reconciled, and replaced DebugLocal resources without changing their container lifetime.
- Add deterministic failed-persistence and sentinel-cleanup tests, plus public duplicate-name integration coverage.
- Remove the obsolete bootstrap retry switches from the environment documentation.

## Contract and scope

- Product V1 behavior only; no migration or compatibility behavior.
- No public route, DTO, CLI, SDK, OpenAPI, generated artifact, event, or persisted-shape contract changed.
- The sentinel is local-only, uniquely identified, and may not enumerate, reset, or mutate user data. An
  unconfirmed cleanup leaves startup unavailable.
- Container lifetime is intentionally unchanged: the acceptance run starts a new AppHost and Grace Server against
  retained DebugLocal Cosmos, Azurite, and Service Bus containers.

## Validation

- `Grace.Server.Unit.Tests` Release build: passed with zero warnings and errors.
- Focused `CosmosWarmupServerTests|PersonalAccessTokenActorTests.CreateFailureDoesNotRetainTokenName`: passed, 2/2.
- `Grace.Server.Tests` Release build: passed with zero warnings and errors.
- Focused `AuthEndpoints.AuthTokenDuplicateNameRejected` Aspire integration test: passed, 1/1.
- New AppHost/Grace Server startup: one bootstrap create, token authentication and listing, case-insensitive
  duplicate rejection, and revoke all passed.
- Fantomas, PowerShell parsing, MarkdownLint, `git diff --check`, and staged-diff hygiene: passed.
- Fast and Full were intentionally not run; focused Release proof plus current GitHub Validate is the selected gate.

## Review status

- Head: `3550aca185f43b68cb8f5894c25e2ffce79e4725`
- GitHub Validate: pending for this exact head.
- Fresh read-only review: pending for this exact head with GPT-5.6-Terra at extra-high reasoning.
