### PR TITLE
Consolidate work-item attachment creation under attachments add

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -143,8 +143,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `208`
-- JSON-ready routed commands: `187`
+- Total leaf commands: `206`
+- JSON-ready routed commands: `185`
 - Conditionally JSON-ready routed commands: `1`
 - Intentionally human-only commands: `0`
 - Deferred routed commands with explicit V2 scope: `11`

--- a/docs/Work items.md
+++ b/docs/Work items.md
@@ -99,22 +99,25 @@ bash / zsh:
   3d5c4d9a-0123-4567-89ab-987654321000
 ```
 
-### Attach summary, prompt, and notes content
+### Add summary, prompt, and notes attachments
+
+Use `--type` to classify the attachment as a summary, prompt, or notes. Every supported type follows the same add,
+upload, and link workflow and requires exactly one of `--file`, `--text`, or `--stdin`.
 
 PowerShell:
 
 ```powershell
-./grace workitem attach summary 42 --file .\summary.md
-./grace workitem attach prompt 42 --file .\prompt.md
-./grace workitem attach notes 42 --text "Reviewer follow-up required before merge."
+./grace workitem attachments add 42 --type summary --file .\summary.md
+./grace workitem attachments add 42 --type prompt --file .\prompt.md
+./grace workitem attachments add 42 --type notes --text "Reviewer follow-up required before merge."
 ```
 
 bash / zsh:
 
 ```bash
