### PR TITLE
Suppress live Watch self echo at server fan-out

### DIFF
--- a/src/Grace.CLI.Tests/ClientIdentity.SDK.Tests.fs
+++ b/src/Grace.CLI.Tests/ClientIdentity.SDK.Tests.fs
@@ -182,6 +182,23 @@ type ClientIdentitySdkTests() =
         Assert.That(httpClient.DefaultRequestHeaders.GetValues(Constants.ClientTypeHeaderKey), Is.EquivalentTo([ "CLI" ]))
         Assert.That(httpClient.DefaultRequestHeaders.GetValues(Constants.ClientVersionHeaderKey), Is.Not.Empty)
 
+    /// Verifies that Watch delivery identity is emitted only while the current process explicitly configures it.
+    [<Test>]
+    member _.WatchProcessIdentityHeaderIsOptionalAndClearable() =
+        let processId = Guid.NewGuid()
+
+        use clientWithoutWatchIdentity = ClientIdentity.getHttpClient "corr-sdk-no-watch"
+        Assert.That(clientWithoutWatchIdentity.DefaultRequestHeaders.Contains(Constants.WatchProcessIdHeaderKey), Is.False)
+
+        ClientIdentity.configureWatchProcessId processId
+        use clientWithWatchIdentity = ClientIdentity.getHttpClient "corr-sdk-watch"
+
+        Assert.That(clientWithWatchIdentity.DefaultRequestHeaders.GetValues(Constants.WatchProcessIdHeaderKey), Is.EquivalentTo([ processId.ToString("N") ]))
+
+        ClientIdentity.clearWatchProcessId ()
+        use clientAfterClear = ClientIdentity.getHttpClient "corr-sdk-watch-cleared"
+        Assert.That(clientAfterClear.DefaultRequestHeaders.Contains(Constants.WatchProcessIdHeaderKey), Is.False)
+
     /// Verifies that lifecycle diagnostics are added to success and error results.
     [<Test>]
     member _.LifecycleDiagnosticsAreAddedToSuccessAndErrorResults() =

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -50,6 +50,7 @@ open Microsoft.Extensions.DependencyInjection
 module Watch =
     exception private WatchCommandExit of int
 
+    let private watchProcessId = Guid.NewGuid()
     let mutable private graceWatchRuntimeModeValue = int GraceWatchRuntimeMode.HealthyIncremental
 
     /// Reads the process-local Grace Watch runtime mode used to gate scans and filesystem observations.
@@ -8258,7 +8259,8 @@ module Watch =
             (fun () -> $"{signalRConnection.State}")
             (fun () -> $"{signalRConnection.ConnectionId}")
             Branch.GetParentBranch
-            (fun repositoryId branchId cancellationToken -> signalRConnection.InvokeAsync("RegisterCurrentBranch", repositoryId, branchId, cancellationToken))
+            (fun repositoryId branchId cancellationToken ->
+                signalRConnection.InvokeAsync("RegisterCurrentBranchSource", repositoryId, branchId, watchProcessId.ToString("N"), cancellationToken))
             (fun branchId parentBranchId cancellationToken ->
                 signalRConnection.InvokeAsync("RegisterParentBranch", branchId, parentBranchId, cancellationToken))
             cancellationToken
@@ -10122,6 +10124,13 @@ module Watch =
                     if not claimedGraceWatchStatus then
                         logToAnsiConsole Colors.Error "GraceWatch is already running."
                         raise (WatchCommandExit -1)
+
+                    ClientIdentity.configureWatchProcessId watchProcessId
+
+                    use watchProcessIdentityLifetime =
+                        { new IDisposable with
+                            member _.Dispose() = ClientIdentity.clearWatchProcessId ()
+                        }
 
                     setGraceWatchRuntimeMode GraceWatchRuntimeMode.StartingUp
 

--- a/src/Grace.SDK/ClientIdentity.SDK.fs
+++ b/src/Grace.SDK/ClientIdentity.SDK.fs
@@ -65,6 +65,7 @@ module ClientIdentity =
 
     let mutable private configuredClientType: ClientType option = Some(ClientType.CLI(getSdkAssemblyFileVersion ()))
     let mutable private configuredApiContractVersion: string option = None
+    let mutable private configuredWatchProcessId: Guid option = None
 
     /// Sets the client type and version stamped into future SDK request headers.
     let configure (clientType: ClientType) = configuredClientType <- Some clientType
@@ -78,16 +79,30 @@ module ClientIdentity =
     /// Clears the API contract version override so requests use the released default.
     let clearApiContractVersionOverride () = configuredApiContractVersion <- None
 
-    /// Restores default SDK identity headers and removes any API contract version override.
+    /// Sets the opaque process identity used only to optimize live Grace Watch notification delivery.
+    let configureWatchProcessId watchProcessId =
+        if watchProcessId = Guid.Empty then
+            invalidArg (nameof watchProcessId) "Grace Watch process identity must not be empty."
+
+        configuredWatchProcessId <- Some watchProcessId
+
+    /// Clears the process-local Grace Watch delivery identity from future SDK requests.
+    let clearWatchProcessId () = configuredWatchProcessId <- None
+
+    /// Restores default SDK identity headers and removes API-version and Watch-process overrides.
     let clear () =
         configuredClientType <- Some(ClientType.CLI(getSdkAssemblyFileVersion ()))
         configuredApiContractVersion <- None
+        configuredWatchProcessId <- None
 
     /// Exposes the currently configured client identity for tests and host diagnostics.
     let tryGetConfiguredClientType () = configuredClientType
 
     /// Exposes the optional API contract version override for tests and host diagnostics.
     let tryGetConfiguredApiContractVersion () = configuredApiContractVersion
+
+    /// Exposes the optional Grace Watch process identity for tests and host diagnostics.
+    let tryGetConfiguredWatchProcessId () = configuredWatchProcessId
 
     /// Converts a client identity into the type and version header values expected by Grace Server.
     let private toHeaderValues clientType =
@@ -115,6 +130,15 @@ module ClientIdentity =
             |> ignore
 
             httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.ClientVersionHeaderKey, clientVersion)
+            |> ignore
+        | None -> ()
+
+        httpClient.DefaultRequestHeaders.Remove(Constants.WatchProcessIdHeaderKey)
+        |> ignore
+
+        match configuredWatchProcessId with
+        | Some watchProcessId ->
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(Constants.WatchProcessIdHeaderKey, watchProcessId.ToString("N"))
             |> ignore
         | None -> ()
 

--- a/src/Grace.Server.Tests/NotificationHub.Tests.fs
+++ b/src/Grace.Server.Tests/NotificationHub.Tests.fs
@@ -5,11 +5,14 @@ open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types.Automation
 open Grace.Types.Common
+open Grace.Types.Reference
 open Microsoft.AspNetCore.Http.Connections.Client
 open Microsoft.AspNetCore.SignalR.Client
 open Microsoft.Extensions.DependencyInjection
 open NUnit.Framework
 open System
