### PR TITLE
Rename work-item status mutation to set-status

### DIFF
--- a/docs/Work items.md
+++ b/docs/Work items.md
@@ -51,8 +51,8 @@ PowerShell:
 ./grace workitem show f88b46e2-5c36-4b52-9e36-716f7d7a9a8b
 ./grace workitem show 42
 
-./grace workitem status f88b46e2-5c36-4b52-9e36-716f7d7a9a8b --set InReview
-./grace workitem status 42 --set Done
+./grace workitem set-status f88b46e2-5c36-4b52-9e36-716f7d7a9a8b --status InReview
+./grace workitem set-status 42 -s Done
 ```
 
 bash / zsh:
@@ -69,8 +69,8 @@ bash / zsh:
 ./grace workitem show f88b46e2-5c36-4b52-9e36-716f7d7a9a8b
 ./grace workitem show 42
 
-./grace workitem status f88b46e2-5c36-4b52-9e36-716f7d7a9a8b --set InReview
-./grace workitem status 42 --set Done
+./grace workitem set-status f88b46e2-5c36-4b52-9e36-716f7d7a9a8b --status InReview
+./grace workitem set-status 42 -s Done
 ```
 
 ### Link references and promotion sets

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -80,7 +80,6 @@ module CommandOutputContractRegistryTests =
         | "--scope" -> "repository"
         | "--role" -> "RepositoryReader"
         | "--search-visibility" -> "Visible"
-        | "--set" -> "Active"
         | "--status" -> "Active"
         | "--type" -> "summary"
         | "--url" -> "https://example.test/webhook"
@@ -455,6 +454,46 @@ module CommandOutputContractRegistryTests =
             entry.ExecutionScope
             |> should equal CompositeLocalAndServer
         | None -> Assert.Fail("branch annotate should have a registry entry.")
+
+    /// Verifies that the work item status mutation has only its explicit mutating registry identity.
+    [<Test>]
+    let ``workitem set-status registry entry is the only status mutation identity`` () =
+        let identity = CommandOutputContract.commandIdentity [ "workitem" ] "set-status"
+        let oldIdentity = CommandOutputContract.commandIdentity [ "workitem" ] "status"
+
+        CommandOutputContract.tryFind oldIdentity
+        |> should equal None
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.Mutating |> should equal true
+
+            entry.CurrentJsonBehavior
+            |> should equal CommonRenderOutputEnvelope
+
+            entry.Category
+            |> should equal MutatingStateTransition
+
+            entry.ExecutionScope |> should equal ServerViaSdk
+
+            entry.EnvelopeContract
+            |> should equal (ExistingGraceResultEnvelope ReuseExistingApiOrSdkDto)
+
+            entry.Features.JsonMode
+            |> should equal ExistingBehavior
+
+            entry.Features.Schema
+            |> should equal ExistingBehavior
+
+            entry.Features.Examples
+            |> should equal ExistingBehavior
+
+            entry.Features.Select
+            |> should equal ExistingBehavior
+
+            entry.ReturnValueContract.Name
+            |> should equal "string"
+        | None -> Assert.Fail("workitem.set-status should have a registry entry.")
 
     /// Verifies that diff blake3 json mode is centrally rendered instead of human progress only.
     [<Test>]

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -1162,6 +1162,37 @@ module HelpDoesNotReadConfigTests =
                 .GetString()
             |> should equal "workitem.attach.summary")
 
+    /// Verifies that set-status machine-readable introspection resolves the renamed command without runtime setup.
+    [<TestCase("--schema", "schema")>]
+    [<TestCase("--examples", "examples")>]
+    let ``workitem set-status introspection is inert and uses the renamed identity`` (introspectionOption: string, expectedKind: string) =
+        withTempDir (fun root ->
+            /// Verifies that the CLI program scenario exits with the expected process status.
+            let exitCode, output =
+                runWithCapturedOutput [| "workitem"
+                                         "set-status"
+                                         "42"
+                                         "--status"
+                                         "Done"
+                                         introspectionOption |]
+
+            exitCode |> should equal 0
+
+            use document = parseJsonOutput output
+            let rootElement = document.RootElement
+
+            rootElement.GetProperty("Kind").GetString()
+            |> should equal expectedKind
+
+            rootElement
+                .GetProperty("Command")
+                .GetProperty("Id")
+                .GetString()
+            |> should equal "workitem.set-status"
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
     /// Verifies that root output json is honored for nested commands before config errors.
     [<Test>]
     let ``root output json is honored for nested commands before config errors`` () =
@@ -2568,6 +2599,14 @@ module RootHelpGroupingTests =
                         "Lifecycle:"
                     ]
             }
