### PR TITLE
Isolate split-approval selector test state

### DIFF
--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -746,8 +746,8 @@ type ApprovalApiIntegrationTests() =
     [<TestCase("role:BranchApprovalResponder", "repo", "RepositoryApprovalResponder")>]
     member _.ResponseRejectsMismatchedSplitApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string) =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
+            let repositoryId = $"{Guid.NewGuid()}"
+            let branchId = $"{Guid.NewGuid()}"
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
 

--- a/src/Grace.Server.Tests/Approval.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Approval.Server.Tests.fs
@@ -86,6 +86,25 @@ module private ApprovalTestHelpers =
             return! client.PostAsync("/authorize/grant-role", createJsonContent parameters)
         }
 
+    /// Creates a repository and returns its fresh repository and default branch scope identities.
+    let createRepositoryScopeAsync () =
+        task {
+            let repositoryId = $"{Guid.NewGuid()}"
+            let parameters = Parameters.Repository.CreateRepositoryParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.RepositoryName <- $"ApprovalRepository{Guid.NewGuid():N}"
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            let! response = Client.PostAsync("/repository/create", createJsonContent parameters)
+            let! responseText = response.Content.ReadAsStringAsync()
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseText)
+            let returnValue = deserialize<GraceReturnValue<string>> responseText
+            let branchId = Common.requireGuidProperty (nameof BranchId) returnValue.Properties[nameof BranchId]
+            return repositoryId, $"{branchId}"
+        }
+
     /// Builds create policy parameters for route calls.
     let createPolicyParameters (repositoryId: string) (branchId: string) =
         let parameters = Parameters.Approval.CreateApprovalPolicyParameters()
@@ -703,8 +722,7 @@ type ApprovalApiIntegrationTests() =
     [<Test>]
     member _.ResponseRejectsResponderRoleCallerWhenSelectorDoesNotMatch() =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
+            let! repositoryId, branchId = ApprovalTestHelpers.createRepositoryScopeAsync ()
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId "group:release-managers"
 
@@ -724,8 +742,7 @@ type ApprovalApiIntegrationTests() =
     [<TestCase("role:ApprovalResponder", "branch", "BranchApprovalResponder", true)>]
     member _.ResponseAcceptsApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string, grantAtBranch: bool) =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
+            let! repositoryId, branchId = ApprovalTestHelpers.createRepositoryScopeAsync ()
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
 