-./grace workitem attach summary 42 --file ./summary.md
-./grace workitem attach prompt 42 --file ./prompt.md
-./grace workitem attach notes 42 --text "Reviewer follow-up required before merge."
+./grace workitem attachments add 42 --type summary --file ./summary.md
+./grace workitem attachments add 42 --type prompt --file ./prompt.md
+./grace workitem attachments add 42 --type notes --text "Reviewer follow-up required before merge."
 ```
 
 ### Retrieve reviewer attachments

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -237,16 +237,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 208
+        |> should equal 206
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 199
+        |> should equal 197
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 187
+        |> should equal 185
 
         countBy ImmediateJsonErrorOnly |> should equal 0
 
@@ -297,7 +297,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 187
+        jsonReady |> should equal 185
         intentionallyHumanOnly |> should equal 0
         conditionalStatus |> should equal 1
         deferredV2 |> should equal 11
@@ -495,6 +495,36 @@ module CommandOutputContractRegistryTests =
             |> should equal "string"
         | None -> Assert.Fail("workitem.set-status should have a registry entry.")
 
+    /// Verifies that attachment creation has one canonical registry identity and no removed attach rows.
+    [<Test>]
+    let ``workitem attachments add is the only attachment creation registry identity`` () =
+        let identity = CommandOutputContract.commandIdentity [ "workitem"; "attachments" ] "add"
+
+        for oldCommand in [ "summary"; "prompt"; "notes" ] do
+            CommandOutputContract.commandIdentity [ "workitem"; "attach" ] oldCommand
+            |> CommandOutputContract.tryFind
+            |> should equal None
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.Mutating |> should equal true
+
+            entry.CurrentJsonBehavior
+            |> should equal CommonRenderOutputEnvelope
+
+            entry.Category
+            |> should equal MutatingStateTransition
+
+            entry.ExecutionScope
+            |> should equal CompositeLocalAndServer
+
+            entry.EnvelopeContract
+            |> should equal (ExistingGraceResultEnvelope RequiresCliDto)
+
+            entry.ReturnValueContract.Name
+            |> should equal "AttachmentResult"
+        | None -> Assert.Fail("workitem.attachments.add should have a registry entry.")
+
     /// Verifies that diff blake3 json mode is centrally rendered instead of human progress only.
     [<Test>]
     let ``diff blake3 json mode is centrally rendered instead of human-progress only`` () =
@@ -519,7 +549,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 187
+        commonEntries.Length |> should equal 185
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -537,7 +567,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 187
+        commonEntries.Length |> should equal 185
 
         let parserInvalidEntries =
             commonEntries
@@ -999,7 +1029,7 @@ module CommandOutputContractRegistryTests =
                 | ConditionalGraceResultEnvelope _ -> true
                 | _ -> false)
 
-        eligibleEntries.Length |> should equal 188
+        eligibleEntries.Length |> should equal 186
 
         for entry in eligibleEntries do
             entry.ReturnValueContract.Status

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -1144,8 +1144,13 @@ module HelpDoesNotReadConfigTests =
             /// Verifies that the CLI program scenario exits with the expected process status.
             let exitCode, output =
                 runWithCapturedOutput [| "workitem"
-                                         "attach"
+                                         "attachments"
+                                         "add"
+                                         "42"
+                                         "--type"
                                          "summary"
+                                         "--text"
+                                         "content"
                                          "--schema" |]
 
             exitCode |> should equal 0
@@ -1160,7 +1165,7 @@ module HelpDoesNotReadConfigTests =
                 .GetProperty("Command")
                 .GetProperty("Id")
                 .GetString()
-            |> should equal "workitem.attach.summary")
+            |> should equal "workitem.attachments.add")
 
     /// Verifies that set-status machine-readable introspection resolves the renamed command without runtime setup.
     [<TestCase("--schema", "schema")>]
@@ -1193,6 +1198,60 @@ module HelpDoesNotReadConfigTests =
             Directory.Exists(Path.Combine(root, ".grace"))
             |> should equal false)
 
+    /// Verifies that attachment help and machine-readable introspection never execute the mutation handler.
+    [<TestCase("--help")>]
+    [<TestCase("--schema")>]
+    [<TestCase("--examples")>]
+    let ``workitem attachments add help schema and examples are inert`` (introspectionOption: string) =
+        withTempDir (fun root ->
+            let args =
+                if introspectionOption = "--help" then
+                    [|
+                        "workitem"
+                        "attachments"
+                        "add"
+                        introspectionOption
+                    |]
+                else
+                    [|
+                        "workitem"
+                        "attachments"
+                        "add"
+                        "42"
+                        "--type"
+                        "summary"
+                        "--text"
+                        "content"
+                        introspectionOption
+                    |]
+
+            /// Verifies that the CLI program scenario exits with the expected process status.
+            let exitCode, _ = runWithCapturedOutput args
+            exitCode |> should equal 0
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    /// Verifies that parser rejection stops attachment creation before local or remote setup begins.
+    [<Test>]
+    let ``workitem attachments add parse failure is inert`` () =
+        withTempDir (fun root ->
+            /// Verifies that the CLI program scenario exits with the expected process status.
+            let exitCode, _, _ =
+                runWithCapturedStdoutAndStderr [| "workitem"
+                                                  "attachments"
+                                                  "add"
+                                                  "42"
+                                                  "--type"
+                                                  "binary"
+                                                  "--text"
+                                                  "content" |]
+
+            exitCode |> should not' (equal 0)
+
+            Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
     /// Verifies that root output json is honored for nested commands before config errors.
     [<Test>]
     let ``root output json is honored for nested commands before config errors`` () =
@@ -1209,9 +1268,11 @@ module HelpDoesNotReadConfigTests =
                 |]
                 [|
                     "workitem"
-                    "attach"
-                    "summary"
+                    "attachments"
+                    "add"
                     "123"
+                    "--type"
+                    "summary"
                     "--text"
                     "summary text"
                 |]
@@ -2770,6 +2831,23 @@ module RootHelpGroupingTests =
 
             createAndUpdate
             |> should not' (contain $"{Environment.NewLine}    status "))
+
+    /// Verifies that grouped work-item help exposes only the canonical attachment command tree.
+    [<Test>]
+    let ``workitem help groups attachments without the old attach command`` () =
+        withGraceUserFileBackups (fun () ->
+            /// Verifies that the CLI program scenario exits with the expected process status.
+            let exitCode, output =
+                runWithCapturedOutput [| "workitem"
+                                         "-h" |]
+
+            exitCode |> should equal 0
+
+            let linkAndAttach = output.Substring(output.IndexOf("Link and attach:", StringComparison.Ordinal))
+            linkAndAttach |> should contain "attachments"
+
+            linkAndAttach
+            |> should not' (contain $"{Environment.NewLine}    attach "))
 
 
 namespace Grace.CLI.Tests

--- a/src/Grace.CLI.Tests/WorkItem.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkItem.CLI.Parsing.Tests.fs
@@ -35,16 +35,6 @@ module WorkItemCommandParsingTests =
         let parseResult = GraceCommand.rootCommand.Parse(args)
         Assert.That(parseResult.Errors.Count, Is.GreaterThan(0))
 
-    /// Builds attach args for test scenarios.
-    let private buildAttachArgs (noun: string) (attachmentType: string) (workItemIdentifier: string) (extraArgs: string array) =
-        [|
-            noun
-            "attach"
-            attachmentType
-            workItemIdentifier
-            yield! extraArgs
-        |]
-
     /// Builds attachments args for test scenarios.
     let private buildAttachmentsArgs (noun: string) (verb: string) (workItemIdentifier: string) (extraArgs: string array) =
         [|
@@ -156,37 +146,118 @@ module WorkItemCommandParsingTests =
                        Guid.NewGuid().ToString() |]
         )
 
-    /// Verifies that workitem attach parses with file text and stdin modes.
-    [<TestCase("workitem", "summary")>]
-    [<TestCase("workitem", "prompt")>]
-    [<TestCase("workitem", "notes")>]
-    [<TestCase("wi", "summary")>]
-    [<TestCase("work-item", "prompt")>]
-    let ``workitem attach parses with file text and stdin modes`` (commandAlias: string, attachmentType: string) =
-        let workItemIdentifier = Guid.NewGuid().ToString()
-
-        let fileArgs =
-            buildAttachArgs
-                commandAlias
-                attachmentType
-                workItemIdentifier
+    /// Verifies that the canonical attachment route accepts every type, input source, alias, and identifier shape.
+    [<TestCase("workitem", "summary", "42")>]
+    [<TestCase("work", "prompt", "43")>]
+    [<TestCase("work-item", "notes", "9e4c0f72-9b4f-4f28-8d8f-d7d73ec4f6fd")>]
+    [<TestCase("wi", "summary", "4f2e4a67-4b51-4c7a-b866-f82638852e9d")>]
+    let ``workitem attachments add parses every type and input source`` (commandAlias: string, attachmentType: string, workItemIdentifier: string) =
+        let inputSources =
+            [|
                 [|
                     "--file"
                     "C:\\temp\\attachment.txt"
                 |]
-            |> withIds
+                [| "--text"; "inline content" |]
+                [| "--stdin" |]
+            |]
 
-        let textArgs =
-            buildAttachArgs commandAlias attachmentType workItemIdentifier [| "--text"; "inline content" |]
-            |> withIds
+        for inputSource in inputSources do
+            assertParsesWithoutErrors (
+                buildAttachmentsArgs
+                    commandAlias
+                    "add"
+                    workItemIdentifier
+                    [|
+                        "--type"
+                        attachmentType
+                        yield! inputSource
+                    |]
+                |> withIds
+            )
 
-        let stdinArgs =
-            buildAttachArgs commandAlias attachmentType workItemIdentifier [| "--stdin" |]
+    /// Verifies that attachment creation requires the canonical lower-case type values.
+    [<TestCase("summary")>]
+    [<TestCase("prompt")>]
+    [<TestCase("notes")>]
+    let ``workitem attachments add accepts canonical lower-case type values`` (attachmentType: string) =
+        let parseResult =
+            buildAttachmentsArgs
+                "workitem"
+                "add"
+                "42"
+                [|
+                    "--type"
+                    attachmentType
+                    "--text"
+                    "content"
+                |]
             |> withIds
+            |> GraceCommand.rootCommand.Parse
 
-        assertParsesWithoutErrors fileArgs
-        assertParsesWithoutErrors textArgs
-        assertParsesWithoutErrors stdinArgs
+        parseResult.Errors.Count |> should equal 0
+
+        let expected =
+            match attachmentType with
+            | "summary" -> Grace.CLI.Command.WorkItemCommand.AttachmentType.Summary
+            | "prompt" -> Grace.CLI.Command.WorkItemCommand.AttachmentType.Prompt
+            | "notes" -> Grace.CLI.Command.WorkItemCommand.AttachmentType.Notes
+            | value -> failwith $"Unexpected test attachment type: {value}"
+
+        parseResult.GetValue<Grace.CLI.Command.WorkItemCommand.AttachmentType>("--type")
+        |> should equal expected
+
+    /// Verifies that normal and JSON modes bind the same one generic attachment action.
+    [<TestCase(false)>]
+    [<TestCase(true)>]
+    let ``workitem attachments add binds one generic action in normal and json modes`` (jsonOutput: bool) =
+        let args = ResizeArray<string>()
+
+        args.AddRange(
+            buildAttachmentsArgs
+                "workitem"
+                "add"
+                "42"
+                [|
+                    "--type"
+                    "summary"
+                    "--text"
+                    "content"
+                |]
+            |> withIds
+        )
+
+        if jsonOutput then
+            args.Add("--output")
+            args.Add("Json")
+
+        let parseResult = GraceCommand.rootCommand.Parse(args.ToArray())
+        parseResult.Errors.Count |> should equal 0
+
+        parseResult.CommandResult.Command.Action.GetType()
+        |> should equal typeof<Grace.CLI.Command.WorkItemCommand.AttachmentsAdd>
+
+    /// Verifies that missing, unknown, and non-canonical attachment type spellings fail in the root parser.
+    [<TestCase("--text", "content")>]
+    [<TestCase("--type", "binary", "--text", "content")>]
+    [<TestCase("--type", "Summary", "--text", "content")>]
+    let ``workitem attachments add rejects missing invalid or non-canonical type values`` ([<ParamArray>] extraArgs: string array) =
+        buildAttachmentsArgs "workitem" "add" "42" extraArgs
+        |> withIds
+        |> assertRejected
+
+    /// Verifies that the removed singular attach tree is not retained as an alias.
+    [<TestCase("summary")>]
+    [<TestCase("prompt")>]
+    [<TestCase("notes")>]
+    let ``workitem old attach syntax is unavailable`` (attachmentType: string) =
+        withIds [| "workitem"
+                   "attach"
+                   attachmentType
+                   "42"
+                   "--text"
+                   "content" |]
+        |> assertRejected
 
     /// Verifies that workitem links list parses for guid and numeric work item identifiers.
     [<TestCase("workitem", "44")>]

--- a/src/Grace.CLI.Tests/WorkItem.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkItem.CLI.Tests.fs
@@ -98,29 +98,33 @@ module WorkItemCommandTests =
         let exitCode = parseResult.Invoke()
         exitCode |> should equal -1
 
-    /// Verifies that workitem attach summary requires exactly one input source.
+    /// Verifies that workitem attachments add requires exactly one input source.
     [<Test>]
-    let ``workitem attach summary requires exactly one input source`` () =
+    let ``workitem attachments add requires exactly one input source`` () =
         let parseResult =
             GraceCommand.rootCommand.Parse(
                 withIdsAndSilent [| "workitem"
-                                    "attach"
-                                    "summary"
-                                    Guid.NewGuid().ToString() |]
+                                    "attachments"
+                                    "add"
+                                    Guid.NewGuid().ToString()
+                                    "--type"
+                                    "summary" |]
             )
 
         let exitCode = parseResult.Invoke()
         exitCode |> should equal -1
 
-    /// Verifies that workitem attach summary rejects multiple input sources.
+    /// Verifies that workitem attachments add rejects multiple input sources.
     [<Test>]
-    let ``workitem attach summary rejects multiple input sources`` () =
+    let ``workitem attachments add rejects multiple input sources`` () =
         let parseResult =
             GraceCommand.rootCommand.Parse(
                 withIdsAndSilent [| "workitem"
-                                    "attach"
-                                    "summary"
+                                    "attachments"
+                                    "add"
                                     Guid.NewGuid().ToString()
+                                    "--type"
+                                    "summary"
                                     "--text"
                                     "hello"
                                     "--stdin" |]
@@ -165,14 +169,16 @@ module WorkItemCommandTests =
         let exitCode = parseResult.Invoke()
         exitCode |> should equal -1
 
-    /// Verifies that workitem attach input source combinations are valid iff exactly one is selected.
+    /// Verifies that workitem attachments add input source combinations are valid iff exactly one is selected.
     [<FsCheck.NUnit.Property(MaxTest = 64)>]
-    let ``workitem attach input source combinations are valid iff exactly one is selected`` (useFile: bool) (useText: bool) (useStdin: bool) =
+    let ``workitem attachments add input source combinations are valid iff exactly one is selected`` (useFile: bool) (useText: bool) (useStdin: bool) =
         let args = List<string>()
         args.Add("workitem")
-        args.Add("attach")
-        args.Add("summary")
+        args.Add("attachments")
+        args.Add("add")
         args.Add(Guid.NewGuid().ToString())
+        args.Add("--type")
+        args.Add("summary")
 
         if useFile then
             args.Add("--file")

--- a/src/Grace.CLI/AGENTS.md
+++ b/src/Grace.CLI/AGENTS.md
@@ -57,7 +57,7 @@ Read `../AGENTS.md` for global expectations before updating CLI code.
 ## Continuous Review Commands
 
 - `grace workitem` (aliases: `work`, `work-item`, `wi`) covers create/show/set-status,
-  linking references or promotion sets, and attach flows (`summary`, `prompt`, `notes`).
+  linking references or promotion sets, and `attachments add --type <summary|prompt|notes>` plus attachment retrieval.
 - `grace review` covers inbox/open/checkpoint/delta/resolve/deepen. Inbox and
   delta remain CLI stubs until server endpoints land.
 - `grace queue` covers status/enqueue/pause/resume/dequeue; prefer

--- a/src/Grace.CLI/Command/WorkItem.CLI.fs
+++ b/src/Grace.CLI/Command/WorkItem.CLI.fs
@@ -26,6 +26,26 @@ open System.Threading.Tasks
 /// Groups the work item command parser, handlers, and output helpers.
 module WorkItemCommand =
 
+    /// Classifies the supported user-facing work-item attachment kinds at the CLI boundary.
+    type internal AttachmentType =
+        | Summary
+        | Prompt
+        | Notes
+
+        /// Returns the canonical lower-case value used by CLI output and existing work-item attachment APIs.
+        member this.Label =
+            match this with
+            | Summary -> "summary"
+            | Prompt -> "prompt"
+            | Notes -> "notes"
+
+        /// Maps CLI attachment classification to the existing durable artifact type.
+        member this.ArtifactType =
+            match this with
+            | Summary -> ArtifactType.AgentSummary
+            | Prompt -> ArtifactType.Prompt
+            | Notes -> ArtifactType.ReviewNotes
+
     /// Defines the options parsed by the work item command handlers.
     module private Options =
         let workItemId =
@@ -74,13 +94,25 @@ module WorkItemCommand =
         let stdin = new Option<bool>("--stdin", Required = false, Description = "Read attachment content from standard input.", Arity = ArgumentArity.ZeroOrOne)
 
         let attachmentType =
-            (new Option<string>(
-                "--type",
-                Required = true,
-                Description = "Attachment type to target: summary, prompt, or notes.",
-                Arity = ArgumentArity.ExactlyOne
-            ))
-                .AcceptOnlyFromAmong([| "summary"; "prompt"; "notes" |])
+            let option =
+                new Option<AttachmentType>(
+                    "--type",
+                    Required = true,
+                    Description = "Attachment type to target: summary, prompt, or notes.",
+                    Arity = ArgumentArity.ExactlyOne
+                )
+
+            option.CustomParser <-
+                Func<ArgumentResult, AttachmentType> (fun argumentResult ->
+                    match argumentResult.Tokens[0].Value with
+                    | "summary" -> AttachmentType.Summary
+                    | "prompt" -> AttachmentType.Prompt
+                    | "notes" -> AttachmentType.Notes
+                    | value ->
+                        argumentResult.AddError($"Argument '{value}' not recognized. Must be one of: summary, prompt, notes.")
+                        Unchecked.defaultof<AttachmentType>)
+
+            option.AcceptOnlyFromAmong([| "summary"; "prompt"; "notes" |])
 
         let latest =
             new Option<bool>(
@@ -308,18 +340,6 @@ module WorkItemCommand =
                                 graceIds.CorrelationId
                         )
         }
-
-    /// Tries to map resolve attachment type and returns a GraceError instead of throwing on unsupported input.
-    let private tryResolveAttachmentType (parseResult: ParseResult) =
-        let attachmentTypeRaw =
-            parseResult.GetValue(Options.attachmentType)
-            |> Option.ofObj
-            |> Option.defaultValue String.Empty
-
-        if String.IsNullOrWhiteSpace attachmentTypeRaw then
-            Error(GraceError.Create (WorkItemError.getErrorMessage WorkItemError.InvalidArtifactType) (getCorrelationId parseResult))
-        else
-            Ok(attachmentTypeRaw.Trim().ToLowerInvariant())
 
     /// Tries to map resolve output file path and returns a GraceError instead of throwing on unsupported input.
     let private tryResolveOutputFilePath (parseResult: ParseResult) =
@@ -603,13 +623,14 @@ module WorkItemCommand =
                 return result |> renderOutput parseResult
             }
 
-    /// Routes the attach command from parsed options through validation, the SDK call, and result rendering.
-    let private attachHandler (artifactType: ArtifactType) (artifactTypeLabel: string) (parseResult: ParseResult) =
+    /// Routes canonical attachment creation through input validation, upload, linking, and result rendering once.
+    let private attachmentsAddHandler (parseResult: ParseResult) =
         task {
             try
                 if parseResult |> verbose then printParseResult parseResult
                 let graceIds = parseResult |> getNormalizedIdsAndNames
                 let workItemRaw = parseResult.GetValue(Arguments.workItemIdentifier)
+                let attachmentType = parseResult.GetValue(Options.attachmentType)
 
                 match tryNormalizeWorkItemIdentifier workItemRaw parseResult with
                 | Error error -> return Error error
@@ -617,7 +638,7 @@ module WorkItemCommand =
                     match! tryGetAttachmentInput parseResult with
                     | Error error -> return Error error
                     | Ok attachmentInput ->
-                        match! createAndUploadArtifact graceIds artifactType attachmentInput with
+                        match! createAndUploadArtifact graceIds attachmentType.ArtifactType attachmentInput with
                         | Error error -> return Error error
                         | Ok artifactId ->
                             let linkParameters =
@@ -636,14 +657,14 @@ module WorkItemCommand =
                             match! WorkItem.LinkArtifact(linkParameters) with
                             | Error error -> return Error error
                             | Ok _ ->
-                                let result = { WorkItem = workItem; ArtifactId = artifactId; ArtifactType = artifactTypeLabel }
+                                let result = { WorkItem = workItem; ArtifactId = artifactId; ArtifactType = attachmentType.Label }
 
                                 if
                                     not (parseResult |> json)
                                     && not (parseResult |> silent)
                                 then
                                     AnsiConsole.MarkupLine(
-                                        $"[green]Attached {Markup.Escape(artifactTypeLabel)} content[/] [grey](artifact {Markup.Escape(artifactId.ToString())})[/] [green]to work item[/] {Markup.Escape(workItem)}"
+                                        $"[green]Attached {Markup.Escape(attachmentType.Label)} content[/] [grey](artifact {Markup.Escape(artifactId.ToString())})[/] [green]to work item[/] {Markup.Escape(workItem)}"
                                     )
 
                                 return Ok(GraceReturnValue.Create result graceIds.CorrelationId)
@@ -651,36 +672,14 @@ module WorkItemCommand =
             | ex -> return Error(GraceError.Create $"{ExceptionResponse.Create ex}" (getCorrelationId parseResult))
         }
 
-    /// Executes the attach summary command by binding ParseResult values to the SDK request and CLI output contract.
-    type AttachSummary() =
+    /// Executes canonical attachment creation by binding one typed command to the generic workflow.
+    type AttachmentsAdd() =
         inherit AsynchronousCommandLineAction()
 
-        /// Runs the asynchronous attach summary action when System.CommandLine dispatches the parsed command.
+        /// Runs the asynchronous attachments add action when System.CommandLine dispatches the parsed command.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
             task {
-                let! result = attachHandler ArtifactType.AgentSummary "summary" parseResult
-                return result |> renderOutput parseResult
-            }
-
-    /// Executes the attach prompt command by binding ParseResult values to the SDK request and CLI output contract.
-    type AttachPrompt() =
-        inherit AsynchronousCommandLineAction()
-
-        /// Runs the asynchronous attach prompt action when System.CommandLine dispatches the parsed command.
-        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
-            task {
-                let! result = attachHandler ArtifactType.Prompt "prompt" parseResult
-                return result |> renderOutput parseResult
-            }
-
-    /// Executes the attach notes command by binding ParseResult values to the SDK request and CLI output contract.
-    type AttachNotes() =
-        inherit AsynchronousCommandLineAction()
-
-        /// Runs the asynchronous attach notes action when System.CommandLine dispatches the parsed command.
-        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
-            task {
-                let! result = attachHandler ArtifactType.ReviewNotes "notes" parseResult
+                let! result = attachmentsAddHandler parseResult
                 return result |> renderOutput parseResult
             }
 
@@ -805,37 +804,35 @@ module WorkItemCommand =
             match tryNormalizeWorkItemIdentifier workItemRaw parseResult with
             | Error error -> return Error error
             | Ok workItem ->
-                match tryResolveAttachmentType parseResult with
+                let attachmentType = parseResult.GetValue(Options.attachmentType)
+                let latest = parseResult.GetValue(Options.latest)
+
+                let parameters =
+                    Parameters.WorkItem.ShowWorkItemAttachmentParameters(
+                        WorkItemId = workItem,
+                        AttachmentType = attachmentType.Label,
+                        Latest = latest,
+                        OwnerId = graceIds.OwnerIdString,
+                        OwnerName = graceIds.OwnerName,
+                        OrganizationId = graceIds.OrganizationIdString,
+                        OrganizationName = graceIds.OrganizationName,
+                        RepositoryId = graceIds.RepositoryIdString,
+                        RepositoryName = graceIds.RepositoryName,
+                        CorrelationId = graceIds.CorrelationId
+                    )
+
+                let! result = WorkItem.ShowAttachment(parameters)
+
+                match result with
                 | Error error -> return Error error
-                | Ok attachmentType ->
-                    let latest = parseResult.GetValue(Options.latest)
+                | Ok graceReturnValue ->
+                    if
+                        not (parseResult |> json)
+                        && not (parseResult |> silent)
+                    then
+                        writeShowAttachmentOutput workItem graceReturnValue.ReturnValue
 
-                    let parameters =
-                        Parameters.WorkItem.ShowWorkItemAttachmentParameters(
-                            WorkItemId = workItem,
-                            AttachmentType = attachmentType,
-                            Latest = latest,
-                            OwnerId = graceIds.OwnerIdString,
-                            OwnerName = graceIds.OwnerName,
-                            OrganizationId = graceIds.OrganizationIdString,
-                            OrganizationName = graceIds.OrganizationName,
-                            RepositoryId = graceIds.RepositoryIdString,
-                            RepositoryName = graceIds.RepositoryName,
-                            CorrelationId = graceIds.CorrelationId
-                        )
-
-                    let! result = WorkItem.ShowAttachment(parameters)
-
-                    match result with
-                    | Error error -> return Error error
-                    | Ok graceReturnValue ->
-                        if
-                            not (parseResult |> json)
-                            && not (parseResult |> silent)
-                        then
-                            writeShowAttachmentOutput workItem graceReturnValue.ReturnValue
-
-                        return Ok graceReturnValue
+                    return Ok graceReturnValue
         }
 
     /// Routes the attachments show command from parsed options through validation, the SDK call, and result rendering.
@@ -1265,38 +1262,17 @@ module WorkItemCommand =
 
         workCommand.Subcommands.Add(linkCommand)
 
-        let attachCommand = new Command("attach", Description = "Attach summary, prompt, or notes content to a work item.")
+        let attachmentsCommand = new Command("attachments", Description = "Add, list, show, and download reviewer attachments by work item ID or number.")
 
-        let attachSummaryCommand =
-            new Command("summary", Description = "Attach summary content to a work item.")
+        let attachmentsAddCommand =
+            new Command("add", Description = "Add summary, prompt, or notes content to a work item.")
+            |> addOption Options.attachmentType
             |> addAttachInputOptions
             |> addCommonOptions
 
-        attachSummaryCommand.Arguments.Add(Arguments.workItemIdentifier)
-        attachSummaryCommand.Action <- new AttachSummary()
-        attachCommand.Subcommands.Add(attachSummaryCommand)
-
-        let attachPromptCommand =
-            new Command("prompt", Description = "Attach prompt content to a work item.")
-            |> addAttachInputOptions
-            |> addCommonOptions
-
-        attachPromptCommand.Arguments.Add(Arguments.workItemIdentifier)
-        attachPromptCommand.Action <- new AttachPrompt()
-        attachCommand.Subcommands.Add(attachPromptCommand)
-
-        let attachNotesCommand =
-            new Command("notes", Description = "Attach notes content to a work item.")
-            |> addAttachInputOptions
-            |> addCommonOptions
-
-        attachNotesCommand.Arguments.Add(Arguments.workItemIdentifier)
-        attachNotesCommand.Action <- new AttachNotes()
-        attachCommand.Subcommands.Add(attachNotesCommand)
-
-        workCommand.Subcommands.Add(attachCommand)
-
-        let attachmentsCommand = new Command("attachments", Description = "List, show, and download reviewer attachments by work item ID or number.")
+        attachmentsAddCommand.Arguments.Add(Arguments.workItemIdentifier)
+        attachmentsAddCommand.Action <- new AttachmentsAdd()
+        attachmentsCommand.Subcommands.Add(attachmentsAddCommand)
 
         let attachmentsListCommand =
             new Command("list", Description = "List summary, prompt, and notes attachments for a work item.")

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -769,9 +769,7 @@ module CommandOutputContract =
         | "webhook.delivery.show"
         | "webhook.test" -> typeof<Grace.Types.Webhooks.WebhookDelivery>
         | "webhook.list" -> typeof<IReadOnlyList<Grace.Types.Webhooks.WebhookRule>>
-        | "workitem.attach.notes"
-        | "workitem.attach.prompt"
-        | "workitem.attach.summary" -> cliLocalResultType "Grace.CLI.Command.WorkItemCommand+AttachmentResult"
+        | "workitem.attachments.add" -> cliLocalResultType "Grace.CLI.Command.WorkItemCommand+AttachmentResult"
         | "workitem.attachments.download" -> cliLocalResultType "Grace.CLI.Command.WorkItemCommand+AttachmentDownloadResult"
         | "workitem.attachments.list" -> typeof<Grace.Shared.Parameters.WorkItem.ListWorkItemAttachmentsResult>
         | "workitem.attachments.show" -> typeof<Grace.Shared.Parameters.WorkItem.ShowWorkItemAttachmentResult>
@@ -1361,9 +1359,7 @@ module CommandOutputContract =
             row [ "webhook" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "test" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "webhook" ] "update" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "workitem"; "attach" ] "notes" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "workitem"; "attach" ] "prompt" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "workitem"; "attach" ] "summary" true true common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "workitem"; "attachments" ] "add" true true common_renderOutput_envelope mutating_state_transition composite_local_server RequiresCliDto
             row [ "workitem"; "attachments" ] "download" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row [ "workitem"; "attachments" ] "list" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "workitem"; "attachments" ] "show" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -667,16 +667,7 @@ module GraceCommand =
     let private workItemHelpSections =
         [
             { Heading = "Create and update"; CommandNames = [ "create"; "show"; "set-status" ] }
-            {
-                Heading = "Link and attach"
-                CommandNames =
-                    [
-                        "link"
-                        "attach"
-                        "attachments"
-                        "links"
-                    ]
-            }
+            { Heading = "Link and attach"; CommandNames = [ "link"; "attachments"; "links" ] }
         ]
 
     let private groupedHelpSectionsByCommandName =


### PR DESCRIPTION
# Consolidate work-item attachment creation under `attachments add`

## Linked issue

Related to #812 under epic #810.

## Summary

- Replace the three `workitem attach` subcommands with one `workitem attachments add` command.
- Parse `summary`, `prompt`, and `notes` through one CLI-level discriminated union and one generic handler.
- Preserve the existing create, upload, link, MIME, hash, SDK, JSON result, and failure behavior.
- Align actual-root parsing, grouped help, executable registry, schema/examples, docs, and CLI guidance.

## Touched paths

- `src/Grace.CLI/Command/WorkItem.CLI.fs`
- `src/Grace.CLI/CommandOutputContract.CLI.fs`
- `src/Grace.CLI/Program.CLI.fs`
- Four matching files under `src/Grace.CLI.Tests`
- `docs/Work items.md`
- `docs/Machine-readable CLI output.md`
- `src/Grace.CLI/AGENTS.md`

## Owned-path compliance

- [x] Changed paths match #812's owned paths, including the recorded current-inventory document expansion.
- [x] Shared CLI registration and help paths are explicitly allowed.
- [x] No alternate task ledger was created.

## Validation profile and public-boundary evidence

- Validation profile: `cli-command`
- Public boundary: actual root parser, typed action binding, help, schema/examples, and executable output registry
- RED: 14 of 223 focused checks failed against the old three-command surface.
- Final focused proof: 234/234 passed; full `Grace.CLI.Tests` passed 1,327/1,327.

## Minimum detail gate evidence

- Product decisions: only `attachments add --type summary|prompt|notes` is supported; old aliases are rejected.
- Invariant tuple: one typed parser and one generic handler preserve the existing create-upload-link workflow.
- Contract propagation: CLI, registry, tests, two active docs, and CLI guidance updated; durable/server/SDK contracts unchanged.
- Stale revalidation: N/A; this slice adds no new durable state or remote behavior.
- Forbidden shapes avoided: no type-specific handlers, arbitrary type strings, hidden aliases, or forbidden-path edits.
- Proof classes: positive, negative, regression, and boundary parser/handler/introspection coverage passed.
- High-risk examples: invalid or missing type, competing inputs, and old syntax fail before side effects.
- Risk traps: help/schema/examples and parse failures remain inert; registry has no orphan old rows.

## Test coverage changes

- [x] Matching parser, handler, output-contract, and Program CLI tests were added or updated.
- [ ] No tests added.

## Reviewer pass

- [x] Owned and forbidden paths reviewed against #812.
- [x] CLI public contract and introspection surfaces reviewed.
- [x] Docs and nearby guidance drift checked.
- [x] No required local validation was omitted.

## Risk surfaces

- [x] CLI public contract
- [x] Docs or workflow
- [ ] Auth, authorization, tenant, or secrets
- [ ] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions

## Docs impact

- [x] Required; work-item docs, current machine-readable registry totals, and CLI guidance are updated.

## Local focused evidence

- [x] RED: 14/223 failed on the missing route, retained old routes/rows, stale totals, and stale help.
- [x] Formatting: targeted Fantomas passed.
- [x] Release build: passed with 0 warnings and 0 errors.
- [x] Focused CLI proof: 234/234 passed.
- [x] Full `Grace.CLI.Tests`: 1,327/1,327 passed.
- [x] MarkdownLint: 0 errors across all changed Markdown files.
- [x] Manual help/schema/examples: canonical `workitem.attachments.add` identity and inert behavior.
- [x] Old syntax: all three forms rejected and manual invocation exited nonzero.
- [x] `git diff --check`: passed.

## Optional local broad preflight

Neither Fast nor Full was run. Focused and full CLI-project proof are the selected local gates; GitHub `Validate` is
the required broad current-head gate.

## Required CI evidence

- Current head SHA: `a5ffb89b636f0b07e798613f56c3a6172d75f0bc`
- GitHub `Validate`: passed
- GitHub Actions run: [Validate 31155556919](https://github.com/ScottArbeit/Grace/actions/runs/31155556919)
- [x] The result is associated with the latest PR revision.

## Validation not run

A live server/blob mutation was not run because this CLI-only tracer preserves the existing remote implementation.
GitHub `Validate` remains required.

## Residual risks

The parser/handler and introspection contract are fully proven locally. Remote create-upload-link behavior is unchanged
and is covered as regression rather than by a new live mutation in this slice.

## Review Status

- Current head SHA: `a5ffb89b636f0b07e798613f56c3a6172d75f0bc`
- Fresh review subagent: `gpt-5.6-terra`, high reasoning, no inherited turns
- `dev-process/CODE_REVIEW.md` followed: yes
- Review verdict: approve, no substantive findings
- Required PR checks: GitHub `Validate` passed
- [x] Review and required checks completed successfully for the same head SHA.
- Finding dispositions: none; the fresh review reported no findings
- Substantive review cycles: 0
- Worker starts: 1/4

## Review/fix prevention

No review finding has required a fix. The worker found and recorded the missing current-inventory docs propagation path
before editing it.

## Rollback or recovery notes

Revert the leaf merge from the epic branch before #813 builds deletion commands on the canonical attachment noun.

## Docs follow-up required

None for this slice.
