### PR TITLE
Make verbose CLI identity defaults and create IDs truthful

### DIFF
--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -259,6 +259,7 @@ namespace Grace.CLI.Tests
 open FsUnit
 open Grace.CLI
 open Grace.CLI.Command
+open Grace.CLI.Text
 open Grace.SDK
 open Grace.Shared
 open Grace.Shared.Client
@@ -431,6 +432,7 @@ module HelpDoesNotReadConfigTests =
             action tempDir
         finally
             Environment.CurrentDirectory <- originalDir
+            resetConfiguration ()
 
             if Directory.Exists(tempDir) then
                 try
@@ -2137,6 +2139,206 @@ module HelpDoesNotReadConfigTests =
             output |> should contain $"{orgId}"
             output |> should contain $"{repoId}"
             output |> should contain $"{branchId}")
+
+    /// Verifies that verbose create output describes deferred hierarchy identities instead of the empty parser sentinel.
+    [<Test>]
+    let ``verbose repository create describes implicit hierarchy identities symbolically`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "repository"
+                        "create"
+                        "--repository-name"
+                        "truthful-identities"
+                        "--output"
+                        "Verbose"
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Common.resolveCreateGraceIdsWith (fun () -> Guid.Parse("99999999-9999-9999-9999-999999999999")) OptionName.RepositoryId parseResult
+
+            let output = captureOutput (fun () -> Common.printParseResultWithResolvedValues parseResult (Some graceIds))
+
+            output
+            |> should contain "owner-id: current OwnerId"
+
+            output
+            |> should contain "organization-id: current OrganizationId"
+
+            output |> should contain "repository-id: new Guid"
+
+            output
+            |> should not' (contain "00000000-0000-0000-0000-000000000000"))
+
+    /// Verifies that every hierarchy create request reuses the exact ID shown in resolved verbose output.
+    [<Test>]
+    let ``hierarchy create requests reuse their single resolved identity`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+            let createdId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+            let cases =
+                [
+                    [|
+                        "owner"
+                        "create"
+                        "--owner-name"
+                        "owner-name"
+                        "--output"
+                        "Verbose"
+                    |],
+                    OptionName.OwnerId,
+                    "OwnerId",
+                    (fun _ graceIds ->
+                        (Grace.CLI.Command.Owner.buildCreateParameters graceIds)
+                            .OwnerId)
+                    [|
+                        "organization"
+                        "create"
+                        "--organization-name"
+                        "organization-name"
+                        "--output"
+                        "Verbose"
+                    |],
+                    OptionName.OrganizationId,
+                    "OrganizationId",
+                    (fun _ graceIds ->
+                        (Grace.CLI.Command.Organization.buildCreateParameters graceIds)
+                            .OrganizationId)
+                    [|
+                        "repository"
+                        "create"
+                        "--repository-name"
+                        "repository-name"
+                        "--output"
+                        "Verbose"
+                    |],
+                    OptionName.RepositoryId,
+                    "RepositoryId",
+                    (fun _ graceIds ->
+                        (Grace.CLI.Command.Repository.buildCreateParameters graceIds)
+                            .RepositoryId)
+                    [|
+                        "branch"
+                        "create"
+                        "--branch-name"
+                        "branch-name"
+                        "--output"
+                        "Verbose"
+                    |],
+                    OptionName.BranchId,
+                    "BranchId",
+                    (fun parseResult graceIds ->
+                        (Grace.CLI.Command.Branch.buildCreateParameters parseResult graceIds String.Empty String.Empty)
+                            .BranchId)
+                ]
+
+            for args, createdIdOptionName, resolvedLabel, requestId in cases do
+                let parseResult = GraceCommand.rootCommand.Parse(args)
+                parseResult.Errors.Count |> should equal 0
+                let mutable generatedCount = 0
+
+                let graceIds =
+                    Common.resolveCreateGraceIdsWith
+                        (fun () ->
+                            generatedCount <- generatedCount + 1
+                            createdId)
+                        createdIdOptionName
+                        parseResult
+
+                generatedCount |> should equal 1
+
+                let output = captureOutput (fun () -> Common.printParseResultWithResolvedValues parseResult (Some graceIds))
+
+                output
+                |> should contain $"{resolvedLabel}: {createdId}"
+
+                requestId parseResult graceIds
+                |> should equal (createdId.ToString())
+
+                output
+                |> should contain $"{createdIdOptionName}: new Guid"
+
+                output
+                |> should not' (contain $"{resolvedLabel}: {Guid.Empty}"))
+
+    /// Verifies that an explicit create ID remains unchanged and bypasses ID generation.
+    [<Test>]
+    let ``explicit repository create identity is displayed and sent unchanged`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+            let explicitId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "repository"
+                        "create"
+                        "--repository-name"
+                        "explicit-identity"
+                        "--repository-id"
+                        explicitId.ToString()
+                        "--output"
+                        "Verbose"
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds =
+                Common.resolveCreateGraceIdsWith
+                    (fun () ->
+                        Assert.Fail("Explicit identity must not generate a replacement GUID.")
+                        Guid.Empty)
+                    OptionName.RepositoryId
+                    parseResult
+
+            let parameters = Grace.CLI.Command.Repository.buildCreateParameters graceIds
+            let output = captureOutput (fun () -> Common.printParseResultWithResolvedValues parseResult (Some graceIds))
+
+            parameters.RepositoryId
+            |> should equal (explicitId.ToString())
+
+            output
+            |> should contain $"--repository-id: {explicitId}"
+
+            output
+            |> should contain $"RepositoryId: {explicitId}"
+
+            output
+            |> should not' (contain "--repository-id: new Guid"))
+
+    /// Verifies that omitted non-hierarchy GUID inputs are described as absent rather than as semantic zero GUIDs.
+    [<Test>]
+    let ``verbose output describes unrelated omitted guid inputs as not supplied`` () =
+        withTempDir (fun root ->
+            writeValidConfigWithDeterministicIds root
+
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "branch"
+                        "create"
+                        "--branch-name"
+                        "child"
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Common.resolveCreateGraceIdsWith (fun () -> Guid.NewGuid()) OptionName.BranchId parseResult
+            let output = captureOutput (fun () -> Common.printParseResultWithResolvedValues parseResult (Some graceIds))
+
+            output
+            |> should contain "--parent-branch-id: not supplied"
+
+            output
+            |> should not' (contain $"--parent-branch-id: {Guid.Empty}"))
 
     /// Verifies that get normalized ids and names falls back to config ids.
     [<Test>]

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -578,6 +578,29 @@ module Branch =
             let referenceId = parseResult.GetValue(Options.referenceId)
             if referenceId = ReferenceId.Empty then ReferenceId.NewGuid() else referenceId
 
+    /// Builds the branch create request from the single identity resolved for verbose output and server submission.
+    let internal buildCreateParameters (parseResult: ParseResult) (graceIds: GraceIds) (parentBranchId: string) (parentBranchName: string) =
+        let initialPermissions =
+            match parseResult.GetValue(Options.initialPermissions) with
+            | null -> Array.empty<ReferenceType>
+            | permissions -> permissions
+
+        CreateBranchParameters(
+            RepositoryId = graceIds.RepositoryIdString,
+            RepositoryName = graceIds.RepositoryName,
+            OwnerId = graceIds.OwnerIdString,
+            OwnerName = graceIds.OwnerName,
+            OrganizationId = graceIds.OrganizationIdString,
+            OrganizationName = graceIds.OrganizationName,
+            BranchId = graceIds.BranchIdString,
+            BranchName = graceIds.BranchName,
+            ParentBranchId = parentBranchId,
+            ParentBranchName = parentBranchName,
+            ReferenceId = getOrCreateReferenceId parseResult,
+            InitialPermissions = initialPermissions,
+            CorrelationId = graceIds.CorrelationId
+        )
+
     // Create subcommand.
     /// Executes the create command by binding ParseResult values to the SDK request and CLI output contract.
     type Create() =
@@ -587,7 +610,10 @@ module Branch =
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 try
-                    if parseResult |> verbose then printParseResult parseResult
+                    let graceIds = resolveCreateGraceIds OptionName.BranchId parseResult
+
+                    if parseResult |> verbose then
+                        printParseResultWithResolvedValues parseResult (Some graceIds)
 
                     let validateIncomingParameters =
                         parseResult
@@ -596,14 +622,6 @@ module Branch =
 
                     match validateIncomingParameters with
                     | Ok _ ->
-                        // In a Create() command, if --branch-id is implicit, that's the current branch taken from graceconfig.json, and the
-                        //   current branch, by default, is the parent branch of the new one. Therefore, we need to set BranchId to a new Guid.
-                        let mutable graceIds = parseResult |> getNormalizedIdsAndNames
-
-                        if parseResult.GetResult(Options.branchId).Implicit then
-                            let branchId = Guid.NewGuid()
-                            graceIds <- { graceIds with BranchId = branchId; BranchIdString = $"{branchId}" }
-
                         let parentBranchId = parseResult.GetValue(Options.parentBranchId)
                         let parentBranchNameResult = parseResult.GetResult(Options.parentBranchName)
                         let parentBranchIdResult = parseResult.GetResult(Options.parentBranchId)
@@ -676,27 +694,7 @@ module Branch =
                                         return String.Empty
                             }
 
-                        let initialPermissions =
-                            match parseResult.GetValue(Options.initialPermissions) with
-                            | null -> Array.empty<ReferenceType>
-                            | permissions -> permissions
-
-                        let parameters =
-                            CreateBranchParameters(
-                                RepositoryId = graceIds.RepositoryIdString,
-                                RepositoryName = graceIds.RepositoryName,
-                                OwnerId = graceIds.OwnerIdString,
-                                OwnerName = graceIds.OwnerName,
-                                OrganizationId = graceIds.OrganizationIdString,
-                                OrganizationName = graceIds.OrganizationName,
-                                BranchId = graceIds.BranchIdString,
-                                BranchName = graceIds.BranchName,
-                                ParentBranchId = parentBranchIdString,
-                                ParentBranchName = parentBranchName,
-                                ReferenceId = getOrCreateReferenceId parseResult,
-                                InitialPermissions = initialPermissions,
-                                CorrelationId = graceIds.CorrelationId
-                            )
+                        let parameters = buildCreateParameters parseResult graceIds parentBranchIdString parentBranchName
 
                         let! result =
                             if parseResult |> hasOutput then

--- a/src/Grace.CLI/Command/Common.CLI.fs
+++ b/src/Grace.CLI/Command/Common.CLI.fs
@@ -744,21 +744,73 @@ module Common =
             OptionName.BranchName
         ]
 
+    /// Describes how an omitted hierarchy identity is presented before command-time resolution.
+    type internal HierarchyIdentityDefaultDisplay = { OptionAlias: string; CurrentDisplay: string; CreateDisplay: string; CreateParentCommand: string }
+
+    /// Defines the shared, configuration-independent hierarchy identity presentation used by help and verbose output.
+    let internal hierarchyIdentityDefaultDisplays =
+        [
+            { OptionAlias = OptionName.OwnerId; CurrentDisplay = "current OwnerId"; CreateDisplay = "new Guid"; CreateParentCommand = "owner" }
+            {
+                OptionAlias = OptionName.OrganizationId
+                CurrentDisplay = "current OrganizationId"
+                CreateDisplay = "new Guid"
+                CreateParentCommand = "organization"
+            }
+            { OptionAlias = OptionName.RepositoryId; CurrentDisplay = "current RepositoryId"; CreateDisplay = "new Guid"; CreateParentCommand = "repository" }
+            { OptionAlias = OptionName.BranchId; CurrentDisplay = "current BranchId"; CreateDisplay = "new Guid"; CreateParentCommand = "branch" }
+        ]
+
+    /// Returns the symbolic human display for an omitted GUID option without resolving configuration or generating an identity.
+    let private tryGetImplicitGuidDisplay (parseResult: ParseResult) (option: Option) (value: obj) =
+        let optionResult = parseResult.GetResult(option.Name) :?> OptionResult
+
+        if isNull optionResult
+           || not optionResult.Implicit
+           || not (value :? Guid)
+           || unbox<Guid> value <> Guid.Empty then
+            None
+        else
+            match hierarchyIdentityDefaultDisplays
+                  |> List.tryFind (fun display -> display.OptionAlias = option.Name)
+                with
+            | Some display ->
+                let isCreate = parseResult.CommandResult.Command.Name.Equals("create", StringComparison.OrdinalIgnoreCase)
+
+                let createsThisIdentity =
+                    isCreate
+                    && parseResult
+                        .CommandResult
+                        .Command
+                        .Parents
+                        .OfType<Command>()
+                        .Any(fun parent -> parent.Name.Equals(display.CreateParentCommand, StringComparison.OrdinalIgnoreCase))
+
+                if createsThisIdentity then
+                    Some display.CreateDisplay
+                else
+                    Some display.CurrentDisplay
+            | None -> Some "not supplied"
+
     /// Resolves shared CLI should show resolved values values from parse results, configuration, or Grace identifiers.
     let private shouldShowResolvedValues (parseResult: ParseResult) =
         resolvedValueOptionNames
         |> List.exists (isOptionPresent parseResult)
 
     /// Tries to map build resolved values text and returns a GraceError instead of throwing on unsupported input.
-    let private tryBuildResolvedValuesText (parseResult: ParseResult) =
+    let private tryBuildResolvedValuesText (parseResult: ParseResult) (resolvedGraceIds: GraceIds option) =
         if
             isNull parseResult
-            || not (configurationFileExists ())
+            || (resolvedGraceIds.IsNone
+                && not (configurationFileExists ()))
             || not (shouldShowResolvedValues parseResult)
         then
             None
         else
-            let graceIds = Services.getNormalizedIdsAndNames parseResult
+            let graceIds =
+                resolvedGraceIds
+                |> Option.defaultWith (fun () -> Services.getNormalizedIdsAndNames parseResult)
+
             let sb = stringBuilderPool.Get()
 
             try
@@ -788,8 +840,8 @@ module Common =
             finally
                 stringBuilderPool.Return sb
 
-    /// Prints the ParseResult with markup.
-    let printParseResult (parseResult: ParseResult) =
+    /// Prints the ParseResult with symbolic implicit GUIDs and optional command-resolved hierarchy values.
+    let printParseResultWithResolvedValues (parseResult: ParseResult) (resolvedGraceIds: GraceIds option) =
         if not <| isNull parseResult then
             let sb = stringBuilderPool.Get()
 
@@ -814,23 +866,35 @@ module Common =
                         with
                         | :? InvalidOperationException -> None
 
+                let mutable synopsis = parseResult.ToString()
+
                 for option in optionList do
                     match tryGetValue option with
                     | Some value ->
-                        if option.ValueType.IsArray then
-                            sb.AppendLine($"{option.Name}: {serialize value}")
+                        match tryGetImplicitGuidDisplay parseResult option value with
+                        | Some display ->
+                            synopsis <- synopsis.Replace($"{option.Name} <{value}>", $"{option.Name} <{display}>", StringComparison.Ordinal)
+
+                            sb.AppendLine($"{option.Name}: {display}")
                             |> ignore
-                        else
-                            sb.AppendLine($"{option.Name}: {value}") |> ignore
+                        | None ->
+                            if option.ValueType.IsArray then
+                                sb.AppendLine($"{option.Name}: {serialize value}")
+                                |> ignore
+                            else
+                                sb.AppendLine($"{option.Name}: {value}") |> ignore
+                    | None when option.ValueType = typeof<Guid> ->
+                        sb.AppendLine($"{option.Name}: not supplied")
+                        |> ignore
                     | None -> ()
 
-                AnsiConsole.MarkupLine($"[{Colors.Verbose}]{escapeBrackets (parseResult.ToString())}[/]")
+                AnsiConsole.MarkupLine($"[{Colors.Verbose}]{escapeBrackets synopsis}[/]")
                 AnsiConsole.WriteLine()
                 AnsiConsole.MarkupLine($"[{Colors.Verbose}]Parameter values:[/]")
                 AnsiConsole.MarkupLine($"[{Colors.Verbose}]{escapeBrackets (sb.ToString())}[/]")
                 AnsiConsole.WriteLine()
 
-                match tryBuildResolvedValuesText parseResult with
+                match tryBuildResolvedValuesText parseResult resolvedGraceIds with
                 | Some resolvedValues ->
                     AnsiConsole.MarkupLine($"[{Colors.Verbose}]Resolved values:[/]")
                     AnsiConsole.MarkupLine($"[{Colors.Verbose}]{escapeBrackets resolvedValues}[/]")
@@ -838,6 +902,30 @@ module Common =
                 | None -> ()
             finally
                 stringBuilderPool.Return sb
+
+    /// Prints the ParseResult with markup using configuration-backed hierarchy resolution when available.
+    let printParseResult (parseResult: ParseResult) = printParseResultWithResolvedValues parseResult None
+
+    /// Resolves one create-owned hierarchy identity exactly once while preserving explicit IDs and all parsed names.
+    let internal resolveCreateGraceIdsWith (newGuid: unit -> Guid) (createdIdOptionName: string) (parseResult: ParseResult) =
+        let graceIds = Services.getNormalizedIdsAndNames parseResult
+        let optionResult = parseResult.GetResult(createdIdOptionName) :?> OptionResult
+
+        if isNull optionResult || not optionResult.Implicit then
+            graceIds
+        else
+            let createdId = newGuid ()
+            let createdIdString = createdId.ToString()
+
+            match createdIdOptionName with
+            | OptionName.OwnerId -> { graceIds with OwnerId = createdId; OwnerIdString = createdIdString }
+            | OptionName.OrganizationId -> { graceIds with OrganizationId = createdId; OrganizationIdString = createdIdString }
+            | OptionName.RepositoryId -> { graceIds with RepositoryId = createdId; RepositoryIdString = createdIdString }
+            | OptionName.BranchId -> { graceIds with BranchId = createdId; BranchIdString = createdIdString }
+            | _ -> invalidArg (nameof createdIdOptionName) $"{createdIdOptionName} is not a create-owned hierarchy identity option."
+
+    /// Resolves one create-owned hierarchy identity for command output, local reporting, and request construction.
+    let resolveCreateGraceIds createdIdOptionName parseResult = resolveCreateGraceIdsWith Guid.NewGuid createdIdOptionName parseResult
 
     /// Prints AnsiConsole markup to the console.
     let writeMarkup (markup: IRenderable) =

--- a/src/Grace.CLI/Command/Organization.CLI.fs
+++ b/src/Grace.CLI/Command/Organization.CLI.fs
@@ -128,6 +128,16 @@ module Organization =
                 Arity = ArgumentArity.ZeroOrOne
             )
 
+    /// Builds the organization create request from the single identity resolved for verbose output and server submission.
+    let internal buildCreateParameters (graceIds: GraceIds) =
+        Parameters.Organization.CreateOrganizationParameters(
+            OwnerId = graceIds.OwnerIdString,
+            OwnerName = graceIds.OwnerName,
+            OrganizationId = graceIds.OrganizationIdString,
+            OrganizationName = graceIds.OrganizationName,
+            CorrelationId = graceIds.CorrelationId
+        )
+
     // Create subcommand.
     /// Executes the create command by binding ParseResult values to the SDK request and CLI output contract.
     type Create() =
@@ -137,42 +147,16 @@ module Organization =
         override this.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 try
-                    if parseResult |> verbose then printParseResult parseResult
+                    let graceIds = resolveCreateGraceIds OptionName.OrganizationId parseResult
 
-                    // In a Create() command, if --organization-id is implicit, that's actually the old OrganizationId taken from graceconfig.json,
-                    //   and we need to set OrganizationId to a new Guid.
-                    let mutable graceIds = parseResult |> getNormalizedIdsAndNames
-
-                    if parseResult
-                        .GetResult(
-                            Options.organizationId
-                        )
-                        .Implicit then
-                        let organizationId = Guid.NewGuid()
-                        graceIds <- { graceIds with OrganizationId = organizationId; OrganizationIdString = $"{organizationId}" }
+                    if parseResult |> verbose then
+                        printParseResultWithResolvedValues parseResult (Some graceIds)
 
                     let validateIncomingParameters = parseResult |> CommonValidations
 
                     match validateIncomingParameters with
                     | Ok _ ->
-                        let organizationId =
-                            if parseResult
-                                .GetResult(
-                                    Options.organizationId
-                                )
-                                .Implicit then
-                                Guid.NewGuid().ToString()
-                            else
-                                graceIds.OrganizationIdString
-
-                        let parameters =
-                            Parameters.Organization.CreateOrganizationParameters(
-                                OwnerId = graceIds.OwnerIdString,
-                                OwnerName = graceIds.OwnerName,
-                                OrganizationId = organizationId,
-                                OrganizationName = graceIds.OrganizationName,
-                                CorrelationId = getCorrelationId parseResult
-                            )
+                        let parameters = buildCreateParameters graceIds
 
                         if parseResult |> hasOutput then
                             let! result =

--- a/src/Grace.CLI/Command/Owner.CLI.fs
+++ b/src/Grace.CLI/Command/Owner.CLI.fs
@@ -91,6 +91,10 @@ module Owner =
         CommonValidations
         >=> ``Either OwnerId or OwnerName must be provided``
 
+    /// Builds the owner create request from the single identity resolved for verbose output and server submission.
+    let internal buildCreateParameters (graceIds: GraceIds) =
+        Parameters.Owner.CreateOwnerParameters(OwnerId = graceIds.OwnerIdString, OwnerName = graceIds.OwnerName, CorrelationId = graceIds.CorrelationId)
+
     // Create subcommand.
     /// Executes the create command by binding ParseResult values to the SDK request and CLI output contract.
     type Create() =
@@ -100,15 +104,10 @@ module Owner =
         override this.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 try
-                    if parseResult |> verbose then printParseResult parseResult
+                    let graceIds = resolveCreateGraceIds OptionName.OwnerId parseResult
 
-                    // In a Create() command, if --owner-id is implicit, that's actually the old OwnerId taken from graceconfig.json,
-                    //   and we need to set OwnerId to a new Guid.
-                    let mutable graceIds = parseResult |> getNormalizedIdsAndNames
-
-                    if parseResult.GetResult(Options.ownerId).Implicit then
-                        let ownerId = Guid.NewGuid()
-                        graceIds <- { graceIds with OwnerId = ownerId; OwnerIdString = $"{ownerId}" }
+                    if parseResult |> verbose then
+                        printParseResultWithResolvedValues parseResult (Some graceIds)
 
                     let validateIncomingParameters =
                         parseResult
@@ -117,14 +116,7 @@ module Owner =
 
                     match validateIncomingParameters with
                     | Ok _ ->
-                        let ownerId =
-                            if parseResult.GetResult(Options.ownerId).Implicit then
-                                Guid.NewGuid().ToString()
-                            else
-                                graceIds.OwnerIdString
-
-                        let parameters =
-                            Parameters.Owner.CreateOwnerParameters(OwnerId = ownerId, OwnerName = graceIds.OwnerName, CorrelationId = graceIds.CorrelationId)
+                        let parameters = buildCreateParameters graceIds
 
                         if parseResult |> hasOutput then
                             let! result =

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -263,6 +263,26 @@ module Repository =
             if parseResult < 0.0f || parseResult > 1.0f then
                 optionResult.AddError("The confidence threshold must be between 0.0 and 1.0."))
 
+    /// Builds the repository create request from the single identity resolved for verbose output and server submission.
+    let internal buildCreateParameters (graceIds: GraceIds) =
+        let ownerId = if graceIds.HasOwner then graceIds.OwnerIdString else $"{Current().OwnerId}"
+
+        let organizationId =
+            if graceIds.HasOrganization then
+                graceIds.OrganizationIdString
+            else
+                $"{Current().OrganizationId}"
+
+        Repository.CreateRepositoryParameters(
+            RepositoryId = graceIds.RepositoryIdString,
+            RepositoryName = graceIds.RepositoryName,
+            OwnerId = ownerId,
+            OwnerName = graceIds.OwnerName,
+            OrganizationId = organizationId,
+            OrganizationName = graceIds.OrganizationName,
+            CorrelationId = graceIds.CorrelationId
+        )
+
     // Create subcommand.
     /// Executes the create command by binding ParseResult values to the SDK request and CLI output contract.
     type Create() =
@@ -272,15 +292,10 @@ module Repository =
         override this.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
                 try
-                    if parseResult |> verbose then printParseResult parseResult
+                    let graceIds = resolveCreateGraceIds OptionName.RepositoryId parseResult
 
-                    // In a Create() command, if --repository-id is implicit, that's actually the old RepositoryId taken from graceconfig.json,
-                    //   and we need to set RepositoryId to a new Guid.
-                    let mutable graceIds = parseResult |> getNormalizedIdsAndNames
-
-                    if parseResult.GetResult(Options.ownerId).Implicit then
-                        let repositoryId = Guid.NewGuid()
-                        graceIds <- { graceIds with RepositoryId = repositoryId; RepositoryIdString = $"{repositoryId}" }
+                    if parseResult |> verbose then
+                        printParseResultWithResolvedValues parseResult (Some graceIds)
 
                     let validateIncomingParameters =
                         parseResult
@@ -288,33 +303,7 @@ module Repository =
 
                     match validateIncomingParameters with
                     | Ok _ ->
-                        let repositoryIdOption = parseResult.GetResult(Options.repositoryId)
-
-                        let repositoryId =
-                            if isNull repositoryIdOption
-                               || repositoryIdOption.Implicit then
-                                Guid.NewGuid().ToString()
-                            else
-                                graceIds.RepositoryIdString
-
-                        let ownerId = if graceIds.HasOwner then graceIds.OwnerIdString else $"{Current().OwnerId}"
-
-                        let organizationId =
-                            if graceIds.HasOrganization then
-                                graceIds.OrganizationIdString
-                            else
-                                $"{Current().OrganizationId}"
-
-                        let parameters =
-                            Repository.CreateRepositoryParameters(
-                                RepositoryId = repositoryId,
-                                RepositoryName = graceIds.RepositoryName,
-                                OwnerId = ownerId,
-                                OwnerName = graceIds.OwnerName,
-                                OrganizationId = organizationId,
-                                OrganizationName = graceIds.OrganizationName,
-                                CorrelationId = getCorrelationId parseResult
-                            )
+                        let parameters = buildCreateParameters graceIds
 
                         if parseResult |> hasOutput then
                             let! result =

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -52,9 +52,6 @@ module GraceCommand =
 
     exception private IntrospectionExit of int
 
-    /// Defines structured data exchanged by CLI helpers.
-    type OptionToUpdate = { optionAlias: string; display: string; displayOnCreate: string; createParentCommand: string }
-
     /// Defines root parser delete grace watch ipc file if owned behavior for Grace CLI startup and help output.
     let private deleteGraceWatchIpcFileIfOwned () =
         if graceWatchStatusUpdateTime <> Instant.MinValue then
@@ -1302,33 +1299,13 @@ module GraceCommand =
                         //   "[default: thing-we-said-in-the-Option-definition] [default:e4def31b-4547-4f6b-9324-56eba666b4b2]"
                         //   i.e. whatever the generated Guid value on create might be.
                         let optionsToUpdate =
-                            [
-                                {
-                                    optionAlias = OptionName.CorrelationId
-                                    display = "new NanoId"
-                                    displayOnCreate = "new NanoId"
-                                    createParentCommand = String.Empty
-                                }
-                                { optionAlias = OptionName.OwnerId; display = "current OwnerId"; displayOnCreate = "new Guid"; createParentCommand = "owner" }
-                                {
-                                    optionAlias = OptionName.OrganizationId
-                                    display = "current OrganizationId"
-                                    displayOnCreate = "new Guid"
-                                    createParentCommand = "organization"
-                                }
-                                {
-                                    optionAlias = OptionName.RepositoryId
-                                    display = "current RepositoryId"
-                                    displayOnCreate = "new Guid"
-                                    createParentCommand = "repository"
-                                }
-                                {
-                                    optionAlias = OptionName.BranchId
-                                    display = "current BranchId"
-                                    displayOnCreate = "new Guid"
-                                    createParentCommand = "branch"
-                                }
-                            ]
+                            {
+                                OptionAlias = OptionName.CorrelationId
+                                CurrentDisplay = "new NanoId"
+                                CreateDisplay = "new NanoId"
+                                CreateParentCommand = String.Empty
+                            }
+                            :: Common.hierarchyIdentityDefaultDisplays
 
                         let isCreate = helpCommand.Name.Equals("create", StringComparison.OrdinalIgnoreCase)
 
@@ -1340,17 +1317,17 @@ module GraceCommand =
                                 let useCreateDisplay =
                                     isCreate
                                     && not
-                                       <| String.IsNullOrWhiteSpace(optionToUpdate.createParentCommand)
+                                       <| String.IsNullOrWhiteSpace(optionToUpdate.CreateParentCommand)
                                     && parentCommands.Any (fun parent ->
-                                        parent.Name.Equals(optionToUpdate.createParentCommand, StringComparison.OrdinalIgnoreCase))
+                                        parent.Name.Equals(optionToUpdate.CreateParentCommand, StringComparison.OrdinalIgnoreCase))
 
                                 let defaultValueText =
                                     if useCreateDisplay then
-                                        optionToUpdate.displayOnCreate
+                                        optionToUpdate.CreateDisplay
                                     else
-                                        optionToUpdate.display
+                                        optionToUpdate.CurrentDisplay
 
-                                optionToUpdate.optionAlias, defaultValueText)
+                                optionToUpdate.OptionAlias, defaultValueText)
                             |> dict
 
                         use writer = new StringWriter()


### PR DESCRIPTION
# Pull Request

## Linked issue

Closes #784

## Summary

Verbose CLI output now describes implicit hierarchy IDs symbolically instead of presenting `Guid.Empty` as a real
default. Owner, organization, repository, and branch create commands also resolve their entity ID once before verbose
output and reuse that exact value for resolved reporting and request construction.

This makes verbose diagnostics trustworthy while preserving parser sentinels, identity precedence, help purity, request
contracts, JSON behavior, and the existing output layout.

## Touched paths

- `src/Grace.CLI/Command/Common.CLI.fs`
- `src/Grace.CLI/Command/Owner.CLI.fs`
- `src/Grace.CLI/Command/Organization.CLI.fs`
- `src/Grace.CLI/Command/Repository.CLI.fs`
- `src/Grace.CLI/Command/Branch.CLI.fs`
- `src/Grace.CLI/Program.CLI.fs`
- `src/Grace.CLI.Tests/Program.CLI.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public behavior: human verbose hierarchy-ID rendering and exact create-ID reuse.
- RED evidence: the new `Name~implicit` focused test failed on baseline because repository-create verbose output showed
  zero GUIDs instead of `current OwnerId` and deferred/create identity descriptions.
