### PR TITLE
Unify Watch path classification and silent admission

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -1595,6 +1595,156 @@ module WatchTests =
             pending.StatusUpdateTriggers
             |> should equal Array.empty<string>)
 
+    /// Verifies the normal maintenance/status/save scan treats the root ignore definition as repository content.
+    [<Test; Category("WatchPathClassification")>]
+    let ``normal working tree scan includes root graceignore`` () =
+        withTempRepo (fun root ->
+            let graceIgnorePath = Path.Combine(root, Constants.GraceIgnoreFileName)
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            File.WriteAllText(graceIgnorePath, "ignored.tmp")
+            Services.clearShouldIgnoreCache ()
+
+            Services.shouldIgnoreFile graceIgnorePath
+            |> should equal false
+
+            let differences =
+                (Services.scanForDifferences status)
+                    .GetAwaiter()
+                    .GetResult()
+
+            differences
+            |> Seq.exists (fun difference ->
+                difference.DifferenceType = DifferenceType.Add
+                && difference.FileSystemEntryType = FileSystemEntryType.File
+                && string difference.RelativePath = Constants.GraceIgnoreFileName)
+            |> should equal true
+
+            let indexedStatus = graceStatusTracking [| Constants.GraceIgnoreFileName |] Array.empty<string>
+
+            let indexedDifferences =
+                (Services.scanForDifferences indexedStatus)
+                    .GetAwaiter()
+                    .GetResult()
+
+            indexedDifferences
+            |> Seq.exists (fun difference ->
+                (difference.DifferenceType = DifferenceType.Add
+                 || difference.DifferenceType = DifferenceType.Delete)
+                && difference.FileSystemEntryType = FileSystemEntryType.File
+                && string difference.RelativePath = Constants.GraceIgnoreFileName)
+            |> should equal false)
+
+    /// Verifies the shared classifier distinguishes repository, ignore, Grace namespace, and exact local-state identities.
+    [<Test; Category("WatchPathClassification")>]
+    let ``shared repository path classifier is boundary aware`` () =
+        withTempRepo (fun root ->
+            let current = Current()
+
+            let input: Services.RepositoryPathClassifierInput =
+                {
+                    RootDirectory = root
+                    GraceDirectory = current.GraceDirectory
+                    GraceStatusFile = current.GraceStatusFile
+                    DirectoryIgnoreEntries = Array.empty
+                    FileIgnoreEntries = [| "ignored.tmp" |]
+                    PathComparison = StringComparison.OrdinalIgnoreCase
+                }
+
+            let classify kind path = Services.classifyRepositoryPath input kind path
+            let graceIgnorePath = Path.Combine(root, Constants.GraceIgnoreFileName)
+            let sharedPrefixPath = Path.Combine(root, ".grace-old", "ordinary.txt")
+            let internalPath = Path.Combine(current.GraceDirectory, "objects", "cached.bin")
+            let outsidePath = Path.Combine(Path.GetDirectoryName(root), $"outside-{Guid.NewGuid():N}.txt")
+
+            classify Services.RepositoryPathKind.FilePath graceIgnorePath
+            |> should equal Services.RepositoryPathClassification.Eligible
+
+            classify Services.RepositoryPathKind.FilePath sharedPrefixPath
+            |> should equal Services.RepositoryPathClassification.Eligible
+
+            classify Services.RepositoryPathKind.FilePath (internalPath.ToUpperInvariant())
+            |> should equal Services.RepositoryPathClassification.GraceInternal
+
+            classify Services.RepositoryPathKind.FilePath (Path.Combine(root, "ignored.tmp"))
+            |> should equal Services.RepositoryPathClassification.Ignored
+
+            classify Services.RepositoryPathKind.FilePath outsidePath
+            |> should equal Services.RepositoryPathClassification.Ignored
+
+            for suffix in
+                [|
+                    String.Empty
+                    "-wal"
+                    "-shm"
+                    "-journal"
+                |] do
+                classify Services.RepositoryPathKind.FilePath (current.GraceStatusFile + suffix)
+                |> should equal Services.RepositoryPathClassification.LocalStateArtifact
+
+            classify Services.RepositoryPathKind.FilePath (current.GraceStatusFile + "-wal.extra")
+            |> should equal Services.RepositoryPathClassification.GraceInternal)
+
+    /// Verifies a configured ignore match cannot create a raw candidate, pending transition, IPC file, or callback output.
+    [<Test; Category("WatchPathClassification"); Category("WatchSilentObservation")>]
+    let ``raw ignored callback stops before ordinary Watch side effects`` () =
+        withTempRepo (fun root ->
+            let ignoredPath = Path.Combine(root, "ignored.tmp")
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+
+            File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), "ignored.tmp")
+            File.WriteAllText(ignoredPath, "ignored payload")
+            resetConfiguration ()
+            activateWatchIgnoreSnapshot ()
+            Watch.setGraceStatusForWatchTests status
+            Watch.setReadGraceStatusFileForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+            Watch.setLocalObservationCandidateSchedulingForWatchTests true
+
+            let output =
+                captureAnsiConsoleOutput (fun () ->
+                    Watch.OnCreated(createdEvent ignoredPath)
+                    Watch.OnChanged(changedEvent ignoredPath)
+                    Watch.OnDeleted(deletedEvent ignoredPath))
+
+            output |> should equal String.Empty
+
+            Watch.localObservationCandidateSnapshotForWatchTests ()
+            |> should equal Array.empty<Watch.WatchObservationCandidate>
+
+            Watch.pendingWatchWorkEvidenceForWatchTests ()
+            |> should equal (false, false)
+
+            File.Exists(Services.IpcFileName())
+            |> should equal false)
+
+    /// Verifies rename admission classifies old and new endpoints independently before ordinary Watch work.
+    [<Test; Category("WatchPathClassification"); Category("WatchSilentObservation")>]
+    let ``raw rename admits only eligible endpoint across ignore boundary`` () =
+        let verifyRename oldFileName newFileName expectedPath expectedKind =
+            withTempRepo (fun root ->
+                let oldPath = Path.Combine(root, oldFileName)
+                let newPath = Path.Combine(root, newFileName)
+
+                File.WriteAllText(Path.Combine(root, Constants.GraceIgnoreFileName), "ignored.tmp")
+                File.WriteAllText(newPath, "renamed payload")
+                resetConfiguration ()
+                activateWatchIgnoreSnapshot ()
+                Watch.setLocalObservationCandidateSchedulingForWatchTests true
+
+                Watch.OnRenamed(renamedEvent oldPath newPath)
+
+                Watch.localObservationCandidateSnapshotForWatchTests ()
+                |> Array.map (fun candidate -> candidate.FullPath, candidate.Kind)
+                |> should
+                    equal
+                    [|
+                        Path.Combine(root, expectedPath), expectedKind
+                    |])
+
+        verifyRename "ignored.tmp" "eligible.txt" "eligible.txt" Watch.CreatedOrChanged
+        verifyRename "eligible.txt" "ignored.tmp" "eligible.txt" Watch.Deleted
+
     /// Verifies that explicit filesystem watcher failures remain visible while discarded observations become silent.
     [<Test; Category("WatchInternalAdmission"); Category("WatchSilentObservation")>]
     let ``filesystem watcher errors retain explicit resync diagnostics`` () =
