### PR TITLE
Retain exact Watch self-echo recognition across duplicate deliveries

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -20289,7 +20289,30 @@ module WatchTests =
         consumption.GetAwaiter().GetResult()
         |> should equal true
 
-        ledger.Count |> should equal 0
+        ledger.Count |> should equal 1
+
+    /// Verifies that both delivery paths can silently recognize the same completed local Reference during its bounded lifetime.
+    [<Test; Category("CurrentBranchSelfReferenceEcho")>]
+    let ``local self-reference ledger recognizes exact completed duplicate deliveries`` () =
+        let nowUtc = DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc)
+        let ledger = Watch.LocalCurrentBranchReferenceEchoLedger(4, TimeSpan.FromMinutes(2.0), (fun () -> nowUtc))
+        let payload = localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "duplicate-self-reference"
+        let intent = ledger.Begin(payload.RepositoryId, payload.BranchId, payload.DirectoryId, payload.Sha256Hash, payload.Blake3Hash, payload.CorrelationId)
+        ledger.Complete(intent, payload.ReferenceId)
+
+        ledger
+            .TryConsume(payload)
+            .GetAwaiter()
+            .GetResult()
+        |> should equal true
+
+        ledger
+            .TryConsume(payload)
+            .GetAwaiter()
+            .GetResult()
+        |> should equal true
+
+        ledger.Count |> should equal 1
 
     /// Verifies that exact identity fields are all required and a failed save never leaves suppressible evidence.
     [<Test; Category("CurrentBranchSelfReferenceEcho")>]
@@ -20443,7 +20466,7 @@ module WatchTests =
                 callbackOutput |> should equal String.Empty
 
                 Watch.localCurrentBranchReferenceEchoLedgerCountForWatchTests ()
-                |> should equal 0
+                |> should equal 1
             finally
                 Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ())
 
@@ -20502,6 +20525,116 @@ module WatchTests =
                 coordinatorCalls |> should equal 0
             finally
                 Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ())
+
+    /// Verifies that lifecycle and direct delivery order cannot expose an exact completed local Reference to coordinator or Watch work.
+    [<TestCase(true); TestCase(false); Category("CurrentBranchSelfReferenceEcho"); Category("CurrentBranchCatchUp")>]
+    let ``exact self-reference stays silent across lifecycle and direct duplicate delivery order`` lifecycleFirst =
+        withTempRepo (fun root ->
+            Watch.clearPendingWatchWorkForTests ()
+
+            try
+                let repositoryId, branchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+                let payload = localSelfReferenceNotification repositoryId branchId "duplicate-delivery-self-reference"
+                let branchDto = branchDtoWithLatestCurrentBranchReference payload
+                let intent = Watch.recordLocalCurrentBranchReferenceIntentForWatchTests payload
+                Watch.completeLocalCurrentBranchReferenceIntentForWatchTests intent payload.ReferenceId
+
+                let pendingBefore = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+                let candidatesBefore = Watch.localObservationCandidateSnapshotForWatchTests ()
+
+                let catchUpGenerationBefore = Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+
+                let coordinatorEffects = ResizeArray<string>()
+
+                /// Fails the test if either delivery enters any injected coordinator side-effect seam.
+                let unexpected name =
+                    coordinatorEffects.Add(name)
+                    Task.FromException<'T>(InvalidOperationException($"Exact duplicate self echo reached {name}."))
+
+                /// Routes the real direct-notification seam while capturing any user-visible Watch output.
+                let runDirectDelivery () =
+                    let mutable result = Unchecked.defaultof<Services.LatestCurrentBranchReferenceDecision option>
+
+                    let output =
+                        captureAnsiConsoleOutput (fun () ->
+                            result <-
+                                (Watch.handleCurrentBranchReferenceNotificationWithClientsForWatchTests
+                                    (fun () -> unexpected "direct BranchDto fetch")
+                                    (fun () -> unexpected "direct local-status read")
+                                    payload)
+                                    .GetAwaiter()
+                                    .GetResult())
+
+                    result, output
+
+                /// Routes the BranchDto-derived lifecycle seam through the same coordinator and captures any Watch output.
+                let runLifecycleDelivery () =
+                    /// Sends the BranchDto-derived payload through the production coordinator admission gate.
+                    let processReference catchUpPayload =
+                        task {
+                            let! outcome =
+                                Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                                    (fun () -> unexpected "lifecycle BranchDto fetch")
+                                    (fun () -> unexpected "lifecycle local-status inspection")
+                                    (fun _ -> coordinatorEffects.Add("lifecycle degraded resync"))
+                                    (fun _ _ -> unexpected "lifecycle safe-point wait")
+                                    (fun _ _ -> unexpected "lifecycle IPC reestablishment")
+                                    (fun _ _ -> unexpected "lifecycle materialization apply")
+                                    catchUpPayload
+
+                            return outcome.Value
+                        }
+
+                    let mutable result =
+                        Unchecked.defaultof<Watch.CurrentBranchReferenceCatchUpResult * Watch.CurrentBranchMaterializationCoordinatorOutcome option>
+
+                    let output =
+                        captureAnsiConsoleOutput (fun () ->
+                            result <-
+                                (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests
+                                    (fun () -> Task.FromResult(Ok(GraceReturnValue.Create branchDto "duplicate-delivery-catch-up-source")))
+                                    processReference)
+                                    .GetAwaiter()
+                                    .GetResult())
+
+                    result, output
+
+                let directResult, directOutput, lifecycleResult, lifecycleOutcome, lifecycleOutput =
+                    if lifecycleFirst then
+                        let (lifecycleResult, lifecycleOutcome), lifecycleOutput = runLifecycleDelivery ()
+                        let directResult, directOutput = runDirectDelivery ()
+                        directResult, directOutput, lifecycleResult, lifecycleOutcome, lifecycleOutput
+                    else
+                        let directResult, directOutput = runDirectDelivery ()
+                        let (lifecycleResult, lifecycleOutcome), lifecycleOutput = runLifecycleDelivery ()
+                        directResult, directOutput, lifecycleResult, lifecycleOutcome, lifecycleOutput
+
+                directResult |> should equal None
+                directOutput |> should equal String.Empty
+
+                lifecycleResult
+                |> should equal Watch.CurrentBranchReferenceCatchUpResult.Processed
+
+                lifecycleOutcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.LocalSelfEchoConsumed
+
+                lifecycleOutput |> should equal String.Empty
+
+                coordinatorEffects.ToArray() |> should be Empty
+
+                Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+                |> should equal pendingBefore
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> should equal candidatesBefore
+
+                Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                |> should equal catchUpGenerationBefore
+
+                Watch.localCurrentBranchReferenceEchoLedgerCountForWatchTests ()
+                |> should equal 1
+            finally
+                Watch.clearPendingWatchWorkForTests ())
 
     /// Verifies that lifecycle catch-up derives the exact coordinator input from BranchDto rather than a prior notification.
     [<Test; Category("CurrentBranchCatchUp")>]

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -91,7 +91,7 @@ module Watch =
             mutable ReferenceId: ReferenceId option
         }
 
