### PR TITLE
Simplify single-process Grace Watch recovery

### DIFF
--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -2930,6 +2930,46 @@ module LocalStateDbTests =
                 |> should be (lessThan 1500L)
             })
 
+    /// Verifies that each committed status transaction returns and persists one monotonic local-status revision.
+    [<Test>]
+    let ``status transactions advance and return committed local-status revision`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let! initialRevision = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+                initialRevision |> should equal 0L
+
+                let status = createTestStatus (Guid.NewGuid()) "revision-root" 100L
+
+                let! replacementRevision = LocalStateDb.replaceStatusSnapshotWithRevision configuration.GraceStatusFile status
+                replacementRevision |> should equal 1L
+
+                let! incrementalRevision = LocalStateDb.applyStatusIncrementalWithRevision configuration.GraceStatusFile status Seq.empty Seq.empty
+
+                incrementalRevision |> should equal 2L
+
+                let! durableRevision = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                durableRevision
+                |> should equal incrementalRevision
+            })
+
+    /// Verifies malformed local-status revision metadata is rejected instead of becoming an incremental baseline.
+    [<Test>]
+    let ``local-status revision reader rejects malformed durable evidence`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeNonQuery connection $"UPDATE meta SET value = 'invalid' WHERE key = '{LocalStateDb.LocalStatusRevisionMetaKey}';"
+
+                let operation = Func<Task>(fun () -> LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile :> Task)
+
+                Assert.ThrowsAsync<InvalidDataException>(operation)
+                |> ignore
+            })
+
     /// Verifies that replace status snapshot is atomic (rollback on failure).
     [<Test>]
     let ``replaceStatusSnapshot is atomic (rollback on failure)`` () =
@@ -2954,6 +2994,7 @@ module LocalStateDbTests =
                     }
 
                 do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusA
+                let! revisionBeforeFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
 
                 use connection = openRawConnection configuration.GraceStatusFile
 
@@ -2988,6 +3029,11 @@ module LocalStateDbTests =
                 |> should equal statusA.LastSuccessfulFileUpload
 
                 readBack.Index.Count |> should equal 1
+
+                let! revisionAfterFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                revisionAfterFailure
+                |> should equal revisionBeforeFailure
             })
 
     /// Verifies that apply status incremental is atomic (rollback on failure).
@@ -3018,6 +3064,7 @@ module LocalStateDbTests =
                     }
 
                 do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile statusA
+                let! revisionBeforeFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
 
                 use connection = openRawConnection configuration.GraceStatusFile
 
@@ -3052,6 +3099,11 @@ module LocalStateDbTests =
                 |> Seq.collect (fun dv -> dv.Files)
                 |> Seq.exists (fun file -> file.RelativePath = "src/file.txt")
                 |> should equal false
+
+                let! revisionAfterFailure = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                revisionAfterFailure
+                |> should equal revisionBeforeFailure
             })
 
     /// Verifies that concurrent ensure db initialized calls do not deadlock or corrupt.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -20289,7 +20289,30 @@ module WatchTests =
         consumption.GetAwaiter().GetResult()
         |> should equal true
 
-        ledger.Count |> should equal 0
+        ledger.Count |> should equal 1
+
+    /// Verifies that both delivery paths can silently recognize the same completed local Reference during its bounded lifetime.
+    [<Test; Category("CurrentBranchSelfReferenceEcho")>]
+    let ``local self-reference ledger recognizes exact completed duplicate deliveries`` () =
+        let nowUtc = DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc)
+        let ledger = Watch.LocalCurrentBranchReferenceEchoLedger(4, TimeSpan.FromMinutes(2.0), (fun () -> nowUtc))
+        let payload = localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "duplicate-self-reference"
+        let intent = ledger.Begin(payload.RepositoryId, payload.BranchId, payload.DirectoryId, payload.Sha256Hash, payload.Blake3Hash, payload.CorrelationId)
+        ledger.Complete(intent, payload.ReferenceId)
+
+        ledger
+            .TryConsume(payload)
+            .GetAwaiter()
+            .GetResult()
+        |> should equal true
+
+        ledger
+            .TryConsume(payload)
+            .GetAwaiter()
+            .GetResult()
+        |> should equal true
+
+        ledger.Count |> should equal 1
 
     /// Verifies that exact identity fields are all required and a failed save never leaves suppressible evidence.
     [<Test; Category("CurrentBranchSelfReferenceEcho")>]
@@ -20443,7 +20466,7 @@ module WatchTests =
                 callbackOutput |> should equal String.Empty
 
                 Watch.localCurrentBranchReferenceEchoLedgerCountForWatchTests ()
-                |> should equal 0
+                |> should equal 1
             finally
                 Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ())
 
@@ -20502,6 +20525,116 @@ module WatchTests =
                 coordinatorCalls |> should equal 0
             finally
                 Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ())
+
+    /// Verifies that lifecycle and direct delivery order cannot expose an exact completed local Reference to coordinator or Watch work.
+    [<TestCase(true); TestCase(false); Category("CurrentBranchSelfReferenceEcho"); Category("CurrentBranchCatchUp")>]
+    let ``exact self-reference stays silent across lifecycle and direct duplicate delivery order`` lifecycleFirst =
+        withTempRepo (fun root ->
+            Watch.clearPendingWatchWorkForTests ()
+
+            try
+                let repositoryId, branchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+                let payload = localSelfReferenceNotification repositoryId branchId "duplicate-delivery-self-reference"
+                let branchDto = branchDtoWithLatestCurrentBranchReference payload
+                let intent = Watch.recordLocalCurrentBranchReferenceIntentForWatchTests payload
+                Watch.completeLocalCurrentBranchReferenceIntentForWatchTests intent payload.ReferenceId
+
+                let pendingBefore = Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+                let candidatesBefore = Watch.localObservationCandidateSnapshotForWatchTests ()
+
+                let catchUpGenerationBefore = Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+
+                let coordinatorEffects = ResizeArray<string>()
+
+                /// Fails the test if either delivery enters any injected coordinator side-effect seam.
+                let unexpected name =
+                    coordinatorEffects.Add(name)
+                    Task.FromException<'T>(InvalidOperationException($"Exact duplicate self echo reached {name}."))
+
+                /// Routes the real direct-notification seam while capturing any user-visible Watch output.
+                let runDirectDelivery () =
+                    let mutable result = Unchecked.defaultof<Services.LatestCurrentBranchReferenceDecision option>
+
+                    let output =
+                        captureAnsiConsoleOutput (fun () ->
+                            result <-
+                                (Watch.handleCurrentBranchReferenceNotificationWithClientsForWatchTests
+                                    (fun () -> unexpected "direct BranchDto fetch")
+                                    (fun () -> unexpected "direct local-status read")
+                                    payload)
+                                    .GetAwaiter()
+                                    .GetResult())
+
+                    result, output
+
+                /// Routes the BranchDto-derived lifecycle seam through the same coordinator and captures any Watch output.
+                let runLifecycleDelivery () =
+                    /// Sends the BranchDto-derived payload through the production coordinator admission gate.
+                    let processReference catchUpPayload =
+                        task {
+                            let! outcome =
+                                Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                                    (fun () -> unexpected "lifecycle BranchDto fetch")
+                                    (fun () -> unexpected "lifecycle local-status inspection")
+                                    (fun _ -> coordinatorEffects.Add("lifecycle degraded resync"))
+                                    (fun _ _ -> unexpected "lifecycle safe-point wait")
+                                    (fun _ _ -> unexpected "lifecycle IPC reestablishment")
+                                    (fun _ _ -> unexpected "lifecycle materialization apply")
+                                    catchUpPayload
+
+                            return outcome.Value
+                        }
+
+                    let mutable result =
+                        Unchecked.defaultof<Watch.CurrentBranchReferenceCatchUpResult * Watch.CurrentBranchMaterializationCoordinatorOutcome option>
+
+                    let output =
+                        captureAnsiConsoleOutput (fun () ->
+                            result <-
+                                (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests
+                                    (fun () -> Task.FromResult(Ok(GraceReturnValue.Create branchDto "duplicate-delivery-catch-up-source")))
+                                    processReference)
+                                    .GetAwaiter()
+                                    .GetResult())
+
+                    result, output
+
+                let directResult, directOutput, lifecycleResult, lifecycleOutcome, lifecycleOutput =
+                    if lifecycleFirst then
+                        let (lifecycleResult, lifecycleOutcome), lifecycleOutput = runLifecycleDelivery ()
+                        let directResult, directOutput = runDirectDelivery ()
+                        directResult, directOutput, lifecycleResult, lifecycleOutcome, lifecycleOutput
+                    else
+                        let directResult, directOutput = runDirectDelivery ()
+                        let (lifecycleResult, lifecycleOutcome), lifecycleOutput = runLifecycleDelivery ()
+                        directResult, directOutput, lifecycleResult, lifecycleOutcome, lifecycleOutput
+
+                directResult |> should equal None
+                directOutput |> should equal String.Empty
+
+                lifecycleResult
+                |> should equal Watch.CurrentBranchReferenceCatchUpResult.Processed
+
+                lifecycleOutcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.LocalSelfEchoConsumed
+
+                lifecycleOutput |> should equal String.Empty
+
+                coordinatorEffects.ToArray() |> should be Empty
+
+                Watch.pendingWatchWorkSnapshotWithoutCandidateDrainForTests ()
+                |> should equal pendingBefore
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> should equal candidatesBefore
+
+                Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                |> should equal catchUpGenerationBefore
+
+                Watch.localCurrentBranchReferenceEchoLedgerCountForWatchTests ()
+                |> should equal 1
+            finally
+                Watch.clearPendingWatchWorkForTests ())
 
     /// Verifies that lifecycle catch-up derives the exact coordinator input from BranchDto rather than a prior notification.
     [<Test; Category("CurrentBranchCatchUp")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -20261,6 +20261,248 @@ module WatchTests =
             ReferenceType = referenceType
         }
 