+open System.Collections.Concurrent
+open System.Collections.Generic
 open System.Net.Http
 open System.Threading
 open System.Threading.Tasks
@@ -29,6 +32,36 @@ module private NotificationHubTestHelpers =
             .AddJsonProtocol(fun options -> options.PayloadSerializerOptions <- Constants.JsonSerializerOptions)
             .WithAutomaticReconnect()
             .Build()
+
+    /// Creates an authenticated HTTP caller with optional Watch-origin delivery metadata.
+    let createSaveClient (watchProcessId: Guid option) =
+        let client = new HttpClient(BaseAddress = Uri graceServerBaseAddress)
+        client.DefaultRequestHeaders.Add("x-grace-user-id", testUserId)
+
+        watchProcessId
+        |> Option.iter (fun processId -> client.DefaultRequestHeaders.Add(Constants.WatchProcessIdHeaderKey, processId.ToString("N")))
+
+        client
+
+    /// Posts one same-root Save through the authenticated production route and returns after the durable command succeeds.
+    let saveReferenceAsync (client: HttpClient) repositoryId (branch: Grace.Types.Branch.BranchDto) referenceId message =
+        task {
+            let parameters = Parameters.Branch.CreateReferenceParameters()
+            parameters.OwnerId <- ownerId
+            parameters.OrganizationId <- organizationId
+            parameters.RepositoryId <- repositoryId
+            parameters.BranchId <- string branch.BranchId
+            parameters.ReferenceId <- referenceId
+            parameters.DirectoryVersionId <- branch.BasedOn.DirectoryId
+            parameters.Sha256Hash <- string branch.BasedOn.Sha256Hash
+            parameters.Blake3Hash <- string branch.BasedOn.Blake3Hash
+            parameters.Message <- message
+            parameters.CorrelationId <- generateCorrelationId ()
+
+            use! response = client.PostAsync("/branch/save", createJsonContent parameters)
+            let! body = response.Content.ReadAsStringAsync()
+            Assert.That(response.IsSuccessStatusCode, Is.True, body)
+        }
 
     /// Defines start agent session behavior for the surrounding tests used by the server integration notification Hub scenario.
     let startAgentSessionAsync repositoryId agentId workItemId operationId =
@@ -150,6 +183,129 @@ module private NotificationHubTestHelpers =
 /// Covers notification hub scenarios.
 [<NonParallelizable>]
 type NotificationHubTests() =
+
+    /// Verifies Watch-originated Save delivery excludes only its exact source while preserving peers, branch isolation, and reconnect fallback.
+    [<Test>]
+    member _.WatchSaveExcludesExactSourceAndReconnectFallsBackToOrdinaryGroupDelivery() =
+        task {
+            let repositoryId = repositoryIds[0]
+            let! defaultBranch = BranchServerTestHelpers.getBranchAsync repositoryId repositoryDefaultBranchIds[0]
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId defaultBranch $"signalr-source-{Guid.NewGuid():N}"
+            let! otherBranch = BranchServerTestHelpers.createBranchAsync repositoryId defaultBranch $"signalr-isolation-{Guid.NewGuid():N}"
+            let sourceProcessId = Guid.NewGuid()
+            let peerProcessId = Guid.NewGuid()
+            let otherProcessId = Guid.NewGuid()
+            let targetReferenceId = Guid.NewGuid()
+            let fallbackReferenceId = Guid.NewGuid()
+            let otherBranchReferenceId = Guid.NewGuid()
+            let sourceCounts = ConcurrentDictionary<Guid, int>()
+            let peerCounts = ConcurrentDictionary<Guid, int>()
+            let otherCounts = ConcurrentDictionary<Guid, int>()
+            let sourceFallback = TaskCompletionSource<CurrentBranchReferenceNotification>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let peerTarget = TaskCompletionSource<CurrentBranchReferenceNotification>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let peerFallback = TaskCompletionSource<CurrentBranchReferenceNotification>(TaskCreationOptions.RunContinuationsAsynchronously)
+            let otherBranchMarker = TaskCompletionSource<CurrentBranchReferenceNotification>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            /// Records one connection's exact Reference deliveries and completes only the expected deterministic markers.
+            let observe
+                (counts: ConcurrentDictionary<Guid, int>)
+                (target: TaskCompletionSource<CurrentBranchReferenceNotification> option)
+                (fallback: TaskCompletionSource<CurrentBranchReferenceNotification> option)
+                (otherMarker: TaskCompletionSource<CurrentBranchReferenceNotification> option)
+                (payload: CurrentBranchReferenceNotification)
+                =
+                counts.AddOrUpdate(payload.ReferenceId, 1, (fun _ count -> count + 1))
+                |> ignore
+
+                if payload.ReferenceId = targetReferenceId then
+                    target
+                    |> Option.iter (fun completion -> completion.TrySetResult(payload) |> ignore)
+                elif payload.ReferenceId = fallbackReferenceId then
+                    fallback
+                    |> Option.iter (fun completion -> completion.TrySetResult(payload) |> ignore)
+                elif payload.ReferenceId = otherBranchReferenceId then
+                    otherMarker
+                    |> Option.iter (fun completion -> completion.TrySetResult(payload) |> ignore)
+
+            use sourceConnection = NotificationHubTestHelpers.createConnection true
+            use peerConnection = NotificationHubTestHelpers.createConnection true
+            use otherConnection = NotificationHubTestHelpers.createConnection true
+
+            use sourceSubscription =
+                sourceConnection.On<CurrentBranchReferenceNotification>(
+                    "NotifyCurrentBranchReference",
+                    Action<CurrentBranchReferenceNotification>(observe sourceCounts None (Some sourceFallback) None)
+                )
+
+            use peerSubscription =
+                peerConnection.On<CurrentBranchReferenceNotification>(
+                    "NotifyCurrentBranchReference",
+                    Action<CurrentBranchReferenceNotification>(observe peerCounts (Some peerTarget) (Some peerFallback) None)
+                )
+
+            use otherSubscription =
+                otherConnection.On<CurrentBranchReferenceNotification>(
+                    "NotifyCurrentBranchReference",
+                    Action<CurrentBranchReferenceNotification>(observe otherCounts None None (Some otherBranchMarker))
+                )
+
+            do! sourceConnection.StartAsync()
+            do! peerConnection.StartAsync()
+            do! otherConnection.StartAsync()
+
+            use cts = new CancellationTokenSource(TimeSpan.FromSeconds(45.0))
+            let repositoryGuid = Guid.Parse repositoryId
+
+            do! sourceConnection.InvokeAsync("RegisterCurrentBranchSource", repositoryGuid, branch.BranchId, sourceProcessId.ToString("N"), cts.Token)
+
+            do! peerConnection.InvokeAsync("RegisterCurrentBranchSource", repositoryGuid, branch.BranchId, peerProcessId.ToString("N"), cts.Token)
+
+            do! otherConnection.InvokeAsync("RegisterCurrentBranchSource", repositoryGuid, otherBranch.BranchId, otherProcessId.ToString("N"), cts.Token)
+
+            use sourceClient = NotificationHubTestHelpers.createSaveClient (Some sourceProcessId)
+            do! NotificationHubTestHelpers.saveReferenceAsync sourceClient repositoryId branch targetReferenceId "hosted source exclusion proof"
+
+            let! _ = peerTarget.Task.WaitAsync(cts.Token)
+
+            // These completed hub invocations are per-connection ordering barriers for the preceding server fan-out.
+            do! sourceConnection.InvokeAsync("RegisterCurrentBranch", repositoryGuid, branch.BranchId, cts.Token)
+
+            do! peerConnection.InvokeAsync("RegisterCurrentBranchSource", repositoryGuid, branch.BranchId, peerProcessId.ToString("N"), cts.Token)
+
+            do! otherConnection.InvokeAsync("RegisterCurrentBranch", repositoryGuid, otherBranch.BranchId, cts.Token)
+
+            Assert.That(sourceCounts.GetValueOrDefault(targetReferenceId), Is.Zero, "the exact source connection must not receive its own Save")
+            Assert.That(peerCounts.GetValueOrDefault(targetReferenceId), Is.EqualTo(1), "a distinct same-branch Watch process must receive the Save once")
+            Assert.That(otherCounts.GetValueOrDefault(targetReferenceId), Is.Zero, "another branch must not receive the Save")
+
+            do! sourceConnection.StopAsync(cts.Token)
+            do! sourceConnection.StartAsync(cts.Token)
+            do! sourceConnection.InvokeAsync("RegisterCurrentBranch", repositoryGuid, branch.BranchId, cts.Token)
+
+            use ordinaryClient = NotificationHubTestHelpers.createSaveClient None
+            do! NotificationHubTestHelpers.saveReferenceAsync ordinaryClient repositoryId branch fallbackReferenceId "hosted reconnect fallback proof"
+            let! _ = sourceFallback.Task.WaitAsync(cts.Token)
+            let! _ = peerFallback.Task.WaitAsync(cts.Token)
+
+            do! NotificationHubTestHelpers.saveReferenceAsync ordinaryClient repositoryId otherBranch otherBranchReferenceId "hosted branch isolation marker"
+
+            let! _ = otherBranchMarker.Task.WaitAsync(cts.Token)
+
+            // Confirm each non-target connection has processed all frames queued before the branch-isolation marker.
+            do! sourceConnection.InvokeAsync("RegisterCurrentBranch", repositoryGuid, branch.BranchId, cts.Token)
+            do! peerConnection.InvokeAsync("RegisterCurrentBranch", repositoryGuid, branch.BranchId, cts.Token)
+            do! otherConnection.InvokeAsync("RegisterCurrentBranch", repositoryGuid, otherBranch.BranchId, cts.Token)
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(sourceCounts.GetValueOrDefault(fallbackReferenceId), Is.EqualTo(1))
+                    Assert.That(peerCounts.GetValueOrDefault(fallbackReferenceId), Is.EqualTo(1))
+                    Assert.That(otherCounts.GetValueOrDefault(fallbackReferenceId), Is.Zero)
+                    Assert.That(sourceCounts.GetValueOrDefault(otherBranchReferenceId), Is.Zero)
+                    Assert.That(peerCounts.GetValueOrDefault(otherBranchReferenceId), Is.Zero)
+                    Assert.That(otherCounts.GetValueOrDefault(otherBranchReferenceId), Is.EqualTo(1)))
+            )
+        }
 
     /// Verifies the authenticated client receives repository automation event scenario.
     [<Test>]