- Focused validation: final Release build and 193 focused CLI tests passed.

## Minimum detail gate evidence

- Product decisions: keep `Guid.Empty` internal; use symbolic implicit-ID text; generate each hierarchy create ID once;
  preserve explicit identity precedence, help purity, machine output, and command layout.
- Invariant tuple: the created hierarchy ID shown in resolved output and sent in the request is
  one identical non-empty GUID; parent/current identities continue to resolve from explicit values or current config.
- Contract propagation: human CLI presentation and focused tests updated; DTOs, server, SDK, OpenAPI, generated clients,
  events, and persisted state are unchanged.
- Stale-source/revalidation proof: N/A; no durable decision or side-effect window was added.
- Forbidden shapes avoided: no option-factory config access or GUID generation, reflection, `ParseResult` mutation,
  duplicate command-specific metadata, request-contract change, or broad output redesign.
- Tests cover symbolic current/create defaults, unrelated omitted GUIDs, explicit values, invalid inputs, exact ID reuse,
  and missing/malformed-config help/schema/examples purity.
- Adversarial cases include explicit name/ID precedence, exact generated-ID reuse, and config-independent help paths.
- CLI/proof traps were addressed with old-code-failing output assertions and deterministic request-building seams.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details: `Program.CLI.Tests.fs` now covers shared implicit-ID rendering, explicit GUID preservation, non-hierarchy omitted
GUIDs, exact create request-ID reuse for all four hierarchy creates, and help/schema/examples purity.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Any genuinely required validation that was not run is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [x] Docs impact: None - commands, options, identity precedence, and workflow are unchanged; output is now truthful.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Local focused evidence

