### PR TITLE
CLI: derive schema and examples from ReturnValue types

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -100,12 +100,22 @@ An error emits a `GraceError` document:
     "Mutating": true,
     "EnvelopeContract": "ExistingGraceResultEnvelope: ReuseExistingApiOrSdkDto",
     "JsonMode": "ExistingBehavior",
-    "Schema": "FutureInertIntrospection",
-    "Examples": "FutureInertIntrospection",
+    "Schema": "ExistingBehavior",
+    "Examples": "ExistingBehavior",
     "Select": "ExistingBehavior"
   }
 }
 ```
+
+For every routed command with an existing JSON success envelope, the registry stores its declared result type.
+`--schema` derives the nested `ReturnValue` schema from that type and Grace's shared JSON options. `--examples`
+constructs a deterministic representative value and serializes it with the same options. Both commands preserve the
+outer `GraceReturnValue<T>` success envelope and the `GraceError` error envelope shown above.
+
+The schema describes the JSON shape Grace already emits; it does not rename or remodel result types for presentation.
+For example, `grace refs` is the alias for `grace branch get-references`, whose result remains
+`BranchDto * ReferenceDto array`. Its `ReturnValue` schema and example are therefore two-element JSON arrays: the
+branch object followed by the reference array.
 
 ## Select Projection
 
@@ -141,7 +151,7 @@ The final registry-backed inventory covers every CLI leaf command with exactly o
 - Source-only/unrouted commands: `9`
 - Deleted commands: `0`
 
-The conditional command is `watch`. `grace watch --check --output Json` returns a `WatchStatusDto` in the normal
+The conditional command is `watch`. `grace watch --check --output Json` returns a `WatchCheckStatusDto` in the normal
 `GraceReturnValue<T>` envelope so scripts and agents can read `IsRunning`, `CanUseIncrementalStatus`, `Mode`,
 `Reason`, and `SafetyFlags`. Foreground `grace watch --output Json` still short-circuits to a `GraceError` document
 instead of starting the continuous workflow.

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -431,10 +431,10 @@ module CommandOutputContractRegistryTests =
             |> should equal ExistingBehavior
 
             entry.Features.Schema
-            |> should equal FutureInertIntrospection
+            |> should equal ExistingBehavior
 
             entry.Features.Examples
-            |> should equal FutureInertIntrospection
+            |> should equal ExistingBehavior
 
             entry.Features.Select
             |> should equal ExistingBehavior
@@ -757,7 +757,7 @@ module CommandOutputContractRegistryTests =
                 |> should not' (contain "GraceError on unsupported or failed modes")
 
                 schema.ReturnValueContract
-                |> should equal "WatchStatusDto"
+                |> should equal "WatchCheckStatusDto"
 
                 use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
 
@@ -949,69 +949,187 @@ module CommandOutputContractRegistryTests =
             |> should equal "success-envelope-shape"
         | None -> Assert.Fail("doctor should have a registry entry.")
 
-    /// Verifies that metadata incomplete registry entries are explicit.
+    /// Verifies that every routed success-envelope command exposes type-derived nested metadata.
     [<Test>]
-    let ``metadata incomplete registry entries are explicit`` () =
-        let identity = CommandOutputContract.commandIdentity [ "repository" ] "init"
+    let ``every routed success envelope has schema ready ReturnValue metadata`` () =
+        let eligibleEntries =
+            CommandOutputContract.routedEntries
+            |> List.filter (fun entry ->
+                match entry.EnvelopeContract with
+                | ExistingGraceResultEnvelope _
+                | ConditionalGraceResultEnvelope _ -> true
+                | _ -> false)
 
-        match CommandOutputContract.tryFind identity with
-        | Some entry ->
+        eligibleEntries.Length |> should equal 188
+
+        for entry in eligibleEntries do
             entry.ReturnValueContract.Status
-            |> should equal MetadataIncomplete
+            |> should equal SchemaReady
+
+            entry.Features.Schema
+            |> should equal ExistingBehavior
+
+            entry.Features.Examples
+            |> should equal ExistingBehavior
 
             let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
 
             match schemaDocument.Schema with
-            | Some schema ->
-                schema.Status
-                |> should equal "metadata-incomplete"
-
-                schema.Notes
-                |> should
-                    contain
-                    "The registry has envelope metadata for this command, but command-specific ReturnValue schema/example metadata has not been declared yet."
-            | None -> Assert.Fail("Metadata-incomplete schema introspection should include a schema document.")
+            | Some schema -> schema.Status |> should equal "schema-ready"
+            | None -> Assert.Fail($"Expected schema metadata for {entry.Identity.CommandId}.")
 
             let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
             examplesDocument.Examples.Length |> should equal 2
 
             examplesDocument.Examples[0].Name
-            |> should equal "metadata-incomplete"
-        | None -> Assert.Fail("repository.init should have a registry entry.")
+            |> should equal "success-envelope-shape"
 
-    /// Verifies that dto and union contracts are not schema ready until their full emitted shapes are declared.
+    /// Verifies that refs keeps its current tuple and nested DTO serialization shape.
     [<Test>]
-    let ``dto and union contracts are not schema ready until their full emitted shapes are declared`` () =
-        let cases =
-            [
-                CommandOutputContract.commandIdentity [ "repository" ] "get", "RepositoryDto metadata is incomplete"
-                CommandOutputContract.commandIdentity [ "workitem" ] "show", "WorkItemDto metadata is incomplete"
-                CommandOutputContract.commandIdentity [ "authorize" ] "check", "PermissionCheckResult metadata is incomplete"
-            ]
+    let ``refs schema and example retain the BranchDto ReferenceDto tuple`` () =
+        let identity = CommandOutputContract.commandIdentity [ "branch" ] "get-references"
 
-        for identity, expectedNote in cases do
-            match CommandOutputContract.tryFind identity with
-            | Some entry ->
-                entry.ReturnValueContract.Status
-                |> should equal MetadataIncomplete
+        let entry =
+            CommandOutputContract.tryFind identity
+            |> Option.get
 
-                let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+        let schemaDocument = CommandOutputContract.introspectionDocument Schema entry
+        let schema = schemaDocument.Schema |> Option.get
+        use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
 
-                match schemaDocument.Schema with
-                | Some schema ->
-                    schema.Status
-                    |> should equal "metadata-incomplete"
+        let returnValueSchema =
+            successSchema
+                .RootElement
+                .GetProperty("properties")
+                .GetProperty("ReturnValue")
 
-                    schema.Notes
-                    |> List.exists (fun note -> note.Contains(expectedNote, StringComparison.Ordinal))
-                    |> should equal true
-                | None -> Assert.Fail($"Expected schema document for {identity.CommandId}.")
+        returnValueSchema.GetProperty("type").GetString()
+        |> should equal "array"
 
-                let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+        let tupleItems = returnValueSchema.GetProperty("prefixItems")
+        tupleItems.GetArrayLength() |> should equal 2
 
-                examplesDocument.Examples[0].Name
-                |> should equal "metadata-incomplete"
-            | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
+        let mutable branchIdSchema = Unchecked.defaultof<JsonElement>
+
+        tupleItems[0]
+            .GetProperty("properties")
+            .TryGetProperty("BranchId", &branchIdSchema)
+        |> should equal true
+
+        tupleItems[ 1 ].GetProperty("type").GetString()
+        |> should equal "array"
+
+        let mutable referenceIdSchema = Unchecked.defaultof<JsonElement>
+
+        tupleItems[1]
+            .GetProperty("items")
+            .GetProperty("properties")
+            .TryGetProperty("ReferenceId", &referenceIdSchema)
+        |> should equal true
+
+        let examplesDocument = CommandOutputContract.introspectionDocument Examples entry
+        use successExample = JsonDocument.Parse(Grace.Shared.Utilities.serialize examplesDocument.Examples[0].Document)
+        let returnValue = successExample.RootElement.GetProperty("ReturnValue")
+
+        returnValue.ValueKind
+        |> should equal JsonValueKind.Array
+
+        returnValue.GetArrayLength() |> should equal 2
+
+        returnValue[0].GetProperty("BranchId").ValueKind
+        |> should equal JsonValueKind.String
+
+        returnValue[1].ValueKind
+        |> should equal JsonValueKind.Array
+
+    /// Verifies representative record, collection, scalar, union, and option result shapes.
+    [<Test>]
+    let ``derived contracts cover representative serializer shapes`` () =
+        let returnValueSchema groupPath commandName =
+            let identity = CommandOutputContract.commandIdentity groupPath commandName
+
+            let entry =
+                CommandOutputContract.tryFind identity
+                |> Option.get
+
+            let schema =
+                (CommandOutputContract.introspectionDocument Schema entry)
+                    .Schema
+                |> Option.get
+
+            let document = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+            document,
+            document
+                .RootElement
+                .GetProperty("properties")
+                .GetProperty("ReturnValue")
+
+        let recordDocument, recordSchema = returnValueSchema [ "repository" ] "get"
+        use _recordDocument = recordDocument
+        let mutable repositoryIdSchema = Unchecked.defaultof<JsonElement>
+
+        recordSchema
+            .GetProperty("properties")
+            .TryGetProperty("RepositoryId", &repositoryIdSchema)
+        |> should equal true
+
+        let collectionDocument, collectionSchema = returnValueSchema [ "webhook" ] "list"
+        use _collectionDocument = collectionDocument
+
+        collectionSchema.GetProperty("type").GetString()
+        |> should equal "array"
+
+        let listDocument, listSchema = returnValueSchema [ "authenticate"; "token" ] "list"
+        use _listDocument = listDocument
+
+        listSchema.GetProperty("type").GetString()
+        |> should equal "array"
+
+        let scalarDocument, scalarSchema = returnValueSchema [ "branch" ] "get-recursive-size"
+        use _scalarDocument = scalarDocument
+
+        let scalarTypes =
+            scalarSchema.GetProperty("type").EnumerateArray()
+            |> Seq.map (fun typeName -> typeName.GetString())
+            |> Set.ofSeq
+
+        scalarTypes |> should contain "integer"
+
+        let diffEntry =
+            CommandOutputContract.tryFind (CommandOutputContract.commandIdentity [ "diff" ] "blake3")
+            |> Option.get
+
+        let diffExample =
+            (CommandOutputContract.introspectionDocument Examples diffEntry)
+                .Examples[0]
+
+        use diffDocument = JsonDocument.Parse(Grace.Shared.Utilities.serialize diffExample.Document)
+
+        diffDocument
+            .RootElement
+            .GetProperty(
+                "ReturnValue"
+            )
+            .ValueKind
+        |> should equal JsonValueKind.Object
+
+        let unionDocument, unionSchema = returnValueSchema [ "authorize" ] "check"
+        use _unionDocument = unionDocument
+
+        unionSchema.GetProperty("anyOf").GetArrayLength()
+        |> should equal 2
+
+        let optionDocument, optionSchema = returnValueSchema [ "review" ] "open"
+        use _optionDocument = optionDocument
+
+        optionSchema.GetProperty("anyOf").EnumerateArray()
+        |> Seq.exists (fun branch ->
+            let mutable typeSchema = Unchecked.defaultof<JsonElement>
+
+            branch.TryGetProperty("type", &typeSchema)
+            && typeSchema.GetString() = "null")
+        |> should equal true
 
     /// Verifies that examples for schema ready commands parse as grace envelopes.
     [<Test>]
@@ -1034,7 +1152,7 @@ module CommandOutputContractRegistryTests =
             let successRoot = success.RootElement
 
             successRoot.GetProperty("ReturnValue").GetString()
-            |> should equal "Signed out."
+            |> should equal "example"
 
             let successProperties = successRoot.GetProperty("Properties")
 
@@ -1056,24 +1174,31 @@ module CommandOutputContractRegistryTests =
             |> should equal "correlation-id"
         | None -> Assert.Fail("authenticate.logout should have a registry entry.")
 
-    /// Verifies that maintenance show journal examples include every required journal row property.
+    /// Verifies that maintenance show journal schemas include every journal row property.
     [<Test>]
-    let ``maintenance show journal example includes quarantine reason`` () =
+    let ``maintenance show journal schema includes quarantine reason`` () =
         let identity = CommandOutputContract.commandIdentity [ "maintenance" ] "show-journal"
 
         match CommandOutputContract.tryFind identity with
         | Some entry ->
-            let document = CommandOutputContract.introspectionDocument Examples entry
-            use success = JsonDocument.Parse(Grace.Shared.Utilities.serialize document.Examples[0].Document)
+            let document = CommandOutputContract.introspectionDocument Schema entry
+            let schema = document.Schema |> Option.get
+            use success = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
 
-            let row =
+            let rowSchema =
                 success
                     .RootElement
+                    .GetProperty("properties")
                     .GetProperty("ReturnValue")
-                    .GetProperty("Rows")[0]
+                    .GetProperty("properties")
+                    .GetProperty("Rows")
+                    .GetProperty("items")
+                    .GetProperty("properties")
 
-            row.GetProperty("QuarantineReason").ValueKind
-            |> should equal JsonValueKind.Null
+            let mutable quarantineReasonSchema = Unchecked.defaultof<JsonElement>
+
+            rowSchema.TryGetProperty("QuarantineReason", &quarantineReasonSchema)
+            |> should equal true
         | None -> Assert.Fail("maintenance.show-journal should have a registry entry.")
 
     /// Verifies that all registry schema and example documents serialize as json.

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -974,7 +974,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Schema")
                 .GetProperty("Status")
                 .GetString()
-            |> should equal "metadata-incomplete"
+            |> should equal "schema-ready"
 
             rootElement.GetProperty("Schema").GetProperty(
                 "SuccessSchema"
@@ -1024,7 +1024,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Document")
                 .GetProperty("ReturnValue")
                 .GetString()
-            |> should equal "Signed out.")
+            |> should equal "example")
 
     /// Verifies that root login alias emits schema introspection.
     [<Test>]
@@ -1099,9 +1099,9 @@ module HelpDoesNotReadConfigTests =
                 .GetString()
             |> should equal "authenticate.logout")
 
-    /// Verifies that examples for missing dto metadata emit explicit unsupported document.
+    /// Verifies that examples for existing DTO results emit a successful Grace envelope.
     [<Test>]
-    let ``examples for missing dto metadata emit explicit unsupported document`` () =
+    let ``examples for DTO results emit type-derived success envelope`` () =
         withTempDir (fun _ ->
             /// Verifies that the CLI program scenario exits with the expected process status.
             let exitCode, output =
@@ -1120,19 +1120,22 @@ module HelpDoesNotReadConfigTests =
             let examples = rootElement.GetProperty("Examples")
 
             examples[ 0 ].GetProperty("Name").GetString()
-            |> should equal "metadata-incomplete"
+            |> should equal "success-envelope-shape"
 
-            examples[0]
-                .GetProperty("Document")
-                .GetProperty("Status")
-                .GetString()
-            |> should equal "metadata-incomplete"
+            examples[0].GetProperty("Document").GetProperty(
+                "ReturnValue"
+            )
+                .GetProperty(
+                "WorkItemId"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.String
 
-            examples[0]
-                .GetProperty("Document")
-                .GetProperty("CommandId")
-                .GetString()
-            |> should equal "workitem.show")
+            examples[0].GetProperty("Document").GetProperty(
+                "Properties"
+            )
+                .ValueKind
+            |> should equal JsonValueKind.Array)
 
     /// Verifies that nested command schema resolves full command id.
     [<Test>]

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -1,8 +1,15 @@
 namespace Grace.CLI
 
 open System
+open System.Collections
 open System.Collections.Generic
 open System.CommandLine
+open System.Reflection
+open System.Text.Json
+open System.Text.Json.Nodes
+open System.Text.Json.Schema
+open System.Text.Json.Serialization.Metadata
+open Microsoft.FSharp.Reflection
 
 /// Groups the command output contract command parser, handlers, and output helpers.
 module CommandOutputContract =
@@ -187,27 +194,6 @@ module CommandOutputContract =
         schema["description"] <- description
         box schema
 
-    /// Constructs the nullable nullable string schema used in generated command-output metadata.
-    let private nullableStringSchema description =
-        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
-        schema["type"] <- [| "string"; "null" |]
-        schema["description"] <- description
-        box schema
-
-    /// Constructs an array schema and attaches the item schema used by repeated command-output fields.
-    let private arraySchema itemSchema description =
-        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
-        schema["type"] <- "array"
-        schema["items"] <- itemSchema
-        schema["description"] <- description
-        box schema
-
-    let private stringDateTimeSchema =
-        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
-        schema["type"] <- "string"
-        schema["format"] <- "date-time"
-        box schema
-
     let private propertyBagSchema =
         let propertyEntry =
             schemaObject
@@ -245,464 +231,312 @@ module CommandOutputContract =
     /// Builds command-output contract metadata for unsupported return value example so automation can rely on stable JSON shapes.
     let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
 
-    let private stringReturnValueSchema = scalarSchema "string"
+    let private reflectionFlags = BindingFlags.Public ||| BindingFlags.NonPublic
 
-    let private maintenanceStatsSchema =
-        schemaObject
-            "MaintenanceStatsDto"
-            [
-                "DirectoryCount", scalarSchema "integer"
-                "FileCount", scalarSchema "integer"
-                "TotalFileSize", scalarSchema "integer"
-                "RootSha256Hash", nullableStringSchema "Root directory SHA-256 hash when the local index contains or records it."
-                "RootBlake3Hash", nullableStringSchema "Root directory BLAKE3 hash when the local index contains it."
-            ]
-            [|
-                "DirectoryCount"
-                "FileCount"
-                "TotalFileSize"
-                "RootSha256Hash"
-                "RootBlake3Hash"
-            |]
+    let private schemaSerializerOptions =
+        let options = JsonSerializerOptions(Grace.Shared.Constants.JsonSerializerOptions)
 
-    let private maintenanceStatsExample =
-        box {| DirectoryCount = 1; FileCount = 2; TotalFileSize = 42L; RootSha256Hash = "0123456789abcdef"; RootBlake3Hash = "af1349b9f5f9a1a6" |}
+        if isNull options.TypeInfoResolver then
+            options.TypeInfoResolver <- DefaultJsonTypeInfoResolver()
 
-    let private maintenanceListContentsFileSchema =
-        schemaObject
-            "MaintenanceListContentsFileDto"
-            [
-                "RelativePath", scalarSchema "string"
-                "FileName", scalarSchema "string"
-                "Sha256Hash", scalarSchema "string"
-                "Blake3Hash", scalarSchema "string"
-                "Size", scalarSchema "integer"
-                "LastWriteTimeUtc", stringDateTimeSchema
-            ]
-            [|
-                "RelativePath"
-                "FileName"
-                "Sha256Hash"
-                "Blake3Hash"
-                "Size"
-                "LastWriteTimeUtc"
-            |]
+        options
 
-    let private maintenanceListContentsDirectorySchema =
-        schemaObject
-            "MaintenanceListContentsDirectoryDto"
-            [
-                "RelativePath", scalarSchema "string"
-                "DirectoryVersionId", scalarSchema "string"
-                "Sha256Hash", scalarSchema "string"
-                "Blake3Hash", scalarSchema "string"
-                "Size", scalarSchema "integer"
-                "LastWriteTimeUtc", stringDateTimeSchema
-                "Files", arraySchema maintenanceListContentsFileSchema "Files in the indexed directory when file listing is enabled."
-            ]
-            [|
-                "RelativePath"
-                "DirectoryVersionId"
-                "Sha256Hash"
-                "Blake3Hash"
-                "Size"
-                "LastWriteTimeUtc"
-                "Files"
-            |]
+    let private schemaExporterOptions = JsonSchemaExporterOptions(TreatNullObliviousAsNonNullable = true)
 
-    let private maintenanceListContentsSchema =
-        schemaObject
-            "MaintenanceListContentsDto"
-            [
-                "Summary", maintenanceStatsSchema
-                "Directories", arraySchema maintenanceListContentsDirectorySchema "Indexed directories returned by maintenance list-contents."
-            ]
-            [| "Summary"; "Directories" |]
+    /// Identifies a closed generic type without relying on its display name.
+    let private isGenericTypeOf genericTypeDefinition (candidate: Type) =
+        candidate.IsGenericType
+        && candidate.GetGenericTypeDefinition() = genericTypeDefinition
 
-    let private maintenanceListContentsExample =
-        box
-            {|
-                Summary = {| DirectoryCount = 1; FileCount = 1; TotalFileSize = 12L; RootSha256Hash = "0123456789abcdef"; RootBlake3Hash = "af1349b9f5f9a1a6" |}
-                Directories =
-                    [|
-                        {|
-                            RelativePath = "."
-                            DirectoryVersionId = "11111111-1111-1111-1111-111111111111"
-                            Sha256Hash = "0123456789abcdef"
-                            Blake3Hash = "af1349b9f5f9a1a6"
-                            Size = 12L
-                            LastWriteTimeUtc = "2026-06-05T00:00:00Z"
-                            Files =
-                                [|
-                                    {|
-                                        RelativePath = "README.md"
-                                        FileName = "README.md"
-                                        Sha256Hash = "abcdef0123456789"
-                                        Blake3Hash = "b9f5f9a1a6af1349"
-                                        Size = 12L
-                                        LastWriteTimeUtc = "2026-06-05T00:00:00Z"
-                                    |}
-                                |]
-                        |}
-                    |]
-            |}
+    /// Finds the JSON array item type for Grace result collections.
+    let private tryCollectionElementType (candidate: Type) =
+        if candidate = typeof<string> then
+            None
+        elif candidate.IsArray then
+            Some(candidate.GetElementType())
+        elif isGenericTypeOf typedefof<list<_>> candidate then
+            Some(candidate.GetGenericArguments()[0])
+        else
+            candidate.GetInterfaces()
+            |> Array.append [| candidate |]
+            |> Array.tryPick (fun implemented ->
+                if implemented.IsGenericType
+                   && implemented.GetGenericTypeDefinition() = typedefof<IEnumerable<_>> then
+                    Some(implemented.GetGenericArguments()[0])
+                else
+                    None)
 
-    let private maintenanceIgnoreEntriesSchema =
-        schemaObject
-            "MaintenanceIgnoreEntriesDto"
-            [
-                "DirectoryEntries", arraySchema (scalarSchema "string") "Configured Grace directory ignore entries."
-                "FileEntries", arraySchema (scalarSchema "string") "Configured Grace file ignore entries."
-            ]
-            [| "DirectoryEntries"; "FileEntries" |]
+    /// Finds string-keyed dictionary value types whose JSON shape is an object property bag.
+    let private tryStringDictionaryValueType (candidate: Type) =
+        candidate.GetInterfaces()
+        |> Array.append [| candidate |]
+        |> Array.tryPick (fun implemented ->
+            if implemented.IsGenericType then
+                let definition = implemented.GetGenericTypeDefinition()
+                let arguments = implemented.GetGenericArguments()
 
-    let private maintenanceIgnoreEntriesExample = box {| DirectoryEntries = [| ".git"; ".grace" |]; FileEntries = [| "*.tmp" |] |}
+                if (definition = typedefof<IDictionary<_, _>>
+                    || definition = typedefof<IReadOnlyDictionary<_, _>>)
+                   && arguments[0] = typeof<string> then
+                    Some arguments[1]
+                else
+                    None
+            else
+                None)
 
-    let private maintenanceScanDifferenceSchema =
-        schemaObject
-            "MaintenanceScanDifferenceDto"
-            [
-                "DifferenceType", scalarSchema "string"
-                "FileSystemEntryType", scalarSchema "string"
-                "RelativePath", scalarSchema "string"
-            ]
-            [|
-                "DifferenceType"
-                "FileSystemEntryType"
-                "RelativePath"
-            |]
+    /// Applies Grace's configured union-tag naming policy to a discriminated-union case.
+    let private unionCaseName (caseInfo: UnionCaseInfo) =
+        Grace.Shared.Constants.JsonSerializerOptions.Converters
+        |> Seq.tryPick (fun converter ->
+            match converter with
+            | :? System.Text.Json.Serialization.JsonFSharpConverter as fsharpConverter ->
+                let namingPolicy = fsharpConverter.Options.UnionTagNamingPolicy
 
-    let private maintenanceScanDirectoryVersionSchema =
-        schemaObject
-            "MaintenanceScanDirectoryVersionDto"
-            [
-                "DirectoryVersionId", scalarSchema "string"
-                "RelativePath", scalarSchema "string"
-                "Sha256Hash", scalarSchema "string"
-                "Blake3Hash", scalarSchema "string"
-            ]
-            [|
-                "DirectoryVersionId"
-                "RelativePath"
-                "Sha256Hash"
-                "Blake3Hash"
-            |]
+                if isNull namingPolicy then
+                    Some caseInfo.Name
+                else
+                    Some(namingPolicy.ConvertName(caseInfo.Name))
+            | _ -> None)
+        |> Option.defaultValue caseInfo.Name
 
-    let private maintenanceScanSchema =
-        schemaObject
-            "MaintenanceScanDto"
-            [
-                "DifferenceCount", scalarSchema "integer"
-                "Differences", arraySchema maintenanceScanDifferenceSchema "Detected filesystem differences compared with the local Grace index."
-                "NewDirectoryVersionCount", scalarSchema "integer"
-                "NewDirectoryVersions", arraySchema maintenanceScanDirectoryVersionSchema "Computed directory versions for detected differences."
-            ]
-            [|
-                "DifferenceCount"
-                "Differences"
-                "NewDirectoryVersionCount"
-                "NewDirectoryVersions"
-            |]
+    /// Derives JSON Schema recursively from a declared result type and Grace's serializer configuration.
+    let rec private schemaForType (visiting: Type list) (resultType: Type) : obj =
+        let nestedSchema nextType = schemaForType (resultType :: visiting) nextType
 
-    let private maintenanceScanExample =
-        box
-            {|
-                DifferenceCount = 1
-                Differences =
-                    [|
-                        {| DifferenceType = "Added"; FileSystemEntryType = "File"; RelativePath = "README.md" |}
-                    |]
-                NewDirectoryVersionCount = 1
-                NewDirectoryVersions =
-                    [|
-                        {|
-                            DirectoryVersionId = "11111111-1111-1111-1111-111111111111"
-                            RelativePath = "."
-                            Sha256Hash = "0123456789abcdef"
-                            Blake3Hash = "af1349b9f5f9a1a6"
-                        |}
-                    |]
-            |}
+        if visiting |> List.exists ((=) resultType) then
+            box true
+        elif resultType = typeof<unit> then
+            scalarSchema "null"
+        elif isGenericTypeOf typedefof<option<_>> resultType then
+            let innerSchema = nestedSchema (resultType.GetGenericArguments()[0])
+            let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+            schema["anyOf"] <- [| innerSchema; scalarSchema "null" |]
+            box schema
+        elif isGenericTypeOf typedefof<list<_>> resultType then
+            let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+            schema["type"] <- "array"
+            schema["items"] <- nestedSchema (resultType.GetGenericArguments()[0])
+            box schema
+        elif FSharpType.IsTuple resultType then
+            let itemSchemas =
+                FSharpType.GetTupleElements resultType
+                |> Array.map nestedSchema
 
-    let private maintenanceJournalRowSchema =
-        schemaObject
-            "MaintenanceJournalRowDto"
-            [
-                "Sequence", scalarSchema "integer"
-                "CreatedAtUnixTicks", scalarSchema "integer"
-                "State", scalarSchema "string"
-                "DifferenceType", scalarSchema "string"
-                "FileSystemEntryType", scalarSchema "string"
-                "RelativePath", nullableStringSchema "Repository-relative path for the normalized replay observation."
-                "QuarantineReason", nullableStringSchema "Reason a startup recovery pass retired this row instead of replaying it."
-            ]
-            [|
-                "Sequence"
-                "CreatedAtUnixTicks"
-                "State"
-                "DifferenceType"
-                "FileSystemEntryType"
-                "RelativePath"
-                "QuarantineReason"
-            |]
+            let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+            schema["type"] <- "array"
+            schema["prefixItems"] <- itemSchemas
+            schema["minItems"] <- itemSchemas.Length
+            schema["maxItems"] <- itemSchemas.Length
+            box schema
+        elif FSharpType.IsRecord(resultType, reflectionFlags) then
+            let fields = FSharpType.GetRecordFields(resultType, reflectionFlags)
 
-    let private maintenanceShowJournalSchema =
-        schemaObject
-            "MaintenanceShowJournalDto"
-            [
-                "DbPath", scalarSchema "string"
-                "AppliedThroughSequence", scalarSchema "integer"
-                "AllocatedSequence", scalarSchema "integer"
-                "TotalRows", scalarSchema "integer"
-                "RowCount", scalarSchema "integer"
-                "StateFilter", scalarSchema "string"
-                "PathFilter", nullableStringSchema "Path filter echoed from the command invocation."
-                "Limit", scalarSchema "integer"
-                "Rows", arraySchema maintenanceJournalRowSchema "Filtered durable Watch journal rows."
-            ]
-            [|
-                "DbPath"
-                "AppliedThroughSequence"
-                "AllocatedSequence"
-                "TotalRows"
-                "RowCount"
-                "StateFilter"
-                "PathFilter"
-                "Limit"
-                "Rows"
-            |]
+            let properties =
+                fields
+                |> Array.map (fun field -> KeyValuePair(field.Name, nestedSchema field.PropertyType))
 
-    let private maintenanceShowJournalExample =
-        box
-            {|
-                DbPath = "C:\\repo\\.grace\\grace-local.db"
-                AppliedThroughSequence = 2L
-                AllocatedSequence = 4L
-                TotalRows = 4L
-                RowCount = 1
-                StateFilter = "pending"
-                PathFilter = null
-                Limit = 1
-                Rows =
-                    [|
-                        {|
-                            Sequence = 4L
-                            CreatedAtUnixTicks = 4L
-                            State = "pending"
-                            DifferenceType = "Change"
-                            FileSystemEntryType = "File"
-                            RelativePath = "src/Program.fs"
-                            QuarantineReason = null
-                        |}
-                    |]
-            |}
+            let required =
+                fields
+                |> Array.filter (fun field -> not (isGenericTypeOf typedefof<option<_>> field.PropertyType))
+                |> Array.map (fun field -> field.Name)
 
-    let private maintenanceClearJournalSchema =
-        schemaObject
-            "MaintenanceClearJournalDto"
-            [
-                "DbPath", scalarSchema "string"
-                "RowsDeleted", scalarSchema "integer"
-                "AppliedThroughSequenceBefore", scalarSchema "integer"
-                "AppliedThroughSequenceAfter", scalarSchema "integer"
-                "AllocatedSequenceBefore", scalarSchema "integer"
-                "AllocatedSequenceAfter", scalarSchema "integer"
-            ]
-            [|
-                "DbPath"
-                "RowsDeleted"
-                "AppliedThroughSequenceBefore"
-                "AppliedThroughSequenceAfter"
-                "AllocatedSequenceBefore"
-                "AllocatedSequenceAfter"
-            |]
+            let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+            schema["title"] <- resultType.Name
+            schema["type"] <- "object"
+            schema["properties"] <- Dictionary<string, obj>(properties)
+            schema["required"] <- required
+            box schema
+        elif FSharpType.IsUnion(resultType, reflectionFlags) then
+            let cases = FSharpType.GetUnionCases(resultType, reflectionFlags)
+            let onlyCaseFields = if cases.Length = 1 then cases[ 0 ].GetFields() else [||]
 
-    let private maintenanceClearJournalExample =
-        box
-            {|
-                DbPath = "C:\\repo\\.grace\\grace-local.db"
-                RowsDeleted = 3L
-                AppliedThroughSequenceBefore = 2L
-                AppliedThroughSequenceAfter = 0L
-                AllocatedSequenceBefore = 3L
-                AllocatedSequenceAfter = 0L
-            |}
+            if cases.Length = 1 && onlyCaseFields.Length = 1 then
+                nestedSchema onlyCaseFields[0].PropertyType
+            elif cases
+                 |> Array.forall (fun caseInfo -> caseInfo.GetFields().Length = 0) then
+                let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                schema["type"] <- "string"
+                schema["enum"] <- cases |> Array.map unionCaseName
+                box schema
+            else
+                let caseSchemas =
+                    cases
+                    |> Array.map (fun caseInfo ->
+                        let fields = caseInfo.GetFields()
 
-    let private watchStatusSchema =
-        schemaObject
-            "WatchStatusDto"
-            [
-                "IsRunning", scalarSchema "boolean"
-                "CanUseIncrementalStatus", scalarSchema "boolean"
-                "Mode", scalarSchema "string"
-                "Reason", scalarSchema "string"
-                "Message", scalarSchema "string"
-                "SafetyFlags", arraySchema (scalarSchema "string") "Compact status facts for agents deciding whether to trust Watch."
-                "IsFresh", scalarSchema "boolean"
-                "HasUsableRootSnapshot", scalarSchema "boolean"
-                "HasDirectoryIndexSnapshot", scalarSchema "boolean"
-                "IsStartupClaim", scalarSchema "boolean"
-                "UpdatedAt", nullableStringSchema "Watch IPC heartbeat timestamp when a status snapshot is readable."
-                "RootDirectoryId", nullableStringSchema "Root directory version id when a status snapshot is readable."
-            ]
-            [|
-                "IsRunning"
-                "CanUseIncrementalStatus"
-                "Mode"
-                "Reason"
-                "Message"
-                "SafetyFlags"
-                "IsFresh"
-                "HasUsableRootSnapshot"
-                "HasDirectoryIndexSnapshot"
-                "IsStartupClaim"
-            |]
+                        if fields.Length = 0 then
+                            let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                            schema["const"] <- unionCaseName caseInfo
+                            box schema
+                        else
+                            let caseValueSchema =
+                                if fields.Length = 1 then
+                                    nestedSchema fields[0].PropertyType
+                                else
+                                    let properties =
+                                        fields
+                                        |> Array.map (fun field -> KeyValuePair(field.Name, nestedSchema field.PropertyType))
 
-    let private watchStatusExample =
-        box
-            {|
-                IsRunning = true
-                CanUseIncrementalStatus = true
-                Mode = "HealthyIncremental"
-                Reason = "running"
-                Message = "GraceWatch is running in HealthyIncremental mode. Incremental status shortcuts are available."
-                SafetyFlags =
-                    [|
-                        "directoryIndex"
-                        "incrementalSafe"
-                        "usableRoot"
-                    |]
-                IsFresh = true
-                HasUsableRootSnapshot = true
-                HasDirectoryIndexSnapshot = true
-                IsStartupClaim = false
-                UpdatedAt = "2026-06-05T00:00:00Z"
-                RootDirectoryId = "11111111-1111-1111-1111-111111111111"
-            |}
+                                    let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                                    schema["type"] <- "object"
+                                    schema["properties"] <- Dictionary<string, obj>(properties)
+                                    schema["required"] <- fields |> Array.map (fun field -> field.Name)
+                                    box schema
 
-    let private doctorCheckSchema =
-        schemaObject
-            "DoctorCheckDto"
-            [
-                "Id", scalarSchema "string"
-                "Category", scalarSchema "string"
-                "Title", scalarSchema "string"
-                "Description", scalarSchema "string"
-                "DefaultEnabled", scalarSchema "boolean"
-                "SupportsOffline", scalarSchema "boolean"
-            ]
-            [|
-                "Id"
-                "Category"
-                "Title"
-                "Description"
-                "DefaultEnabled"
-                "SupportsOffline"
-            |]
+                            let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                            schema["type"] <- "object"
 
-    let private doctorCheckResultSchema =
-        schemaObject
-            "DoctorCheckResultDto"
-            [
-                "Id", scalarSchema "string"
-                "Category", scalarSchema "string"
-                "Title", scalarSchema "string"
-                "Status", scalarSchema "string"
-                "Severity", scalarSchema "string"
-                "Summary", scalarSchema "string"
-            ]
-            [|
-                "Id"
-                "Category"
-                "Title"
-                "Status"
-                "Severity"
-                "Summary"
-            |]
+                            schema["properties"] <- Dictionary<string, obj>(
+                                [
+                                    KeyValuePair(unionCaseName caseInfo, caseValueSchema)
+                                ]
+                            )
 
-    let private doctorSummarySchema =
-        schemaObject
-            "DoctorSummaryDto"
-            [
-                "Total", scalarSchema "integer"
-                "Ok", scalarSchema "integer"
-                "Warning", scalarSchema "integer"
-                "Failed", scalarSchema "integer"
-                "Skipped", scalarSchema "integer"
-            ]
-            [|
-                "Total"
-                "Ok"
-                "Warning"
-                "Failed"
-                "Skipped"
-            |]
+                            schema["required"] <- [| unionCaseName caseInfo |]
+                            box schema)
 
-    let private doctorReportSchema =
-        schemaObject
-            "DoctorReportDto"
-            [
-                "ReportVersion", scalarSchema "string"
-                "Status", scalarSchema "string"
-                "ExitCode", scalarSchema "integer"
-                "Full", scalarSchema "boolean"
-                "Offline", scalarSchema "boolean"
-                "Strict", scalarSchema "boolean"
-                "ListOnly", scalarSchema "boolean"
-                "RequestedChecks", arraySchema (scalarSchema "string") "Requested check IDs or categories after token normalization."
-                "Catalog", arraySchema doctorCheckSchema "Inert doctor check catalog entries included in the report."
-                "Checks", arraySchema doctorCheckResultSchema "Scaffolded check results; no real diagnostics run in this slice."
-                "Summary", doctorSummarySchema
-            ]
-            [|
-                "ReportVersion"
-                "Status"
-                "ExitCode"
-                "Full"
-                "Offline"
-                "Strict"
-                "ListOnly"
-                "RequestedChecks"
-                "Catalog"
-                "Checks"
-                "Summary"
-            |]
+                let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                schema["anyOf"] <- caseSchemas
+                box schema
+        else
+            match tryStringDictionaryValueType resultType, tryCollectionElementType resultType with
+            | Some valueType, _ ->
+                let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                schema["type"] <- "object"
+                schema["additionalProperties"] <- nestedSchema valueType
+                box schema
+            | None, Some elementType ->
+                let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+                schema["type"] <- "array"
+                schema["items"] <- nestedSchema elementType
+                box schema
+            | None, None ->
+                try
+                    box (JsonSchemaExporter.GetJsonSchemaAsNode(schemaSerializerOptions, resultType, schemaExporterOptions))
+                with
+                | _ -> box true
 
-    let private doctorReportExample =
-        box
-            {|
-                ReportVersion = "doctor-report-v1"
-                Status = "Ok"
-                ExitCode = 0
-                Full = false
-                Offline = false
-                Strict = false
-                ListOnly = true
-                RequestedChecks = [| "cli.catalog" |]
-                Catalog =
-                    [|
-                        {|
-                            Id = "cli.catalog"
-                            Category = "CLI"
-                            Title = "CLI command catalog"
-                            Description = "Verifies that the Grace CLI command catalog is available. Scaffold only; no runtime probe is executed."
-                            DefaultEnabled = true
-                            SupportsOffline = true
-                        |}
-                    |]
-                Checks =
-                    [|
-                        {|
-                            Id = "cli.catalog"
-                            Category = "CLI"
-                            Title = "CLI command catalog"
-                            Status = "Ok"
-                            Severity = "Info"
-                            Summary = "Scaffolded check only; no diagnostic probe ran in this slice."
-                        |}
-                    |]
-                Summary = {| Total = 1; Ok = 1; Warning = 0; Failed = 0; Skipped = 0 |}
-            |}
+    /// Constructs a deterministic value that the unchanged Grace serializer can turn into an example document.
+    let rec private representativeValue (visiting: Type list) depth (resultType: Type) : obj =
+        let nestedValue nextType = representativeValue (resultType :: visiting) (depth + 1) nextType
+
+        if depth >= 16
+           || visiting |> List.exists ((=) resultType) then
+            null
+        elif resultType = typeof<string> then
+            box "example"
+        elif resultType = typeof<Guid> then
+            box (Guid.Parse("11111111-1111-1111-1111-111111111111"))
+        elif resultType = typeof<Uri> then
+            box (Uri("https://example.invalid/grace"))
+        elif resultType = typeof<DateTime> then
+            box (DateTime(2026, 6, 5, 0, 0, 0, DateTimeKind.Utc))
+        elif resultType = typeof<DateTimeOffset> then
+            box (DateTimeOffset(2026, 6, 5, 0, 0, 0, TimeSpan.Zero))
+        elif resultType = typeof<unit> then
+            box ()
+        elif isGenericTypeOf typedefof<option<_>> resultType then
+            null
+        elif resultType.IsArray then
+            box (Array.CreateInstance(resultType.GetElementType(), 0))
+        elif isGenericTypeOf typedefof<list<_>> resultType then
+            let emptyCase =
+                FSharpType.GetUnionCases(resultType, reflectionFlags)
+                |> Array.find (fun caseInfo -> caseInfo.GetFields().Length = 0)
+
+            FSharpValue.MakeUnion(emptyCase, [||], reflectionFlags)
+        elif FSharpType.IsTuple resultType then
+            let values =
+                FSharpType.GetTupleElements resultType
+                |> Array.map nestedValue
+
+            FSharpValue.MakeTuple(values, resultType)
+        elif FSharpType.IsRecord(resultType, reflectionFlags) then
+            let values =
+                FSharpType.GetRecordFields(resultType, reflectionFlags)
+                |> Array.map (fun field -> nestedValue field.PropertyType)
+
+            FSharpValue.MakeRecord(resultType, values, reflectionFlags)
+        elif FSharpType.IsUnion(resultType, reflectionFlags) then
+            let caseInfo = FSharpType.GetUnionCases(resultType, reflectionFlags)[0]
+
+            let values =
+                caseInfo.GetFields()
+                |> Array.map (fun field -> nestedValue field.PropertyType)
+
+            FSharpValue.MakeUnion(caseInfo, values, reflectionFlags)
+        elif resultType.IsEnum then
+            Enum.GetValues(resultType).GetValue(0)
+        elif resultType = typeof<obj> then
+            box (Dictionary<string, obj>())
+        else
+            match tryStringDictionaryValueType resultType, tryCollectionElementType resultType with
+            | Some valueType, _ ->
+                let dictionaryType = typedefof<Dictionary<_, _>>.MakeGenericType (typeof<string>, valueType)
+                Activator.CreateInstance(dictionaryType)
+            | None, Some elementType ->
+                if resultType.IsInterface then
+                    box (Array.CreateInstance(elementType, 0))
+                else
+                    try
+                        Activator.CreateInstance(resultType)
+                    with
+                    | _ -> box (Array.CreateInstance(elementType, 0))
+            | None, None ->
+                try
+                    Activator.CreateInstance(resultType)
+                with
+                | _ -> null
+
+    /// Serializes a deterministic representative through the same options used by runtime JSON output.
+    let private representativeExample resultType =
+        try
+            let value = representativeValue [] 0 resultType
+            let json = JsonSerializer.Serialize(value, resultType, Grace.Shared.Constants.JsonSerializerOptions)
+            box (JsonNode.Parse(json))
+        with
+        | _ -> null
+
+    /// Formats a declared CLR/F# type as concise CLI contract metadata.
+    let rec private contractTypeName (resultType: Type) =
+        if resultType = typeof<unit> then
+            "unit"
+        elif resultType = typeof<string> then
+            "string"
+        elif resultType = typeof<bool> then
+            "bool"
+        elif resultType = typeof<int> then
+            "int"
+        elif resultType = typeof<int64> then
+            "int64"
+        elif resultType.IsArray then
+            $"{contractTypeName (resultType.GetElementType())} array"
+        elif FSharpType.IsTuple resultType then
+            FSharpType.GetTupleElements resultType
+            |> Array.map contractTypeName
+            |> String.concat " * "
+        elif isGenericTypeOf typedefof<option<_>> resultType then
+            $"{contractTypeName (resultType.GetGenericArguments()[0])} option"
+        elif isGenericTypeOf typedefof<list<_>> resultType then
+            $"{contractTypeName (resultType.GetGenericArguments()[0])} list"
+        elif resultType.IsGenericType then
+            let genericName = resultType.Name.Split('`')[0]
+
+            resultType.GetGenericArguments()
+            |> Array.map contractTypeName
+            |> String.concat ", "
+            |> fun arguments -> $"{genericName}<{arguments}>"
+        else
+            resultType.Name
+
+    /// Resolves private CLI-local result records without making their implementation types public.
+    let private cliLocalResultType fullName =
+        match Assembly
+                  .GetExecutingAssembly()
+                  .GetType(fullName, false)
+            with
+        | null -> invalidOp $"CLI output result type '{fullName}' was not found."
+        | resultType -> resultType
 
     /// Builds command-output contract metadata for supported return value contract so automation can rely on stable JSON shapes.
     let private supportedReturnValueContract name provenance schema example notes =