@@ -3896,7 +4046,7 @@ module WatchTests =
             |> should equal true)
 
     /// Verifies Watch treats only the `.grace` directory and its descendants as internal while ordinary similarly prefixed paths retain normal ignore behavior.
-    [<Test>]
+    [<Test; Category("WatchPathClassification")>]
     let ``Watch ignores only separator bounded grace directory paths`` () =
         withTempRepo (fun root ->
             let gracePath = Path.Combine(root, Constants.GraceConfigDirectory, "objects", "cache.bin")
@@ -16744,7 +16894,7 @@ module WatchTests =
                 |> should equal $"{cleanStatusFromNonWatch.RootDirectoryId}")
 
     /// Verifies that local-state artifact callbacks remain quiet until their committed revision is checked.
-    [<Test>]
+    [<Test; Category("WatchPathClassification")>]
     let ``watch local-state artifact callbacks do not publish pending ipc`` () =
         withTempRepo (fun _ ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
@@ -16773,7 +16923,9 @@ module WatchTests =
                             "-shm"
                             "-journal"
                         |] do
-                        Watch.OnChanged(changedEvent (Current().GraceStatusFile + suffix)))
+                        Watch.OnCreated(createdEvent (Current().GraceStatusFile + suffix))
+                        Watch.OnChanged(changedEvent (Current().GraceStatusFile + suffix))
+                        Watch.OnDeleted(deletedEvent (Current().GraceStatusFile + suffix)))
 
             callbackOutput |> should equal String.Empty
 
@@ -16958,7 +17110,7 @@ module WatchTests =
             |> should equal false)
 
     /// Verifies duplicate SQLite callbacks coalesce into one quiet revision read for a Watch-owned commit.
-    [<Test>]
+    [<Test; Category("WatchPathClassification")>]
     let ``watch duplicate local-state callbacks perform one quiet revision check`` () =
         withTempRepo (fun _ ->
             let mutable reads = 0
@@ -16967,9 +17119,10 @@ module WatchTests =
 
             Watch.setKnownLocalStatusRevisionForWatchTests 7L
 
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile))
+            Watch.OnCreated(createdEvent (Current().GraceStatusFile))
             Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-wal"))
