### PR TITLE
Move missing local-state repair to Grace Doctor

### DIFF
--- a/docs/Grace doctor.md
+++ b/docs/Grace doctor.md
@@ -1,8 +1,9 @@
 # Grace Doctor
 
-`grace doctor` inspects the local Grace environment and reports diagnostics for people, scripts, and agents. It is a
-read-only command: it does not create configuration, initialize local state, migrate databases, repair object-cache
-rows, acquire credentials, refresh tokens, open a browser, or upload support bundles.
+`grace doctor` inspects the local Grace environment and reports diagnostics for people, scripts, and agents. The default
+command is strictly read-only: it does not create configuration, initialize local state, migrate databases, repair
+object-cache rows, acquire credentials, refresh tokens, open a browser, or upload support bundles. The explicit
+`--repair-local-state` gesture is the sole exception and owns exact, non-destructive local-state reconstruction.
 
 Use it when a Grace checkout, local state database, authentication environment, or server connection looks suspicious and
 you need a structured first look before deciding what to fix.
@@ -14,6 +15,7 @@ grace doctor
 grace --output Json doctor
 grace doctor --list-checks
 grace --output Json doctor --check Authentication --select Summary
+grace doctor --repair-local-state
 ```
 
 bash / zsh:
@@ -23,6 +25,7 @@ grace doctor
 grace --output Json doctor
 grace doctor --list-checks
 grace --output Json doctor --check Authentication --select Summary
+grace doctor --repair-local-state
 ```
 
 ## Command Behavior
@@ -47,6 +50,7 @@ parsing or storing doctor evidence.
 | `--list-checks` | Lists the catalog and marks each returned check as skipped; diagnostic probes do not run. |
 | `--check <id-or-category>` | Runs only matching check IDs or categories. Repeat the option or separate values with commas. |
 | `--strict` | Returns exit code `1` when the report status is `Warning`; failures already return `1`. |
+| `--repair-local-state` | Rebuilds exact status and the matching ordered event boundary without changing working-tree or server content. |
 
 Check selection is case-insensitive. Category tokens can use spaces or hyphens, so `--check working-tree` matches
 `working-tree.scan`. Exact check IDs can also select non-default or full-profile diagnostics without `--full`.
@@ -202,31 +206,37 @@ Doctor can help explain local authentication setup without exposing secrets:
 Do not paste doctor JSON into public places without reviewing paths and environment names. The report is designed to
 avoid raw secrets, but summaries may include local file paths or configured server URIs.
 
-## Repair Deferral
+## Exact Local-State Repair
 
-`grace doctor` does not repair problems in v1. It does not:
+Use `grace doctor --repair-local-state` only when a materialized working tree remains intact but its local SQLite state
+is missing or unusable. Repair:
 
-- Create `.grace` directories or configuration files.
-- Initialize, migrate, rewrite, move, or back up the local SQLite database.
-- Create missing SQLite tables or indexes.
-- Repair object-cache rows.
-- Acquire, refresh, store, revoke, or rotate credentials.
-- Upload support bundles.
+- Refuses a live Watch process for the configured repository and branch.
+- Computes the complete retained tree without changing its bytes.
+- Resolves the real root identity and requires that exact root in the configured branch history.
+- Uses the latest matching ordered event when the same root occurs more than once.
+- Fetches the complete immutable server directory closure and preserves its real descendant identities.
+- Rechecks configuration and local bytes immediately before one atomic status-and-cursor commit.
 
-Use the diagnostic result to choose the next command. For example, working-tree drift can be investigated with
-`grace maintenance scan` and intentionally accepted into local state with `grace maintenance update-index`.
+Repair never uploads files, creates directory versions, publishes Save or Reference events, or materializes server
+content into the working tree. No exact root, changed bytes, a repository or branch mismatch, cancellation, server
+failure, or SQLite failure leaves no partially initialized status. The default command never invokes this path.
 
 ## V1 Boundaries
 
 The current v1 command does not document or implement:
 
-- Automatic repair or `--repair`.
+- Automatic repair, unmatched-root baselines, or implicit repair from Watch and other writable commands.
 - Full/Aspire/cloud resource probes.
 - Support bundle upload.
 - Browser or device-code authentication flows inside doctor.
 - Token refresh or secure-store mutation inside doctor.
 
 These are explicit deferrals, not hidden current behavior.
+
+The Issue #340 final audit below records the original read-only Doctor slice. Issue #823 supersedes only its repair
+deferral: default diagnostics remain read-only, while `--repair-local-state` is an explicit exact-only maintenance
+gesture.
 
 ## Final Audit
 

--- a/docs/What grace watch does.md
+++ b/docs/What grace watch does.md
@@ -40,12 +40,13 @@ Of course, it's open-source, please feel free to examine [Watch.CLI.fs](https://
   wake Watch; startup, reconnect, and each wake replay server-ordered Commit, Checkpoint, and Save events after the
   opaque cursor stored for the current repository and branch. Watch advances that cursor only after successful
   materialization or verified same-root acknowledgement.
-- If `.grace/grace-local.db` is reset and the current branch cursor is missing, Watch does not choose the branch's
-  latest Reference or overwrite the working directory. Grace Server recovers an exact cursor only when the repository,
-  branch, root ID, SHA-256, and BLAKE3 tuple belongs to a Save, Commit, or Checkpoint event for that same repository and
-  branch. Watch then replays only later events. Branch bases (Created or Rebased), every other Reference kind, and
-  unmatched roots use the same immutable server-history snapshot's tail as a conservative baseline, even when a root
-  tuple matches. This baseline preserves every local file and follows only future events.
+- Watch starts only when the local SQLite database contains a complete status tree and a matching ordered remote-event
+  boundary for the configured repository and branch. Missing, schema-only, corrupt, incompatible, or mismatched state
+  fails before callback admission, working-tree scan, upload, Save, cursor mutation, or materialization.
+- Watch never reconstructs missing local state, invents descendant identities, or establishes an unmatched server-tail
+  baseline. If a materialized working tree still exactly matches a root in configured branch history, stop Watch and
+  run `grace doctor --repair-local-state`. The explicit repair preserves local bytes, fetches the server's immutable
+  recursive directory closure, and atomically records its real identities with the latest matching event boundary.
 - `grace connect --retrieve-default-branch false` does not establish a materialized local root. Watch treats a missing
   or incomplete root as non-incremental state and never selects a historical Reference to fill it implicitly.
 - When it starts, it scans the working directory and all (not-ignored) subdirectories and files for changes since the last time the local Grace Status file was updated.

--- a/docs/adr/0010-current-branch-materialization-trust-boundary.md
+++ b/docs/adr/0010-current-branch-materialization-trust-boundary.md
@@ -30,7 +30,8 @@ overwrite local work when IPC, local durable state, or the object cache is incom
 - Materialization uses exact Reference targets. It does not broad-scan the repository, maintain root-history policy,
   or download missing objects while applying. Required cached objects are preflighted before mutation.
 - Missing, stale, unreadable, blocked, or ambiguous IPC/local-state evidence leaves the current event cursor
-  unacknowledged. Missing-cursor recovery is a separate decision and does not fall back to `BranchDto`.
+  unacknowledged. Watch fails closed; only explicit exact `grace doctor --repair-local-state` maintenance may reconstruct
+  missing status and its matching boundary, and it does not fall back to `BranchDto`.
 - Remote materialization creates no local Save. Its Grace-owned marker suppresses apply-owned observations while the
   exact target plan mutates the working tree.
 - Watch publishes a clean IPC snapshot only after the exact apply succeeds, durable `GraceStatus` is updated, the

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -163,6 +163,50 @@ module DoctorCliTests =
     /// Builds local state db path test data used to exercise CLI doctor behavior.
     let private localStateDbPath root = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName)
 
+    /// Verifies repair rejects a persisted rewrite after cached configuration acquisition before server or SQLite work.
+    [<Test; Category("OperationalConfigurationSnapshotRace")>]
+    let ``doctor repair rejects cached and first persisted configuration mismatch before side effects`` () =
+        withTempDir (fun root ->
+            withIsolatedHome root (fun _ ->
+                let cachedServerUri = "http://127.0.0.1:59999"
+                let persistedServerUri = "http://127.0.0.1:59998"
+                let configPath = writeGraceConfig root cachedServerUri
+                Configuration.resetConfiguration ()
+                Configuration.Current() |> ignore
+                let originalConfig = File.ReadAllText(configPath)
+                let mutable serverReadCalls = 0
+
+                Doctor.setAfterRepairCachedConfigurationForTests (fun () ->
+                    File.WriteAllText(configPath, originalConfig.Replace(cachedServerUri, persistedServerUri)))
+
+                Doctor.setBeforeRepairFirstServerReadForTests (fun () -> serverReadCalls <- serverReadCalls + 1)
+
+                try
+                    let exitCode, standardOut, standardError =
+                        runWithCapturedStdoutAndStderr [| "--output"
+                                                          "Json"
+                                                          "doctor"
+                                                          "--repair-local-state" |]
+
+                    exitCode |> should equal -1
+                    standardError |> should equal String.Empty
+
+                    use document = JsonDocument.Parse(standardOut)
+
+                    document
+                        .RootElement
+                        .GetProperty("Error")
+                        .GetString()
+                    |> should contain "cached and persisted repository configuration do not match"
+
+                    serverReadCalls |> should equal 0
+
+                    File.Exists(localStateDbPath root)
+                    |> should equal false
+                finally
+                    Doctor.resetAfterRepairCachedConfigurationForTests ()
+                    Doctor.resetBeforeRepairFirstServerReadForTests ()))
+
     /// Gets corrupt backups needed by the test scenario.
     let private getCorruptBackups root =
         let graceDir = Path.Combine(root, Constants.GraceConfigDirectory)

--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -508,7 +508,23 @@ module DoctorCliTests =
             standardOut |> should contain "--check"
             standardOut |> should contain "--strict"
 
+            standardOut
+            |> should contain "--repair-local-state"
+
             Directory.Exists(Path.Combine(root, ".grace"))
+            |> should equal false)
+
+    /// Verifies that explicit repair without repository configuration fails without creating local state.
+    [<Test>]
+    let ``doctor repair without configuration is non destructive`` () =
+        withTempDir (fun root ->
+            let exitCode, _, _ =
+                runWithCapturedStdoutAndStderr [| "doctor"
+                                                  "--repair-local-state" |]
+
+            exitCode |> should not' (equal 0)
+
+            Directory.Exists(Path.Combine(root, Constants.GraceConfigDirectory))
             |> should equal false)
 
     /// Verifies that doctor list checks emits clean json envelope without config.
@@ -3626,6 +3642,18 @@ notes.txt # inline comment
                 [
                     [| "doctor"; "--schema" |], "schema"
                     [| "doctor"; "--examples" |], "examples"
+                    [|
+                        "doctor"
+                        "--repair-local-state"
+                        "--schema"
+                    |],
+                    "schema"
+                    [|
+                        "doctor"
+                        "--repair-local-state"
+                        "--examples"
+                    |],
+                    "examples"
                 ] do
                 /// Verifies that the CLI doctor scenario exits with the expected process status.
                 let exitCode, standardOut, standardError = runWithCapturedStdoutAndStderr args

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -733,6 +733,77 @@ module LocalStateDbTests =
                 Assert.That(storedBoundary, Is.EqualTo(None))
             })
 