@@ -761,131 +595,223 @@ module CommandOutputContract =
         | JsonModeErrorOnly reason -> $"Unsupported: {reason}"
         | SourceOnlyUnsupported reason -> $"Unsupported: {reason}"
 
-    /// Builds command-output contract metadata for return value contract for so automation can rely on stable JSON shapes.
+    /// Maps each JSON-success command to the exact result type declared by its current handler or SDK call.
+    let private declaredResultTypeFor commandId =
+        match commandId with
+        | "authorize.can"
+        | "authorize.check" -> typeof<Grace.Types.Authorization.PermissionCheckResult>
+        | "authorize.grant-role"
+        | "authorize.list-role-assignments"
+        | "authorize.revoke-role"
+        | "authorize.show" -> typeof<Grace.Types.Authorization.RoleAssignment list>
+        | "authorize.list-path-permissions"
+        | "authorize.remove-path-permission"
+        | "authorize.upsert-path-permission" -> typeof<Grace.Types.Common.PathPermission list>
+        | "authorize.list-roles" -> typeof<Grace.Types.Authorization.RoleDefinition list>
+        | "admin.reminder.list" -> typeof<IEnumerable<Grace.Types.Reminder.ReminderDto>>
+        | "admin.reminder.get" -> typeof<Grace.Types.Reminder.ReminderDto>
+        | "admin.reminder.create"
+        | "admin.reminder.delete"
+        | "admin.reminder.reschedule"
+        | "admin.reminder.update-time" -> typeof<string>
+        | "agent.add-summary" -> cliLocalResultType "Grace.CLI.Command.AgentCommand+AddSummaryResult"
+        | "agent.bootstrap"
+        | "agent.work.start"
+        | "agent.work.status"
+        | "agent.work.stop" -> typeof<Grace.Types.Automation.AgentSessionOperationResult>
+        | "alias.list" -> typeof<Grace.CLI.Common.LocalOutputDto.AliasListDto>
+        | "approval.policy.create"
+        | "approval.policy.delete"
+        | "approval.policy.disable"
+        | "approval.policy.enable"
+        | "approval.policy.show"
+        | "approval.policy.update" -> typeof<Grace.Types.Webhooks.ApprovalPolicy>
+        | "approval.policy.evaluate"
+        | "approval.policy.list" -> typeof<IReadOnlyList<Grace.Types.Webhooks.ApprovalPolicy>>
+        | "approval.request.approve"
+        | "approval.request.reject"
+        | "approval.request.show"
+        | "approval.request.wait" -> typeof<Grace.Types.Webhooks.ApprovalRequest>
+        | "approval.request.history"
+        | "approval.request.list" -> typeof<IReadOnlyList<Grace.Types.Webhooks.ApprovalRequest>>
+        | "authenticate.login"
+        | "authenticate.logout"
+        | "authenticate.token.clear"
+        | "authenticate.token.set"
+        | "authenticate.token.status" -> typeof<string>
+        | "authenticate.status" -> typeof<Grace.CLI.Command.Auth.AuthStatusOutput>
+        | "authenticate.token.create" -> typeof<Grace.Types.PersonalAccessToken.PersonalAccessTokenCreated>
+        | "authenticate.token.list" -> typeof<Grace.Types.PersonalAccessToken.PersonalAccessTokenSummary list>
+        | "authenticate.token.revoke" -> typeof<Grace.Types.PersonalAccessToken.PersonalAccessTokenSummary>
+        | "authenticate.whoami" -> typeof<Grace.CLI.Command.Auth.AuthInfo>
+        | "branch.annotate" -> typeof<Grace.Types.Annotation.BranchAnnotationDto>
+        | "branch.assign"
+        | "branch.checkpoint"
+        | "branch.commit"
+        | "branch.create"
+        | "branch.create-external"
+        | "branch.delete"
+        | "branch.enable-assign"
+        | "branch.enable-auto-rebase"
+        | "branch.enable-checkpoints"
+        | "branch.enable-commit"
+        | "branch.enable-external"
+        | "branch.enable-promotion"
+        | "branch.enable-save"
+        | "branch.enable-tag"
+        | "branch.promote"
+        | "branch.save"
+        | "branch.set-name"
+        | "branch.set-promotion-mode"
+        | "branch.tag"
+        | "branch.update-parent-branch" -> typeof<string>
+        | "branch.get" -> typeof<Grace.Types.Branch.BranchDto>
+        | "branch.get-checkpoints"
+        | "branch.get-commits"
+        | "branch.get-externals"
+        | "branch.get-promotions"
+        | "branch.get-references"
+        | "branch.get-saves"
+        | "branch.get-tags" -> typeof<Grace.Types.Branch.BranchDto * Grace.Types.Reference.ReferenceDto array>
+        | "branch.get-recursive-size" -> typeof<int64>
+        | "branch.list-contents" -> typeof<IEnumerable<Grace.Types.DirectoryVersion.DirectoryVersionDto>>
+        | "candidate.attestations" -> typeof<Grace.Shared.Parameters.Review.CandidateAttestationsResult>
+        | "candidate.cancel"
+        | "candidate.gate.rerun"
+        | "candidate.retry" -> typeof<Grace.Shared.Parameters.Review.CandidateActionResult>
+        | "candidate.get" -> typeof<Grace.Shared.Parameters.Review.CandidateProjectionSnapshotResult>
+        | "candidate.required-actions" -> typeof<Grace.Shared.Parameters.Review.CandidateRequiredActionsResult>
+        | "config.write" -> typeof<unit>
+        | "connect" -> typeof<Grace.CLI.Common.LocalOutputDto.ConnectDto>
+        | "diff.blake3" -> typeof<Grace.Types.Diff.DiffDto>
+        | "directory-version.get-zip-file" -> typeof<Uri>
+        | "history.delete" -> typeof<Grace.CLI.Common.LocalOutputDto.HistoryDeleteDto>
+        | "history.off"
+        | "history.on" -> typeof<Grace.CLI.Common.LocalOutputDto.HistoryRecordingDto>
+        | "history.search"
+        | "history.show" -> typeof<Grace.CLI.Common.LocalOutputDto.HistoryEntriesDto>
+        | "doctor" -> typeof<Grace.CLI.Common.LocalOutputDto.DoctorReportDto>
+        | "maintenance.check-ignore-entries" -> typeof<Grace.CLI.Common.LocalOutputDto.MaintenanceIgnoreEntriesDto>
+        | "maintenance.clear-journal" -> typeof<Grace.CLI.Common.LocalOutputDto.MaintenanceClearJournalDto>
+        | "maintenance.list-contents" -> typeof<Grace.CLI.Common.LocalOutputDto.MaintenanceListContentsDto>
+        | "maintenance.scan" -> typeof<Grace.CLI.Common.LocalOutputDto.MaintenanceScanDto>
+        | "maintenance.show-journal" -> typeof<Grace.CLI.Common.LocalOutputDto.MaintenanceShowJournalDto>
+        | "maintenance.stats"
+        | "maintenance.update-index" -> typeof<Grace.CLI.Common.LocalOutputDto.MaintenanceStatsDto>
+        | "organization.create"
+        | "organization.delete"
+        | "organization.set-description"
+        | "organization.set-name"
+        | "organization.set-search-visibility"
+        | "organization.set-type"
+        | "organization.undelete" -> typeof<string>
+        | "organization.get" -> typeof<Grace.Types.Organization.OrganizationDto>
+        | "owner.create"
+        | "owner.delete"
+        | "owner.set-description"
+        | "owner.set-name"
+        | "owner.set-search-visibility"
+        | "owner.set-type"
+        | "owner.undelete" -> typeof<string>
+        | "owner.get" -> typeof<Grace.Types.Owner.OwnerDto>
+        | "promotion-set.apply"
+        | "promotion-set.conflicts.resolve"
+        | "promotion-set.create"
+        | "promotion-set.delete"
+        | "promotion-set.recompute"
+        | "promotion-set.request-approval"
+        | "promotion-set.update-input-promotions" -> typeof<string>
+        | "promotion-set.conflicts.show" -> cliLocalResultType "Grace.CLI.Command.PromotionSetCommand+ConflictShowResult"
+        | "promotion-set.get"
+        | "promotion-set.show" -> typeof<Grace.Types.PromotionSet.PromotionSetDto>
+        | "promotion-set.get-events" -> typeof<IReadOnlyList<Grace.Types.PromotionSet.PromotionSetEvent>>
+        | "promotion-set.list" -> typeof<(Grace.Types.PromotionSet.PromotionSetDto * Grace.Types.Webhooks.PromotionSetApprovalSummary option) list>
+        | "queue.dequeue"
+        | "queue.enqueue"
+        | "queue.pause"
+        | "queue.resume" -> typeof<string>
+        | "queue.status" -> typeof<Grace.Types.Queue.PromotionQueue>
+        | "repository.create"
+        | "repository.delete"
+        | "repository.set-allows-large-files"
+        | "repository.set-anonymous-access"
+        | "repository.set-checkpoint-days"
+        | "repository.set-conflict-resolution-policy"
+        | "repository.set-default-server-api-version"
+        | "repository.set-description"
+        | "repository.set-diff-cache-days"
+        | "repository.set-directory-version-cache-days"
+        | "repository.set-logical-delete-days"
+        | "repository.set-name"
+        | "repository.set-record-saves"
+        | "repository.set-save-days"
+        | "repository.set-status"
+        | "repository.set-visibility"
+        | "repository.undelete" -> typeof<string>
+        | "repository.get" -> typeof<Grace.Types.Repository.RepositoryDto>
+        | "repository.get-branches" -> typeof<IEnumerable<Grace.Types.Branch.BranchDto>>
+        | "repository.init" -> typeof<Grace.CLI.Common.LocalOutputDto.RepositoryInitDto>
+        | "review.checkpoint"
+        | "review.deepen"
+        | "review.resolve" -> typeof<string>
+        | "review.inbox" -> typeof<obj>
+        | "review.open" -> typeof<Grace.Types.Review.ReviewNotes option>
+        | "review.report.export" -> typeof<Grace.CLI.Common.LocalOutputDto.ReviewReportExportDto>
+        | "review.report.show" -> typeof<Grace.SDK.ReviewReportResult>
+        | "watch" -> cliLocalResultType "Grace.CLI.Command.Watch+WatchCheckStatusDto"
+        | "webhook.create"
+        | "webhook.delete"
+        | "webhook.disable"
+        | "webhook.enable"
+        | "webhook.show"
+        | "webhook.update" -> typeof<Grace.Types.Webhooks.WebhookRule>
+        | "webhook.deliveries" -> typeof<IReadOnlyList<Grace.Types.Webhooks.WebhookDelivery>>
+        | "webhook.delivery.show"
+        | "webhook.test" -> typeof<Grace.Types.Webhooks.WebhookDelivery>
+        | "webhook.list" -> typeof<IReadOnlyList<Grace.Types.Webhooks.WebhookRule>>
+        | "workitem.attach.notes"
+        | "workitem.attach.prompt"
+        | "workitem.attach.summary" -> cliLocalResultType "Grace.CLI.Command.WorkItemCommand+AttachmentResult"
+        | "workitem.attachments.download" -> cliLocalResultType "Grace.CLI.Command.WorkItemCommand+AttachmentDownloadResult"
+        | "workitem.attachments.list" -> typeof<Grace.Shared.Parameters.WorkItem.ListWorkItemAttachmentsResult>
+        | "workitem.attachments.show" -> typeof<Grace.Shared.Parameters.WorkItem.ShowWorkItemAttachmentResult>
+        | "workitem.create"
+        | "workitem.link.prset"
+        | "workitem.link.ref"
+        | "workitem.links.remove.notes"
+        | "workitem.links.remove.prompt"
+        | "workitem.links.remove.prset"
+        | "workitem.links.remove.ref"
+        | "workitem.links.remove.summary"
+        | "workitem.status" -> typeof<string>
+        | "workitem.links.list" -> typeof<Grace.Types.WorkItem.WorkItemLinksDto>
+        | "workitem.show" -> typeof<Grace.Types.WorkItem.WorkItemDto>
+        | unknown -> invalidOp $"JSON-success command '{unknown}' does not declare a ReturnValue type in CommandOutputContract."
+
+    /// Builds type-derived schema and examples for every command that already emits a Grace success envelope.
+    let private typeDerivedReturnValueContract commandId =
+        let resultType = declaredResultTypeFor commandId
+
+        supportedReturnValueContract
+            (contractTypeName resultType)
+            $"Declared ReturnValue type: {resultType.FullName}"
+            (schemaForType [] resultType)
+            (representativeExample resultType)
+            [
+                "ReturnValue schema and example are derived from the declared result type and Grace's configured JSON serializer policy."
+            ]
+
+    /// Selects a derived contract only for commands with a real JSON success path.
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
-        match identity.CommandId, envelopeContract with
-        | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceIgnoreEntriesDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceIgnoreEntriesSchema
-                maintenanceIgnoreEntriesExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance check-ignore-entries in the common Grace result envelope."
-                ]
-        | "maintenance.list-contents", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceListContentsDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceListContentsSchema
-                maintenanceListContentsExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance list-contents in the common Grace result envelope."
-                ]
-        | "maintenance.scan", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceScanDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceScanSchema
-                maintenanceScanExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance scan in the common Grace result envelope."
-                ]
-        | "maintenance.show-journal", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceShowJournalDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceShowJournalSchema
-                maintenanceShowJournalExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance show-journal in the common Grace result envelope."
-                    "Rows expose durable sequence diagnostics and derived applied/pending state without storing raw watcher events as replay data."
-                ]
-        | "maintenance.clear-journal", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceClearJournalDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceClearJournalSchema
-                maintenanceClearJournalExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance clear-journal in the common Grace result envelope."
-                    "The command clears only Watch journal rows, SQLite allocation metadata, and the AppliedThroughSequence watermark."
-                ]
-        | "maintenance.stats", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceStatsDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceStatsSchema
-                maintenanceStatsExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance stats in the common Grace result envelope."
-                ]
-        | "maintenance.update-index", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "MaintenanceStatsDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                maintenanceStatsSchema
-                maintenanceStatsExample
-                [
-                    "Command-specific CLI DTO emitted by maintenance update-index in the common Grace result envelope after the local index is updated."
-                ]
-        | "doctor", ExistingGraceResultEnvelope RequiresCliDto ->
-            supportedReturnValueContract
-                "DoctorReportDto"
-                "Grace.CLI.Command.Common.LocalOutputDto"
-                doctorReportSchema
-                doctorReportExample
-                [
-                    "Command-specific CLI DTO emitted by grace doctor in the common Grace result envelope."
-                    "Doctor schema and examples are intentionally available in the S0 scaffold because later slices add real diagnostics behind the stable DTO."
-                ]
-        | "repository.get", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            incompleteReturnValueContract
-                "RepositoryDto"
-                "RepositoryDto metadata is incomplete: src/Grace.Types/Repository.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
-        | "workitem.show", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            incompleteReturnValueContract
-                "WorkItemDto"
-                "WorkItemDto metadata is incomplete: src/Grace.Types/WorkItem.Types.fs declares additional emitted fields that are not yet represented in the CLI contract registry."
-        | ("authorize.can"
-          | "authorize.check"),
-          ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            incompleteReturnValueContract
-                "PermissionCheckResult"
-                "PermissionCheckResult metadata is incomplete: src/Grace.Types/Authorization.Types.fs emits the Allowed/Denied discriminated union, not an object with Allowed and Reason fields."
-        | "authenticate.logout", ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto ->
-            supportedReturnValueContract
-                "string"
-                "GraceReturnValue<string>"
-                stringReturnValueSchema
-                (box "Signed out.")
-                [
-                    "Representative scalar ReturnValue schema for a common Grace result envelope command."
-                ]
-        | "watch", ConditionalGraceResultEnvelope (RequiresCliDto, _) ->
-            supportedReturnValueContract
-                "WatchStatusDto"
-                "Grace.CLI.Command.Watch"
-                watchStatusSchema
-                watchStatusExample
-                [
-                    "`grace watch --check` emits this status DTO in JSON mode. Foreground `grace watch --output Json` remains unsupported because the watcher is a continuous workflow."
-                ]
-        | "watch", JsonModeErrorOnly reason -> unsupportedReturnValueContract "WatchStatusDto" reason
-        | _, SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
-        | _, JsonModeErrorOnly reason -> unsupportedReturnValueContract "unsupported" reason
-        | _, MigrationRequiredToGraceResultEnvelope disposition ->
+        match envelopeContract with
+        | ExistingGraceResultEnvelope _
+        | ConditionalGraceResultEnvelope _ -> typeDerivedReturnValueContract identity.CommandId
+        | SourceOnlyUnsupported reason -> unsupportedReturnValueContract "unsupported" reason
+        | JsonModeErrorOnly reason -> unsupportedReturnValueContract "unsupported" reason
+        | MigrationRequiredToGraceResultEnvelope disposition ->
             incompleteReturnValueContract
                 (outputDtoDispositionText disposition)
                 "This command is routed, but its JSON success path still requires migration before schema/examples can describe the emitted ReturnValue."