+            {
+                Args = [| "workitem"; "-h" |]
+                Headings =
+                    [
+                        "Create and update:"
+                        "Link and attach:"
+                    ]
+            }
         ]
 
     /// Sets ansi console output needed by the test scenario.
@@ -2714,6 +2753,23 @@ module RootHelpGroupingTests =
 
                 for heading in expectation.Headings do
                     output |> should contain heading)
+
+    /// Verifies that work item help exposes only the explicit status mutation verb in its update group.
+    [<Test>]
+    let ``workitem help groups set-status without the old status command`` () =
+        withGraceUserFileBackups (fun () ->
+            /// Verifies that the CLI program scenario exits with the expected process status.
+            let exitCode, output =
+                runWithCapturedOutput [| "workitem"
+                                         "-h" |]
+
+            exitCode |> should equal 0
+
+            let createAndUpdate = sliceBetween output "Create and update:" "Link and attach:"
+            createAndUpdate |> should contain "set-status"
+
+            createAndUpdate
+            |> should not' (contain $"{Environment.NewLine}    status "))
 
 
 namespace Grace.CLI.Tests

--- a/src/Grace.CLI.Tests/WorkItem.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkItem.CLI.Parsing.Tests.fs
@@ -30,6 +30,11 @@ module WorkItemCommandParsingTests =
         let parseResult = GraceCommand.rootCommand.Parse(args)
         parseResult.Errors.Count |> should equal 0
 
+    /// Asserts that the actual root parser rejects the supplied command line.
+    let private assertRejected (args: string array) =
+        let parseResult = GraceCommand.rootCommand.Parse(args)
+        Assert.That(parseResult.Errors.Count, Is.GreaterThan(0))
+
     /// Builds attach args for test scenarios.
     let private buildAttachArgs (noun: string) (attachmentType: string) (workItemIdentifier: string) (extraArgs: string array) =
         [|
@@ -82,6 +87,46 @@ module WorkItemCommandParsingTests =
                        "--title"
                        "Alias command" |]
         )