--- a/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs
@@ -1,11 +1,13 @@
 namespace Grace.Server.Tests
 
 open Grace.Server.Notification
+open Grace.Server.Branch
 open Grace.Server.Security
 open Grace.Types.Common
 open Grace.Types.Authorization
 open Grace.Types.Reference
 open Microsoft.AspNetCore.SignalR
+open Microsoft.AspNetCore.Http
 open NUnit.Framework
 open System
 open System.Collections.Generic
@@ -31,7 +33,7 @@ type NotificationServerTests() =
         { Grace.Types.Branch.BranchDto.Default with OwnerId = ownerId; OrganizationId = organizationId; RepositoryId = repositoryId; BranchId = branchId }
 
     /// Creates a fake SignalR hub context that records current-branch group sends without a hosted server.
-    let recordingHubContext (observedGroups: ResizeArray<string>) (observedPayloads: ResizeArray<CurrentBranchReferenceNotification>) =
+    let recordingHubContext (observedTargets: ResizeArray<string * string * string array>) (observedPayloads: ResizeArray<CurrentBranchReferenceNotification>) =
         let client =
             { new IGraceClientConnection with
                 member _.RegisterRepository _ = Task.CompletedTask
@@ -58,10 +60,13 @@ type NotificationServerTests() =
                 member _.Clients _ = client
 
                 member _.Group groupName =
-                    observedGroups.Add groupName
+                    observedTargets.Add("Group", groupName, Array.empty)
                     client
 
-                member _.GroupExcept(_, _) = client
+                member _.GroupExcept(groupName, excludedConnectionIds) =
+                    observedTargets.Add("GroupExcept", groupName, excludedConnectionIds |> Seq.toArray)
+                    client
+
                 member _.Groups _ = client
                 member _.User _ = client
                 member _.Users _ = client
@@ -365,7 +370,7 @@ type NotificationServerTests() =
     [<Test>]
     member _.ServerSideCurrentBranchBroadcastTargetsCurrentBranchGroup() =
         task {
-            let observedGroups = ResizeArray<string>()
+            let observedTargets = ResizeArray<string * string * string array>()
             let observedPayloads = ResizeArray<CurrentBranchReferenceNotification>()
             let repositoryId = Guid.Parse("44444444-4444-4444-4444-444444444444")
             let branchId = Guid.Parse("55555555-5555-5555-5555-555555555555")
@@ -378,18 +383,246 @@ type NotificationServerTests() =
                     ReferenceType = ReferenceType.Save
                 }
 
-            let hubContext = recordingHubContext observedGroups observedPayloads
+            let hubContext = recordingHubContext observedTargets observedPayloads
 
             do! notifyCurrentBranchReferenceClients hubContext payload
 
             Assert.Multiple(
                 Action (fun () ->
-                    Assert.That(observedGroups, Has.Count.EqualTo(1))
-                    Assert.That(observedGroups[0], Is.EqualTo(currentBranchGroupKey repositoryId branchId))
+                    Assert.That(observedTargets, Has.Count.EqualTo(1))
+                    let selector, groupName, excludedConnectionIds = observedTargets[0]
+                    Assert.That(selector, Is.EqualTo("Group"))
+                    Assert.That(groupName, Is.EqualTo(currentBranchGroupKey repositoryId branchId))
+                    Assert.That(excludedConnectionIds, Is.Empty)
                     Assert.That(observedPayloads, Has.Count.EqualTo(1))
                     Assert.That(observedPayloads[0], Is.EqualTo(payload)))
             )
         }
