### PR TITLE
Coalesce Watch local-state revisions

### DIFF
--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -2930,6 +2930,46 @@ module LocalStateDbTests =
                 |> should be (lessThan 1500L)
             })
 
+    /// Verifies that each committed status transaction returns and persists one monotonic local-status revision.
+    [<Test>]
+    let ``status transactions advance and return committed local-status revision`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let! initialRevision = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+                initialRevision |> should equal 0L
+
+                let status = createTestStatus (Guid.NewGuid()) "revision-root" 100L
+
+                let! replacementRevision = LocalStateDb.replaceStatusSnapshotWithRevision configuration.GraceStatusFile status
+                replacementRevision |> should equal 1L
+
+                let! incrementalRevision = LocalStateDb.applyStatusIncrementalWithRevision configuration.GraceStatusFile status Seq.empty Seq.empty
+
+                incrementalRevision |> should equal 2L
+
+                let! durableRevision = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                durableRevision
+                |> should equal incrementalRevision
+            })
+
+    /// Verifies malformed local-status revision metadata is rejected instead of becoming an incremental baseline.
+    [<Test>]
+    let ``local-status revision reader rejects malformed durable evidence`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeNonQuery connection $"UPDATE meta SET value = 'invalid' WHERE key = '{LocalStateDb.LocalStatusRevisionMetaKey}';"
+
+                let operation = Func<Task>(fun () -> LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile :> Task)
+
+                Assert.ThrowsAsync<InvalidDataException>(operation)
+                |> ignore
+            })
+
     /// Verifies that replace status snapshot is atomic (rollback on failure).
     [<Test>]
     let ``replaceStatusSnapshot is atomic (rollback on failure)`` () =
@@ -2954,6 +2994,7 @@ module LocalStateDbTests =
                     }
 
                 do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusA
+                let! revisionBeforeFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
 
                 use connection = openRawConnection configuration.GraceStatusFile
 
@@ -2988,6 +3029,11 @@ module LocalStateDbTests =
                 |> should equal statusA.LastSuccessfulFileUpload
 
                 readBack.Index.Count |> should equal 1
+
+                let! revisionAfterFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                revisionAfterFailure
+                |> should equal revisionBeforeFailure
             })
 
     /// Verifies that apply status incremental is atomic (rollback on failure).
@@ -3018,6 +3064,7 @@ module LocalStateDbTests =
                     }
 
                 do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusA
+                let! revisionBeforeFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
 
                 use connection = openRawConnection configuration.GraceStatusFile
 
@@ -3052,6 +3099,11 @@ module LocalStateDbTests =
                 |> Seq.collect (fun dv -> dv.Files)
                 |> Seq.exists (fun file -> file.RelativePath = "src/file.txt")
                 |> should equal false
+
+                let! revisionAfterFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                revisionAfterFailure
+                |> should equal revisionBeforeFailure
             })
 
     /// Verifies that concurrent ensure db initialized calls do not deadlock or corrupt.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -7420,14 +7420,12 @@ module WatchTests =
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
-    /// Verifies that delayed GraceStatus artifact observations still publish refresh work after switch completion.
+    /// Verifies delayed local-state callbacks remain revision signals and cannot gain candidate scope after a root change.
     [<Test>]
-    let ``update marker deletion preserves delayed GraceStatus artifact refresh observation`` () =
-        withTempRepo (fun _ ->
+    let ``delayed local-state callback stays out of candidate scope after root change`` () =
+        withTempRepo (fun root ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
-            let updateMarkerFile = Services.updateInProgressFileName ()
-            let markerCompletedUtc = DateTime.UtcNow
             let graceStatusFile = Current().GraceStatusFile
 
             Services.setGraceWatchHasPendingWorkForStatus false
@@ -7436,23 +7434,31 @@ module WatchTests =
                 .GetAwaiter()
                 .GetResult()
 
-            Directory.CreateDirectory(Path.GetDirectoryName(graceStatusFile))
-            |> ignore
-
-            File.WriteAllText(graceStatusFile, "Grace-owned local state refresh")
-            File.SetLastWriteTimeUtc(graceStatusFile, markerCompletedUtc.AddSeconds(-1.0))
-            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+            Watch.setKnownLocalStatusRevisionForWatchTests 4L
 
             Watch.OnChanged(changedEvent graceStatusFile)
 
-            Watch.graceStatusHasChangedForWatchTests ()
+            Current().RootDirectory <- Path.Combine(root, "new-root")
+            Watch.processDueLocalObservationCandidatesForWatchTests (DateTime.UtcNow.AddMinutes(1.0))
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.isEmpty
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
+
+            Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+            |> should equal None
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
             |> should equal true
 
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
-            |> should equal true
+            |> should equal false
 
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
-            |> should equal false)
+            |> should equal true)
 
     /// Builds GraceStatus around explicit file versions so tests can model content-equivalent uploads.
     let private graceStatusTrackingFileVersions (trackedFiles: LocalFileVersion array) =
@@ -16719,9 +16725,9 @@ module WatchTests =
                 readWatchStatusJsonStringProperty "RootDirectoryId"
                 |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}")
 
-    /// Verifies that a pending GraceStatus artifact refresh publishes dirty IPC before the timer reloads status.
+    /// Verifies that local-state artifact callbacks remain quiet until their committed revision is checked.
     [<Test>]