-            Watch.OnChanged(changedEvent (Current().GraceStatusFile + "-shm"))
+            Watch.OnDeleted(deletedEvent (Current().GraceStatusFile + "-shm"))
+            Watch.OnDeleted(deletedEvent (Current().GraceStatusFile + "-journal"))
 
             (Watch.processLocalStatusRevisionCheckForWatchTests
                 (fun () ->

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -895,6 +895,133 @@ module Services =
 
             false
 
+    /// Identifies the filesystem shape available when Grace classifies a repository path.
+    type RepositoryPathKind =
+        /// The path is known to represent a file.
+        | FilePath
+        /// The path is known to represent a directory.
+        | DirectoryPath
+        /// The path is missing or its final filesystem shape is not yet known.
+        | UnknownPath
+        /// The path shape could not be recovered from trusted local status.
+        | StatusUnavailablePath
+
+    /// Describes the only four admission outcomes shared by repository scans and Watch callbacks.
+    type RepositoryPathClassification =
+        /// The path may continue through ordinary repository processing.
+        | Eligible
+        /// The path is outside the repository, temporary, or matched by configured ignore rules.
+        | Ignored
+        /// The path is the Grace directory itself or a separator-bounded descendant.
+        | GraceInternal
+        /// The path is the exact local SQLite database or one of its supported side files.
+        | LocalStateArtifact
+
+    /// Supplies the repository identity, ignore snapshot, and platform comparison used for one path decision.
+    type RepositoryPathClassifierInput =
+        {
+            RootDirectory: string
+            GraceDirectory: string
+            GraceStatusFile: string
+            DirectoryIgnoreEntries: string array
+            FileIgnoreEntries: string array
+            PathComparison: StringComparison
+        }
+
+    /// Normalizes a path for boundary-aware repository identity checks.
+    let private normalizeRepositoryClassifierPath path =
+        path
+        |> Path.GetFullPath
+        |> Path.TrimEndingDirectorySeparator
+
+    /// Reports whether a path is a directory itself or a separator-bounded descendant under the supplied comparison policy.
+    let isPathWithinDirectoryWithComparison pathComparison directoryPath candidatePath =
+        let normalizedDirectory = normalizeRepositoryClassifierPath directoryPath
+        let normalizedCandidate = normalizeRepositoryClassifierPath candidatePath
+
+        let directoryPrefix =
+            if Path.EndsInDirectorySeparator(normalizedDirectory) then
+                normalizedDirectory
+            else
+                normalizedDirectory
+                + string Path.DirectorySeparatorChar
+
+        String.Equals(normalizedCandidate, normalizedDirectory, pathComparison)
+        || normalizedCandidate.StartsWith(directoryPrefix, pathComparison)
+
+    /// Classifies a normalized repository path before indexing or Watch can perform ordinary side effects.
+    let classifyRepositoryPath (input: RepositoryPathClassifierInput) pathKind candidatePath =
+        let normalizedCandidate = normalizeRepositoryClassifierPath candidatePath
+        let normalizedStatusFile = normalizeRepositoryClassifierPath input.GraceStatusFile
+
+        let isLocalStateArtifact =
+            String.Equals(normalizedCandidate, normalizedStatusFile, input.PathComparison)
+            || String.Equals(normalizedCandidate, normalizedStatusFile + "-wal", input.PathComparison)
+            || String.Equals(normalizedCandidate, normalizedStatusFile + "-shm", input.PathComparison)
+            || String.Equals(normalizedCandidate, normalizedStatusFile + "-journal", input.PathComparison)
+
+        let isInsideRepository = isPathWithinDirectoryWithComparison input.PathComparison input.RootDirectory normalizedCandidate
+
+        let isGraceInternal = isPathWithinDirectoryWithComparison input.PathComparison input.GraceDirectory normalizedCandidate
+
+        /// Checks whether configured directory rules match the candidate's parent directory.
+        let directoryRuleMatchesParent graceIgnoreLine =
+            let parent = FileInfo(normalizedCandidate).Directory
+
+            not (isNull parent)
+            && checkIgnoreLineAgainstDirectory parent graceIgnoreLine
+
+        /// Checks whether configured directory rules match the candidate as a directory.
+        let directoryRuleMatchesCandidate graceIgnoreLine = checkIgnoreLineAgainstDirectory (DirectoryInfo(normalizedCandidate)) graceIgnoreLine
+
+        let matchesConfiguredIgnore =
+            match pathKind with
+            | RepositoryPathKind.StatusUnavailablePath -> false
+            | RepositoryPathKind.DirectoryPath ->
+                input.DirectoryIgnoreEntries
+                |> Array.exists directoryRuleMatchesCandidate
+            | RepositoryPathKind.FilePath ->
+                normalizedCandidate.EndsWith(".gracetmp", input.PathComparison)
+                || input.DirectoryIgnoreEntries
+                   |> Array.exists directoryRuleMatchesParent
+                || input.DirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedCandidate graceIgnoreLine)
+                || input.FileIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedCandidate graceIgnoreLine)
+            | RepositoryPathKind.UnknownPath ->
+                normalizedCandidate.EndsWith(".gracetmp", input.PathComparison)
+                || input.DirectoryIgnoreEntries
+                   |> Array.exists directoryRuleMatchesParent
+                || input.DirectoryIgnoreEntries
+                   |> Array.exists directoryRuleMatchesCandidate
+                || input.DirectoryIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedCandidate graceIgnoreLine)
+                || input.FileIgnoreEntries
+                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedCandidate graceIgnoreLine)
+
+        if isLocalStateArtifact then LocalStateArtifact
+        elif not isInsideRepository then Ignored
+        elif isGraceInternal then GraceInternal
+        elif matchesConfiguredIgnore then Ignored
+        else Eligible
+
+    /// Builds the live repository classification inputs used by normal indexing, status, and save paths.
+    let private currentRepositoryPathClassifierInput () =
+        let current = Current()
+
+        {
+            RootDirectory = current.RootDirectory
+            GraceDirectory = current.GraceDirectory
+            GraceStatusFile = current.GraceStatusFile
+            DirectoryIgnoreEntries = current.GraceDirectoryIgnoreEntries
+            FileIgnoreEntries = current.GraceFileIgnoreEntries
+            PathComparison =
+                if runningOnWindows then
+                    StringComparison.OrdinalIgnoreCase
+                else
+                    StringComparison.Ordinal
+        }
+
     /// Checks whether a repository file path should be skipped by Grace indexing.
     let shouldIgnoreFile (filePath: FilePath) =
         let mutable shouldIgnore = false
@@ -903,29 +1030,15 @@ module Services =
         if wasAlreadyCached then
             shouldIgnore
         else
-            // Ignore it if:
-            //   it's in the .grace directory, or
-            //   it's the Grace Status file, or
-            //   it's a Grace-owned temporary file, or
-            //   it's a directory itself, or
-            //   it matches something in graceignore.txt.
-            let fileInfo = FileInfo(filePath)
-
             let shouldIgnoreThisFile =
-                filePath.StartsWith(Current().GraceDirectory, StringComparison.InvariantCultureIgnoreCase) // it's in the /.grace directory
-                || filePath.Equals(Current().GraceStatusFile, StringComparison.InvariantCultureIgnoreCase) // it's the Grace local state DB
-                || filePath.Equals(Current().GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase) // sqlite WAL
-                || filePath.Equals(Current().GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase) // sqlite SHM
-                || filePath.Equals(Current().GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase) // sqlite journal
-                || filePath.EndsWith(".gracetmp") // it's a Grace temporary file
-                || Directory.Exists(filePath) // it's a directory
-                //|| fileInfo.Attributes.HasFlag(FileAttributes.Temporary)                                          // it's temporary - why doesn't this work
-                || Current().GraceDirectoryIgnoreEntries // one of the directories in the path matches a directory ignore line
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine)
-                || Current().GraceDirectoryIgnoreEntries // the file name matches a directory ignore line (which is weird, but possible)
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
-                || Current().GraceFileIgnoreEntries // the file name matches a file ignore line
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
+                let pathKind =
+                    if Directory.Exists(filePath) then
+                        RepositoryPathKind.DirectoryPath
+                    else
+                        RepositoryPathKind.FilePath
+
+                classifyRepositoryPath (currentRepositoryPathClassifierInput ()) pathKind filePath
+                <> Eligible
 
 
             //logToAnsiConsole Colors.Verbose $"In shouldIgnoreFile: filePath: {filePath}; shouldIgnore: {shouldIgnoreThisFile}"
@@ -944,12 +1057,9 @@ module Services =
         if wasAlreadyCached then
             shouldIgnore
         else
