### PR TITLE
Make Watch pending reasons and IPC transitions truthful

### DIFF
--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -16215,8 +16215,148 @@ module WatchTests =
             File.ReadAllText(Services.IpcFileName())
             |> should equal dirtyJson)
 
+    /// Verifies coordinator-owned pending state remains distinct from ordinary local observation work.
+    [<Test; Category("WatchPendingReasons")>]
+    let ``watch pending reasons keep manual materialization separate from local candidates`` () =
+        withTempRepo (fun root ->
+            Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+
+            Watch.pendingWatchWorkReasonNamesForWatchTests ()
+            |> should
+                equal
+                [|
+                    "remote materialization is applying"
+                |]
+
+            let filePath = Path.Combine(root, "reasoned-pending.txt")
+            File.WriteAllText(filePath, "pending content")
+            Watch.OnChanged(changedEvent filePath)
+
+            Watch.pendingWatchWorkReasonNamesForWatchTests ()
+            |> should
+                equal
+                [|
+                    "file uploads are pending"
+                    "remote materialization is applying"
+                |])
+
+    /// Verifies reason transitions remain diagnostic while an unchanged public dirty contract is not rewritten.
+    [<Test; Category("WatchPendingReasons")>]
+    let ``watch reason transition logs once without rewriting unchanged dirty ipc`` () =
+        withTempRepo (fun root ->
+            let status = graceStatusTracking Array.empty<string> Array.empty<string>
+            let directoryIds = HashSet<DirectoryVersionId>(status.Index.Keys)
+            let diagnostics = ResizeArray<string>()
+
+            try
+                Watch.setPendingWatchReasonDiagnosticForWatchTests diagnostics.Add
+                Services.setGraceWatchHasPendingWorkForStatus false
+
+                (Services.updateGraceWatchInterprocessFile status (Some directoryIds))
+                    .GetAwaiter()
+                    .GetResult()
+
+                Watch.setGraceWatchPendingWorkStatusFlagForWatchTests true
+                Watch.setReadGraceStatusFileForPendingWorkTransitionForWatchTests (fun () -> Task.FromResult(status))
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                let manualDirtyJson = File.ReadAllText(Services.IpcFileName())
+
+                Watch.forgetPendingWatchWorkPublicationForWatchTests ()
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                File.ReadAllText(Services.IpcFileName())
+                |> should equal manualDirtyJson
+
+                let filePath = Path.Combine(root, "reason-transition.txt")
+                File.WriteAllText(filePath, "pending content")
+
+                Watch.OnChanged(changedEvent filePath)
+                Watch.OnChanged(changedEvent filePath)
+
+                File.ReadAllText(Services.IpcFileName())
+                |> should equal manualDirtyJson
+
+                diagnostics.ToArray()
+                |> should
+                    equal
+                    [|
+                        "remote materialization is applying"
+                        "file uploads are pending; remote materialization is applying"
+                    |]
+            finally
+                Watch.resetPendingWatchReasonDiagnosticForWatchTests ())
+
+    /// Verifies duplicate cursor wakes stay quiet while a changed safe-point reason remains visible.
+    [<Test; Category("WatchPendingReasons")>]
+    let ``remote event wait diagnostics are transition based`` () =
+        withTempRepo (fun _ ->
+            let current = Current()
+
+            let payload =
+                { CurrentBranchReferenceNotification.Default with
+                    RepositoryId = current.RepositoryId
+                    BranchId = current.BranchId
+                    ReferenceId = Guid.NewGuid()
+                }
+
+            let diagnostics = ResizeArray<string>()
+
+            try
+                Watch.setCurrentBranchWaitDiagnosticForWatchTests (fun _ waitKind reason -> diagnostics.Add($"{waitKind}: {reason}"))
+
+                Watch.reportCurrentBranchWaitTransitionForWatchTests payload (Watch.CurrentBranchMaterializationStatusGate.Blocked "file uploads are pending")
+                Watch.reportCurrentBranchWaitTransitionForWatchTests payload (Watch.CurrentBranchMaterializationStatusGate.Blocked "file uploads are pending")
+
+                Watch.reportCurrentBranchWaitTransitionForWatchTests
+                    payload
+                    (Watch.CurrentBranchMaterializationStatusGate.Blocked "durable Watch journal observations are pending")
+
+                diagnostics.ToArray()
+                |> should
+                    equal
+                    [|
+                        "safe local Watch point: file uploads are pending"
+                        "safe local Watch point: durable Watch journal observations are pending"
+                    |]
+            finally
+                Watch.resetCurrentBranchWaitDiagnosticForWatchTests ())
+
+    /// Verifies unreadable durable evidence stays dirty and observable without repeating an unchanged error reason.
+    [<Test; Category("WatchPendingReasons")>]
+    let ``unreadable durable journal reason remains dirty and logs once`` () =
+        withTempRepo (fun _ ->
+            let diagnostics = ResizeArray<string>()
+
+            try
+                Watch.setPendingWatchReasonDiagnosticForWatchTests diagnostics.Add
+
+                Watch.setWatchJournalStatusClientForWatchTests (fun () ->
+                    Task.FromException<LocalStateDb.WatchJournalPendingWorkSummary>(InvalidOperationException("injected unreadable journal")))
+
+                Watch.pendingWatchWorkReasonNamesForWatchTests ()
+                |> should
+                    equal
+                    [|
+                        "durable Watch journal is unreadable"
+                    |]
+
+                let processablePending, hasPending = Watch.pendingWatchWorkEvidenceForWatchTests ()
+                processablePending |> should equal false
+                hasPending |> should equal true
+
+                diagnostics.ToArray()
+                |> should
+                    equal
+                    [|
+                        "durable Watch journal is unreadable"
+                    |]
+            finally
+                Watch.resetWatchJournalClientsForWatchTests ()
+                Watch.resetPendingWatchReasonDiagnosticForWatchTests ())
+
     /// Verifies that durable journal evidence marks Watch status dirty even when process-local queues are empty.
-    [<Test>]
+    [<Test; Category("WatchPendingReasons")>]
     let ``watch durable pending journal evidence publishes dirty transition`` () =
         withTempRepo (fun _ ->
             let status = graceStatusTracking Array.empty<string> Array.empty<string>
@@ -16235,6 +16375,13 @@ module WatchTests =
                     .GetResult()
 
                 Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                let durableDirtyJson = File.ReadAllText(Services.IpcFileName())
+                Watch.forgetPendingWatchWorkPublicationForWatchTests ()
+                Watch.publishPendingWatchWorkTransitionIfNeededForWatchTests ()
+
+                File.ReadAllText(Services.IpcFileName())
+                |> should equal durableDirtyJson
 
                 readWatchStatusJsonBooleanProperty "HasPendingWatchWork"
                 |> should equal true
@@ -26065,28 +26212,41 @@ module WatchTests =
 
             let reestablishIpc _ _ = Task.FromResult(())
             let applyReference _ _ = Task.FromException<unit>(InvalidOperationException("process-local Watch queues must not apply"))
+            let diagnostics = ResizeArray<string>()
 
-            let outcome =
-                (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
-                    getBranch
-                    inspectStatus
-                    requestDegradedResync
-                    waitForSafePoint
-                    reestablishIpc
-                    applyReference
-                    notification)
-                    .Result
+            try
+                Watch.setCurrentBranchWaitDiagnosticForWatchTests (fun _ waitKind reason -> diagnostics.Add($"{waitKind}: {reason}"))
 
-            outcome.Value.Reason
-            |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                let outcome =
+                    (Watch.handleCurrentBranchReferenceMaterializationWithClientsForWatchTests
+                        getBranch
+                        inspectStatus
+                        requestDegradedResync
+                        waitForSafePoint
+                        reestablishIpc
+                        applyReference
+                        notification)
+                        .Result
 
-            safePointWaits.ToArray()
-            |> should
-                equal
-                [|
-                    "process-local Watch queues have pending local observations"
-                    "process-local Watch queues have pending local observations"
-                |])
+                outcome.Value.Reason
+                |> should equal Watch.CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+
+                safePointWaits.ToArray()
+                |> should
+                    equal
+                    [|
+                        "file uploads are pending"
+                        "file uploads are pending"
+                    |]
+
+                diagnostics.ToArray()
+                |> should
+                    equal
+                    [|
+                        "safe local Watch point: file uploads are pending"
+                    |]
+            finally
+                Watch.resetCurrentBranchWaitDiagnosticForWatchTests ())
 
     /// Verifies that the materialization gate waits while the existing Grace update marker is present.
     [<Test; Category("CurrentBranchMaterializationCoordinator"); Category("BranchSwitchSerialization")>]

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -19279,20 +19279,23 @@ module WatchTests =
 
                     Services.updateGraceWatchInterprocessFile currentStatus directoryIds
 