-        | _, ConditionalGraceResultEnvelope (disposition, condition) ->
-            incompleteReturnValueContract
-                (outputDtoDispositionText disposition)
-                $"This command has a conditional JSON success path, but command-specific ReturnValue schema/example metadata has not been declared yet. {condition}"
-        | _, ExistingGraceResultEnvelope disposition ->
-            incompleteReturnValueContract
-                (outputDtoDispositionText disposition)
-                "The registry has envelope metadata for this command, but command-specific ReturnValue schema/example metadata has not been declared yet."
 
     /// Builds the command document section of the machine-readable command-output contract.
     let private commandDocument (identity: CommandIdentity) =
@@ -1061,10 +987,8 @@ module CommandOutputContract =
             { JsonMode = UnsupportedUntilRouted; Schema = UnsupportedUntilRouted; Examples = UnsupportedUntilRouted; Select = UnsupportedUntilRouted }
         | ImmediateJsonErrorOnly ->
             { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = RequiresMigration }
-        | ConditionalCheckStatusEnvelope ->
-            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
-        | CommonRenderOutputEnvelope ->
-            { JsonMode = ExistingBehavior; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = ExistingBehavior }
+        | ConditionalCheckStatusEnvelope -> { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
+        | CommonRenderOutputEnvelope -> { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
         | _ -> { JsonMode = RequiresMigration; Schema = FutureInertIntrospection; Examples = FutureInertIntrospection; Select = FutureReturnValueProjection }
 
     /// Builds command-output contract metadata for envelope for so automation can rely on stable JSON shapes.
@@ -1127,11 +1051,7 @@ module CommandOutputContract =
             ExecutionScope = executionScope
             Mutating = mutating
             EnvelopeContract = envelopeContract
-            Features =
-                if identity.CommandId.Equals("doctor", StringComparison.Ordinal) then
-                    { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
-                else
-                    featuresFor behavior
+            Features = featuresFor behavior
             ReturnValueContract = returnValueContractFor identity envelopeContract
         }
 


### PR DESCRIPTION
# CLI discovery contract: typed nested schemas and examples

## Summary

Derives CLI `--schema` success metadata from each command's actual existing `ReturnValue` type and makes
`--examples` serialize representative typed values through Grace's configured JSON serializer. The public
`cli-json-v1` outer `GraceReturnValue<T>` and `GraceError` contracts remain unchanged.

Closes #792

## Why

People and agents need to discover a command's usable result shape before executing it. Previously, most commands
truthfully described the wrapper but left the nested `ReturnValue` as an unsupported placeholder. The registry now
exposes that existing nested shape without changing runtime output.

## Contract and risk handling

- The runtime `-o Json` envelope is unchanged; `ReturnValue` remains nested in `GraceReturnValue<T>`.
- Schema and example generation reuse Grace's F# JSON configuration and are inert: no handler, configuration, ID,
  network, or mutation work runs.
- `refs` remains its real two-item tuple contract, represented in JSON as `[BranchDto, ReferenceDto[]]`.
- Source-only, error-only, and migration-required entries remain explicitly unsupported or incomplete.

## Validation

- Release build: 0 warnings and 0 errors.
- `Grace.CLI.Tests`: 1,278 passed, 0 failed, 0 skipped.
- Focused command-output contract tests: 24 passed.
- Registry audit: all 188 eligible success paths are schema-ready.
- MarkdownLint and `git diff --check`: clean.

## Documentation

Updated `docs/Machine-readable CLI output.md`. ADR 0004 already mandates the retained envelope and registry-derived
result shape, so no ADR decision change is needed.

## Review Status

- Worker starts: 1 of 4 used for the initial implementation.
- Worker self-review: complete; no residual correctness findings reported.
- Independent current-head review: approved on `e479d19eb519d65450472958499429c9d3c298b8`; no findings.
- Reviewer proof: all 188 registered representative values deserialize through their declared types using Grace JSON
  options; focused registry suite passed 24 of 24.
- Required GitHub `Validate`: passed for `e479d19eb519d65450472958499429c9d3c298b8` in 8m13s.