-    /// Tracks only exact current-process save References long enough to consume their SignalR or lifecycle echo.
+    /// Tracks exact current-process save References long enough to silence every matching SignalR or lifecycle delivery.
     type internal LocalCurrentBranchReferenceEchoLedger(capacity: int, lifetime: TimeSpan, utcNow: unit -> DateTime) =
         let ledgerLock = obj ()
         let entries = Dictionary<Guid, LocalCurrentBranchReferenceEchoEntry>()
@@ -104,15 +104,14 @@ module Watch =
             if lifetime <= TimeSpan.Zero then
                 invalidArg (nameof lifetime) "The local self-reference ledger lifetime must be positive."
 
-        /// Removes one entry and releases any early notification waiting for its terminal save result.
-        let removeEntry token completion =
+        /// Removes one entry and releases any early notification to ordinary coordinator handling.
+        let removeEntry token =
             match entries.TryGetValue(token) with
             | true, entry ->
                 entries.Remove(token) |> ignore
                 insertionOrder.Remove(token) |> ignore
 
-                entry.Completion.TrySetResult(completion)
-                |> ignore
+                entry.Completion.TrySetResult(None) |> ignore
             | _ -> ()
 
         /// Removes expired intents in insertion order before any admission decision uses them.
@@ -123,7 +122,7 @@ module Watch =
                 let token = insertionOrder.First.Value
 
                 match entries.TryGetValue(token) with
-                | true, entry when entry.ExpiresAtUtc <= nowUtc -> removeEntry token None
+                | true, entry when entry.ExpiresAtUtc <= nowUtc -> removeEntry token
                 | true, _ -> pruning <- false
                 | _ -> insertionOrder.RemoveFirst()
 
@@ -152,7 +151,7 @@ module Watch =
 
                 while entries.Count >= capacity
                       && not (isNull insertionOrder.First) do
-                    removeEntry insertionOrder.First.Value None
+                    removeEntry insertionOrder.First.Value
 
                 let token = Guid.NewGuid()
 