-                (Watch.processChangedFilesWithClients
-                    readStatus
-                    readStatus
-                    upload
-                    updateGraceStatus
-                    scanForDifferences
-                    updateGraceStatusFromDifferences
-                    applyIncremental
-                    updateIpc)
-                    .GetAwaiter()
-                    .GetResult()
+                /// Drives the active resync recovery helper with the same unchanged durable-only journal state.
+                let processRecovery () =
+                    (Watch.processChangedFilesWithClients
+                        readStatus
+                        readStatus
+                        upload
+                        updateGraceStatus
+                        scanForDifferences
+                        updateGraceStatusFromDifferences
+                        applyIncremental
+                        updateIpc)
+                        .GetAwaiter()
+                        .GetResult()
 
-                publicationCalls
-                |> should be (greaterThanOrEqualTo 2)
+                processRecovery ()
+
+                publicationCalls |> should equal 1
 
                 Watch.hasManualPendingWatchWorkStatusFlagForWatchTests ()
                 |> should equal true
@@ -19305,16 +19308,46 @@ module WatchTests =
 
                 pendingRows |> should equal 1L
 
-                let inspection = Services.inspectGraceWatchStatus().Result
+                let firstInspection = Services.inspectGraceWatchStatus().Result
 
-                match inspection.Status with
-                | Some publishedStatus ->
-                    publishedStatus.HasPendingWatchWork
-                    |> should equal true
+                let firstPublishedStatus =
+                    firstInspection.Status
+                    |> Option.defaultWith (fun () -> failwith "Expected verified dirty Watch IPC after durable work arrived during recovery publication.")
 
-                    publishedStatus.IsWorkingTreeClean
-                    |> should equal false
-                | None -> Assert.Fail("Expected verified dirty Watch IPC after durable work arrived during recovery publication.")
+                firstPublishedStatus.HasPendingWatchWork
+                |> should equal true
+
+                firstPublishedStatus.IsWorkingTreeClean
+                |> should equal false
+
+                Watch.lastPublishedHasPendingWatchWorkForWatchTests ()
+                |> should equal (Some true)
+
+                firstPublishedStatus.UpdatedAt.Minus(Duration.FromMilliseconds(1.0))
+                |> updatePersistedWatchStatusUpdatedAt
+
+                let unchangedContractJson = File.ReadAllText(Services.IpcFileName())
+
+                processRecovery ()
+
+                publicationCalls |> should equal 1
+
+                File.ReadAllText(Services.IpcFileName())
+                |> should equal unchangedContractJson
+
+                let retryInspection = Services.inspectGraceWatchStatus().Result
+
+                match retryInspection.Status with
+                | Some retryStatus ->
+                    retryStatus.LastFileUploadInstant
+                    |> should equal firstPublishedStatus.LastFileUploadInstant
+
+                    retryStatus.LastDirectoryVersionInstant
+                    |> should equal firstPublishedStatus.LastDirectoryVersionInstant
+                | None -> Assert.Fail("Expected unchanged verified dirty Watch IPC after durable-only recovery retry.")
+
+                Watch.lastPublishedHasPendingWatchWorkForWatchTests ()
+                |> should equal (Some true)
             finally
                 Watch.resetWatchJournalClientsForWatchTests ())
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3350,34 +3350,77 @@ module Watch =
 
             Ok summary.HasPendingRows
         with
-        | ex ->
-            logToAnsiConsole
-                Colors.Error
-                $"Grace Watch could not inspect durable journal pending work; treating status as dirty until local state can be read: {Markup.Escape(ex.Message)}."
+        | ex -> Error ex.Message
 
-            Error ex.Message
+    /// Names each active producer that can prevent Watch from advertising a clean local boundary.
+    type internal PendingWatchWorkReason =
+        | ResyncRequired
+        | LocalObservationConfidenceLost
+        | GraceStatusRefreshPending
+        | LocalObservationCandidatesPending
+        | FileUploadsPending
+        | FileRecoveryPending
+        | DirectoryInspectionsPending
+        | StatusTriggersPending
+        | StatusDifferencesPending
+        | DurableJournalPending
+        | DurableJournalUnreadable
+        | RemoteMaterializationApplying
 
-    /// Reports whether unresolved durable journal rows must keep Watch status dirty.
-    let private hasPendingDurableWatchJournalEvidence () =
-        match inspectDurableWatchJournalPendingEvidence () with
-        | Ok hasPendingRows -> hasPendingRows
-        | Error _ -> true
+        /// Describes the concrete producer in diagnostics without changing the public Watch IPC contract.
+        member this.Description =
+            match this with
+            | ResyncRequired -> "Watch resync is pending"
+            | LocalObservationConfidenceLost -> "local observation confidence is lost"
+            | GraceStatusRefreshPending -> "Grace Status refresh is pending"
+            | LocalObservationCandidatesPending -> "local observation candidates are pending"
+            | FileUploadsPending -> "file uploads are pending"
+            | FileRecoveryPending -> "file recovery evidence is pending"
+            | DirectoryInspectionsPending -> "directory inspections are pending"
+            | StatusTriggersPending -> "status triggers are pending"
+            | StatusDifferencesPending -> "status differences are pending"
+            | DurableJournalPending -> "durable Watch journal observations are pending"
+            | DurableJournalUnreadable -> "durable Watch journal is unreadable"
+            | RemoteMaterializationApplying -> "remote materialization is applying"
 
-    /// Describes pending Watch work without merging process-local queues and durable journal evidence.
+        /// Reports whether this reason is ordinary local work rather than durable or coordinator-owned evidence.
+        member this.IsProcessableLocalWork =
+            match this with
+            | DurableJournalPending
+            | DurableJournalUnreadable
+            | RemoteMaterializationApplying -> false
+            | _ -> true
+
+    /// Describes pending Watch work without merging distinct local, durable, and coordinator-owned causes.
     type private PendingWatchWorkEvidence =
         {
-            HasProcessablePendingWork: bool
-            HasManualPendingStatusEvidence: bool
-            HasDurableWatchJournalEvidence: bool
-            HasLocalObservationConfidenceLoss: bool
+            Reasons: PendingWatchWorkReason array
         }
 
         /// Reports whether Watch work, confidence loss, or durable journal evidence must keep IPC dirty.
-        member this.HasPendingWork =
-            this.HasProcessablePendingWork
-            || this.HasManualPendingStatusEvidence
-            || this.HasDurableWatchJournalEvidence
-            || this.HasLocalObservationConfidenceLoss
+        member this.HasPendingWork = this.Reasons.Length > 0
+
+        /// Reports whether process-local work can advance during the current timer pass.
+        member this.HasProcessablePendingWork =
+            this.Reasons
+            |> Array.exists (fun reason -> reason.IsProcessableLocalWork)
+
+        /// Reports whether the coordinator-owned remote apply latch contributes to this snapshot.
+        member this.HasManualPendingStatusEvidence =
+            this.Reasons
+            |> Array.contains RemoteMaterializationApplying
+
+        /// Reports whether durable journal rows or an unreadable journal contribute to this snapshot.
+        member this.HasDurableWatchJournalEvidence =
+            this.Reasons
+            |> Array.exists (fun reason ->
+                reason = DurableJournalPending
+                || reason = DurableJournalUnreadable)
+
+        /// Reports whether raw local observation confidence has been lost.
+        member this.HasLocalObservationConfidenceLoss =
+            this.Reasons
+            |> Array.contains LocalObservationConfidenceLost
 
         /// Reports whether durable journal evidence is the only reason IPC must be dirty.
         member this.HasDurableOnlyPendingWork =