+    /// A writer that claims SQLite after Doctor's final validation remains authoritative and makes repair fail closed.
+    [<Test; Category("LocalStateRepairWriterExclusion")>]
+    let ``local state repair refuses writer claiming database before replacement`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let writerRoot = Guid.Parse("67676767-8020-4000-8000-676767676767")
+                let writerStatus = { createTestStatus writerRoot (Sha256Hash "writer") 11L with RootDirectoryBlake3Hash = Blake3Hash "writer-blake3" }
+
+                let writerBoundary =
+                    { Grace.Types.Reference.ReferenceMaterializationBoundaryDto.Default with
+                        RepositoryId = configuration.RepositoryId
+                        BranchId = configuration.BranchId
+                        DirectoryId = writerRoot
+                        Sha256Hash = writerStatus.RootDirectorySha256Hash
+                        Blake3Hash = writerStatus.RootDirectoryBlake3Hash
+                        EventCursor = "writer-boundary"
+                    }
+
+                let doctorRoot = Guid.Parse("68686868-8020-4000-8000-686868686868")
+                let doctorStatus = { createTestStatus doctorRoot (Sha256Hash "doctor") 12L with RootDirectoryBlake3Hash = Blake3Hash "doctor-blake3" }
+
+                let doctorBoundary =
+                    { writerBoundary with
+                        DirectoryId = doctorRoot
+                        Sha256Hash = doctorStatus.RootDirectorySha256Hash
+                        Blake3Hash = doctorStatus.RootDirectoryBlake3Hash
+                        EventCursor = "doctor-boundary"
+                    }
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                let! baseline = LocalStateDb.captureLocalStateRepairBaseline configuration.GraceStatusFile
+                use writer = openRawConnection configuration.GraceStatusFile
+
+                let beginAndStageWriter () =
+                    executeNonQuery writer "BEGIN IMMEDIATE;"
+                    executeNonQuery writer "DELETE FROM status_directories;"
+                    executeNonQuery writer "DELETE FROM status_files;"
+
+                    executeNonQuery
+                        writer
+                        $"UPDATE status_meta SET root_directory_version_id = '{writerRoot}', root_directory_sha256_hash = 'writer', root_directory_blake3_hash = 'writer-blake3' WHERE id = 1;"
+
+                    executeNonQuery
+                        writer
+                        $"INSERT INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ('.', '', '{writerRoot}', 'writer', 'writer-blake3', 0, 0, 0);"
+
+                    executeNonQuery
+                        writer
+                        $"INSERT OR REPLACE INTO remote_reference_boundaries (repository_id, branch_id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, event_cursor) VALUES ('{configuration.RepositoryId}', '{configuration.BranchId}', '{writerRoot}', 'writer', 'writer-blake3', 'writer-boundary');"
+
+                Assert.ThrowsAsync<InvalidOperationException>(
+                    Func<Task> (fun () ->
+                        LocalStateDb.replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepairWithBeforeWriteClaim
+                            configuration.GraceStatusFile
+                            baseline
+                            doctorStatus
+                            doctorBoundary
+                            CancellationToken.None
+                            beginAndStageWriter
+                        :> Task)
+                )
+                |> ignore
+
+                executeNonQuery writer "COMMIT;"
+
+                let! storedStatus = LocalStateDb.readStatusMeta configuration.GraceStatusFile
+                let! storedBoundary = LocalStateDb.readRemoteReferenceBoundary configuration.GraceStatusFile configuration.RepositoryId configuration.BranchId
+                Assert.That(storedStatus.RootDirectoryId, Is.EqualTo(writerStatus.RootDirectoryId))
+                Assert.That(storedBoundary, Is.EqualTo(Some writerBoundary))
+            })
+
     /// A terminal replay acknowledgement advances the exact cursor and accepted root without rewriting status tables.
     [<Test; Category("CurrentBranchCursorReplay")>]
     let ``remote reference cursor acknowledgement advances exact boundary`` () =
@@ -3646,10 +3717,13 @@ module LocalStateDbTests =
             })
 
     /// Verifies that ensure db initialized treats paths case insensitively on windows.
-    [<Test>]
+    [<Test; Category("LocalStatePathComparison")>]
     let ``ensureDbInitialized treats paths case-insensitively on Windows`` () =
         withTempDir (fun _ configuration ->
             task {
+                if not (OperatingSystem.IsWindows()) then
+                    Assert.Ignore("Windows path aliases are case-insensitive only on Windows.")
+
                 let pathA = configuration.GraceStatusFile.ToLowerInvariant()
                 let pathB = configuration.GraceStatusFile.ToUpperInvariant()
 
@@ -3667,6 +3741,40 @@ module LocalStateDbTests =
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 schemaVersion |> should equal "9"
+            })
+
+    /// Verifies non-Windows filesystems can initialize case-distinct local-state paths without rewriting the temp root.
+    [<Test; Category("LocalStatePathComparison")>]
+    let ``ensureDbInitialized preserves case-distinct paths on non-Windows`` () =
+        withTempDir (fun root configuration ->
+            task {
+                if OperatingSystem.IsWindows() then
+                    Assert.Ignore("Case-distinct local-state paths are a non-Windows contract.")
+
+                let alternateGraceDirectory = Path.Combine(root, Constants.GraceConfigDirectory.ToUpperInvariant())
+
+                Directory.CreateDirectory(alternateGraceDirectory)
+                |> ignore
+
+                let alternatePath = Path.Combine(alternateGraceDirectory, Constants.GraceLocalStateDbFileName)
+
+                do!
+                    Task
+                        .WhenAll(
+                            [|
+                                LocalStateDb.ensureDbInitialized configuration.GraceStatusFile :> Task
+                                LocalStateDb.ensureDbInitialized alternatePath :> Task
+                            |]
+                        )
+                        .WaitAsync(TimeSpan.FromSeconds(15.0))
+
+                File.Exists(configuration.GraceStatusFile)
+                |> should equal true
+
+                File.Exists(alternatePath) |> should equal true
+
+                Path.GetFullPath(configuration.GraceStatusFile)
+                |> should not' (equal (Path.GetFullPath(alternatePath)))
             })
 
     /// Verifies that replace status snapshot fully clears old snapshot rows.
@@ -4068,6 +4176,111 @@ module LocalStateDbTests =
 
                     error
                     |> should contain "reset the local state database"
+            })
+
+    /// Verifies Watch's shared local-state reader accepts a complete nested graph and rejects truncation or malformed relationships.
+    [<TestCase("valid")>]
+    [<TestCase("truncated")>]
+    [<TestCase("disconnected")>]
+    [<TestCase("duplicate-path")>]
+    [<TestCase("malformed-file-parent")>]
+    [<Category("CompleteLocalStatusTree")>]
+    let ``complete status reader validates the full rooted graph`` shape =
+        withTempDir (fun _ configuration ->
+            task {
+                let now = Instant.FromUnixTimeTicks(2001L)
+                let lastWrite = DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc)
+                let rootId = Guid.NewGuid()
+                let childId = Guid.NewGuid()
+                let file = createFileVersionWithHashes "src/nested.txt" "file-sha" "file-blake3" false 12L now lastWrite
+
+                let childEntries =
+                    [|
+                        Grace.Shared.Services.DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash
+                    |]
+
+                let childSha = Grace.Shared.Services.computeSha256ForDirectoryEntries "src" childEntries
+                let childBlake3 = Grace.Shared.Services.computeBlake3ForDirectory "src" childEntries
+
+                let child =
+                    LocalDirectoryVersion.CreateWithHashes
+                        childId
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+                        "src"
+                        childSha
+                        childBlake3
+                        (List<DirectoryVersionId>())
+                        (List<LocalFileVersion>([| file |]))
+                        file.Size
+                        lastWrite
+
+                let rootEntries =
+                    [|
+                        Grace.Shared.Services.DirectoryVersionPreimageEntry.Directory child.RelativePath child.Size child.Blake3Hash child.Sha256Hash
+                    |]
+
+                let rootSha = Grace.Shared.Services.computeSha256ForDirectoryEntries Constants.RootDirectoryPath rootEntries
+                let rootBlake3 = Grace.Shared.Services.computeBlake3ForDirectory Constants.RootDirectoryPath rootEntries
+
+                let root =
+                    LocalDirectoryVersion.CreateWithHashes
+                        rootId
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+                        Constants.RootDirectoryPath
+                        rootSha
+                        rootBlake3
+                        (List<DirectoryVersionId>([| childId |]))
+                        (List<LocalFileVersion>())
+                        child.Size
+                        lastWrite
+
+                let index = GraceIndex()
+                index.TryAdd(rootId, root) |> ignore
+                index.TryAdd(childId, child) |> ignore
+
+                let status =
+                    { GraceStatus.Default with
+                        Index = index
+                        RootDirectoryId = rootId
+                        RootDirectorySha256Hash = rootSha
+                        RootDirectoryBlake3Hash = rootBlake3
+                    }
+
+                do! LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile status
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+
+                    match shape with
+                    | "valid" -> ()
+                    | "truncated" ->
+                        executeNonQuery connection "DELETE FROM status_files WHERE relative_path = 'src/nested.txt';"
+                        executeNonQuery connection "DELETE FROM status_directories WHERE relative_path = 'src';"
+                    | "disconnected" -> executeNonQuery connection "UPDATE status_directories SET parent_path = 'missing' WHERE relative_path = 'src';"
+                    | "duplicate-path" ->
+                        executeNonQuery
+                            connection
+                            $"UPDATE status_files SET relative_path = 'src', directory_path = '.', directory_version_id = '{rootId}' WHERE relative_path = 'src/nested.txt';"
+                    | "malformed-file-parent" ->
+                        executeNonQuery connection "UPDATE status_files SET directory_path = '.' WHERE relative_path = 'src/nested.txt';"
+                    | _ -> invalidOp $"Unexpected complete-tree test shape: {shape}"
+
+                let! result =
+                    LocalStateDb.readCompleteStatusSnapshotReadOnly
+                        configuration.GraceStatusFile
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+
+                match shape, result with
+                | "valid", Ok readBack -> readBack.Index.Count |> should equal 2
+                | "valid", Error error -> Assert.Fail($"Expected a valid complete status tree, got: {error}")
+                | _, Error error -> error |> should contain "status tree"
+                | _, Ok _ -> Assert.Fail($"Expected malformed status shape '{shape}' to fail closed.")
             })
 
     /// Verifies that read status snapshot tolerates missing status meta row.

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -15972,6 +15972,71 @@ module WatchTests =
                     Watch.resetAfterWatchStartupClaimForTests ()
                     Watch.resetBeforeWatchCallbackRuntimeSetupForTests ()))
 
+    /// Verifies a persisted server-only rewrite after claim aborts before callback, network, scan, or cursor work.
+    [<Test; Category("WatchStartupLocalStateTrust"); Category("OperationalConfigurationSnapshotRace")>]
+    let ``watch rejects persisted server uri rewrite after startup claim`` () =
+        withTempRepo (fun root ->
+            clearWatchAuthEnv (fun () ->
+                let nestedDirectory = Path.Combine(root, "src")
+
+                Directory.CreateDirectory(nestedDirectory)
+                |> ignore
+
+                File.WriteAllText(Path.Combine(nestedDirectory, "nested.txt"), "trusted nested bytes")
+                writeTrustedNestedWatchState root
+                Services.setLastScanForDifferencesSuccessfulForWatchTests false
+                let configPath = Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)
+                let cachedServerUri = Current().ServerUri
+                let changedServerUri = "http://127.0.0.1:59999"
+                let originalConfig = File.ReadAllText(configPath)
+
+                let boundaryBefore =
+                    LocalStateDb.readRemoteReferenceBoundary (Current().GraceStatusFile) (Current().RepositoryId) (Current().BranchId)
+                    |> fun pending -> pending.GetAwaiter().GetResult()
+
+                let mutable callbackRuntimeSetupCalls = 0
+                Watch.setBeforeWatchCallbackRuntimeSetupForTests (fun () -> callbackRuntimeSetupCalls <- callbackRuntimeSetupCalls + 1)
+
+                Watch.setAfterWatchStartupClaimForTests (fun () -> File.WriteAllText(configPath, originalConfig.Replace(cachedServerUri, changedServerUri)))
+
+                try
+                    let exitCode, output = runWithCapturedOutput [| "watch" |]
+                    exitCode |> should equal -1
+
+                    output |> should contain "operational repository"
+
+                    output
+                    |> should contain "changed after validation"
+
+                    output |> should not' (contain "access token")
+                    callbackRuntimeSetupCalls |> should equal 0
+
+                    Services.wasLastScanForDifferencesSuccessful ()
+                    |> should equal false
+
+                    let claimStatus: Services.GraceWatchStatus = deserialize (File.ReadAllText(Services.IpcFileName()))
+                    claimStatus.IsStartupClaim |> should equal true
+
+                    Watch
+                        .pendingWatchWorkSnapshotForTests()
+                        .FilesToProcess
+                    |> should equal Array.empty<string>
+
+                    Watch
+                        .pendingWatchWorkSnapshotForTests()
+                        .StatusUpdateTriggers
+                    |> should equal Array.empty<string>
+
+                    let boundaryAfter =
+                        LocalStateDb.readRemoteReferenceBoundary (Current().GraceStatusFile) (Current().RepositoryId) (Current().BranchId)
+                        |> Async.AwaitTask
+                        |> Async.RunSynchronously
+
+                    boundaryAfter |> should equal boundaryBefore
+                finally
+                    Watch.resetAfterWatchStartupClaimForTests ()
+                    Watch.resetBeforeWatchCallbackRuntimeSetupForTests ()))
+
     /// Verifies that watch exits nonzero when live watcher status already exists.
     [<Test>]
     let ``watch exits nonzero when live watcher status already exists`` () =

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -171,6 +171,9 @@ module WatchTests =
     /// Builds a healthy live Watch status snapshot for IPC compatibility tests.
     let private liveWatchStatus rootDirectoryId : Services.GraceWatchStatus =
         let current = Current()
+        let entries = Array.empty<DirectoryVersionPreimageEntry>
+        let rootSha = computeSha256ForDirectoryEntries Constants.RootDirectoryPath entries
+        let rootBlake3 = computeBlake3ForDirectory Constants.RootDirectoryPath entries
 
         {
             UpdatedAt = getCurrentInstant ()
@@ -183,12 +186,58 @@ module WatchTests =
             HasPendingWatchWork = false
             IsWorkingTreeClean = true
             RootDirectoryId = rootDirectoryId
-            RootDirectorySha256Hash = Sha256Hash "live-watch-root"
-            RootDirectoryBlake3Hash = Blake3Hash "live-watch-root-blake3"
+            RootDirectorySha256Hash = rootSha
+            RootDirectoryBlake3Hash = rootBlake3
             LastFileUploadInstant = Instant.MinValue
             LastDirectoryVersionInstant = Instant.MinValue
             DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
         }
+
+    /// Persists a complete root-only status and matching boundary for valid Watch IPC lifecycle tests.
+    let private writeTrustedRootOnlyWatchState rootDirectoryId =
+        let current = Current()
+        let status = liveWatchStatus rootDirectoryId
+
+        let rootDirectory =
+            LocalDirectoryVersion.CreateWithHashes
+                rootDirectoryId
+                current.OwnerId
+                current.OrganizationId
+                current.RepositoryId
+                Constants.RootDirectoryPath
+                status.RootDirectorySha256Hash
+                status.RootDirectoryBlake3Hash
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>())
+                0L
+                DateTime.UtcNow
+
+        let index = GraceIndex()
+
+        index.TryAdd(rootDirectoryId, rootDirectory)
+        |> ignore
+
+        let graceStatus =
+            { GraceStatus.Default with
+                Index = index
+                RootDirectoryId = rootDirectoryId
+                RootDirectorySha256Hash = status.RootDirectorySha256Hash
+                RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
+            }
+
+        let boundary =
+            { ReferenceMaterializationBoundaryDto.Default with
+                RepositoryId = current.RepositoryId
+                BranchId = current.BranchId
+                DirectoryId = rootDirectoryId
+                Sha256Hash = status.RootDirectorySha256Hash
+                Blake3Hash = status.RootDirectoryBlake3Hash
+                EventCursor = "branch-event-v1:1"
+            }
+
+        (Services.writeGraceStatusFileWithRemoteReferenceBoundary graceStatus boundary CancellationToken.None)
+            .GetAwaiter()
+            .GetResult()
 
     /// Applies the current repository identity used by Watch IPC trust tests.
     let private configureCurrentWatchIdentity rootDirectory repositoryName branchName =
@@ -364,9 +413,7 @@ module WatchTests =
 
         let ipcFileName = Services.IpcFileName()
 
-        (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
-            .GetAwaiter()
-            .GetResult()
+        writeTrustedRootOnlyWatchState rootDirectoryId
 
         Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
         |> ignore
@@ -376,6 +423,9 @@ module WatchTests =
 
     /// Reads file if exists needed by the test scenario.
     let private readFileIfExists path = if File.Exists(path) then Some(File.ReadAllText(path)) else None
+
+    /// Reads binary file bytes without treating SQLite state as text.
+    let private readBytesIfExists path = if File.Exists(path) then Some(File.ReadAllBytes(path)) else None
 
     /// Deletes local-state database files so status trust tests can prove fail-closed durable inspection.
     let private deleteLocalStateDbFiles () =
@@ -15711,24 +15761,216 @@ module WatchTests =
             pending.FilesToProcess
             |> should equal [| newPath |])
 
-    /// Verifies that Watch refuses a missing local database before authentication or runtime callback setup.
-    [<Test>]
-    let ``watch fails closed when local state is missing`` () =
+    /// Builds a canonical nested status and matching branch boundary for public Watch startup tests.
+    let private writeTrustedNestedWatchState root =
+        let current = Current()
+        let now = getCurrentInstant ()
+        let lastWrite = DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc)
+        let rootId = DirectoryVersionId.NewGuid()
+        let childId = DirectoryVersionId.NewGuid()
+        let file = localFileVersionFromWorkingTree root "src/nested.txt"
+
+        let childEntries =
+            [|
+                DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash
+            |]
+
+        let childSha = computeSha256ForDirectoryEntries "src" childEntries
+        let childBlake3 = computeBlake3ForDirectory "src" childEntries
+
+        let child =
+            LocalDirectoryVersion.CreateWithHashes
+                childId
+                current.OwnerId
+                current.OrganizationId
+                current.RepositoryId
+                "src"
+                childSha
+                childBlake3
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>([| file |]))
+                file.Size
+                lastWrite
+
+        let rootEntries =
+            [|
+                DirectoryVersionPreimageEntry.Directory child.RelativePath child.Size child.Blake3Hash child.Sha256Hash
+            |]
+
+        let rootSha = computeSha256ForDirectoryEntries Constants.RootDirectoryPath rootEntries
+        let rootBlake3 = computeBlake3ForDirectory Constants.RootDirectoryPath rootEntries
+
+        let rootDirectory =
+            LocalDirectoryVersion.CreateWithHashes
+                rootId
+                current.OwnerId
+                current.OrganizationId
+                current.RepositoryId
+                Constants.RootDirectoryPath
+                rootSha
+                rootBlake3
+                (List<DirectoryVersionId>([| childId |]))
+                (List<LocalFileVersion>())
+                child.Size
+                lastWrite
+
+        let index = GraceIndex()
+        index.TryAdd(rootId, rootDirectory) |> ignore
+        index.TryAdd(childId, child) |> ignore
+
+        let status =
+            { GraceStatus.Default with
+                Index = index
+                RootDirectoryId = rootId
+                RootDirectorySha256Hash = rootSha
+                RootDirectoryBlake3Hash = rootBlake3
+                LastSuccessfulFileUpload = now
+                LastSuccessfulDirectoryVersionUpload = now
+            }
+
+        let boundary =
+            { ReferenceMaterializationBoundaryDto.Default with
+                RepositoryId = current.RepositoryId
+                BranchId = current.BranchId
+                DirectoryId = rootId
+                Sha256Hash = rootSha
+                Blake3Hash = rootBlake3
+                EventCursor = "branch-event-v1:1"
+            }
+
+        (Services.writeGraceStatusFileWithRemoteReferenceBoundary status boundary CancellationToken.None)
+            .GetAwaiter()
+            .GetResult()
+
+    /// Applies a readable malformed SQLite status shape after a complete trusted snapshot is written.
+    let private mutateWatchState shape =
+        use connection = new SqliteConnection($"Data Source={Current().GraceStatusFile}")
+        connection.Open()
+        use command = connection.CreateCommand()
+
+        command.CommandText <-
+            match shape with
+            | "truncated" -> "DELETE FROM status_directories WHERE relative_path = 'src';"
+            | "cyclic" -> "UPDATE status_directories SET parent_path = 'src' WHERE relative_path = '.';"
+            | "hash-inconsistent" -> "UPDATE status_directories SET sha256_hash = 'changed-child-sha' WHERE relative_path = 'src';"
+            | _ -> invalidOp $"Unexpected malformed Watch state shape: {shape}."
+
+        command.ExecuteNonQuery() |> ignore
+
+    /// Verifies the public Watch command refuses untrusted SQLite state without creating or replacing its IPC file.
+    [<TestCase("missing")>]
+    [<TestCase("schema-only")>]
+    [<TestCase("truncated")>]
+    [<TestCase("cyclic")>]
+    [<TestCase("hash-inconsistent")>]
+    [<Category("WatchStartupLocalStateTrust")>]
+    let ``watch refuses untrusted local state before IPC claim`` shape =
         withTempRepo (fun root ->
             clearWatchAuthEnv (fun () ->
-                /// Verifies that the CLI watch scenario exits with the expected process status.
-                let exitCode, output = runWithCapturedOutput [| "watch" |]
+                let nestedDirectory = Path.Combine(root, "src")
 
-                if exitCode <> -1 then
-                    Assert.Fail(
-                        $"Expected watch to exit with -1 when auth is missing. Actual: {exitCode}.{Environment.NewLine}Output:{Environment.NewLine}{output}"
-                    )
+                Directory.CreateDirectory(nestedDirectory)
+                |> ignore
 
-                output
-                |> should contain "requires healthy initialized local"
+                File.WriteAllText(Path.Combine(nestedDirectory, "nested.txt"), "trusted nested bytes")
 
-                File.Exists(Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName))
-                |> should equal false))
+                match shape with
+                | "missing" -> deleteLocalStateDbFiles ()
+                | "schema-only" ->
+                    (LocalStateDb.ensureDbInitialized (Current().GraceStatusFile))
+                        .GetAwaiter()
+                        .GetResult()
+                | _ ->
+                    writeTrustedNestedWatchState root
+                    mutateWatchState shape
+
+                SqliteConnection.ClearAllPools()
+                let dbBytesBefore = readBytesIfExists (Current().GraceStatusFile)
+                let ipcFileName = Services.IpcFileName()
+
+                Directory.CreateDirectory(Path.GetDirectoryName(ipcFileName))
+                |> ignore
+
+                let stoppedBytes = $"stopped-watch-bytes-{shape}"
+                File.WriteAllText(ipcFileName, stoppedBytes)
+                Services.setLastScanForDifferencesSuccessfulForWatchTests false
+                let mutable callbackRuntimeSetupCalls = 0
+                Watch.setBeforeWatchCallbackRuntimeSetupForTests (fun () -> callbackRuntimeSetupCalls <- callbackRuntimeSetupCalls + 1)
+
+                try
+                    /// Verifies that the CLI watch scenario exits with the expected process status.
+                    let exitCode, output = runWithCapturedOutput [| "watch" |]
+
+                    if exitCode <> -1 then
+                        Assert.Fail(
+                            $"Expected watch to exit with -1 for {shape} local state. Actual: {exitCode}.{Environment.NewLine}Output:{Environment.NewLine}{output}"
+                        )
+
+                    output |> should contain "initialized local"
+
+                    output |> should not' (contain "access token")
+
+                    File.ReadAllText(ipcFileName)
+                    |> should equal stoppedBytes
+
+                    callbackRuntimeSetupCalls |> should equal 0
+
+                    Services.wasLastScanForDifferencesSuccessful ()
+                    |> should equal false
+
+                    SqliteConnection.ClearAllPools()
+
+                    readBytesIfExists (Current().GraceStatusFile)
+                    |> should equal dbBytesBefore
+                finally
+                    Watch.resetBeforeWatchCallbackRuntimeSetupForTests ()))
+
+    /// Verifies a trusted state changed after the IPC claim is rejected before callback setup or scanning.
+    [<Test; Category("WatchStartupLocalStateTrust")>]
+    let ``watch revalidates trusted local state after IPC claim`` () =
+        withTempRepo (fun root ->
+            clearWatchAuthEnv (fun () ->
+                let nestedDirectory = Path.Combine(root, "src")
+
+                Directory.CreateDirectory(nestedDirectory)
+                |> ignore
+
+                File.WriteAllText(Path.Combine(nestedDirectory, "nested.txt"), "trusted nested bytes")
+                writeTrustedNestedWatchState root
+                Services.setLastScanForDifferencesSuccessfulForWatchTests false
+                let mutable callbackRuntimeSetupCalls = 0
+
+                Watch.setBeforeWatchCallbackRuntimeSetupForTests (fun () -> callbackRuntimeSetupCalls <- callbackRuntimeSetupCalls + 1)
+                Watch.setAfterWatchStartupClaimForTests (fun () -> writeTrustedNestedWatchState root)
+
+                try
+                    let exitCode, output = runWithCapturedOutput [| "watch" |]
+                    exitCode |> should equal -1
+
+                    output
+                    |> should contain "local state changed after"
+
+                    output |> should contain "Watch startup claim"
+
+                    output |> should not' (contain "access token")
+
+                    callbackRuntimeSetupCalls |> should equal 0
+
+                    Services.wasLastScanForDifferencesSuccessful ()
+                    |> should equal false
+
+                    Watch
+                        .pendingWatchWorkSnapshotForTests()
+                        .FilesToProcess
+                    |> should equal Array.empty<string>
+
+                    Watch
+                        .pendingWatchWorkSnapshotForTests()
+                        .StatusUpdateTriggers
+                    |> should equal Array.empty<string>
+                finally
+                    Watch.resetAfterWatchStartupClaimForTests ()
+                    Watch.resetBeforeWatchCallbackRuntimeSetupForTests ()))
 
     /// Verifies that watch exits nonzero when live watcher status already exists.
     [<Test>]
@@ -15780,6 +16022,8 @@ module WatchTests =
     let ``watch startup claim blocks second ordinary start without usable status`` () =
         withTempRepo (fun _ ->
             clearWatchAuthEnv (fun () ->
+                writeTrustedRootOnlyWatchState (DirectoryVersionId.NewGuid())
+
                 let claimed =
                     Services
                         .tryClaimGraceWatchInterprocessFile()

--- a/src/Grace.CLI.Tests/Watch.Tests.fs
+++ b/src/Grace.CLI.Tests/Watch.Tests.fs
@@ -15711,10 +15711,10 @@ module WatchTests =
             pending.FilesToProcess
             |> should equal [| newPath |])
 
-    /// Verifies that watch exits with auth guidance when no token is configured.
+    /// Verifies that Watch refuses a missing local database before authentication or runtime callback setup.
     [<Test>]
-    let ``watch exits with auth guidance when no token is configured`` () =
-        withTempRepo (fun _ ->
+    let ``watch fails closed when local state is missing`` () =
+        withTempRepo (fun root ->
             clearWatchAuthEnv (fun () ->
                 /// Verifies that the CLI watch scenario exits with the expected process status.
                 let exitCode, output = runWithCapturedOutput [| "watch" |]
@@ -15725,10 +15725,10 @@ module WatchTests =
                     )
 
                 output
-                |> should contain "Unable to acquire an access token for SignalR"
+                |> should contain "requires healthy initialized local"
 
-                output
-                |> should contain "Authentication is not configured."))
+                File.Exists(Path.Combine(root, Constants.GraceConfigDirectory, Constants.GraceLocalStateDbFileName))
+                |> should equal false))
 
     /// Verifies that watch exits nonzero when live watcher status already exists.
     [<Test>]

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -1434,6 +1434,42 @@ module Doctor =
     /// Restores production repair validation after deterministic stale-state tests.
     let internal resetBeforeRepairFinalValidationForTests () = beforeRepairFinalValidation <- fun () -> ()
 
+    /// Identifies every effective server, working-tree, and local-state input used by exact repair.
+    type private LocalStateRepairConfigurationIdentity =
+        {
+            RepositoryId: RepositoryId
+            BranchId: BranchId
+            ServerUri: string
+            ConfigurationPath: string
+            RootDirectory: string
+            GraceDirectory: string
+            GraceStatusFile: string
+        }
+
+    /// Canonicalizes an effective repair URI so equivalent trailing separators do not look like server changes.
+    let private canonicalRepairServerUri (value: string) =
+        match Uri.TryCreate(value, UriKind.Absolute) with
+        | true, uri when
+            uri.Scheme = Uri.UriSchemeHttp
+            || uri.Scheme = Uri.UriSchemeHttps
+            ->
+            uri.AbsoluteUri.TrimEnd('/')
+        | _ -> invalidOp $"Grace Doctor requires an absolute HTTP or HTTPS server URI for local-state repair: {value}"
+
+    /// Captures the effective persisted inputs that select repair's server, working tree, and SQLite database.
+    let private localStateRepairConfigurationIdentity (inspection: Grace.Shared.Client.Configuration.GraceConfigurationInspection) =
+        let configuration = inspection.Configuration
+
+        {
+            RepositoryId = configuration.RepositoryId
+            BranchId = configuration.BranchId
+            ServerUri = canonicalRepairServerUri configuration.ServerUri
+            ConfigurationPath = Path.GetFullPath(inspection.Path)
+            RootDirectory = Path.GetFullPath(configuration.RootDirectory)
+            GraceDirectory = Path.GetFullPath(configuration.GraceDirectory)
+            GraceStatusFile = Path.GetFullPath(configuration.GraceStatusFile)
+        }
+
     /// Performs exact-only local-state reconstruction while revalidating configuration and bytes before the atomic commit.
     let private repairLocalState (parseResult: ParseResult) (cancellationToken: CancellationToken) =
         task {
@@ -1445,18 +1481,39 @@ module Doctor =
                && watchInspection.HasCurrentRepositoryIdentity then
                 invalidOp "Grace Doctor refused local-state repair because Grace Watch is active for this repository and branch."
 
+            let capturedConfigurationIdentity =
+                match tryInspectCurrentDirectoryConfiguration () with
+                | Ok inspection -> localStateRepairConfigurationIdentity inspection
+                | Error error -> invalidOp $"Grace Doctor could not read the configured repository identity: {error}"
+
+            let pathComparison =
+                if OperatingSystem.IsWindows() then
+                    StringComparison.OrdinalIgnoreCase
+                else
+                    StringComparison.Ordinal
+
             let requireCurrentConfiguration () =
                 match tryInspectCurrentDirectoryConfiguration () with
-                | Ok persisted when
-                    persisted.Configuration.RepositoryId = current.RepositoryId
-                    && persisted.Configuration.BranchId = current.BranchId
-                    ->
-                    ()
-                | Ok _ -> invalidOp "Repository or branch configuration changed during local-state repair."
+                | Ok persisted ->
+                    let candidate = localStateRepairConfigurationIdentity persisted
+
+                    if
+                        candidate.RepositoryId
+                        <> capturedConfigurationIdentity.RepositoryId
+                        || candidate.BranchId
+                           <> capturedConfigurationIdentity.BranchId
+                        || not (String.Equals(candidate.ServerUri, capturedConfigurationIdentity.ServerUri, StringComparison.Ordinal))
+                        || not (String.Equals(candidate.ConfigurationPath, capturedConfigurationIdentity.ConfigurationPath, pathComparison))
+                        || not (String.Equals(candidate.RootDirectory, capturedConfigurationIdentity.RootDirectory, pathComparison))
+                        || not (String.Equals(candidate.GraceDirectory, capturedConfigurationIdentity.GraceDirectory, pathComparison))
+                        || not (String.Equals(candidate.GraceStatusFile, capturedConfigurationIdentity.GraceStatusFile, pathComparison))
+                    then
+                        invalidOp "Server, working-tree, or local-state configuration changed during local-state repair."
                 | Error error -> invalidOp $"Grace Doctor could not read the configured repository identity: {error}"
 
             requireCurrentConfiguration ()
             LocalStateDb.ensureNoActiveWriterForLocalStateRepair current.GraceStatusFile
+            let! repairBaseline = LocalStateDb.captureLocalStateRepairBaseline current.GraceStatusFile
             let! retained = Grace.CLI.Services.createNewGraceStatusFile GraceStatus.Default parseResult
 
             if
@@ -1592,9 +1649,17 @@ module Doctor =
                && finalWatchInspection.HasCurrentRepositoryIdentity then
                 invalidOp "Grace Watch started before local-state repair could commit."
 
-            LocalStateDb.ensureNoActiveWriterForLocalStateRepair current.GraceStatusFile
-            LocalStateDb.invalidateInitializationCacheForLocalStateRepair current.GraceStatusFile
-            let! _ = LocalStateDb.replaceStatusSnapshotWithRemoteReferenceBoundary current.GraceStatusFile exactStatus boundary cancellationToken
+            match repairBaseline with
+            | LocalStateDb.UnreadableLocalStateDatabase _ -> LocalStateDb.invalidateInitializationCacheForLocalStateRepair current.GraceStatusFile
+            | _ -> ()
+
+            let! _ =
+                LocalStateDb.replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepair
+                    current.GraceStatusFile
+                    repairBaseline
+                    exactStatus
+                    boundary
+                    cancellationToken
 
             return
                 repairReport

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -5,8 +5,11 @@ open Grace.CLI.Common
 open Grace.CLI.Text
 open Grace.Shared
 open Grace.Shared.Client
+open Grace.Shared.Client.Configuration
+open Grace.Shared.Parameters.Branch
 open Grace.SDK
 open Grace.Types.Common
+open Grace.Types.Reference
 open Spectre.Console
 open System
 open System.Collections.Generic
@@ -152,6 +155,15 @@ module Doctor =
                 OptionName.Strict,
                 Required = false,
                 Description = "Return a failing exit code when the doctor report status is Warning.",
+                Arity = ArgumentArity.Zero,
+                DefaultValueFactory = (fun _ -> false)
+            )
+
+        let repairLocalState =
+            new Option<bool>(
+                "--repair-local-state",
+                Required = false,
+                Description = "Rebuild exact local status and its matching remote-event boundary without changing working-tree or server content.",
                 Arity = ArgumentArity.Zero,
                 DefaultValueFactory = (fun _ -> false)
             )
@@ -1347,38 +1359,297 @@ module Doctor =
 
         AnsiConsole.Write(table)
 
+    /// Builds the single-result report returned by the explicit local-state repair gesture.
+    let private repairReport status summary exitCode =
+        let check: LocalOutputDto.DoctorCheckDto =
+            {
+                Id = "state.repair-local-state"
+                Category = "Local state"
+                Title = "Exact local-state repair"
+                Description = "Rebuilds local status only from an unchanged working tree with an exact server root and event boundary."
+                DefaultEnabled = false
+                SupportsOffline = false
+            }
+
+        let result: LocalOutputDto.DoctorCheckResultDto =
+            {
+                Id = check.Id
+                Category = check.Category
+                Title = check.Title
+                Status = status
+                Severity = (if exitCode = 0 then "Info" else "Error")
+                Summary = summary
+            }
+
+        let doctorSummary: LocalOutputDto.DoctorSummaryDto =
+            { Total = 1; Ok = (if exitCode = 0 then 1 else 0); Warning = 0; Failed = (if exitCode = 0 then 0 else 1); Skipped = 0 }
+
+        let report: LocalOutputDto.DoctorReportDto =
+            {
+                ReportVersion = ReportVersion
+                Status = status
+                ExitCode = exitCode
+                Full = false
+                Offline = false
+                Strict = false
+                ListOnly = false
+                RequestedChecks = [| check.Id |]
+                Catalog = [| check |]
+                Checks = [| result |]
+                Summary = doctorSummary
+            }
+
+        report
+
+    /// Converts the immutable server directory closure into the exact local status identities used by later saves.
+    let private statusFromServerClosure rootDirectoryId (directoryVersions: Grace.Types.DirectoryVersion.DirectoryVersionDto array) =
+        let index = GraceIndex()
+
+        for directoryVersionDto in directoryVersions do
+            let directoryVersion = directoryVersionDto.DirectoryVersion.ToLocalDirectoryVersion(DateTime.UtcNow)
+
+            index.TryAdd(directoryVersion.DirectoryVersionId, directoryVersion)
+            |> ignore
+
+        let mutable root = LocalDirectoryVersion.Default
+
+        if
+            not (index.TryGetValue(rootDirectoryId, &root))
+            || root.RelativePath <> Constants.RootDirectoryPath
+        then
+            invalidOp "Grace Server did not return the exact recursive root directory closure."
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = root.DirectoryVersionId
+            RootDirectorySha256Hash = root.Sha256Hash
+            RootDirectoryBlake3Hash = root.Blake3Hash
+        }
+
+    let mutable private beforeRepairFinalValidation = fun () -> ()
+
+    /// Installs the deterministic seam used to prove stale local bytes and configuration cannot cross repair validation.
+    let internal setBeforeRepairFinalValidationForTests probe = beforeRepairFinalValidation <- probe
+
+    /// Restores production repair validation after deterministic stale-state tests.
+    let internal resetBeforeRepairFinalValidationForTests () = beforeRepairFinalValidation <- fun () -> ()
+
+    /// Performs exact-only local-state reconstruction while revalidating configuration and bytes before the atomic commit.
+    let private repairLocalState (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            cancellationToken.ThrowIfCancellationRequested()
+            let current = Current()
+            let! watchInspection = Grace.CLI.Services.inspectGraceWatchStatus ()
+
+            if watchInspection.IsFresh
+               && watchInspection.HasCurrentRepositoryIdentity then
+                invalidOp "Grace Doctor refused local-state repair because Grace Watch is active for this repository and branch."
+
+            let requireCurrentConfiguration () =
+                match tryInspectCurrentDirectoryConfiguration () with
+                | Ok persisted when
+                    persisted.Configuration.RepositoryId = current.RepositoryId
+                    && persisted.Configuration.BranchId = current.BranchId
+                    ->
+                    ()
+                | Ok _ -> invalidOp "Repository or branch configuration changed during local-state repair."
+                | Error error -> invalidOp $"Grace Doctor could not read the configured repository identity: {error}"
+
+            requireCurrentConfiguration ()
+            LocalStateDb.ensureNoActiveWriterForLocalStateRepair current.GraceStatusFile
+            let! retained = Grace.CLI.Services.createNewGraceStatusFile GraceStatus.Default parseResult
+
+            if
+                retained.RootDirectoryId = DirectoryVersionId.Empty
+                || String.IsNullOrWhiteSpace(string retained.RootDirectorySha256Hash)
+            then
+                invalidOp "Grace Doctor could not compute a complete retained working-tree root."
+
+            let lookup =
+                Grace.Shared.Parameters.DirectoryVersion.GetBySha256HashParameters(
+                    OwnerId = $"{current.OwnerId}",
+                    OwnerName = current.OwnerName,
+                    OrganizationId = $"{current.OrganizationId}",
+                    OrganizationName = current.OrganizationName,
+                    RepositoryId = $"{current.RepositoryId}",
+                    RepositoryName = current.RepositoryName,
+                    Sha256Hash = retained.RootDirectorySha256Hash,
+                    CorrelationId = getCorrelationId parseResult
+                )
+
+            let! resolvedRootResult = DirectoryVersion.GetBySha256Hash lookup
+
+            let resolvedRoot =
+                match resolvedRootResult with
+                | Ok value when
+                    value.ReturnValue.RelativePath = Constants.RootDirectoryPath
+                    && value.ReturnValue.Blake3Hash = retained.RootDirectoryBlake3Hash
+                    ->
+                    value.ReturnValue
+                | Ok _ -> invalidOp "The retained working tree does not exactly match a server root for this repository."
+                | Error _ -> invalidOp "No exact server root matches the retained working tree."
+
+            let referencesParameters =
+                GetReferencesParameters(
+                    OwnerId = $"{current.OwnerId}",
+                    OwnerName = current.OwnerName,
+                    OrganizationId = $"{current.OrganizationId}",
+                    OrganizationName = current.OrganizationName,
+                    RepositoryId = $"{current.RepositoryId}",
+                    RepositoryName = current.RepositoryName,
+                    BranchId = $"{current.BranchId}",
+                    BranchName = current.BranchName,
+                    MaxCount = Int32.MaxValue,
+                    CorrelationId = getCorrelationId parseResult
+                )
+
+            match! Grace.SDK.Branch.GetReferences referencesParameters with
+            | Ok value when
+                value.ReturnValue
+                |> Array.exists (fun (reference: ReferenceDto) ->
+                    reference.RepositoryId = current.RepositoryId
+                    && reference.BranchId = current.BranchId
+                    && reference.DirectoryId = resolvedRoot.DirectoryVersionId
+                    && reference.Sha256Hash = resolvedRoot.Sha256Hash
+                    && reference.Blake3Hash = resolvedRoot.Blake3Hash)
+                ->
+                ()
+            | _ -> invalidOp "The exact retained root is not present in the configured branch history."
+
+            let boundaryParameters =
+                ResolveReferenceEventBoundaryParameters(
+                    OwnerId = $"{current.OwnerId}",
+                    OwnerName = current.OwnerName,
+                    OrganizationId = $"{current.OrganizationId}",
+                    OrganizationName = current.OrganizationName,
+                    RepositoryId = $"{current.RepositoryId}",
+                    RepositoryName = current.RepositoryName,
+                    BranchId = $"{current.BranchId}",
+                    BranchName = current.BranchName,
+                    DirectoryVersionId = resolvedRoot.DirectoryVersionId,
+                    Sha256Hash = resolvedRoot.Sha256Hash,
+                    Blake3Hash = resolvedRoot.Blake3Hash,
+                    CorrelationId = getCorrelationId parseResult
+                )
+
+            let! boundaryResult = Branch.ResolveReferenceEventBoundary boundaryParameters
+
+            let boundary =
+                match boundaryResult with
+                | Ok value when
+                    value.ReturnValue.DirectoryId = resolvedRoot.DirectoryVersionId
+                    && value.ReturnValue.Sha256Hash = resolvedRoot.Sha256Hash
+                    && value.ReturnValue.Blake3Hash = resolvedRoot.Blake3Hash
+                    && not (String.IsNullOrWhiteSpace value.ReturnValue.EventCursor)
+                    ->
+                    value.ReturnValue
+                | _ -> invalidOp "The exact retained root is not present in the configured branch ordered history."
+
+            let closureParameters =
+                Grace.Shared.Parameters.DirectoryVersion.GetParameters(
+                    OwnerId = $"{current.OwnerId}",
+                    OwnerName = current.OwnerName,
+                    OrganizationId = $"{current.OrganizationId}",
+                    OrganizationName = current.OrganizationName,
+                    RepositoryId = $"{current.RepositoryId}",
+                    RepositoryName = current.RepositoryName,
+                    DirectoryVersionId = $"{resolvedRoot.DirectoryVersionId}",
+                    CorrelationId = getCorrelationId parseResult
+                )
+
+            let! closureResult = DirectoryVersion.GetDirectoryVersionsRecursive closureParameters
+
+            let exactStatus =
+                match closureResult with
+                | Ok value ->
+                    value.ReturnValue
+                    |> Seq.toArray
+                    |> statusFromServerClosure resolvedRoot.DirectoryVersionId
+                | Error error -> invalidOp $"Grace Doctor could not read the exact immutable server closure: {error.Error}"
+
+            let! firstDifferences = Grace.CLI.Services.scanForDifferences exactStatus
+
+            if
+                not (Grace.CLI.Services.wasLastScanForDifferencesSuccessful ())
+                || firstDifferences.Count <> 0
+            then
+                invalidOp "Working-tree bytes or paths do not match the exact server closure."
+
+            cancellationToken.ThrowIfCancellationRequested()
+            beforeRepairFinalValidation ()
+            requireCurrentConfiguration ()
+            let! finalDifferences = Grace.CLI.Services.scanForDifferences exactStatus
+
+            if
+                not (Grace.CLI.Services.wasLastScanForDifferencesSuccessful ())
+                || finalDifferences.Count <> 0
+            then
+                invalidOp "Working-tree bytes changed before local-state repair could commit."
+
+            let! finalWatchInspection = Grace.CLI.Services.inspectGraceWatchStatus ()
+
+            if finalWatchInspection.IsFresh
+               && finalWatchInspection.HasCurrentRepositoryIdentity then
+                invalidOp "Grace Watch started before local-state repair could commit."
+
+            LocalStateDb.ensureNoActiveWriterForLocalStateRepair current.GraceStatusFile
+            LocalStateDb.invalidateInitializationCacheForLocalStateRepair current.GraceStatusFile
+            let! _ = LocalStateDb.replaceStatusSnapshotWithRemoteReferenceBoundary current.GraceStatusFile exactStatus boundary cancellationToken
+
+            return
+                repairReport
+                    "Ok"
+                    $"Repaired exact local status for root {resolvedRoot.DirectoryVersionId} at event cursor {boundary.EventCursor}; working-tree and server content were unchanged."
+                    0
+        }
+
     /// Executes the invoke command by binding ParseResult values to the SDK request and CLI output contract.
     type Invoke() =
-        inherit SynchronousCommandLineAction()
+        inherit AsynchronousCommandLineAction()
 
         /// Runs the asynchronous invoke action when System.CommandLine dispatches the parsed command.
-        override _.Invoke(parseResult: ParseResult) : int =
-            if
-                (parseResult |> verbose)
-                && not (parseResult |> hasSelect)
-            then
-                printParseResult parseResult
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            task {
+                if
+                    (parseResult |> verbose)
+                    && not (parseResult |> hasSelect)
+                then
+                    printParseResult parseResult
 
-            let full = parseResult.GetValue(Options.full)
-            let offline = parseResult.GetValue(Options.offline)
-            let strict = parseResult.GetValue(Options.strict)
-            let listChecks = parseResult.GetValue(Options.listChecks)
+                if parseResult.GetValue(Options.repairLocalState) then
+                    try
+                        let! report = repairLocalState parseResult cancellationToken
+                        let renderResult = renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
 
-            let requestedTokens =
-                parseResult.GetValue(Options.check)
-                |> tokenizeChecks
+                        if renderResult = 0
+                           && shouldRenderHumanReport parseResult then
+                            renderHumanReport report
 
-            match validateChecks parseResult full offline listChecks requestedTokens with
-            | Error error -> renderOutput parseResult (Error error)
-            | Ok checks ->
-                let report = createReport full offline strict listChecks requestedTokens checks
-                let renderResult = renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
+                        return if renderResult <> 0 then renderResult else report.ExitCode
+                    with
+                    | ex -> return renderOutput parseResult (Error(GraceError.Create ex.Message (getCorrelationId parseResult)))
+                else
+                    let full = parseResult.GetValue(Options.full)
+                    let offline = parseResult.GetValue(Options.offline)
+                    let strict = parseResult.GetValue(Options.strict)
+                    let listChecks = parseResult.GetValue(Options.listChecks)
 
-                if renderResult = 0
-                   && shouldRenderHumanReport parseResult then
-                    renderHumanReport report
+                    let requestedTokens =
+                        parseResult.GetValue(Options.check)
+                        |> tokenizeChecks
 
-                if renderResult <> 0 then renderResult else diagnosticExitCode strict report
+                    match validateChecks parseResult full offline listChecks requestedTokens with
+                    | Error error -> return renderOutput parseResult (Error error)
+                    | Ok checks ->
+                        let report = createReport full offline strict listChecks requestedTokens checks
+                        let renderResult = renderOutput parseResult (Ok(GraceReturnValue.Create report (getCorrelationId parseResult)))
+
+                        if renderResult = 0
+                           && shouldRenderHumanReport parseResult then
+                            renderHumanReport report
+
+                        return if renderResult <> 0 then renderResult else diagnosticExitCode strict report
+            }
 
     let Build =
         let doctorCommand =
@@ -1388,6 +1659,7 @@ module Doctor =
             |> addOption Options.listChecks
             |> addOption Options.check
             |> addOption Options.strict
+            |> addOption Options.repairLocalState
 
         doctorCommand.Action <- Invoke()
         doctorCommand

--- a/src/Grace.CLI/Command/Doctor.CLI.fs
+++ b/src/Grace.CLI/Command/Doctor.CLI.fs
@@ -1428,92 +1428,46 @@ module Doctor =
 
     let mutable private beforeRepairFinalValidation = fun () -> ()
 
+    let mutable private afterRepairCachedConfiguration = fun () -> ()
+
+    let mutable private beforeRepairFirstServerRead = fun () -> ()
+
+    /// Installs the deterministic seam used to rewrite persisted configuration after repair acquires cached configuration.
+    let internal setAfterRepairCachedConfigurationForTests probe = afterRepairCachedConfiguration <- probe
+
+    /// Restores production repair configuration capture after deterministic cache-race tests.
+    let internal resetAfterRepairCachedConfigurationForTests () = afterRepairCachedConfiguration <- fun () -> ()
+
+    /// Installs an observer at repair's first server read so configuration races can prove an early abort.
+    let internal setBeforeRepairFirstServerReadForTests probe = beforeRepairFirstServerRead <- probe
+
+    /// Restores the production first-server-read boundary after deterministic repair tests.
+    let internal resetBeforeRepairFirstServerReadForTests () = beforeRepairFirstServerRead <- fun () -> ()
+
     /// Installs the deterministic seam used to prove stale local bytes and configuration cannot cross repair validation.
     let internal setBeforeRepairFinalValidationForTests probe = beforeRepairFinalValidation <- probe
 
     /// Restores production repair validation after deterministic stale-state tests.
     let internal resetBeforeRepairFinalValidationForTests () = beforeRepairFinalValidation <- fun () -> ()
 
-    /// Identifies every effective server, working-tree, and local-state input used by exact repair.
-    type private LocalStateRepairConfigurationIdentity =
-        {
-            RepositoryId: RepositoryId
-            BranchId: BranchId
-            ServerUri: string
-            ConfigurationPath: string
-            RootDirectory: string
-            GraceDirectory: string
-            GraceStatusFile: string
-        }
-
-    /// Canonicalizes an effective repair URI so equivalent trailing separators do not look like server changes.
-    let private canonicalRepairServerUri (value: string) =
-        match Uri.TryCreate(value, UriKind.Absolute) with
-        | true, uri when
-            uri.Scheme = Uri.UriSchemeHttp
-            || uri.Scheme = Uri.UriSchemeHttps
-            ->
-            uri.AbsoluteUri.TrimEnd('/')
-        | _ -> invalidOp $"Grace Doctor requires an absolute HTTP or HTTPS server URI for local-state repair: {value}"
-
-    /// Captures the effective persisted inputs that select repair's server, working tree, and SQLite database.
-    let private localStateRepairConfigurationIdentity (inspection: Grace.Shared.Client.Configuration.GraceConfigurationInspection) =
-        let configuration = inspection.Configuration
-
-        {
-            RepositoryId = configuration.RepositoryId
-            BranchId = configuration.BranchId
-            ServerUri = canonicalRepairServerUri configuration.ServerUri
-            ConfigurationPath = Path.GetFullPath(inspection.Path)
-            RootDirectory = Path.GetFullPath(configuration.RootDirectory)
-            GraceDirectory = Path.GetFullPath(configuration.GraceDirectory)
-            GraceStatusFile = Path.GetFullPath(configuration.GraceStatusFile)
-        }
-
     /// Performs exact-only local-state reconstruction while revalidating configuration and bytes before the atomic commit.
     let private repairLocalState (parseResult: ParseResult) (cancellationToken: CancellationToken) =
         task {
             cancellationToken.ThrowIfCancellationRequested()
             let current = Current()
-            let! watchInspection = Grace.CLI.Services.inspectGraceWatchStatus ()
+            afterRepairCachedConfiguration ()
+            let operationalConfiguration = Grace.CLI.Services.captureOperationalConfigurationSnapshot "Doctor" current
+            let! watchInspection = Grace.CLI.Services.inspectGraceWatchStatusForOperationalConfiguration operationalConfiguration
 
             if watchInspection.IsFresh
                && watchInspection.HasCurrentRepositoryIdentity then
                 invalidOp "Grace Doctor refused local-state repair because Grace Watch is active for this repository and branch."
 
-            let capturedConfigurationIdentity =
-                match tryInspectCurrentDirectoryConfiguration () with
-                | Ok inspection -> localStateRepairConfigurationIdentity inspection
-                | Error error -> invalidOp $"Grace Doctor could not read the configured repository identity: {error}"
-
-            let pathComparison =
-                if OperatingSystem.IsWindows() then
-                    StringComparison.OrdinalIgnoreCase
-                else
-                    StringComparison.Ordinal
-
-            let requireCurrentConfiguration () =
-                match tryInspectCurrentDirectoryConfiguration () with
-                | Ok persisted ->
-                    let candidate = localStateRepairConfigurationIdentity persisted
-
-                    if
-                        candidate.RepositoryId
-                        <> capturedConfigurationIdentity.RepositoryId
-                        || candidate.BranchId
-                           <> capturedConfigurationIdentity.BranchId
-                        || not (String.Equals(candidate.ServerUri, capturedConfigurationIdentity.ServerUri, StringComparison.Ordinal))
-                        || not (String.Equals(candidate.ConfigurationPath, capturedConfigurationIdentity.ConfigurationPath, pathComparison))
-                        || not (String.Equals(candidate.RootDirectory, capturedConfigurationIdentity.RootDirectory, pathComparison))
-                        || not (String.Equals(candidate.GraceDirectory, capturedConfigurationIdentity.GraceDirectory, pathComparison))
-                        || not (String.Equals(candidate.GraceStatusFile, capturedConfigurationIdentity.GraceStatusFile, pathComparison))
-                    then
-                        invalidOp "Server, working-tree, or local-state configuration changed during local-state repair."
-                | Error error -> invalidOp $"Grace Doctor could not read the configured repository identity: {error}"
+            let requireCurrentConfiguration () = Grace.CLI.Services.requireOperationalConfigurationSnapshotCurrent "Doctor" current operationalConfiguration
 
             requireCurrentConfiguration ()
-            LocalStateDb.ensureNoActiveWriterForLocalStateRepair current.GraceStatusFile
-            let! repairBaseline = LocalStateDb.captureLocalStateRepairBaseline current.GraceStatusFile
+            LocalStateDb.ensureNoActiveWriterForLocalStateRepair operationalConfiguration.GraceStatusFile
+            let! repairBaseline = LocalStateDb.captureLocalStateRepairBaseline operationalConfiguration.GraceStatusFile
             let! retained = Grace.CLI.Services.createNewGraceStatusFile GraceStatus.Default parseResult
 
             if
@@ -1524,16 +1478,17 @@ module Doctor =
 
             let lookup =
                 Grace.Shared.Parameters.DirectoryVersion.GetBySha256HashParameters(
-                    OwnerId = $"{current.OwnerId}",
-                    OwnerName = current.OwnerName,
-                    OrganizationId = $"{current.OrganizationId}",
-                    OrganizationName = current.OrganizationName,
-                    RepositoryId = $"{current.RepositoryId}",
-                    RepositoryName = current.RepositoryName,
+                    OwnerId = $"{operationalConfiguration.OwnerId}",
+                    OwnerName = operationalConfiguration.OwnerName,
+                    OrganizationId = $"{operationalConfiguration.OrganizationId}",
+                    OrganizationName = operationalConfiguration.OrganizationName,
+                    RepositoryId = $"{operationalConfiguration.RepositoryId}",
+                    RepositoryName = operationalConfiguration.RepositoryName,
                     Sha256Hash = retained.RootDirectorySha256Hash,
                     CorrelationId = getCorrelationId parseResult
                 )
 
+            beforeRepairFirstServerRead ()
             let! resolvedRootResult = DirectoryVersion.GetBySha256Hash lookup
 
             let resolvedRoot =
@@ -1548,14 +1503,14 @@ module Doctor =
 
             let referencesParameters =
                 GetReferencesParameters(
-                    OwnerId = $"{current.OwnerId}",
-                    OwnerName = current.OwnerName,
-                    OrganizationId = $"{current.OrganizationId}",
-                    OrganizationName = current.OrganizationName,
-                    RepositoryId = $"{current.RepositoryId}",
-                    RepositoryName = current.RepositoryName,
-                    BranchId = $"{current.BranchId}",
-                    BranchName = current.BranchName,
+                    OwnerId = $"{operationalConfiguration.OwnerId}",
+                    OwnerName = operationalConfiguration.OwnerName,
+                    OrganizationId = $"{operationalConfiguration.OrganizationId}",
+                    OrganizationName = operationalConfiguration.OrganizationName,
+                    RepositoryId = $"{operationalConfiguration.RepositoryId}",
+                    RepositoryName = operationalConfiguration.RepositoryName,
+                    BranchId = $"{operationalConfiguration.BranchId}",
+                    BranchName = operationalConfiguration.BranchName,
                     MaxCount = Int32.MaxValue,
                     CorrelationId = getCorrelationId parseResult
                 )
@@ -1564,8 +1519,8 @@ module Doctor =
             | Ok value when
                 value.ReturnValue
                 |> Array.exists (fun (reference: ReferenceDto) ->
-                    reference.RepositoryId = current.RepositoryId
-                    && reference.BranchId = current.BranchId
+                    reference.RepositoryId = operationalConfiguration.RepositoryId
+                    && reference.BranchId = operationalConfiguration.BranchId
                     && reference.DirectoryId = resolvedRoot.DirectoryVersionId
                     && reference.Sha256Hash = resolvedRoot.Sha256Hash
                     && reference.Blake3Hash = resolvedRoot.Blake3Hash)
@@ -1575,14 +1530,14 @@ module Doctor =
 
             let boundaryParameters =
                 ResolveReferenceEventBoundaryParameters(
-                    OwnerId = $"{current.OwnerId}",
-                    OwnerName = current.OwnerName,
-                    OrganizationId = $"{current.OrganizationId}",
-                    OrganizationName = current.OrganizationName,
-                    RepositoryId = $"{current.RepositoryId}",
-                    RepositoryName = current.RepositoryName,
-                    BranchId = $"{current.BranchId}",
-                    BranchName = current.BranchName,
+                    OwnerId = $"{operationalConfiguration.OwnerId}",
+                    OwnerName = operationalConfiguration.OwnerName,
+                    OrganizationId = $"{operationalConfiguration.OrganizationId}",
+                    OrganizationName = operationalConfiguration.OrganizationName,
+                    RepositoryId = $"{operationalConfiguration.RepositoryId}",
+                    RepositoryName = operationalConfiguration.RepositoryName,
+                    BranchId = $"{operationalConfiguration.BranchId}",
+                    BranchName = operationalConfiguration.BranchName,
                     DirectoryVersionId = resolvedRoot.DirectoryVersionId,
                     Sha256Hash = resolvedRoot.Sha256Hash,
                     Blake3Hash = resolvedRoot.Blake3Hash,
@@ -1604,12 +1559,12 @@ module Doctor =
 
             let closureParameters =
                 Grace.Shared.Parameters.DirectoryVersion.GetParameters(
-                    OwnerId = $"{current.OwnerId}",
-                    OwnerName = current.OwnerName,
-                    OrganizationId = $"{current.OrganizationId}",
-                    OrganizationName = current.OrganizationName,
-                    RepositoryId = $"{current.RepositoryId}",
-                    RepositoryName = current.RepositoryName,
+                    OwnerId = $"{operationalConfiguration.OwnerId}",
+                    OwnerName = operationalConfiguration.OwnerName,
+                    OrganizationId = $"{operationalConfiguration.OrganizationId}",
+                    OrganizationName = operationalConfiguration.OrganizationName,
+                    RepositoryId = $"{operationalConfiguration.RepositoryId}",
+                    RepositoryName = operationalConfiguration.RepositoryName,
                     DirectoryVersionId = $"{resolvedRoot.DirectoryVersionId}",
                     CorrelationId = getCorrelationId parseResult
                 )
@@ -1643,19 +1598,22 @@ module Doctor =
             then
                 invalidOp "Working-tree bytes changed before local-state repair could commit."
 
-            let! finalWatchInspection = Grace.CLI.Services.inspectGraceWatchStatus ()
+            let! finalWatchInspection = Grace.CLI.Services.inspectGraceWatchStatusForOperationalConfiguration operationalConfiguration
 
             if finalWatchInspection.IsFresh
                && finalWatchInspection.HasCurrentRepositoryIdentity then
                 invalidOp "Grace Watch started before local-state repair could commit."
 
             match repairBaseline with
-            | LocalStateDb.UnreadableLocalStateDatabase _ -> LocalStateDb.invalidateInitializationCacheForLocalStateRepair current.GraceStatusFile
+            | LocalStateDb.UnreadableLocalStateDatabase _ ->
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair operationalConfiguration.GraceStatusFile
             | _ -> ()
+
+            requireCurrentConfiguration ()
 
             let! _ =
                 LocalStateDb.replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepair
-                    current.GraceStatusFile
+                    operationalConfiguration.GraceStatusFile
                     repairBaseline
                     exactStatus
                     boundary

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -9,6 +9,7 @@ open Grace.SDK
 open Grace.Shared
 open Grace.Shared.Parameters
 open Grace.Types.Common
+open Grace.Types.Reference
 open Grace.Shared.Utilities
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Parameters.DirectoryVersion
@@ -375,6 +376,14 @@ module Repository =
         else
             Ok parseResult
 
+    let mutable private beforeRepositoryInitializationSave = fun () -> ()
+
+    /// Installs the deterministic seam used to prove initialization publication failures cannot create trusted local state.
+    let internal setBeforeRepositoryInitializationSaveForTests probe = beforeRepositoryInitializationSave <- probe
+
+    /// Restores the production repository-initialization publication path after deterministic failure tests.
+    let internal resetBeforeRepositoryInitializationSaveForTests () = beforeRepositoryInitializationSave <- fun () -> ()
+
     /// Routes the init command from parsed options through validation, the SDK call, and result rendering.
     let private initHandler (parseResult: ParseResult) (parameters: InitParameters) =
         task {
@@ -459,10 +468,7 @@ module Repository =
 
                                                     t1.Value <- 100.0
 
-                                                    // Write the new Grace status file to disk.
-                                                    t2.StartTask()
-                                                    do! writeGraceStatusFile graceStatus
-                                                    t2.Value <- 100.0
+                                                    // Local status is committed only after the complete tree and matching Reference succeed.
 
                                                     // Ensure all files are in the object cache.
                                                     t3.StartTask()
@@ -510,6 +516,7 @@ module Repository =
                                                     // Ensure all files are uploaded to object storage.
                                                     t5.StartTask()
                                                     let incrementAmount = 100.0 / double fileVersions.Count
+                                                    let mutable fileUploadFailed = false
 
                                                     match Current().ObjectStorageProvider with
                                                     | ObjectStorageProvider.Unknown -> ()
@@ -590,7 +597,9 @@ module Repository =
                                                                                             ))
                                                                                     )
 
-                                                                            | Error error -> AnsiConsole.Write((new Panel($"{error}")).BorderColor(Color.Red3))
+                                                                            | Error error ->
+                                                                                fileUploadFailed <- true
+                                                                                AnsiConsole.Write((new Panel($"{error}")).BorderColor(Color.Red3))
                                                                         }
                                                                     ))
                                                             )
@@ -599,6 +608,7 @@ module Repository =
                                                         if errors |> Seq.isEmpty then
                                                             ()
                                                         else
+                                                            fileUploadFailed <- true
                                                             AnsiConsole.MarkupLine($"{errors.Count} errors occurred.")
 
                                                             let mutable error = GraceError.Create String.Empty String.Empty
@@ -612,6 +622,9 @@ module Repository =
                                                     | GoogleCloudStorage -> ()
 
                                                     t5.Value <- 100.0
+
+                                                    if fileUploadFailed then
+                                                        invalidOp "Repository initialization could not upload every file."
 
                                                     // Ensure all directory versions are uploaded to Grace Server.
                                                     t6.StartTask()
@@ -672,6 +685,7 @@ module Repository =
 
                                                     AnsiConsole.MarkupLine($"[{Colors.Important}]succeeded: {succeeded.Count}; errors: {errors.Count}.[/]")
 
+                                                    let directoryUploadFailed = not errors.IsEmpty
                                                     let mutable error = GraceError.Create String.Empty String.Empty
 
                                                     while not <| errors.IsEmpty do
@@ -681,7 +695,81 @@ module Repository =
 
                                                         AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error.EscapeMarkup()}[/]")
 
-                                                    return graceStatus
+                                                    if directoryUploadFailed then
+                                                        invalidOp "Repository initialization could not publish every directory version."
+
+                                                    let rootDirectoryVersion =
+                                                        graceStatus.Index.Values.First (fun directoryVersion ->
+                                                            directoryVersion.RelativePath = Constants.RootDirectoryPath)
+
+                                                    let enableSaveParameters =
+                                                        Parameters.Branch.EnableFeatureParameters(
+                                                            OwnerId = parameters.OwnerId,
+                                                            OwnerName = parameters.OwnerName,
+                                                            OrganizationId = parameters.OrganizationId,
+                                                            OrganizationName = parameters.OrganizationName,
+                                                            RepositoryId = parameters.RepositoryId,
+                                                            RepositoryName = parameters.RepositoryName,
+                                                            BranchId = $"{Current().BranchId}",
+                                                            BranchName = Current().BranchName,
+                                                            Enabled = true,
+                                                            CorrelationId = getCorrelationId parseResult
+                                                        )
+
+                                                    match! Grace.SDK.Branch.EnableSave enableSaveParameters with
+                                                    | Error error -> invalidOp $"Repository initialization could not enable its first Save: {error.Error}"
+                                                    | Ok _ -> ()
+
+                                                    beforeRepositoryInitializationSave ()
+
+                                                    match!
+                                                        createSaveReference
+                                                            rootDirectoryVersion
+                                                            "Initialized repository from the existing working tree."
+                                                            (getCorrelationId parseResult)
+                                                        with
+                                                    | Error error -> return invalidOp $"Repository initialization could not publish its Save: {error.Error}"
+                                                    | Ok save ->
+                                                        let referenceId =
+                                                            match parseCreatedReferenceId (getCorrelationId parseResult) save with
+                                                            | Ok value -> value
+                                                            | Error error -> invalidOp error.Error
+
+                                                        let boundaryParameters =
+                                                            Parameters.Branch.GetReferenceMaterializationBoundaryParameters(
+                                                                OwnerId = parameters.OwnerId,
+                                                                OwnerName = parameters.OwnerName,
+                                                                OrganizationId = parameters.OrganizationId,
+                                                                OrganizationName = parameters.OrganizationName,
+                                                                RepositoryId = parameters.RepositoryId,
+                                                                RepositoryName = parameters.RepositoryName,
+                                                                BranchId = $"{Current().BranchId}",
+                                                                BranchName = Current().BranchName,
+                                                                ReferenceId = $"{referenceId}",
+                                                                CorrelationId = getCorrelationId parseResult
+                                                            )
+
+                                                        match! Grace.SDK.Branch.GetReferenceMaterializationBoundary boundaryParameters with
+                                                        | Error error ->
+                                                            return
+                                                                invalidOp
+                                                                    $"Repository initialization could not resolve its published event boundary: {error.Error}"
+                                                        | Ok boundaryResult ->
+                                                            let boundary = boundaryResult.ReturnValue
+
+                                                            if boundary.DirectoryId
+                                                               <> rootDirectoryVersion.DirectoryVersionId
+                                                               || boundary.Sha256Hash
+                                                                  <> rootDirectoryVersion.Sha256Hash
+                                                               || boundary.Blake3Hash
+                                                                  <> rootDirectoryVersion.Blake3Hash
+                                                               || String.IsNullOrWhiteSpace boundary.EventCursor then
+                                                                invalidOp "Repository initialization received a mismatched event boundary."
+
+                                                            t2.StartTask()
+                                                            do! writeGraceStatusFileWithRemoteReferenceBoundary graceStatus boundary CancellationToken.None
+                                                            t2.Value <- 100.0
+                                                            return graceStatus
 
                                                 })
 
@@ -715,17 +803,12 @@ module Repository =
 
                                     return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
                                 else
-                                    // Do the whole thing with no output
-                                    let output: LocalOutputDto.RepositoryInitDto =
-                                        {
-                                            Message = "Initialized repository."
-                                            DirectoryCount = None
-                                            FileCount = None
-                                            TotalFileSize = None
-                                            RootSha256Hash = None
-                                        }
-
-                                    return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
+                                    return
+                                        Error(
+                                            GraceError.Create
+                                                "Repository initialization requires normal or verbose output until its progress workflow supports an inert renderer."
+                                                (parseResult |> getCorrelationId)
+                                        )
                             else
                                 return
                                     Error(GraceError.Create (RepositoryError.getErrorMessage RepositoryIsAlreadyInitialized) (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Repository.CLI.fs
+++ b/src/Grace.CLI/Command/Repository.CLI.fs
@@ -418,9 +418,21 @@ module Repository =
                             if isEmpty.ReturnValue = true then
                                 let repositoryId = RepositoryId.Parse(parameters.RepositoryId)
 
-                                if parseResult |> hasOutput then
+                                match parseResult |> hasOutput with
+                                | showProgress ->
+                                    let initializationProgress =
+                                        if showProgress then
+                                            progress
+                                        else
+                                            let settings = AnsiConsoleSettings()
+                                            settings.Out <- AnsiConsoleOutput(TextWriter.Null)
+
+                                            AnsiConsole
+                                                .Create(settings)
+                                                .Progress(AutoRefresh = false, AutoClear = true, HideCompleted = true)
+
                                     let! graceStatus =
-                                        progress
+                                        initializationProgress
                                             .Columns(progressColumns)
                                             .StartAsync(fun progressContext ->
                                                 task {
@@ -599,7 +611,9 @@ module Repository =
 
                                                                             | Error error ->
                                                                                 fileUploadFailed <- true
-                                                                                AnsiConsole.Write((new Panel($"{error}")).BorderColor(Color.Red3))
+
+                                                                                if showProgress then
+                                                                                    AnsiConsole.Write((new Panel($"{error}")).BorderColor(Color.Red3))
                                                                         }
                                                                     ))
                                                             )
@@ -609,13 +623,14 @@ module Repository =
                                                             ()
                                                         else
                                                             fileUploadFailed <- true
-                                                            AnsiConsole.MarkupLine($"{errors.Count} errors occurred.")
+                                                            if showProgress then AnsiConsole.MarkupLine($"{errors.Count} errors occurred.")
 
                                                             let mutable error = GraceError.Create String.Empty String.Empty
 
                                                             while not <| errors.IsEmpty do
                                                                 if errors.TryDequeue(&error) then
-                                                                    AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error.EscapeMarkup()}[/]")
+                                                                    if showProgress then
+                                                                        AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error.EscapeMarkup()}[/]")
 
                                                             ()
                                                     | AWSS3 -> ()
@@ -683,7 +698,8 @@ module Repository =
 
                                                     t6.Value <- 100.0
 
-                                                    AnsiConsole.MarkupLine($"[{Colors.Important}]succeeded: {succeeded.Count}; errors: {errors.Count}.[/]")
+                                                    if showProgress then
+                                                        AnsiConsole.MarkupLine($"[{Colors.Important}]succeeded: {succeeded.Count}; errors: {errors.Count}.[/]")
 
                                                     let directoryUploadFailed = not errors.IsEmpty
                                                     let mutable error = GraceError.Create String.Empty String.Empty
@@ -693,7 +709,8 @@ module Repository =
 
                                                         if error.Error.Contains("TRetval") then logToConsole $"********* {error.Error}"
 
-                                                        AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error.EscapeMarkup()}[/]")
+                                                        if showProgress then
+                                                            AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error.EscapeMarkup()}[/]")
 
                                                     if directoryUploadFailed then
                                                         invalidOp "Repository initialization could not publish every directory version."
@@ -784,13 +801,14 @@ module Repository =
 
                                     let rootDirectoryVersion = graceStatus.Index.Values.First(fun d -> d.RelativePath = Constants.RootDirectoryPath)
 
-                                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories scanned: {graceStatus.Index.Count}.[/]")
+                                    if showProgress then
+                                        AnsiConsole.MarkupLine($"[{Colors.Highlighted}]Number of directories scanned: {graceStatus.Index.Count}.[/]")
 
-                                    AnsiConsole.MarkupLine(
-                                        $"[{Colors.Highlighted}]Number of files scanned: {fileCount}; total file size: {totalFileSize:N0}.[/]"
-                                    )
+                                        AnsiConsole.MarkupLine(
+                                            $"[{Colors.Highlighted}]Number of files scanned: {fileCount}; total file size: {totalFileSize:N0}.[/]"
+                                        )
 
-                                    AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(0, 8)}[/]"
+                                        AnsiConsole.MarkupLine $"[{Colors.Highlighted}]Root SHA-256 hash: {rootDirectoryVersion.Sha256Hash.Substring(0, 8)}[/]"
 
                                     let output: LocalOutputDto.RepositoryInitDto =
                                         {
@@ -802,13 +820,6 @@ module Repository =
                                         }
 
                                     return Ok(GraceReturnValue.Create output (parseResult |> getCorrelationId))
-                                else
-                                    return
-                                        Error(
-                                            GraceError.Create
-                                                "Repository initialization requires normal or verbose output until its progress workflow supports an inert renderer."
-                                                (parseResult |> getCorrelationId)
-                                        )
                             else
                                 return
                                     Error(GraceError.Create (RepositoryError.getErrorMessage RepositoryIsAlreadyInitialized) (parseResult |> getCorrelationId))

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -2371,7 +2371,7 @@ module Services =
         task {
 
             let fileInfo = FileInfo(Path.Combine(Current().RootDirectory, difference.RelativePath))
-            let relativeDirectoryPath = getLocalRelativeDirectory fileInfo.DirectoryName (Current().RootDirectory)
+            let relativeDirectoryPath = normalizeFilePath (getLocalRelativeDirectory fileInfo.DirectoryName (Current().RootDirectory))
 
             let directoryVersion =
                 let mutable changedDirectoryVersion = LocalDirectoryVersion.Default
@@ -2439,7 +2439,7 @@ module Services =
         =
 
         let fileInfo = FileInfo(Path.Combine(Current().RootDirectory, difference.RelativePath))
-        let relativeDirectoryPath = getLocalRelativeDirectory fileInfo.DirectoryName (Current().RootDirectory)
+        let relativeDirectoryPath = normalizeFilePath (getLocalRelativeDirectory fileInfo.DirectoryName (Current().RootDirectory))
 
         let directoryVersion =
             newGraceStatus

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -47,6 +47,118 @@ module Services =
 
     let mutable lockObject = new Lock()
 
+    /// Freezes every configured input that selects a CLI command's server, repository tree, or local-state database.
+    type internal OperationalConfigurationSnapshot =
+        {
+            OwnerId: OwnerId
+            OwnerName: OwnerName
+            OrganizationId: OrganizationId
+            OrganizationName: OrganizationName
+            RepositoryId: RepositoryId
+            RepositoryName: RepositoryName
+            BranchId: BranchId
+            BranchName: BranchName
+            ObjectStorageProvider: ObjectStorageProvider
+            ServerUri: string
+            ConfigurationPath: string
+            RootDirectory: string
+            GraceDirectory: string
+            GraceStatusFile: string
+            GraceFileIgnoreEntries: string array
+            GraceDirectoryIgnoreEntries: string array
+        }
+
+    /// Canonicalizes the configured HTTP endpoint used by operational snapshot comparisons.
+    let private canonicalOperationalServerUri (value: string) =
+        match Uri.TryCreate(value, UriKind.Absolute) with
+        | true, uri when
+            uri.Scheme = Uri.UriSchemeHttp
+            || uri.Scheme = Uri.UriSchemeHttps
+            ->
+            uri.AbsoluteUri.TrimEnd('/')
+        | _ -> invalidOp $"Grace requires an absolute HTTP or HTTPS server URI: {value}"
+
+    /// Copies mutable Grace configuration into the immutable shape used across command trust boundaries.
+    let private operationalConfigurationSnapshot configurationPath (configuration: GraceConfiguration) =
+        {
+            OwnerId = configuration.OwnerId
+            OwnerName = configuration.OwnerName
+            OrganizationId = configuration.OrganizationId
+            OrganizationName = configuration.OrganizationName
+            RepositoryId = configuration.RepositoryId
+            RepositoryName = configuration.RepositoryName
+            BranchId = configuration.BranchId
+            BranchName = configuration.BranchName
+            ObjectStorageProvider = configuration.ObjectStorageProvider
+            ServerUri = canonicalOperationalServerUri configuration.ServerUri
+            ConfigurationPath = Path.GetFullPath(configurationPath)
+            RootDirectory = Path.GetFullPath(configuration.RootDirectory)
+            GraceDirectory = Path.GetFullPath(configuration.GraceDirectory)
+            GraceStatusFile = Path.GetFullPath(configuration.GraceStatusFile)
+            GraceFileIgnoreEntries = Array.copy configuration.GraceFileIgnoreEntries
+            GraceDirectoryIgnoreEntries = Array.copy configuration.GraceDirectoryIgnoreEntries
+        }
+
+    /// Compares operational snapshots with platform path semantics and exact server/configuration semantics.
+    let private operationalConfigurationSnapshotsMatch expected actual =
+        let pathComparison =
+            if OperatingSystem.IsWindows() then
+                StringComparison.OrdinalIgnoreCase
+            else
+                StringComparison.Ordinal
+
+        let samePath left right = String.Equals(left, right, pathComparison)
+
+        actual.OwnerId = expected.OwnerId
+        && actual.OwnerName = expected.OwnerName
+        && actual.OrganizationId = expected.OrganizationId
+        && actual.OrganizationName = expected.OrganizationName
+        && actual.RepositoryId = expected.RepositoryId
+        && actual.RepositoryName = expected.RepositoryName
+        && actual.BranchId = expected.BranchId
+        && actual.BranchName = expected.BranchName
+        && actual.ObjectStorageProvider = expected.ObjectStorageProvider
+        && String.Equals(actual.ServerUri, expected.ServerUri, StringComparison.Ordinal)
+        && samePath actual.ConfigurationPath expected.ConfigurationPath
+        && samePath actual.RootDirectory expected.RootDirectory
+        && samePath actual.GraceDirectory expected.GraceDirectory
+        && samePath actual.GraceStatusFile expected.GraceStatusFile
+        && actual.GraceFileIgnoreEntries.Length = expected.GraceFileIgnoreEntries.Length
+        && Array.forall2 (=) actual.GraceFileIgnoreEntries expected.GraceFileIgnoreEntries
+        && actual.GraceDirectoryIgnoreEntries.Length = expected.GraceDirectoryIgnoreEntries.Length
+        && Array.forall2 (=) actual.GraceDirectoryIgnoreEntries expected.GraceDirectoryIgnoreEntries
+
+    /// Captures persisted operational configuration only after it agrees with the already-loaded process configuration.
+    let internal captureOperationalConfigurationSnapshot commandName (cached: GraceConfiguration) =
+        let cachedConfigurationPath = Path.Combine(cached.ConfigurationDirectory, Constants.GraceConfigFileName)
+        let cachedSnapshot = operationalConfigurationSnapshot cachedConfigurationPath cached
+
+        let persistedSnapshot =
+            match tryInspectCurrentDirectoryConfiguration () with
+            | Ok inspection -> operationalConfigurationSnapshot inspection.Path inspection.Configuration
+            | Error error -> invalidOp $"Grace {commandName} could not read persisted repository configuration: {error}"
+
+        if not (operationalConfigurationSnapshotsMatch cachedSnapshot persistedSnapshot) then
+            invalidOp $"Grace {commandName} cached and persisted repository configuration do not match."
+
+        persistedSnapshot
+
+    /// Revalidates cached and freshly persisted inputs against the exact operational snapshot accepted at command entry.
+    let internal requireOperationalConfigurationSnapshotCurrent commandName (cached: GraceConfiguration) expected =
+        let cachedConfigurationPath = Path.Combine(cached.ConfigurationDirectory, Constants.GraceConfigFileName)
+        let cachedCandidate = operationalConfigurationSnapshot cachedConfigurationPath cached
+
+        let persistedCandidate =
+            match tryInspectCurrentDirectoryConfiguration () with
+            | Ok inspection -> operationalConfigurationSnapshot inspection.Path inspection.Configuration
+            | Error error -> invalidOp $"Grace {commandName} could not reread persisted repository configuration: {error}"
+
+        if
+            not (operationalConfigurationSnapshotsMatch expected cachedCandidate)
+            || not (operationalConfigurationSnapshotsMatch expected persistedCandidate)
+        then
+            invalidOp $"Grace {commandName} operational repository configuration changed after validation."
+
     /// Utility method to write to the console using color.
     let logToAnsiConsole (color: string) message =
         lock lockObject (fun () ->
@@ -2825,12 +2937,12 @@ module Services =
 
         IpcFileNameForIdentity current.RepositoryId current.RepositoryName current.RootDirectory current.BranchId current.BranchName
 
-    /// Reads Watch IPC status for diagnostics without logging file paths, stack traces, or raw JSON.
-    let inspectGraceWatchStatus () =
+    /// Reads one explicit Watch IPC path without consulting mutable process configuration.
+    let private inspectGraceWatchStatusAtPath ipcFileName =
         task {
-            if System.IO.File.Exists(IpcFileName()) then
+            if System.IO.File.Exists(ipcFileName) then
                 try
-                    let json = System.IO.File.ReadAllText(IpcFileName())
+                    let json = System.IO.File.ReadAllText(ipcFileName)
 
                     let status = deserializeNormalizedGraceWatchStatus json
 
@@ -2872,6 +2984,14 @@ module Services =
                         ReadError = None
                     }
         }
+
+    /// Reads Watch IPC status for an immutable operational repository identity.
+    let internal inspectGraceWatchStatusForOperationalConfiguration (snapshot: OperationalConfigurationSnapshot) =
+        IpcFileNameForIdentity snapshot.RepositoryId snapshot.RepositoryName snapshot.RootDirectory snapshot.BranchId snapshot.BranchName
+        |> inspectGraceWatchStatusAtPath
+
+    /// Reads Watch IPC status for diagnostics without logging file paths, stack traces, or raw JSON.
+    let inspectGraceWatchStatus () = inspectGraceWatchStatusAtPath (IpcFileName())
 
     /// Builds the persisted Grace Watch status snapshot used by check and startup coordination.
     let private createGraceWatchStatusWithPendingWork

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -8067,35 +8067,10 @@ module Watch =
     let internal resetBeforeWatchCallbackRuntimeSetupForTests () = beforeWatchCallbackRuntimeSetup <- fun () -> ()
 
     /// Reads only a complete status tree whose root and branch boundary agree without mutating local state.
-    let private requireInitializedLocalStateForWatch () =
+    let private requireInitializedLocalStateForWatch cachedConfiguration operationalConfiguration =
         task {
-            let current = Current()
-
-            let pathComparison =
-                if OperatingSystem.IsWindows() then
-                    StringComparison.OrdinalIgnoreCase
-                else
-                    StringComparison.Ordinal
-
-            let persistedConfiguration =
-                match tryInspectCurrentDirectoryConfiguration () with
-                | Ok inspection -> inspection.Configuration
-                | Error error -> invalidOp $"Grace Watch could not read persisted repository configuration before startup: {error}"
-
-            if
-                persistedConfiguration.OwnerId <> current.OwnerId
-                || persistedConfiguration.OrganizationId
-                   <> current.OrganizationId
-                || persistedConfiguration.RepositoryId
-                   <> current.RepositoryId
-                || persistedConfiguration.BranchId
-                   <> current.BranchId
-                || not (String.Equals(Path.GetFullPath(persistedConfiguration.RootDirectory), Path.GetFullPath(current.RootDirectory), pathComparison))
-                || not (String.Equals(Path.GetFullPath(persistedConfiguration.GraceStatusFile), Path.GetFullPath(current.GraceStatusFile), pathComparison))
-            then
-                invalidOp "Grace Watch cached and persisted repository configuration do not match."
-
-            let inspection = Grace.CLI.LocalStateDb.inspectReadOnly current.GraceStatusFile
+            requireOperationalConfigurationSnapshotCurrent "Watch" cachedConfiguration operationalConfiguration
+            let inspection = Grace.CLI.LocalStateDb.inspectReadOnly operationalConfiguration.GraceStatusFile
 
             if not inspection.OpenedReadOnly
                || inspection.SchemaVersion
@@ -8106,10 +8081,14 @@ module Watch =
                || inspection.ForeignKeyViolations.Length > 0 then
                 invalidOp "Grace Watch requires healthy initialized local state; run materializing grace connect or grace doctor --repair-local-state."
 
-            let! revisionBefore = Grace.CLI.LocalStateDb.readLocalStatusRevisionReadOnly current.GraceStatusFile
+            let! revisionBefore = Grace.CLI.LocalStateDb.readLocalStatusRevisionReadOnly operationalConfiguration.GraceStatusFile
 
             let! statusResult =
-                Grace.CLI.LocalStateDb.readCompleteStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
+                Grace.CLI.LocalStateDb.readCompleteStatusSnapshotReadOnly
+                    operationalConfiguration.GraceStatusFile
+                    operationalConfiguration.OwnerId
+                    operationalConfiguration.OrganizationId
+                    operationalConfiguration.RepositoryId
 
             let status =
                 match statusResult with
@@ -8128,7 +8107,11 @@ module Watch =
                || root.Blake3Hash <> status.RootDirectoryBlake3Hash then
                 invalidOp "Grace Watch requires a complete initialized local status tree; run materializing grace connect or grace doctor --repair-local-state."
 
-            let! boundaryResult = Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId
+            let! boundaryResult =
+                Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
+                    operationalConfiguration.GraceStatusFile
+                    operationalConfiguration.RepositoryId
+                    operationalConfiguration.BranchId
 
             let boundary =
                 match boundaryResult with
@@ -8143,7 +8126,7 @@ module Watch =
                     invalidOp
                         "Grace Watch requires a matching initialized remote-event boundary; run materializing grace connect or grace doctor --repair-local-state."
 
-            let! revisionAfter = Grace.CLI.LocalStateDb.readLocalStatusRevisionReadOnly current.GraceStatusFile
+            let! revisionAfter = Grace.CLI.LocalStateDb.readLocalStatusRevisionReadOnly operationalConfiguration.GraceStatusFile
 
             if revisionAfter <> revisionBefore then
                 invalidOp "Grace Watch local state changed while startup trust was being validated."
@@ -8151,12 +8134,12 @@ module Watch =
             return
                 {
                     Status = status
-                    OwnerId = current.OwnerId
-                    OrganizationId = current.OrganizationId
-                    RepositoryId = current.RepositoryId
-                    BranchId = current.BranchId
-                    RootDirectory = Path.GetFullPath(current.RootDirectory)
-                    GraceStatusFile = Path.GetFullPath(current.GraceStatusFile)
+                    OwnerId = operationalConfiguration.OwnerId
+                    OrganizationId = operationalConfiguration.OrganizationId
+                    RepositoryId = operationalConfiguration.RepositoryId
+                    BranchId = operationalConfiguration.BranchId
+                    RootDirectory = operationalConfiguration.RootDirectory
+                    GraceStatusFile = operationalConfiguration.GraceStatusFile
                     LocalStatusRevision = revisionAfter
                     Boundary = boundary
                 }
@@ -10412,7 +10395,11 @@ module Watch =
                         let watchCheckStatus = toWatchCheckStatusDto trustInspection
                         raise (WatchCommandExit(renderWatchCheckStatus parseResult watchCheckStatus))
 
-                    let! initializedStateBeforeClaim = requireInitializedLocalStateForWatch ()
+                    let cachedOperationalConfiguration = Current()
+
+                    let operationalConfiguration = captureOperationalConfigurationSnapshot "Watch" cachedOperationalConfiguration
+
+                    let! initializedStateBeforeClaim = requireInitializedLocalStateForWatch cachedOperationalConfiguration operationalConfiguration
 
                     let! graceWatchClaim = claimGraceWatchInterprocessFile ()
 
@@ -10421,7 +10408,7 @@ module Watch =
                         raise (WatchCommandExit -1)
 
                     afterWatchStartupClaim ()
-                    let! initializedStateAfterClaim = requireInitializedLocalStateForWatch ()
+                    let! initializedStateAfterClaim = requireInitializedLocalStateForWatch cachedOperationalConfiguration operationalConfiguration
                     requireWatchLocalStateUnchangedAfterClaim initializedStateBeforeClaim initializedStateAfterClaim
                     beforeWatchCallbackRuntimeSetup ()
                     let initializedStatus = initializedStateAfterClaim.Status
@@ -10446,7 +10433,7 @@ module Watch =
                     setLocalObservationCandidateSchedulingActive true
 
                     // Create the FileSystemWatcher, but don't enable it yet.
-                    use rootDirectoryFileSystemWatcher = createFileSystemWatcher (Current().RootDirectory)
+                    use rootDirectoryFileSystemWatcher = createFileSystemWatcher operationalConfiguration.RootDirectory
 
                     use created =
                         Observable
@@ -10522,7 +10509,7 @@ module Watch =
 
                     do!
                         initializeLocalStatusRevisionBeforeArtifactCallbacks
-                            (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                            (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision operationalConfiguration.GraceStatusFile)
                             (fun () ->
                                 task {
                                     // Create the inter-process communication file.
@@ -10539,7 +10526,7 @@ module Watch =
                     logToAnsiConsole Colors.Verbose $"The change processor timer will tick every {timerTimeSpan.TotalSeconds:F1} seconds."
 
                     // Open a SignalR connection to the server.
-                    let signalRUrl = Uri($"{Current().ServerUri}/notifications")
+                    let signalRUrl = Uri($"{operationalConfiguration.ServerUri}/notifications")
                     logToConsole $"signalRUrl: {signalRUrl}."
 
                     match! getSignalRAccessToken () with
@@ -10646,11 +10633,11 @@ module Watch =
 
                     do! signalRConnection.StartAsync(cancellationToken)
                     // Repository-wide notifications are keyed only by RepositoryId, so same-process branch switches do not change this group.
-                    do! signalRConnection.InvokeAsync("RegisterRepository", Current().RepositoryId, cancellationToken)
+                    do! signalRConnection.InvokeAsync("RegisterRepository", operationalConfiguration.RepositoryId, cancellationToken)
 
                     logToAnsiConsole
                         Colors.Highlighted
-                        $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in repository {Current().RepositoryName} ({Current().RepositoryId}); connectionId: {signalRConnection.ConnectionId}."
+                        $"SignalR Hub connection state: {signalRConnection.State}. Listening for changes in repository {operationalConfiguration.RepositoryName} ({operationalConfiguration.RepositoryId}); connectionId: {signalRConnection.ConnectionId}."
 
                     match! registerCurrentSignalRParentBranch signalRConnection cancellationToken with
                     | Ok _ -> ()
@@ -10720,7 +10707,7 @@ module Watch =
                                     task {
                                         do!
                                             processLocalStatusRevisionCheck
-                                                (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision (Current().GraceStatusFile))
+                                                (fun () -> Grace.CLI.LocalStateDb.readLocalStatusRevision operationalConfiguration.GraceStatusFile)
                                                 recordGraceStatusRefreshObservation
                                                 requestGraceWatchExplicitResync
 

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -8037,238 +8037,53 @@ module Watch =
             invalidOp "Watch local root does not acknowledge the replayed Reference."
         | _ -> ()
 
-    /// Reports whether durable local status still carries the exact materialized root advertised by clean Watch IPC.
-    let private graceStatusMatchesWatchRoot (graceStatus: GraceStatus) (status: GraceWatchStatus) =
-        let mutable root = LocalDirectoryVersion.Default
-
-        graceStatus.RootDirectoryId = status.RootDirectoryId
-        && graceStatus.RootDirectorySha256Hash = status.RootDirectorySha256Hash
-        && graceStatus.RootDirectoryBlake3Hash = status.RootDirectoryBlake3Hash
-        && not (isNull graceStatus.Index)
-        && graceStatus.Index.TryGetValue(graceStatus.RootDirectoryId, &root)
-        && root.RelativePath = Constants.RootDirectoryPath
-        && root.Sha256Hash = status.RootDirectorySha256Hash
-        && root.Blake3Hash = status.RootDirectoryBlake3Hash
-
-    /// Rebuilds the complete retained working-tree snapshot and rejects reset evidence that no longer matches its clean IPC root.
-    let private reconstructResetRecoveryStatus (status: GraceWatchStatus) =
+    /// Reads only a complete status tree whose root and branch boundary agree before Watch creates callback infrastructure.
+    let private requireInitializedLocalStateForWatch () =
         task {
-            let! reconstructed = createNewGraceStatusFileForRoot status.RootDirectoryId GraceStatus.Default Grace.CLI.Services.parseResult
-
-            if not (graceStatusMatchesWatchRoot reconstructed status) then
-                invalidOp "Watch retained working tree did not match the clean IPC root during startup recovery."
-
-            return reconstructed
-        }
-
-    /// Establishes a missing reset boundary from the atomically retained clean IPC root before startup may scan or mutate files.
-    let private establishMissingCurrentBranchReferenceBoundaryBeforeStartupScan
-        (retainedStatus: GraceWatchStatus option)
-        (currentStatus: GraceStatus)
-        (cancellationToken: CancellationToken)
-        =
-        task {
-            cancellationToken.ThrowIfCancellationRequested()
             let current = Current()
+            let inspection = Grace.CLI.LocalStateDb.inspectReadOnly current.GraceStatusFile
+
+            if not inspection.OpenedReadOnly
+               || inspection.SchemaVersion
+                  <> Some Grace.CLI.LocalStateDb.SchemaVersion
+               || inspection.MissingRequiredTables.Length > 0
+               || inspection.MissingRequiredIndexes.Length > 0
+               || inspection.IntegrityCheckRows <> [| "ok" |]
+               || inspection.ForeignKeyViolations.Length > 0 then
+                invalidOp "Grace Watch requires healthy initialized local state; run materializing grace connect or grace doctor --repair-local-state."
+
+            let! statusResult =
+                Grace.CLI.LocalStateDb.readStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
+
+            let status =
+                match statusResult with
+                | Ok value -> value
+                | Error error -> invalidOp $"Grace Watch could not read initialized local status: {error}"
+
+            let mutable root = LocalDirectoryVersion.Default
+
+            if status.RootDirectoryId = DirectoryVersionId.Empty
+               || String.IsNullOrWhiteSpace(string status.RootDirectorySha256Hash)
+               || String.IsNullOrWhiteSpace(string status.RootDirectoryBlake3Hash)
+               || isNull status.Index
+               || not (status.Index.TryGetValue(status.RootDirectoryId, &root))
+               || root.RelativePath <> Constants.RootDirectoryPath
+               || root.Sha256Hash <> status.RootDirectorySha256Hash
+               || root.Blake3Hash <> status.RootDirectoryBlake3Hash then
+                invalidOp "Grace Watch requires a complete initialized local status tree; run materializing grace connect or grace doctor --repair-local-state."
 
             match! Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId with
-            | Some _ -> return currentStatus
-            | None ->
-                let resetDatabaseNeedsReconstruction =
-                    currentStatus.RootDirectoryId = DirectoryVersionId.Empty
-                    && String.IsNullOrWhiteSpace(string currentStatus.RootDirectorySha256Hash)
-                    && (isNull currentStatus.Index
-                        || currentStatus.Index.IsEmpty)
-
-                let! reconstructedResetStatus =
-                    match retainedStatus with
-                    | Some retainedRoot when resetDatabaseNeedsReconstruction ->
-                        task {
-                            let! reconstructed = reconstructResetRecoveryStatus retainedRoot
-                            return Some reconstructed
-                        }
-                    | _ -> Task.FromResult(None)
-
-                cancellationToken.ThrowIfCancellationRequested()
-
-                let rootDirectoryId, rootSha256Hash, rootBlake3Hash, statusToPersist =
-                    match retainedStatus with
-                    | Some retainedRoot when graceStatusMatchesWatchRoot currentStatus retainedRoot ->
-                        retainedRoot.RootDirectoryId, retainedRoot.RootDirectorySha256Hash, retainedRoot.RootDirectoryBlake3Hash, currentStatus
-                    | Some retainedRoot when resetDatabaseNeedsReconstruction ->
-                        match reconstructedResetStatus with
-                        | Some reconstructed ->
-                            retainedRoot.RootDirectoryId, retainedRoot.RootDirectorySha256Hash, retainedRoot.RootDirectoryBlake3Hash, reconstructed
-                        | None -> invalidOp "Watch did not reconstruct the reset working-tree status."
-                    | Some _ -> invalidOp "Watch durable status did not match the retained IPC root before startup recovery."
-                    | None ->
-                        let mutable durableRoot = LocalDirectoryVersion.Default
-
-                        if
-                            not (isNull currentStatus.Index)
-                            && currentStatus.Index.TryGetValue(currentStatus.RootDirectoryId, &durableRoot)
-                            && durableRoot.RelativePath = Constants.RootDirectoryPath
-                            && durableRoot.Sha256Hash = currentStatus.RootDirectorySha256Hash
-                            && durableRoot.Blake3Hash = currentStatus.RootDirectoryBlake3Hash
-                            && currentStatus.RootDirectoryId
-                               <> DirectoryVersionId.Empty
-                            && not (String.IsNullOrWhiteSpace(string currentStatus.RootDirectorySha256Hash))
-                            && not (String.IsNullOrWhiteSpace(string currentStatus.RootDirectoryBlake3Hash))
-                        then
-                            currentStatus.RootDirectoryId, currentStatus.RootDirectorySha256Hash, currentStatus.RootDirectoryBlake3Hash, currentStatus
-                        else
-                            invalidOp "Watch cannot establish a missing remote Reference boundary without a complete durable or retained root."
-
-                let requirePersistedCurrentBranch () =
-                    match tryInspectCurrentDirectoryConfiguration () with
-                    | Ok persisted when
-                        persisted.Configuration.RepositoryId = current.RepositoryId
-                        && persisted.Configuration.BranchId = current.BranchId
-                        ->
-                        ()
-                    | Ok _ -> invalidOp "Watch repository or branch identity changed during startup boundary recovery."
-                    | Error error -> invalidOp $"Watch could not read persisted repository identity during startup boundary recovery: {error}"
-
-                requirePersistedCurrentBranch ()
-
-                let parameters =
-                    ResolveReferenceEventBoundaryParameters(
-                        OwnerId = $"{current.OwnerId}",
-                        OwnerName = current.OwnerName,
-                        OrganizationId = $"{current.OrganizationId}",
-                        OrganizationName = current.OrganizationName,
-                        RepositoryId = $"{current.RepositoryId}",
-                        RepositoryName = current.RepositoryName,
-                        BranchId = $"{current.BranchId}",
-                        BranchName = current.BranchName,
-                        DirectoryVersionId = rootDirectoryId,
-                        Sha256Hash = rootSha256Hash,
-                        Blake3Hash = rootBlake3Hash,
-                        CorrelationId = generateCorrelationId ()
-                    )
-
-                let! resolved = Grace.SDK.Branch.ResolveReferenceEventBoundary parameters
-
-                let boundary =
-                    match resolved with
-                    | Ok returnValue -> returnValue.ReturnValue
-                    | Error error -> invalidOp $"Grace Server could not establish the startup remote Reference boundary: {error.Error}"
-
-                if boundary.RepositoryId <> current.RepositoryId
-                   || boundary.BranchId <> current.BranchId
-                   || boundary.DirectoryId <> rootDirectoryId
-                   || boundary.Sha256Hash <> rootSha256Hash
-                   || boundary.Blake3Hash <> rootBlake3Hash
-                   || String.IsNullOrWhiteSpace boundary.EventCursor then
-                    invalidOp "Grace Server returned an incomplete or mismatched startup remote Reference boundary."
-
-                cancellationToken.ThrowIfCancellationRequested()
-                requirePersistedCurrentBranch ()
-
-                let! _ =
-                    Grace.CLI.LocalStateDb.replaceStatusSnapshotWithRemoteReferenceBoundary current.GraceStatusFile statusToPersist boundary cancellationToken
-
-                return statusToPersist
-        }
-
-    /// Runs the production pre-scan reset recovery path for hosted process-level acceptance tests.
-    let internal establishMissingCurrentBranchReferenceBoundaryBeforeStartupScanForHostedTests retainedStatus currentStatus cancellationToken =
-        establishMissingCurrentBranchReferenceBoundaryBeforeStartupScan retainedStatus currentStatus cancellationToken
-
-    /// Resolves and atomically records an absent cursor only while branch, clean status, and exact local root stay stable.
-    let private resolveMissingCurrentBranchReferenceBoundary (cancellationToken: CancellationToken) =
-        task {
-            cancellationToken.ThrowIfCancellationRequested()
-            let current = Current()
-
-            let requirePersistedCurrentBranch () =
-                match tryInspectCurrentDirectoryConfiguration () with
-                | Ok persisted when
-                    persisted.Configuration.RepositoryId = current.RepositoryId
-                    && persisted.Configuration.BranchId = current.BranchId
-                    ->
-                    ()
-                | Ok _ -> invalidOp "Watch repository or branch identity changed during missing-cursor recovery."
-                | Error error -> invalidOp $"Watch could not read persisted repository identity during missing-cursor recovery: {error}"
-
-            let inspectCleanLocalRoot () =
-                task {
-                    let! inspection = inspectGraceWatchStatus ()
-
-                    let gatePayload = { CurrentBranchReferenceNotification.Default with RepositoryId = current.RepositoryId; BranchId = current.BranchId }
-
-                    match currentBranchMaterializationStatusGate true None gatePayload inspection with
-                    | Clean status -> return status
-                    | NotCurrentBranch -> return invalidOp "Watch branch identity changed during missing-cursor recovery."
-                    | Blocked reason -> return invalidOp $"Watch local work blocked missing-cursor recovery: {reason}."
-                    | Degraded reason -> return invalidOp $"Watch local state blocked missing-cursor recovery: {reason}."
-                }
-
-            requirePersistedCurrentBranch ()
-            let! capturedWatchStatus = inspectCleanLocalRoot ()
-            let! capturedGraceStatus = readGraceStatusFile ()
-
-            if not (graceStatusMatchesWatchRoot capturedGraceStatus capturedWatchStatus) then
-                invalidOp "Watch durable status did not match clean IPC during missing-cursor recovery."
-
-            match! Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId with
-            | Some boundary -> return Some boundary
-            | None ->
-                let parameters =
-                    ResolveReferenceEventBoundaryParameters(
-                        OwnerId = $"{current.OwnerId}",
-                        OwnerName = current.OwnerName,
-                        OrganizationId = $"{current.OrganizationId}",
-                        OrganizationName = current.OrganizationName,
-                        RepositoryId = $"{current.RepositoryId}",
-                        RepositoryName = current.RepositoryName,
-                        BranchId = $"{current.BranchId}",
-                        BranchName = current.BranchName,
-                        DirectoryVersionId = capturedWatchStatus.RootDirectoryId,
-                        Sha256Hash = capturedWatchStatus.RootDirectorySha256Hash,
-                        Blake3Hash = capturedWatchStatus.RootDirectoryBlake3Hash,
-                        CorrelationId = generateCorrelationId ()
-                    )
-
-                match! Grace.SDK.Branch.ResolveReferenceEventBoundary parameters with
-                | Error _ -> return None
-                | Ok returnValue ->
-                    let boundary = returnValue.ReturnValue
-
-                    if boundary.RepositoryId <> current.RepositoryId
-                       || boundary.BranchId <> current.BranchId
-                       || boundary.DirectoryId
-                          <> capturedWatchStatus.RootDirectoryId
-                       || boundary.Sha256Hash
-                          <> capturedWatchStatus.RootDirectorySha256Hash
-                       || boundary.Blake3Hash
-                          <> capturedWatchStatus.RootDirectoryBlake3Hash
-                       || String.IsNullOrWhiteSpace boundary.EventCursor then
-                        invalidOp "Grace Server returned an incomplete or mismatched missing-cursor boundary."
-
-                    cancellationToken.ThrowIfCancellationRequested()
-                    requirePersistedCurrentBranch ()
-                    let! finalWatchStatus = inspectCleanLocalRoot ()
-                    let! finalGraceStatus = readGraceStatusFile ()
-
-                    if
-                        finalWatchStatus.RootDirectoryId
-                        <> capturedWatchStatus.RootDirectoryId
-                        || finalWatchStatus.RootDirectorySha256Hash
-                           <> capturedWatchStatus.RootDirectorySha256Hash
-                        || finalWatchStatus.RootDirectoryBlake3Hash
-                           <> capturedWatchStatus.RootDirectoryBlake3Hash
-                        || not (graceStatusMatchesWatchRoot finalGraceStatus finalWatchStatus)
-                    then
-                        invalidOp "Watch local root changed before missing-cursor recovery could commit."
-
-                    match! Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId with
-                    | Some _ -> return invalidOp "Watch remote Reference boundary changed during missing-cursor recovery."
-                    | None ->
-                        let! stored =
-                            Grace.CLI.LocalStateDb.establishRemoteReferenceBoundaryIfAbsent current.GraceStatusFile finalGraceStatus boundary cancellationToken
-
-                        return Some stored
+            | Some boundary when
+                boundary.DirectoryId = status.RootDirectoryId
+                && boundary.Sha256Hash = status.RootDirectorySha256Hash
+                && boundary.Blake3Hash = status.RootDirectoryBlake3Hash
+                && not (String.IsNullOrWhiteSpace boundary.EventCursor)
+                ->
+                return status
+            | _ ->
+                return
+                    invalidOp
+                        "Grace Watch requires a matching initialized remote-event boundary; run materializing grace connect or grace doctor --repair-local-state."
         }
 
     /// Persists an opaque cursor only after current branch, safe-state, root, and prior-boundary evidence are reread.
@@ -8339,7 +8154,7 @@ module Watch =
                     {
                         ReadBoundary =
                             fun () -> Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId
-                        ResolveMissingBoundary = resolveMissingCurrentBranchReferenceBoundary
+                        ResolveMissingBoundary = fun _ -> Task.FromResult(None)
                         Replay =
                             fun boundary ->
                                 let parameters =
@@ -10489,6 +10304,8 @@ module Watch =
                         logToAnsiConsole Colors.Error "GraceWatch is already running."
                         raise (WatchCommandExit -1)
 
+                    let! initializedStatus = requireInitializedLocalStateForWatch ()
+
                     ClientIdentity.configureWatchProcessId watchProcessId
 
                     use watchProcessIdentityLifetime =
@@ -10579,13 +10396,8 @@ module Watch =
                             .Select(fun e -> e.EventArgs)
                             .Subscribe(OnGraceUpdateInProgressDeleted)
 
-                    // Load the Grace Index file.
-                    let! status = readGraceStatusFile ()
-
-                    let! startupBoundaryStatus =
-                        establishMissingCurrentBranchReferenceBoundaryBeforeStartupScan graceWatchClaim.RetainedStatus status cancellationToken
-
-                    graceStatus <- startupBoundaryStatus
+                    // Use only the read-only validated status captured before callback infrastructure was created.
+                    graceStatus <- initializedStatus
                     updateGraceStatusDirectoryIds graceStatus
 
                     do!

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -8053,7 +8053,7 @@ module Watch =
                 invalidOp "Grace Watch requires healthy initialized local state; run materializing grace connect or grace doctor --repair-local-state."
 
             let! statusResult =
-                Grace.CLI.LocalStateDb.readStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
+                Grace.CLI.LocalStateDb.readCompleteStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
 
             let status =
                 match statusResult with

--- a/src/Grace.CLI/Command/Watch.CLI.fs
+++ b/src/Grace.CLI/Command/Watch.CLI.fs
@@ -8037,10 +8037,64 @@ module Watch =
             invalidOp "Watch local root does not acknowledge the replayed Reference."
         | _ -> ()
 
-    /// Reads only a complete status tree whose root and branch boundary agree before Watch creates callback infrastructure.
+    /// Captures every durable and configured identity that must remain stable across the Watch IPC startup claim.
+    type private InitializedWatchLocalState =
+        {
+            Status: GraceStatus
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            BranchId: BranchId
+            RootDirectory: string
+            GraceStatusFile: string
+            LocalStatusRevision: int64
+            Boundary: ReferenceMaterializationBoundaryDto
+        }
+
+    let mutable private afterWatchStartupClaim = fun () -> ()
+    let mutable private beforeWatchCallbackRuntimeSetup = fun () -> ()
+
+    /// Installs a deterministic mutation after IPC claim so tests can prove the second trust boundary fails closed.
+    let internal setAfterWatchStartupClaimForTests probe = afterWatchStartupClaim <- probe
+
+    /// Restores the production Watch startup path after post-claim race tests.
+    let internal resetAfterWatchStartupClaimForTests () = afterWatchStartupClaim <- fun () -> ()
+
+    /// Installs an observer at the first callback/runtime setup boundary for public startup-order tests.
+    let internal setBeforeWatchCallbackRuntimeSetupForTests probe = beforeWatchCallbackRuntimeSetup <- probe
+
+    /// Restores the production callback/runtime setup boundary after public startup-order tests.
+    let internal resetBeforeWatchCallbackRuntimeSetupForTests () = beforeWatchCallbackRuntimeSetup <- fun () -> ()
+
+    /// Reads only a complete status tree whose root and branch boundary agree without mutating local state.
     let private requireInitializedLocalStateForWatch () =
         task {
             let current = Current()
+
+            let pathComparison =
+                if OperatingSystem.IsWindows() then
+                    StringComparison.OrdinalIgnoreCase
+                else
+                    StringComparison.Ordinal
+
+            let persistedConfiguration =
+                match tryInspectCurrentDirectoryConfiguration () with
+                | Ok inspection -> inspection.Configuration
+                | Error error -> invalidOp $"Grace Watch could not read persisted repository configuration before startup: {error}"
+
+            if
+                persistedConfiguration.OwnerId <> current.OwnerId
+                || persistedConfiguration.OrganizationId
+                   <> current.OrganizationId
+                || persistedConfiguration.RepositoryId
+                   <> current.RepositoryId
+                || persistedConfiguration.BranchId
+                   <> current.BranchId
+                || not (String.Equals(Path.GetFullPath(persistedConfiguration.RootDirectory), Path.GetFullPath(current.RootDirectory), pathComparison))
+                || not (String.Equals(Path.GetFullPath(persistedConfiguration.GraceStatusFile), Path.GetFullPath(current.GraceStatusFile), pathComparison))
+            then
+                invalidOp "Grace Watch cached and persisted repository configuration do not match."
+
             let inspection = Grace.CLI.LocalStateDb.inspectReadOnly current.GraceStatusFile
 
             if not inspection.OpenedReadOnly
@@ -8051,6 +8105,8 @@ module Watch =
                || inspection.IntegrityCheckRows <> [| "ok" |]
                || inspection.ForeignKeyViolations.Length > 0 then
                 invalidOp "Grace Watch requires healthy initialized local state; run materializing grace connect or grace doctor --repair-local-state."
+
+            let! revisionBefore = Grace.CLI.LocalStateDb.readLocalStatusRevisionReadOnly current.GraceStatusFile
 
             let! statusResult =
                 Grace.CLI.LocalStateDb.readCompleteStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
@@ -8072,19 +8128,77 @@ module Watch =
                || root.Blake3Hash <> status.RootDirectoryBlake3Hash then
                 invalidOp "Grace Watch requires a complete initialized local status tree; run materializing grace connect or grace doctor --repair-local-state."
 
-            match! Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId with
-            | Some boundary when
-                boundary.DirectoryId = status.RootDirectoryId
-                && boundary.Sha256Hash = status.RootDirectorySha256Hash
-                && boundary.Blake3Hash = status.RootDirectoryBlake3Hash
-                && not (String.IsNullOrWhiteSpace boundary.EventCursor)
-                ->
-                return status
-            | _ ->
-                return
+            let! boundaryResult = Grace.CLI.LocalStateDb.readRemoteReferenceBoundary current.GraceStatusFile current.RepositoryId current.BranchId
+
+            let boundary =
+                match boundaryResult with
+                | Some boundary when
+                    boundary.DirectoryId = status.RootDirectoryId
+                    && boundary.Sha256Hash = status.RootDirectorySha256Hash
+                    && boundary.Blake3Hash = status.RootDirectoryBlake3Hash
+                    && not (String.IsNullOrWhiteSpace boundary.EventCursor)
+                    ->
+                    boundary
+                | _ ->
                     invalidOp
                         "Grace Watch requires a matching initialized remote-event boundary; run materializing grace connect or grace doctor --repair-local-state."
+
+            let! revisionAfter = Grace.CLI.LocalStateDb.readLocalStatusRevisionReadOnly current.GraceStatusFile
+
+            if revisionAfter <> revisionBefore then
+                invalidOp "Grace Watch local state changed while startup trust was being validated."
+
+            return
+                {
+                    Status = status
+                    OwnerId = current.OwnerId
+                    OrganizationId = current.OrganizationId
+                    RepositoryId = current.RepositoryId
+                    BranchId = current.BranchId
+                    RootDirectory = Path.GetFullPath(current.RootDirectory)
+                    GraceStatusFile = Path.GetFullPath(current.GraceStatusFile)
+                    LocalStatusRevision = revisionAfter
+                    Boundary = boundary
+                }
         }
+
+    /// Rejects any configured or durable identity change across the atomic Watch IPC startup claim.
+    let private requireWatchLocalStateUnchangedAfterClaim expected actual =
+        let pathComparison =
+            if OperatingSystem.IsWindows() then
+                StringComparison.OrdinalIgnoreCase
+            else
+                StringComparison.Ordinal
+
+        let samePath left right = String.Equals(Path.GetFullPath(left), Path.GetFullPath(right), pathComparison)
+
+        if actual.OwnerId <> expected.OwnerId
+           || actual.OrganizationId <> expected.OrganizationId
+           || actual.RepositoryId <> expected.RepositoryId
+           || actual.BranchId <> expected.BranchId
+           || not (samePath actual.RootDirectory expected.RootDirectory)
+           || not (samePath actual.GraceStatusFile expected.GraceStatusFile)
+           || actual.LocalStatusRevision
+              <> expected.LocalStatusRevision
+           || actual.Status.RootDirectoryId
+              <> expected.Status.RootDirectoryId
+           || actual.Status.RootDirectorySha256Hash
+              <> expected.Status.RootDirectorySha256Hash
+           || actual.Status.RootDirectoryBlake3Hash
+              <> expected.Status.RootDirectoryBlake3Hash
+           || actual.Boundary.RepositoryId
+              <> expected.Boundary.RepositoryId
+           || actual.Boundary.BranchId
+              <> expected.Boundary.BranchId
+           || actual.Boundary.DirectoryId
+              <> expected.Boundary.DirectoryId
+           || actual.Boundary.Sha256Hash
+              <> expected.Boundary.Sha256Hash
+           || actual.Boundary.Blake3Hash
+              <> expected.Boundary.Blake3Hash
+           || actual.Boundary.EventCursor
+              <> expected.Boundary.EventCursor then
+            invalidOp "Grace Watch local state changed after the Watch startup claim; startup was aborted before callback or runtime setup."
 
     /// Persists an opaque cursor only after current branch, safe-state, root, and prior-boundary evidence are reread.
     let private acknowledgeCurrentBranchReferenceReplayCursor
@@ -10298,13 +10412,19 @@ module Watch =
                         let watchCheckStatus = toWatchCheckStatusDto trustInspection
                         raise (WatchCommandExit(renderWatchCheckStatus parseResult watchCheckStatus))
 
+                    let! initializedStateBeforeClaim = requireInitializedLocalStateForWatch ()
+
                     let! graceWatchClaim = claimGraceWatchInterprocessFile ()
 
                     if not graceWatchClaim.Claimed then
                         logToAnsiConsole Colors.Error "GraceWatch is already running."
                         raise (WatchCommandExit -1)
 
-                    let! initializedStatus = requireInitializedLocalStateForWatch ()
+                    afterWatchStartupClaim ()
+                    let! initializedStateAfterClaim = requireInitializedLocalStateForWatch ()
+                    requireWatchLocalStateUnchangedAfterClaim initializedStateBeforeClaim initializedStateAfterClaim
+                    beforeWatchCallbackRuntimeSetup ()
+                    let initializedStatus = initializedStateAfterClaim.Status
 
                     ClientIdentity.configureWatchProcessId watchProcessId
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -1692,6 +1692,7 @@ module LocalStateDb =
 
                                         logTrace "status_meta ensuring default row"
                                         insertStatusMetaIfMissing connection
+                                        insertLocalStatusRevisionIfMissing connection
                                 })
 
                         initializedDbs[normalizedPath] <- true
@@ -3076,6 +3077,35 @@ module LocalStateDb =
         (cancellationToken: CancellationToken)
         =
         replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken ignore
+
+    /// Refuses exact local-state repair when another SQLite connection currently owns the write claim.
+    let ensureNoActiveWriterForLocalStateRepair (dbPath: string) =
+        if File.Exists(dbPath) then
+            sqliteInitialized.Value |> ignore
+            let builder = SqliteConnectionStringBuilder()
+            builder.DataSource <- dbPath
+            builder.Mode <- SqliteOpenMode.ReadWrite
+            builder.Pooling <- false
+            builder.DefaultTimeout <- 1
+
+            use connection = new SqliteConnection(builder.ToString())
+
+            try
+                connection.Open()
+                executePragma connection "PRAGMA busy_timeout = 1;"
+                executeNonQuery connection "BEGIN IMMEDIATE;"
+                executeNonQuery connection "ROLLBACK;"
+            with
+            | :? SqliteException as ex when ex.SqliteErrorCode = 5 || ex.SqliteErrorCode = 6 ->
+                invalidOp "Grace Doctor refused local-state repair because another SQLite writer is active."
+            | :? SqliteException as ex when ex.SqliteErrorCode = 26 ->
+                // Corrupt databases remain eligible for explicit exact repair; initialization quarantines them later.
+                ()
+
+    /// Forces explicit exact repair to revalidate the current database file even when this process initialized an earlier file at the same path.
+    let invalidateInitializationCacheForLocalStateRepair (dbPath: string) =
+        initializedDbs.TryRemove(Path.GetFullPath(dbPath))
+        |> ignore
 
     /// Persists a matching status and boundary while exposing the final pre-commit seam for deterministic rollback proof.
     let internal replaceStatusSnapshotWithRemoteReferenceBoundaryWithBeforeCommit

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -2805,6 +2805,17 @@ module LocalStateDb =
             return readLocalStatusRevisionInternal connection
         }
 
+    /// Reads the committed status revision without creating, migrating, or repairing local SQLite state.
+    let internal readLocalStatusRevisionReadOnly (dbPath: string) =
+        task {
+            if not (File.Exists(dbPath)) then
+                invalidOp "Local state database does not exist."
+
+            let immutableSnapshot = shouldUseImmutableReadOnlySnapshot dbPath
+            use connection = openReadOnlyConnection dbPath immutableSnapshot
+            return readLocalStatusRevisionInternal connection
+        }
+
     /// Reads status meta internal data needed by the CLI workflow.
     let private readStatusMetaInternal (connection: SqliteConnection) =
         use cmd = connection.CreateCommand()

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -203,6 +203,26 @@ module LocalStateDb =
 
             raise ex
 
+    /// Opens Doctor's final repair transaction without pooling or ordinary writer retry delays.
+    let private openLocalStateRepairConnection (dbPath: string) =
+        sqliteInitialized.Value |> ignore
+        let builder = SqliteConnectionStringBuilder()
+        builder.DataSource <- dbPath
+        builder.Mode <- SqliteOpenMode.ReadWriteCreate
+        builder.Pooling <- false
+        builder.DefaultTimeout <- 1
+        let connection = new SqliteConnection(builder.ToString())
+
+        try
+            connection.Open()
+            applyConnectionPragmas connection
+            executePragma connection "PRAGMA busy_timeout = 1;"
+            connection
+        with
+        | ex ->
+            connection.Dispose()
+            raise ex
+
     let private schemaStatements =
         [|
             "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
@@ -2893,12 +2913,47 @@ module LocalStateDb =
                 parameters.AddWithValue("$last_dir", graceStatus.LastSuccessfulDirectoryVersionUpload.ToUnixTimeTicks())
                 |> ignore)
 
+    /// Captures the durable local-state generation that explicit Doctor repair must not overwrite.
+    type LocalStateRepairBaseline =
+        | MissingLocalStateDatabase
+        | ExistingLocalStateDatabase of revision: int64
+        | UnreadableLocalStateDatabase of length: int64 * lastWriteTimeUtc: DateTime
+
+    /// Reads the local-state generation without initializing, quarantining, or otherwise changing the database.
+    let captureLocalStateRepairBaseline (dbPath: string) =
+        task {
+            let normalizedPath = Path.GetFullPath(dbPath)
+
+            if not (File.Exists(normalizedPath)) then
+                return MissingLocalStateDatabase
+            else
+                try
+                    sqliteInitialized.Value |> ignore
+                    let builder = SqliteConnectionStringBuilder()
+                    builder.DataSource <- normalizedPath
+                    builder.Mode <- SqliteOpenMode.ReadOnly
+                    builder.Pooling <- false
+                    builder.DefaultTimeout <- 1
+                    use connection = new SqliteConnection(builder.ToString())
+                    connection.Open()
+                    executePragma connection "PRAGMA busy_timeout = 1;"
+                    return ExistingLocalStateDatabase(readLocalStatusRevisionInternal connection)
+                with
+                | :? SqliteException as ex when ex.SqliteErrorCode = 5 || ex.SqliteErrorCode = 6 ->
+                    return invalidOp "Grace Doctor refused local-state repair because another SQLite writer is active."
+                | _ ->
+                    let file = FileInfo(normalizedPath)
+                    return UnreadableLocalStateDatabase(file.Length, file.LastWriteTimeUtc)
+        }
+
     /// Coordinates local SQLite state for replace status snapshot, including Grace status, object cache, or watch metadata.
     let private replaceStatusSnapshotWithRevisionCore
         (dbPath: string)
         (graceStatus: GraceStatus)
         (boundary: ReferenceMaterializationBoundaryDto option)
         (cancellationToken: CancellationToken)
+        (repairBaseline: LocalStateRepairBaseline option)
+        (beforeWriteClaim: unit -> unit)
         (beforeCommit: unit -> unit)
         =
         task {
@@ -2918,155 +2973,199 @@ module LocalStateDb =
             | _ -> ()
 
             cancellationToken.ThrowIfCancellationRequested()
-            do! ensureDbInitialized dbPath
+
+            match repairBaseline with
+            | Some MissingLocalStateDatabase when File.Exists(dbPath) -> invalidOp "Local state was created after Grace Doctor captured its repair baseline."
+            | Some (ExistingLocalStateDatabase _) when not (File.Exists(dbPath)) ->
+                invalidOp "Local state was removed after Grace Doctor captured its repair baseline."
+            | Some (UnreadableLocalStateDatabase (expectedLength, expectedLastWriteTimeUtc)) ->
+                let current = FileInfo(dbPath)
+
+                if not current.Exists
+                   || current.Length <> expectedLength
+                   || current.LastWriteTimeUtc
+                      <> expectedLastWriteTimeUtc then
+                    invalidOp "Unreadable local state changed after Grace Doctor captured its repair baseline."
+            | _ -> ()
+
+            match repairBaseline with
+            | Some (ExistingLocalStateDatabase _) -> ()
+            | _ -> do! ensureDbInitialized dbPath
+
             cancellationToken.ThrowIfCancellationRequested()
 
-            return!
-                executeWithRevisionRetry (fun () ->
-                    task {
-                        let connection = openConnection dbPath
+            let replaceOnce () =
+                task {
+                    let connection =
+                        match repairBaseline with
+                        | Some _ -> openLocalStateRepairConnection dbPath
+                        | None -> openConnection dbPath
+
+                    try
+                        cancellationToken.ThrowIfCancellationRequested()
+
+                        beforeWriteClaim ()
+                        executeNonQuery connection "BEGIN IMMEDIATE;"
 
                         try
+                            match repairBaseline with
+                            | Some baseline ->
+                                let expectedRevision =
+                                    match baseline with
+                                    | ExistingLocalStateDatabase revision -> revision
+                                    | MissingLocalStateDatabase
+                                    | UnreadableLocalStateDatabase _ -> 0L
+
+                                if readLocalStatusRevisionInternal connection
+                                   <> expectedRevision then
+                                    invalidOp "Local status changed after Grace Doctor captured its repair baseline."
+                            | None -> ()
+
+                            executeNonQuery connection "DELETE FROM status_directories;"
+                            executeNonQuery connection "DELETE FROM status_files;"
+                            setStatusMeta connection graceStatus
+
+                            use directoryCommand = connection.CreateCommand()
+
+                            directoryCommand.CommandText <-
+                                "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($relative_path, $parent_path, $directory_version_id, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write);"
+
+                            directoryCommand.Parameters.Add("$relative_path", SqliteType.Text)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$parent_path", SqliteType.Text)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$created_at", SqliteType.Integer)
+                            |> ignore
+
+                            directoryCommand.Parameters.Add("$last_write", SqliteType.Integer)
+                            |> ignore
+
+                            use fileCommand = connection.CreateCommand()
+
+                            fileCommand.CommandText <-
+                                "INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($relative_path, $directory_path, $directory_version_id, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write);"
+
+                            fileCommand.Parameters.Add("$relative_path", SqliteType.Text)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$directory_path", SqliteType.Text)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$is_binary", SqliteType.Integer)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$created_at", SqliteType.Integer)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$uploaded", SqliteType.Integer)
+                            |> ignore
+
+                            fileCommand.Parameters.Add("$last_write", SqliteType.Integer)
+                            |> ignore
+
+                            graceStatus.Index.Values
+                            |> Seq.iter (fun directory ->
+                                let parentPath =
+                                    match getParentPath directory.RelativePath with
+                                    | Some path -> path
+                                    | None -> String.Empty
+
+                                directoryCommand.Parameters["$relative_path"].Value <- directory.RelativePath
+                                directoryCommand.Parameters["$parent_path"].Value <- parentPath
+                                directoryCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
+                                directoryCommand.Parameters["$sha256_hash"].Value <- directory.Sha256Hash
+                                directoryCommand.Parameters["$blake3_hash"].Value <- directory.Blake3Hash
+                                directoryCommand.Parameters["$size_bytes"].Value <- directory.Size
+                                directoryCommand.Parameters["$created_at"].Value <- directory.CreatedAt.ToUnixTimeTicks()
+                                directoryCommand.Parameters["$last_write"].Value <- directory.LastWriteTimeUtc.Ticks
+                                directoryCommand.ExecuteNonQuery() |> ignore
+
+                                directory.Files
+                                |> Seq.iter (fun file ->
+                                    fileCommand.Parameters["$relative_path"].Value <- file.RelativePath
+                                    fileCommand.Parameters["$directory_path"].Value <- directory.RelativePath
+                                    fileCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
+                                    fileCommand.Parameters["$sha256_hash"].Value <- file.Sha256Hash
+                                    fileCommand.Parameters["$blake3_hash"].Value <- file.Blake3Hash
+                                    fileCommand.Parameters["$is_binary"].Value <- if file.IsBinary then 1 else 0
+                                    fileCommand.Parameters["$size_bytes"].Value <- file.Size
+                                    fileCommand.Parameters["$created_at"].Value <- file.CreatedAt.ToUnixTimeTicks()
+                                    fileCommand.Parameters["$uploaded"].Value <- if file.UploadedToObjectStorage then 1 else 0
+                                    fileCommand.Parameters["$last_write"].Value <- file.LastWriteTimeUtc.Ticks
+                                    fileCommand.ExecuteNonQuery() |> ignore))
+
+                            match boundary with
+                            | Some boundary ->
+                                executeNonQueryWithParams
+                                    connection
+                                    "INSERT OR REPLACE INTO remote_reference_boundaries (repository_id, branch_id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, event_cursor) VALUES ($repository_id, $branch_id, $root_id, $root_sha256_hash, $root_blake3_hash, $event_cursor);"
+                                    (fun parameters ->
+                                        parameters.AddWithValue("$repository_id", boundary.RepositoryId.ToString())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$branch_id", boundary.BranchId.ToString())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$root_id", boundary.DirectoryId.ToString())
+                                        |> ignore
+
+                                        parameters.AddWithValue("$root_sha256_hash", boundary.Sha256Hash)
+                                        |> ignore
+
+                                        parameters.AddWithValue("$root_blake3_hash", boundary.Blake3Hash)
+                                        |> ignore
+
+                                        parameters.AddWithValue("$event_cursor", boundary.EventCursor)
+                                        |> ignore)
+                            | None -> ()
+
+                            beforeCommit ()
                             cancellationToken.ThrowIfCancellationRequested()
-                            executeNonQuery connection "BEGIN IMMEDIATE;"
+                            let committedRevision = incrementLocalStatusRevision connection
+                            executeNonQuery connection "COMMIT;"
+                            return committedRevision
+                        with
+                        | ex ->
+                            executeNonQuery connection "ROLLBACK;"
+                            return raise ex
+                    finally
+                        connection.Dispose()
+                }
 
-                            try
-                                executeNonQuery connection "DELETE FROM status_directories;"
-                                executeNonQuery connection "DELETE FROM status_files;"
-                                setStatusMeta connection graceStatus
-
-                                use directoryCommand = connection.CreateCommand()
-
-                                directoryCommand.CommandText <-
-                                    "INSERT OR REPLACE INTO status_directories (relative_path, parent_path, directory_version_id, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($relative_path, $parent_path, $directory_version_id, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write);"
-
-                                directoryCommand.Parameters.Add("$relative_path", SqliteType.Text)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$parent_path", SqliteType.Text)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$created_at", SqliteType.Integer)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$last_write", SqliteType.Integer)
-                                |> ignore
-
-                                use fileCommand = connection.CreateCommand()
-
-                                fileCommand.CommandText <-
-                                    "INSERT OR REPLACE INTO status_files (relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($relative_path, $directory_path, $directory_version_id, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write);"
-
-                                fileCommand.Parameters.Add("$relative_path", SqliteType.Text)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$directory_path", SqliteType.Text)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$is_binary", SqliteType.Integer)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$created_at", SqliteType.Integer)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$uploaded", SqliteType.Integer)
-                                |> ignore
-
-                                fileCommand.Parameters.Add("$last_write", SqliteType.Integer)
-                                |> ignore
-
-                                graceStatus.Index.Values
-                                |> Seq.iter (fun directory ->
-                                    let parentPath =
-                                        match getParentPath directory.RelativePath with
-                                        | Some path -> path
-                                        | None -> String.Empty
-
-                                    directoryCommand.Parameters["$relative_path"].Value <- directory.RelativePath
-                                    directoryCommand.Parameters["$parent_path"].Value <- parentPath
-                                    directoryCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
-                                    directoryCommand.Parameters["$sha256_hash"].Value <- directory.Sha256Hash
-                                    directoryCommand.Parameters["$blake3_hash"].Value <- directory.Blake3Hash
-                                    directoryCommand.Parameters["$size_bytes"].Value <- directory.Size
-                                    directoryCommand.Parameters["$created_at"].Value <- directory.CreatedAt.ToUnixTimeTicks()
-                                    directoryCommand.Parameters["$last_write"].Value <- directory.LastWriteTimeUtc.Ticks
-                                    directoryCommand.ExecuteNonQuery() |> ignore
-
-                                    directory.Files
-                                    |> Seq.iter (fun file ->
-                                        fileCommand.Parameters["$relative_path"].Value <- file.RelativePath
-                                        fileCommand.Parameters["$directory_path"].Value <- directory.RelativePath
-                                        fileCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
-                                        fileCommand.Parameters["$sha256_hash"].Value <- file.Sha256Hash
-                                        fileCommand.Parameters["$blake3_hash"].Value <- file.Blake3Hash
-                                        fileCommand.Parameters["$is_binary"].Value <- if file.IsBinary then 1 else 0
-                                        fileCommand.Parameters["$size_bytes"].Value <- file.Size
-                                        fileCommand.Parameters["$created_at"].Value <- file.CreatedAt.ToUnixTimeTicks()
-                                        fileCommand.Parameters["$uploaded"].Value <- if file.UploadedToObjectStorage then 1 else 0
-                                        fileCommand.Parameters["$last_write"].Value <- file.LastWriteTimeUtc.Ticks
-                                        fileCommand.ExecuteNonQuery() |> ignore))
-
-                                match boundary with
-                                | Some boundary ->
-                                    executeNonQueryWithParams
-                                        connection
-                                        "INSERT OR REPLACE INTO remote_reference_boundaries (repository_id, branch_id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, event_cursor) VALUES ($repository_id, $branch_id, $root_id, $root_sha256_hash, $root_blake3_hash, $event_cursor);"
-                                        (fun parameters ->
-                                            parameters.AddWithValue("$repository_id", boundary.RepositoryId.ToString())
-                                            |> ignore
-
-                                            parameters.AddWithValue("$branch_id", boundary.BranchId.ToString())
-                                            |> ignore
-
-                                            parameters.AddWithValue("$root_id", boundary.DirectoryId.ToString())
-                                            |> ignore
-
-                                            parameters.AddWithValue("$root_sha256_hash", boundary.Sha256Hash)
-                                            |> ignore
-
-                                            parameters.AddWithValue("$root_blake3_hash", boundary.Blake3Hash)
-                                            |> ignore
-
-                                            parameters.AddWithValue("$event_cursor", boundary.EventCursor)
-                                            |> ignore)
-                                | None -> ()
-
-                                beforeCommit ()
-                                cancellationToken.ThrowIfCancellationRequested()
-                                let committedRevision = incrementLocalStatusRevision connection
-                                executeNonQuery connection "COMMIT;"
-                                return committedRevision
-                            with
-                            | ex ->
-                                executeNonQuery connection "ROLLBACK;"
-                                return raise ex
-                        finally
-                            connection.Dispose()
-                    })
+            match repairBaseline with
+            | Some _ ->
+                try
+                    return! replaceOnce ()
+                with
+                | :? SqliteException as ex when isBusyOrLocked ex ->
+                    return invalidOp "Grace Doctor refused local-state repair because another SQLite writer is active."
+            | None -> return! executeWithRevisionRetry replaceOnce
         }
 
     /// Replaces status and its matching branch-scoped remote Reference boundary in one SQLite transaction.
@@ -3076,7 +3175,7 @@ module LocalStateDb =
         (boundary: ReferenceMaterializationBoundaryDto)
         (cancellationToken: CancellationToken)
         =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken ignore
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken None ignore ignore
 
     /// Refuses exact local-state repair when another SQLite connection currently owns the write claim.
     let ensureNoActiveWriterForLocalStateRepair (dbPath: string) =
@@ -3115,11 +3214,32 @@ module LocalStateDb =
         (cancellationToken: CancellationToken)
         (beforeCommit: unit -> unit)
         =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken beforeCommit
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken None ignore beforeCommit
+
+    /// Replaces exact repair status only if no writer changed or owns the captured local-state generation.
+    let replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepair
+        (dbPath: string)
+        (baseline: LocalStateRepairBaseline)
+        (graceStatus: GraceStatus)
+        (boundary: ReferenceMaterializationBoundaryDto)
+        (cancellationToken: CancellationToken)
+        =
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken (Some baseline) ignore ignore
+
+    /// Exposes the final repair write-claim seam so deterministic tests can race a real SQLite writer.
+    let internal replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepairWithBeforeWriteClaim
+        (dbPath: string)
+        (baseline: LocalStateRepairBaseline)
+        (graceStatus: GraceStatus)
+        (boundary: ReferenceMaterializationBoundaryDto)
+        (cancellationToken: CancellationToken)
+        (beforeWriteClaim: unit -> unit)
+        =
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken (Some baseline) beforeWriteClaim ignore
 
     /// Replaces status without changing any branch-scoped remote Reference boundary.
     let replaceStatusSnapshotWithRevision (dbPath: string) (graceStatus: GraceStatus) =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus None CancellationToken.None ignore
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus None CancellationToken.None None ignore ignore
 
     /// Reads the boundary for one repository and branch without falling back to global metadata.
     let readRemoteReferenceBoundary (dbPath: string) repositoryId branchId =
@@ -3778,6 +3898,7 @@ module LocalStateDb =
     type private StatusFileRow =
         {
             RelativePath: string
+            DirectoryPath: string
             DirectoryVersionId: DirectoryVersionId
             Sha256Hash: Sha256Hash
             Blake3Hash: Blake3Hash
@@ -3845,24 +3966,26 @@ module LocalStateDb =
                 use fileCommand = connection.CreateCommand()
 
                 fileCommand.CommandText <-
-                    "SELECT relative_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+                    "SELECT relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
 
                 use fileReader = fileCommand.ExecuteReader()
 
                 while fileReader.Read() do
                     let relativePath = fileReader.GetString(0)
-                    let directoryVersionId = Guid.Parse(fileReader.GetString(1))
-                    let sha256Hash = fileReader.GetString(2)
-                    let blake3Hash = fileReader.GetString(3)
-                    let isBinary = fileReader.GetInt64(4) = 1L
-                    let sizeBytes = fileReader.GetInt64(5)
-                    let createdAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(6))
-                    let uploaded = fileReader.GetInt64(7) = 1L
-                    let lastWriteTimeUtc = DateTime(fileReader.GetInt64(8), DateTimeKind.Utc)
+                    let directoryPath = fileReader.GetString(1)
+                    let directoryVersionId = Guid.Parse(fileReader.GetString(2))
+                    let sha256Hash = fileReader.GetString(3)
+                    let blake3Hash = fileReader.GetString(4)
+                    let isBinary = fileReader.GetInt64(5) = 1L
+                    let sizeBytes = fileReader.GetInt64(6)
+                    let createdAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(7))
+                    let uploaded = fileReader.GetInt64(8) = 1L
+                    let lastWriteTimeUtc = DateTime(fileReader.GetInt64(9), DateTimeKind.Utc)
 
                     files.Add(
                         {
                             RelativePath = relativePath
+                            DirectoryPath = directoryPath
                             DirectoryVersionId = directoryVersionId
                             Sha256Hash = sha256Hash
                             Blake3Hash = blake3Hash
@@ -4048,7 +4171,7 @@ module LocalStateDb =
                                 use fileCommand = connection.CreateCommand()
 
                                 fileCommand.CommandText <-
-                                    "SELECT relative_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
+                                    "SELECT relative_path, directory_path, directory_version_id, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks FROM status_files;"
 
                                 use fileReader = fileCommand.ExecuteReader()
 
@@ -4056,16 +4179,66 @@ module LocalStateDb =
                                     files.Add(
                                         {
                                             RelativePath = fileReader.GetString(0)
-                                            DirectoryVersionId = Guid.Parse(fileReader.GetString(1))
-                                            Sha256Hash = fileReader.GetString(2)
-                                            Blake3Hash = fileReader.GetString(3)
-                                            IsBinary = fileReader.GetInt64(4) = 1L
-                                            SizeBytes = fileReader.GetInt64(5)
-                                            CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(6))
-                                            UploadedToObjectStorage = fileReader.GetInt64(7) = 1L
-                                            LastWriteTimeUtc = DateTime(fileReader.GetInt64(8), DateTimeKind.Utc)
+                                            DirectoryPath = fileReader.GetString(1)
+                                            DirectoryVersionId = Guid.Parse(fileReader.GetString(2))
+                                            Sha256Hash = fileReader.GetString(3)
+                                            Blake3Hash = fileReader.GetString(4)
+                                            IsBinary = fileReader.GetInt64(5) = 1L
+                                            SizeBytes = fileReader.GetInt64(6)
+                                            CreatedAt = Instant.FromUnixTimeTicks(fileReader.GetInt64(7))
+                                            UploadedToObjectStorage = fileReader.GetInt64(8) = 1L
+                                            LastWriteTimeUtc = DateTime(fileReader.GetInt64(9), DateTimeKind.Utc)
                                         }
                                     )
+
+                                let directoryPaths =
+                                    HashSet<string>(
+                                        directories
+                                        |> Seq.map (fun directory -> directory.RelativePath),
+                                        StringComparer.Ordinal
+                                    )
+
+                                let directoryIds = HashSet<DirectoryVersionId>()
+
+                                let malformedStructureRows =
+                                    seq {
+                                        let roots =
+                                            directories
+                                            |> Seq.filter (fun directory -> directory.RelativePath = Grace.Shared.Constants.RootDirectoryPath)
+                                            |> Seq.toArray
+
+                                        if roots.Length <> 1
+                                           || roots[0].ParentPath <> String.Empty then
+                                            yield "root"
+
+                                        for directory in directories do
+                                            if not (directoryIds.Add(directory.DirectoryVersionId)) then
+                                                yield $"duplicate-directory-id:{directory.DirectoryVersionId}"
+
+                                            if directory.RelativePath
+                                               <> Grace.Shared.Constants.RootDirectoryPath then
+                                                match getParentPath directory.RelativePath with
+                                                | Some expectedParent when
+                                                    expectedParent = directory.ParentPath
+                                                    && directoryPaths.Contains(expectedParent)
+                                                    ->
+                                                    ()
+                                                | _ -> yield $"directory:{directory.RelativePath}"
+
+                                        for file in files do
+                                            match getParentPath file.RelativePath with
+                                            | Some expectedParent when
+                                                expectedParent = file.DirectoryPath
+                                                && not (directoryPaths.Contains(file.RelativePath))
+                                                && directories
+                                                   |> Seq.exists (fun directory ->
+                                                       directory.DirectoryVersionId = file.DirectoryVersionId
+                                                       && directory.RelativePath = file.DirectoryPath)
+                                                ->
+                                                ()
+                                            | _ -> yield $"file:{file.RelativePath}"
+                                    }
+                                    |> Seq.toArray
 
                                 let emptyBlake3Rows =
                                     seq {
@@ -4081,7 +4254,13 @@ module LocalStateDb =
                                     }
                                     |> Seq.toArray
 
-                                if emptyBlake3Rows.Length > 0 then
+                                if malformedStructureRows.Length > 0 then
+                                    let rows = String.concat ", " malformedStructureRows
+
+                                    return
+                                        Error
+                                            $"Local state database contains a malformed or disconnected status tree: {rows}. Run materializing grace connect or grace doctor --repair-local-state."
+                                elif emptyBlake3Rows.Length > 0 then
                                     let rows = String.concat ", " emptyBlake3Rows
 
                                     return
@@ -4169,4 +4348,100 @@ module LocalStateDb =
                                             }
                     with
                     | ex -> return Error ex.Message
+        }
+
+    /// Verifies that a status snapshot is one complete rooted graph whose hashes cover every descendant.
+    let validateCompleteStatusTree (status: GraceStatus) =
+        try
+            if isNull status.Index then
+                Error "The status index is missing."
+            else
+                let visiting = HashSet<DirectoryVersionId>()
+                let visited = HashSet<DirectoryVersionId>()
+
+                let rec validateDirectory expectedParentPath directoryId =
+                    if visiting.Contains(directoryId) then
+                        invalidOp $"The status tree contains a directory cycle at {directoryId}."
+
+                    let mutable directory = LocalDirectoryVersion.Default
+
+                    if not (status.Index.TryGetValue(directoryId, &directory)) then
+                        invalidOp $"The status tree references missing directory {directoryId}."
+
+                    match expectedParentPath with
+                    | None when
+                        directory.RelativePath
+                        <> Grace.Shared.Constants.RootDirectoryPath
+                        ->
+                        invalidOp "The claimed status root does not use the repository root path."
+                    | Some parentPath when
+                        getParentPath directory.RelativePath
+                        <> Some parentPath
+                        ->
+                        invalidOp $"Directory {directory.RelativePath} is not a direct child of {parentPath}."
+                    | _ -> ()
+
+                    visiting.Add(directoryId) |> ignore
+
+                    let childDirectories =
+                        directory.Directories
+                        |> Seq.map (fun childId ->
+                            validateDirectory (Some directory.RelativePath) childId
+                            status.Index[childId])
+                        |> Seq.toArray
+
+                    let entries =
+                        seq {
+                            yield!
+                                childDirectories
+                                |> Seq.map (fun child ->
+                                    Grace.Shared.Services.DirectoryVersionPreimageEntry.Directory
+                                        child.RelativePath
+                                        child.Size
+                                        child.Blake3Hash
+                                        child.Sha256Hash)
+
+                            yield!
+                                directory.Files
+                                |> Seq.map (fun file ->
+                                    if getParentPath file.RelativePath
+                                       <> Some directory.RelativePath then
+                                        invalidOp $"File {file.RelativePath} is not a direct child of {directory.RelativePath}."
+
+                                    Grace.Shared.Services.DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash)
+                        }
+                        |> Seq.toArray
+
+                    let expectedSha256 = Grace.Shared.Services.computeSha256ForDirectoryEntries directory.RelativePath entries
+                    let expectedBlake3 = Grace.Shared.Services.computeBlake3ForDirectory directory.RelativePath entries
+
+                    if directory.Sha256Hash <> expectedSha256
+                       || directory.Blake3Hash <> expectedBlake3 then
+                        invalidOp $"Directory {directory.RelativePath} does not match its complete child graph."
+
+                    visiting.Remove(directoryId) |> ignore
+                    visited.Add(directoryId) |> ignore
+
+                validateDirectory None status.RootDirectoryId
+                let mutable root = LocalDirectoryVersion.Default
+
+                if visited.Count <> status.Index.Count
+                   || not (status.Index.TryGetValue(status.RootDirectoryId, &root))
+                   || root.Sha256Hash <> status.RootDirectorySha256Hash
+                   || root.Blake3Hash <> status.RootDirectoryBlake3Hash then
+                    Error "The status tree is disconnected or does not match its claimed root identity."
+                else
+                    Ok()
+        with
+        | ex -> Error ex.Message
+
+    /// Reads local status without mutation and accepts it only when its full rooted graph is internally complete.
+    let readCompleteStatusSnapshotReadOnly dbPath ownerId organizationId repositoryId =
+        task {
+            match! readStatusSnapshotReadOnly dbPath ownerId organizationId repositoryId with
+            | Error error -> return Error error
+            | Ok status ->
+                match validateCompleteStatusTree status with
+                | Ok () -> return Ok status
+                | Error error -> return Error $"Local state database contains an incomplete status tree: {error}"
         }

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -2382,6 +2382,51 @@ type BranchServer() =
                         File.WriteAllText(configPath, originalConfig)
                         resetConfiguration ()
 
+                        let changedServerUri = "http://127.0.0.1:59999"
+
+                        Grace.CLI.Command.Doctor.setBeforeRepairFinalValidationForTests (fun () ->
+                            File.WriteAllText(configPath, originalConfig.Replace(configuration.ServerUri, changedServerUri)))
+
+                        let changedServerExitCode =
+                            Grace.CLI.GraceCommand.main [| "doctor"
+                                                           "--repair-local-state"
+                                                           "--output"
+                                                           "Json" |]
+
+                        Grace.CLI.Command.Doctor.resetBeforeRepairFinalValidationForTests ()
+                        Assert.That(changedServerExitCode, Is.EqualTo(-1))
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+                        File.WriteAllText(configPath, originalConfig)
+                        resetConfiguration ()
+
+                        let originalWorkingDirectory = Environment.CurrentDirectory
+                        let alternateRoot = Path.Combine(Path.GetTempPath(), $"grace-doctor-config-race-{Guid.NewGuid():N}")
+                        let alternateGraceDirectory = Path.Combine(alternateRoot, Constants.GraceConfigDirectory)
+
+                        Directory.CreateDirectory(alternateGraceDirectory)
+                        |> ignore
+
+                        File.WriteAllText(Path.Combine(alternateGraceDirectory, Constants.GraceConfigFileName), originalConfig)
+
+                        try
+                            Grace.CLI.Command.Doctor.setBeforeRepairFinalValidationForTests (fun () -> Environment.CurrentDirectory <- alternateRoot)
+
+                            let changedRootAndStatusPathExitCode =
+                                Grace.CLI.GraceCommand.main [| "doctor"
+                                                               "--repair-local-state"
+                                                               "--output"
+                                                               "Json" |]
+
+                            Grace.CLI.Command.Doctor.resetBeforeRepairFinalValidationForTests ()
+                            Assert.That(changedRootAndStatusPathExitCode, Is.EqualTo(-1))
+                            Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+                            Assert.That(File.Exists(Path.Combine(alternateGraceDirectory, Constants.GraceLocalStateDbFileName)), Is.False)
+                        finally
+                            Environment.CurrentDirectory <- originalWorkingDirectory
+                            Grace.CLI.Command.Doctor.resetBeforeRepairFinalValidationForTests ()
+                            resetConfiguration ()
+                            Directory.Delete(alternateRoot, true)
+
                         do! Grace.CLI.LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
 
                         do

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -14,6 +14,7 @@ open Grace.Types.Annotation
 open Grace.Types.Common
 open Grace.Types.PersonalAccessToken
 open NUnit.Framework
+open Spectre.Console
 open System
 open System.Collections.Generic
 open System.IO
@@ -26,6 +27,23 @@ open System.Threading.Tasks
 
 /// Groups shared helpers for branch server test helpers.
 module BranchServerTestHelpers =
+    /// Runs one public Grace CLI command while capturing its machine-readable stdout contract.
+    let runGraceCommandWithCapturedStdout args =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+        let originalConsole = AnsiConsole.Console
+
+        try
+            Console.SetOut(writer)
+            let settings = AnsiConsoleSettings()
+            settings.Out <- AnsiConsoleOutput(writer)
+            AnsiConsole.Console <- AnsiConsole.Create(settings)
+            let exitCode = Grace.CLI.GraceCommand.main args
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            AnsiConsole.Console <- originalConsole
+
     /// Asserts ok for integration responses.
     let private assertOk (response: HttpResponseMessage) =
         task {
@@ -2089,7 +2107,7 @@ type BranchServer() =
     [<Test; NonParallelizable>]
     member _.ProductionRepositoryInitializationCommitsExactStateOnlyAfterPublication() =
         task {
-            let runInitialization shouldFailBeforeSave =
+            let runInitialization outputMode shouldFailBeforeSave =
                 BranchServerTestHelpers.withExplicitSdkConfigurationForServerAsync (fun () ->
                     task {
                         do! BranchServerTestHelpers.configureSdkForServerAsync ()
@@ -2144,18 +2162,52 @@ type BranchServer() =
                                 Grace.CLI.Command.Repository.setBeforeRepositoryInitializationSaveForTests (fun () ->
                                     invalidOp "forced repository initialization publication failure")
 
-                            let initExitCode =
-                                Grace.CLI.GraceCommand.main [| "repository"
-                                                               "init"
-                                                               "--directory"
-                                                               repositoryConfiguration.RootDirectory
-                                                               "--output"
-                                                               "Normal" |]
+                            let initExitCode, initOutput =
+                                BranchServerTestHelpers.runGraceCommandWithCapturedStdout [| "repository"
+                                                                                             "init"
+                                                                                             "--directory"
+                                                                                             repositoryConfiguration.RootDirectory
+                                                                                             "--output"
+                                                                                             outputMode |]
 
                             Grace.CLI.Command.Repository.resetBeforeRepositoryInitializationSaveForTests ()
 
+                            if outputMode = "Json" then
+                                use initJson = System.Text.Json.JsonDocument.Parse(initOutput)
+
+                                Assert.That(
+                                    initJson
+                                        .RootElement
+                                        .GetProperty("CorrelationId")
+                                        .GetString(),
+                                    Is.Not.Empty,
+                                    initOutput
+                                )
+
+                                if shouldFailBeforeSave then
+                                    Assert.That(
+                                        initJson
+                                            .RootElement
+                                            .GetProperty("Error")
+                                            .GetString(),
+                                        Does.Contain("forced repository initialization publication failure")
+                                    )
+                                else
+                                    let initReturnValue = initJson.RootElement.GetProperty("ReturnValue")
+                                    Assert.That(initReturnValue.GetProperty("Message").GetString(), Is.EqualTo("Initialized repository."))
+
+                                    Assert.That(
+                                        initReturnValue
+                                            .GetProperty("DirectoryCount")
+                                            .GetInt32(),
+                                        Is.EqualTo(3)
+                                    )
+                            else
+                                Assert.That(initOutput, Is.Empty, $"{outputMode} output must not leak human progress or result text.")
+
                             if shouldFailBeforeSave then
                                 Assert.That(initExitCode, Is.EqualTo(-1))
+
                                 let! statusAfterFailure = Grace.CLI.LocalStateDb.readStatusMeta repositoryConfiguration.GraceStatusFile
                                 Assert.That(statusAfterFailure.RootDirectoryId, Is.EqualTo(DirectoryVersionId.Empty))
 
@@ -2229,8 +2281,10 @@ type BranchServer() =
                             Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, previousGraceToken)
                     })
 
-            do! runInitialization false
-            do! runInitialization true
+            do! runInitialization "Json" false
+            do! runInitialization "Json" true
+            do! runInitialization "Minimal" false
+            do! runInitialization "Silent" false
         }
 
     /// Explicit Doctor repair restores exact nested identities, then ordinary Save and one-time remote replay remain healthy.

--- a/src/Grace.Server.Tests/Branch.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Branch.Server.Tests.fs
@@ -907,6 +907,7 @@ module BranchServerTestHelpers =
             let configurationDirectory = Path.Combine(root, Constants.GraceConfigDirectory)
             let configurationPath = Path.Combine(configurationDirectory, Constants.GraceConfigFileName)
             let previousDirectory = Environment.CurrentDirectory
+            let previousGraceToken = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
 
             try
                 Directory.CreateDirectory(configurationDirectory)
@@ -924,6 +925,7 @@ module BranchServerTestHelpers =
                 return! testBody ()
             finally
                 Grace.SDK.Auth.clearTokenProvider ()
+                Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, previousGraceToken)
                 Environment.CurrentDirectory <- previousDirectory
                 resetConfiguration ()
 
@@ -944,6 +946,9 @@ module BranchServerTestHelpers =
 
             Grace.SDK.Auth.setTokenProvider (fun () -> task { return Some token })
         }
+
+    /// Creates a real PAT for hosted public CLI command tests that configure authentication from the process environment.
+    let createPublicCliTokenAsync () = createPersonalAccessTokenAsync ()
 
     /// Gets first annotatable file from the running test server.
     let getFirstAnnotatableFileAsync (repositoryId: string) (branch: Branch.BranchDto) =
@@ -2080,345 +2085,356 @@ type BranchServer() =
                     })
         }
 
-    /// A reset local database recovers through production Watch, materializes one later event, and durably acknowledges its cursor.
+    /// Repository creation from nested existing code records exact status only after its matching Save and event boundary succeed.
     [<Test; NonParallelizable>]
-    member _.ProductionWatchMissingBoundaryRecoveryReplaysExactlyOneLaterReference() =
+    member _.ProductionRepositoryInitializationCommitsExactStateOnlyAfterPublication() =
         task {
-            let repositoryId = repositoryIds[0]
-            let parentBranchId = repositoryDefaultBranchIds[0]
-            let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId parentBranchId
-            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"WatchRecovery{Guid.NewGuid():N}"
-            let retainedDirectoryPath = RelativePath $"retained-{Guid.NewGuid():N}"
-            let retainedRelativePath = RelativePath $"{retainedDirectoryPath}/baseline.txt"
-            let retainedPayload = Encoding.UTF8.GetBytes("retained baseline content")
-
-            let retainedFileVersion =
-                FileVersion.CreateWithHashes
-                    retainedRelativePath
-                    (BranchServerTestHelpers.sha256Hex retainedPayload)
-                    (BranchServerTestHelpers.blake3Hex retainedPayload)
-                    String.Empty
-                    false
-                    (int64 retainedPayload.Length)
-
-            let retainedDirectory = BranchServerTestHelpers.createDirectoryVersionWithFile repositoryId retainedDirectoryPath retainedFileVersion
-            let recoveredRoot = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId Constants.RootDirectoryPath [ retainedDirectory ]
-
-            do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId retainedPayload retainedFileVersion
-            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ retainedDirectory; recoveredRoot ]
-
-            let! recoveredSave =
-                BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch recoveredRoot.DirectoryVersionId recoveredRoot.Sha256Hash
-
-            let! recoveredSaveBody = recoveredSave.Content.ReadAsStringAsync()
-            Assert.That(recoveredSave.StatusCode, Is.EqualTo(HttpStatusCode.OK), recoveredSaveBody)
-
-            let! retainedBaselineBlob = BranchServerTestHelpers.getFileObjectAzuriteBlockBlobClientAsync repositoryId retainedFileVersion
-            let! _ = retainedBaselineBlob.DeleteIfExistsAsync()
-            let! retainedBaselineBlobBeforeReset = retainedBaselineBlob.ExistsAsync()
-            Assert.That(retainedBaselineBlobBeforeReset.Value, Is.False)
-
-            let relativePath = RelativePath $"watch-runtime-{Guid.NewGuid():N}.txt"
-            let payload = Encoding.UTF8.GetBytes("production missing-boundary replay")
-
-            let fileVersion =
-                FileVersion.CreateWithHashes
-                    relativePath
-                    (BranchServerTestHelpers.sha256Hex payload)
-                    (BranchServerTestHelpers.blake3Hex payload)
-                    String.Empty
-                    false
-                    (int64 payload.Length)
-
-            do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId payload fileVersion
-            let laterRoot = BranchServerTestHelpers.createDirectoryVersionWithFile repositoryId Constants.RootDirectoryPath fileVersion
-            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ laterRoot ]
-            let! laterSave = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch laterRoot.DirectoryVersionId laterRoot.Sha256Hash
-            let! laterSaveBody = laterSave.Content.ReadAsStringAsync()
-            Assert.That(laterSave.StatusCode, Is.EqualTo(HttpStatusCode.OK), laterSaveBody)
-
-            do!
+            let runInitialization shouldFailBeforeSave =
                 BranchServerTestHelpers.withExplicitSdkConfigurationForServerAsync (fun () ->
                     task {
                         do! BranchServerTestHelpers.configureSdkForServerAsync ()
-                        let configuration = Current()
-                        configuration.OwnerId <- Guid.Parse(ownerId)
-                        configuration.OrganizationId <- Guid.Parse(organizationId)
-                        configuration.RepositoryId <- Guid.Parse(repositoryId)
-                        configuration.RepositoryName <- "watch-runtime-repository"
-                        configuration.BranchId <- branch.BranchId
-                        configuration.BranchName <- string branch.BranchName
-
-                        saveConfigFile (Path.Combine(configuration.RootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)) configuration
-
-                        let localRetainedDirectory = retainedDirectory.ToLocalDirectoryVersion(DateTime.UtcNow)
-                        let localRoot = recoveredRoot.ToLocalDirectoryVersion(DateTime.UtcNow)
-                        let index = GraceIndex()
-
-                        index.TryAdd(localRetainedDirectory.DirectoryVersionId, localRetainedDirectory)
-                        |> ignore
-
-                        index.TryAdd(localRoot.DirectoryVersionId, localRoot)
-                        |> ignore
-
-                        let initialStatus =
-                            { GraceStatus.Default with
-                                Index = index
-                                RootDirectoryId = localRoot.DirectoryVersionId
-                                RootDirectorySha256Hash = localRoot.Sha256Hash
-                                RootDirectoryBlake3Hash = localRoot.Blake3Hash
-                            }
-
-                        let objectCachePath = Grace.CLI.Services.getLocalObjectCachePathForFileVersion fileVersion
-
-                        Directory.CreateDirectory(Path.GetDirectoryName(objectCachePath))
-                        |> ignore
-
-                        File.WriteAllBytes(objectCachePath, payload)
-
-                        let retainedPath = Path.Combine(configuration.RootDirectory, string retainedRelativePath)
-
-                        Directory.CreateDirectory(Path.GetDirectoryName(retainedPath))
-                        |> ignore
-
-                        File.WriteAllBytes(retainedPath, retainedPayload)
-
-                        Grace.CLI.Command.Watch.clearPendingWatchWorkForTests ()
-                        Grace.CLI.Command.Watch.resetWatchIgnoreSnapshotForWatchTests ()
-                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
-                        do! Grace.CLI.LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
-                        do! Grace.CLI.Services.writeGraceStatusFile initialStatus
-                        do! Grace.CLI.Services.updateGraceWatchInterprocessFile initialStatus (Some(HashSet<DirectoryVersionId>(index.Keys)))
-
-                        let ipcPath = Grace.CLI.Services.IpcFileName()
-                        let retainedStatus = deserialize<Grace.CLI.Services.GraceWatchStatus> (File.ReadAllText(ipcPath))
-
-                        File.WriteAllText(
-                            ipcPath,
-                            serialize { retainedStatus with UpdatedAt = retainedStatus.UpdatedAt.Minus(NodaTime.Duration.FromMinutes(10.0)) }
-                        )
-
-                        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools()
-                        GC.Collect()
-                        GC.WaitForPendingFinalizers()
-
-                        [|
-                            configuration.GraceStatusFile
-                            configuration.GraceStatusFile + "-wal"
-                            configuration.GraceStatusFile + "-shm"
-                            configuration.GraceStatusFile + "-journal"
-                        |]
-                        |> Array.iter (fun path -> if File.Exists(path) then File.Delete(path))
+                        let! publicCliToken = BranchServerTestHelpers.createPublicCliTokenAsync ()
+                        let previousGraceToken = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
+                        Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, publicCliToken)
 
                         try
-                            Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
-                            Assert.That(File.Exists(ipcPath), Is.True)
+                            let initialConfiguration = Current()
+                            initialConfiguration.OwnerId <- Guid.Parse(ownerId)
+                            initialConfiguration.OrganizationId <- Guid.Parse(organizationId)
+                            initialConfiguration.ObjectStorageProvider <- ObjectStorageProvider.AzureBlobStorage
 
-                            let! claim = Grace.CLI.Services.claimGraceWatchInterprocessFile ()
-                            Assert.That(claim.Claimed, Is.True)
-                            Assert.That(claim.RetainedStatus.IsSome, Is.True)
-                            Grace.CLI.Command.Watch.setGraceWatchRuntimeModeForWatchTests Grace.CLI.Services.GraceWatchRuntimeMode.StartingUp
+                            let configPath = Path.Combine(initialConfiguration.RootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)
 
-                            match Grace.CLI.Command.Watch.tryActivateWatchIgnoreSnapshotForWatchTests () with
-                            | Ok () -> ()
-                            | Error error -> Assert.Fail($"Expected production Watch ignore snapshot activation, got {error}.")
+                            saveConfigFile configPath initialConfiguration
+                            let nestedParentPath = RelativePath $"create-{Guid.NewGuid():N}"
+                            let nestedDirectoryPath = RelativePath $"{nestedParentPath}/deeper"
+                            let nestedFilePath = Path.Combine(initialConfiguration.RootDirectory, string nestedDirectoryPath, "existing.txt")
 
-                            let! resetStatus = Grace.CLI.Services.readGraceStatusFile ()
-                            Assert.That(resetStatus.RootDirectoryId, Is.EqualTo(DirectoryVersionId.Empty))
-                            let materializedPath = Path.Combine(configuration.RootDirectory, string relativePath)
-                            Assert.That(Directory.Exists(Path.Combine(configuration.RootDirectory, string retainedDirectoryPath)), Is.True)
-                            Assert.That(Convert.ToHexString(File.ReadAllBytes(retainedPath)), Is.EqualTo(Convert.ToHexString(retainedPayload)))
-
-                            use cancelled = new System.Threading.CancellationTokenSource()
-                            cancelled.Cancel()
-
-                            Assert.ThrowsAsync<OperationCanceledException>(
-                                Func<Task> (fun () ->
-                                    Grace.CLI.Command.Watch.establishMissingCurrentBranchReferenceBoundaryBeforeStartupScanForHostedTests
-                                        claim.RetainedStatus
-                                        resetStatus
-                                        cancelled.Token
-                                    :> Task)
-                            )
+                            Directory.CreateDirectory(Path.GetDirectoryName(nestedFilePath))
                             |> ignore
 
-                            let! afterCancellation =
-                                Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
-                                    configuration.GraceStatusFile
-                                    configuration.RepositoryId
-                                    configuration.BranchId
+                            File.WriteAllText(nestedFilePath, "nested repository initialization")
+                            let newRepositoryId = Guid.NewGuid()
+                            let newRepositoryName = $"ExistingCode{Guid.NewGuid():N}"
 
-                            Assert.That(afterCancellation, Is.EqualTo(None))
-                            Assert.That(File.Exists(materializedPath), Is.False)
+                            let createExitCode =
+                                Grace.CLI.GraceCommand.main [| "repository"
+                                                               "create"
+                                                               "--repository-name"
+                                                               newRepositoryName
+                                                               "--repository-id"
+                                                               string newRepositoryId
+                                                               "--owner-id"
+                                                               ownerId
+                                                               "--organization-id"
+                                                               organizationId
+                                                               "--output"
+                                                               "Json" |]
 
-                            let configPath = Path.Combine(configuration.RootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)
-                            File.Delete(configPath)
+                            Assert.That(createExitCode, Is.EqualTo(0))
+                            resetConfiguration ()
+                            let repositoryConfiguration = Current()
+                            Assert.That(repositoryConfiguration.RepositoryId, Is.EqualTo(newRepositoryId))
+                            Assert.That(File.Exists(repositoryConfiguration.GraceStatusFile), Is.False)
 
-                            try
-                                Assert.ThrowsAsync<InvalidOperationException>(
-                                    Func<Task> (fun () ->
-                                        Grace.CLI.Command.Watch.establishMissingCurrentBranchReferenceBoundaryBeforeStartupScanForHostedTests
-                                            claim.RetainedStatus
-                                            resetStatus
-                                            System.Threading.CancellationToken.None
-                                        :> Task)
-                                )
-                                |> ignore
-                            finally
-                                saveConfigFile configPath configuration
+                            let! referencesBeforeInitialization =
+                                BranchServerTestHelpers.getBranchReferencesAsync (string newRepositoryId) (string repositoryConfiguration.BranchId)
 
-                            let! afterFailure =
-                                Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
-                                    configuration.GraceStatusFile
-                                    configuration.RepositoryId
-                                    configuration.BranchId
+                            if shouldFailBeforeSave then
+                                Grace.CLI.Command.Repository.setBeforeRepositoryInitializationSaveForTests (fun () ->
+                                    invalidOp "forced repository initialization publication failure")
 
-                            Assert.That(afterFailure, Is.EqualTo(None))
-                            Assert.That(File.Exists(materializedPath), Is.False)
+                            let initExitCode =
+                                Grace.CLI.GraceCommand.main [| "repository"
+                                                               "init"
+                                                               "--directory"
+                                                               repositoryConfiguration.RootDirectory
+                                                               "--output"
+                                                               "Normal" |]
 
-                            let! recoveredStatus =
-                                Grace.CLI.Command.Watch.establishMissingCurrentBranchReferenceBoundaryBeforeStartupScanForHostedTests
-                                    claim.RetainedStatus
-                                    resetStatus
-                                    System.Threading.CancellationToken.None
+                            Grace.CLI.Command.Repository.resetBeforeRepositoryInitializationSaveForTests ()
 
-                            let! referencesBeforeStartupScan = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
-                            let! retainedBaselineBlobBeforeStartupScan = retainedBaselineBlob.ExistsAsync()
-                            Assert.That(retainedBaselineBlobBeforeStartupScan.Value, Is.False)
+                            if shouldFailBeforeSave then
+                                Assert.That(initExitCode, Is.EqualTo(-1))
+                                let! statusAfterFailure = Grace.CLI.LocalStateDb.readStatusMeta repositoryConfiguration.GraceStatusFile
+                                Assert.That(statusAfterFailure.RootDirectoryId, Is.EqualTo(DirectoryVersionId.Empty))
 
-                            let! startupScan = Grace.CLI.Command.Watch.tryScanForDifferencesWithWatchIgnoreSnapshotForWatchTests recoveredStatus
+                                let! boundaryAfterFailure =
+                                    Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
+                                        repositoryConfiguration.GraceStatusFile
+                                        repositoryConfiguration.RepositoryId
+                                        repositoryConfiguration.BranchId
 
-                            let startupDifferences =
-                                match startupScan with
-                                | Ok differences -> differences
-                                | Error error ->
-                                    Assert.Fail($"Expected production startup scan success, got {error}.")
-                                    List<FileSystemDifference>()
+                                Assert.That(boundaryAfterFailure, Is.EqualTo(None))
 
-                            for difference in startupDifferences do
-                                Grace.CLI.Command.Watch.queueStartupDifferenceForWatch difference
+                                let! referencesAfterFailure =
+                                    BranchServerTestHelpers.getBranchReferencesAsync (string newRepositoryId) (string repositoryConfiguration.BranchId)
 
-                            do! Grace.CLI.Command.Watch.processChangedFiles ()
+                                Assert.That(referencesAfterFailure.Length, Is.EqualTo(referencesBeforeInitialization.Length))
+                            else
+                                Assert.That(initExitCode, Is.EqualTo(0))
+                                let! initializedStatus = Grace.CLI.Services.readGraceStatusFile ()
+                                Assert.That(initializedStatus.RootDirectoryId, Is.Not.EqualTo(DirectoryVersionId.Empty))
+                                Assert.That(initializedStatus.Index.Count, Is.EqualTo(3))
 
-                            let! referencesAfterStartupProcessing = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+                                let initializedPaths =
+                                    initializedStatus.Index.Values
+                                    |> Seq.map (fun directory -> directory.RelativePath)
+                                    |> Set.ofSeq
 
-                            Assert.That(startupDifferences, Is.Empty, "The reconstructed retained baseline must be empty at the production scanner seam.")
+                                Assert.That(initializedPaths, Does.Contain(Constants.RootDirectoryPath))
+                                Assert.That(initializedPaths, Does.Contain(nestedParentPath))
+                                Assert.That(initializedPaths, Does.Contain(nestedDirectoryPath))
 
-                            Assert.That(
-                                referencesAfterStartupProcessing
-                                |> Array.map (fun reference -> $"{reference.ReferenceId}")
-                                |> Array.sort
-                                |> String.concat ",",
-                                Is.EqualTo(
-                                    referencesBeforeStartupScan
-                                    |> Array.map (fun reference -> $"{reference.ReferenceId}")
-                                    |> Array.sort
-                                    |> String.concat ","
-                                ),
-                                "Production startup processing must not publish a Save for retained baseline content."
-                            )
+                                let! initializedBoundary =
+                                    Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
+                                        repositoryConfiguration.GraceStatusFile
+                                        repositoryConfiguration.RepositoryId
+                                        repositoryConfiguration.BranchId
 
-                            let! retainedBaselineBlobAfterStartupProcessing = retainedBaselineBlob.ExistsAsync()
+                                Assert.That(initializedBoundary.IsSome, Is.True)
+                                Assert.That(initializedBoundary.Value.DirectoryId, Is.EqualTo(initializedStatus.RootDirectoryId))
+                                Assert.That(initializedBoundary.Value.Sha256Hash, Is.EqualTo(initializedStatus.RootDirectorySha256Hash))
+                                Assert.That(initializedBoundary.Value.Blake3Hash, Is.EqualTo(initializedStatus.RootDirectoryBlake3Hash))
+                                Assert.That(initializedBoundary.Value.EventCursor, Is.Not.Empty)
+                                let! branch = BranchServerTestHelpers.getBranchAsync (string newRepositoryId) (string repositoryConfiguration.BranchId)
 
-                            Assert.That(
-                                retainedBaselineBlobAfterStartupProcessing.Value,
-                                Is.False,
-                                "Production startup must not upload retained baseline bytes."
-                            )
+                                let! closureResponse =
+                                    BranchServerTestHelpers.listContentsByShaAndBlake3HashResponseAsync
+                                        (string newRepositoryId)
+                                        branch
+                                        initializedStatus.RootDirectorySha256Hash
+                                        initializedStatus.RootDirectoryBlake3Hash
 
-                            Assert.That(
-                                referencesAfterStartupProcessing
-                                |> Array.exists (fun reference -> reference.DirectoryId = laterRoot.DirectoryVersionId),
-                                Is.True,
-                                "The server Reference set must still contain the cursor-new Reference after baseline processing."
-                            )
+                                let! closureBody = closureResponse.Content.ReadAsStringAsync()
+                                Assert.That(closureResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), closureBody)
 
-                            Assert.That(Convert.ToHexString(File.ReadAllBytes(retainedPath)), Is.EqualTo(Convert.ToHexString(retainedPayload)))
+                                let closure =
+                                    (deserialize<GraceReturnValue<DirectoryVersion.DirectoryVersionDto array>> closureBody)
+                                        .ReturnValue
 
-                            do!
-                                Grace.CLI.Command.Watch.completeStartupRecoveryIfPendingWorkDrainedWithCatchUpForWatchTests
-                                    Grace.CLI.Services.readGraceStatusFile
-                                    Grace.CLI.Services.updateGraceWatchInterprocessFile
-                                    Grace.CLI.Command.Watch.processChangedFiles
-                                    (fun () -> Grace.CLI.Command.Watch.replayCurrentBranchReferenceEventsForHostedTests System.Threading.CancellationToken.None)
+                                let localIds =
+                                    initializedStatus.Index.Keys
+                                    |> Seq.map string
+                                    |> Set.ofSeq
 
-                            Assert.That(File.Exists(materializedPath), Is.True)
-                            Assert.That(Convert.ToHexString(File.ReadAllBytes(materializedPath)), Is.EqualTo(Convert.ToHexString(payload)))
+                                let serverIds =
+                                    closure
+                                    |> Seq.map (fun directory -> string directory.DirectoryVersion.DirectoryVersionId)
+                                    |> Set.ofSeq
 
-                            let! durableStatus = Grace.CLI.Services.readGraceStatusFile ()
-                            Assert.That(durableStatus.RootDirectoryId, Is.EqualTo(laterRoot.DirectoryVersionId))
-                            Assert.That(durableStatus.RootDirectorySha256Hash, Is.EqualTo(laterRoot.Sha256Hash))
-                            Assert.That(durableStatus.RootDirectoryBlake3Hash, Is.EqualTo(laterRoot.Blake3Hash))
-
-                            let! boundary =
-                                Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
-                                    configuration.GraceStatusFile
-                                    configuration.RepositoryId
-                                    configuration.BranchId
-
-                            Assert.That(boundary.IsSome, Is.True)
-                            Assert.That(boundary.Value.DirectoryId, Is.EqualTo(laterRoot.DirectoryVersionId))
-                            Assert.That(boundary.Value.EventCursor, Is.EqualTo("branch-event-v1:2"))
+                                Assert.That((serverIds = localIds), Is.True)
                         finally
-                            Grace.CLI.Command.Watch.clearPendingWatchWorkForTests ()
-                            Grace.CLI.Command.Watch.resetWatchIgnoreSnapshotForWatchTests ()
-                            if File.Exists(ipcPath) then File.Delete(ipcPath)
+                            Grace.CLI.Command.Repository.resetBeforeRepositoryInitializationSaveForTests ()
+                            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, previousGraceToken)
                     })
+
+            do! runInitialization false
+            do! runInitialization true
         }
 
-    /// A real DB reset with an unmatched retained root preserves local files and starts at the current server tail.
+    /// Explicit Doctor repair restores exact nested identities, then ordinary Save and one-time remote replay remain healthy.
     [<Test; NonParallelizable>]
-    member _.ProductionWatchMissingBoundaryRecoveryBaselinesUnmatchedRootWithoutMutation() =
+    member _.ProductionDoctorRepairRestoresExactStateThenSaveAndReplaySucceed() =
         task {
             let repositoryId = repositoryIds[0]
             let parentBranchId = repositoryDefaultBranchIds[0]
             let! parentBranch = BranchServerTestHelpers.getBranchAsync repositoryId parentBranchId
-            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"WatchBaseline{Guid.NewGuid():N}"
-            let serverRoot = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId Constants.RootDirectoryPath []
-            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ serverRoot ]
-            let! serverSave = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch serverRoot.DirectoryVersionId serverRoot.Sha256Hash
-            let! serverSaveBody = serverSave.Content.ReadAsStringAsync()
-            Assert.That(serverSave.StatusCode, Is.EqualTo(HttpStatusCode.OK), serverSaveBody)
+            let! branch = BranchServerTestHelpers.createBranchAsync repositoryId parentBranch $"DoctorRepair{Guid.NewGuid():N}"
+            let nestedParentPath = RelativePath $"nested-{Guid.NewGuid():N}"
+            let nestedDirectoryPath = RelativePath $"{nestedParentPath}/deeper"
+            let nestedRelativePath = RelativePath $"{nestedDirectoryPath}/baseline.txt"
+            let nestedPayload = Encoding.UTF8.GetBytes("doctor exact nested baseline")
+
+            let nestedFileVersion =
+                FileVersion.CreateWithHashes
+                    nestedRelativePath
+                    (BranchServerTestHelpers.sha256Hex nestedPayload)
+                    (BranchServerTestHelpers.blake3Hex nestedPayload)
+                    String.Empty
+                    false
+                    (int64 nestedPayload.Length)
+
+            let nestedDirectory = BranchServerTestHelpers.createDirectoryVersionWithFile repositoryId nestedDirectoryPath nestedFileVersion
+            let nestedParent = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId nestedParentPath [ nestedDirectory ]
+            let exactRoot = BranchServerTestHelpers.createDirectoryVersion (Guid.NewGuid()) repositoryId Constants.RootDirectoryPath [ nestedParent ]
+
+            do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId nestedPayload nestedFileVersion
+
+            do!
+                BranchServerTestHelpers.saveDirectoryVersionsAsync
+                    repositoryId
+                    [
+                        nestedDirectory
+                        nestedParent
+                        exactRoot
+                    ]
+
+            let! firstExactSave = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch exactRoot.DirectoryVersionId exactRoot.Sha256Hash
+            let! firstExactSaveBody = firstExactSave.Content.ReadAsStringAsync()
+            Assert.That(firstExactSave.StatusCode, Is.EqualTo(HttpStatusCode.OK), firstExactSaveBody)
+
+            let! secondExactSave = BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch exactRoot.DirectoryVersionId exactRoot.Sha256Hash
+            let! secondExactSaveBody = secondExactSave.Content.ReadAsStringAsync()
+            Assert.That(secondExactSave.StatusCode, Is.EqualTo(HttpStatusCode.OK), secondExactSaveBody)
 
             do!
                 BranchServerTestHelpers.withExplicitSdkConfigurationForServerAsync (fun () ->
                     task {
                         do! BranchServerTestHelpers.configureSdkForServerAsync ()
+                        let! publicCliToken = BranchServerTestHelpers.createPublicCliTokenAsync ()
+                        let previousGraceToken = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken)
+                        Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, publicCliToken)
                         let configuration = Current()
                         configuration.OwnerId <- Guid.Parse(ownerId)
+                        configuration.OwnerName <- String.Empty
                         configuration.OrganizationId <- Guid.Parse(organizationId)
+                        configuration.OrganizationName <- String.Empty
                         configuration.RepositoryId <- Guid.Parse(repositoryId)
-                        configuration.RepositoryName <- "watch-baseline-repository"
+                        configuration.RepositoryName <- String.Empty
                         configuration.BranchId <- branch.BranchId
-                        configuration.BranchName <- string branch.BranchName
+                        configuration.BranchName <- String.Empty
+                        configuration.ObjectStorageProvider <- ObjectStorageProvider.AzureBlobStorage
 
-                        saveConfigFile (Path.Combine(configuration.RootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)) configuration
+                        let configPath = Path.Combine(configuration.RootDirectory, Constants.GraceConfigDirectory, Constants.GraceConfigFileName)
+                        saveConfigFile configPath configuration
+                        let nestedPath = Path.Combine(configuration.RootDirectory, string nestedRelativePath)
 
-                        let retainedFilePath = Path.Combine(configuration.RootDirectory, $"retained-{Guid.NewGuid():N}.txt")
-                        let retainedBytes = Encoding.UTF8.GetBytes("unmatched local content wins")
-                        File.WriteAllBytes(retainedFilePath, retainedBytes)
+                        Directory.CreateDirectory(Path.GetDirectoryName(nestedPath))
+                        |> ignore
 
-                        let! initialStatus =
-                            Grace.CLI.Services.createNewGraceStatusFileForRoot (DirectoryVersionId.NewGuid()) GraceStatus.Default Grace.CLI.Services.parseResult
+                        File.WriteAllBytes(nestedPath, nestedPayload)
+                        let originalBytes = File.ReadAllBytes(nestedPath)
+                        let! retainedStatus = Grace.CLI.Services.createNewGraceStatusFile GraceStatus.Default Grace.CLI.Services.parseResult
 
-                        Grace.CLI.Command.Watch.clearPendingWatchWorkForTests ()
-                        Grace.CLI.Command.Watch.resetWatchIgnoreSnapshotForWatchTests ()
-                        do! Grace.CLI.LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
-                        do! Grace.CLI.Services.writeGraceStatusFile initialStatus
-
-                        do! Grace.CLI.Services.updateGraceWatchInterprocessFile initialStatus (Some(HashSet<DirectoryVersionId>(initialStatus.Index.Keys)))
-
-                        let ipcPath = Grace.CLI.Services.IpcFileName()
-                        let retainedStatus = deserialize<Grace.CLI.Services.GraceWatchStatus> (File.ReadAllText(ipcPath))
-
-                        File.WriteAllText(
-                            ipcPath,
-                            serialize { retainedStatus with UpdatedAt = retainedStatus.UpdatedAt.Minus(NodaTime.Duration.FromMinutes(10.0)) }
+                        Assert.That(
+                            string retainedStatus.RootDirectorySha256Hash,
+                            Is.EqualTo(string exactRoot.Sha256Hash),
+                            $"retained BLAKE3={retainedStatus.RootDirectoryBlake3Hash}; server BLAKE3={exactRoot.Blake3Hash}"
                         )
 
+                        Assert.That(retainedStatus.RootDirectoryBlake3Hash, Is.EqualTo(exactRoot.Blake3Hash))
+
+                        let lookup =
+                            Parameters.DirectoryVersion.GetBySha256HashParameters(
+                                OwnerId = ownerId,
+                                OrganizationId = organizationId,
+                                RepositoryId = repositoryId,
+                                Sha256Hash = retainedStatus.RootDirectorySha256Hash,
+                                CorrelationId = generateCorrelationId ()
+                            )
+
+                        let! lookupResult = Grace.SDK.DirectoryVersion.GetBySha256Hash lookup
+
+                        match lookupResult with
+                        | Ok value ->
+                            Assert.That(value.ReturnValue.DirectoryVersionId, Is.EqualTo(exactRoot.DirectoryVersionId))
+                            Assert.That(value.ReturnValue.RelativePath, Is.EqualTo(Constants.RootDirectoryPath))
+                            Assert.That(value.ReturnValue.Blake3Hash, Is.EqualTo(exactRoot.Blake3Hash))
+                        | Error error -> Assert.Fail($"Expected exact hosted root lookup, got {error.Error}.")
+
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+                        let! referencesBeforeRepair = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+                        let! nestedBlob = BranchServerTestHelpers.getFileObjectAzuriteBlockBlobClientAsync repositoryId nestedFileVersion
+                        let! nestedBlobBeforeRepair = nestedBlob.ExistsAsync()
+                        Assert.That(nestedBlobBeforeRepair.Value, Is.True)
+
+                        let nestedBlobNamespace =
+                            let separator = nestedBlob.Name.LastIndexOf('/')
+                            if separator < 0 then nestedBlob.Name else nestedBlob.Name[..separator]
+
+                        let blobNamesBeforeRepair =
+                            nestedBlob
+                                .GetParentBlobContainerClient()
+                                .GetBlobs()
+                            |> Seq.filter (fun blob -> blob.Name.StartsWith(nestedBlobNamespace, StringComparison.Ordinal))
+                            |> Seq.map (fun blob -> blob.Name)
+                            |> Set.ofSeq
+
+                        Grace.CLI.Command.Doctor.setBeforeRepairFinalValidationForTests (fun () -> File.AppendAllText(nestedPath, "stale"))
+
+                        let changedBytesExitCode =
+                            Grace.CLI.GraceCommand.main [| "doctor"
+                                                           "--repair-local-state"
+                                                           "--output"
+                                                           "Json" |]
+
+                        Grace.CLI.Command.Doctor.resetBeforeRepairFinalValidationForTests ()
+                        Assert.That(changedBytesExitCode, Is.EqualTo(-1))
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+                        File.WriteAllBytes(nestedPath, originalBytes)
+
+                        let originalConfig = File.ReadAllText(configPath)
+                        let changedBranchId = Guid.NewGuid().ToString()
+
+                        Grace.CLI.Command.Doctor.setBeforeRepairFinalValidationForTests (fun () ->
+                            File.WriteAllText(configPath, originalConfig.Replace(branch.BranchId.ToString(), changedBranchId)))
+
+                        let changedConfigExitCode =
+                            Grace.CLI.GraceCommand.main [| "doctor"
+                                                           "--repair-local-state"
+                                                           "--output"
+                                                           "Json" |]
+
+                        Grace.CLI.Command.Doctor.resetBeforeRepairFinalValidationForTests ()
+                        Assert.That(changedConfigExitCode, Is.EqualTo(-1))
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+                        File.WriteAllText(configPath, originalConfig)
+                        resetConfiguration ()
+
+                        do! Grace.CLI.LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                        do
+                            use connection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={configuration.GraceStatusFile}")
+                            connection.Open()
+                            use command = connection.CreateCommand()
+
+                            command.CommandText <-
+                                "CREATE TRIGGER reject_doctor_boundary BEFORE INSERT ON remote_reference_boundaries BEGIN SELECT RAISE(ABORT, 'forced doctor boundary failure'); END;"
+
+                            command.ExecuteNonQuery() |> ignore
+
+                        let sqliteFailureExitCode =
+                            Grace.CLI.GraceCommand.main [| "doctor"
+                                                           "--repair-local-state"
+                                                           "--output"
+                                                           "Json" |]
+
+                        Assert.That(sqliteFailureExitCode, Is.EqualTo(-1))
+                        let! statusAfterSqliteFailure = Grace.CLI.LocalStateDb.readStatusMeta configuration.GraceStatusFile
+                        Assert.That(statusAfterSqliteFailure.RootDirectoryId, Is.EqualTo(DirectoryVersionId.Empty))
+
+                        let! boundaryAfterSqliteFailure =
+                            Grace.CLI.LocalStateDb.readRemoteReferenceBoundary configuration.GraceStatusFile configuration.RepositoryId configuration.BranchId
+
+                        Assert.That(boundaryAfterSqliteFailure, Is.EqualTo(None))
+
+                        do
+                            use activeWriter = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={configuration.GraceStatusFile};Pooling=False")
+                            activeWriter.Open()
+                            use beginWriter = activeWriter.CreateCommand()
+                            beginWriter.CommandText <- "BEGIN IMMEDIATE;"
+                            beginWriter.ExecuteNonQuery() |> ignore
+
+                            let activeWriterExitCode =
+                                Grace.CLI.GraceCommand.main [| "doctor"
+                                                               "--repair-local-state"
+                                                               "--output"
+                                                               "Json" |]
+
+                            Assert.That(activeWriterExitCode, Is.EqualTo(-1))
+                            use rollbackWriter = activeWriter.CreateCommand()
+                            rollbackWriter.CommandText <- "ROLLBACK;"
+                            rollbackWriter.ExecuteNonQuery() |> ignore
+
+                        let! statusAfterActiveWriter = Grace.CLI.LocalStateDb.readStatusMeta configuration.GraceStatusFile
+                        Assert.That(statusAfterActiveWriter.RootDirectoryId, Is.EqualTo(DirectoryVersionId.Empty))
+
+                        let! boundaryAfterActiveWriter =
+                            Grace.CLI.LocalStateDb.readRemoteReferenceBoundary configuration.GraceStatusFile configuration.RepositoryId configuration.BranchId
+
+                        Assert.That(boundaryAfterActiveWriter, Is.EqualTo(None))
                         Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools()
-                        GC.Collect()
-                        GC.WaitForPendingFinalizers()
 
                         [|
                             configuration.GraceStatusFile
@@ -2428,88 +2444,267 @@ type BranchServer() =
                         |]
                         |> Array.iter (fun path -> if File.Exists(path) then File.Delete(path))
 
-                        try
-                            let! claim = Grace.CLI.Services.claimGraceWatchInterprocessFile ()
-                            Assert.That(claim.Claimed, Is.True)
-                            Assert.That(claim.RetainedStatus.IsSome, Is.True)
-                            Grace.CLI.Command.Watch.setGraceWatchRuntimeModeForWatchTests Grace.CLI.Services.GraceWatchRuntimeMode.StartingUp
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+                        Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, "not-a-valid-pat")
 
+                        let serverFailureExitCode =
+                            Grace.CLI.GraceCommand.main [| "doctor"
+                                                           "--repair-local-state"
+                                                           "--output"
+                                                           "Json" |]
+
+                        Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, publicCliToken)
+                        Assert.That(serverFailureExitCode, Is.EqualTo(-1))
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.False)
+
+                        let repairExitCode =
+                            Grace.CLI.GraceCommand.main [| "doctor"
+                                                           "--repair-local-state"
+                                                           "--output"
+                                                           "Json" |]
+
+                        Assert.That(repairExitCode, Is.EqualTo(0))
+                        resetConfiguration ()
+                        let configuration = Current()
+                        Assert.That(configuration.RepositoryId, Is.EqualTo(Guid.Parse(repositoryId)))
+                        Assert.That(File.Exists(configuration.GraceStatusFile), Is.True)
+                        Assert.That(Convert.ToHexString(File.ReadAllBytes(nestedPath)), Is.EqualTo(Convert.ToHexString(originalBytes)))
+
+                        let! repairedStatus = Grace.CLI.Services.readGraceStatusFile ()
+                        Assert.That(repairedStatus.RootDirectoryId, Is.EqualTo(exactRoot.DirectoryVersionId))
+                        Assert.That(repairedStatus.Index.Keys, Does.Contain(exactRoot.DirectoryVersionId))
+                        Assert.That(repairedStatus.Index.Keys, Does.Contain(nestedParent.DirectoryVersionId))
+                        Assert.That(repairedStatus.Index.Keys, Does.Contain(nestedDirectory.DirectoryVersionId))
+
+                        for directoryVersion in repairedStatus.Index.Values do
+                            Assert.That(
+                                directoryVersion.RepositoryId,
+                                Is.EqualTo(Guid.Parse(repositoryId)),
+                                $"Repaired directory {directoryVersion.RelativePath} must retain repository scope."
+                            )
+
+                        let repairedNestedDirectory = repairedStatus.Index[nestedDirectory.DirectoryVersionId]
+                        Assert.That(repairedNestedDirectory.Files, Has.Count.EqualTo(1))
+                        Assert.That(repairedNestedDirectory.Files[0].Sha256Hash, Is.EqualTo(nestedFileVersion.Sha256Hash))
+                        Assert.That(repairedNestedDirectory.Files[0].Blake3Hash, Is.EqualTo(nestedFileVersion.Blake3Hash))
+
+                        let! repairedBoundary =
+                            Grace.CLI.LocalStateDb.readRemoteReferenceBoundary configuration.GraceStatusFile configuration.RepositoryId configuration.BranchId
+
+                        Assert.That(repairedBoundary.IsSome, Is.True)
+                        Assert.That(repairedBoundary.Value.DirectoryId, Is.EqualTo(exactRoot.DirectoryVersionId))
+                        Assert.That(repairedBoundary.Value.EventCursor, Is.EqualTo("branch-event-v1:2"))
+
+                        let! referencesAfterRepair = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+
+                        let referenceIds (references: Reference.ReferenceDto array) =
+                            references
+                            |> Array.map (fun reference -> string reference.ReferenceId)
+                            |> Array.sort
+                            |> String.concat ","
+
+                        Assert.That(referenceIds referencesAfterRepair, Is.EqualTo(referenceIds referencesBeforeRepair))
+
+                        let! nestedBlobAfterRepair = nestedBlob.ExistsAsync()
+                        Assert.That(nestedBlobAfterRepair.Value, Is.True)
+
+                        let blobNamesAfterRepair =
+                            nestedBlob
+                                .GetParentBlobContainerClient()
+                                .GetBlobs()
+                            |> Seq.filter (fun blob -> blob.Name.StartsWith(nestedBlobNamespace, StringComparison.Ordinal))
+                            |> Seq.map (fun blob -> blob.Name)
+                            |> Set.ofSeq
+
+                        Assert.That((blobNamesAfterRepair = blobNamesBeforeRepair), Is.True)
+
+                        let! closureAfterRepairResponse =
+                            BranchServerTestHelpers.listContentsByShaAndBlake3HashResponseAsync repositoryId branch exactRoot.Sha256Hash exactRoot.Blake3Hash
+
+                        let! closureAfterRepairBody = closureAfterRepairResponse.Content.ReadAsStringAsync()
+                        Assert.That(closureAfterRepairResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK), closureAfterRepairBody)
+
+                        let closureAfterRepair =
+                            (deserialize<GraceReturnValue<DirectoryVersion.DirectoryVersionDto array>> closureAfterRepairBody)
+                                .ReturnValue
+
+                        let closureIdsAfterRepair =
+                            closureAfterRepair
+                            |> Seq.map (fun directory -> directory.DirectoryVersion.DirectoryVersionId)
+                            |> Set.ofSeq
+
+                        let expectedClosureIds =
+                            [
+                                exactRoot.DirectoryVersionId
+                                nestedParent.DirectoryVersionId
+                                nestedDirectory.DirectoryVersionId
+                            ]
+                            |> Set.ofList
+
+                        Assert.That((closureIdsAfterRepair = expectedClosureIds), Is.True)
+
+                        Grace.CLI.Command.Watch.clearPendingWatchWorkForTests ()
+                        Grace.CLI.Command.Watch.resetWatchIgnoreSnapshotForWatchTests ()
+                        Grace.CLI.Command.Watch.setGraceWatchRuntimeModeForWatchTests Grace.CLI.Services.GraceWatchRuntimeMode.StartingUp
+
+                        try
                             match Grace.CLI.Command.Watch.tryActivateWatchIgnoreSnapshotForWatchTests () with
                             | Ok () -> ()
                             | Error error -> Assert.Fail($"Expected production Watch ignore snapshot activation, got {error}.")
 
-                            let! resetStatus = Grace.CLI.Services.readGraceStatusFile ()
+                            let localEditPath = Path.Combine(configuration.RootDirectory, string nestedDirectoryPath, "local-edit.txt")
+                            File.WriteAllText(localEditPath, "ordinary local edit after Doctor repair")
+                            let! localDifferences = Grace.CLI.Command.Watch.tryScanForDifferencesWithWatchIgnoreSnapshotForWatchTests repairedStatus
 
-                            let! recoveredStatus =
-                                Grace.CLI.Command.Watch.establishMissingCurrentBranchReferenceBoundaryBeforeStartupScanForHostedTests
-                                    claim.RetainedStatus
-                                    resetStatus
-                                    System.Threading.CancellationToken.None
+                            let localDifferences =
+                                match localDifferences with
+                                | Ok differences -> differences
+                                | Error error ->
+                                    Assert.Fail($"Expected post-repair production scan success, got {error}.")
+                                    List<FileSystemDifference>()
 
-                            Assert.That(Convert.ToHexString(File.ReadAllBytes(retainedFilePath)), Is.EqualTo(Convert.ToHexString(retainedBytes)))
-                            Assert.That(recoveredStatus.RootDirectoryId, Is.EqualTo(initialStatus.RootDirectoryId))
+                            Assert.That(localDifferences, Is.Not.Empty)
 
-                            let! boundary =
+                            let! _, projectedDirectoryVersions = Grace.CLI.Services.getNewGraceStatusAndDirectoryVersions repairedStatus localDifferences
+
+                            for directoryVersion in projectedDirectoryVersions do
+                                Assert.That(
+                                    directoryVersion.RepositoryId,
+                                    Is.EqualTo(Guid.Parse(repositoryId)),
+                                    $"Projected directory {directoryVersion.RelativePath} must retain repository scope."
+                                )
+
+                            for difference in localDifferences do
+                                Grace.CLI.Command.Watch.queueStartupDifferenceForWatch difference
+
+                            do! Grace.CLI.Command.Watch.processChangedFiles ()
+
+                            let! referencesAfterLocalSave = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+                            Assert.That(referencesAfterLocalSave, Has.Length.EqualTo(referencesAfterRepair.Length + 1))
+                            let! statusAfterLocalSave = Grace.CLI.Services.readGraceStatusFile ()
+                            Assert.That(statusAfterLocalSave.RootDirectoryId, Is.Not.EqualTo(exactRoot.DirectoryVersionId))
+                            Grace.CLI.Command.Watch.clearPendingWatchWorkForTests ()
+                            Grace.CLI.Command.Watch.setGraceStatusForWatchTests statusAfterLocalSave
+                            Grace.CLI.Command.Watch.updateGraceStatusDirectoryIds statusAfterLocalSave
+
+                            do!
+                                Grace.CLI.Services.updateGraceWatchInterprocessFile
+                                    statusAfterLocalSave
+                                    (Some(HashSet<DirectoryVersionId>(statusAfterLocalSave.Index.Keys)))
+
+                            let remoteRelativePath = RelativePath $"remote-{Guid.NewGuid():N}.txt"
+                            let remotePayload = Encoding.UTF8.GetBytes("one later remote reference")
+
+                            let remoteFileVersion =
+                                FileVersion.CreateWithHashes
+                                    remoteRelativePath
+                                    (BranchServerTestHelpers.sha256Hex remotePayload)
+                                    (BranchServerTestHelpers.blake3Hex remotePayload)
+                                    String.Empty
+                                    false
+                                    (int64 remotePayload.Length)
+
+                            do! BranchServerTestHelpers.uploadFileToObjectStorageAsync repositoryId remotePayload remoteFileVersion
+                            let remoteObjectCachePath = Grace.CLI.Services.getLocalObjectCachePathForFileVersion remoteFileVersion
+
+                            Directory.CreateDirectory(Path.GetDirectoryName(remoteObjectCachePath))
+                            |> ignore
+
+                            File.WriteAllBytes(remoteObjectCachePath, remotePayload)
+                            let remoteRoot = BranchServerTestHelpers.createDirectoryVersionWithFile repositoryId Constants.RootDirectoryPath remoteFileVersion
+                            do! BranchServerTestHelpers.saveDirectoryVersionsAsync repositoryId [ remoteRoot ]
+
+                            let! remoteSave =
+                                BranchServerTestHelpers.saveReferenceResponseAsync repositoryId branch remoteRoot.DirectoryVersionId remoteRoot.Sha256Hash
+
+                            let! remoteSaveBody = remoteSave.Content.ReadAsStringAsync()
+                            Assert.That(remoteSave.StatusCode, Is.EqualTo(HttpStatusCode.OK), remoteSaveBody)
+
+                            do! Grace.CLI.Command.Watch.replayCurrentBranchReferenceEventsForHostedTests System.Threading.CancellationToken.None
+                            let remotePath = Path.Combine(configuration.RootDirectory, string remoteRelativePath)
+                            Assert.That(Convert.ToHexString(File.ReadAllBytes(remotePath)), Is.EqualTo(Convert.ToHexString(remotePayload)))
+
+                            let! replayedBoundary =
                                 Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
                                     configuration.GraceStatusFile
                                     configuration.RepositoryId
                                     configuration.BranchId
 
-                            Assert.That(boundary.IsSome, Is.True)
-                            Assert.That(boundary.Value.DirectoryId, Is.EqualTo(initialStatus.RootDirectoryId))
-                            Assert.That(boundary.Value.Sha256Hash, Is.EqualTo(initialStatus.RootDirectorySha256Hash))
-                            Assert.That(boundary.Value.Blake3Hash, Is.EqualTo(initialStatus.RootDirectoryBlake3Hash))
-                            Assert.That(boundary.Value.EventCursor, Is.EqualTo("branch-event-v1:1"))
+                            Assert.That(replayedBoundary.IsSome, Is.True)
+                            Assert.That(replayedBoundary.Value.DirectoryId, Is.EqualTo(remoteRoot.DirectoryVersionId))
 
-                            let! referencesBeforeStartupScan = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+                            let replayedCursor = replayedBoundary.Value.EventCursor
+                            do! Grace.CLI.Command.Watch.replayCurrentBranchReferenceEventsForHostedTests System.Threading.CancellationToken.None
 
-                            let! startupScan = Grace.CLI.Command.Watch.tryScanForDifferencesWithWatchIgnoreSnapshotForWatchTests recoveredStatus
+                            let! replayedAgainBoundary =
+                                Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
+                                    configuration.GraceStatusFile
+                                    configuration.RepositoryId
+                                    configuration.BranchId
 
-                            let startupDifferences =
-                                match startupScan with
-                                | Ok differences -> differences
-                                | Error error ->
-                                    Assert.Fail($"Expected production startup scan success, got {error}.")
-                                    List<FileSystemDifference>()
+                            Assert.That(replayedAgainBoundary.Value.EventCursor, Is.EqualTo(replayedCursor))
+                            Assert.That(Convert.ToHexString(File.ReadAllBytes(remotePath)), Is.EqualTo(Convert.ToHexString(remotePayload)))
 
-                            for difference in startupDifferences do
-                                Grace.CLI.Command.Watch.queueStartupDifferenceForWatch difference
+                            let ipcFilePath = Grace.CLI.Services.IpcFileName()
 
-                            do! Grace.CLI.Command.Watch.processChangedFiles ()
+                            if File.Exists(ipcFilePath) then File.Delete(ipcFilePath)
 
-                            let! referencesAfterStartupProcessing = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+                            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools()
 
-                            Assert.That(startupDifferences, Is.Empty, "Unmatched retained content must be the production scanner baseline.")
+                            [|
+                                configuration.GraceStatusFile
+                                configuration.GraceStatusFile + "-wal"
+                                configuration.GraceStatusFile + "-shm"
+                                configuration.GraceStatusFile + "-journal"
+                            |]
+                            |> Array.iter (fun path -> if File.Exists(path) then File.Delete(path))
 
-                            Assert.That(
-                                referencesAfterStartupProcessing
-                                |> Array.map (fun reference -> $"{reference.ReferenceId}")
-                                |> Array.sort
-                                |> String.concat ",",
-                                Is.EqualTo(
-                                    referencesBeforeStartupScan
-                                    |> Array.map (fun reference -> $"{reference.ReferenceId}")
-                                    |> Array.sort
-                                    |> String.concat ","
-                                ),
-                                "Unmatched startup processing must not publish retained local content."
-                            )
+                            let stateDirectory = Path.GetDirectoryName(configuration.GraceStatusFile)
 
-                            do!
-                                Grace.CLI.Command.Watch.completeStartupRecoveryIfPendingWorkDrainedWithCatchUpForWatchTests
-                                    Grace.CLI.Services.readGraceStatusFile
-                                    Grace.CLI.Services.updateGraceWatchInterprocessFile
-                                    Grace.CLI.Command.Watch.processChangedFiles
-                                    (fun () -> Grace.CLI.Command.Watch.replayCurrentBranchReferenceEventsForHostedTests System.Threading.CancellationToken.None)
+                            let corruptBackupsBefore =
+                                Directory
+                                    .GetFiles(
+                                        stateDirectory,
+                                        "grace-local.corrupt.*.db"
+                                    )
+                                    .Length
 
-                            Assert.That(Convert.ToHexString(File.ReadAllBytes(retainedFilePath)), Is.EqualTo(Convert.ToHexString(retainedBytes)))
+                            File.WriteAllBytes(configuration.GraceStatusFile, Encoding.UTF8.GetBytes("corrupt local state"))
+                            let! referencesBeforeCorruptRepair = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
 
-                            let! branchAfterRecovery = BranchServerTestHelpers.getBranchAsync repositoryId $"{branch.BranchId}"
-                            Assert.That(branchAfterRecovery.LatestReference.DirectoryId, Is.EqualTo(serverRoot.DirectoryVersionId))
+                            let corruptRepairExitCode =
+                                Grace.CLI.GraceCommand.main [| "doctor"
+                                                               "--repair-local-state"
+                                                               "--output"
+                                                               "Json" |]
+
+                            Assert.That(corruptRepairExitCode, Is.EqualTo(0))
+
+                            let corruptBackupsAfter =
+                                Directory
+                                    .GetFiles(
+                                        stateDirectory,
+                                        "grace-local.corrupt.*.db"
+                                    )
+                                    .Length
+
+                            Assert.That(corruptBackupsAfter, Is.EqualTo(corruptBackupsBefore + 1))
+                            let! repairedAfterCorruption = Grace.CLI.Services.readGraceStatusFile ()
+                            Assert.That(repairedAfterCorruption.RootDirectoryId, Is.EqualTo(remoteRoot.DirectoryVersionId))
+
+                            let! boundaryAfterCorruption =
+                                Grace.CLI.LocalStateDb.readRemoteReferenceBoundary
+                                    configuration.GraceStatusFile
+                                    configuration.RepositoryId
+                                    configuration.BranchId
+
+                            Assert.That(boundaryAfterCorruption.Value.DirectoryId, Is.EqualTo(remoteRoot.DirectoryVersionId))
+                            let! referencesAfterCorruptRepair = BranchServerTestHelpers.getBranchReferencesAsync repositoryId $"{branch.BranchId}"
+                            Assert.That(referenceIds referencesAfterCorruptRepair, Is.EqualTo(referenceIds referencesBeforeCorruptRepair))
                         finally
                             Grace.CLI.Command.Watch.clearPendingWatchWorkForTests ()
                             Grace.CLI.Command.Watch.resetWatchIgnoreSnapshotForWatchTests ()
-                            if File.Exists(ipcPath) then File.Delete(ipcPath)
+                            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceToken, previousGraceToken)
                     })
         }
 


### PR DESCRIPTION
# Move missing local-state repair to Grace Doctor

## Why this matters

Grace Watch must consume trustworthy initialization state; it must not silently invent repository history when the local
SQLite database is missing or corrupt. Repository creation and materializing `grace connect` own normal initialization,
while an explicit exact-only Doctor repair provides a deliberate maintenance path.

Related to #823.
Part of #801.

## Summary

- add explicit `grace doctor --repair-local-state` exact reconstruction using the immutable recursive server closure
- keep default Doctor read-only and make Watch fail closed before callbacks, scans, uploads, saves, or materialization
- atomically establish complete local status plus the exact reference-event boundary after repository publication
- preserve real nested directory identities and select the latest matching repeated-root event
- bound active-writer refusal and invalidate stale initialization state after database replacement
- normalize Windows nested add/delete parent paths used by the first post-repair Save
- remove superseded Watch reset-recovery behavior and update Doctor, Watch, and trust-boundary documentation

## Validation

- Release build: `Grace.CLI.Tests` — 0 warnings, 0 errors
- focused Doctor, Watch, and LocalStateDb tests — 760 passed, 1 intentional platform skip
- Release build: `Grace.Server.Tests` — 0 warnings, 0 errors
- hosted public-command Doctor plus JSON/Minimal/Silent repository initialization proofs — 2 passed
- Fantomas on touched F# files
- MarkdownLint on changed documentation — 0 errors
- `git diff --check`

The hosted proof covers missing and corrupt database repair, complete recursive identities, latest repeated-root boundary,
unchanged server and local content during repair, byte/config/server/SQLite/active-writer failures, a later nested Save,
exactly-once replay, nested repository initialization, and forced publication failure.

## Contract propagation

- CLI behavior and help: changed
- local SQLite status and reference boundary: changed
- Watch startup behavior: changed
- server routes, shared DTOs, SDK public API, OpenAPI, and generated clients: N/A; no contract shape changed
- documentation and tests: changed

## Review Status

- Worker starts: 5/5
- Current head: `75836854232a267adaf92989fcfd5fcb62c119be`
- Fresh exact-head review: session 4 approved with no findings
- Required GitHub Validate: passed for exact current head
- [ ] Review and required checks both pass for the same head SHA