+
+    /// Proves a live publication excludes only the exact connected Watch subscription bound before publication.
+    [<Test>]
+    member _.CurrentBranchBroadcastExcludesOnlyExactPublishingWatchConnection() =
+        task {
+            let sourceProcessId = Guid.NewGuid()
+            let peerProcessId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let referenceId = Guid.NewGuid()
+            let sourceConnectionId = $"source-{Guid.NewGuid():N}"
+            let peerConnectionId = $"peer-same-machine-{Guid.NewGuid():N}"
+
+            registerWatchSourceSubscription sourceConnectionId sourceProcessId repositoryId branchId
+            registerWatchSourceSubscription peerConnectionId peerProcessId repositoryId branchId
+
+            prepareWatchPublicationSource sourceProcessId repositoryId branchId referenceId
+            |> ignore
+
+            let observedTargets = ResizeArray<string * string * string array>()
+            let observedPayloads = ResizeArray<CurrentBranchReferenceNotification>()
+            let payload = { CurrentBranchReferenceNotification.Default with RepositoryId = repositoryId; BranchId = branchId; ReferenceId = referenceId }
+
+            do! notifyCurrentBranchReferenceClients (recordingHubContext observedTargets observedPayloads) payload
+
+            let selector, groupName, excludedConnectionIds = observedTargets[0]
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(selector, Is.EqualTo("GroupExcept"))
+                    Assert.That(groupName, Is.EqualTo(currentBranchGroupKey repositoryId branchId))
+                    Assert.That(excludedConnectionIds, Has.Length.EqualTo(1))
+                    Assert.That(excludedConnectionIds[0], Is.EqualTo(sourceConnectionId))
+                    Assert.That(excludedConnectionIds, Does.Not.Contain(peerConnectionId))
+                    Assert.That(observedPayloads, Has.Count.EqualTo(1))
+                    Assert.That(observedPayloads[0], Is.EqualTo(payload)))
+            )
+        }
+
+    /// Proves absent, malformed, cross-branch, and expired source bindings use the ordinary group delivery path.
+    [<Test>]
+    member _.CurrentBranchBroadcastFallsThroughWhenSourceBindingIsNotExactAndLive() =
+        task {
+            let sourceProcessId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let publishedRepositoryId = Guid.NewGuid()
+            let subscribedBranchId = Guid.NewGuid()
+            let publishedBranchId = Guid.NewGuid()
+            let connectionId = $"source-{Guid.NewGuid():N}"
+            registerWatchSourceSubscription connectionId sourceProcessId repositoryId subscribedBranchId
+
+            let cases =
+                [|
+                    "absent", Guid.Empty, repositoryId, subscribedBranchId, Guid.NewGuid()
+                    "malformed-equivalent", Guid.NewGuid(), repositoryId, subscribedBranchId, Guid.NewGuid()
+                    "cross-branch", sourceProcessId, repositoryId, publishedBranchId, Guid.NewGuid()
+                    "cross-repository", sourceProcessId, publishedRepositoryId, subscribedBranchId, Guid.NewGuid()
+                |]
+
+            for caseName, processId, caseRepositoryId, caseBranchId, referenceId in cases do
+                prepareWatchPublicationSource processId caseRepositoryId caseBranchId referenceId
+                |> ignore
+
+                let observedTargets = ResizeArray<string * string * string array>()
+
+                let payload =
+                    { CurrentBranchReferenceNotification.Default with RepositoryId = caseRepositoryId; BranchId = caseBranchId; ReferenceId = referenceId }
+
+                do! notifyCurrentBranchReferenceClients (recordingHubContext observedTargets (ResizeArray())) payload
+
+                let selector, _, excludedConnectionIds = observedTargets[0]
+                Assert.That(selector, Is.EqualTo("Group"), caseName)
+                Assert.That(excludedConnectionIds, Is.Empty, caseName)
+        }
+
+    /// Proves a same-connection branch refresh invalidates a publication bound to the previous subscription tuple.
+    [<Test>]
+    member _.CurrentBranchBroadcastFallsThroughAfterSubscriptionRefresh() =
+        task {
+            let sourceProcessId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let previousBranchId = Guid.NewGuid()
+            let currentBranchId = Guid.NewGuid()
+            let referenceId = Guid.NewGuid()
+            let connectionId = $"refresh-{Guid.NewGuid():N}"
+            registerWatchSourceSubscription connectionId sourceProcessId repositoryId previousBranchId
+
+            prepareWatchPublicationSource sourceProcessId repositoryId previousBranchId referenceId
+            |> ignore
+
+            registerWatchSourceSubscription connectionId sourceProcessId repositoryId currentBranchId
+
+            let observedTargets = ResizeArray<string * string * string array>()
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with RepositoryId = repositoryId; BranchId = previousBranchId; ReferenceId = referenceId }
+
+            do! notifyCurrentBranchReferenceClients (recordingHubContext observedTargets (ResizeArray())) payload
+
+            let selector, _, excludedConnectionIds = observedTargets[0]
+            Assert.That(selector, Is.EqualTo("Group"))
+            Assert.That(excludedConnectionIds, Does.Not.Contain(connectionId))
+        }
+
+    /// Proves disconnect, reconnect, subscription refresh, and process-ID reuse cannot suppress the replacement connection.
+    [<Test>]
+    member _.CurrentBranchBroadcastFallsThroughAfterSourceConnectionIdentityChanges() =
+        task {
+            let sourceProcessId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let referenceId = Guid.NewGuid()
+            let originalConnectionId = $"original-{Guid.NewGuid():N}"
+            let replacementConnectionId = $"replacement-{Guid.NewGuid():N}"
+
+            registerWatchSourceSubscription originalConnectionId sourceProcessId repositoryId branchId
+
+            prepareWatchPublicationSource sourceProcessId repositoryId branchId referenceId
+            |> ignore
+
+            unregisterWatchSourceSubscription originalConnectionId
+            registerWatchSourceSubscription replacementConnectionId sourceProcessId repositoryId branchId
+
+            let observedTargets = ResizeArray<string * string * string array>()
+            let payload = { CurrentBranchReferenceNotification.Default with RepositoryId = repositoryId; BranchId = branchId; ReferenceId = referenceId }
+            do! notifyCurrentBranchReferenceClients (recordingHubContext observedTargets (ResizeArray())) payload
+
+            let selector, _, excludedConnectionIds = observedTargets[0]
+            Assert.That(selector, Is.EqualTo("Group"))
+            Assert.That(excludedConnectionIds, Does.Not.Contain(replacementConnectionId))
+        }
+
+    /// Proves one transient publication binding is consumed so repeated live delivery falls back to the client ledger.
+    [<Test>]
+    member _.CurrentBranchBroadcastConsumesSourceBindingAfterFirstPublication() =
+        task {
+            let sourceProcessId = Guid.NewGuid()
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let referenceId = Guid.NewGuid()
+            let connectionId = $"source-{Guid.NewGuid():N}"
+            registerWatchSourceSubscription connectionId sourceProcessId repositoryId branchId
+
+            prepareWatchPublicationSource sourceProcessId repositoryId branchId referenceId
+            |> ignore
+
+            let observedTargets = ResizeArray<string * string * string array>()
+            let payload = { CurrentBranchReferenceNotification.Default with RepositoryId = repositoryId; BranchId = branchId; ReferenceId = referenceId }
+            let hubContext = recordingHubContext observedTargets (ResizeArray())
+
+            do! notifyCurrentBranchReferenceClients hubContext payload
+            do! notifyCurrentBranchReferenceClients hubContext payload
+
+            let selectors =
+                observedTargets
+                |> Seq.map (fun (selector, _, _) -> selector)
+                |> Seq.toArray
+
+            Assert.That(selectors, Has.Length.EqualTo(2))
+            Assert.That(selectors[0], Is.EqualTo("GroupExcept"))
+            Assert.That(selectors[1], Is.EqualTo("Group"))
+        }
+
+    /// Proves malformed or absent HTTP delivery metadata is ignored while a canonical process ID remains usable.
+    [<Test>]
+    member _.WatchProcessHeaderParsingFailsSafe() =
+        let processId = Guid.NewGuid()
+        let validContext = DefaultHttpContext()
+
+        validContext.Request.Headers[
+            Grace.Shared.Constants.WatchProcessIdHeaderKey
+        ] <- processId.ToString("N")
+
+        let malformedContext = DefaultHttpContext()
+
+        malformedContext.Request.Headers[
+            Grace.Shared.Constants.WatchProcessIdHeaderKey
+        ] <- "not-a-process-id"
+
+        let absentContext = DefaultHttpContext()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(tryGetWatchProcessId validContext, Is.EqualTo(Some processId))
+                Assert.That(tryGetWatchProcessId malformedContext, Is.EqualTo(None))
+                Assert.That(tryGetWatchProcessId absentContext, Is.EqualTo(None)))
+        )
+
+    /// Proves failed mutations and expiry both remove suppression without advancing any replay or client cursor state.
+    [<Test>]
+    member _.WatchPublicationBindingsAreRemovableAndExpiring() =
+        let sourceProcessId = Guid.NewGuid()
+        let repositoryId = Guid.NewGuid()
+        let branchId = Guid.NewGuid()
+        let connectionId = $"source-{Guid.NewGuid():N}"
+        let failedReferenceId = Guid.NewGuid()
+        let expiredReferenceId = Guid.NewGuid()
+        let replacedByMissingReferenceId = Guid.NewGuid()
+        let now = DateTimeOffset.Parse("2026-08-07T08:00:00Z")
+        registerWatchSourceSubscription connectionId sourceProcessId repositoryId branchId
+
+        let failedBinding = prepareWatchPublicationSourceAt now sourceProcessId repositoryId branchId failedReferenceId
+
+        failedBinding
+        |> Option.iter removeWatchPublicationSource
+
+        prepareWatchPublicationSourceAt now sourceProcessId repositoryId branchId expiredReferenceId
+        |> ignore
+
+        prepareWatchPublicationSourceAt now sourceProcessId repositoryId branchId replacedByMissingReferenceId
+        |> ignore
+
+        prepareWatchPublicationSourceAt now Guid.Empty repositoryId branchId replacedByMissingReferenceId
+        |> ignore
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(tryTakeWatchPublicationSourceConnectionAt now repositoryId branchId failedReferenceId, Is.EqualTo(None))
+                Assert.That(tryTakeWatchPublicationSourceConnectionAt now repositoryId branchId replacedByMissingReferenceId, Is.EqualTo(None))
+
+                Assert.That(
+                    tryTakeWatchPublicationSourceConnectionAt (now + TimeSpan.FromMinutes(3.0)) repositoryId branchId expiredReferenceId,
+                    Is.EqualTo(None)
+                ))
+        )
 
     /// Verifies that commit current-branch broadcasts are ordered after zip generation and derived diff work.
     [<Test>]