@@ -3385,6 +3428,56 @@ module Watch =
             && not this.HasProcessablePendingWork
             && not this.HasManualPendingStatusEvidence
             && not this.HasLocalObservationConfidenceLoss
+
+    let private pendingWatchReasonDiagnosticLock = obj ()
+    let mutable private lastReportedPendingWatchReasons: PendingWatchWorkReason array option = None
+
+    let mutable private pendingWatchReasonDiagnostic =
+        fun (description: string) ->
+            let color =
+                if description.Contains("unreadable", StringComparison.Ordinal) then
+                    Colors.Error
+                else
+                    Colors.Important
+
+            logToAnsiConsole color $"Grace Watch pending reason transition: {description}."
+
+    /// Emits one diagnostic only when the concrete pending-reason set changes.
+    let private reportPendingWatchReasonTransition (evidence: PendingWatchWorkEvidence) =
+        let descriptionToReport =
+            lock pendingWatchReasonDiagnosticLock (fun () ->
+                match lastReportedPendingWatchReasons, evidence.Reasons with
+                | Some previous, current when previous = current -> None
+                | None, current when current.Length = 0 ->
+                    lastReportedPendingWatchReasons <- Some Array.empty
+                    None
+                | _ ->
+                    lastReportedPendingWatchReasons <- Some(Array.copy evidence.Reasons)
+
+                    evidence.Reasons
+                    |> Array.map (fun reason -> reason.Description)
+                    |> String.concat "; "
+                    |> function
+                        | "" -> Some "no pending Watch reason"
+                        | description -> Some description)
+
+        descriptionToReport
+        |> Option.iter pendingWatchReasonDiagnostic
+
+    /// Captures the concrete process-local producers without treating the manual remote-apply latch as local work.
+    let private readProcessLocalPendingWatchReasons () =
+        [|
+            if isGraceWatchResyncPending () then ResyncRequired
+            if hasLocalObservationConfidenceLoss () then LocalObservationConfidenceLost
+            if graceStatusHasChanged then GraceStatusRefreshPending
+            if hasPendingLocalObservationCandidates () then
+                LocalObservationCandidatesPending
+            if not filesToProcess.IsEmpty then FileUploadsPending
+            if not fileRecoveryEvidence.IsEmpty then FileRecoveryPending
+            if not directoriesToProcess.IsEmpty then DirectoryInspectionsPending
+            if not statusUpdateTriggers.IsEmpty then StatusTriggersPending
+            if hasPendingStatusDifferences () then StatusDifferencesPending
+        |]
 
     /// Distinguishes exact IPC verification from the pending-work state that snapshot advertises.
     type private PendingWatchWorkPublicationVerification =
@@ -3404,50 +3497,71 @@ module Watch =
         /// Recovery could not prove a clean result and must retain fail-closed pending state.
         | UnverifiedRecoveryPublication
 
-    /// Reports whether Watch has queued process-local work other than a startup catch-up marker.
-    let private hasProcessablePendingWatchWorkExceptManual () =
-        isGraceWatchResyncPending ()
-        || hasLocalObservationConfidenceLoss ()
-        || graceStatusHasChanged
-        || hasPendingLocalObservationCandidates ()
-        || not (
-            filesToProcess.IsEmpty
-            && fileRecoveryEvidence.IsEmpty
-            && directoriesToProcess.IsEmpty
-            && statusUpdateTriggers.IsEmpty
-            && not (hasPendingStatusDifferences ())
-        )
+    /// Reads process-local and durable pending-work facts once for a single status publication decision.
+    let private readPendingWatchWorkEvidence () =
+        let durableReason =
+            match inspectDurableWatchJournalPendingEvidence () with
+            | Ok true -> Some DurableJournalPending
+            | Ok false -> None
+            | Error _ -> Some DurableJournalUnreadable
 
-    /// Evaluates pending Watch work without counting the startup catch-up marker against its own clean publication.
+        let reasons =
+            [|
+                yield! readProcessLocalPendingWatchReasons ()
+                match durableReason with
+                | Some reason -> yield reason
+                | None -> ()
+                if hasManualPendingWatchWorkStatusFlag () then
+                    yield RemoteMaterializationApplying
+            |]
+
+        let evidence = { Reasons = reasons }
+        reportPendingWatchReasonTransition evidence
+        evidence
+
+    /// Reports whether Watch has queued process-local work other than the remote materialization latch.
+    let private hasProcessablePendingWatchWorkExceptManual () =
+        readProcessLocalPendingWatchReasons ()
+        |> Array.exists (fun reason -> reason.IsProcessableLocalWork)
+
+    /// Evaluates pending Watch work without counting the coordinator-owned remote materialization latch.
     let private hasPendingWatchWorkExceptManual () =
-        hasProcessablePendingWatchWorkExceptManual ()
-        || hasPendingDurableWatchJournalEvidence ()
+        let evidence = readPendingWatchWorkEvidence ()
+
+        evidence.Reasons
+        |> Array.exists (fun reason -> reason <> RemoteMaterializationApplying)
 
     /// Reports whether Watch has queued process-local work that can advance during the current timer pass.
     let private hasProcessablePendingWatchWork () = hasProcessablePendingWatchWorkExceptManual ()
 
-    /// Evaluates has pending watch work against parsed options, process state, and durable journal evidence.
-    let private hasPendingWatchWork () =
-        hasManualPendingWatchWorkStatusFlag ()
-        || hasProcessablePendingWatchWork ()
-        || hasPendingDurableWatchJournalEvidence ()
-
-    /// Reads process-local and durable pending-work facts once for a single status publication decision.
-    let private readPendingWatchWorkEvidence () =
-        let hasProcessablePendingWork = hasProcessablePendingWatchWork ()
-
-        {
-            HasProcessablePendingWork = hasProcessablePendingWork
-            HasManualPendingStatusEvidence = hasManualPendingWatchWorkStatusFlag ()
-            HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence ()
-            HasLocalObservationConfidenceLoss = hasLocalObservationConfidenceLoss ()
-        }
+    /// Evaluates all pending Watch reasons from one coherent publication snapshot.
+    let private hasPendingWatchWork () = (readPendingWatchWorkEvidence ()).HasPendingWork
 
     /// Exposes pending Watch work checks to tests without running the foreground timer loop.
     let internal pendingWatchWorkEvidenceForWatchTests () =
         let evidence = readPendingWatchWorkEvidence ()
 
         evidence.HasProcessablePendingWork, evidence.HasPendingWork
+
+    /// Lists the concrete pending reasons in stable diagnostic order for focused Watch tests.
+    let internal pendingWatchWorkReasonNamesForWatchTests () =
+        (readPendingWatchWorkEvidence ()).Reasons
+        |> Array.map (fun reason -> reason.Description)
+
+    /// Captures pending-reason transition diagnostics without redirecting process-wide console output.
+    let internal setPendingWatchReasonDiagnosticForWatchTests diagnostic = pendingWatchReasonDiagnostic <- diagnostic
+
+    /// Restores production pending-reason diagnostics after a focused Watch test.
+    let internal resetPendingWatchReasonDiagnosticForWatchTests () =
+        pendingWatchReasonDiagnostic <-
+            fun (description: string) ->
+                let color =
+                    if description.Contains("unreadable", StringComparison.Ordinal) then
+                        Colors.Error
+                    else
+                        Colors.Important
+
+                logToAnsiConsole color $"Grace Watch pending reason transition: {description}."
 
     /// Reads the generation for Grace Status DB refresh events observed from the filesystem.
     let private currentGraceStatusRefreshGeneration () = Volatile.Read(&graceStatusRefreshGeneration)
@@ -3599,6 +3713,9 @@ module Watch =
     /// Reports the cached pending-work result so recovery tests can prove failed dirty reassertion discards clean evidence.
     let internal lastPublishedHasPendingWatchWorkForWatchTests () = lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork)
 
+    /// Drops the in-memory publication cache so tests can prove persisted semantic equality prevents a rewrite.
+    let internal forgetPendingWatchWorkPublicationForWatchTests () = lock watchStatusPublishLock (fun () -> lastPublishedHasPendingWatchWork <- None)
+
     /// Returns the exact verified status scope retained for callback admission in focused Watch tests.
     let internal lastPublishedWatchObservationScopeForWatchTests () = lock watchStatusPublishLock (fun () -> lastPublishedWatchObservationScope)
 