-            let directoryInfo = DirectoryInfo(directoryPath)
-
             let shouldIgnoreDirectory =
-                directoryInfo.FullName.StartsWith(Current().GraceDirectory)
-                || Current()
-                    .GraceDirectoryIgnoreEntries.Any(fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory directoryInfo graceIgnoreLine)
+                classifyRepositoryPath (currentRepositoryPathClassifierInput ()) RepositoryPathKind.DirectoryPath directoryPath
+                <> Eligible
 
             shouldIgnoreCache.TryAdd(directoryPath, shouldIgnoreDirectory)
             |> ignore
@@ -1008,52 +1118,33 @@ module Services =
             FileIgnoreEntries: string array
         }
 
-    /// Normalizes Grace ids for full path by keeping explicit scope values and clearing implicit child scopes.
-    let private normalizeFullPath path =
-        Path
-            .GetFullPath(path)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-
-    /// Evaluates is within grace directory against parsed options and command state.
-    let private isWithinGraceDirectory (scanInput: WorkingTreeScanInput) path =
-        let graceDirectory = normalizeFullPath scanInput.GraceDirectory
-        let candidate = Path.GetFullPath(path)
-
-        candidate.Equals(graceDirectory, StringComparison.OrdinalIgnoreCase)
-        || candidate.StartsWith(
-            graceDirectory
-            + string Path.DirectorySeparatorChar,
-            StringComparison.OrdinalIgnoreCase
-        )
-        || candidate.StartsWith(
-            graceDirectory
-            + string Path.AltDirectorySeparatorChar,
-            StringComparison.OrdinalIgnoreCase
-        )
+    /// Converts a copied scan snapshot into the shared repository path-classification contract.
+    let private repositoryPathClassifierInputForScan pathComparison (scanInput: WorkingTreeScanInput) =
+        {
+            RootDirectory = scanInput.RootDirectory
+            GraceDirectory = scanInput.GraceDirectory
+            GraceStatusFile = scanInput.GraceStatusFile
+            DirectoryIgnoreEntries = scanInput.DirectoryIgnoreEntries
+            FileIgnoreEntries = scanInput.FileIgnoreEntries
+            PathComparison = pathComparison
+        }
 
     /// Coordinates should ignore file for scan behavior for this CLI command path.
-    let private shouldIgnoreFileForScan (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (filePath: FilePath) =
+    let private shouldIgnoreFileForScan pathComparison (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (filePath: FilePath) =
         let mutable shouldIgnore = false
 
         if cache.TryGetValue(filePath, &shouldIgnore) then
             shouldIgnore
         else
-            let fileInfo = FileInfo(filePath)
-
             let shouldIgnoreThisFile =
-                isWithinGraceDirectory scanInput filePath
-                || filePath.Equals(scanInput.GraceStatusFile, StringComparison.InvariantCultureIgnoreCase)
-                || filePath.Equals(scanInput.GraceStatusFile + "-wal", StringComparison.InvariantCultureIgnoreCase)
-                || filePath.Equals(scanInput.GraceStatusFile + "-shm", StringComparison.InvariantCultureIgnoreCase)
-                || filePath.Equals(scanInput.GraceStatusFile + "-journal", StringComparison.InvariantCultureIgnoreCase)
-                || filePath.EndsWith(".gracetmp", StringComparison.OrdinalIgnoreCase)
-                || Directory.Exists(filePath)
-                || scanInput.DirectoryIgnoreEntries
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine)
-                || scanInput.DirectoryIgnoreEntries
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
-                || scanInput.FileIgnoreEntries
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile filePath graceIgnoreLine)
+                let pathKind =
+                    if Directory.Exists(filePath) then
+                        RepositoryPathKind.DirectoryPath
+                    else
+                        RepositoryPathKind.FilePath
+
+                classifyRepositoryPath (repositoryPathClassifierInputForScan pathComparison scanInput) pathKind filePath
+                <> Eligible
 
             cache.TryAdd(filePath, shouldIgnoreThisFile)
             |> ignore
@@ -1061,17 +1152,20 @@ module Services =
             shouldIgnoreThisFile
 
     /// Coordinates should ignore directory for scan behavior for this CLI command path.
-    let private shouldIgnoreDirectoryForScan (scanInput: WorkingTreeScanInput) (cache: ConcurrentDictionary<FilePath, bool>) (directoryPath: string) =
+    let private shouldIgnoreDirectoryForScan
+        pathComparison
+        (scanInput: WorkingTreeScanInput)
+        (cache: ConcurrentDictionary<FilePath, bool>)
+        (directoryPath: string)
+        =
         let mutable shouldIgnore = false
 
         if cache.TryGetValue(directoryPath, &shouldIgnore) then
             shouldIgnore
         else
-            let directoryInfo = DirectoryInfo(directoryPath)
-
             let shouldIgnoreDirectory =
-                isWithinGraceDirectory scanInput directoryInfo.FullName
-                || scanInput.DirectoryIgnoreEntries.Any(fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory directoryInfo graceIgnoreLine)
+                classifyRepositoryPath (repositoryPathClassifierInputForScan pathComparison scanInput) RepositoryPathKind.DirectoryPath directoryPath
+                <> Eligible
 
             cache.TryAdd(directoryPath, shouldIgnoreDirectory)
             |> ignore
@@ -1111,27 +1205,27 @@ module Services =
         }
 
     /// Reads working directory write times for scan from ParseResult, local configuration, or Grace ids.
-    let private getWorkingDirectoryWriteTimesForScan (scanInput: WorkingTreeScanInput) =
+    let private getWorkingDirectoryWriteTimesForScan pathComparison (scanInput: WorkingTreeScanInput) =
         let cache = ConcurrentDictionary<FilePath, bool>()
         let localWriteTimes = Dictionary<FileSystemEntryType * RelativePath, DateTime>()
 
         /// Coordinates rec behavior for this CLI command path.
         let rec collect (directoryInfo: DirectoryInfo) =