+
+    /// Verifies that every supported status value routes through set-status for both work item identifier shapes.
+    [<TestCase("42", "--status", "Active")>]
+    [<TestCase("43", "--status", "Backlog")>]
+    [<TestCase("44", "--status", "Blocked")>]
+    [<TestCase("45", "--status", "Canceled")>]
+    [<TestCase("46", "--status", "Done")>]
+    [<TestCase("9e4c0f72-9b4f-4f28-8d8f-d7d73ec4f6fd", "-s", "InReview")>]
+    let ``workitem set-status accepts every status exactly once plus guid and positive-number identifiers``
+        (
+            workItemIdentifier: string,
+            statusOption: string,
+            status: string
+        )
+        =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIds [| "workitem"
+                           "set-status"
+                           workItemIdentifier
+                           statusOption
+                           status |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        parseResult.CommandResult.Command.Name
+        |> should equal "set-status"
+
+    /// Verifies that missing and unsupported status values are rejected by the actual root parser.
+    [<TestCase("workitem", "set-status", "42")>]
+    [<TestCase("workitem", "set-status", "42", "--status")>]
+    [<TestCase("workitem", "set-status", "42", "--status", "Unknown")>]
+    let ``workitem set-status rejects missing or unsupported status values`` ([<ParamArray>] args: string array) = args |> withIds |> assertRejected
+
+    /// Verifies that neither the old command nor the old option remains registered.
+    [<TestCase("workitem", "status", "42", "--set", "Done")>]
+    [<TestCase("workitem", "status", "42", "--status", "Done")>]
+    [<TestCase("workitem", "set-status", "42", "--set", "Done")>]
+    let ``workitem status and set option are unavailable`` ([<ParamArray>] args: string array) = args |> withIds |> assertRejected
 
     /// Verifies that workitem link ref parses for guid and numeric work item identifiers.
     [<TestCase("workitem", "40")>]

--- a/src/Grace.CLI.Tests/WorkItem.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkItem.CLI.Tests.fs
@@ -46,6 +46,28 @@ module WorkItemCommandTests =
         let exitCode = parseResult.Invoke()
         exitCode |> should equal -1
 
+    /// Verifies that set-status dispatches the existing work item validation handler.
+    [<Test>]
+    let ``workitem set-status rejects invalid work item identifier through its bound action`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                withIdsAndSilent [| "workitem"
+                                    "set-status"
+                                    "not-a-work-item"
+                                    "--status"
+                                    "Done" |]
+            )
+
+        parseResult.Errors.Count |> should equal 0
+
+        parseResult.CommandResult.Command.Name
+        |> should equal "set-status"
+
+        parseResult.CommandResult.Command.Action.GetType()
+        |> should equal typeof<Grace.CLI.Command.WorkItemCommand.SetStatus>
+
+        parseResult.Invoke() |> should equal -1
+
     /// Verifies that workitem link ref rejects invalid reference id.
     [<Test>]
     let ``workitem link ref rejects invalid reference id`` () =

--- a/src/Grace.CLI/AGENTS.md
+++ b/src/Grace.CLI/AGENTS.md
@@ -27,8 +27,8 @@ Read `../AGENTS.md` for global expectations before updating CLI code.
 
 1. Keep handlers thin; move heavier logic into services or helpers that are
    straightforward to unit test.
-2. Preserve existing option names and switches. Introduce new aliases when
-   expanding behavior instead of breaking existing scripts.
+2. Preserve existing option names and switches unless a tracked decision explicitly replaces the public contract
+   without compatibility aliases. Do not restore a deliberately removed command or option as a hidden alias.
 3. Capture new command patterns or usage tips in this document to guide future  
    agents.
 4. Root and selected subcommand help grouping lives in
@@ -56,7 +56,7 @@ Read `../AGENTS.md` for global expectations before updating CLI code.
 
 ## Continuous Review Commands
 
-- `grace workitem` (aliases: `work`, `work-item`, `wi`) covers create/show/status,
+- `grace workitem` (aliases: `work`, `work-item`, `wi`) covers create/show/set-status,
   linking references or promotion sets, and attach flows (`summary`, `prompt`, `notes`).
 - `grace review` covers inbox/open/checkpoint/delta/resolve/deepen. Inbox and
   delta remain CLI stubs until server endpoints land.

--- a/src/Grace.CLI/Command/WorkItem.CLI.fs
+++ b/src/Grace.CLI/Command/WorkItem.CLI.fs
@@ -48,8 +48,15 @@ module WorkItemCommand =
                 Arity = ArgumentArity.ExactlyOne
             )
 
-        let statusSet =
-            (new Option<string>("--set", Required = true, Description = "Set the work item status.", Arity = ArgumentArity.ExactlyOne))
+        /// Selects the durable status assigned by the set-status command.
+        let status =
+            (new Option<string>(
+                OptionName.Status,
+                [| "-s" |],
+                Required = true,
+                Description = "Status to assign to the work item.",
+                Arity = ArgumentArity.ExactlyOne
+            ))
                 .AcceptOnlyFromAmong(listCases<WorkItemStatus> ())
 
         let file =
@@ -463,8 +470,8 @@ module WorkItemCommand =
                 return result |> renderOutput parseResult
             }
 
-    /// Routes the status command from parsed options through validation, the SDK call, and result rendering.
-    let private statusHandler (parseResult: ParseResult) =
+    /// Routes the set-status command from parsed options through validation and the existing SDK update call.
+    let private setStatusHandler (parseResult: ParseResult) =
         task {
             try
                 if parseResult |> verbose then printParseResult parseResult
@@ -474,7 +481,7 @@ module WorkItemCommand =
                 match tryNormalizeWorkItemIdentifier workItemRaw parseResult with
                 | Error error -> return Error error
                 | Ok workItem ->
-                    let statusValue = parseResult.GetValue(Options.statusSet)
+                    let statusValue = parseResult.GetValue(Options.status)
 
                     match discriminatedUnionFromString<WorkItemStatus> statusValue with
                     | None -> return Error(GraceError.Create (WorkItemError.getErrorMessage WorkItemError.InvalidStatus) (getCorrelationId parseResult))
@@ -497,14 +504,14 @@ module WorkItemCommand =
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }
 
-    /// Executes the status command by binding ParseResult values to the SDK request and CLI output contract.
-    type Status() =
+    /// Executes set-status while preserving the existing work item update result envelope.
+    type SetStatus() =
         inherit AsynchronousCommandLineAction()
 
-        /// Runs the asynchronous status action when System.CommandLine dispatches the parsed command.
+        /// Runs the asynchronous set-status action when System.CommandLine dispatches the parsed command.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
             task {
-                let! result = statusHandler parseResult
+                let! result = setStatusHandler parseResult
                 return result |> renderOutput parseResult
             }
 
@@ -1227,14 +1234,14 @@ module WorkItemCommand =
         showCommand.Action <- new Show()
         workCommand.Subcommands.Add(showCommand)
 
-        let statusCommand =
-            new Command("status", Description = "Update the status of a work item by ID or number.")
-            |> addOption Options.statusSet
+        let setStatusCommand =
+            new Command("set-status", Description = "Set the status of a work item by ID or number.")
+            |> addOption Options.status
             |> addCommonOptions
 
-        statusCommand.Arguments.Add(Arguments.workItemIdentifier)
-        statusCommand.Action <- new Status()
-        workCommand.Subcommands.Add(statusCommand)
+        setStatusCommand.Arguments.Add(Arguments.workItemIdentifier)
+        setStatusCommand.Action <- new SetStatus()
+        workCommand.Subcommands.Add(setStatusCommand)
 
         let linkCommand = new Command("link", Description = "Link related entities to a work item.")
 

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -783,7 +783,7 @@ module CommandOutputContract =
         | "workitem.links.remove.prset"
         | "workitem.links.remove.ref"
         | "workitem.links.remove.summary"
-        | "workitem.status" -> typeof<string>
+        | "workitem.set-status" -> typeof<string>
         | "workitem.links.list" -> typeof<Grace.Types.WorkItem.WorkItemLinksDto>
         | "workitem.show" -> typeof<Grace.Types.WorkItem.WorkItemDto>
         | unknown -> invalidOp $"JSON-success command '{unknown}' does not declare a ReturnValue type in CommandOutputContract."
@@ -1409,7 +1409,7 @@ module CommandOutputContract =
                 server_via_sdk
                 ReuseExistingApiOrSdkDto
             row [ "workitem" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "workitem" ] "status" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem" ] "set-status" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
         ]
 
     /// Tries to map find and returns a GraceError instead of throwing on unsupported input.

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -666,7 +666,7 @@ module GraceCommand =
 
     let private workItemHelpSections =
         [
-            { Heading = "Create and update"; CommandNames = [ "create"; "show"; "status" ] }
+            { Heading = "Create and update"; CommandNames = [ "create"; "show"; "set-status" ] }
             {
                 Heading = "Link and attach"
                 CommandNames =


### PR DESCRIPTION
# Rename work-item status mutation to `set-status`

## Linked issue

Related to #811 under epic #810.

## Summary

- Replace `grace workitem status <work-item> --set <status>` with
  `grace workitem set-status <work-item> --status <status>`.
- Register lowercase `-s` as the only short status option and remove the old command and option surface.
- Keep the existing `WorkItem.Update` runtime path and result envelope unchanged.
- Align grouped help, output contracts, schema/examples, tests, docs, and CLI agent guidance.

## Touched paths

- `docs/Work items.md`
- `src/Grace.CLI/AGENTS.md`
- `src/Grace.CLI/Command/WorkItem.CLI.fs`
- `src/Grace.CLI/CommandOutputContract.CLI.fs`
- `src/Grace.CLI/Program.CLI.fs`
- Matching files under `src/Grace.CLI.Tests`

## Owned-path compliance

- [x] Changed paths match #811's owned paths.
- [x] Shared CLI registration and help paths are explicitly allowed by #811.
- [x] No alternate task ledger was created.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public boundary: actual root parser, grouped help, machine-readable schema/examples, and output registry
- RED evidence: 12 focused assertions failed against the old contract, including continued acceptance of
  `status --set`.
- Focused validation: Release build passed; 173 focused CLI tests passed.

## Minimum detail gate evidence

- Product decisions: only `set-status --status/-s` is supported; compatibility aliases are rejected.
- Invariant tuple: root parser, handler binding, help/introspection, and output registry expose one aligned mutation.
- Contract propagation: CLI, registry, tests, docs, and local CLI guidance updated; server/SDK/actor contracts unchanged.
- Stale revalidation: N/A; this slice changes CLI parsing and registration only.
- Forbidden shapes avoided: no compatibility alias, server change, SDK change, actor change, or result-envelope change.
- Proof classes: positive, negative, regression, and boundary parser/introspection coverage passed.
- High-risk examples: old command and old option are rejected; unsupported and missing statuses remain structured errors.
- Risk traps: schema/examples remain inert and use the registered `workitem.set-status` identity.

## Test coverage changes

- [x] Tests added or updated in the matching WorkItem parsing, WorkItem command, output-contract, and Program CLI suites.
- [ ] No tests added.

## Reviewer pass

- [x] Owned and forbidden paths reviewed against #811.
- [x] CLI public contract and introspection surfaces reviewed.
- [x] Docs and nearby agent-guidance drift checked.
- [x] No required local validation was omitted.

## Risk surfaces

- [x] CLI public contract
- [x] Docs or workflow
- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions

## Docs impact

- [x] Required; `docs/Work items.md` and CLI agent guidance are updated.

## Local focused evidence

- [x] RED: 12 of 25 new-contract assertions failed against the old implementation.
- [x] Formatting: targeted Fantomas passed.
- [x] Build: `dotnet build --configuration Release src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj` passed with 0 warnings
  and 0 errors.
- [x] Focused proof: 173 passed, 0 failed.
- [x] MarkdownLint: 0 errors across both changed Markdown files.
- [x] Manual validation: help, schema, examples, JSON-mode old-syntax rejection, missing status, and unsupported status
  all matched the issue contract.
- [x] `git diff --check` passed.

## Optional local broad preflight

Neither Fast nor Full was run. Focused local proof is the selected slice gate; GitHub `Validate` is the required broad
current-head gate.

## Required CI evidence

- Current head SHA: `8e3b9433ad35bf417f87d21f78640b61ff1c5890`
- GitHub `Validate`: passed
- GitHub Actions run: [Validate 31153553337](https://github.com/ScottArbeit/Grace/actions/runs/31153553337)
- [x] The result is associated with the latest PR revision.

## Validation not run

None. Normal omission of local Fast/Full after focused proof is not skipped validation.

## Residual risks

No known implementation risk. The command rename is intentionally breaking because Grace has no production legacy
contract to preserve for this issue.

## Review Status

- Current head SHA: `8e3b9433ad35bf417f87d21f78640b61ff1c5890`
- Fresh review subagent: `gpt-5.6-terra`, high reasoning, no inherited turns
- `dev-process/CODE_REVIEW.md` followed: yes
- Review verdict: approve, no substantive findings
- Required PR checks: GitHub `Validate` passed
- [x] Review and required checks completed successfully for the same head SHA.
- Finding dispositions: none; the fresh review reported no findings
- Substantive review cycles: 0
- Worker starts: 1/4

## Review/fix prevention

No review finding has required a fix.

## Rollback or recovery notes

Revert the leaf merge from the epic branch before later attachment-command slices build on this CLI registration.

## Docs follow-up required

None for this slice.