@@ -3619,6 +3736,9 @@ module Watch =
         else
             Blake3Hash String.Empty
 
+    /// Supplies one process-stable non-incremental status payload so unchanged recovery reasons do not change observable IPC timestamps.
+    let private nonIncrementalPendingWorkPublicationStatus = GraceStatus.Default
+
     /// Verifies the on-disk Watch IPC snapshot has the exact pending-work and content identity expected by a publication.
     let private statusMatchesExpectedPendingWorkPublication
         (expectedStatus: GraceStatus)
@@ -3626,11 +3746,20 @@ module Watch =
         hasPendingWork
         (status: GraceWatchStatus)
         =
-        status.HasPendingWatchWork = hasPendingWork
+        let current = Current()
+
+        status.RepositoryId = current.RepositoryId
+        && status.RepositoryName = current.RepositoryName
+        && status.BranchId = current.BranchId
+        && status.BranchName = current.BranchName
+        && String.Equals(status.RootDirectory, current.RootDirectory, watchPathComparison)
+        && status.HasPendingWatchWork = hasPendingWork
         && status.IsWorkingTreeClean = not hasPendingWork
         && status.RootDirectoryId = expectedStatus.RootDirectoryId
         && status.RootDirectorySha256Hash = expectedStatus.RootDirectorySha256Hash
         && status.RootDirectoryBlake3Hash = expectedRootDirectoryBlake3Hash expectedStatus
+        && status.LastFileUploadInstant = expectedStatus.LastSuccessfulFileUpload
+        && status.LastDirectoryVersionInstant = expectedStatus.LastSuccessfulDirectoryVersionUpload
         && not (isNull status.DirectoryIds)
         && status.DirectoryIds.SetEquals(expectedDirectoryIds)
 
@@ -3659,6 +3788,18 @@ module Watch =
     let private statusMatchesVerifiedPublication expectedStatus expectedDirectoryIds hasPendingWork publicationStartedAt (status: GraceWatchStatus) =
         status.UpdatedAt >= publicationStartedAt
         && statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork status
+
+    /// Compares the observable Watch IPC contract while deliberately ignoring only its heartbeat timestamp.
+    let private inspectionMatchesExpectedPendingWorkContract
+        expectedStatus
+        expectedDirectoryIds
+        expectedMode
+        hasPendingWork
+        (inspection: GraceWatchStatusInspection)
+        =
+        inspection.EffectiveMode = Some expectedMode
+        && (inspection.Status
+            |> Option.exists (statusMatchesExpectedPendingWorkPublication expectedStatus expectedDirectoryIds hasPendingWork))
 
     /// Advances pending-work and observation-scope caches together only after the exact IPC snapshot proves it reached disk.
     let private cachePendingWatchWorkPublicationIfVerified expectedStatus expectedDirectoryIds expectedObservationScope hasPendingWork publicationStartedAt =
@@ -3790,24 +3931,34 @@ module Watch =
             isGraceWatchResyncAttemptCurrent attempt
             && currentGraceWatchRuntimeMode () = GraceWatchRuntimeMode.HealthyIncremental
 
+        let durableReason =
+            match inspectDurableWatchJournalPendingEvidence () with
+            | Ok true -> Some DurableJournalPending
+            | Ok false -> None
+            | Error _ -> Some DurableJournalUnreadable
+
         {
-            HasProcessablePendingWork =
-                not recoveryStillOwnsPublication
-                || graceStatusHasChanged
-                || hasPendingLocalObservationCandidates ()
-                || not (
-                    filesToProcess.IsEmpty
-                    && directoriesToProcess.IsEmpty
-                    && statusUpdateTriggers.IsEmpty
-                    && not (hasPendingStatusDifferences ())
-                )
-            HasManualPendingStatusEvidence = false
-            HasDurableWatchJournalEvidence = hasPendingDurableWatchJournalEvidence ()
-            HasLocalObservationConfidenceLoss =
-                hasUnconsumedLocalObservationConfidenceLoss ()
-                || (not recoveryStillOwnsPublication
-                    && Volatile.Read(&localObservationConfidenceLossActive)
-                       <> 0)
+            Reasons =
+                [|
+                    if not recoveryStillOwnsPublication then yield ResyncRequired
+                    if graceStatusHasChanged then yield GraceStatusRefreshPending
+                    if hasPendingLocalObservationCandidates () then
+                        yield LocalObservationCandidatesPending
+                    if not filesToProcess.IsEmpty then yield FileUploadsPending
+                    if not directoriesToProcess.IsEmpty then yield DirectoryInspectionsPending
+                    if not statusUpdateTriggers.IsEmpty then yield StatusTriggersPending
+                    if hasPendingStatusDifferences () then yield StatusDifferencesPending
+
+                    if hasUnconsumedLocalObservationConfidenceLoss ()
+                       || (not recoveryStillOwnsPublication
+                           && Volatile.Read(&localObservationConfidenceLossActive)
+                              <> 0) then
+                        yield LocalObservationConfidenceLost
+
+                    match durableReason with
+                    | Some reason -> yield reason
+                    | None -> ()
+                |]
         }
 
     /// Publishes clean IPC for one recovered resync attempt while retaining its own fail-closed pending anchors.
@@ -3861,18 +4012,14 @@ module Watch =
             let hasPendingWork = pendingEvidence.HasPendingWork
             let mutable transitionWasPublished = false
 
-            if
-                File.Exists(IpcFileName())
-                && lastPublishedHasPendingWatchWork
-                   <> Some hasPendingWork
-            then
+            if File.Exists(IpcFileName()) then
                 setGraceWatchHasPendingWorkForStatus hasPendingWork
 
                 let runtimeMode = currentGraceWatchRuntimeMode ()
 
                 let shouldPublish, statusForPublish, directoryIdsForPublish =
                     if pendingEvidence.HasDurableOnlyPendingWork then
-                        true, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                        true, nonIncrementalPendingWorkPublicationStatus, Some(HashSet<DirectoryVersionId>())
                     elif
                         runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                         && not (isGraceWatchResyncPending ())
@@ -3892,7 +4039,7 @@ module Watch =
                                     Colors.Error
                                     $"Grace Watch could not read Grace Status for pending-work dirty status transition; publishing non-incremental status and retrying later: {ex.Message}"
 
-                                true, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                                true, nonIncrementalPendingWorkPublicationStatus, Some(HashSet<DirectoryVersionId>())
                             else
                                 lastPublishedHasPendingWatchWork <- None
 
@@ -3900,44 +4047,64 @@ module Watch =
                                     Colors.Error
                                     $"Grace Watch could not read Grace Status for pending-work clean status transition; retrying later: {ex.Message}"
 
-                                false, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                                false, nonIncrementalPendingWorkPublicationStatus, Some(HashSet<DirectoryVersionId>())
                     else
-                        true, GraceStatus.Default, Some(HashSet<DirectoryVersionId>())
+                        true, nonIncrementalPendingWorkPublicationStatus, Some(HashSet<DirectoryVersionId>())
 
                 if shouldPublish then
-                    let publicationStartedAt = getCurrentInstant ()
+                    let expectedDirectoryIds =
+                        directoryIdsForPublish
+                        |> Option.defaultWith (fun () -> statusForPublish.Index.Keys.ToHashSet())
 
-                    try
-                        let writeTask =
-                            if runtimeMode = GraceWatchRuntimeMode.Suspended then
-                                updateGraceWatchInterprocessFileForSuspendedMode statusForPublish directoryIdsForPublish
-                            else
-                                updateGraceWatchInterprocessFile statusForPublish directoryIdsForPublish
+                    let expectedMode =
+                        if runtimeMode = GraceWatchRuntimeMode.Suspended then
+                            GraceWatchRuntimeMode.Suspended
+                        elif hasWatchObservationRootIdentity statusForPublish then
+                            GraceWatchRuntimeMode.HealthyIncremental
+                        else
+                            GraceWatchRuntimeMode.Resynchronizing
 