-            if not (shouldIgnoreDirectoryForScan scanInput cache directoryInfo.FullName) then
+            if not (shouldIgnoreDirectoryForScan pathComparison scanInput cache directoryInfo.FullName) then
                 let directoryFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, directoryInfo.FullName)))
 
                 localWriteTimes[(FileSystemEntryType.Directory, directoryFullPath)] <- directoryInfo.LastWriteTimeUtc
 
                 directoryInfo
                     .GetFiles()
-                    .Where(fun file -> not (shouldIgnoreFileForScan scanInput cache file.FullName))
+                    .Where(fun file -> not (shouldIgnoreFileForScan pathComparison scanInput cache file.FullName))
                 |> Seq.iter (fun fileInfo ->
                     let fileFullPath = RelativePath(normalizeFilePath (Path.GetRelativePath(scanInput.RootDirectory, fileInfo.FullName)))
                     localWriteTimes[(FileSystemEntryType.File, fileFullPath)] <- fileInfo.LastWriteTimeUtc)
 
                 directoryInfo
                     .GetDirectories()
-                    .Where(fun directory -> not (shouldIgnoreDirectoryForScan scanInput cache directory.FullName))
+                    .Where(fun directory -> not (shouldIgnoreDirectoryForScan pathComparison scanInput cache directory.FullName))
                 |> Seq.iter collect
 
         collect (DirectoryInfo(scanInput.RootDirectory))
@@ -1143,8 +1237,8 @@ module Services =
         || (existingBlake3Hash <> Blake3Hash String.Empty
             && newFileVersion.Blake3Hash <> existingBlake3Hash)
 
-    /// Coordinates scan working tree for differences read only behavior for this CLI command path.
-    let scanWorkingTreeForDifferencesReadOnly (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
+    /// Scans a copied working-tree snapshot using the caller's repository path-identity comparison.
+    let scanWorkingTreeForDifferencesReadOnlyWithComparison pathComparison (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
         task {
             try
                 let lookupCache = Dictionary<FileSystemEntryType * RelativePath, DateTime * Sha256Hash * Blake3Hash>()
@@ -1162,7 +1256,7 @@ module Services =
                         lookupCache.TryAdd((FileSystemEntryType.File, file.RelativePath), (file.LastWriteTimeUtc, file.Sha256Hash, file.Blake3Hash))
                         |> ignore
 
-                let localWriteTimes = getWorkingDirectoryWriteTimesForScan scanInput
+                let localWriteTimes = getWorkingDirectoryWriteTimesForScan pathComparison scanInput
                 let differences = List<FileSystemDifference>()
 
                 for kvp in localWriteTimes do
@@ -1193,6 +1287,16 @@ module Services =
             with
             | ex -> return Error ex.Message
         }
+
+    /// Scans a copied working-tree snapshot using the current platform's default path comparison.
+    let scanWorkingTreeForDifferencesReadOnly (scanInput: WorkingTreeScanInput) (previousGraceStatus: GraceStatus) =
+        let pathComparison =
+            if runningOnWindows then
+                StringComparison.OrdinalIgnoreCase
+            else
+                StringComparison.Ordinal
+
+        scanWorkingTreeForDifferencesReadOnlyWithComparison pathComparison scanInput previousGraceStatus
 
     /// Gets the LocalDirectoryVersion for the root directory of the repository from GraceStatus.
     let getRootDirectoryVersion (graceStatus: GraceStatus) =

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -903,8 +903,8 @@ module Services =
         | DirectoryPath
         /// The path is missing or its final filesystem shape is not yet known.
         | UnknownPath
-        /// The path shape could not be recovered from trusted local status.
-        | StatusUnavailablePath
+        /// The path is a tracked removal or status could not be read, so configured ignores cannot discard reconciliation.
+        | RemovalReconciliationPath
 
     /// Describes the only four admission outcomes shared by repository scans and Watch callbacks.
     type RepositoryPathClassification =
@@ -976,7 +976,7 @@ module Services =
 
         let matchesConfiguredIgnore =
             match pathKind with
-            | RepositoryPathKind.StatusUnavailablePath -> false
+            | RepositoryPathKind.RemovalReconciliationPath -> false
             | RepositoryPathKind.DirectoryPath ->
                 input.DirectoryIgnoreEntries
                 |> Array.exists directoryRuleMatchesCandidate

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -921,13 +921,13 @@ module Watch =
         | DeletedPathKindUnknown
         | DeletedPathStatusUnavailable
 
-    /// Maps Watch's tracked delete evidence into the shared repository path-classification shape.
+    /// Maps tracked or uncertain removals to reconciliation while unknown paths retain configured-ignore admission.
     let private repositoryPathKindForDeletedPath pathKind =
         match pathKind with
-        | DeletedFile -> RepositoryPathKind.FilePath
-        | DeletedDirectory -> RepositoryPathKind.DirectoryPath
+        | DeletedFile
+        | DeletedDirectory
+        | DeletedPathStatusUnavailable -> RepositoryPathKind.RemovalReconciliationPath
         | DeletedPathKindUnknown -> RepositoryPathKind.UnknownPath
-        | DeletedPathStatusUnavailable -> RepositoryPathKind.StatusUnavailablePath
 
     /// Coordinates repository relative path behavior for this CLI command path.
     let private repositoryRelativePath (fullPath: string) =
@@ -1809,7 +1809,7 @@ module Watch =
     let private classifyRawLocalObservation (fallbackKind: WatchObservationKind) (fullPath: string) =
         match fallbackKind with
         | Deleted ->
-            match classifyRepositoryPathForWatch RepositoryPathKind.UnknownPath fullPath with
+            match classifyRepositoryPathForWatch RepositoryPathKind.RemovalReconciliationPath fullPath with
             | RepositoryPathClassification.Eligible ->
                 let pathKind =
                     match repositoryRelativePath fullPath with

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -372,53 +372,42 @@ module Watch =
 
     /// Reports whether a candidate path is the Grace internal directory itself or belongs to its descendant namespace.
     let private isPathWithinDirectoryForWatch (directoryPath: string) (candidatePath: string) =
-        let normalizedDirectory =
-            directoryPath
-            |> Path.GetFullPath
-            |> Path.TrimEndingDirectorySeparator
-
-        let normalizedCandidate =
-            candidatePath
-            |> Path.GetFullPath
-            |> Path.TrimEndingDirectorySeparator
-
-        String.Equals(normalizedCandidate, normalizedDirectory, watchPathComparison)
-        || normalizedCandidate.StartsWith(
-            normalizedDirectory
-            + string Path.DirectorySeparatorChar,
-            watchPathComparison
-        )
+        isPathWithinDirectoryWithComparison watchPathComparison directoryPath candidatePath
 
     /// Exposes Watch namespace containment for deterministic path-comparison tests.
     let internal isPathWithinDirectoryForWatchTests directoryPath candidatePath = isPathWithinDirectoryForWatch directoryPath candidatePath
 
+    /// Converts the immutable Watch-lifetime ignore snapshot into the shared repository path-classification contract.
+    let private repositoryPathClassifierInputForWatch (snapshot: WatchIgnoreSnapshot) =
+        {
+            RootDirectory = snapshot.RootDirectory
+            GraceDirectory = snapshot.GraceDirectory
+            GraceStatusFile = snapshot.GraceStatusFile
+            DirectoryIgnoreEntries = snapshot.DirectoryEntries
+            FileIgnoreEntries = snapshot.FileEntries
+            PathComparison = watchPathComparison
+        }
+
+    /// Classifies one Watch path against the immutable lifetime snapshot before ordinary observation side effects.
+    let private classifyRepositoryPathForWatch pathKind fullPath =
+        let snapshot = currentWatchIgnoreSnapshot ()
+        classifyRepositoryPath (repositoryPathClassifierInputForWatch snapshot) pathKind fullPath
+
     /// Checks a file path against the copied Watch-lifetime ignore snapshot.
     let private shouldIgnoreFileForWatch fullPath =
-        let snapshot = currentWatchIgnoreSnapshot ()
-        let fileInfo = FileInfo(fullPath)
+        let pathKind =
+            if Directory.Exists(fullPath) then
+                RepositoryPathKind.DirectoryPath
+            else
+                RepositoryPathKind.FilePath
 
-        isPathWithinDirectoryForWatch snapshot.GraceDirectory fullPath
-        || fullPath.Equals(snapshot.GraceStatusFile, watchPathComparison)
-        || fullPath.Equals(snapshot.GraceStatusFile + "-wal", watchPathComparison)
-        || fullPath.Equals(snapshot.GraceStatusFile + "-shm", watchPathComparison)
-        || fullPath.Equals(snapshot.GraceStatusFile + "-journal", watchPathComparison)
-        || fullPath.EndsWith(".gracetmp", watchPathComparison)
-        || Directory.Exists(fullPath)
-        || (not (isNull fileInfo.Directory)
-            && snapshot.DirectoryEntries
-               |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine))
-        || snapshot.DirectoryEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile fullPath graceIgnoreLine)
-        || snapshot.FileEntries
-           |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile fullPath graceIgnoreLine)
+        classifyRepositoryPathForWatch pathKind fullPath
+        <> Eligible
 
     /// Checks a directory path against the copied Watch-lifetime ignore snapshot.
     let private shouldIgnoreDirectoryForWatch directoryPath =