--- a/src/Grace.Server/Branch.Server.fs
+++ b/src/Grace.Server/Branch.Server.fs
@@ -40,6 +40,142 @@ module Branch =
 
     let private branchHashLookupErrorItemKey = "BranchHashLookupError"
 
+    /// Identifies one live Watch subscription without treating process identity as repository identity.
+    [<Struct>]
+    type internal WatchSourceSubscriptionKey = { ProcessId: Guid; RepositoryId: RepositoryId; BranchId: BranchId }
+
+    /// Identifies one transient live publication independently from the durable replay stream.
+    [<Struct>]
+    type internal WatchPublicationKey = { RepositoryId: RepositoryId; BranchId: BranchId; ReferenceId: ReferenceId }
+
+    /// Retains the exact connection selected before Reference publication begins.
+    type private PendingWatchPublication = { Subscription: WatchSourceSubscriptionKey; ConnectionId: string; ExpiresAtUtc: DateTimeOffset }
+
+    let private watchSourceSuppressionLock = obj ()
+    let private watchSubscriptionByConnection = Dictionary<string, WatchSourceSubscriptionKey>(StringComparer.Ordinal)
+    let private watchConnectionBySubscription = Dictionary<WatchSourceSubscriptionKey, string>()
+    let private pendingWatchPublications = Dictionary<WatchPublicationKey, PendingWatchPublication>()
+    let private watchPublicationBindingLifetime = TimeSpan.FromMinutes(2.0)
+
+    /// Removes one exact connection binding without disturbing a replacement registered for the same process identity.
+    let private unregisterWatchSourceSubscriptionLocked connectionId =
+        match watchSubscriptionByConnection.TryGetValue connectionId with
+        | true, subscription ->
+            watchSubscriptionByConnection.Remove connectionId
+            |> ignore
+
+            match watchConnectionBySubscription.TryGetValue subscription with
+            | true, currentConnectionId when String.Equals(currentConnectionId, connectionId, StringComparison.Ordinal) ->
+                watchConnectionBySubscription.Remove subscription
+                |> ignore
+            | _ -> ()
+        | _ -> ()
+
+    /// Binds a fresh Watch process identity to the exact authorized SignalR connection and branch subscription.
+    let internal registerWatchSourceSubscription connectionId processId repositoryId branchId =
+        lock watchSourceSuppressionLock (fun () ->
+            unregisterWatchSourceSubscriptionLocked connectionId
+
+            if
+                processId <> Guid.Empty
+                && not (String.IsNullOrWhiteSpace connectionId)
+            then
+                let subscription = { ProcessId = processId; RepositoryId = repositoryId; BranchId = branchId }
+
+                match watchConnectionBySubscription.TryGetValue subscription with
+                | true, replacedConnectionId ->
+                    watchSubscriptionByConnection.Remove replacedConnectionId
+                    |> ignore
+                | _ -> ()
+
+                watchConnectionBySubscription[subscription] <- connectionId
+                watchSubscriptionByConnection[connectionId] <- subscription)
+
+    /// Removes the disconnected connection from transient Watch source delivery state.
+    let internal unregisterWatchSourceSubscription connectionId =
+        lock watchSourceSuppressionLock (fun () -> unregisterWatchSourceSubscriptionLocked connectionId)
+
+    /// Drops expired publication bindings while holding the shared transient lifecycle lock.
+    let private pruneExpiredWatchPublicationsLocked now =
+        pendingWatchPublications
+        |> Seq.choose (fun entry -> if entry.Value.ExpiresAtUtc <= now then Some entry.Key else None)
+        |> Seq.toArray
+        |> Array.iter (fun key -> pendingWatchPublications.Remove key |> ignore)
+
+    /// Captures the exact active connection before the authorized Reference mutation can publish its broker event.
+    let internal prepareWatchPublicationSourceAt now processId repositoryId branchId referenceId =
+        lock watchSourceSuppressionLock (fun () ->
+            pruneExpiredWatchPublicationsLocked now
+            let publication = { RepositoryId = repositoryId; BranchId = branchId; ReferenceId = referenceId }
+
+            pendingWatchPublications.Remove publication
+            |> ignore
+
+            if processId = Guid.Empty then
+                None
+            else
+                let subscription = { ProcessId = processId; RepositoryId = repositoryId; BranchId = branchId }
+
+                match watchConnectionBySubscription.TryGetValue subscription with
+                | true, connectionId ->
+                    pendingWatchPublications[publication] <- {
+                                                                 Subscription = subscription
+                                                                 ConnectionId = connectionId
+                                                                 ExpiresAtUtc = now + watchPublicationBindingLifetime
+                                                             }
+
+                    Some publication
+                | _ -> None)
+
+    /// Captures a source connection using the current server clock.
+    let internal prepareWatchPublicationSource processId repositoryId branchId referenceId =
+        prepareWatchPublicationSourceAt DateTimeOffset.UtcNow processId repositoryId branchId referenceId
+
+    /// Removes a pending binding when the corresponding Reference mutation fails or is cancelled.
+    let internal removeWatchPublicationSource publication =
+        lock watchSourceSuppressionLock (fun () ->
+            pendingWatchPublications.Remove publication
+            |> ignore)
+
+    /// Consumes one live source binding only while its original connection and branch subscription remain exact.
+    let internal tryTakeWatchPublicationSourceConnectionAt now repositoryId branchId referenceId =
+        lock watchSourceSuppressionLock (fun () ->
+            pruneExpiredWatchPublicationsLocked now
+            let publication = { RepositoryId = repositoryId; BranchId = branchId; ReferenceId = referenceId }
+
+            match pendingWatchPublications.TryGetValue publication with
+            | true, pending ->
+                pendingWatchPublications.Remove publication
+                |> ignore
+
+                match watchConnectionBySubscription.TryGetValue pending.Subscription, watchSubscriptionByConnection.TryGetValue pending.ConnectionId with
+                | (true, currentConnectionId), (true, currentSubscription) when
+                    String.Equals(currentConnectionId, pending.ConnectionId, StringComparison.Ordinal)
+                    && currentSubscription = pending.Subscription
+                    ->
+                    Some pending.ConnectionId
+                | _ -> None
+            | _ -> None)
+
+    /// Consumes one live source binding using the current server clock.
+    let internal tryTakeWatchPublicationSourceConnection repositoryId branchId referenceId =
+        tryTakeWatchPublicationSourceConnectionAt DateTimeOffset.UtcNow repositoryId branchId referenceId
+
+    /// Reads one well-formed Watch process identity from delivery metadata without rejecting the HTTP request.
+    let internal tryGetWatchProcessId (context: HttpContext) =
+        match context.Request.Headers.TryGetValue Constants.WatchProcessIdHeaderKey with
+        | true, values when values.Count = 1 ->
+            let mutable processId = Guid.Empty
+
+            if
+                Guid.TryParseExact(values[0], "N", &processId)
+                && processId <> Guid.Empty
+            then
+                Some processId
+            else
+                None
+        | _ -> None
+
     /// Implements branch hash lookup description for the server request pipeline.
     let private branchHashLookupDescription (sha256Hash: Sha256Hash) (blake3Hash: Blake3Hash) =
         let sha256HashText = string sha256Hash