+    /// Builds an exact local self-reference payload with every suppression identity field populated.
+    let private localSelfReferenceNotification repositoryId branchId correlationId =
+        { validCurrentBranchReferenceNotification
+              repositoryId
+              branchId
+              ReferenceType.Save
+              (Guid.NewGuid())
+              (Sha256Hash "self-reference-root-sha256")
+              (Blake3Hash "self-reference-root-blake3") with
+            CorrelationId = correlationId
+        }
+
+    /// Verifies that a notification arriving before save completion waits at the ledger and is consumed only after exact promotion.
+    [<Test; Category("CurrentBranchSelfReferenceEcho")>]
+    let ``local self-reference ledger waits for successful reference promotion before consuming early echo`` () =
+        let nowUtc = DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc)
+        let ledger = Watch.LocalCurrentBranchReferenceEchoLedger(4, TimeSpan.FromMinutes(2.0), (fun () -> nowUtc))
+        let payload = localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "early-self-reference"
+        let intent = ledger.Begin(payload.RepositoryId, payload.BranchId, payload.DirectoryId, payload.Sha256Hash, payload.Blake3Hash, payload.CorrelationId)
+        let consumption = ledger.TryConsume(payload)
+
+        consumption.IsCompleted |> should equal false
+
+        ledger.Complete(intent, payload.ReferenceId)
+
+        consumption.GetAwaiter().GetResult()
+        |> should equal true
+
+        ledger.Count |> should equal 0
+
+    /// Verifies that exact identity fields are all required and a failed save never leaves suppressible evidence.
+    [<Test; Category("CurrentBranchSelfReferenceEcho")>]
+    let ``local self-reference ledger preserves mismatches and failed save notifications as ordinary work`` () =
+        let nowUtc = DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc)
+        let payload = localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "mismatch-self-reference"
+
+        let mismatchCases =
+            [|
+                { payload with CorrelationId = "other-correlation" }
+                { payload with ReferenceId = Guid.NewGuid() }
+                { payload with DirectoryId = Guid.NewGuid() }
+                { payload with Sha256Hash = Sha256Hash "other-sha256" }
+                { payload with Blake3Hash = Blake3Hash "other-blake3" }
+                { payload with RepositoryId = Guid.NewGuid() }
+                { payload with BranchId = Guid.NewGuid() }
+            |]
+
+        for mismatch in mismatchCases do
+            let ledger = Watch.LocalCurrentBranchReferenceEchoLedger(4, TimeSpan.FromMinutes(2.0), (fun () -> nowUtc))
+
+            let intent =
+                ledger.Begin(payload.RepositoryId, payload.BranchId, payload.DirectoryId, payload.Sha256Hash, payload.Blake3Hash, payload.CorrelationId)
+
+            ledger.Complete(intent, payload.ReferenceId)
+
+            ledger
+                .TryConsume(mismatch)
+                .GetAwaiter()
+                .GetResult()
+            |> should equal false
+
+            ledger.Count |> should equal 1
+
+        let failedLedger = Watch.LocalCurrentBranchReferenceEchoLedger(4, TimeSpan.FromMinutes(2.0), (fun () -> nowUtc))
+
+        let failedIntent =
+            failedLedger.Begin(payload.RepositoryId, payload.BranchId, payload.DirectoryId, payload.Sha256Hash, payload.Blake3Hash, payload.CorrelationId)
+
+        failedLedger.Fail(failedIntent)
+
+        failedLedger
+            .TryConsume(payload)
+            .GetAwaiter()
+            .GetResult()
+        |> should equal false
+
+        failedLedger.Count |> should equal 0
+
+    /// Verifies that expiry, capacity eviction, restart, and branch-transition reset cannot suppress retained identities.
+    [<Test; Category("CurrentBranchSelfReferenceEcho")>]
+    let ``local self-reference ledger is short lived bounded and cleared across process or branch lifetimes`` () =
+        let mutable nowUtc = DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc)
+
+        let payloads =
+            [|
+                localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "bounded-self-reference-1"
+                localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "bounded-self-reference-2"
+                localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "bounded-self-reference-3"
+            |]
+
+        let ledger = Watch.LocalCurrentBranchReferenceEchoLedger(2, TimeSpan.FromSeconds(30.0), (fun () -> nowUtc))
+
+        let handles =
+            payloads
+            |> Array.map (fun payload ->
+                let handle =
+                    ledger.Begin(payload.RepositoryId, payload.BranchId, payload.DirectoryId, payload.Sha256Hash, payload.Blake3Hash, payload.CorrelationId)
+
+                ledger.Complete(handle, payload.ReferenceId)
+                handle)
+
+        ledger.Count |> should equal 2
+
+        ledger
+            .TryConsume(payloads[0])
+            .GetAwaiter()
+            .GetResult()
+        |> should equal false
+
+        ledger
+            .TryConsume(payloads[1])
+            .GetAwaiter()
+            .GetResult()
+        |> should equal true
+
+        nowUtc <- nowUtc.AddMinutes(1.0)
+
+        ledger
+            .TryConsume(payloads[2])
+            .GetAwaiter()
+            .GetResult()
+        |> should equal false
+
+        ledger.Count |> should equal 0
+
+        let restartedLedger = Watch.LocalCurrentBranchReferenceEchoLedger(2, TimeSpan.FromSeconds(30.0), (fun () -> nowUtc))
+        let restartedPayload = localSelfReferenceNotification (Guid.NewGuid()) (Guid.NewGuid()) "restarted-self-reference"
+
+        let restartedIntent =
+            restartedLedger.Begin(
+                restartedPayload.RepositoryId,
+                restartedPayload.BranchId,
+                restartedPayload.DirectoryId,
+                restartedPayload.Sha256Hash,
+                restartedPayload.Blake3Hash,
+                restartedPayload.CorrelationId
+            )
+
+        restartedLedger.Complete(restartedIntent, restartedPayload.ReferenceId)
+        restartedLedger.Clear()
+
+        restartedLedger
+            .TryConsume(restartedPayload)
+            .GetAwaiter()
+            .GetResult()
+        |> should equal false
+
+        handles |> should haveLength 3
+
+    /// Verifies that exact direct SignalR echoes stop before every coordinator side effect or callback seam.
+    [<Test; Category("CurrentBranchSelfReferenceEcho")>]
+    let ``exact direct self-reference echo is consumed before coordinator work`` () =
+        withTempRepo (fun root ->
+            Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ()
+
+            try
+                let repositoryId, branchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+                let payload = localSelfReferenceNotification repositoryId branchId "direct-self-reference"
+                let intent = Watch.recordLocalCurrentBranchReferenceIntentForWatchTests payload
+                Watch.completeLocalCurrentBranchReferenceIntentForWatchTests intent payload.ReferenceId
+                let mutable coordinatorCalls = 0
+                let mutable handlerResult = Unchecked.defaultof<Services.LatestCurrentBranchReferenceDecision option>
+
+                let callbackOutput =
+                    captureAnsiConsoleOutput (fun () ->
+                        handlerResult <-
+                            (Watch.handleCurrentBranchReferenceNotificationWithClientsForWatchTests
+                                (fun () ->
+                                    coordinatorCalls <- coordinatorCalls + 1
+                                    Task.FromResult(Error(GraceError.Create "Exact self echo reached BranchDto fetch." payload.CorrelationId)))
+                                (fun () ->
+                                    coordinatorCalls <- coordinatorCalls + 1
+                                    Task.FromResult(None))
+                                payload)
+                                .GetAwaiter()
+                                .GetResult())
+
+                coordinatorCalls |> should equal 0
+                handlerResult |> should equal None
+                callbackOutput |> should equal String.Empty
+
+                Watch.localCurrentBranchReferenceEchoLedgerCountForWatchTests ()
+                |> should equal 0
+            finally
+                Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ())
+
+    /// Verifies that BranchDto lifecycle catch-up restores the local correlation and uses the same coordinator suppression gate.
+    [<Test; Category("CurrentBranchSelfReferenceEcho"); Category("CurrentBranchCatchUp")>]
+    let ``exact lifecycle catch-up self-reference uses shared coordinator gate`` () =
+        withTempRepo (fun root ->
+            Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ()
+
+            try
+                let repositoryId, branchId = configureCurrentWatchIdentity root "current-repo" "current-branch"
+                let payload = localSelfReferenceNotification repositoryId branchId "catch-up-self-reference"
+                let branchDto = branchDtoWithLatestCurrentBranchReference payload
+                let intent = Watch.recordLocalCurrentBranchReferenceIntentForWatchTests payload
+                Watch.completeLocalCurrentBranchReferenceIntentForWatchTests intent payload.ReferenceId
+                let mutable coordinatorCalls = 0
+                let observedCorrelations = ResizeArray<CorrelationId>()
+
+                let unexpected name =
+                    coordinatorCalls <- coordinatorCalls + 1
+                    Task.FromException<'T>(InvalidOperationException($"Exact catch-up self echo reached {name}."))
+
+                let processReference catchUpPayload =
+                    task {
+                        observedCorrelations.Add(catchUpPayload.CorrelationId)
+
+                        let! outcome =
+                            Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                                (fun () -> unexpected "BranchDto fetch")
+                                (fun () -> unexpected "local-status inspection")
+                                (fun _ -> coordinatorCalls <- coordinatorCalls + 1)
+                                (fun _ _ -> unexpected "safe-point wait")
+                                (fun _ _ -> unexpected "IPC reestablishment")
+                                (fun _ _ -> unexpected "materialization apply")
+                                catchUpPayload
+
+                        return outcome.Value
+                    }
+
+                let result, outcome =
+                    (Watch.catchUpCurrentBranchReferenceWithClientsForWatchTests
+                        (fun () -> Task.FromResult(Ok(GraceReturnValue.Create branchDto "catch-up-self-reference-source")))
+                        processReference)
+                        .GetAwaiter()
+                        .GetResult()
+
+                result
+                |> should equal Watch.CurrentBranchReferenceCatchUpResult.Processed
+
+                outcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.LocalSelfEchoConsumed
+
+                observedCorrelations.ToArray()
+                |> should equal [| payload.CorrelationId |]
+
+                coordinatorCalls |> should equal 0
+            finally
+                Watch.resetLocalCurrentBranchReferenceEchoLedgerForWatchTests ())
+
     /// Verifies that lifecycle catch-up derives the exact coordinator input from BranchDto rather than a prior notification.
     [<Test; Category("CurrentBranchCatchUp")>]
     let ``current branch catch-up routes BranchDto latest reference through coordinator`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -427,10 +427,12 @@ module WatchTests =
             Watch.resetWatchIgnoreSnapshotForWatchTests ()
             deleteWatchStatusFileIfExists ()
             Watch.clearPendingWatchWorkForTests ()
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
             Watch.setLocalObservationCandidateSchedulingForWatchTests false
             action tempDir
         finally
             Watch.clearPendingWatchWorkForTests ()
+            Watch.resetCurrentBranchReferenceCatchUpSchedulerForWatchTests ()
             Watch.resetWatchIgnoreSnapshotForWatchTests ()
             Services.clearShouldIgnoreCache ()
             Services.clearWorkingDirectoryWriteTimesForWatchRescan ()
@@ -7420,14 +7422,12 @@ module WatchTests =
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
-    /// Verifies that delayed GraceStatus artifact observations still publish refresh work after switch completion.
+    /// Verifies delayed local-state callbacks remain revision signals and cannot gain candidate scope after a root change.
     [<Test>]
-    let ``update marker deletion preserves delayed GraceStatus artifact refresh observation`` () =
-        withTempRepo (fun _ ->
+    let ``delayed local-state callback stays out of candidate scope after root change`` () =
+        withTempRepo (fun root ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
-            let updateMarkerFile = Services.updateInProgressFileName ()
-            let markerCompletedUtc = DateTime.UtcNow
             let graceStatusFile = Current().GraceStatusFile
 
             Services.setGraceWatchHasPendingWorkForStatus false
@@ -7436,23 +7436,31 @@ module WatchTests =
                 .GetAwaiter()
                 .GetResult()
 
-            Directory.CreateDirectory(Path.GetDirectoryName(graceStatusFile))
-            |> ignore
-
-            File.WriteAllText(graceStatusFile, "Grace-owned local state refresh")
-            File.SetLastWriteTimeUtc(graceStatusFile, markerCompletedUtc.AddSeconds(-1.0))
-            recordCompletedUpdateMarkerDeletion updateMarkerFile markerCompletedUtc
+            Watch.setKnownLocalStatusRevisionForWatchTests 4L
 
             Watch.OnChanged(changedEvent graceStatusFile)
 
-            Watch.graceStatusHasChangedForWatchTests ()
+            Current().RootDirectory <- Path.Combine(root, "new-root")
+            Watch.processDueLocalObservationCandidatesForWatchTests (DateTime.UtcNow.AddMinutes(1.0))
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.isEmpty
+            |> should equal true
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
+
+            Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+            |> should equal None
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
             |> should equal true
 
             readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
-            |> should equal true
+            |> should equal false
 
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
-            |> should equal false)
+            |> should equal true)
 
     /// Builds GraceStatus around explicit file versions so tests can model content-equivalent uploads.
     let private graceStatusTrackingFileVersions (trackedFiles: LocalFileVersion array) =
@@ -16719,9 +16727,9 @@ module WatchTests =
                 readWatchStatusJsonStringProperty "RootDirectoryId"
                 |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}")
 
-    /// Verifies that a pending GraceStatus artifact refresh publishes dirty IPC before the timer reloads status.
+    /// Verifies that local-state artifact callbacks remain quiet until their committed revision is checked.
     [<Test>]
-    let ``watch grace status artifact change publishes dirty ipc`` () =
+    let ``watch local-state artifact callbacks do not publish pending ipc`` () =
         withTempRepo (fun _ ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
@@ -16738,21 +16746,52 @@ module WatchTests =
             readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
             |> should equal true
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+            let cleanIpc = File.ReadAllText(Services.IpcFileName())
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            let callbackOutput =
+                captureAnsiConsoleOutput (fun () ->
+                    for suffix in
+                        [|
+                            String.Empty
+                            "-wal"
+                            "-shm"
+                            "-journal"
+                        |] do
+                        Watch.OnChanged(changedEvent (Current().GraceStatusFile + suffix)))
+
+            callbackOutput |> should equal String.Empty
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.isEmpty
             |> should equal true
 
-            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            Watch.isGraceWatchResyncPendingForWatchTests ()
             |> should equal false
+
+            Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+            |> should equal None
+
+            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+            |> should equal false
+
+            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            |> should equal true
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal cleanIpc
 
             Services.getGraceWatchStatus().Result
-            |> should equal None)
+            |> Option.isSome
+            |> should equal true)
 
-    /// Verifies that a blocked dirty IPC write can retry while the GraceStatus refresh flag is already pending.
+    /// Verifies startup establishes the durable revision before SQLite artifact callbacks can be admitted.
     [<Test>]
-    let ``watch grace status artifact change retries dirty ipc while refresh is pending`` () =
+    let ``watch startup records durable revision before admitting local-state callbacks`` () =
         withTempRepo (fun _ ->
+            let mutable initializationReadCompleted = false
+            let mutable callbacksObservedInitialization = false
+            let mutable revisionReads = 0
+            let mutable failures = 0
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
             let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
 
@@ -16762,24 +16801,277 @@ module WatchTests =
                 .GetAwaiter()
                 .GetResult()
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
-            |> should equal false
+            let initialIpc = File.ReadAllText(Services.IpcFileName())
+            let initialScope = Watch.lastPublishedWatchObservationScopeForWatchTests ()
 
-            use blockedIpc = new FileStream(Services.IpcFileName(), FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            (Watch.initializeLocalStatusRevisionBeforeArtifactCallbacksForWatchTests
+                (fun () ->
+                    revisionReads <- revisionReads + 1
+                    initializationReadCompleted <- true
+                    Task.FromResult(6L))
+                (fun () ->
+                    task {
+                        callbacksObservedInitialization <- initializationReadCompleted
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
-            blockedIpc.Dispose()
+                        let callbackOutput = captureAnsiConsoleOutput (fun () -> Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal")))
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
-            |> should equal false
+                        callbackOutput |> should equal String.Empty
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+                        Watch.localObservationCandidateSnapshotForWatchTests ()
+                        |> Array.isEmpty
+                        |> should equal true
 
-            readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
+                        Watch.pendingWatchWorkEvidenceForWatchTests ()
+                        |> should equal (false, false)
+
+                        Watch.isGraceWatchResyncPendingForWatchTests ()
+                        |> should equal false
+
+                        Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+                        |> should equal None
+
+                        Watch.lastPublishedWatchObservationScopeForWatchTests ()
+                        |> should equal initialScope
+
+                        File.ReadAllText(Services.IpcFileName())
+                        |> should equal initialIpc
+                    })
+                (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () ->
+                    revisionReads <- revisionReads + 1
+                    Task.FromResult(6L))
+                (fun () -> Assert.Fail("The startup revision callback must clear silently."))
+                (fun reason -> Assert.Fail(reason)))
+                .GetAwaiter()
+                .GetResult()
+
+            callbacksObservedInitialization
             |> should equal true
 
-            readWatchStatusJsonBooleanProperty "IsWorkingTreeClean"
+            revisionReads |> should equal 2
+            failures |> should equal 0
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
             |> should equal false)
+
+    /// Verifies a Watch-owned commit cannot hide a later external commit observed by the coalesced timer read.
+    [<Test>]
+    let ``watch owned revision commit then external revision commit schedules only controlled refresh`` () =
+        withTempRepo (fun _ ->
+            let mutable durableRevision = 19L
+            let mutable failures = 0
+            let mutable publications = 0
+            let initialStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let initialDirectoryIds = HashSet<DirectoryVersionId>(initialStatus.Index.Keys)
+            let updatedStatus = { initialStatus with RootDirectorySha256Hash = Sha256Hash "external-race-root" }
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile initialStatus (Some initialDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let initialIpc = File.ReadAllText(Services.IpcFileName())
+            let initialScope = Watch.lastPublishedWatchObservationScopeForWatchTests ()
+
+            (Watch.initializeLocalStatusRevisionBeforeArtifactCallbacksForWatchTests
+                (fun () -> Task.FromResult(durableRevision))
+                (fun () -> task { return () })
+                (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            (Watch.runWatchOwnedLocalStatusWriteForWatchTests (fun () ->
+                durableRevision <- 20L
+                Task.FromResult(durableRevision)))
+                .GetAwaiter()
+                .GetResult()
+
+            let callbackOutput = captureAnsiConsoleOutput (fun () -> Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-shm")))
+
+            callbackOutput |> should equal String.Empty
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> Array.isEmpty
+            |> should equal true
+
+            Watch.pendingWatchWorkEvidenceForWatchTests ()
+            |> should equal (false, false)
+
+            Watch.isGraceWatchResyncPendingForWatchTests ()
+            |> should equal false
+
+            Watch.currentBranchReferenceCatchUpPendingGenerationForWatchTests ()
+            |> should equal None
+
+            Watch.lastPublishedWatchObservationScopeForWatchTests ()
+            |> should equal initialScope
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal initialIpc
+
+            durableRevision <- 21L
+
+            (Watch.processLocalStatusRevisionCheckWithRefreshForWatchTests (fun () -> Task.FromResult(durableRevision)) (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            failures |> should equal 0
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal true
+
+            publications |> should equal 0
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests updatedStatus (fun status directoryIds ->
+                publications <- publications + 1
+                Services.updateGraceWatchInterprocessFile status directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            publications |> should equal 1
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal false
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal false)
+
+    /// Verifies duplicate SQLite callbacks coalesce into one quiet revision read for a Watch-owned commit.
+    [<Test>]
+    let ``watch duplicate local-state callbacks perform one quiet revision check`` () =
+        withTempRepo (fun _ ->
+            let mutable reads = 0
+            let mutable advances = 0
+            let mutable failures = 0
+
+            Watch.setKnownLocalStatusRevisionForWatchTests 7L
+
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-shm"))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () ->
+                    reads <- reads + 1
+                    Task.FromResult(7L))
+                (fun () -> advances <- advances + 1)
+                (fun _ -> failures <- failures + 1))
+                .GetAwaiter()
+                .GetResult()
+
+            reads |> should equal 1
+            advances |> should equal 0
+            failures |> should equal 0
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal false)
+
+    /// Verifies a greater external revision schedules exactly one controlled status refresh without immediate IPC work.
+    [<Test>]
+    let ``watch external local-status revision schedules one controlled refresh`` () =
+        withTempRepo (fun _ ->
+            let initialStatus = graceStatusTracking Array.empty<string> Array.empty<string>
+            let initialDirectoryIds = HashSet<DirectoryVersionId>(initialStatus.Index.Keys)
+            let updatedStatus = { initialStatus with RootDirectorySha256Hash = Sha256Hash "external-revision-root" }
+            let mutable publications = 0
+
+            Services.setGraceWatchHasPendingWorkForStatus false
+
+            (Services.updateGraceWatchInterprocessFile initialStatus (Some initialDirectoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            let initialIpc = File.ReadAllText(Services.IpcFileName())
+            Watch.setKnownLocalStatusRevisionForWatchTests 11L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-journal"))
+
+            (Watch.processLocalStatusRevisionCheckWithRefreshForWatchTests (fun () -> Task.FromResult(12L)) (fun reason -> Assert.Fail(reason)))
+                .GetAwaiter()
+                .GetResult()
+
+            File.ReadAllText(Services.IpcFileName())
+            |> should equal initialIpc
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal true
+
+            (Watch.publishGraceStatusRefreshSnapshotForWatchTests updatedStatus (fun status directoryIds ->
+                publications <- publications + 1
+                Services.updateGraceWatchInterprocessFile status directoryIds))
+                .GetAwaiter()
+                .GetResult()
+
+            publications |> should equal 1
+
+            Watch.graceStatusHasChangedForWatchTests ()
+            |> should equal false
+
+            readWatchStatusJsonStringProperty "RootDirectorySha256Hash"
+            |> should equal $"{updatedStatus.RootDirectorySha256Hash}")
+
+    /// Verifies an external revision committed after Watch's own revision remains visible to the coalesced timer check.
+    [<Test>]
+    let ``watch own revision followed by external revision preserves newer commit`` () =
+        withTempRepo (fun _ ->
+            let mutable advances = 0
+            Watch.setKnownLocalStatusRevisionForWatchTests 20L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () -> Task.FromResult(21L))
+                (fun () -> advances <- advances + 1)
+                (fun reason -> Assert.Fail(reason)))
+                .GetAwaiter()
+                .GetResult()
+
+            advances |> should equal 1)
+
+    /// Verifies regressed local-status evidence remains pending and enters the fail-closed path.
+    [<Test>]
+    let ``watch regressed local-status revision fails closed and retries`` () =
+        withTempRepo (fun _ ->
+            let mutable failure = None
+            Watch.setKnownLocalStatusRevisionForWatchTests 30L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () -> Task.FromResult(29L))
+                (fun () -> Assert.Fail("A regressed revision must not be accepted."))
+                (fun reason -> failure <- Some reason))
+                .GetAwaiter()
+                .GetResult()
+
+            failure |> Option.isSome |> should equal true
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal true)
+
+    /// Verifies unreadable local-status revision evidence remains pending and enters the fail-closed path.
+    [<Test>]
+    let ``watch unreadable local-status revision fails closed and retries`` () =
+        withTempRepo (fun _ ->
+            let mutable failure = None
+            Watch.setKnownLocalStatusRevisionForWatchTests 40L
+            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
+
+            (Watch.processLocalStatusRevisionCheckForWatchTests
+                (fun () -> Task.FromException<int64>(InvalidDataException("invalid revision metadata")))
+                (fun () -> Assert.Fail("Unreadable revision evidence must not be accepted."))
+                (fun reason -> failure <- Some reason))
+                .GetAwaiter()
+                .GetResult()
+
+            failure
+            |> Option.exists (fun reason -> reason.Contains("invalid revision metadata", StringComparison.Ordinal))
+            |> should equal true
+
+            Watch.localStatusRevisionCheckPendingForWatchTests ()
+            |> should equal true)
 
     /// Verifies that a consumed GraceStatus refresh can publish clean IPC during the same timer tick.
     [<Test>]

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -524,6 +524,10 @@ module Watch =
     let mutable graceStatusMemoryStream: MemoryStream = null
     let mutable graceStatusHasChanged = false
     let mutable private graceStatusRefreshGeneration = 0L
+    let mutable private localStatusRevisionCheckGeneration = 0L
+    let mutable private lastKnownLocalStatusRevision = 0L
+    let mutable private localStatusRevisionInitialized = 0
+    let private localStatusRevisionGate = new SemaphoreSlim(1, 1)
     let private watchStatusPublishLock = obj ()
     let mutable private lastPublishedHasPendingWatchWork: bool option = None
 
@@ -818,7 +822,6 @@ module Watch =
         | CreatedOrChanged
         | Changed
         | Deleted
-        | GraceStatusArtifact
 
     /// Captures the immutable repository and root identity that owned a raw local observation at admission.
     type internal WatchObservationScope =
@@ -1169,11 +1172,8 @@ module Watch =
         let snapshot = currentWatchIgnoreSnapshot ()
         isPathWithinDirectoryForWatch snapshot.GraceDirectory fullPath
 
-    /// Preserves status coordination while rejecting other Grace-owned paths before raw candidate scope capture.
-    let private tryClassifyRawLocalObservation fallbackKind fullPath =
-        if isGraceStatusArtifact fullPath then Some GraceStatusArtifact
-        elif isGraceInternalRawObservationPath fullPath then None
-        else Some fallbackKind
+    /// Rejects Grace-owned paths before raw candidate scope capture.
+    let private tryClassifyRawLocalObservation fallbackKind fullPath = if isGraceInternalRawObservationPath fullPath then None else Some fallbackKind
 
     /// Finds the tracked file entry that owns a repository-relative path with the requested comparison.
     let private tryFindTrackedFileWithComparison (comparison: StringComparison) (status: GraceStatus) (relativePath: RelativePath) =
@@ -3267,6 +3267,120 @@ module Watch =
 
         graceStatusHasChanged <- true
 
+    /// Coalesces status DB, WAL, SHM, and journal callbacks without creating ordinary filesystem work.
+    let private recordLocalStatusRevisionCheckObservation () =
+        Interlocked.Increment(&localStatusRevisionCheckGeneration)
+        |> ignore
+
+    /// Records the latest trusted revision established at startup, committed by Watch, or accepted from an external writer.
+    let private recordKnownLocalStatusRevision revision =
+        Volatile.Write(&lastKnownLocalStatusRevision, revision)
+        Volatile.Write(&localStatusRevisionInitialized, 1)
+
+    /// Runs a Watch-owned status transaction and records its committed revision under the timer check gate.
+    let private runWatchOwnedLocalStatusWrite writeStatus =
+        task {
+            do! localStatusRevisionGate.WaitAsync()
+
+            try
+                let! committedRevision = writeStatus ()
+                recordKnownLocalStatusRevision committedRevision
+            finally
+                localStatusRevisionGate.Release() |> ignore
+        }
+
+    /// Reads one coalesced revision signal and routes external advances or untrusted evidence without publishing from callbacks.
+    let private processLocalStatusRevisionCheck readRevision revisionAdvanced revisionUntrusted =
+        task {
+            if
+                Volatile.Read(&localStatusRevisionCheckGeneration)
+                <> 0L
+            then
+                do! localStatusRevisionGate.WaitAsync()
+
+                try
+                    let observedGeneration = Volatile.Read(&localStatusRevisionCheckGeneration)
+
+                    if observedGeneration <> 0L then
+                        let! revisionResult =
+                            task {
+                                try
+                                    let! revision = readRevision ()
+                                    return Ok revision
+                                with
+                                | ex -> return Error ex
+                            }
+
+                        match revisionResult with
+                        | Error ex -> revisionUntrusted $"local-status revision could not be read: {ex.Message}"
+                        | Ok durableRevision ->
+                            if Volatile.Read(&localStatusRevisionInitialized) = 0 then
+                                revisionUntrusted "local-status revision was not established before callback processing"
+                            else
+                                let knownRevision = Volatile.Read(&lastKnownLocalStatusRevision)
+
+                                if durableRevision < knownRevision then
+                                    revisionUntrusted $"local-status revision regressed from {knownRevision} to {durableRevision}"
+                                else
+                                    if durableRevision > knownRevision then
+                                        recordKnownLocalStatusRevision durableRevision
+                                        revisionAdvanced ()
+
+                                    Interlocked.CompareExchange(&localStatusRevisionCheckGeneration, 0L, observedGeneration)
+                                    |> ignore
+                finally
+                    localStatusRevisionGate.Release() |> ignore
+        }
+
+    /// Establishes the durable revision that owns startup status before filesystem callbacks are enabled.
+    let private initializeLocalStatusRevision readRevision revisionUntrusted =
+        task {
+            try
+                let! revision = readRevision ()
+                recordKnownLocalStatusRevision revision
+            with
+            | ex -> revisionUntrusted $"local-status revision could not be established at startup: {ex.Message}"
+        }
+
+    /// Establishes the durable startup revision before enabling any source of local-state artifact callbacks.
+    let private initializeLocalStatusRevisionBeforeArtifactCallbacks readRevision admitCallbacks revisionUntrusted =
+        task {
+            do! initializeLocalStatusRevision readRevision revisionUntrusted
+            do! admitCallbacks ()
+        }
+
+    /// Applies a Watch-owned incremental status mutation and remembers its committed local-status revision.
+    let private applyGraceStatusIncrementalAndRecordRevision graceStatus directoryVersions differences =
+        runWatchOwnedLocalStatusWrite (fun () ->
+            Grace.CLI.LocalStateDb.applyStatusIncrementalWithRevision (Current().GraceStatusFile) graceStatus directoryVersions differences)
+
+    /// Replaces a Watch-owned status snapshot and remembers its committed local-status revision.
+    let private writeGraceStatusFileAndRecordRevision graceStatus =
+        runWatchOwnedLocalStatusWrite (fun () -> Grace.CLI.LocalStateDb.replaceStatusSnapshotWithRevision (Current().GraceStatusFile) graceStatus)
+
+    /// Exposes deterministic local-status revision processing without starting the foreground timer.
+    let internal processLocalStatusRevisionCheckForWatchTests readRevision revisionAdvanced revisionUntrusted =
+        processLocalStatusRevisionCheck readRevision revisionAdvanced revisionUntrusted
+
+    /// Exercises the production external-revision transition while keeping revision reads and failure handling deterministic.
+    let internal processLocalStatusRevisionCheckWithRefreshForWatchTests readRevision revisionUntrusted =
+        processLocalStatusRevisionCheck readRevision recordGraceStatusRefreshObservation revisionUntrusted
+
+    /// Exercises startup revision initialization and callback admission in production order with deterministic clients.
+    let internal initializeLocalStatusRevisionBeforeArtifactCallbacksForWatchTests readRevision admitCallbacks revisionUntrusted =
+        initializeLocalStatusRevisionBeforeArtifactCallbacks readRevision admitCallbacks revisionUntrusted
+
+    /// Exercises the production gate that records a Watch-owned committed local-status revision.
+    let internal runWatchOwnedLocalStatusWriteForWatchTests writeStatus = runWatchOwnedLocalStatusWrite writeStatus
+
+    /// Establishes a known local-status revision for callback and restart tests.
+    let internal setKnownLocalStatusRevisionForWatchTests revision = recordKnownLocalStatusRevision revision
+
+    /// Reports whether SQLite artifact callbacks still owe one coalesced revision check.
+    let internal localStatusRevisionCheckPendingForWatchTests () =
+        Volatile.Read(&localStatusRevisionCheckGeneration)
+        <> 0L
+
     /// Clears exactly the Grace Status refresh generation consumed by a successful publication.
     let private tryClearGraceStatusRefreshGeneration observedGeneration =
         if Interlocked.CompareExchange(&graceStatusRefreshGeneration, 0L, observedGeneration) = observedGeneration then
@@ -3812,19 +3926,9 @@ module Watch =
         | Some _ -> publishPendingWatchWorkTransitionIfNeeded ()
         | None -> ()
 
-    /// Records that durable Grace Status changed and immediately advertises pending Watch work to other commands.
-    let private markGraceStatusChangedAndPublishPendingWorkTransition () =
-        recordGraceStatusRefreshObservation ()
-
-        publishPendingWatchWorkTransitionIfNeeded ()
-
     /// Applies a due create or rename candidate after its quiet window has separated raw callbacks from filesystem work.
     let private applyCreatedOrChangedLocalObservationCandidate fullPath observedAt =
-        if updateNotInProgress ()
-           && isGraceStatusArtifact fullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
-            false
-        elif isDelayedGraceOwnedFileObservation fullPath observedAt then
+        if isDelayedGraceOwnedFileObservation fullPath observedAt then
             false
         elif Directory.Exists(fullPath) then
             let queuedDirectoryWork = enqueueFinalDirectoryWork fullPath
@@ -3864,38 +3968,33 @@ module Watch =
 
     /// Applies a due delete candidate after the current marker and final filesystem state can be examined safely.
     let private applyDeletedLocalObservationCandidate fullPath observedAt =
-        if updateNotInProgress ()
-           && isGraceStatusArtifact fullPath then
-            markGraceStatusChangedAndPublishPendingWorkTransition ()
+        let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
+
+        if isDelayedGraceOwnedFileObservation fullPath observedAt
+           && not canceledFileUpload then
             false
-        else
-            let canceledFileUpload = cancelPendingUploadsForDeletedPath fullPath
+        elif enqueueStatusUpdateTrigger fullPath then
+            match repositoryRelativePath fullPath with
+            | Some relativePath ->
+                let invalidatedRelativePath = RelativePath relativePath
 
-            if isDelayedGraceOwnedFileObservation fullPath observedAt
-               && not canceledFileUpload then
-                false
-            elif enqueueStatusUpdateTrigger fullPath then
+                if
+                    canceledFileUpload
+                    || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
+                then
+                    clearProcessedFileRelativePathsPendingStatusForPaths [ invalidatedRelativePath ]
+                    removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+            | None -> ()
+
+            if canceledFileUpload then
                 match repositoryRelativePath fullPath with
-                | Some relativePath ->
-                    let invalidatedRelativePath = RelativePath relativePath
-
-                    if
-                        canceledFileUpload
-                        || not (finalPathMatchesEntryType FileSystemEntryType.File invalidatedRelativePath)
-                    then
-                        clearProcessedFileRelativePathsPendingStatusForPaths [ invalidatedRelativePath ]
-                        removeUploadedFileVersionsForPaths [ invalidatedRelativePath ]
+                | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
                 | None -> ()
 
-                if canceledFileUpload then
-                    match repositoryRelativePath fullPath with
-                    | Some relativePath -> addCanceledFileUploadDeleteRelativePath (RelativePath relativePath)
-                    | None -> ()
-
-                logToAnsiConsole Colors.Deleted $"I saw that {fullPath} was deleted."
-                true
-            else
-                false
+            logToAnsiConsole Colors.Deleted $"I saw that {fullPath} was deleted."
+            true
+        else
+            false
 
     /// Claims every due candidate, then reconciles IPC from the complete post-claim pending state even when no local work was queued.
     let private processDueLocalObservationCandidates now =
@@ -3952,9 +4051,6 @@ module Watch =
 
                                         removalQueuedWork || finalQueuedWork
                                     | Deleted -> applyDeletedLocalObservationCandidate candidate.FullPath candidate.LastSeenAt
-                                    | GraceStatusArtifact ->
-                                        markGraceStatusChangedAndPublishPendingWorkTransition ()
-                                        false
 
                         queuedPendingWork <- queuedPendingWork || candidateQueuedWork
                     | None -> ()
@@ -3979,11 +4075,6 @@ module Watch =
                 | CreatedOrChanged -> applyCreatedOrChangedLocalObservationCandidate fullPath observedAt
                 | Changed -> applyChangedLocalObservationCandidate fullPath observedAt
                 | Deleted -> applyDeletedLocalObservationCandidate fullPath observedAt
-                | GraceStatusArtifact ->
-                    if updateNotInProgress () then
-                        markGraceStatusChangedAndPublishPendingWorkTransition ()
-
-                    false
 
             if queuedPendingWork then publishPendingWatchWorkTransitionIfNeeded ()
 
@@ -4572,6 +4663,12 @@ module Watch =
 
         Interlocked.Exchange(&graceStatusRefreshGeneration, 0L)
         |> ignore
+
+        Interlocked.Exchange(&localStatusRevisionCheckGeneration, 0L)
+        |> ignore
+
+        Volatile.Write(&lastKnownLocalStatusRevision, 0L)
+        Volatile.Write(&localStatusRevisionInitialized, 0)
 
         stableFileIdentityNowForWatch <- fun () -> DateTime.UtcNow
 
@@ -6229,7 +6326,7 @@ module Watch =
                             | Error error -> return Error error
                         }
                 ReadGraceStatus = readGraceStatusFile
-                WriteGraceStatus = writeGraceStatusFile
+                WriteGraceStatus = writeGraceStatusFileAndRecordRevision
                 RequestResync = requestGraceWatchExplicitResync
                 TryCreateUpdateMarker = tryCreateCurrentBranchMaterializationMarkerForWatchTests
                 IsUpdateMarkerOwned = currentBranchMaterializationMarkerIsOwned
@@ -7480,11 +7577,14 @@ module Watch =
 
     /// Admits one raw callback through the shared Grace-internal namespace guard before scheduling or direct test processing.
     let private admitRawLocalObservation fallbackKind fullPath seenAt =
-        match tryClassifyRawLocalObservation fallbackKind fullPath with
-        | None -> ()
-        | Some kind when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate kind fullPath seenAt
-        | Some kind when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately kind fullPath
-        | Some _ -> ()
+        if isGraceStatusArtifact fullPath then
+            recordLocalStatusRevisionCheckObservation ()
+        else
+            match tryClassifyRawLocalObservation fallbackKind fullPath with
+            | None -> ()
+            | Some kind when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate kind fullPath seenAt
+            | Some kind when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately kind fullPath
+            | Some _ -> ()
 
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =
@@ -7821,7 +7921,7 @@ module Watch =
 
                                     if statusSideEffectStillAllowed "local status application" then
                                         // Apply incremental changes to the Grace Status DB.
-                                        do! applyGraceStatusIncremental newGraceStatusWithUpdatedTime newDirectoryVersions differences
+                                        do! applyGraceStatusIncrementalAndRecordRevision newGraceStatusWithUpdatedTime newDirectoryVersions differences
 
                                         for fileVersion in directoryUploadedFileVersions do
                                             let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
@@ -8908,7 +9008,7 @@ module Watch =
             updateGraceStatus
             scanForDifferencesWithWatchIgnoreSnapshot
             updateGraceStatusFromDifferences
-            applyGraceStatusIncremental
+            applyGraceStatusIncrementalAndRecordRevision
             updateGraceWatchInterprocessFile
 
     /// Coordinates queue startup difference for watch behavior for this CLI command path.
@@ -9374,12 +9474,19 @@ module Watch =
                     graceStatus <- status
                     updateGraceStatusDirectoryIds graceStatus
 
-                    // Create the inter-process communication file.
-                    do! publishStartupCatchUpPendingStatus graceStatus graceStatusDirectoryIds updateGraceWatchInterprocessFile
+                    do!
+                        initializeLocalStatusRevisionBeforeArtifactCallbacks
+                            (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                            (fun () ->
+                                task {
+                                    // Create the inter-process communication file.
+                                    do! publishStartupCatchUpPendingStatus graceStatus graceStatusDirectoryIds updateGraceWatchInterprocessFile
 
-                    // Enable the FileSystemWatcher.
-                    rootDirectoryFileSystemWatcher.EnableRaisingEvents <- true
-                    updateInProgressFileSystemWatcher.EnableRaisingEvents <- true
+                                    // Enable the FileSystemWatcher only after the durable local-status revision is established.
+                                    rootDirectoryFileSystemWatcher.EnableRaisingEvents <- true
+                                    updateInProgressFileSystemWatcher.EnableRaisingEvents <- true
+                                })
+                            (fun reason -> requestGraceWatchExplicitResync reason)
 
                     let timerTimeSpan = TimeSpan.FromSeconds(1.0)
 
@@ -9573,6 +9680,12 @@ module Watch =
                             processWatchTimerLocalRecoveryWithCatchUp
                                 (fun () ->
                                     task {
+                                        do!
+                                            processLocalStatusRevisionCheck
+                                                (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                                                recordGraceStatusRefreshObservation
+                                                requestGraceWatchExplicitResync
+
                                         // Grace Status may have changed from branch switch, or other commands.
                                         if graceStatusHasChanged then
                                             let refreshGeneration = currentGraceStatusRefreshGeneration ()

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -91,7 +91,7 @@ module Watch =
             mutable ReferenceId: ReferenceId option
         }
 
-    /// Tracks only exact current-process save References long enough to consume their SignalR or lifecycle echo.
+    /// Tracks exact current-process save References long enough to silence every matching SignalR or lifecycle delivery.
     type internal LocalCurrentBranchReferenceEchoLedger(capacity: int, lifetime: TimeSpan, utcNow: unit -> DateTime) =
         let ledgerLock = obj ()
         let entries = Dictionary<Guid, LocalCurrentBranchReferenceEchoEntry>()
@@ -104,15 +104,14 @@ module Watch =
             if lifetime <= TimeSpan.Zero then
                 invalidArg (nameof lifetime) "The local self-reference ledger lifetime must be positive."
 
-        /// Removes one entry and releases any early notification waiting for its terminal save result.
-        let removeEntry token completion =
+        /// Removes one entry and releases any early notification to ordinary coordinator handling.
+        let removeEntry token =
             match entries.TryGetValue(token) with
             | true, entry ->
                 entries.Remove(token) |> ignore
                 insertionOrder.Remove(token) |> ignore
 
-                entry.Completion.TrySetResult(completion)
-                |> ignore
+                entry.Completion.TrySetResult(None) |> ignore
             | _ -> ()
 
         /// Removes expired intents in insertion order before any admission decision uses them.
@@ -123,7 +122,7 @@ module Watch =
                 let token = insertionOrder.First.Value
 
                 match entries.TryGetValue(token) with
-                | true, entry when entry.ExpiresAtUtc <= nowUtc -> removeEntry token None
+                | true, entry when entry.ExpiresAtUtc <= nowUtc -> removeEntry token
                 | true, _ -> pruning <- false
                 | _ -> insertionOrder.RemoveFirst()
 
@@ -152,7 +151,7 @@ module Watch =
 
                 while entries.Count >= capacity
                       && not (isNull insertionOrder.First) do
-                    removeEntry insertionOrder.First.Value None
+                    removeEntry insertionOrder.First.Value
 
                 let token = Guid.NewGuid()
 
@@ -188,11 +187,11 @@ module Watch =
 
                     entry.Completion.TrySetResult(Some referenceId)
                     |> ignore
-                | true, _ -> removeEntry token None
+                | true, _ -> removeEntry token
                 | _ -> ())
 
         /// Removes a failed or uncertain save intent so its later notification follows ordinary coordinator behavior.
-        member _.Fail(LocalCurrentBranchReferenceEchoIntentHandle token) = lock ledgerLock (fun () -> removeEntry token None)
+        member _.Fail(LocalCurrentBranchReferenceEchoIntentHandle token) = lock ledgerLock (fun () -> removeEntry token)
 
         /// Restores the original correlation for a BranchDto-derived form of an exact completed local Reference.
         member _.TryFindCompletedCorrelation(payload: CurrentBranchReferenceNotification) =
@@ -203,7 +202,7 @@ module Watch =
                 |> Seq.tryFind (fun entry -> completedReferenceMatchesPayload entry payload)
                 |> Option.map (fun entry -> entry.Identity.CorrelationId))
 
-        /// Consumes one exact completed local notification before it can enter materialization coordination.
+        /// Recognizes an exact completed local notification without retiring evidence needed by its other delivery path.
         member _.TryConsume(payload: CurrentBranchReferenceNotification) =
             task {
                 let pendingCompletion =
@@ -229,7 +228,7 @@ module Watch =
                         }
 
                     if not completedBeforeExpiry then
-                        lock ledgerLock (fun () -> removeEntry token None)
+                        lock ledgerLock (fun () -> removeEntry token)
                         return false
                     else
                         let! completedReferenceId = completionTask
@@ -243,7 +242,6 @@ module Watch =
                                     referenceId = payload.ReferenceId
                                     && completedReferenceMatchesPayload entry payload
                                     ->
-                                    removeEntry token (Some referenceId)
                                     true
                                 | _ -> false)
             }
@@ -254,7 +252,7 @@ module Watch =
                 let tokens = insertionOrder |> Seq.toArray
 
                 for token in tokens do
-                    removeEntry token None)
+                    removeEntry token)
 
         /// Reports retained entries after pruning for deterministic capacity and expiry tests.
         member _.Count =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -66,6 +66,237 @@ module Watch =
     /// Reads Grace Watch runtime mode for tests that exercise confidence-loss transitions.
     let internal currentGraceWatchRuntimeModeForWatchTests () = currentGraceWatchRuntimeMode ()
 
+    /// Identifies one process-local save attempt without exposing its mutable ledger entry.
+    [<Struct>]
+    type internal LocalCurrentBranchReferenceEchoIntentHandle = private LocalCurrentBranchReferenceEchoIntentHandle of Guid
+
+    /// Carries the exact locally emitted root identity that a returned Reference may later complete.
+    type private LocalCurrentBranchReferenceEchoIntentIdentity =
+        {
+            RepositoryId: RepositoryId
+            BranchId: BranchId
+            DirectoryId: DirectoryVersionId
+            Sha256Hash: Sha256Hash
+            Blake3Hash: Blake3Hash
+            CorrelationId: CorrelationId
+        }
+
+    /// Holds one bounded local intent while notification-before-response ordering settles.
+    type private LocalCurrentBranchReferenceEchoEntry =
+        {
+            Token: Guid
+            Identity: LocalCurrentBranchReferenceEchoIntentIdentity
+            ExpiresAtUtc: DateTime
+            Completion: TaskCompletionSource<ReferenceId option>
+            mutable ReferenceId: ReferenceId option
+        }
+
+    /// Tracks only exact current-process save References long enough to consume their SignalR or lifecycle echo.
+    type internal LocalCurrentBranchReferenceEchoLedger(capacity: int, lifetime: TimeSpan, utcNow: unit -> DateTime) =
+        let ledgerLock = obj ()
+        let entries = Dictionary<Guid, LocalCurrentBranchReferenceEchoEntry>()
+        let insertionOrder = LinkedList<Guid>()
+
+        do
+            if capacity <= 0 then
+                invalidArg (nameof capacity) "The local self-reference ledger capacity must be positive."
+
+            if lifetime <= TimeSpan.Zero then
+                invalidArg (nameof lifetime) "The local self-reference ledger lifetime must be positive."
+
+        /// Removes one entry and releases any early notification waiting for its terminal save result.
+        let removeEntry token completion =
+            match entries.TryGetValue(token) with
+            | true, entry ->
+                entries.Remove(token) |> ignore
+                insertionOrder.Remove(token) |> ignore
+
+                entry.Completion.TrySetResult(completion)
+                |> ignore
+            | _ -> ()
+
+        /// Removes expired intents in insertion order before any admission decision uses them.
+        let pruneExpired nowUtc =
+            let mutable pruning = true
+
+            while pruning && not (isNull insertionOrder.First) do
+                let token = insertionOrder.First.Value
+
+                match entries.TryGetValue(token) with
+                | true, entry when entry.ExpiresAtUtc <= nowUtc -> removeEntry token None
+                | true, _ -> pruning <- false
+                | _ -> insertionOrder.RemoveFirst()
+
+        /// Reports whether a notification exactly matches the save identity known before the server assigns its response.
+        let intentMatchesPayload identity (payload: CurrentBranchReferenceNotification) =
+            identity.RepositoryId = payload.RepositoryId
+            && identity.BranchId = payload.BranchId
+            && identity.DirectoryId = payload.DirectoryId
+            && identity.Sha256Hash = payload.Sha256Hash
+            && identity.Blake3Hash = payload.Blake3Hash
+            && String.Equals(identity.CorrelationId, payload.CorrelationId, StringComparison.Ordinal)
+
+        /// Reports whether BranchDto-derived catch-up names the exact completed local Reference and root.
+        let completedReferenceMatchesPayload (entry: LocalCurrentBranchReferenceEchoEntry) (payload: CurrentBranchReferenceNotification) =
+            entry.ReferenceId = Some payload.ReferenceId
+            && entry.Identity.RepositoryId = payload.RepositoryId
+            && entry.Identity.BranchId = payload.BranchId
+            && entry.Identity.DirectoryId = payload.DirectoryId
+            && entry.Identity.Sha256Hash = payload.Sha256Hash
+            && entry.Identity.Blake3Hash = payload.Blake3Hash
+
+        /// Records an exact local save intent before its server publication can race the response.
+        member _.Begin(repositoryId, branchId, directoryId, sha256Hash, blake3Hash, correlationId) =
+            lock ledgerLock (fun () ->
+                pruneExpired (utcNow ())
+
+                while entries.Count >= capacity
+                      && not (isNull insertionOrder.First) do
+                    removeEntry insertionOrder.First.Value None
+
+                let token = Guid.NewGuid()
+
+                let entry =
+                    {
+                        Token = token
+                        Identity =
+                            {
+                                RepositoryId = repositoryId
+                                BranchId = branchId
+                                DirectoryId = directoryId
+                                Sha256Hash = sha256Hash
+                                Blake3Hash = blake3Hash
+                                CorrelationId = correlationId
+                            }
+                        ExpiresAtUtc = (utcNow ()).Add(lifetime)
+                        Completion = TaskCompletionSource<ReferenceId option>(TaskCreationOptions.RunContinuationsAsynchronously)
+                        ReferenceId = None
+                    }
+
+                entries.Add(token, entry)
+                insertionOrder.AddLast(token) |> ignore
+                LocalCurrentBranchReferenceEchoIntentHandle token)
+
+        /// Promotes a local intent only after the save response and local status application both succeed.
+        member _.Complete(LocalCurrentBranchReferenceEchoIntentHandle token, referenceId) =
+            lock ledgerLock (fun () ->
+                pruneExpired (utcNow ())
+
+                match entries.TryGetValue(token) with
+                | true, entry when referenceId <> ReferenceId.Empty ->
+                    entry.ReferenceId <- Some referenceId
+
+                    entry.Completion.TrySetResult(Some referenceId)
+                    |> ignore
+                | true, _ -> removeEntry token None
+                | _ -> ())
+
+        /// Removes a failed or uncertain save intent so its later notification follows ordinary coordinator behavior.
+        member _.Fail(LocalCurrentBranchReferenceEchoIntentHandle token) = lock ledgerLock (fun () -> removeEntry token None)
+
+        /// Restores the original correlation for a BranchDto-derived form of an exact completed local Reference.
+        member _.TryFindCompletedCorrelation(payload: CurrentBranchReferenceNotification) =
+            lock ledgerLock (fun () ->
+                pruneExpired (utcNow ())
+
+                entries.Values
+                |> Seq.tryFind (fun entry -> completedReferenceMatchesPayload entry payload)
+                |> Option.map (fun entry -> entry.Identity.CorrelationId))
+
+        /// Consumes one exact completed local notification before it can enter materialization coordination.
+        member _.TryConsume(payload: CurrentBranchReferenceNotification) =
+            task {
+                let pendingCompletion =
+                    lock ledgerLock (fun () ->
+                        pruneExpired (utcNow ())
+
+                        entries.Values
+                        |> Seq.tryFind (fun entry -> intentMatchesPayload entry.Identity payload)
+                        |> Option.map (fun entry -> entry.Token, entry.ExpiresAtUtc, entry.Completion.Task))
+
+                match pendingCompletion with
+                | None -> return false
+                | Some (token, expiresAtUtc, completionTask) ->
+                    let remainingLifetime = expiresAtUtc - utcNow ()
+
+                    let! completedBeforeExpiry =
+                        task {
+                            if remainingLifetime <= TimeSpan.Zero then
+                                return false
+                            else
+                                let! completedTask = Task.WhenAny(completionTask :> Task, Task.Delay(remainingLifetime))
+                                return Object.ReferenceEquals(completedTask, completionTask)
+                        }
+
+                    if not completedBeforeExpiry then
+                        lock ledgerLock (fun () -> removeEntry token None)
+                        return false
+                    else
+                        let! completedReferenceId = completionTask
+
+                        return
+                            lock ledgerLock (fun () ->
+                                pruneExpired (utcNow ())
+
+                                match completedReferenceId, entries.TryGetValue(token) with
+                                | Some referenceId, (true, entry) when
+                                    referenceId = payload.ReferenceId
+                                    && completedReferenceMatchesPayload entry payload
+                                    ->
+                                    removeEntry token (Some referenceId)
+                                    true
+                                | _ -> false)
+            }
+
+        /// Discards all process-local evidence and releases notifications waiting on incomplete saves.
+        member _.Clear() =
+            lock ledgerLock (fun () ->
+                let tokens = insertionOrder |> Seq.toArray
+
+                for token in tokens do
+                    removeEntry token None)
+
+        /// Reports retained entries after pruning for deterministic capacity and expiry tests.
+        member _.Count =
+            lock ledgerLock (fun () ->
+                pruneExpired (utcNow ())
+                entries.Count)
+
+    let private localCurrentBranchReferenceEchoLedger = LocalCurrentBranchReferenceEchoLedger(64, TimeSpan.FromMinutes(2.0), (fun () -> DateTime.UtcNow))
+
+    /// Begins a production local save intent using the repository identity and complete root version being published.
+    let private beginLocalCurrentBranchReferenceIntent (rootDirectoryVersion: LocalDirectoryVersion) correlationId =
+        let current = Current()
+
+        localCurrentBranchReferenceEchoLedger.Begin(
+            current.RepositoryId,
+            current.BranchId,
+            rootDirectoryVersion.DirectoryVersionId,
+            rootDirectoryVersion.Sha256Hash,
+            rootDirectoryVersion.Blake3Hash,
+            correlationId
+        )
+
+    /// Records the identity carried by a test notification before simulating save completion.
+    let internal recordLocalCurrentBranchReferenceIntentForWatchTests (payload: CurrentBranchReferenceNotification) =
+        localCurrentBranchReferenceEchoLedger.Begin(
+            payload.RepositoryId,
+            payload.BranchId,
+            payload.DirectoryId,
+            payload.Sha256Hash,
+            payload.Blake3Hash,
+            payload.CorrelationId
+        )
+
+    /// Promotes a focused-test intent with the server-created Reference identity.
+    let internal completeLocalCurrentBranchReferenceIntentForWatchTests intent referenceId = localCurrentBranchReferenceEchoLedger.Complete(intent, referenceId)
+
+    /// Clears process-local self-reference evidence between focused Watch test lifetimes.
+    let internal resetLocalCurrentBranchReferenceEchoLedgerForWatchTests () = localCurrentBranchReferenceEchoLedger.Clear()
+
+    /// Reports retained production-ledger entries for false-positive-resistant coordinator tests.
+    let internal localCurrentBranchReferenceEchoLedgerCountForWatchTests () = localCurrentBranchReferenceEchoLedger.Count
+
     /// Provides the fallback path comparison until the repository volume can be probed.
     let private defaultWatchPathComparison () =
         if OperatingSystem.IsWindows() then
@@ -4467,6 +4698,8 @@ module Watch =
 
     /// Completes a Grace-owned branch transition, then records any failed target activation after releasing the status publication monitor.
     let private completeGraceUpdateTransitionAfterMarkerDeletion completedUtc =
+        localCurrentBranchReferenceEchoLedger.Clear()
+
         let deferredTransitionConfigurationReloadReason =
             lock watchStatusPublishLock (fun () ->
                 let mutable deferredConfigurationReloadReason = None
@@ -4628,6 +4861,7 @@ module Watch =
     /// Clears inherited pending watch work for tests values so explicitly scoped access commands do not target child resources accidentally.
     let internal clearPendingWatchWorkForTests () =
         clearLocalObservationCandidateScheduler ()
+        localCurrentBranchReferenceEchoLedger.Clear()
         setLocalObservationCandidateSchedulingActive false
         Volatile.Write(&markerCompletionConfidenceLossActive, 0)
         Volatile.Write(&localObservationConfidenceLossActive, 0)
@@ -6177,7 +6411,7 @@ module Watch =
         }
 
     /// Applies one BranchDto-confirmed Reference through exact targets and object-cache-only file content.
-    let private applyCurrentBranchReferenceMaterializationWithAcceptedStatus clients payload acceptedStatus =
+    let private applyCurrentBranchReferenceMaterializationWithAcceptedStatus clients (payload: CurrentBranchReferenceNotification) acceptedStatus =
         task {
             configureWatchPathComparisonForCurrentRepository ()
 
@@ -6295,7 +6529,7 @@ module Watch =
         }
 
     /// Applies one BranchDto-confirmed current-branch Reference without downloading missing object content.
-    let private applyCurrentBranchReferenceMaterialization payload acceptedStatus =
+    let private applyCurrentBranchReferenceMaterialization (payload: CurrentBranchReferenceNotification) acceptedStatus =
         applyCurrentBranchReferenceMaterializationWithAcceptedStatusForWatchTests
             {
                 GetRemoteDirectoryVersions =
@@ -6369,6 +6603,8 @@ module Watch =
         | WaitingForSafePoint = 4
         /// Watch could not trust local IPC/status authority even after degraded resync revalidation.
         | WaitingForDegradedResync = 5
+        /// The exact completed Reference was emitted by this Watch process and never entered coordinator work.
+        | LocalSelfEchoConsumed = 6
 
     /// Carries the terminal coordinator result for one exact same-branch Reference notification.
     type internal CurrentBranchMaterializationCoordinatorOutcome =
@@ -6984,7 +7220,15 @@ module Watch =
         (clients: CurrentBranchMaterializationCoordinatorClients)
         (payload: CurrentBranchReferenceNotification)
         =
-        WorkingDirectoryMaterialization.runSerializedLane (fun () -> processCurrentBranchMaterializationNotification clients payload)
+        task {
+            let! localSelfEchoConsumed = localCurrentBranchReferenceEchoLedger.TryConsume(payload)
+
+            if localSelfEchoConsumed then
+                return
+                    { ReferenceId = payload.ReferenceId; Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LocalSelfEchoConsumed; Decision = None }
+            else
+                return! WorkingDirectoryMaterialization.runSerializedLane (fun () -> processCurrentBranchMaterializationNotification clients payload)
+        }
 
     /// Reads the current BranchDto so same-branch notifications are checked against server latest-reference authority.
     let private getCurrentBranchForCurrentBranchReferenceNotification (payload: CurrentBranchReferenceNotification) =
@@ -7122,20 +7366,25 @@ module Watch =
         else
             latestReference
             |> Option.map (fun reference ->
-                ({ CurrentBranchReferenceNotification.Default with
-                     ReferenceId = reference.ReferenceId
-                     OwnerId = reference.OwnerId
-                     OrganizationId = reference.OrganizationId
-                     RepositoryId = reference.RepositoryId
-                     BranchId = reference.BranchId
-                     BranchName = branchDto.BranchName
-                     DirectoryId = reference.DirectoryId
-                     Sha256Hash = reference.Sha256Hash
-                     Blake3Hash = reference.Blake3Hash
-                     ReferenceType = reference.ReferenceType
-                     ReferenceText = reference.ReferenceText
-                     CorrelationId = correlationId
-                 }: CurrentBranchReferenceNotification))
+                let payload =
+                    ({ CurrentBranchReferenceNotification.Default with
+                         ReferenceId = reference.ReferenceId
+                         OwnerId = reference.OwnerId
+                         OrganizationId = reference.OrganizationId
+                         RepositoryId = reference.RepositoryId
+                         BranchId = reference.BranchId
+                         BranchName = branchDto.BranchName
+                         DirectoryId = reference.DirectoryId
+                         Sha256Hash = reference.Sha256Hash
+                         Blake3Hash = reference.Blake3Hash
+                         ReferenceType = reference.ReferenceType
+                         ReferenceText = reference.ReferenceText
+                         CorrelationId = correlationId
+                     }: CurrentBranchReferenceNotification)
+
+                match localCurrentBranchReferenceEchoLedger.TryFindCompletedCorrelation(payload) with
+                | Some localCorrelationId -> { payload with CorrelationId = localCorrelationId }
+                | None -> payload)
 
     /// Re-reads BranchDto and sends its exact latest Reference through the existing serialized materialization lane.
     let private catchUpCurrentBranchReferenceWithClients
@@ -7909,32 +8158,73 @@ module Watch =
 
                             // If there are changes either to files or just to directories, create a save reference.
                             if (differences.Count > 0) then
-                                let! saveReferenceResult =
-                                    if statusSideEffectStillAllowed "save reference creation" then
-                                        createSaveReference (getRootDirectoryVersion newGraceStatus) message correlationId
+                                let rootDirectoryVersion = getRootDirectoryVersion newGraceStatus
+                                let saveReferenceCreationAllowed = statusSideEffectStillAllowed "save reference creation"
+
+                                let localReferenceIntent =
+                                    if saveReferenceCreationAllowed then
+                                        Some(beginLocalCurrentBranchReferenceIntent rootDirectoryVersion correlationId)
                                     else
-                                        Task.FromResult(Error(GraceError.Create "Watch confidence lost before save reference creation." correlationId))
+                                        None
+
+                                let! saveReferenceResult =
+                                    task {
+                                        try
+                                            if saveReferenceCreationAllowed then
+                                                return! createSaveReference rootDirectoryVersion message correlationId
+                                            else
+                                                return Error(GraceError.Create "Watch confidence lost before save reference creation." correlationId)
+                                        with
+                                        | ex ->
+                                            localReferenceIntent
+                                            |> Option.iter localCurrentBranchReferenceEchoLedger.Fail
+
+                                            return raise ex
+                                    }
 
                                 match saveReferenceResult with
                                 | Ok returnValue ->
+                                    let completedLocalReferenceId =
+                                        match parseCreatedReferenceId correlationId returnValue with
+                                        | Ok referenceId -> Some referenceId
+                                        | Error _ -> None
+
                                     let newGraceStatusWithUpdatedTime = { newGraceStatus with LastSuccessfulDirectoryVersionUpload = getCurrentInstant () }
 
                                     if statusSideEffectStillAllowed "local status application" then
-                                        // Apply incremental changes to the Grace Status DB.
-                                        do! applyGraceStatusIncrementalAndRecordRevision newGraceStatusWithUpdatedTime newDirectoryVersions differences
+                                        try
+                                            // Apply incremental changes to the Grace Status DB.
+                                            do! applyGraceStatusIncrementalAndRecordRevision newGraceStatusWithUpdatedTime newDirectoryVersions differences
 
-                                        for fileVersion in directoryUploadedFileVersions do
-                                            let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
+                                            match localReferenceIntent, completedLocalReferenceId with
+                                            | Some intent, Some referenceId -> localCurrentBranchReferenceEchoLedger.Complete(intent, referenceId)
+                                            | Some intent, None -> localCurrentBranchReferenceEchoLedger.Fail(intent)
+                                            | _ -> ()
 
-                                            uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
-                                            |> ignore
+                                            for fileVersion in directoryUploadedFileVersions do
+                                                let mutable removedFileVersion = Unchecked.defaultof<FileVersion>
 
-                                        //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
-                                        graceStatusHasChanged <- currentGraceStatusRefreshGeneration () <> 0L // We *just* changed it ourselves, but a newer observed refresh must still be processed.
-                                        return Some newGraceStatusWithUpdatedTime
+                                                uploadedFileVersions.TryRemove(uploadedFileVersionIdentity fileVersion, &removedFileVersion)
+                                                |> ignore
+
+                                            //logToAnsiConsole Colors.Important $"Setting graceStatusHasChanged to false in updateGraceStatus(). Current value: {graceStatusHasChanged}."
+                                            graceStatusHasChanged <- currentGraceStatusRefreshGeneration () <> 0L // We *just* changed it ourselves, but a newer observed refresh must still be processed.
+                                            return Some newGraceStatusWithUpdatedTime
+                                        with
+                                        | ex ->
+                                            localReferenceIntent
+                                            |> Option.iter localCurrentBranchReferenceEchoLedger.Fail
+
+                                            return raise ex
                                     else
+                                        localReferenceIntent
+                                        |> Option.iter localCurrentBranchReferenceEchoLedger.Fail
+
                                         return None
                                 | Error error ->
+                                    localReferenceIntent
+                                    |> Option.iter localCurrentBranchReferenceEchoLedger.Fail
+
                                     logToAnsiConsole Colors.Error $"{Markup.Escape(error.Error)}"
                                     return None
                             else
@@ -9371,6 +9661,13 @@ module Watch =
                 use localObservationCandidateLifetime =
                     { new IDisposable with
                         member _.Dispose() = retireLocalObservationCandidateScheduler ()
+                    }
+
+                localCurrentBranchReferenceEchoLedger.Clear()
+
+                use localCurrentBranchReferenceEchoLifetime =
+                    { new IDisposable with
+                        member _.Dispose() = localCurrentBranchReferenceEchoLedger.Clear()
                     }
 
                 try

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -25,6 +25,10 @@ module LocalStateDb =
     [<Literal>]
     let WatchJournalAppliedThroughSequenceMetaKey = "AppliedThroughSequence"
 
+    /// Identifies the monotonic metadata value that coordinates committed local-status changes across Grace processes.
+    [<Literal>]
+    let LocalStatusRevisionMetaKey = "LocalStatusRevision"
+
     /// Keeps a bounded diagnostic tail of already-applied Watch journal rows.
     [<Literal>]
     let WatchJournalRetainedAppliedRows = 1024L
@@ -91,11 +95,34 @@ module LocalStateDb =
                     do! operation ()
                 with
                 | :? SqliteException as ex when isBusyOrLocked ex ->
-                    if attempt >= retryDelaysMs.Length then return raise ex
-                    let jitter = Random.Shared.Next(0, 50)
-                    let delayMs = retryDelaysMs[attempt] + jitter
-                    do! Task.Delay(delayMs)
-                    return! run (attempt + 1)
+                    if attempt >= retryDelaysMs.Length then
+                        return raise ex
+                    else
+                        let jitter = Random.Shared.Next(0, 50)
+                        let delayMs = retryDelaysMs[attempt] + jitter
+                        do! Task.Delay(delayMs)
+                        return! run (attempt + 1)
+                | ex -> return raise ex
+            }
+
+        run 0
+
+    /// Retries a local-state transaction that returns its exact committed revision.
+    let private executeWithRevisionRetry (operation: unit -> Task<int64>) =
+        /// Runs the revision-returning transaction until it commits or reaches the bounded busy retry limit.
+        let rec run attempt =
+            task {
+                try
+                    return! operation ()
+                with
+                | :? SqliteException as ex when isBusyOrLocked ex ->
+                    if attempt >= retryDelaysMs.Length then
+                        return raise ex
+                    else
+                        let jitter = Random.Shared.Next(0, 50)
+                        let delayMs = retryDelaysMs[attempt] + jitter
+                        do! Task.Delay(delayMs)
+                        return! run (attempt + 1)
                 | ex -> return raise ex
             }
 
@@ -1232,6 +1259,42 @@ module LocalStateDb =
             parameters.AddWithValue("$key", WatchJournalAppliedThroughSequenceMetaKey)
             |> ignore)
 
+    /// Persists the initial local-status revision without treating schema initialization as a status mutation.
+    let private insertLocalStatusRevisionIfMissing (connection: SqliteConnection) =
+        executeNonQueryWithParams connection "INSERT OR IGNORE INTO meta (key, value) VALUES ($key, '0');" (fun parameters ->
+            parameters.AddWithValue("$key", LocalStatusRevisionMetaKey)
+            |> ignore)
+
+    /// Parses a persisted local-status revision only when it preserves the monotonic nonnegative counter invariant.
+    let private tryParseLocalStatusRevision (value: string) =
+        match Int64.TryParse(value) with
+        | true, revision when revision >= 0L -> Some revision
+        | _ -> None
+
+    /// Reads the committed local-status revision and rejects missing, duplicate, or malformed metadata.
+    let private readLocalStatusRevisionInternal (connection: SqliteConnection) =
+        if countMetaValues connection LocalStatusRevisionMetaKey
+           <> 1 then
+            raise (InvalidDataException($"{LocalStatusRevisionMetaKey} must have exactly one metadata row."))
+
+        match tryGetMetaValue connection LocalStatusRevisionMetaKey with
+        | Some value ->
+            match tryParseLocalStatusRevision value with
+            | Some revision -> revision
+            | None -> raise (InvalidDataException($"{LocalStatusRevisionMetaKey} must be a non-negative 64-bit integer."))
+        | None -> raise (InvalidDataException($"{LocalStatusRevisionMetaKey} is missing."))
+
+    /// Advances the local-status revision inside the transaction that owns the corresponding status mutation.
+    let private incrementLocalStatusRevision (connection: SqliteConnection) =
+        let currentRevision = readLocalStatusRevisionInternal connection
+
+        if currentRevision = Int64.MaxValue then
+            raise (InvalidDataException($"{LocalStatusRevisionMetaKey} cannot advance beyond Int64.MaxValue."))
+
+        let committedRevision = currentRevision + 1L
+        setMetaValue connection LocalStatusRevisionMetaKey $"{committedRevision}"
+        committedRevision
+
     /// Parses Watch journal recovery metadata only when it preserves the nonnegative sequence invariant.
     let private tryParseWatchJournalAppliedThroughSequence (value: string) =
         match Int64.TryParse(value) with
@@ -1592,6 +1655,7 @@ module LocalStateDb =
                                                     logTrace "status_meta ensuring default row"
                                                     insertStatusMetaIfMissing connection
                                                     insertWatchJournalAppliedThroughIfMissing connection
+                                                    insertLocalStatusRevisionIfMissing connection
 
                                                     if not (hasPersistedValidWatchJournalAppliedThroughSequenceMeta connection) then
                                                         recreate <- true
@@ -2704,6 +2768,14 @@ module LocalStateDb =
             LastSuccessfulDirectoryVersionUpload: Instant
         }
 
+    /// Reads the committed local-status revision used to coalesce SQLite artifact callbacks.
+    let readLocalStatusRevision (dbPath: string) =
+        task {
+            do! ensureDbInitialized dbPath
+            use connection = openConnection dbPath
+            return readLocalStatusRevisionInternal connection
+        }
+
     /// Reads status meta internal data needed by the CLI workflow.
     let private readStatusMetaInternal (connection: SqliteConnection) =
         use cmd = connection.CreateCommand()
@@ -2813,12 +2885,12 @@ module LocalStateDb =
                 |> ignore)
 
     /// Coordinates local SQLite state for replace status snapshot, including Grace status, object cache, or watch metadata.
-    let replaceStatusSnapshot (dbPath: string) (graceStatus: GraceStatus) =
+    let replaceStatusSnapshotWithRevision (dbPath: string) (graceStatus: GraceStatus) =
         task {
             do! ensureDbInitialized dbPath
 
             return!
-                executeWithRetry (fun () ->
+                executeWithRevisionRetry (fun () ->
                     task {
                         let connection = openConnection dbPath
 
@@ -2925,7 +2997,9 @@ module LocalStateDb =
                                         fileCommand.Parameters["$last_write"].Value <- file.LastWriteTimeUtc.Ticks
                                         fileCommand.ExecuteNonQuery() |> ignore))
 
+                                let committedRevision = incrementLocalStatusRevision connection
                                 executeNonQuery connection "COMMIT;"
+                                return committedRevision
                             with
                             | ex ->
                                 executeNonQuery connection "ROLLBACK;"
@@ -2933,6 +3007,13 @@ module LocalStateDb =
                         finally
                             connection.Dispose()
                     })
+        }
+
+    /// Replaces the local status snapshot while preserving the existing unit-returning caller contract.
+    let replaceStatusSnapshot (dbPath: string) (graceStatus: GraceStatus) =
+        task {
+            let! _ = replaceStatusSnapshotWithRevision dbPath graceStatus
+            return ()
         }
 
     /// Persists upsert object cache changes in the local SQLite state database.
@@ -3180,7 +3261,7 @@ module LocalStateDb =
                     })
         }
 
-    let applyStatusIncremental
+    let applyStatusIncrementalWithRevision
         (dbPath: string)
         (newGraceStatus: GraceStatus)
         (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
@@ -3190,7 +3271,7 @@ module LocalStateDb =
             do! ensureDbInitialized dbPath
 
             return!
-                executeWithRetry (fun () ->
+                executeWithRevisionRetry (fun () ->
                     task {
                         let connection = openConnection dbPath
 
@@ -3322,7 +3403,9 @@ module LocalStateDb =
                                             directoryDeleteCommand.Parameters["$relative_path"].Value <- difference.RelativePath
                                             directoryDeleteCommand.ExecuteNonQuery() |> ignore)
 
+                                let committedRevision = incrementLocalStatusRevision connection
                                 executeNonQuery connection "COMMIT;"
+                                return committedRevision
                             with
                             | ex ->
                                 executeNonQuery connection "ROLLBACK;"
@@ -3330,6 +3413,18 @@ module LocalStateDb =
                         finally
                             connection.Dispose()
                     })
+        }
+
+    /// Applies an incremental local status mutation while preserving the existing unit-returning caller contract.
+    let applyStatusIncremental
+        (dbPath: string)
+        (newGraceStatus: GraceStatus)
+        (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>)
+        (differences: IEnumerable<FileSystemDifference>)
+        =
+        task {
+            let! _ = applyStatusIncrementalWithRevision dbPath newGraceStatus newDirectoryVersions differences
+            return ()
         }
 
     /// Models the explicit access-assignment scope selected by mutually exclusive CLI options.


### PR DESCRIPTION
# Simplify single-process Grace Watch recovery

Closes #794.

## Why this matters

On a one-user repository with local emulators, `grace watch` previously reprocessed its own local-state SQLite
artifacts and its own server-broadcast Reference. That produced recovery-like noise—zero-diff resync/catch-up
activity and repeated IPC writes—during ordinary local saves. This epic keeps real multi-client behavior safe while
making the normal single-process path quiet and direct.

## Delivered behavior

- #795 adds a transactional local-status revision in the existing SQLite metadata and turns Watch-owned DB/WAL/SHM/
  journal callbacks into silent coalesced revision checks instead of observation candidates or immediate IPC work.
- #796 adds a bounded, process-local exact self-reference ledger. Direct SignalR and lifecycle/recovery deliveries
  use the same early coordinator gate, so exact completed local duplicates are silent while mismatched and external
  References remain ordinary work.
- #799 retains exact completed recognition within the same bounded lifetime so lifecycle/direct duplicate ordering
  cannot fall through to a noisy same-root skip.

## Validation

- Leaf #797: focused revision/artifact/callback/atomic tests, two fresh reviews (first found and closed a proof gap),
  and current-head Validate `31095168971` passed.
- Leaf #798: focused self-echo/coordinator/catch-up tests, fresh review, and current-head Validate `31097419160`
  passed.
- Follow-up #799: RED reproduction of the live duplicate-delivery defect, focused 63/63, fresh review, and
  current-head Validate `31100388682` passed.
- Final isolated Windows/DebugLocal acceptance on this exact epic head: a real save created Reference
  `a2836944-8363-485b-95e9-6b0cca54a2ee`, emitted one repository broadcast, and produced zero same-root skip logs,
  resyncs, blocked catch-up retries, callback diagnostics, materializations, save errors, or redundant post-save IPC
  events. Four subsequent read-only `branch get` calls left IPC unchanged (6 to 6) and byte-identical.

The full GitHub Validate run and a fresh exact-head review of this integration PR remain the required final gates.
The isolated acceptance is one Windows/DebugLocal ordering sample, not a reconnect or stress campaign.

## Contract propagation and documentation

No public CLI, SDK, HTTP, OpenAPI, generated artifact, server routing, SignalR payload, or persisted public contract
changed. The only durable addition is an internal monotonic status revision in existing local SQLite metadata for
cross-process coordination. User documentation is N/A: user commands and remote-reference semantics are unchanged;
only routine self-generated recovery noise disappears.

## Review Status

- Integration branch: `epic/794-single-process-watch-recovery`.
- Base: `e6bea21e54842d348bddff2c4b03809b7f553761` (`main`).
- Head: `36153653589e783801e0235b121ff4cc59f5c9c6`.
- Final exact-head review: approved with no P1/P2 findings on `36153653589e783801e0235b121ff4cc59f5c9c6`.
- Final GitHub Validate: `full` run `31103446095` passed on the current head.