-    let ``watch grace status artifact change publishes dirty ipc`` () =
+    let ``watch local-state artifact callbacks do not publish pending ipc`` () =
         withTempRepo (fun _ ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
@@ -16738,48 +16744,175 @@ module WatchTests =
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
             |> should equal true
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+            let cleanIpc = File.ReadAllText(Services.IpcFileName())
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            let callbackOutput =
+                captureAnsiConsoleOutput (fun () ->
+                    for suffix in
+                        [|
+                            String.Empty
+                            "-wal"
+                            "-shm"
+                            "-journal"
+                        |] do
+                        Watch.OnChanged(changedEvent (Current().GraceStatusFile + suffix)))
+
+            callbackOutput |> should equal String.Empty
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.isEmpty
             |> should equal true
 
-            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            Watch.isGraceWatchResyncPendingForWatchTests ()
             |> should equal false
+
+            Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+            |> should equal None
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal cleanIpc
 
             Services.getGraceWatchStatus().Result
-            |> should equal None)
+            |> Option.isSome
+            |> should equal true)
 
-    /// Verifies that a blocked dirty IPC write can retry while the GraceStatus refresh flag is already pending.
+    /// Verifies duplicate SQLite callbacks coalesce into one quiet revision read for a Watch-owned commit.
     [<Test>]
-    let ``watch grace status artifact change retries dirty ipc while refresh is pending`` () =
+    let ``watch duplicate local-state callbacks perform one quiet revision check`` () =
         withTempRepo (fun _ ->
-            let status = graceStatusTracking Array.empty<string> Array.empty<string>
-            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let mutable reads = 0
+            let mutable advances = 0
+            let mutable failures = 0
 
-            Services.setGraceWatchHasPendingWorkForStatus false
+            Watch.setKnownLocalStatusRevisionForWatchTests 7L
 
-            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-shm"))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () ->
+                    reads <- reads + 1
+                    Task.FromResult(7L))
+                (fun () -> advances <- advances + 1)
+                (fun _ -> failures <- failures + 1))
                 .GetAwaiter()
                 .GetResult()
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
-            |> should equal false
+            reads |> should equal 1
+            advances |> should equal 0
+            failures |> should equal 0
 
-            use blockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal false)
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
-            blockedIpc.Dispose()
+    /// Verifies a greater external revision schedules exactly one controlled status refresh without immediate IPC work.
+    [<Test>]
+    let ``watch external local-status revision schedules one controlled refresh`` () =
+        withTempRepo (fun _ ->
+            let initialStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let initialDirectoryIds = HashSet<DirectoryVersionId>(initialStatus.Index.Keys)
+            let updatedStatus = { initialStatus with RootDirectorySha256Hash = Sha256Hash "external-revision-root" }
+            let mutable publications = 0
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
-            |> should equal false
+            Services.setGraceWatchHasPendingWorkForStatus false
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+            (Services.updateGraceWatchInterprocessFile initialStatus (Some initialDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            let initialIpc = File.ReadAllText(Services.IpcFileName())
+            Watch.setKnownLocalStatusRevisionForWatchTests 11L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-journal"))
+
+            (Watch.processLocalStatusRevisionCheckWithRefreshForWatchTests (fun () -> Task.FromResult(12L)) (fun reason -> Assert.Fail(reason)))
+                .GetAwaiter()
+                .GetResult()
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal initialIpc
+
+            Watch.graceStatusHasChangedForWatchTests ()
             |> should equal true
 
-            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
-            |> should equal false)
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests updatedStatus (fun status directoryIds ->
+                publications <- publications + 1
+                Services.updateGraceWatchInterprocessFile status directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            publications |> should equal 1
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal false
+
+            readWatchStatusJsonStringProperty "RootDirectorySha256Hash"
+            |> should equal $"{updatedStatus.RootDirectorySha256Hash}")
+
+    /// Verifies an external revision committed after Watch's own revision remains visible to the coalesced timer check.
+    [<Test>]
+    let ``watch own revision followed by external revision preserves newer commit`` () =
+        withTempRepo (fun _ ->
+            let mutable advances = 0
+            Watch.setKnownLocalStatusRevisionForWatchTests 20L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () -> Task.FromResult(21L))
+                (fun () -> advances <- advances + 1)
+                (fun reason -> Assert.Fail(reason)))
+                .GetAwaiter()
+                .GetResult()
+
+            advances |> should equal 1)
+
+    /// Verifies regressed local-status evidence remains pending and enters the fail-closed path.
+    [<Test>]
+    let ``watch regressed local-status revision fails closed and retries`` () =
+        withTempRepo (fun _ ->
+            let mutable failure = None
+            Watch.setKnownLocalStatusRevisionForWatchTests 30L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () -> Task.FromResult(29L))
+                (fun () -> Assert.Fail("A regressed revision must not be accepted."))
+                (fun reason -> failure <- Some reason))
+                .GetAwaiter()
+                .GetResult()
+
+            failure |> Option.isSome |> should equal true
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal true)
+
+    /// Verifies unreadable local-status revision evidence remains pending and enters the fail-closed path.
+    [<Test>]
+    let ``watch unreadable local-status revision fails closed and retries`` () =
+        withTempRepo (fun _ ->
+            let mutable failure = None
+            Watch.setKnownLocalStatusRevisionForWatchTests 40L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () -> Task.FromException<int64>(InvalidDataException("invalid revision metadata")))
+                (fun () -> Assert.Fail("Unreadable revision evidence must not be accepted."))
+                (fun reason -> failure <- Some reason))
+                .GetAwaiter()
+                .GetResult()
+
+            failure
+            |> Option.exists (fun reason -> reason.Contains("invalid revision metadata", StringComparison.Ordinal))
+            |> should equal true
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal true)
 
     /// Verifies that a consumed GraceStatus refresh can publish clean IPC during the same timer tick.
     [<Test>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -427,10 +427,12 @@ module WatchTests =
             Watch.resetWatchIgnoreSnapshotForWatchTests ()
             deleteWatchStatusFileIfExists ()
             Watch.clearPendingWatchWorkForTests ()
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
             Watch.setLocalObservationCandidateSchedulingForWatchTests false
             action tempDir
         finally
             Watch.clearPendingWatchWorkForTests ()
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
             Watch.resetWatchIgnoreSnapshotForWatchTests ()
             Services.clearShouldIgnoreCache ()
             Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
@@ -16781,6 +16783,163 @@ module WatchTests =
             Services.getGraceWatchStatus().Result
             |> Option.isSome
             |> should equal true)