-        let snapshot = currentWatchIgnoreSnapshot ()
-        let directoryInfo = DirectoryInfo(directoryPath)
-
-        isPathWithinDirectoryForWatch snapshot.GraceDirectory directoryInfo.FullName
-        || snapshot.DirectoryEntries.Any(fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory directoryInfo graceIgnoreLine)
+        classifyRepositoryPathForWatch RepositoryPathKind.DirectoryPath directoryPath
+        <> Eligible
 
     /// Checks whether a directory remains eligible under the copied Watch-lifetime ignore snapshot.
     let private shouldNotIgnoreDirectoryForWatch directoryPath = not <| shouldIgnoreDirectoryForWatch directoryPath
@@ -442,7 +431,7 @@ module Watch =
                 FileIgnoreEntries = snapshot.FileEntries
             }
 
-        scanWorkingTreeForDifferencesReadOnly scanInput previousGraceStatus
+        scanWorkingTreeForDifferencesReadOnlyWithComparison watchPathComparison scanInput previousGraceStatus
 
     /// Scans the working tree with the copied Watch-lifetime ignore inputs instead of live configuration values.
     let private scanForDifferencesWithWatchIgnoreSnapshot (previousGraceStatus: GraceStatus) =
@@ -932,6 +921,14 @@ module Watch =
         | DeletedPathKindUnknown
         | DeletedPathStatusUnavailable
 
+    /// Maps Watch's tracked delete evidence into the shared repository path-classification shape.
+    let private repositoryPathKindForDeletedPath pathKind =
+        match pathKind with
+        | DeletedFile -> RepositoryPathKind.FilePath
+        | DeletedDirectory -> RepositoryPathKind.DirectoryPath
+        | DeletedPathKindUnknown -> RepositoryPathKind.UnknownPath
+        | DeletedPathStatusUnavailable -> RepositoryPathKind.StatusUnavailablePath
+
     /// Coordinates repository relative path behavior for this CLI command path.
     let private repositoryRelativePath (fullPath: string) =
         let rootDirectory =
@@ -1388,23 +1385,6 @@ module Watch =
         | :? IOException as ex -> AmbiguousMarkerBoundary $"could not read active update marker boundary: {ex.Message}"
         | :? UnauthorizedAccessException as ex -> AmbiguousMarkerBoundary $"could not read active update marker boundary: {ex.Message}"
 