@@ -715,6 +851,7 @@ module Branch =
         (validations: Validations<'T>)
         (command: 'T -> ValueTask<BranchCommand>)
         (postSuccess: unit -> Task<Result<unit, GraceError>>)
+        (onFailure: unit -> unit)
         =
         task {
             let startTime = getCurrentInstant ()
@@ -769,6 +906,8 @@ module Branch =
 
                                 return! context |> result500ServerError graceError
                         | Error graceError ->
+                            onFailure ()
+
                             graceError
                                 .enhance(parameterDictionary)
                                 .enhance(nameof OwnerId, graceIds.OwnerId)
@@ -796,7 +935,9 @@ module Branch =
                     let! cmd = command parameters
 
                     match tryGetBranchHashLookupError context with
-                    | Some graceError -> return! context |> result400BadRequest graceError
+                    | Some graceError ->
+                        onFailure ()
+                        return! context |> result400BadRequest graceError
                     | None ->
                         let! result = handleCommand cmd
                         let duration = getDurationRightAligned_ms startTime
@@ -834,6 +975,8 @@ module Branch =
                     return! context |> result400BadRequest graceError
             with
             | ex ->
+                onFailure ()
+
                 log.LogError(
                     ex,
                     "{CurrentInstant}: Exception in Branch.Server.processCommand. CorrelationId: {correlationId}.",
@@ -855,7 +998,16 @@ module Branch =
 
     /// Coordinates process command processing for Grace Server.
     let processCommand<'T when 'T :> BranchParameters> (context: HttpContext) (validations: Validations<'T>) (command: 'T -> ValueTask<BranchCommand>) =
-        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok()))
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok())) ignore
+
+    /// Coordinates a branch command whose transient pre-publication state must be cleared after failure or cancellation.
+    let processCommandWithFailure<'T when 'T :> BranchParameters>
+        (context: HttpContext)
+        (validations: Validations<'T>)
+        (command: 'T -> ValueTask<BranchCommand>)
+        onFailure
+        =
+        processCommandWithPostSuccess context validations command (fun () -> Task.FromResult(Ok())) onFailure
 
     /// Resolves resolve root directory version for reference command data from request or repository state.
     let private resolveRootDirectoryVersionForReferenceCommand repositoryId directoryVersionId sha256Hash blake3Hash correlationId =
@@ -1116,7 +1268,7 @@ module Branch =
                     }
 
                 context.Items.Add("Command", nameof Create)
-                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin
+                return! processCommandWithPostSuccess context validations command ensureCreatorAdmin ignore
             }
 
     /// Rebases a branch on its parent branch.
