### PR TITLE
Silence discarded Grace Watch observations

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -37,6 +37,20 @@ module WatchTests =
         settings.Out <- AnsiConsoleOutput(writer)
         AnsiConsole.Console <- AnsiConsole.Create(settings)
 
+    /// Captures direct Watch callback output written through Spectre.Console.
+    let private captureAnsiConsoleOutput (action: unit -> unit) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+            action ()
+            writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
     /// Runs with captured output for test scenarios.
     let private runWithCapturedOutput (args: string array) =
         use writer = new StringWriter()
@@ -1531,7 +1545,7 @@ module WatchTests =
             |> should equal Array.empty<Watch.WatchObservationCandidate>)
 
     /// Verifies that Grace object-cache callbacks never capture stale root scope or request recovery work.
-    [<Test; Category("WatchInternalAdmission")>]
+    [<Test; Category("WatchInternalAdmission"); Category("WatchSilentObservation")>]
     let ``raw internal cache callback is rejected before stale root scope admission`` () =
         withTempRepo (fun root ->
             let acceptedStatus = graceStatusTracking Array.empty<string> Array.empty<string>
@@ -1544,8 +1558,12 @@ module WatchTests =
             Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(acceptedStatus))
             Watch.setLocalObservationCandidateSchedulingForWatchTests true
 
-            Watch.OnCreated(createdEvent internalPath)
-            Watch.OnChanged(changedEvent internalPath)
+            let output =
+                captureAnsiConsoleOutput (fun () ->
+                    Watch.OnCreated(createdEvent internalPath)
+                    Watch.OnChanged(changedEvent internalPath))
+
+            output |> should equal String.Empty
 
             Watch.localObservationCandidateSnapshotForWatchTests ()
             |> should equal Array.empty<Watch.WatchObservationCandidate>
@@ -1574,6 +1592,18 @@ module WatchTests =
 
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
+
+    /// Verifies that explicit filesystem watcher failures remain visible while discarded observations become silent.
+    [<Test; Category("WatchInternalAdmission"); Category("WatchSilentObservation")>]
+    let ``filesystem watcher errors retain explicit resync diagnostics`` () =
+        withTempRepo (fun _ ->
+            let output = captureAnsiConsoleOutput (fun () -> Watch.OnError(ErrorEventArgs(InternalBufferOverflowException("watch buffer overflow"))))
+
+            output
+            |> should contain "FileSystemWatcher threw an"
+
+            output |> should contain "watch buffer overflow"
+            output |> should contain "resynchronizing before")
 
     /// Verifies that stale root rejection remains fail-closed for an ordinary user callback.
     [<Test; Category("WatchInternalAdmission")>]
@@ -19564,15 +19594,26 @@ module WatchTests =
 
             applyFromDifferencesCalls |> should equal 1)
 