-    /// Evaluates is grace status artifact against parsed options and command state.
-    let private isGraceStatusArtifact (fullPath: string) =
-        let statusFile = Current().GraceStatusFile
-
-        fullPath.Equals(statusFile, watchPathComparison)
-        || fullPath.Equals(statusFile + "-wal", watchPathComparison)
-        || fullPath.Equals(statusFile + "-shm", watchPathComparison)
-        || fullPath.Equals(statusFile + "-journal", watchPathComparison)
-
-    /// Identifies Grace-owned paths using only the Watch-lifetime namespace snapshot, without consulting final filesystem state.
-    let private isGraceInternalRawObservationPath fullPath =
-        let snapshot = currentWatchIgnoreSnapshot ()
-        isPathWithinDirectoryForWatch snapshot.GraceDirectory fullPath
-
-    /// Rejects Grace-owned paths before raw candidate scope capture.
-    let private tryClassifyRawLocalObservation fallbackKind fullPath = if isGraceInternalRawObservationPath fullPath then None else Some fallbackKind
-
     /// Finds the tracked file entry that owns a repository-relative path with the requested comparison.
     let private tryFindTrackedFileWithComparison (comparison: StringComparison) (status: GraceStatus) (relativePath: RelativePath) =
         let normalizedRelativePath = normalizeRelativePath relativePath
@@ -1824,6 +1804,26 @@ module Watch =
             trackedDeletedPathKind status relativePath
         with
         | _ -> DeletedPathStatusUnavailable
+
+    /// Classifies one raw callback path from current filesystem shape or trusted tracked delete evidence.
+    let private classifyRawLocalObservation (fallbackKind: WatchObservationKind) (fullPath: string) =
+        match fallbackKind with
+        | Deleted ->
+            match classifyRepositoryPathForWatch RepositoryPathKind.UnknownPath fullPath with
+            | RepositoryPathClassification.Eligible ->
+                let pathKind =
+                    match repositoryRelativePath fullPath with
+                    | Some relativePath ->
+                        relativePath
+                        |> readTrackedDeletedPathKind
+                        |> repositoryPathKindForDeletedPath
+                    | None -> RepositoryPathKind.UnknownPath
+
+                classifyRepositoryPathForWatch pathKind fullPath
+            | classification -> classification
+        | _ when Directory.Exists(fullPath) -> classifyRepositoryPathForWatch RepositoryPathKind.DirectoryPath fullPath
+        | _ when File.Exists(fullPath) -> classifyRepositoryPathForWatch RepositoryPathKind.FilePath fullPath
+        | _ -> classifyRepositoryPathForWatch RepositoryPathKind.UnknownPath fullPath
 
     /// Reports whether a marker completion instant is recent enough to suppress delayed Watch callbacks.
     let private isRecentGraceUpdateMarkerCompletion completedUtc =
@@ -2465,48 +2465,10 @@ module Watch =
 
         { Applicable = applicable; Resolved = resolved }
 
-    /// Coordinates should ignore deleted path behavior for this CLI command path.
+    /// Checks a deleted path against the shared classifier while preserving status-unavailable recovery behavior.
     let private shouldIgnoreDeletedPath (pathKind: DeletedPathKind) (fullPath: string) =
-        let snapshot = currentWatchIgnoreSnapshot ()
-        let normalizedFullPath = Path.GetFullPath(fullPath)
-        let graceDirectory = Path.TrimEndingDirectorySeparator(snapshot.GraceDirectory)
-        let fileInfo = FileInfo(fullPath)
-        let deletedDirectoryInfo = DirectoryInfo(normalizedFullPath)
-
-        let isInGraceDirectory = isPathWithinDirectoryForWatch graceDirectory normalizedFullPath
-
-        let isGraceStatusArtifact =
-            normalizedFullPath.Equals(snapshot.GraceStatusFile, watchPathComparison)
-            || normalizedFullPath.Equals(snapshot.GraceStatusFile + "-wal", watchPathComparison)
-            || normalizedFullPath.Equals(snapshot.GraceStatusFile + "-shm", watchPathComparison)
-            || normalizedFullPath.Equals(snapshot.GraceStatusFile + "-journal", watchPathComparison)
-
-        if isInGraceDirectory || isGraceStatusArtifact then
-            true
-        elif pathKind = DeletedPathStatusUnavailable then
-            false
-        else
-            /// Coordinates directory ignore matches behavior for this CLI command path.
-            let directoryIgnoreMatches graceIgnoreLine =
-                if isNull fileInfo.Directory then
-                    false
-                else
-                    checkIgnoreLineAgainstDirectory fileInfo.Directory graceIgnoreLine
-
-            (pathKind <> DeletedDirectory
-             && normalizedFullPath.EndsWith(".gracetmp", watchPathComparison))
-            || (pathKind = DeletedPathKindUnknown
-                && snapshot.DirectoryEntries
-                   |> Array.exists directoryIgnoreMatches)
-            || (pathKind = DeletedPathKindUnknown
-                && snapshot.DirectoryEntries
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstDirectory deletedDirectoryInfo graceIgnoreLine))
-            || (pathKind <> DeletedDirectory
-                && snapshot.DirectoryEntries
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
-            || (pathKind = DeletedPathKindUnknown
-                && snapshot.FileEntries
-                   |> Array.exists (fun graceIgnoreLine -> checkIgnoreLineAgainstFile normalizedFullPath graceIgnoreLine))
+        classifyRepositoryPathForWatch (repositoryPathKindForDeletedPath pathKind) fullPath
+        <> Eligible
 
     /// Coordinates enqueue status update trigger behavior for this CLI command path.
     let private enqueueStatusUpdateTrigger fullPath =
@@ -8265,16 +8227,15 @@ module Watch =
                 signalRConnection.InvokeAsync("RegisterParentBranch", branchId, parentBranchId, cancellationToken))
             cancellationToken
 
-    /// Admits one raw callback through the shared Grace-internal namespace guard before scheduling or direct test processing.
+    /// Admits one raw callback only after the shared classifier selects its complete side-effect boundary.
     let private admitRawLocalObservation fallbackKind fullPath seenAt =