@@ -1378,6 +1530,14 @@ module Branch =
         fun (next: HttpFunc) (context: HttpContext) ->
             task {
                 let graceIds = getGraceIds context
+                let mutable pendingWatchPublication: WatchPublicationKey option = None
+
+                /// Clears delivery-only source state when the durable Reference mutation does not succeed.
+                let clearPendingWatchPublication () =
+                    pendingWatchPublication
+                    |> Option.iter removeWatchPublicationSource
+
+                    pendingWatchPublication <- None
 
                 /// Implements validations for the server request pipeline.
                 let validations (parameters: CreateReferenceParameters) =
@@ -1400,20 +1560,33 @@ module Branch =
 
                 /// Implements command for the server request pipeline.
                 let command (parameters: CreateReferenceParameters) =
-                    referenceCommandFromRoot
-                        context
-                        BranchCommand.Save
-                        graceIds.RepositoryId
-                        parameters.ReferenceId
-                        parameters.DirectoryVersionId
-                        parameters.Sha256Hash
-                        parameters.Blake3Hash
-                        (ReferenceText parameters.Message)
-                        parameters.CorrelationId
+                    task {
+                        let! branchCommand =
+                            referenceCommandFromRoot
+                                context
+                                BranchCommand.Save
+                                graceIds.RepositoryId
+                                parameters.ReferenceId
+                                parameters.DirectoryVersionId
+                                parameters.Sha256Hash
+                                parameters.Blake3Hash
+                                (ReferenceText parameters.Message)
+                                parameters.CorrelationId
+
+                        pendingWatchPublication <-
+                            prepareWatchPublicationSource
+                                (tryGetWatchProcessId context
+                                 |> Option.defaultValue Guid.Empty)
+                                graceIds.RepositoryId
+                                graceIds.BranchId
+                                parameters.ReferenceId
+
+                        return branchCommand
+                    }
                     |> ValueTask<BranchCommand>
 
                 context.Items.Add("Command", nameof Save)
-                return! processCommand context validations command
+                return! processCommandWithFailure context validations command clearPendingWatchPublication
             }
 
     /// Creates a tag reference pointing to the specified root directory version in the branch.

--- a/src/Grace.Server/Notification.Server.fs
+++ b/src/Grace.Server/Notification.Server.fs
@@ -171,6 +171,7 @@ module Notification =
             let items = this.Context.Items
             let connectionId = this.Context.ConnectionId
             let cleared = clearCurrentBranchGroupMembershipState items
+            Branch.unregisterWatchSourceSubscription connectionId
 
             if cleared then
                 log.LogInformation(
@@ -210,8 +211,8 @@ module Notification =
                 do! this.Groups.AddToGroupAsync(this.Context.ConnectionId, $"{parentBranchId}")
             }
 