@@ -746,8 +763,7 @@ type ApprovalApiIntegrationTests() =
     [<TestCase("role:BranchApprovalResponder", "repo", "RepositoryApprovalResponder")>]
     member _.ResponseRejectsMismatchedSplitApprovalResponderRoleSelectors(selector: string, scopeKind: string, roleId: string) =
         task {
-            let repositoryId = $"{Guid.NewGuid()}"
-            let branchId = $"{Guid.NewGuid()}"
+            let! repositoryId, branchId = ApprovalTestHelpers.createRepositoryScopeAsync ()
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId selector
 
@@ -772,8 +788,7 @@ type ApprovalApiIntegrationTests() =
     [<Test>]
     member _.BodySuppliedScopeEscalationDoesNotBypassStoredScope() =
         task {
-            let repositoryId = repositoryIds[0]
-            let allowedBranchId = repositoryDefaultBranchIds[0]
+            let! repositoryId, allowedBranchId = ApprovalTestHelpers.createRepositoryScopeAsync ()
             let storedBranchId = $"{Guid.NewGuid()}"
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId storedBranchId $"user:{userId}"
@@ -793,8 +808,7 @@ type ApprovalApiIntegrationTests() =
     [<Test>]
     member _.DuplicateResponseIsIdempotentAfterTerminalDecision() =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
+            let! repositoryId, branchId = ApprovalTestHelpers.createRepositoryScopeAsync ()
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 
@@ -815,8 +829,7 @@ type ApprovalApiIntegrationTests() =
     [<Test>]
     member _.RequestHistoryReturnsActorBackedEventsFromStoredRepositoryPartition() =
         task {
-            let repositoryId = repositoryIds[0]
-            let branchId = repositoryDefaultBranchIds[0]
+            let! repositoryId, branchId = ApprovalTestHelpers.createRepositoryScopeAsync ()
             let userId = $"{Guid.NewGuid()}"
             let! requestId = ApprovalTestHelpers.seedRequest repositoryId branchId $"user:{userId}"
 


### PR DESCRIPTION
## Linked issue

Related to #782

## Summary

Isolates the split-approval selector integration test from durable AccessControl actors populated by preceding full-suite tests. Each parameter case now uses fresh repository and branch identities, so role-grant setup reaches the intended selector mismatch assertion deterministically. Production approval, authorization, actor, route, and error behavior is unchanged.

## Touched paths

- `src/Grace.Server.Tests/Approval.Server.Tests.fs`

## Owned-path compliance

- [x] Changed path matches issue #782.
- [x] No production or shared helper path was edited.
- [x] No alternate task ledger was created.

## Validation profile and public-boundary evidence

- Validation profile: `server-api` integration proof.
- Boundary: approval seed, role-grant, and approval response HTTP routes.
- RED evidence: the same branch-scoped case failed in Full runs 30798087678 and 30800747674 after one minute with role-grant HTTP 500.
- Focused evidence: both prior state producers and both mismatch parameter cases pass together.

## Minimum detail gate evidence

- Invariant: each test case owns an isolated owner/org/repo/branch scope identity and reaches selector validation.
- Durable state producer: AccessControl actors keyed by complete repository or branch scope.
- Forbidden shapes avoided: no retries, sleeps, swallowed 500, weakened status, broad serialization, or production change.
- Positive: isolated role grant and seeded request setup succeed.
- Regression/negative: both mismatched selector cases still assert `BadRequest`.
- Boundary: repository- and branch-scoped cases both pass after the preceding shared-state producers.
- Stale-state proof: fresh repository and branch GUIDs cannot address actors populated by prior fixture-identity tests.
- Contract propagation: production/API/SDK/DTO/OpenAPI/generated/persisted/events/docs unchanged.

## Test coverage changes

- [x] Existing integration test updated to isolate its durable scope identities; assertions are unchanged.

## Risk surfaces

- [x] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] Server or API contract
- [x] Orleans actor behavior
- [ ] CLI public contract
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow

## Docs impact

- [x] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Local focused evidence

- [x] Targeted Fantomas: unchanged.
- [x] Release build: 0 warnings, 0 errors.
- [x] Focused Aspire filter with the two identified producer tests and two parameter cases: 6/6 passed.
- [x] `git diff --check` and `git show --check` passed.
- [x] Base freshness: branch is one commit ahead of current `origin/main`.

## Optional local broad preflight

- Neither Fast nor Full; focused Aspire proves the integration seam and GitHub Validate is the required broad gate.

## Required CI evidence

- Current head SHA: `5e12e9b6347da059044b1bb534bb5b6ac8bc8a42`
- GitHub Validate: pending.
- Run link: pending.
- [ ] Same-head result confirmed.

## Residual risks

Full-suite ordering is the producer that focused clean runs could not force to fail. Fresh scope identity removes the shared actor key; current-head Validate must confirm the full-suite result.

## Review Status

- Worker starts: 1/4.
- Substantive review cycles: 0.
- Current head: `5e12e9b6347da059044b1bb534bb5b6ac8bc8a42`
- Fresh review: pending.
- Validate: pending.
- [ ] Review and checks pass on the same head.

## Review/fix prevention

- Root-cause class: authority-source gap / test isolation.
- Prevention: issue #782 names actor scope identity as the isolation unit; no broader template/docs change needed unless this pattern recurs.

## Rollback or recovery notes

Test-only identity isolation. Revert the commit if it masks a product failure; no runtime or persisted product data is changed.

## Docs follow-up required

None.