-                        writeTask.GetAwaiter().GetResult()
-                    with
-                    | ex ->
-                        lastPublishedHasPendingWatchWork <- None
-                        logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
-
-                    transitionWasPublished <-
+                    let existingContractMatches =
                         try
-                            let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
-
-                            let expectedDirectoryIds =
-                                directoryIdsForPublish
-                                |> Option.defaultWith (fun () -> statusForPublish.Index.Keys.ToHashSet())
-
-                            inspection.Status
-                            |> Option.exists (statusMatchesVerifiedPublication statusForPublish expectedDirectoryIds hasPendingWork publicationStartedAt)
+                            inspectGraceWatchStatus().GetAwaiter().GetResult()
+                            |> inspectionMatchesExpectedPendingWorkContract statusForPublish expectedDirectoryIds expectedMode hasPendingWork
                         with
                         | _ -> false
 
-                    if transitionWasPublished then
+                    if existingContractMatches then
+                        transitionWasPublished <- true
                         lastPublishedHasPendingWatchWork <- Some hasPendingWork
                     else
-                        lastPublishedHasPendingWatchWork <- None
-                        logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check."
+                        let publicationStartedAt = getCurrentInstant ()
+
+                        try
+                            let writeTask =
+                                if runtimeMode = GraceWatchRuntimeMode.Suspended then
+                                    updateGraceWatchInterprocessFileForSuspendedMode statusForPublish directoryIdsForPublish
+                                else
+                                    updateGraceWatchInterprocessFile statusForPublish directoryIdsForPublish
+
+                            writeTask.GetAwaiter().GetResult()
+                        with
+                        | ex ->
+                            lastPublishedHasPendingWatchWork <- None
+                            logToAnsiConsole Colors.Error $"Grace Watch failed to publish pending-work status transition: {ex.Message}"
+
+                        transitionWasPublished <-
+                            try
+                                let inspection = inspectGraceWatchStatus().GetAwaiter().GetResult()
+
+                                inspectionMatchesExpectedPendingWorkContract statusForPublish expectedDirectoryIds expectedMode hasPendingWork inspection
+                                && (inspection.Status
+                                    |> Option.exists (fun status -> status.UpdatedAt >= publicationStartedAt))
+                            with
+                            | _ -> false
+
+                        if transitionWasPublished then
+                            lastPublishedHasPendingWatchWork <- Some hasPendingWork
+                        else
+                            lastPublishedHasPendingWatchWork <- None
+                            logToAnsiConsole Colors.Important $"Grace Watch will retry pending-work status publication on the next transition check."
 
             transitionWasPublished)
 
@@ -3994,9 +4161,10 @@ module Watch =
             setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
 
         let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+        let dirtyStatus = nonIncrementalPendingWorkPublicationStatus
 
         let dirtyPublicationVerified =
-            tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () -> writeSnapshot GraceStatus.Default emptyDirectoryIds)
+            tryPublishWatchIpcWithFreshPendingWorkProbe dirtyStatus emptyDirectoryIds (fun () -> writeSnapshot dirtyStatus emptyDirectoryIds)
             && (try
                     inspectGraceWatchStatus().GetAwaiter().GetResult()
                     |> isGraceWatchResyncRequiredStatusPublished
@@ -4078,7 +4246,7 @@ module Watch =
 
                     let status, directoryIds =
                         if pendingEvidence.HasDurableOnlyPendingWork then
-                            GraceStatus.Default, HashSet<DirectoryVersionId>()
+                            nonIncrementalPendingWorkPublicationStatus, HashSet<DirectoryVersionId>()
                         elif
                             runtimeMode = GraceWatchRuntimeMode.HealthyIncremental
                             && not (isGraceWatchResyncPending ())
@@ -4090,7 +4258,7 @@ module Watch =
 
                             status, status.Index.Keys.ToHashSet()
                         else
-                            GraceStatus.Default, HashSet<DirectoryVersionId>()
+                            nonIncrementalPendingWorkPublicationStatus, HashSet<DirectoryVersionId>()
 
                     if tryVerifyCurrentPendingWorkPublication status directoryIds true then
                         lastPublishedHasPendingWatchWork <- Some true
@@ -4874,6 +5042,9 @@ module Watch =
         lock watchStatusPublishLock (fun () ->
             lastPublishedHasPendingWatchWork <- None
             setGraceWatchHasPendingWorkForStatus false)
+
+        lock pendingWatchReasonDiagnosticLock (fun () -> lastReportedPendingWatchReasons <- None)
+        resetPendingWatchReasonDiagnosticForWatchTests ()
 
         readGraceStatusFileForDeletedPathClassification <- readGraceStatusFile
         readGraceStatusFileForPendingWorkTransition <- readGraceStatusFile
@@ -6595,6 +6766,63 @@ module Watch =
         | Blocked of string
         | Degraded of string
 
+    let private currentBranchWaitTransitionLock = obj ()
+    let mutable private lastReportedCurrentBranchWait: (RepositoryId * BranchId * ReferenceId * string * string) option = None
+
+    let mutable private currentBranchWaitDiagnostic =
+        fun (payload: CurrentBranchReferenceNotification) waitKind reason ->
+            let color = if waitKind = "safe local Watch point" then Colors.Verbose else Colors.Important
+
+            logToAnsiConsole color $"Current-branch reference notification {payload.ReferenceId} is waiting for {waitKind}: {reason}."
+
+    /// Reports a changed event wait reason once while suppressing duplicate replay diagnostics for the same reason.
+    let private reportCurrentBranchWaitTransition (payload: CurrentBranchReferenceNotification) gate =
+        let waitKind, reason =
+            match gate with
+            | Blocked reason -> "safe local Watch point", reason
+            | Degraded reason -> "degraded Watch IPC resync", reason
+            | _ -> invalidArg (nameof gate) "Only waiting materialization gates have transition diagnostics."
+
+        let transition = payload.RepositoryId, payload.BranchId, payload.ReferenceId, waitKind, reason
+
+        let changed =
+            lock currentBranchWaitTransitionLock (fun () ->
+                if lastReportedCurrentBranchWait = Some transition then
+                    false
+                else
+                    lastReportedCurrentBranchWait <- Some transition
+                    true)
+
+        if changed then currentBranchWaitDiagnostic payload waitKind reason
+
+    /// Retires diagnostic state only after the matching remote event reaches a non-waiting outcome.
+    let private retireCurrentBranchWaitTransition (payload: CurrentBranchReferenceNotification) =
+        lock currentBranchWaitTransitionLock (fun () ->
+            match lastReportedCurrentBranchWait with
+            | Some (repositoryId, branchId, referenceId, _, _) when
+                repositoryId = payload.RepositoryId
+                && branchId = payload.BranchId
+                && referenceId = payload.ReferenceId
+                ->
+                lastReportedCurrentBranchWait <- None
+            | _ -> ())
+
+    /// Captures transition-filtered remote wait diagnostics for focused tests.
+    let internal setCurrentBranchWaitDiagnosticForWatchTests diagnostic = currentBranchWaitDiagnostic <- diagnostic
+
+    /// Exercises the production wait-transition filter without starting SignalR or cursor replay.
+    let internal reportCurrentBranchWaitTransitionForWatchTests payload gate = reportCurrentBranchWaitTransition payload gate
+
+    /// Restores production remote wait diagnostics after a focused Watch test.
+    let internal resetCurrentBranchWaitDiagnosticForWatchTests () =
+        currentBranchWaitDiagnostic <-
+            fun payload waitKind reason ->
+                let color = if waitKind = "safe local Watch point" then Colors.Verbose else Colors.Important
+
+                logToAnsiConsole color $"Current-branch reference notification {payload.ReferenceId} is waiting for {waitKind}: {reason}."
+
+        lock currentBranchWaitTransitionLock (fun () -> lastReportedCurrentBranchWait <- None)
+
     /// Coordinates a same-branch Reference once clean IPC and BranchDto latest authority have both been proven.
     type private CurrentBranchMaterializationCoordinatorClients =
         {
@@ -6645,6 +6873,8 @@ module Watch =
         payload
         (inspection: GraceWatchStatusInspection)
         =
+        let processLocalReasons = readProcessLocalPendingWatchReasons ()
+
         let inspectionMatchesOwnedPendingPublication =
             match ownedPendingPublication, inspection.Status, inspection.EffectiveMode with
             | Some publication, Some status, Some GraceWatchRuntimeMode.HealthyIncremental when
@@ -6663,8 +6893,11 @@ module Watch =
         elif not ignoreOwnedMaterializationPendingLatch
              && hasManualPendingWatchWorkStatusFlag () then
             Blocked "materialization pending status has not reached IPC"
-        elif hasProcessablePendingWatchWork () then
-            Blocked "process-local Watch queues have pending local observations"
+        elif processLocalReasons.Length > 0 then
+            processLocalReasons
+            |> Array.map (fun reason -> reason.Description)
+            |> String.concat "; "
+            |> Blocked
         elif inspection.IsUsable
              || inspectionMatchesOwnedPendingPublication then
             if not (hasReadableLocalStateDbAuthority ()) then
@@ -6971,9 +7204,7 @@ module Watch =
                                                                             publishPendingWatchWorkTransitionIfNeeded ()
                                                                             return raise ex
                                                 | Blocked reason ->
-                                                    logToAnsiConsole
-                                                        Colors.Verbose
-                                                        $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point after lease acquisition: {reason}."
+                                                    reportCurrentBranchWaitTransition payload (Blocked reason)
 
                                                     postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Blocked reason)
 
@@ -6984,9 +7215,7 @@ module Watch =
                                                             Decision = Some acceptedDecision
                                                         }
                                                 | Degraded reason ->