+
+    /// Verifies startup establishes the durable revision before SQLite artifact callbacks can be admitted.
+    [<Test>]
+    let ``watch startup records durable revision before admitting local-state callbacks`` () =
+        withTempRepo (fun _ ->
+            let mutable initializationReadCompleted = false
+            let mutable callbacksObservedInitialization = false
+            let mutable revisionReads = 0
+            let mutable failures = 0
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let initialIpc = File.ReadAllText(Services.IpcFileName())
+            let initialScope = Watch.lastPublishedWatchObservationScopeForWatchTests ()
+
+            (Watch.initializeLocalStatusRevisionBeforeArtifactCallbacksForWatchTests
+                (fun () ->
+                    revisionReads <- revisionReads + 1
+                    initializationReadCompleted <- true
+                    Task.FromResult(6L))
+                (fun () ->
+                    task {
+                        callbacksObservedInitialization <- initializationReadCompleted
+
+                        let callbackOutput = captureAnsiConsoleOutput (fun () -> Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal")))
+
+                        callbackOutput |> should equal String.Empty
+
+                        Watch.localObservationCandidateSnapshotForWatchTests ()
+                        |> Array.isEmpty
+                        |> should equal true
+
+                        Watch.pendingWatchWorkEvidenceForWatchTests ()
+                        |> should equal (false, false)
+
+                        Watch.isGraceWatchResyncPendingForWatchTests ()
+                        |> should equal false
+
+                        Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                        |> should equal None
+
+                        Watch.lastPublishedWatchObservationScopeForWatchTests ()
+                        |> should equal initialScope
+
+                        File.ReadAllText(Services.IpcFileName())
+                        |> should equal initialIpc
+                    })
+                (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () ->
+                    revisionReads <- revisionReads + 1
+                    Task.FromResult(6L))
+                (fun () -> Assert.Fail("The startup revision callback must clear silently."))
+                (fun reason -> Assert.Fail(reason)))
+                .GetAwaiter()
+                .GetResult()
+
+            callbacksObservedInitialization
+            |> should equal true
+
+            revisionReads |> should equal 2
+            failures |> should equal 0
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal false)
+
+    /// Verifies a Watch-owned commit cannot hide a later external commit observed by the coalesced timer read.
+    [<Test>]
+    let ``watch owned revision commit then external revision commit schedules only controlled refresh`` () =
+        withTempRepo (fun _ ->
+            let mutable durableRevision = 19L
+            let mutable failures = 0
+            let mutable publications = 0
+            let initialStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let initialDirectoryIds = HashSet<DirectoryVersionId>(initialStatus.Index.Keys)
+            let updatedStatus = { initialStatus with RootDirectorySha256Hash = Sha256Hash "external-race-root" }
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile initialStatus (Some initialDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let initialIpc = File.ReadAllText(Services.IpcFileName())
+            let initialScope = Watch.lastPublishedWatchObservationScopeForWatchTests ()
+
+            (Watch.initializeLocalStatusRevisionBeforeArtifactCallbacksForWatchTests
+                (fun () -> Task.FromResult(durableRevision))
+                (fun () -> task { return () })
+                (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            (Watch.runWatchOwnedLocalStatusWriteForWatchTests (fun () ->
+                durableRevision <- 20L
+                Task.FromResult(durableRevision)))
+                .GetAwaiter()
+                .GetResult()
+
+            let callbackOutput = captureAnsiConsoleOutput (fun () -> Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-shm")))
+
+            callbackOutput |> should equal String.Empty
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.isEmpty
+            |> should equal true
+
+            Watch.pendingWatchWorkEvidenceForWatchTests ()
+            |> should equal (false, false)
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
+
+            Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+            |> should equal None
+
+            Watch.lastPublishedWatchObservationScopeForWatchTests ()
+            |> should equal initialScope
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal initialIpc
+
+            durableRevision <- 21L
+
+            (Watch.processLocalStatusRevisionCheckWithRefreshForWatchTests (fun () -> Task.FromResult(durableRevision)) (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            failures |> should equal 0
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal true
+
+            publications |> should equal 0
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests updatedStatus (fun status directoryIds ->
+                publications <- publications + 1
+                Services.updateGraceWatchInterprocessFile status directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            publications |> should equal 1
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal false
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal false)
 
     /// Verifies duplicate SQLite callbacks coalesce into one quiet revision read for a Watch-owned commit.
     [<Test>]

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3342,6 +3342,13 @@ module Watch =
             | ex -> revisionUntrusted $"local-status revision could not be established at startup: {ex.Message}"
         }
 
+    /// Establishes the durable startup revision before enabling any source of local-state artifact callbacks.
+    let private initializeLocalStatusRevisionBeforeArtifactCallbacks readRevision admitCallbacks revisionUntrusted =
+        task {
+            do! initializeLocalStatusRevision readRevision revisionUntrusted
+            do! admitCallbacks ()
+        }
+
     /// Applies a Watch-owned incremental status mutation and remembers its committed local-status revision.
     let private applyGraceStatusIncrementalAndRecordRevision graceStatus directoryVersions differences =
         runWatchOwnedLocalStatusWrite (fun () ->
@@ -3358,6 +3365,13 @@ module Watch =
     /// Exercises the production external-revision transition while keeping revision reads and failure handling deterministic.
     let internal processLocalStatusRevisionCheckWithRefreshForWatchTests readRevision revisionUntrusted =
         processLocalStatusRevisionCheck readRevision recordGraceStatusRefreshObservation revisionUntrusted
+
+    /// Exercises startup revision initialization and callback admission in production order with deterministic clients.
+    let internal initializeLocalStatusRevisionBeforeArtifactCallbacksForWatchTests readRevision admitCallbacks revisionUntrusted =
+        initializeLocalStatusRevisionBeforeArtifactCallbacks readRevision admitCallbacks revisionUntrusted
+
+    /// Exercises the production gate that records a Watch-owned committed local-status revision.
+    let internal runWatchOwnedLocalStatusWriteForWatchTests writeStatus = runWatchOwnedLocalStatusWrite writeStatus
 
     /// Establishes a known local-status revision for callback and restart tests.
     let internal setKnownLocalStatusRevisionForWatchTests revision = recordKnownLocalStatusRevision revision
@@ -9461,16 +9475,18 @@ module Watch =
                     updateGraceStatusDirectoryIds graceStatus
 
                     do!
-                        initializeLocalStatusRevision
+                        initializeLocalStatusRevisionBeforeArtifactCallbacks
                             (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                            (fun () ->
+                                task {
+                                    // Create the inter-process communication file.
+                                    do! publishStartupCatchUpPendingStatus graceStatus graceStatusDirectoryIds updateGraceWatchInterprocessFile
+
+                                    // Enable the FileSystemWatcher only after the durable local-status revision is established.
+                                    rootDirectoryFileSystemWatcher.EnableRaisingEvents <- true
+                                    updateInProgressFileSystemWatcher.EnableRaisingEvents <- true
+                                })
                             (fun reason -> requestGraceWatchExplicitResync reason)
-
-                    // Create the inter-process communication file.
-                    do! publishStartupCatchUpPendingStatus graceStatus graceStatusDirectoryIds updateGraceWatchInterprocessFile
-
-                    // Enable the FileSystemWatcher.
-                    rootDirectoryFileSystemWatcher.EnableRaisingEvents <- true
-                    updateInProgressFileSystemWatcher.EnableRaisingEvents <- true
 
                     let timerTimeSpan = TimeSpan.FromSeconds(1.0)
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -524,6 +524,10 @@ module Watch =
     let mutable graceStatusMemoryStream: MemoryStream = null
     let mutable graceStatusHasChanged = false
     let mutable private graceStatusRefreshGeneration = 0L
+    let mutable private localStatusRevisionCheckGeneration = 0L
+    let mutable private lastKnownLocalStatusRevision = 0L
+    let mutable private localStatusRevisionInitialized = 0
+    let private localStatusRevisionGate = new SemaphoreSlim(1, 1)
     let private watchStatusPublishLock = obj ()
     let mutable private lastPublishedHasPendingWatchWork: bool option = None
 
@@ -818,7 +822,6 @@ module Watch =
         | CreatedOrChanged
         | Changed
         | Deleted
-        | GraceStatusArtifact
 
     /// Captures the immutable repository and root identity that owned a raw local observation at admission.
     type internal WatchObservationScope =
@@ -1169,11 +1172,8 @@ module Watch =
         let snapshot = currentWatchIgnoreSnapshot ()
         isPathWithinDirectoryForWatch snapshot.GraceDirectory fullPath
 
-    /// Preserves status coordination while rejecting other Grace-owned paths before raw candidate scope capture.
-    let private tryClassifyRawLocalObservation fallbackKind fullPath =
-        if isGraceStatusArtifact fullPath then Some GraceStatusArtifact
-        elif isGraceInternalRawObservationPath fullPath then None
-        else Some fallbackKind
+    /// Rejects Grace-owned paths before raw candidate scope capture.
+    let private tryClassifyRawLocalObservation fallbackKind fullPath = if isGraceInternalRawObservationPath fullPath then None else Some fallbackKind
 
     /// Finds the tracked file entry that owns a repository-relative path with the requested comparison.
     let private tryFindTrackedFileWithComparison (comparison: StringComparison) (status: GraceStatus) (relativePath: RelativePath) =
@@ -3267,6 +3267,106 @@ module Watch =
 
         graceStatusHasChanged <- true
 
+    /// Coalesces status DB, WAL, SHM, and journal callbacks without creating ordinary filesystem work.
+    let private recordLocalStatusRevisionCheckObservation () =
+        Interlocked.Increment(&localStatusRevisionCheckGeneration)
+        |> ignore
+
+    /// Records the latest trusted revision established at startup, committed by Watch, or accepted from an external writer.
+    let private recordKnownLocalStatusRevision revision =
+        Volatile.Write(&lastKnownLocalStatusRevision, revision)
+        Volatile.Write(&localStatusRevisionInitialized, 1)
+
+    /// Runs a Watch-owned status transaction and records its committed revision under the timer check gate.
+    let private runWatchOwnedLocalStatusWrite writeStatus =
+        task {
+            do! localStatusRevisionGate.WaitAsync()
+
+            try
+                let! committedRevision = writeStatus ()
+                recordKnownLocalStatusRevision committedRevision
+            finally
+                localStatusRevisionGate.Release() |> ignore
+        }
+
+    /// Reads one coalesced revision signal and routes external advances or untrusted evidence without publishing from callbacks.
+    let private processLocalStatusRevisionCheck readRevision revisionAdvanced revisionUntrusted =
+        task {
+            if
+                Volatile.Read(&localStatusRevisionCheckGeneration)
+                <> 0L
+            then
+                do! localStatusRevisionGate.WaitAsync()
+
+                try
+                    let observedGeneration = Volatile.Read(&localStatusRevisionCheckGeneration)
+
+                    if observedGeneration <> 0L then
+                        let! revisionResult =
+                            task {
+                                try
+                                    let! revision = readRevision ()
+                                    return Ok revision
+                                with
+                                | ex -> return Error ex
+                            }
+
+                        match revisionResult with
+                        | Error ex -> revisionUntrusted $"local-status revision could not be read: {ex.Message}"
+                        | Ok durableRevision ->
+                            if Volatile.Read(&localStatusRevisionInitialized) = 0 then
+                                revisionUntrusted "local-status revision was not established before callback processing"
+                            else
+                                let knownRevision = Volatile.Read(&lastKnownLocalStatusRevision)
+
+                                if durableRevision < knownRevision then
+                                    revisionUntrusted $"local-status revision regressed from {knownRevision} to {durableRevision}"
+                                else
+                                    if durableRevision > knownRevision then
+                                        recordKnownLocalStatusRevision durableRevision
+                                        revisionAdvanced ()
+
+                                    Interlocked.CompareExchange(&localStatusRevisionCheckGeneration, 0L, observedGeneration)
+                                    |> ignore
+                finally
+                    localStatusRevisionGate.Release() |> ignore
+        }
+
+    /// Establishes the durable revision that owns startup status before filesystem callbacks are enabled.
+    let private initializeLocalStatusRevision readRevision revisionUntrusted =
+        task {
+            try
+                let! revision = readRevision ()
+                recordKnownLocalStatusRevision revision
+            with
+            | ex -> revisionUntrusted $"local-status revision could not be established at startup: {ex.Message}"
+        }
+
+    /// Applies a Watch-owned incremental status mutation and remembers its committed local-status revision.
+    let private applyGraceStatusIncrementalAndRecordRevision graceStatus directoryVersions differences =
+        runWatchOwnedLocalStatusWrite (fun () ->
+            Grace.CLI.LocalStateDb.applyStatusIncrementalWithRevision (Current().GraceStatusFile) graceStatus directoryVersions differences)
+
+    /// Replaces a Watch-owned status snapshot and remembers its committed local-status revision.
+    let private writeGraceStatusFileAndRecordRevision graceStatus =
+        runWatchOwnedLocalStatusWrite (fun () -> Grace.CLI.LocalStateDb.replaceStatusSnapshotWithRevision (Current().GraceStatusFile) graceStatus)
+
+    /// Exposes deterministic local-status revision processing without starting the foreground timer.
+    let internal processLocalStatusRevisionCheckForWatchTests readRevision revisionAdvanced revisionUntrusted =
+        processLocalStatusRevisionCheck readRevision revisionAdvanced revisionUntrusted
+
+    /// Exercises the production external-revision transition while keeping revision reads and failure handling deterministic.
+    let internal processLocalStatusRevisionCheckWithRefreshForWatchTests readRevision revisionUntrusted =
+        processLocalStatusRevisionCheck readRevision recordGraceStatusRefreshObservation revisionUntrusted
+
+    /// Establishes a known local-status revision for callback and restart tests.
+    let internal setKnownLocalStatusRevisionForWatchTests revision = recordKnownLocalStatusRevision revision
+
+    /// Reports whether SQLite artifact callbacks still owe one coalesced revision check.
+    let internal localStatusRevisionCheckPendingForWatchTests () =
+        Volatile.Read(&localStatusRevisionCheckGeneration)
+        <> 0L
+
     /// Clears exactly the Grace Status refresh generation consumed by a successful publication.
     let private tryClearGraceStatusRefreshGeneration observedGeneration =
         if Interlocked.CompareExchange(&graceStatusRefreshGeneration, 0L, observedGeneration) = observedGeneration then
@@ -3812,19 +3912,9 @@ module Watch =
         | Some _ -> publishPendingWatchWorkTransitionIfNeeded ()
         | None -> ()
 
-    /// Records that durable Grace Status changed and immediately advertises pending Watch work to other commands.
-    let private markGraceStatusChangedAndPublishPendingWorkTransition () =
-        recordGraceStatusRefreshObservation ()
-
-        publishPendingWatchWorkTransitionIfNeeded ()
-
     /// Applies a due create or rename candidate after its quiet window has separated raw callbacks from filesystem work.
     let private applyCreatedOrChangedLocalObservationCandidate fullPath observedAt =
-        if updateNotInProgress ()
-           && isGraceStatusArtifact fullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
-            false
-        elif isDelayedGraceOwnedFileObservation fullPath observedAt then
+        if isDelayedGraceOwnedFileObservation fullPath observedAt then
             false
         elif Directory.Exists(fullPath) then
             let queuedDirectoryWork = enqueueFinalDirectoryWork fullPath
@@ -3864,38 +3954,33 @@ module Watch =
 
     /// Applies a due delete candidate after the current marker and final filesystem state can be examined safely.
     let private applyDeletedLocalObservationCandidate fullPath observedAt =
-        if updateNotInProgress ()
-           && isGraceStatusArtifact fullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
+        let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
+
+        if isDelayedGraceOwnedFileObservation fullPath observedAt
+           && not canceledFileUpload then
             false
-        else
-            let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
+        elif enqueueStatusUpdateTrigger fullPath then
+            match repositoryRelativePath fullPath with
+            | Some relativePath ->
+                let invalidatedRelativePath = RelativePath relativePath
 
-            if isDelayedGraceOwnedFileObservation fullPath observedAt
-               && not canceledFileUpload then
-                false
-            elif enqueueStatusUpdateTrigger fullPath then
+                if
+                    canceledFileUpload
+                    || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
+                then
+                    clearProcessedFileRelativePathsPendingStatusForPaths [ invalidatedRelativePath ]
+                    removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+            | None -> ()
+
+            if canceledFileUpload then
                 match repositoryRelativePath fullPath with
-                | Some relativePath ->
-                    let invalidatedRelativePath = RelativePath relativePath
-
-                    if
-                        canceledFileUpload
-                        || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
-                    then
-                        clearProcessedFileRelativePathsPendingStatusForPaths [ invalidatedRelativePath ]
-                        removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+                | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
                 | None -> ()
 
-                if canceledFileUpload then
-                    match repositoryRelativePath fullPath with
-                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
-                    | None -> ()
-
-                logToAnsiConsole Colors.Deleted $"I saw that {fullPath} was deleted."
-                true
-            else
-                false
+            logToAnsiConsole Colors.Deleted $"I saw that {fullPath} was deleted."
+            true
+        else
+            false
 
     /// Claims every due candidate, then reconciles IPC from the complete post-claim pending state even when no local work was queued.
     let private processDueLocalObservationCandidates now =
@@ -3952,9 +4037,6 @@ module Watch =
 
                                         removalQueuedWork || finalQueuedWork
                                     | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                    | GraceStatusArtifact ->
-                                        markGraceStatusChangedAndPublishPendingWorkTransition ()
-                                        false
 
                         queuedPendingWork <- queuedPendingWork || candidateQueuedWork
                     | None -> ()
@@ -3979,11 +4061,6 @@ module Watch =
                 | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
                 | Changed -> applyChangedLocalObservationCandidate fullPath observedAt
                 | Deleted -> applyDeletedLocalObservationCandidate fullPath observedAt
-                | GraceStatusArtifact ->
-                    if updateNotInProgress () then
-                        markGraceStatusChangedAndPublishPendingWorkTransition ()
-
-                    false
 
             if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
 
@@ -4572,6 +4649,12 @@ module Watch =
 
         Interlocked.Exchange(&graceStatusRefreshGeneration, 0L)
         |> ignore
+
+        Interlocked.Exchange(&localStatusRevisionCheckGeneration, 0L)
+        |> ignore
+
+        Volatile.Write(&lastKnownLocalStatusRevision, 0L)
+        Volatile.Write(&localStatusRevisionInitialized, 0)
 
         stableFileIdentityNowForWatch <- fun () -> DateTime.UtcNow
 
@@ -6229,7 +6312,7 @@ module Watch =
                             | Error error -> return Error error
                         }
                 ReadGraceStatus = readGraceStatusFile
-                WriteGraceStatus = writeGraceStatusFile
+                WriteGraceStatus = writeGraceStatusFileAndRecordRevision
                 RequestResync = requestGraceWatchExplicitResync
                 TryCreateUpdateMarker = tryCreateCurrentBranchMaterializationMarkerForWatchTests
                 IsUpdateMarkerOwned = currentBranchMaterializationMarkerIsOwned
@@ -7480,11 +7563,14 @@ module Watch =
 
     /// Admits one raw callback through the shared Grace-internal namespace guard before scheduling or direct test processing.
     let private admitRawLocalObservation fallbackKind fullPath seenAt =
-        match tryClassifyRawLocalObservation fallbackKind fullPath with
-        | None -> ()
-        | Some kind when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate kind fullPath seenAt
-        | Some kind when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately kind fullPath
-        | Some _ -> ()
+        if isGraceStatusArtifact fullPath then
+            recordLocalStatusRevisionCheckObservation ()
+        else
+            match tryClassifyRawLocalObservation fallbackKind fullPath with
+            | None -> ()
+            | Some kind when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate kind fullPath seenAt
+            | Some kind when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately kind fullPath
+            | Some _ -> ()
 
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =
@@ -7821,7 +7907,7 @@ module Watch =
 
                                     if statusSideEffectStillAllowed "local status application" then
                                         // Apply incremental changes to the Grace Status DB.
-                                        do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+                                        do! applyGraceStatusIncrementalAndRecordRevision newGraceStatusWithUpdatedTime newDirectoryVersions differences
 
                                         for fileVersion in directoryUploadedFileVersions do
                                             let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
@@ -8908,7 +8994,7 @@ module Watch =
             updateGraceStatus
             scanForDifferencesWithWatchIgnoreSnapshot
             updateGraceStatusFromDifferences
-            applyGraceStatusIncremental
+            applyGraceStatusIncrementalAndRecordRevision
             updateGraceWatchInterprocessFile
 
     /// Coordinates queue startup difference for watch behavior for this CLI command path.
@@ -9374,6 +9460,11 @@ module Watch =
                     graceStatus <- status
                     updateGraceStatusDirectoryIds graceStatus
 
+                    do!
+                        initializeLocalStatusRevision
+                            (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                            (fun reason -> requestGraceWatchExplicitResync reason)
+
                     // Create the inter-process communication file.
                     do! publishStartupCatchUpPendingStatus graceStatus graceStatusDirectoryIds updateGraceWatchInterprocessFile
 
@@ -9573,6 +9664,12 @@ module Watch =
                             processWatchTimerLocalRecoveryWithCatchUp
                                 (fun () ->
                                     task {
+                                        do!
+                                            processLocalStatusRevisionCheck
+                                                (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                                                recordGraceStatusRefreshObservation
+                                                requestGraceWatchExplicitResync
+
                                         // Grace Status may have changed from branch switch, or other commands.
                                         if graceStatusHasChanged then
                                             let refreshGeneration = currentGraceStatusRefreshGeneration ()

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -25,6 +25,10 @@ module LocalStateDb =
     [<Literal>]
     let WatchJournalAppliedThroughSequenceMetaKey = "AppliedThroughSequence"
 
+    /// Identifies the monotonic metadata value that coordinates committed local-status changes across Grace processes.
+    [<Literal>]
+    let LocalStatusRevisionMetaKey = "LocalStatusRevision"
+
     /// Keeps a bounded diagnostic tail of already-applied Watch journal rows.
     [<Literal>]
     let WatchJournalRetainedAppliedRows = 1024L
@@ -91,11 +95,34 @@ module LocalStateDb =
                     do! operation ()
                 with
                 | :? SqliteException as ex when isBusyOrLocked ex ->
-                    if attempt >= retryDelaysMs.Length then return raise ex
-                    let jitter = Random.Shared.Next(0, 50)
-                    let delayMs = retryDelaysMs[attempt] + jitter
-                    do! Task.Delay(delayMs)
-                    return! run (attempt + 1)
+                    if attempt >= retryDelaysMs.Length then
+                        return raise ex
+                    else
+                        let jitter = Random.Shared.Next(0, 50)
+                        let delayMs = retryDelaysMs[attempt] + jitter
+                        do! Task.Delay(delayMs)
+                        return! run (attempt + 1)
+                | ex -> return raise ex
+            }
+
+        run 0
+
+    /// Retries a local-state transaction that returns its exact committed revision.
+    let private executeWithRevisionRetry (operation: unit -> Task<int64>) =
+        /// Runs the revision-returning transaction until it commits or reaches the bounded busy retry limit.
+        let rec run attempt =
+            task {
+                try
+                    return! operation ()
+                with
+                | :? SqliteException as ex when isBusyOrLocked ex ->
+                    if attempt >= retryDelaysMs.Length then
+                        return raise ex
+                    else
+                        let jitter = Random.Shared.Next(0, 50)
+                        let delayMs = retryDelaysMs[attempt] + jitter
+                        do! Task.Delay(delayMs)
+                        return! run (attempt + 1)
                 | ex -> return raise ex
             }
 
@@ -1232,6 +1259,42 @@ module LocalStateDb =
             parameters.AddWithValue("$key", WatchJournalAppliedThroughSequenceMetaKey)
             |> ignore)
 
+    /// Persists the initial local-status revision without treating schema initialization as a status mutation.
+    let private insertLocalStatusRevisionIfMissing (connection: SqliteConnection) =
+        executeNonQueryWithParams connection "INSERT OR IGNORE INTO meta (key, value) VALUES ($key, '0');" (fun parameters ->
+            parameters.AddWithValue("$key", LocalStatusRevisionMetaKey)
+            |> ignore)
+
+    /// Parses a persisted local-status revision only when it preserves the monotonic nonnegative counter invariant.
+    let private tryParseLocalStatusRevision (value: string) =
+        match Int64.TryParse(value) with
+        | true, revision when revision >= 0L -> Some revision
+        | _ -> None
+
+    /// Reads the committed local-status revision and rejects missing, duplicate, or malformed metadata.
+    let private readLocalStatusRevisionInternal (connection: SqliteConnection) =
+        if countMetaValues connection LocalStatusRevisionMetaKey
+           <> 1 then
+            raise (InvalidDataException($"{LocalStatusRevisionMetaKey} must have exactly one metadata row."))
+
+        match tryGetMetaValue connection LocalStatusRevisionMetaKey with
+        | Some value ->
+            match tryParseLocalStatusRevision value with
+            | Some revision -> revision
+            | None -> raise (InvalidDataException($"{LocalStatusRevisionMetaKey} must be a non-negative 64-bit integer."))
+        | None -> raise (InvalidDataException($"{LocalStatusRevisionMetaKey} is missing."))
+
+    /// Advances the local-status revision inside the transaction that owns the corresponding status mutation.
+    let private incrementLocalStatusRevision (connection: SqliteConnection) =
+        let currentRevision = readLocalStatusRevisionInternal connection
+
+        if currentRevision = Int64.MaxValue then
+            raise (InvalidDataException($"{LocalStatusRevisionMetaKey} cannot advance beyond Int64.MaxValue."))
+
+        let committedRevision = currentRevision + 1L
+        setMetaValue connection LocalStatusRevisionMetaKey $"{committedRevision}"
+        committedRevision
+
     /// Parses Watch journal recovery metadata only when it preserves the nonnegative sequence invariant.
     let private tryParseWatchJournalAppliedThroughSequence (value: string) =
         match Int64.TryParse(value) with
@@ -1592,6 +1655,7 @@ module LocalStateDb =
                                                     logTrace "status_meta ensuring default row"
                                                     insertStatusMetaIfMissing connection
                                                     insertWatchJournalAppliedThroughIfMissing connection
+                                                    insertLocalStatusRevisionIfMissing connection
 
                                                     if not (hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection) then
                                                         recreate <- true
@@ -2704,6 +2768,14 @@ module LocalStateDb =
             LastSuccessfulDirectoryVersionUpload: Instant
         }
 
+    /// Reads the committed local-status revision used to coalesce SQLite artifact callbacks.
+    let readLocalStatusRevision (dbPath: string) =
+        task {
+            do! ensureDbInitialized dbPath
+            use connection = openConnection dbPath
+            return readLocalStatusRevisionInternal connection
+        }
+
     /// Reads status meta internal data needed by the CLI workflow.
     let private readStatusMetaInternal (connection: SqliteConnection) =
         use cmd = connection.CreateCommand()
@@ -2813,12 +2885,12 @@ module LocalStateDb =
                 |> ignore)
 
     /// Coordinates local SQLite state for replace status snapshot, including Grace status, object cache, or watch metadata.
-    let replaceStatusSnapshot (dbPath: string) (graceStatus: GraceStatus) =
+    let replaceStatusSnapshotWithRevision (dbPath: string) (graceStatus: GraceStatus) =
         task {
             do! ensureDbInitialized dbPath
 
             return!
-                executeWithRetry (fun () ->
+                executeWithRevisionRetry (fun () ->
                     task {
                         let connection = openConnection dbPath
 
@@ -2925,7 +2997,9 @@ module LocalStateDb =
                                         fileCommand.Parameters["$last_write"].Value <- file.LastWriteTimeUtc.Ticks
                                         fileCommand.ExecuteNonQuery() |> ignore))
 
+                                let committedRevision = incrementLocalStatusRevision connection
                                 executeNonQuery connection "COMMIT;"
+                                return committedRevision
                             with
                             | ex ->
                                 executeNonQuery connection "ROLLBACK;"
@@ -2933,6 +3007,13 @@ module LocalStateDb =
                         finally
                             connection.Dispose()
                     })
+        }
+
+    /// Replaces the local status snapshot while preserving the existing unit-returning caller contract.
+    let replaceStatusSnapshot (dbPath: string) (graceStatus: GraceStatus) =
+        task {
+            let! _ = replaceStatusSnapshotWithRevision dbPath graceStatus
+            return ()
         }
 
     /// Persists upsert object cache changes in the local SQLite state database.
@@ -3180,7 +3261,7 @@ module LocalStateDb =
                     })
         }
 
-    let applyStatusIncremental
+    let applyStatusIncrementalWithRevision
         (dbPath: string)
         (newGraceStatus: GraceStatus)
         (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
@@ -3190,7 +3271,7 @@ module LocalStateDb =
             do! ensureDbInitialized dbPath
 
             return!
-                executeWithRetry (fun () ->
+                executeWithRevisionRetry (fun () ->
                     task {
                         let connection = openConnection dbPath
 
@@ -3322,7 +3403,9 @@ module LocalStateDb =
                                             directoryDeleteCommand.Parameters["$relative_path"].Value <- difference.RelativePath
                                             directoryDeleteCommand.ExecuteNonQuery() |> ignore)
 
+                                let committedRevision = incrementLocalStatusRevision connection
                                 executeNonQuery connection "COMMIT;"
+                                return committedRevision
                             with
                             | ex ->
                                 executeNonQuery connection "ROLLBACK;"
@@ -3330,6 +3413,18 @@ module LocalStateDb =
                         finally
                             connection.Dispose()
                     })
+        }
+
+    /// Applies an incremental local status mutation while preserving the existing unit-returning caller contract.
+    let applyStatusIncremental
+        (dbPath: string)
+        (newGraceStatus: GraceStatus)
+        (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
+        (differences: IEnumerable<FileSystemDifference>)
+        =
+        task {
+            let! _ = applyStatusIncrementalWithRevision dbPath newGraceStatus newDirectoryVersions differences
+            return ()
         }
 
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.


### PR DESCRIPTION
# Coalesce Watch local-state revisions

Related to #795 and the single-process Watch recovery epic #794.

Grace Watch must not treat its own `grace-local.db` artifacts as ordinary repository content. This change
coalesces those callbacks into a durable local-status revision check, preventing the status database from
re-entering candidate discovery, catch-up scheduling, or immediate IPC publication.

## Delivered behavior

- Add a monotonic `LocalStatusRevision` to the existing SQLite `meta` store.
- Commit each status mutation and its returned revision in one existing explicit transaction.
- Record each Watch-owned revision under the shared timer/write gate.
- Make DB, WAL, SHM, and journal callbacks silent coalesced revision checks.
- Reload and publish only when a newer external revision is observed; retain the check and use the existing
  explicit-resync path if the durable revision is unreadable or regresses.

## Validation

- Demonstrated the prior regression: a Watch-owned artifact callback set `HasPendingWatchWork`.
- Formatted the four changed F# files with Fantomas.
- Release build completed with 0 warnings and 0 errors.
- Focused tests passed: revision 7/7, artifact 12/12, callback 13/13, and atomic 4/4.
- `git diff --check` passed.

GitHub Validate is the required broad current-head gate. Fast and Full were not run because the focused proof
covers this slice and repository guidance avoids duplicating broad local certification.

## Scope and documentation

Changed paths are `LocalStateDb.CLI.fs`, `Watch.CLI.fs`, and their focused tests. Server contracts, SignalR
payloads, public CLI/HTTP/SDK/OpenAPI/generated surfaces, persisted schemas beyond the existing local metadata
store, and user documentation are unaffected. Documentation is N/A: the visible Watch contract does not change.

## Review Status

- Base: `e6bea21e54842d348bddff2c4b03809b7f553761` (`epic/794-single-process-watch-recovery`).
- Initial head `d0cb8e78f6b9b03580fdeab151947edceafa10a6` was superseded after one valid review proof gap and two
  in-scope full-suite failures.
- Current head: `65845a36fca4027efbdc653d60994abe48fdf2c9`.
- Worker starts: 2/4. The second worker added production-path startup and `N` then external `N + 1` proof and
  reset leaked process-static catch-up scheduler state at the temporary-repository fixture boundary.
- Fresh exact-head review: approved with no substantive findings on `65845a36fca4027efbdc653d60994abe48fdf2c9`.
- GitHub Validate: `full` run `31095168971` passed on the current head.