- [x] Focused proof: `dotnet test --no-build --configuration Release
  src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --filter
  "Name~single|Name~symbolically|Name~unrelated|Name~unchanged|Name~invalid|Name~without|Name~rewrites|Name~registry-derived"`
  passed 193/193.
- [x] Formatting/linting: targeted `dotnet tool run fantomas -- <seven changed F# files>` passed with no final changes.
- [x] Generated-file/freshness or syntax checks: `dotnet build --configuration Release
  src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed with 0 warnings/errors; `git diff --check` and
  `git diff --cached --check` passed.
- [x] Manual validation: N/A; deterministic CLI output and request-building seams prove the behavior without a server.

## Optional local broad preflight

- [x] Neither Fast nor Full was run; focused proof is complete and GitHub `Validate` is the required broad gate.

## Required CI evidence

- Current head SHA: `e635168fcb2bda8b2b0c0e0c837063b26887b875`
- GitHub `Validate` state: passed (`full`, 7m54s)
- GitHub Actions run: [Validate 30889483458](https://github.com/ScottArbeit/Grace/actions/runs/30889483458)
- [x] The result was triggered by and remains associated with the latest PR revision.

## Validation not run

No required validation was omitted. Local Fast/Full and server-backed manual testing are not required because focused
deterministic proof exists and current-head GitHub `Validate` supplies the broad gate.

## Residual risks

The change affects shared human verbose presentation across CLI commands. Focused coverage checks hierarchy and
non-hierarchy GUID behavior; GitHub `Validate` and an independent current-head review remain required before merge.

## Review Status

- Current head SHA: `e635168fcb2bda8b2b0c0e0c837063b26887b875`
- Implementation/fix worker starts used: **1/4**
- Fresh review subagent: `gpt-5.6-terra`, `reasoning_effort: high`, `fork_turns: none`
- `dev-process/CODE_REVIEW.md` followed: yes
- Review verdict for current head: approve; no blocking or non-blocking findings
- Required PR checks for current head: `Validate / full` passed in run 30889483458
- [x] Review and required checks both completed successfully for the same head SHA.
- Finding dispositions and detailed review/fix comments: no findings; exact-head review recorded in PR comment

## Review/fix prevention

No fresh findings yet. The issue already records the identity-reporting invariant, false-positive-resistant tests,
forbidden eager-resolution shapes, and contract-propagation waivers.

## Rollback or recovery notes

Revert the single implementation commit. No data, state, server contract, or migration recovery is involved.

## Docs follow-up required

None expected; final review must confirm no help, schema, examples, README, CONTRIBUTING, or AGENTS drift.