-                                                    logToAnsiConsole
-                                                        Colors.Important
-                                                        $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync after lease acquisition: {reason}."
+                                                    reportCurrentBranchWaitTransition payload (Degraded reason)
 
                                                     postLeaseRetryGate <- Some(CurrentBranchMaterializationStatusGate.Degraded reason)
 
@@ -7038,9 +7267,7 @@ module Watch =
                                 terminalOutcome <- cleanOutcome
                                 terminal <- true
                         | Blocked reason as gate ->
-                            logToAnsiConsole
-                                Colors.Verbose
-                                $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point: {reason}."
+                            reportCurrentBranchWaitTransition payload gate
 
                             if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                 terminalOutcome <-
@@ -7077,9 +7304,7 @@ module Watch =
                                 degradedResyncRequestedForReason <- Some reason
 
                             if not terminal then
-                                logToAnsiConsole
-                                    Colors.Important
-                                    $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
+                                reportCurrentBranchWaitTransition payload (Degraded reason)
 
                                 if canRetry () then
                                     do! clients.ReestablishIpc payload reason
@@ -7143,9 +7368,7 @@ module Watch =
 
                             terminal <- true
                         | Blocked reason as gate ->
-                            logToAnsiConsole
-                                Colors.Verbose
-                                $"Current-branch reference notification {payload.ReferenceId} is waiting for a safe local Watch point: {reason}."
+                            reportCurrentBranchWaitTransition payload gate
 
                             if not (currentBranchReferenceNotificationTargetsCurrentBranch payload) then
                                 terminalOutcome <-
@@ -7182,9 +7405,7 @@ module Watch =
                                 degradedResyncRequestedForReason <- Some reason
 
                             if not terminal then
-                                logToAnsiConsole
-                                    Colors.Important
-                                    $"Current-branch reference notification {payload.ReferenceId} is waiting for degraded Watch IPC resync: {reason}."
+                                reportCurrentBranchWaitTransition payload (Degraded reason)
 
                                 if canRetry () then
                                     do! clients.ReestablishIpc payload reason
@@ -7219,10 +7440,19 @@ module Watch =
             let! localSelfEchoConsumed = localCurrentBranchReferenceEchoLedger.TryConsume(payload)
 
             if localSelfEchoConsumed then
+                retireCurrentBranchWaitTransition payload
+
                 return
                     { ReferenceId = payload.ReferenceId; Reason = CurrentBranchMaterializationCoordinatorOutcomeReason.LocalSelfEchoConsumed; Decision = None }
             else
-                return! WorkingDirectoryMaterialization.runSerializedLane (fun () -> processCurrentBranchMaterializationNotification clients payload)
+                let! outcome = WorkingDirectoryMaterialization.runSerializedLane (fun () -> processCurrentBranchMaterializationNotification clients payload)
+
+                match outcome.Reason with
+                | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint
+                | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync -> ()
+                | _ -> retireCurrentBranchWaitTransition payload
+
+                return outcome
         }
 
     /// Reads the current BranchDto so same-branch notifications are checked against server latest-reference authority.
@@ -7575,7 +7805,9 @@ module Watch =
                     | CurrentBranchReferenceCatchUpResult.Processed, Some coordinatorOutcome ->
                         match coordinatorOutcome.Reason, coordinatorOutcome.Decision with
                         | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForSafePoint, _ ->
-                            retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "local Watch work is still pending"
+                            // Cursor replay owns active remote waits and already reports their concrete safe-point reason.
+                            // This legacy BranchDto test seam retains only its bounded scheduling behavior.
+                            scheduler.Retry(claim, nowUtc) |> ignore
                         | CurrentBranchMaterializationCoordinatorOutcomeReason.WaitingForDegradedResync, _ ->
                             retryCurrentBranchReferenceCatchUp scheduler nowUtc claim "local Watch state requires resync"
                         | CurrentBranchMaterializationCoordinatorOutcomeReason.LatestEligibleReferenceRejected, Some decision when
@@ -8008,8 +8240,7 @@ module Watch =
                     logToAnsiConsole Colors.Verbose "Watch replay kept the current local root unchanged because no safe remote event boundary was established."
                 | CurrentBranchReferenceReplayOutcomeReason.ReplayFailed ->
                     logToAnsiConsole Colors.Error "Watch could not replay the current branch cursor; the durable cursor remains unchanged."
-                | CurrentBranchReferenceReplayOutcomeReason.EventNotAcknowledged ->
-                    logToAnsiConsole Colors.Verbose "Watch replay stopped at an event that has not reached a safe terminal acknowledgement."
+                | CurrentBranchReferenceReplayOutcomeReason.EventNotAcknowledged -> ()
                 | CurrentBranchReferenceReplayOutcomeReason.IntervalAcknowledged -> ()
                 | _ -> logToAnsiConsole Colors.Error "Watch replay returned an unsupported local outcome; the durable cursor remains unchanged."
             with
@@ -10071,6 +10302,11 @@ module Watch =
                 use localCurrentBranchReferenceEchoLifetime =
                     { new IDisposable with
                         member _.Dispose() = localCurrentBranchReferenceEchoLedger.Clear()
+                    }
+
+                use currentBranchWaitDiagnosticLifetime =
+                    { new IDisposable with
+                        member _.Dispose() = resetCurrentBranchWaitDiagnosticForWatchTests ()
                     }
 
                 try

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -3848,7 +3848,7 @@ module Watch =
 
                 let statusForVerification, directoryIdsForVerification =
                     if pendingEvidence.HasDurableOnlyPendingWork then
-                        GraceStatus.Default, HashSet<DirectoryVersionId>()
+                        nonIncrementalPendingWorkPublicationStatus, HashSet<DirectoryVersionId>()
                     else
                         expectedStatus, expectedDirectoryIds
 
@@ -3859,23 +3859,39 @@ module Watch =
                         None
 
                 try
-                    if pendingEvidence.HasDurableOnlyPendingWork then
-                        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                    let existingDurableOnlyContractMatches =
+                        pendingEvidence.HasDurableOnlyPendingWork
+                        && (try
+                                let expectedMode =
+                                    match currentGraceWatchRuntimeMode () with
+                                    | GraceWatchRuntimeMode.Suspended -> GraceWatchRuntimeMode.Suspended
+                                    | _ -> GraceWatchRuntimeMode.Resynchronizing
 
-                        match currentGraceWatchRuntimeMode () with
-                        | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds)
-                        | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some emptyDirectoryIds)
-                        |> fun writeTask -> writeTask.GetAwaiter().GetResult()
+                                inspectGraceWatchStatus().GetAwaiter().GetResult()
+                                |> inspectionMatchesExpectedPendingWorkContract statusForVerification directoryIdsForVerification expectedMode hasPendingWork
+                            with
+                            | _ -> false)
+
+                    if existingDurableOnlyContractMatches then
+                        transitionWasPublished <- true
+                        lastPublishedHasPendingWatchWork <- Some hasPendingWork
                     else