-        if isGraceStatusArtifact fullPath then
-            recordLocalStatusRevisionCheckObservation ()
-        else
-            match tryClassifyRawLocalObservation fallbackKind fullPath with
-            | None -> ()
-            | Some kind when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate kind fullPath seenAt
-            | Some kind when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately kind fullPath
-            | Some _ -> ()
+        match classifyRawLocalObservation fallbackKind fullPath with
+        | LocalStateArtifact -> recordLocalStatusRevisionCheckObservation ()
+        | GraceInternal
+        | Ignored -> ()
+        | Eligible when isLocalObservationCandidateSchedulingActive () -> acceptLocalObservationCandidate fallbackKind fullPath seenAt
+        | Eligible when useImmediateLocalObservationProcessingForWatchTests () -> processLocalObservationImmediately fallbackKind fullPath
+        | Eligible -> ()
 
     /// Coordinates on created behavior for this CLI command path.
     let OnCreated (args: FileSystemEventArgs) =


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #806

Part of #801

## Summary

Use one boundary-aware repository path classifier for normal indexing and Watch callback admission. Root
`.graceignore` and other shared-prefix siblings remain ordinary files, true `.grace` descendants stay internal, and
exact local SQLite artifacts retain only silent revision coordination.

The classifier is now the first Watch callback side-effect boundary and independently classifies rename endpoints.
Ignored/internal paths stop before ordinary logs, candidates, uploads, catch-up, pending state, and IPC work while
preserving replay, cursor, source-delivery, delete-recovery, ignore-grammar, and current lexical symlink behavior.

## Touched paths

- `src/Grace.CLI/Command/Services.CLI.fs`
- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: Product V1.
- Public behavior target: index/save includes root `.graceignore`; ignored/internal Watch callbacks remain silent; exact
  local database artifacts retain revision coordination only.
- RED evidence: three focused tests failed because `.graceignore` was omitted and ignored change/rename endpoints
  created raw candidates.
- Focused validation: warning-free Release build plus 12/12 path-classification, silent-admission, rename, and database
  artifact tests passed.

## Minimum detail gate evidence

- Product decisions: existing ignore grammar, lexical symlink/reparse policy, delete recovery, and local database
  coordination remain unchanged.
- Invariant tuple: normalized path, frozen repository root/Grace directory, platform comparison, ignore result, and
  exact database artifact name select one of `Eligible`, `Ignored`, `GraceInternal`, or `LocalStateArtifact`.
- Contract propagation: internal CLI classifier and tests only; no DTO, route, SDK, OpenAPI, generated, persisted, or
  public command/status shape changed.
- Revalidation proof: immutable scans and Watch callbacks use the same frozen-volume comparison; raw callback
  classification precedes ordinary side effects.
- Forbidden shapes avoided: no unbounded raw Grace-directory prefix check, per-callback duplicate containment rule,
  generic suppression of database side files, or Watch-only repair.
- Positive, negative, regression, and boundary coverage: root `.graceignore`, true descendants, configured ignores,
  shared prefixes, drive-root/separator/case boundaries, independent rename endpoints, missing/delete paths, and
  database/WAL/SHM/journal callbacks.
- Risk traps: callback ordering, platform comparison, rename asymmetry, database coordination, and false-positive
  silence assertions.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `Watch.Tests.fs` adds retained-`.graceignore` scanning, four-outcome classifier boundaries, silent raw/final callback
  admission, independent rename endpoints, indexed-file no-surprise Add/Delete behavior, and database side-file
  create/change/delete coordination coverage.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Any genuinely required validation that was not run is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [x] Docs impact: None - command syntax, ignore grammar, and public status contract remain unchanged; no published
  wording contradicted the corrected boundary behavior.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Local focused evidence

- [x] Focused proof: Release CLI build passed with 0 warnings and 0 errors; focused path-classification,
  silent-admission, rename, and local-state coordination selection passed 12/12. After CI exposed tracked-removal
  regressions, the exact/adjacent selection passed 65/65, dedicated #806 categories passed 10/10, and the full
  `Grace.CLI.Tests` project passed 1323/1323.
- [x] Formatting/linting: targeted Fantomas passed for all three touched F# files; `git diff --check` passed.
- [x] Generated-file/freshness or syntax checks: active CLI-source audit found no remaining raw Grace-directory
  `StartsWith` checks.
- [x] Manual validation: disposable temporary-repository scanning provided the retained-`.graceignore` reset-repository
  proof. Shared DebugLocal was not restarted because it adds no classifier-specific evidence.

## Optional local broad preflight

- [x] Fast, Full, or neither: neither; the focused Release gate is the selected local proof and GitHub Validate is the
  required broad gate.

## Required CI evidence

- Current head SHA: `086db9212a7a3ef2299aed7e31f57dd5828f5a4f`
- GitHub `Validate` state: passed.
- GitHub Actions run link: [31170766722](https://github.com/ScottArbeit/Grace/actions/runs/31170766722).
- [x] The result was triggered by and remains associated with the latest PR revision.

## Validation not run

None. Local Full/emulator validation is not required because the changed behavior is deterministic path classification
and callback admission, covered by disposable filesystem fixtures; GitHub Validate remains required.

## Residual risks

- Symlink/reparse handling remains the existing lexical policy by design; this issue does not introduce filesystem
  identity resolution.

## Review Status

- Worker starts: 2/4.
- Current head SHA: `086db9212a7a3ef2299aed7e31f57dd5828f5a4f`
- Fresh review subagent: `gpt-5.6-terra`, `reasoning_effort: high`, `fork_turns: none`
- `dev-process/CODE_REVIEW.md` followed: yes, review session 2.
- Review verdict for current head: approve; no fix-now findings.
- Required PR checks for current head: GitHub Validate run 31170766722 passed.
- [x] Review and required checks both completed successfully for the same head SHA.
- Finding dispositions and detailed review/fix comments: session 1 approved, but its exact-head CI exposed eight tracked
  removal regressions. Worker 2 fixed the shared family in `086db921`; session 2 approved the corrected head.

## Review/fix prevention

- **Root-cause class:** acceptance-criteria / negative-proof gap. The issue required ignored callback silence but did
  not initially state the inherited tracked-removal exception. The issue now distinguishes untracked ignored admission
  from required reconciliation of content already present in local status.

## Rollback or recovery notes

Reverting the commit restores the prior prefix-based behavior. No durable shape, migration, server event, remote cursor,
or recovery action is involved.

## Docs follow-up required

None currently; fresh review will confirm the no-docs disposition.