-    /// Verifies that suspended mode does not queue or apply filesystem observations.
-    [<Test>]
-    let ``suspended runtime mode does not apply observations`` () =
+    /// Verifies that suspended mode silently leaves filesystem observation state unchanged.
+    [<Test; Category("WatchSilentObservation")>]
+    let ``suspended runtime mode silently discards observations`` () =
         withTempRepo (fun root ->
             Watch.setGraceWatchRuntimeModeForWatchTests Services.GraceWatchRuntimeMode.Suspended
 
             let filePath = Path.Combine(root, "suspended-observation.txt")
             File.WriteAllText(filePath, "suspended observation")
-            Watch.OnChanged(changedEvent filePath)
+
+            let pendingBefore = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+            let candidatesBefore = Watch.localObservationCandidateSnapshotForWatchTests ()
+            let output = captureAnsiConsoleOutput (fun () -> Watch.OnChanged(changedEvent filePath))
+
+            output |> should equal String.Empty
+
+            Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+            |> should equal pendingBefore
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal candidatesBefore
 
             Watch
                 .pendingWatchWorkSnapshotForTests()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -307,10 +307,6 @@ module Watch =
 
         recordWatchLifecycleEventForWatch <- fun event -> Grace.CLI.LocalStateDb.recordWatchLifecycleEvent (Current().GraceStatusFile) event
 
-    /// Reports that a filesystem observation was ignored because the current runtime mode cannot capture it.
-    let private logObservationSuppressed fullPath =
-        logToAnsiConsole Colors.Verbose $"Grace Watch ignored filesystem observation for {fullPath} while runtime mode is {currentGraceWatchRuntimeMode ()}."
-
     let private uploadedFileVersions = ConcurrentDictionary<RelativePath * Sha256Hash * Blake3Hash, FileVersion>()
 
     /// Reads uploaded file version identity data needed by the command workflow without changing remote state.
@@ -3829,7 +3825,6 @@ module Watch =
             markGraceStatusChangedAndPublishPendingWorkTransition ()
             false
         elif isDelayedGraceOwnedFileObservation fullPath observedAt then
-            logObservationSuppressed fullPath
             false
         elif Directory.Exists(fullPath) then
             let queuedDirectoryWork = enqueueFinalDirectoryWork fullPath
@@ -3878,7 +3873,6 @@ module Watch =
 
             if isDelayedGraceOwnedFileObservation fullPath observedAt
                && not canceledFileUpload then
-                logObservationSuppressed fullPath
                 false
             elif enqueueStatusUpdateTrigger fullPath then
                 match repositoryRelativePath fullPath with
@@ -3912,13 +3906,11 @@ module Watch =
         for dueCandidate in dueCandidates do
             if localObservationIncrementalWorkBlocked () then
                 match tryClaimLocalObservationCandidate scheduler dueCandidate now with
-                | Some candidate ->
-                    claimedCandidate <- true
-                    logObservationSuppressed candidate.FullPath
+                | Some _ -> claimedCandidate <- true
                 | None -> ()
             else
                 match tryGetActiveGraceUpdateMarkerObservationBoundary () with
-                | ActiveMarker markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> logObservationSuppressed dueCandidate.FullPath
+                | ActiveMarker markerObservedAt when dueCandidate.LastSeenAt < markerObservedAt -> ()
                 | markerBoundary ->
                     match tryClaimLocalObservationCandidate scheduler dueCandidate now with
                     | Some candidate ->
@@ -3928,11 +3920,8 @@ module Watch =
                             match markerBoundary with
                             | AmbiguousMarkerBoundary reason ->
                                 recordLocalObservationConfidenceLoss reason
-                                logObservationSuppressed candidate.FullPath
                                 false
-                            | ActiveMarker _ ->
-                                logObservationSuppressed candidate.FullPath
-                                false
+                            | ActiveMarker _ -> false
                             | NoActiveMarker ->
                                 match candidate.Scope with
                                 | Some scope when not (watchObservationScopeMatchesCurrent scope) ->
@@ -3981,7 +3970,7 @@ module Watch =
     /// Applies an observation immediately only for direct callback harnesses that did not start the Watch lifetime.
     let private processLocalObservationImmediately kind fullPath =
         if localObservationIncrementalWorkBlocked () then
-            logObservationSuppressed fullPath
+            ()
         else
             let observedAt = DateTime.UtcNow
 
@@ -3993,8 +3982,6 @@ module Watch =
                 | GraceStatusArtifact ->
                     if updateNotInProgress () then
                         markGraceStatusChangedAndPublishPendingWorkTransition ()
-                    else
-                        logObservationSuppressed fullPath
 
                     false
 
@@ -7494,28 +7481,24 @@ module Watch =
     /// Admits one raw callback through the shared Grace-internal namespace guard before scheduling or direct test processing.
     let private admitRawLocalObservation fallbackKind fullPath seenAt =
         match tryClassifyRawLocalObservation fallbackKind fullPath with
-        | None -> logObservationSuppressed fullPath
+        | None -> ()
         | Some kind when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate kind fullPath seenAt
         | Some kind when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately kind fullPath
-        | Some _ -> logObservationSuppressed fullPath
+        | Some _ -> ()
 
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
-            logObservationSuppressed args.FullPath
+            ()
         elif updateNotInProgress () then
             admitRawLocalObservation CreatedOrChanged args.FullPath DateTime.UtcNow
-        else
-            logObservationSuppressed args.FullPath
 
     /// Coordinates on changed behavior for this CLI command path.
     let OnChanged (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
-            logObservationSuppressed args.FullPath
+            ()
         elif updateNotInProgress () then
             admitRawLocalObservation Changed args.FullPath DateTime.UtcNow
-        else
-            logObservationSuppressed args.FullPath
 
     /// Reads enqueue directory contents for upload data needed by the command workflow without changing remote state.
     let private enqueueDirectoryContentsForUpload directoryPath = tryEnqueueDirectoryContentsForUpload directoryPath
@@ -7552,22 +7535,18 @@ module Watch =
     /// Coordinates on deleted behavior for this CLI command path.
     let OnDeleted (args: FileSystemEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
-            logObservationSuppressed args.FullPath
+            ()
         elif updateNotInProgress () then
             admitRawLocalObservation Deleted args.FullPath DateTime.UtcNow
-        else
-            logObservationSuppressed args.FullPath
 
     /// Coordinates on renamed behavior for this CLI command path.
     let OnRenamed (args: RenamedEventArgs) =
         if not (canCaptureFilesystemObservation ()) then
-            logObservationSuppressed args.FullPath
+            ()
         elif updateNotInProgress () then
             let seenAt = DateTime.UtcNow
             admitRawLocalObservation Deleted args.OldFullPath seenAt
             admitRawLocalObservation CreatedOrChanged args.FullPath seenAt
-        else
-            logObservationSuppressed args.FullPath
 
     /// Coordinates on error behavior for this CLI command path.
     let OnError (args: ErrorEventArgs) =


### PR DESCRIPTION
# Silence discarded Grace Watch observations

## Summary

Closes #790.

Discarded `grace watch` filesystem observations no longer emit per-path log entries. This makes Grace Watch useful in a
fresh repository by suppressing routine `.grace` and runtime-gated callback noise while retaining meaningful lifecycle,
accepted-change, and error/recovery diagnostics.

## Contract and scope

- Every filesystem observation discarded by Watch is silent, including Grace-internal paths, inactive capture, runtime
  mode/update-marker gates, delayed Grace-owned observations, and post-classification gates.
- Scheduler, candidate claiming, pending-state publication, confidence-loss/resync behavior, and `OnError` diagnostics
  are unchanged.
- The owned diff is limited to `Watch.CLI.fs` and `Watch.Tests.fs`; no public CLI, parser, IPC/status, recovery,
  project, or documentation contract changes are included.

## Proof

- RED proof: the pre-change raw internal callback emitted 498 characters of ignored-observation output.
- `dotnet tool run fantomas -- src/Grace.CLI/Command/Watch.CLI.fs src/Grace.CLI.Tests/Watch.Tests.fs`
- `dotnet build src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release`
- `dotnet test src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj --configuration Release --no-build --filter "TestCategory=WatchSilentObservation"`
  - Passed 3/3 with direct AnsiConsole output capture: internal callback silence/no work, runtime-gated user callback
    silence/no pending state, and retained explicit `OnError` resynchronization output.
- `git diff --check`

`validate.ps1 -Fast/-Full` was not run because the focused Release build and captured-output test gate cover this bounded
logging correction. Current-head GitHub Validate is the required broad gate.

## Review status

- Worker starts: 1/4.
- Current head: `b90c1151268e158edceb45c3c69dcc7f391fc6d0`.
- Fresh independent review on this exact head: approved with no findings.
- GitHub Validate / full on this exact head: passed.