-                        writeSnapshot().GetAwaiter().GetResult()
+                        if pendingEvidence.HasDurableOnlyPendingWork then
+                            match currentGraceWatchRuntimeMode () with
+                            | GraceWatchRuntimeMode.Suspended ->
+                                updateGraceWatchInterprocessFileForSuspendedMode statusForVerification (Some directoryIdsForVerification)
+                            | _ -> updateGraceWatchInterprocessFile statusForVerification (Some directoryIdsForVerification)
+                            |> fun writeTask -> writeTask.GetAwaiter().GetResult()
+                        else
+                            writeSnapshot().GetAwaiter().GetResult()
 
-                    transitionWasPublished <-
-                        cachePendingWatchWorkPublicationIfVerified
-                            statusForVerification
-                            directoryIdsForVerification
-                            observationScopeForVerification
-                            hasPendingWork
-                            publicationStartedAt
+                        transitionWasPublished <-
+                            cachePendingWatchWorkPublicationIfVerified
+                                statusForVerification
+                                directoryIdsForVerification
+                                observationScopeForVerification
+                                hasPendingWork
+                                publicationStartedAt
 
                     publishedHasPendingWork <- if transitionWasPublished then Some hasPendingWork else None
                 with
@@ -4457,14 +4473,16 @@ module Watch =
     /// Publishes a non-incremental IPC snapshot so other Grace processes do not trust stale Watch status during resync.
     let private publishGraceWatchResyncRequired () =
         let hasPendingWork = hasPendingWatchWork ()
+        let emptyDirectoryIds = HashSet<DirectoryVersionId>()
 
         try
             lock watchStatusPublishLock (fun () -> setGraceWatchHasPendingWorkForStatus hasPendingWork)
 
             let writeTask =
                 match currentGraceWatchRuntimeMode () with
-                | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
-                | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some(HashSet<DirectoryVersionId>()))
+                | GraceWatchRuntimeMode.Suspended ->
+                    updateGraceWatchInterprocessFileForSuspendedMode nonIncrementalPendingWorkPublicationStatus (Some emptyDirectoryIds)
+                | _ -> updateGraceWatchInterprocessFile nonIncrementalPendingWorkPublicationStatus (Some emptyDirectoryIds)
 
             writeTask.GetAwaiter().GetResult()
 
@@ -4734,11 +4752,12 @@ module Watch =
     /// Publishes a branch-scoped non-incremental transition snapshot when Watch cannot safely resume.
     let private publishNonIncrementalTransitionCompletionStatus context =
         let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+        let nonIncrementalStatus = nonIncrementalPendingWorkPublicationStatus
 
-        publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
+        publishWatchIpcWithFreshPendingWorkProbe nonIncrementalStatus emptyDirectoryIds (fun () ->
             match currentGraceWatchRuntimeMode () with
-            | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds)
-            | _ -> updateGraceWatchInterprocessFile GraceStatus.Default (Some emptyDirectoryIds))
+            | GraceWatchRuntimeMode.Suspended -> updateGraceWatchInterprocessFileForSuspendedMode nonIncrementalStatus (Some emptyDirectoryIds)
+            | _ -> updateGraceWatchInterprocessFile nonIncrementalStatus (Some emptyDirectoryIds))
 
         logToAnsiConsole Colors.Important $"Grace Watch published non-incremental IPC for branch transition completion: {context}."
 
@@ -9006,10 +9025,11 @@ module Watch =
                         updateGraceWatchInterprocessFileClient trustedStatus (Some directoryIds))
                 else
                     let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                    let nonIncrementalStatus = nonIncrementalPendingWorkPublicationStatus
 
                     let verified =
-                        tryPublishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                            updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
+                        tryPublishWatchIpcWithFreshPendingWorkProbe nonIncrementalStatus emptyDirectoryIds (fun () ->
+                            updateGraceWatchInterprocessFileClient nonIncrementalStatus (Some emptyDirectoryIds))
 
                     logToAnsiConsole
                         Colors.Important
@@ -9500,22 +9520,41 @@ module Watch =
                                                 logToAnsiConsole
                                                     (if dirtyPublicationVerified then Colors.Important else Colors.Error)
                                                     $"Grace Watch kept newer resync attempt pending after stale attempt {resyncAttempt} completed provisional clean publication; dirty resync IPC was {dirtyPublicationOutcome} before return."
-                                        | recoveryPublication ->
+                                        | VerifiedDirtyRecoveryPublication ->
+                                            let dirtyResyncIpcAlreadyVerified =
+                                                try
+                                                    inspectGraceWatchStatus().GetAwaiter().GetResult()
+                                                    |> isGraceWatchResyncRequiredStatusPublished
+                                                with
+                                                | _ -> false
+
+                                            if dirtyResyncIpcAlreadyVerified then
+                                                if isGraceWatchResyncAttemptCurrent resyncAttempt then
+                                                    setGraceWatchRuntimeMode GraceWatchRuntimeMode.Resynchronizing
+
+                                                logToAnsiConsole
+                                                    Colors.Important
+                                                    $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was verified dirty, not a verified clean recovery; dirty resync IPC was already verified before return."
+                                            else
+                                                let dirtyPublicationVerified =
+                                                    reassertDirtyResyncIpcAfterProvisionalCleanRecovery resyncAttempt (fun status directoryIds ->
+                                                        updateGraceWatchInterprocessFileClient status (Some directoryIds))
+
+                                                let dirtyPublicationOutcome = if dirtyPublicationVerified then "verified" else "unproven"
+
+                                                logToAnsiConsole
+                                                    (if dirtyPublicationVerified then Colors.Important else Colors.Error)
+                                                    $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was verified dirty, not a verified clean recovery; dirty resync IPC was {dirtyPublicationOutcome} before return."
+                                        | UnverifiedRecoveryPublication ->
                                             let dirtyPublicationVerified =
                                                 reassertDirtyResyncIpcAfterProvisionalCleanRecovery resyncAttempt (fun status directoryIds ->
                                                     updateGraceWatchInterprocessFileClient status (Some directoryIds))
-
-                                            let recoveryPublicationOutcome =
-                                                match recoveryPublication with
-                                                | VerifiedDirtyRecoveryPublication -> "verified dirty"
-                                                | UnverifiedRecoveryPublication -> "unproven"
-                                                | VerifiedCleanRecoveryPublication -> "unexpected verified clean"
 
                                             let dirtyPublicationOutcome = if dirtyPublicationVerified then "verified" else "unproven"
 
                                             logToAnsiConsole
                                                 (if dirtyPublicationVerified then Colors.Important else Colors.Error)
-                                                $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was {recoveryPublicationOutcome}, not a verified clean recovery; dirty resync IPC was {dirtyPublicationOutcome} before return."
+                                                $"Grace Watch retained resync attempt {resyncAttempt} because recovery IPC publication was unproven, not a verified clean recovery; dirty resync IPC was {dirtyPublicationOutcome} before return."
                                     else
                                         let clearedResyncAttempt = tryClearGraceWatchResyncAttemptAndMarkerCompletionConfidenceLoss resyncAttempt
 
@@ -9872,9 +9911,10 @@ module Watch =
                             updateGraceWatchInterprocessFileClient graceStatus (Some graceStatusDirectoryIds))
                     else
                         let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                        let nonIncrementalStatus = nonIncrementalPendingWorkPublicationStatus
 
-                        publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                            updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
+                        publishWatchIpcWithFreshPendingWorkProbe nonIncrementalStatus emptyDirectoryIds (fun () ->
+                            updateGraceWatchInterprocessFileClient nonIncrementalStatus (Some emptyDirectoryIds))
 
                         logToAnsiConsole
                             Colors.Important