@@ -188,11 +187,11 @@ module Watch =
 
                     entry.Completion.TrySetResult(Some referenceId)
                     |> ignore
-                | true, _ -> removeEntry token None
+                | true, _ -> removeEntry token
                 | _ -> ())
 
         /// Removes a failed or uncertain save intent so its later notification follows ordinary coordinator behavior.
-        member _.Fail(LocalCurrentBranchReferenceEchoIntentHandle token) = lock ledgerLock (fun () -> removeEntry token None)
+        member _.Fail(LocalCurrentBranchReferenceEchoIntentHandle token) = lock ledgerLock (fun () -> removeEntry token)
 
         /// Restores the original correlation for a BranchDto-derived form of an exact completed local Reference.
         member _.TryFindCompletedCorrelation(payload: CurrentBranchReferenceNotification) =
@@ -203,7 +202,7 @@ module Watch =
                 |> Seq.tryFind (fun entry -> completedReferenceMatchesPayload entry payload)
                 |> Option.map (fun entry -> entry.Identity.CorrelationId))
 
-        /// Consumes one exact completed local notification before it can enter materialization coordination.
+        /// Recognizes an exact completed local notification without retiring evidence needed by its other delivery path.
         member _.TryConsume(payload: CurrentBranchReferenceNotification) =
             task {
                 let pendingCompletion =
@@ -229,7 +228,7 @@ module Watch =
                         }
 
                     if not completedBeforeExpiry then
-                        lock ledgerLock (fun () -> removeEntry token None)
+                        lock ledgerLock (fun () -> removeEntry token)
                         return false
                     else
                         let! completedReferenceId = completionTask
@@ -243,7 +242,6 @@ module Watch =
                                     referenceId = payload.ReferenceId
                                     && completedReferenceMatchesPayload entry payload
                                     ->
-                                    removeEntry token (Some referenceId)
                                     true
                                 | _ -> false)
             }
@@ -254,7 +252,7 @@ module Watch =
                 let tokens = insertionOrder |> Seq.toArray
 
                 for token in tokens do
-                    removeEntry token None)
+                    removeEntry token)
 
         /// Reports retained entries after pruning for deterministic capacity and expiry tests.
         member _.Count =


### PR DESCRIPTION
# Retain exact Watch self-echo recognition across duplicate deliveries

## Summary

Related to reopened #796 and epic #794.

Live acceptance found that lifecycle catch-up could consume an exact completed local self-echo before its later
direct SignalR delivery arrived. The duplicate then did no work but emitted the ordinary same-root skip log. This
small follow-up preserves exact completed-reference recognition for the existing bounded ledger lifetime, so both
delivery paths remain silent without suppressing a mismatched or remote notification.

## Delivered behavior

- Retain a successfully completed exact local Reference entry within the existing 64-entry, two-minute process-local
  bound instead of consuming it after the first recognized delivery.
- Require the same exact correlation, repository, branch, Reference ID, directory ID, and both root hashes for every
  recognized delivery.
- Keep lifecycle then direct and direct then lifecycle deliveries silent before coordinator/candidate/pending IPC,
  materialization, recovery, catch-up, resync, or callback output.
- Retain existing fallthrough behavior for mismatch, failed/uncertain save, expiry, eviction, restart, and branch
  transition.

## Validation

- RED: the duplicate-delivery regression failed under consume-once behavior (one failure, five passes).
- Targeted Fantomas passed.
- Release build completed with 0 warnings and 0 errors.
- Focused self-echo, current-branch coordinator, and catch-up regressions passed 63/63, including the prior 60.
- `git diff --check` passed.

GitHub Validate is the required broad current-head gate. Fast and Full were not run locally because the focused
proof covers this correction and the repository avoids duplicating broad certification.

## Scope and documentation

Only `Watch.CLI.fs` and `Watch.Tests.fs` change. No server, SignalR payload, SQLite, public CLI/HTTP/SDK/OpenAPI,
generated artifact, persisted-shape, or documentation contract changes. Documentation is N/A: this is an internal
duplicate-delivery correction to the existing silent self-echo behavior.

## Review Status

- Worker starts: 2/4 for #796.
- Base: `07db3aa9b3a98bd577741962439f8c3a218d885f` (`epic/794-single-process-watch-recovery`).
- Head: `64608a223f30495eca3831192c34080f53209aa3`.
- Fresh exact-head review: approved with no P1/P2 findings on `64608a223f30495eca3831192c34080f53209aa3`.
- GitHub Validate: `full` run `31100388682` passed on the current head.
- Live acceptance rerun: pending after merge.