-        /// Adds the current SignalR connection to the current-branch group used for same-branch Reference notifications.
-        member this.RegisterCurrentBranch(repositoryId: RepositoryId, branchId: BranchId) =
+        /// Authorizes and replaces the current-branch subscription before optionally binding its delivery-only process identity.
+        member private this.RegisterCurrentBranchCore(repositoryId: RepositoryId, branchId: BranchId, sourceProcessId: Guid option) =
             task {
                 log.LogInformation(
                     "{CurrentInstant}: Node: {HostName}; ConnectionId: {ConnectionId} registering for current BranchId: {BranchId} in RepositoryId: {RepositoryId}.",
@@ -247,7 +248,29 @@ module Notification =
                     raise (HubException("Current-branch SignalR registration requires branch read permission."))
 
                 do! replaceCurrentBranchGroupMembership this.Groups this.Context.ConnectionId this.Context.Items repositoryId branchId CancellationToken.None
+
+                match sourceProcessId with
+                | Some processId -> Branch.registerWatchSourceSubscription this.Context.ConnectionId processId repositoryId branchId
+                | None -> Branch.unregisterWatchSourceSubscription this.Context.ConnectionId
             }
+
+        /// Adds a source-unaware SignalR client to the current-branch group while preserving legacy delivery behavior.
+        member this.RegisterCurrentBranch(repositoryId: RepositoryId, branchId: BranchId) = this.RegisterCurrentBranchCore(repositoryId, branchId, None)
+
+        /// Adds a Watch connection to the current-branch group and binds a well-formed opaque process identity for live delivery optimization.
+        member this.RegisterCurrentBranchSource(repositoryId: RepositoryId, branchId: BranchId, sourceProcessId: string) =
+            let mutable processId = Guid.Empty
+
+            let parsedProcessId =
+                if
+                    Guid.TryParseExact(sourceProcessId, "N", &processId)
+                    && processId <> Guid.Empty
+                then
+                    Some processId
+                else
+                    None
+
+            this.RegisterCurrentBranchCore(repositoryId, branchId, parsedProcessId)
 
         /// Broadcasts repository-scoped notifications to clients registered for the repository group.
         member this.NotifyRepository((repositoryId: RepositoryId), (referenceId: ReferenceId)) =
@@ -373,11 +396,14 @@ module Notification =
         =
         task {
             if not <| isNull hubContext then
-                do!
-                    hubContext
-                        .Clients
-                        .Group(currentBranchGroupKey payload.RepositoryId payload.BranchId)
-                        .NotifyCurrentBranchReference(payload)
+                let groupKey = currentBranchGroupKey payload.RepositoryId payload.BranchId
+
+                let clients =
+                    match Branch.tryTakeWatchPublicationSourceConnection payload.RepositoryId payload.BranchId payload.ReferenceId with
+                    | Some connectionId -> hubContext.Clients.GroupExcept(groupKey, [| connectionId |])
+                    | None -> hubContext.Clients.Group(groupKey)
+
+                do! clients.NotifyCurrentBranchReference(payload)
         }
 
     /// Implements route automation event for the server request pipeline.

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -198,6 +198,10 @@ module Constants =
     [<Literal>]
     let ClientVersionHeaderKey = "X-Grace-Client-Version"
 
+    /// The best-effort delivery header that identifies one live Grace Watch process.
+    [<Literal>]
+    let WatchProcessIdHeaderKey = "X-Grace-Watch-Process-Id"
+
     /// The response header that exposes SDK lifecycle status for recognized Grace clients.
     [<Literal>]
     let SdkLifecycleStatusHeaderKey = "X-Grace-Client-Support-Status"


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #805

Part of #801

## Summary

Suppress the live current-branch SignalR echo to exactly the Watch process that originated a save while preserving
delivery to peer Watch processes, branch isolation, ordered replay, cursor behavior, and the existing client-side exact
echo ledger.

Watch now creates one fresh opaque process ID and supplies it during authenticated SignalR registration and through an
internal header on Watch-originated saves. The server transiently binds that process identity to one exact subscribed
connection and consumes a matching publication binding for `GroupExcept` fan-out. Missing, stale, disconnected,
reconnected, reused, or mismatched bindings fall back to ordinary group delivery.

## Touched paths

- `src/Grace.Server/Branch.Server.fs`
- `src/Grace.Server/Notification.Server.fs`
- `src/Grace.Shared/Constants.Shared.fs`
- `src/Grace.SDK/ClientIdentity.SDK.fs`
- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.Server.Unit.Tests/Notification.Server.Tests.fs`
- `src/Grace.Server.Tests/NotificationHub.Tests.fs`
- `src/Grace.CLI.Tests/ClientIdentity.SDK.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: Product V1.
- Public behavior target: source Watch process is excluded from live same-branch fan-out; every eligible peer remains.
- RED evidence: focused tests first failed because the transient binding and exact fan-out seams did not exist.
- Focused validation: Release solution compilation plus 30 server notification tests and 25 Watch
  header/echo-ledger/cursor-replay tests passed.

## Minimum detail gate evidence

- Product decisions: fresh opaque per-process identity is delivery-only and best effort; no machine/user suppression or
  durable registry. Owner decision A accepts the random ID as bearer metadata under a non-hostile local secrecy
  assumption; a copied valid ID may suppress its registered connection without adding a second connection proof.
- Invariant tuple: process ID, exact SignalR connection, repository, branch, and Reference must all match before one
  live connection is excluded.
- Contract propagation: internal header/registration and SDK seam updated; persisted events, replay DTO,
  `CurrentBranchReferenceNotification`, OpenAPI, and generated clients remain unchanged because source metadata is
  transient and not part of replay/public payloads.
- Revalidation proof: route validation and root resolution precede publication binding; live fan-out rechecks exact
  connection/repository/branch/Reference state and otherwise broadcasts normally.
- Forbidden shapes avoided: no `Clients.Others` on the unrelated HTTP request, global user/machine suppression,
  persistent process registry, or replay filtering.
- Positive, negative, regression, and boundary coverage: peer delivery, exact source exclusion, branch mismatch,
  missing/malformed/stale/disconnected/reconnected/refreshed/reused bindings, repeated publication, ledger fallback,
  and ordered cursor replay.
- Risk traps: SignalR membership, async publication timing, expiration/cleanup, unknown/malformed/reused identity
  containment, the explicitly accepted copied-valid-ID risk, authorization ordering, and false suppression default.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `Notification.Server.Tests.fs` covers exact `GroupExcept` selection and safe ordinary-group fallback across the
  transient subscription/publication lifecycle.
- `NotificationHub.Tests.fs` crosses authenticated SignalR registration, the Watch Save header, `/branch/save`, Service
  Bus processing, and production fan-out. It proves source zero, same-branch peer one, other branch zero, and reconnect
  fallback without sleep-based negative assertions.
- `ClientIdentity.SDK.Tests.fs` covers optional and clearable Watch process identity headers.
- Existing exact echo-ledger and cursor-replay tests remain green.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Any genuinely required validation that was not run is explicitly listed with a reason.

## Risk surfaces

- [x] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [ ] CLI public contract
- [x] Server or API contract
- [x] Orleans actor behavior
- [x] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [x] Docs impact: None - the process identity is an internal delivery optimization; the SignalR notification payload,
  CLI surface, persisted event contract, replay behavior, OpenAPI, and generated clients do not change.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Local focused evidence

- [x] Focused proof:
  `dotnet test src\Grace.slnx --configuration Release --filter "FullyQualifiedName~NotificationServerTests|FullyQualifiedName~ClientIdentitySdkTests.WatchProcessIdentityHeaderIsOptionalAndClearable|TestCategory=CurrentBranchSelfReferenceEcho|TestCategory=CurrentBranchCursorReplay"`
  passed 30/30 server and 25/25 CLI tests with Release solution compilation. The authenticated hosted notification
  fixture passed 3/3 after the final test-only proof commit.
- [x] Formatting/linting: targeted Fantomas passed for all seven touched F# files; `git diff --check` passed.
- [x] Generated-file/freshness or syntax checks: N/A; no generated or OpenAPI contract changed.
- [x] Manual validation: worker 2 ran separate source, peer, and other-branch Watch directories against the exact-head
  DebugLocal runtime. Peer delivery, branch isolation, and reconnect fallback passed. Object-cache materialization was
  explicitly outside Epic #801; exact source exclusion was then proven by the authenticated hosted fixture.

## Optional local broad preflight

- [x] Fast, Full, or neither: neither; the focused Release solution/test gate is the selected local proof and GitHub
  Validate is the required broad gate.

## Required CI evidence

- Current head SHA: `7688852784ef1ae469b5eb4c1776ba45ba8bae79`
- GitHub `Validate` state: passed.
- GitHub Actions run link: [31166177257](https://github.com/ScottArbeit/Grace/actions/runs/31166177257).
- [x] The result was triggered by and remains associated with the latest PR revision.

## Validation not run

None. Cache read-through and peer object materialization are explicitly outside Epic #801 and #805.

## Residual risks

- Suppression is intentionally process-local and best effort. Lost or cross-instance binding state restores ordinary
  delivery, with the unchanged client ledger providing the exact fallback.
- Owner decision A accepts that a different authenticated writer which has copied a valid random process ID may
  suppress the connection registered by that ID. Product V1 assumes non-hostile local handling and adds no second
  server-issued connection proof.

## Review Status

- Worker starts: 3/4.
- Current head SHA: `7688852784ef1ae469b5eb4c1776ba45ba8bae79`
- Fresh review subagent: `gpt-5.6-terra`, `reasoning_effort: high`, `fork_turns: none`
- `dev-process/CODE_REVIEW.md` followed: yes, review session 2.
- Review verdict for current head: no implementation or proof defect; copied-valid-ID semantics required owner choice.
- Required PR checks for current head: GitHub Validate run 31166177257 passed.
- [x] Review and required checks both completed successfully for the same head SHA.
- Finding dispositions and detailed review/fix comments: session 1's integration-proof finding was closed by the
  hosted test in `76888527`. Owner decision A accepts copied-valid-ID bearer behavior; no code change is required.

## Review/fix prevention

- **Root-cause class:** acceptance-criteria / negative-proof gap. The original issue combined best-effort process
  identity with an ambiguous spoof example. The issue now records copied-valid-ID behavior as an accepted Product V1
  risk while preserving safe fallback for unknown, malformed, stale, disconnected, reconnected, reused, and mismatched
  bindings.

## Rollback or recovery notes

Reverting the commit restores ordinary branch-group broadcast. No durable data, persisted shape, replay cursor, or
migration requires recovery.

## Docs follow-up required

None. Review session 2 confirmed the internal-only contract classification.