@@ -9907,14 +9947,16 @@ module Watch =
                         updateGraceWatchInterprocessFileClient graceStatusFromDisk (Some graceStatusDirectoryIds))
                 elif runtimeMode = GraceWatchRuntimeMode.Suspended then
                     let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                    let nonIncrementalStatus = nonIncrementalPendingWorkPublicationStatus
 
-                    publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                        updateGraceWatchInterprocessFileForSuspendedMode GraceStatus.Default (Some emptyDirectoryIds))
+                    publishWatchIpcWithFreshPendingWorkProbe nonIncrementalStatus emptyDirectoryIds (fun () ->
+                        updateGraceWatchInterprocessFileForSuspendedMode nonIncrementalStatus (Some emptyDirectoryIds))
                 else
                     let emptyDirectoryIds = HashSet<DirectoryVersionId>()
+                    let nonIncrementalStatus = nonIncrementalPendingWorkPublicationStatus
 
-                    publishWatchIpcWithFreshPendingWorkProbe GraceStatus.Default emptyDirectoryIds (fun () ->
-                        updateGraceWatchInterprocessFileClient GraceStatus.Default (Some emptyDirectoryIds))
+                    publishWatchIpcWithFreshPendingWorkProbe nonIncrementalStatus emptyDirectoryIds (fun () ->
+                        updateGraceWatchInterprocessFileClient nonIncrementalStatus (Some emptyDirectoryIds))
 
                     logToAnsiConsole
                         Colors.Important


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #807

Part of #801

## Summary

Replace Boolean-only Watch pending checks with named internal reasons and make retry diagnostics plus IPC publication
transition based. Genuine cursor-new remote events now wait on truthful local causes without masquerading as generic
local work, repeating unchanged logs, or rewriting semantically unchanged IPC state.

The public Watch status shape remains unchanged. IPC comparison now covers the observable contract while excluding only
the heartbeat timestamp, and durable-only/recovery state uses a process-stable non-incremental payload. The obsolete
generic `local Watch work is still pending` diagnostic is removed from the dead legacy retry path.

## Touched paths

- `src/Grace.CLI/Command/Watch.CLI.fs`
- `src/Grace.CLI.Tests/Watch.Tests.fs`

## Owned-path compliance

- [x] My changed paths match the linked issue's owned paths.
- [x] Any sensitive/shared path edits are explicitly allowed by the issue.
- [x] I did not create or edit alternate task ledgers outside the issue/PR workflow.

## Validation profile and public-boundary evidence

- Validation profile: Product V1.
- Public behavior target: a genuine remote event waits with a specific reason; unchanged waiting does not churn IPC or
  logs; draining the reason preserves exactly-once apply/ack ownership.
- RED evidence: tests first failed because reason/transition seams were absent and later exposed durable-only IPC
  timestamp churn.
- Final local gate: `pwsh ./scripts/validate.ps1 -Fast` passed the Release build and all 1,327 CLI tests; selected
  Operations, Types, Authorization, and Server unit suites also passed.

## Minimum detail gate evidence

- Product decisions: reasons remain internal; no public field, CLI option, heartbeat redesign, or durable lifecycle was
  added.
- Invariant tuple: runtime mode, named local reason set, durable journal/status state, cursor-new remote event, and last
  observable IPC contract determine whether a transition log/write is required.
- Contract propagation: internal Watch implementation/tests only; public status shape, DTOs, routes, SDK, OpenAPI,
  generated clients, cursor persistence, and IPC schema remain unchanged.
- Revalidation proof: active wait paths snapshot named producers and recheck current state before transition publication;
  last-published state advances only after a successful write.
- Forbidden shapes avoided: no `LatestReference` re-query, blind polling write, manual-latch-as-local-work, repeated
  generic log, delay-based test, or new public status field.
- Positive, negative, regression, and boundary coverage: named wait→drain, clean/no-event silence, unchanged reason,
  reason transitions, semantic IPC equality, write failure retry, unreadable journal, resync/confidence/status/candidate/
  upload/recovery reasons, multiple/duplicate events, cancellation, and coordinator retry suppression.
- Risk traps: snapshot interleaving, event ownership, newer reason preservation, last-published timing, journal failure,
  stable timestamps, and false-positive silence assertions.

## Test coverage changes

- [x] Tests added or updated; list the test files and covered behavior below.
- [ ] No tests added; explain why new tests were not required for this change.

Details:

- `Watch.Tests.fs` adds deterministic reason snapshots, transition diagnostics, semantic IPC suppression, write-failure
  retry, durable-only timestamp stability, active cursor-wait transitions, and coordinator/cursor regressions without
  sleep-based assertions.

## Reviewer pass

- [x] Owned paths and forbidden paths reviewed against the issue.
- [x] Sensitive surfaces reviewed and marked below.
- [x] README, CONTRIBUTING, AGENTS, and docs drift checked.
- [x] Any genuinely required validation that was not run is explicitly listed with a reason.

## Risk surfaces

- [ ] Auth, authorization, tenant, or secrets
- [x] Storage, Cosmos DB, Service Bus, Redis, or Aspire
- [x] CLI public contract
- [ ] Server or API contract
- [ ] Orleans actor behavior
- [ ] SDK or client contract
- [ ] Deployment, Docker, or GitHub Actions
- [ ] Docs or workflow
- [ ] None of the above

## Docs impact

- [ ] Required; updated relevant docs.
- [x] Docs impact: None - the public status/IPC shape and command syntax are unchanged; diagnostics become truthful and
  self-describing, and no reviewed document promises the obsolete generic wording.
- [ ] Not applicable; no user-facing, contributor-facing, or agent-facing behavior changed.

## Local focused evidence

- [x] Focused proof: 62 Watch reason/coordinator/cursor tests and 25 materialization-publication regressions passed.
- [x] Formatting/linting: targeted Fantomas and `git diff --check` passed.
- [x] Generated-file/freshness or syntax checks: N/A; no generated/public contract changed.
- [x] Manual validation: two exact-branch Watch processes proved one named file-upload wait, one transition diagnostic,
  byte/timestamp-stable IPC during unchanged waiting, and absence of the legacy generic message. The event remained
  unacknowledged/replayable when the writer fixture lacked object-cache content.

## Optional local broad preflight

- [x] Fast, Full, or neither: `-Fast` passed as the issue-selected final local gate; Full was not stacked.

## Required CI evidence

- Current head SHA: `8a7779c3f2b838f67a58ed428e42815c73a76bdc`
- GitHub `Validate` state: passed on the current head.
- GitHub Actions run link: [31178207166](https://github.com/ScottArbeit/Grace/actions/runs/31178207166).
- [x] The result was triggered by and remains associated with the latest PR revision.

## Validation not run

- Exact-branch runtime apply/ack completion was blocked after the proven wait transition because the writer fixture did
  not make `remote-event.txt` object-cache content materializable. Epic #801 explicitly excludes cache behavior and
  cache read-through; Watch failed closed and retained the event for replay. Focused tests prove drain/apply/ack once.

## Residual risks

- The runtime smoke does not prove downstream object materialization; that capability is explicitly outside this Epic.
  The #807 reason, IPC, diagnostic, and event-retention boundaries were directly observed.

## Review Status

- Worker starts: 2/4.
- Current head SHA: `8a7779c3f2b838f67a58ed428e42815c73a76bdc`
- Fresh review subagent: `gpt-5.6-terra`, `reasoning_effort: high`, `fork_turns: none`
- `dev-process/CODE_REVIEW.md` followed: yes, review session 2.
- Review verdict for current head: approve; no new P1-P3 findings.
- Required PR checks for current head: Validate run 31178207166 passed.
- [x] Review and required checks both completed successfully for the same head SHA.
- Finding disposition: session 1 P2 closed by `8a7779c3`; the process-stable payload is reused for write and verification.

## Review/fix prevention

- Classification: validation / stale-evidence gap. The ordinary transition test did not cover the distinct active recovery helper. The fix adds deterministic real-coordinator recovery proof and audits every non-incremental publication seam.

## Rollback or recovery notes

Reverting the commit restores Boolean pending summaries, repeated generic retry diagnostics, and Boolean-only IPC
suppression. No persisted schema, migration, server event, or cursor repair is required.

## Docs follow-up required

None currently; fresh review will verify the internal-only/public-shape disposition.
