### PR TITLE
Persist bounded Working Directory Update completion

### DIFF
--- a/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Doctor.CLI.Tests.fs
@@ -2661,7 +2661,7 @@ module DoctorCliTests =
                 (findCheckById checks "state.db.schema-version")
                     .GetProperty("Summary")
                     .GetString()
-                |> should contain "schema_version is 9"
+                |> should contain $"schema_version is {LocalStateDb.SchemaVersion}"
 
                 (findCheckById checks "object-cache.index-readable")
                     .GetProperty("Summary")
@@ -3121,7 +3121,7 @@ module DoctorCliTests =
                         |> should equal "Ok"
 
                         checks[ 0 ].GetProperty("Summary").GetString()
-                        |> should contain "schema_version is 9"
+                        |> should contain $"schema_version is {LocalStateDb.SchemaVersion}"
 
                         let trace = readTrace tracePath
                         trace |> should contain repoDbPath

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -4373,33 +4373,6 @@ module LocalStateDbTests =
                 |> should equal 2
             })
 
-    /// Verifies the development-only v10 database is replaced rather than migrated into the bounded completion schema.
-    [<Test>]
-    let ``working directory update schema v11 resets v10 completion data`` () =
-        withTempDir (fun _ configuration ->
-            task {
-                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
-
-                use seedConnection = openRawConnection configuration.GraceStatusFile
-                executeNonQuery seedConnection "UPDATE meta SET value = '10' WHERE key = 'schema_version';"
-
-                executeNonQuery
-                    seedConnection
-                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ('stale-operation', 'Branch', 'stale-target', 'repository', 'branch', 'root', 'sha256', 'blake3', 'previous-branch', 'selected-reference', NULL, 'Terminal', 1);"
-
-                seedConnection.Close()
-                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
-                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
-
-                use connection = openRawConnection configuration.GraceStatusFile
-
-                executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                |> should equal LocalStateDb.SchemaVersion
-
-                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
-                |> should equal 0
-            })
-
     /// Verifies that apply status incremental is atomic (rollback on failure).
     [<Test>]
     let ``applyStatusIncremental is atomic (rollback on failure)`` () =

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -2,6 +2,7 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.CLI.Command
 open Grace.Shared.Client.Configuration
 open Grace.Shared
 open Grace.Shared.Utilities
@@ -255,6 +256,22 @@ module LocalStateDbTests =
             connection
             "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
 
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS remote_reference_boundaries (repository_id TEXT NOT NULL, branch_id TEXT NOT NULL, root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, event_cursor TEXT NOT NULL, PRIMARY KEY (repository_id, branch_id));"
+
+        executeNonQuery
+            connection
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL);"
+
+        executeNonQuery
+            connection
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_pending ON working_directory_update_completions(finalization_state) WHERE finalization_state = 'Pending';"
+
+        executeNonQuery
+            connection
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_terminal_caller ON working_directory_update_completions(caller_kind) WHERE finalization_state = 'Terminal';"
+
         executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
         executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_files_directory_version_id ON status_files(directory_version_id);"
         executeNonQuery connection "CREATE INDEX IF NOT EXISTS ix_status_files_sha256 ON status_files(sha256_hash);"
@@ -279,13 +296,13 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
+            "CREATE TABLE IF NOT EXISTS watch_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, difference_type TEXT NOT NULL, entry_type TEXT NOT NULL, relative_path TEXT NOT NULL, quarantined_at_unix_ticks INTEGER, quarantine_reason TEXT);"
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
+            "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
 
-        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '7');"
+        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '10');"
         executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
         executeNonQuery
@@ -325,6 +342,55 @@ module LocalStateDbTests =
             LastSuccessfulFileUpload = Instant.FromUnixTimeTicks(ticks)
             LastSuccessfulDirectoryVersionUpload = Instant.FromUnixTimeTicks(ticks)
         }
+
+    /// Requires a successful private Working Directory Update contract construction in local-state tests.
+    let private requiredWorkingDirectoryUpdate value =
+        match value with
+        | Ok result -> result
+        | Error error -> failwith error
+
+    /// Builds a status snapshot whose root exactly matches the Working Directory Update target.
+    let private completionStatus (configuration: GraceConfiguration) rootId sha256Hash blake3Hash ticks =
+        let lastWrite = DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc)
+
+        let rootDirectory =
+            LocalDirectoryVersion.CreateWithHashes
+                rootId
+                configuration.OwnerId
+                configuration.OrganizationId
+                configuration.RepositoryId
+                Constants.RootDirectoryPath
+                sha256Hash
+                blake3Hash
+                (List<DirectoryVersionId>())
+                (List<LocalFileVersion>())
+                0L
+                lastWrite
+
+        let index = GraceIndex()
+        index.TryAdd(rootId, rootDirectory) |> ignore
+
+        { GraceStatus.Default with
+            Index = index
+            RootDirectoryId = rootId
+            RootDirectorySha256Hash = sha256Hash
+            RootDirectoryBlake3Hash = blake3Hash
+            LastSuccessfulFileUpload = Instant.FromUnixTimeTicks(ticks)
+            LastSuccessfulDirectoryVersionUpload = Instant.FromUnixTimeTicks(ticks)
+        },
+        rootDirectory
+
+    /// Builds a complete Branch operation and its exact matching target for local completion tests.
+    let private completionTargetAndOperation (configuration: GraceConfiguration) rootId sha256Hash blake3Hash =
+        let target =
+            WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+            |> requiredWorkingDirectoryUpdate
+
+        let operation =
+            WorkingDirectoryUpdate.Operation.branchSwitch (Guid.NewGuid()) (Guid.NewGuid()) target
+            |> requiredWorkingDirectoryUpdate
+
+        target, operation
 
     /// Exercises private behavior.
     type private WorkerCommand = { FileName: string; ArgumentsPrefix: string }
@@ -380,7 +446,7 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -1800,7 +1866,7 @@ module LocalStateDbTests =
 
                 let lifecycleColumns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('watch_lifecycle_events');"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 lifecycleColumns |> should equal 13
 
                 let corruptAfter =
@@ -1843,7 +1909,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2132,7 +2198,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2169,7 +2235,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
                 sequencePk |> should equal 1
@@ -2221,7 +2287,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -2261,7 +2327,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -2301,7 +2367,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
@@ -2343,7 +2409,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let duplicateRows = executeScalarInt connection "SELECT COUNT(*) FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 duplicateRows |> should equal 1
 
@@ -2388,7 +2454,7 @@ module LocalStateDbTests =
                     with
                     | :? SqliteException -> false
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 duplicateInsertSucceeded |> should equal false
 
@@ -2427,7 +2493,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2466,7 +2532,7 @@ module LocalStateDbTests =
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
                 let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
                 allocationRows |> should equal 0
@@ -2504,7 +2570,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2541,7 +2607,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2578,7 +2644,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2624,7 +2690,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2671,7 +2737,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2717,7 +2783,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2765,7 +2831,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2806,7 +2872,7 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2836,7 +2902,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2891,7 +2957,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "9")
+                |> should equal (Some "10")
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -2936,7 +3002,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "9")
+                |> should equal (Some "10")
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -3242,7 +3308,7 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -3279,7 +3345,7 @@ module LocalStateDbTests =
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
                 let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
                 readRootBlake3Hash |> should equal rootBlake3Hash
@@ -3335,7 +3401,7 @@ module LocalStateDbTests =
                 let watchJournalCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 watchJournalCount |> should equal 1
                 appliedThrough |> should equal "0"
 
@@ -3387,7 +3453,7 @@ module LocalStateDbTests =
 
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 hiddenRequiredColumns |> should equal 0
                 journalColumns |> should equal 15
                 appliedThrough |> should equal "0"
@@ -3424,7 +3490,7 @@ module LocalStateDbTests =
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 rootBlake3Columns |> should equal 1
                 statusMetaCount |> should equal 1
 
@@ -3465,7 +3531,7 @@ module LocalStateDbTests =
                 let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
                 statusDirectoryCount |> should equal 0
                 statusMetaCount |> should equal 1
 
@@ -3626,6 +3692,347 @@ module LocalStateDbTests =
                 |> should equal revisionBeforeFailure
             })
 
+    /// Verifies a pending Working Directory Update completion durably joins the exact status and object-cache facts.
+    [<Test>]
+    let ``working directory update completion atomically persists matching local facts across sqlite restart`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "a")
+                let blake3Hash = Blake3Hash(String.replicate 64 "b")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 123L
+                let target, operation = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
+
+                let! revision = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target operation
+
+                revision |> should equal 1L
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
+                |> should equal 1
+
+                executeScalarIntWithTextParameter
+                    connection
+                    "SELECT COUNT(*) FROM status_directories WHERE directory_version_id = $root_id;"
+                    "$root_id"
+                    (rootId.ToString())
+                |> should equal 1
+
+                executeScalarIntWithTextParameter
+                    connection
+                    "SELECT COUNT(*) FROM object_cache_directories WHERE directory_version_id = $root_id;"
+                    "$root_id"
+                    (rootId.ToString())
+                |> should equal 1
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions WHERE finalization_state = 'Pending';"
+                |> should equal 1
+
+                let! completion = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target operation
+
+                completion
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Pending)
+            })
+
+    /// Verifies Connect cursor progress and its terminal completion cannot commit separately from matching local facts.
+    [<Test>]
+    let ``working directory update completion atomically persists connect cursor`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "c")
+                let blake3Hash = Blake3Hash(String.replicate 64 "d")
+                let cursor = "connect-cursor-001"
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 234L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let localRootScope =
+                    WorkingDirectoryUpdate.LocalRootScope.create configuration.RootDirectory
+                    |> requiredWorkingDirectoryUpdate
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.connectBootstrap target cursor localRootScope
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] (Some cursor) target operation
+
+                let nextCursor = "connect-cursor-002"
+
+                let nextOperation =
+                    WorkingDirectoryUpdate.Operation.connectBootstrap target nextCursor localRootScope
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (Some nextCursor)
+                        target
+                        nextOperation
+
+                use connection = openRawConnection configuration.GraceStatusFile
+                use command = connection.CreateCommand()
+
+                command.CommandText <- "SELECT event_cursor FROM remote_reference_boundaries WHERE repository_id = $repository_id AND branch_id = $branch_id;"
+
+                command.Parameters.AddWithValue("$repository_id", configuration.RepositoryId.ToString())
+                |> ignore
+
+                command.Parameters.AddWithValue("$branch_id", configuration.BranchId.ToString())
+                |> ignore
+
+                command.ExecuteScalar() :?> string
+                |> should equal nextCursor
+
+                let! supersededCompletion = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target operation
+                let! completion = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target nextOperation
+
+                supersededCompletion |> should equal None
+
+                completion
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
+            })
+
+    /// Verifies an injected pre-commit failure rolls back every local fact in the update completion transaction.
+    [<Test>]
+    let ``working directory update pre-commit failure leaves no completion facts`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                let! revisionBefore = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "e")
+                let blake3Hash = Blake3Hash(String.replicate 64 "f")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 345L
+                let target, operation = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
+
+                let failingCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletionWithBeforeCommit
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            None
+                            target
+                            operation
+                            (fun () -> raise (InvalidOperationException("injected before commit")))
+                        :> Task)
+
+                Assert.ThrowsAsync<InvalidOperationException>(failingCommit)
+                |> ignore
+
+                let! persistedStatus = LocalStateDb.readStatusMeta configuration.GraceStatusFile
+                let! revisionAfter = LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                persistedStatus.RootDirectoryId
+                |> should equal DirectoryVersionId.Empty
+
+                revisionAfter |> should equal revisionBefore
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
+                |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directories;"
+                |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM remote_reference_boundaries;"
+                |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
+                |> should equal 0
+            })
+
+    /// Verifies one mismatched target hash rejects the whole completion before any durable row appears.
+    [<Test>]
+    let ``working directory update completion rejects one-hash status mismatch`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "1")
+                let targetBlake3Hash = Blake3Hash(String.replicate 64 "2")
+                let statusBlake3Hash = Blake3Hash(String.replicate 64 "3")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash statusBlake3Hash 456L
+                let target, operation = completionTargetAndOperation configuration rootId sha256Hash targetBlake3Hash
+
+                let mismatchedCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target operation :> Task)
+
+                Assert.ThrowsAsync<ArgumentException>(mismatchedCommit)
+                |> ignore
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
+                |> should equal 0
+            })
+
+    /// Verifies object-cache root metadata cannot diverge by one hash from matching status and target facts.
+    [<Test>]
+    let ``working directory update completion rejects one-hash object metadata mismatch`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "6")
+                let blake3Hash = Blake3Hash(String.replicate 64 "7")
+                let mismatchedBlake3Hash = Blake3Hash(String.replicate 64 "8")
+                let status, _ = completionStatus configuration rootId sha256Hash blake3Hash 457L
+                let target, operation = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
+
+                let mismatchedRoot =
+                    LocalDirectoryVersion.CreateWithHashes
+                        rootId
+                        configuration.OwnerId
+                        configuration.OrganizationId
+                        configuration.RepositoryId
+                        Constants.RootDirectoryPath
+                        sha256Hash
+                        mismatchedBlake3Hash
+                        (List<DirectoryVersionId>())
+                        (List<LocalFileVersion>())
+                        0L
+                        (DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc))
+
+                let mismatchedCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ mismatchedRoot ] None target operation
+                        :> Task)
+
+                Assert.ThrowsAsync<ArgumentException>(mismatchedCommit)
+                |> ignore
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directories;"
+                |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
+                |> should equal 0
+            })
+
+    /// Verifies pending completion is never displaced and terminal supersession stays scoped to one caller kind.
+    [<Test>]
+    let ``working directory update completion retention preserves pending and other callers`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "4")
+                let blake3Hash = Blake3Hash(String.replicate 64 "5")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 567L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let branchOperation () =
+                    WorkingDirectoryUpdate.Operation.branchSwitch (Guid.NewGuid()) (Guid.NewGuid()) target
+                    |> requiredWorkingDirectoryUpdate
+
+                let firstBranch = branchOperation ()
+
+                let watch =
+                    WorkingDirectoryUpdate.Operation.watchReplay configuration.RepositoryId configuration.BranchId "watch-cursor-001"
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target firstBranch
+
+                do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target firstBranch
+
+                let! _ = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target watch
+
+                do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target watch
+
+                let secondBranch = branchOperation ()
+
+                let! _ = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target secondBranch
+
+                let displacedPending = branchOperation ()
+
+                let conflictingCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target displacedPending
+                        :> Task)
+
+                Assert.ThrowsAsync<InvalidOperationException>(conflictingCommit)
+                |> ignore
+
+                let! pending = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target secondBranch
+                let! firstBranchBeforeFinalization = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target firstBranch
+                let! watchBeforeFinalization = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target watch
+
+                pending
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Pending)
+
+                firstBranchBeforeFinalization
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
+
+                watchBeforeFinalization
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
+
+                do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target secondBranch
+
+                let! firstBranchAfterFinalization = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target firstBranch
+                let! secondBranchAfterFinalization = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target secondBranch
+                let! watchAfterFinalization = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target watch
+
+                firstBranchAfterFinalization |> should equal None
+
+                secondBranchAfterFinalization
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
+
+                watchAfterFinalization
+                |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions WHERE finalization_state = 'Pending';"
+                |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions WHERE finalization_state = 'Terminal';"
+                |> should equal 2
+            })
+
+    /// Verifies the development-only v9 database is replaced rather than migrated into the bounded completion schema.
+    [<Test>]
+    let ``working directory update schema v10 resets v9 completion data`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use seedConnection = openRawConnection configuration.GraceStatusFile
+                executeNonQuery seedConnection "UPDATE meta SET value = '9' WHERE key = 'schema_version';"
+
+                executeNonQuery
+                    seedConnection
+                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, finalization_state, completed_at_unix_ticks) VALUES ('stale-operation', 'Branch', 'stale-target', 'Terminal', 1);"
+
+                seedConnection.Close()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                |> should equal "10"
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
+                |> should equal 0
+            })
+
     /// Verifies that apply status incremental is atomic (rollback on failure).
     [<Test>]
     let ``applyStatusIncremental is atomic (rollback on failure)`` () =
@@ -3710,7 +4117,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -3740,7 +4147,7 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "9"
+                schemaVersion |> should equal "10"
             })
 
     /// Verifies non-Windows filesystems can initialize case-distinct local-state paths without rewriting the temp root.
@@ -4088,7 +4495,7 @@ module LocalStateDbTests =
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '9');"
+                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '10');"
 
                     executeNonQuery
                         connection
@@ -5103,7 +5510,7 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "9"
+                    schemaVersion |> should equal "10"
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -3762,8 +3762,28 @@ module LocalStateDbTests =
                     WorkingDirectoryUpdate.Operation.connectBootstrap target cursor localRootScope
                     |> requiredWorkingDirectoryUpdate
 
+                let mismatchedIdentityCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            (Some("different-connect-cursor", localRootScope))
+                            target
+                            operation
+                        :> Task)
+
+                Assert.ThrowsAsync<ArgumentException>(mismatchedIdentityCommit)
+                |> ignore
+
                 let! _ =
-                    LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] (Some cursor) target operation
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (Some(cursor, localRootScope))
+                        target
+                        operation
 
                 let nextCursor = "connect-cursor-002"
 
@@ -3776,7 +3796,7 @@ module LocalStateDbTests =
                         configuration.GraceStatusFile
                         status
                         [ rootDirectory ]
-                        (Some nextCursor)
+                        (Some(nextCursor, localRootScope))
                         target
                         nextOperation
 

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -262,7 +262,7 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND branch_selected_reference_id IS NOT NULL AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
 
         executeNonQuery
             connection
@@ -302,7 +302,7 @@ module LocalStateDbTests =
             connection
             "CREATE TABLE IF NOT EXISTS watch_lifecycle_events (sequence INTEGER PRIMARY KEY AUTOINCREMENT, created_at_unix_ticks INTEGER NOT NULL, repository_id TEXT, branch_id TEXT, workspace_root TEXT, watch_root TEXT, root_directory_version_id TEXT, root_directory_sha256_hash TEXT, root_directory_blake3_hash TEXT, watch_mode TEXT, event_type TEXT NOT NULL, message TEXT NOT NULL, replayable INTEGER NOT NULL CHECK (replayable = 0));"
 
-        executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '10');"
+        executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{LocalStateDb.SchemaVersion}');"
         executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('AppliedThroughSequence', '0');"
 
         executeNonQuery
@@ -380,17 +380,22 @@ module LocalStateDbTests =
         },
         rootDirectory
 
-    /// Builds a complete Branch operation and its exact matching target for local completion tests.
+    /// Builds a complete Branch operation, exact target, and bounded finalization details for local completion tests.
     let private completionTargetAndOperation (configuration: GraceConfiguration) rootId sha256Hash blake3Hash =
         let target =
             WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
             |> requiredWorkingDirectoryUpdate
 
+        let previousBranchId = Guid.NewGuid()
+        let selectedReferenceId = Guid.NewGuid()
+
         let operation =
-            WorkingDirectoryUpdate.Operation.branchSwitch (Guid.NewGuid()) (Guid.NewGuid()) target
+            WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target
             |> requiredWorkingDirectoryUpdate
 
-        target, operation
+        let completionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(previousBranchId, selectedReferenceId)
+
+        target, operation, completionDetails
 
     /// Exercises private behavior.
     type private WorkerCommand = { FileName: string; ArgumentsPrefix: string }
@@ -446,7 +451,9 @@ module LocalStateDbTests =
                 use cmd = connection.CreateCommand()
                 cmd.CommandText <- "SELECT value FROM meta WHERE key = 'schema_version';"
                 let schemaVersion = cmd.ExecuteScalar() :?> string
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 cmd.CommandText <- "SELECT COUNT(*) FROM status_meta;"
                 let statusMetaCount = Convert.ToInt32(cmd.ExecuteScalar())
@@ -1866,7 +1873,9 @@ module LocalStateDbTests =
 
                 let lifecycleColumns = executeScalarInt connection "SELECT COUNT(*) FROM pragma_table_info('watch_lifecycle_events');"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 lifecycleColumns |> should equal 13
 
                 let corruptAfter =
@@ -1909,7 +1918,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2198,7 +2209,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2235,7 +2248,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let sequencePk = executeScalarInt connection "SELECT pk FROM pragma_table_info('watch_journal') WHERE name = 'sequence';"
                 sequencePk |> should equal 1
@@ -2287,7 +2302,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -2327,7 +2344,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let tableSql = executeScalarString connection "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
 
@@ -2367,7 +2386,9 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
 
                 let! readThrough = LocalStateDb.readWatchJournalAppliedThroughSequence configuration.GraceStatusFile
@@ -2409,7 +2430,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let duplicateRows = executeScalarInt connection "SELECT COUNT(*) FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 duplicateRows |> should equal 1
 
@@ -2454,7 +2477,9 @@ module LocalStateDbTests =
                     with
                     | :? SqliteException -> false
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 duplicateInsertSucceeded |> should equal false
 
@@ -2493,7 +2518,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2532,7 +2559,9 @@ module LocalStateDbTests =
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
                 let allocationRows = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'watch_journal';"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
                 allocationRows |> should equal 0
@@ -2570,7 +2599,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2607,7 +2638,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2644,7 +2677,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2690,7 +2725,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2737,7 +2774,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2783,7 +2822,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2831,7 +2872,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2872,7 +2915,9 @@ module LocalStateDbTests =
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
                 let journalRows = executeScalarInt connection "SELECT COUNT(*) FROM watch_journal;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 appliedThrough |> should equal "0"
                 journalRows |> should equal 0
 
@@ -2902,7 +2947,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let corruptAfter =
                     getCorruptBackups configuration.GraceStatusFile
@@ -2957,7 +3004,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "10")
+                |> should equal (Some LocalStateDb.SchemaVersion)
 
                 inspection.MissingRequiredTables
                 |> should equal Array.empty<string>
@@ -3002,7 +3049,7 @@ module LocalStateDbTests =
                 inspection.OpenError |> should equal None
 
                 inspection.SchemaVersion
-                |> should equal (Some "10")
+                |> should equal (Some LocalStateDb.SchemaVersion)
 
                 inspection.IntegrityCheckRows
                 |> should equal [| "ok" |]
@@ -3308,7 +3355,9 @@ module LocalStateDbTests =
                 let schemaVersion = executeScalarString connection2 "SELECT value FROM meta WHERE key = 'schema_version';"
                 let readRootId = executeScalarString connection2 "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection2 "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 readRootId
                 |> should not' (equal (rootId.ToString()))
@@ -3345,7 +3394,10 @@ module LocalStateDbTests =
                 let readRootId = executeScalarString connection "SELECT root_directory_version_id FROM status_meta WHERE id = 1;"
                 let readRootHash = executeScalarString connection "SELECT root_directory_sha256_hash FROM status_meta WHERE id = 1;"
                 let readRootBlake3Hash = executeScalarString connection "SELECT root_directory_blake3_hash FROM status_meta WHERE id = 1;"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 readRootId |> should equal (rootId.ToString())
                 readRootHash |> should equal rootHash
                 readRootBlake3Hash |> should equal rootBlake3Hash
@@ -3401,7 +3453,9 @@ module LocalStateDbTests =
                 let watchJournalCount = executeScalarInt connection "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'watch_journal';"
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 watchJournalCount |> should equal 1
                 appliedThrough |> should equal "0"
 
@@ -3453,7 +3507,9 @@ module LocalStateDbTests =
 
                 let appliedThrough = executeScalarString connection "SELECT value FROM meta WHERE key = 'AppliedThroughSequence';"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 hiddenRequiredColumns |> should equal 0
                 journalColumns |> should equal 15
                 appliedThrough |> should equal "0"
@@ -3490,7 +3546,9 @@ module LocalStateDbTests =
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 rootBlake3Columns |> should equal 1
                 statusMetaCount |> should equal 1
 
@@ -3531,7 +3589,9 @@ module LocalStateDbTests =
                 let statusDirectoryCount = executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
 
-                schemaVersion |> should equal "10"
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
+
                 statusDirectoryCount |> should equal 0
                 statusMetaCount |> should equal 1
 
@@ -3701,9 +3761,16 @@ module LocalStateDbTests =
                 let sha256Hash = Sha256Hash(String.replicate 64 "a")
                 let blake3Hash = Blake3Hash(String.replicate 64 "b")
                 let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 123L
-                let target, operation = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
+                let target, operation, completionDetails = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
 
-                let! revision = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target operation
+                let! revision =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        completionDetails
+                        target
+                        operation
 
                 revision |> should equal 1L
 
@@ -3739,6 +3806,114 @@ module LocalStateDbTests =
                 |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Pending)
             })
 
+    /// Verifies restart reconstructs exact Branch and Watch finalizers and rejects altered persisted facts.
+    [<Test>]
+    let ``working directory update pending finalization reconstructs typed Branch and Watch facts after restart`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "c")
+                let blake3Hash = Blake3Hash(String.replicate 64 "d")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 223L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let previousBranchId = Guid.NewGuid()
+                let selectedReferenceId = Guid.NewGuid()
+
+                let branchOperation =
+                    WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target
+                    |> requiredWorkingDirectoryUpdate
+
+                let branchCompletionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(previousBranchId, selectedReferenceId)
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        branchCompletionDetails
+                        target
+                        branchOperation
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let! branchPending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile
+
+                match branchPending with
+                | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingBranchFinalization (persistedTarget,
+                                                                                                          persistedOperation,
+                                                                                                          persistedPreviousBranchId,
+                                                                                                          persistedSelectedReferenceId)) ->
+                    WorkingDirectoryUpdate.Target.canonical persistedTarget
+                    |> should equal (WorkingDirectoryUpdate.Target.canonical target)
+
+                    WorkingDirectoryUpdate.Operation.value persistedOperation
+                    |> should equal (WorkingDirectoryUpdate.Operation.value branchOperation)
+
+                    persistedPreviousBranchId
+                    |> should equal previousBranchId
+
+                    persistedSelectedReferenceId
+                    |> should equal selectedReferenceId
+                | _ -> failwith "Expected the persisted Branch finalizer after restart."
+
+                do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target branchOperation
+
+                let watchCursor = "typed-watch-cursor-001"
+
+                let watchOperation =
+                    WorkingDirectoryUpdate.Operation.watchReplay configuration.RepositoryId configuration.BranchId watchCursor
+                    |> requiredWorkingDirectoryUpdate
+
+                let watchCompletionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.WatchFinalization watchCursor
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        watchCompletionDetails
+                        target
+                        watchOperation
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let! watchPending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile
+
+                match watchPending with
+                | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingWatchFinalization (persistedTarget, persistedOperation, persistedCursor)) ->
+                    WorkingDirectoryUpdate.Target.canonical persistedTarget
+                    |> should equal (WorkingDirectoryUpdate.Target.canonical target)
+
+                    WorkingDirectoryUpdate.Operation.value persistedOperation
+                    |> should equal (WorkingDirectoryUpdate.Operation.value watchOperation)
+
+                    persistedCursor |> should equal watchCursor
+                | _ -> failwith "Expected the persisted Watch finalizer after restart."
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+
+                    executeNonQuery
+                        connection
+                        "UPDATE working_directory_update_completions SET watch_event_cursor = 'altered-watch-cursor' WHERE finalization_state = 'Pending';"
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+
+                let alteredRead = Func<Task>(fun () -> LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile :> Task)
+
+                Assert.ThrowsAsync<InvalidOperationException>(alteredRead)
+                |> ignore
+            })
+
     /// Verifies Connect cursor progress and its terminal completion cannot commit separately from matching local facts.
     [<Test>]
     let ``working directory update completion atomically persists connect cursor`` () =
@@ -3762,13 +3937,15 @@ module LocalStateDbTests =
                     WorkingDirectoryUpdate.Operation.connectBootstrap target cursor localRootScope
                     |> requiredWorkingDirectoryUpdate
 
+                let completionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.ConnectCompletion(cursor, localRootScope)
+
                 let mismatchedIdentityCommit =
                     Func<Task> (fun () ->
                         LocalStateDb.commitWorkingDirectoryUpdateCompletion
                             configuration.GraceStatusFile
                             status
                             [ rootDirectory ]
-                            (Some("different-connect-cursor", localRootScope))
+                            (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.ConnectCompletion("different-connect-cursor", localRootScope))
                             target
                             operation
                         :> Task)
@@ -3781,7 +3958,7 @@ module LocalStateDbTests =
                         configuration.GraceStatusFile
                         status
                         [ rootDirectory ]
-                        (Some(cursor, localRootScope))
+                        completionDetails
                         target
                         operation
 
@@ -3791,28 +3968,58 @@ module LocalStateDbTests =
                     WorkingDirectoryUpdate.Operation.connectBootstrap target nextCursor localRootScope
                     |> requiredWorkingDirectoryUpdate
 
+                let nextCompletionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.ConnectCompletion(nextCursor, localRootScope)
+
                 let! _ =
                     LocalStateDb.commitWorkingDirectoryUpdateCompletion
                         configuration.GraceStatusFile
                         status
                         [ rootDirectory ]
-                        (Some(nextCursor, localRootScope))
+                        nextCompletionDetails
                         target
                         nextOperation
 
-                use connection = openRawConnection configuration.GraceStatusFile
-                use command = connection.CreateCommand()
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
 
-                command.CommandText <- "SELECT event_cursor FROM remote_reference_boundaries WHERE repository_id = $repository_id AND branch_id = $branch_id;"
+                let! persistedStatus = LocalStateDb.readStatusMeta configuration.GraceStatusFile
 
-                command.Parameters.AddWithValue("$repository_id", configuration.RepositoryId.ToString())
-                |> ignore
+                let! persistedBoundary =
+                    LocalStateDb.readRemoteReferenceBoundary configuration.GraceStatusFile configuration.RepositoryId configuration.BranchId
 
-                command.Parameters.AddWithValue("$branch_id", configuration.BranchId.ToString())
-                |> ignore
+                persistedStatus.RootDirectoryId
+                |> should equal rootId
 
-                command.ExecuteScalar() :?> string
-                |> should equal nextCursor
+                persistedStatus.RootDirectorySha256Hash
+                |> should equal sha256Hash
+
+                persistedStatus.RootDirectoryBlake3Hash
+                |> should equal blake3Hash
+
+                match persistedBoundary with
+                | Some boundary ->
+                    boundary.RepositoryId
+                    |> should equal configuration.RepositoryId
+
+                    boundary.BranchId
+                    |> should equal configuration.BranchId
+
+                    boundary.DirectoryId |> should equal rootId
+                    boundary.Sha256Hash |> should equal sha256Hash
+                    boundary.Blake3Hash |> should equal blake3Hash
+                    boundary.EventCursor |> should equal nextCursor
+                | None -> failwith "Expected Connect cursor boundary after reopening the local state database."
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+
+                    executeScalarIntWithTextParameter
+                        connection
+                        "SELECT COUNT(*) FROM object_cache_directories WHERE directory_version_id = $root_id;"
+                        "$root_id"
+                        (rootId.ToString())
+                    |> should equal 1
 
                 let! supersededCompletion = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target operation
                 let! completion = LocalStateDb.readWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target nextOperation
@@ -3834,7 +4041,22 @@ module LocalStateDbTests =
                 let sha256Hash = Sha256Hash(String.replicate 64 "e")
                 let blake3Hash = Blake3Hash(String.replicate 64 "f")
                 let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 345L
-                let target, operation = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let cursor = "rollback-connect-cursor"
+
+                let localRootScope =
+                    WorkingDirectoryUpdate.LocalRootScope.create configuration.RootDirectory
+                    |> requiredWorkingDirectoryUpdate
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.connectBootstrap target cursor localRootScope
+                    |> requiredWorkingDirectoryUpdate
+
+                let completionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.ConnectCompletion(cursor, localRootScope)
 
                 let failingCommit =
                     Func<Task> (fun () ->
@@ -3842,7 +4064,7 @@ module LocalStateDbTests =
                             configuration.GraceStatusFile
                             status
                             [ rootDirectory ]
-                            None
+                            completionDetails
                             target
                             operation
                             (fun () -> raise (InvalidOperationException("injected before commit")))
@@ -3885,11 +4107,18 @@ module LocalStateDbTests =
                 let targetBlake3Hash = Blake3Hash(String.replicate 64 "2")
                 let statusBlake3Hash = Blake3Hash(String.replicate 64 "3")
                 let status, rootDirectory = completionStatus configuration rootId sha256Hash statusBlake3Hash 456L
-                let target, operation = completionTargetAndOperation configuration rootId sha256Hash targetBlake3Hash
+                let target, operation, completionDetails = completionTargetAndOperation configuration rootId sha256Hash targetBlake3Hash
 
                 let mismatchedCommit =
                     Func<Task> (fun () ->
-                        LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target operation :> Task)
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            completionDetails
+                            target
+                            operation
+                        :> Task)
 
                 Assert.ThrowsAsync<ArgumentException>(mismatchedCommit)
                 |> ignore
@@ -3911,7 +4140,7 @@ module LocalStateDbTests =
                 let blake3Hash = Blake3Hash(String.replicate 64 "7")
                 let mismatchedBlake3Hash = Blake3Hash(String.replicate 64 "8")
                 let status, _ = completionStatus configuration rootId sha256Hash blake3Hash 457L
-                let target, operation = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
+                let target, operation, completionDetails = completionTargetAndOperation configuration rootId sha256Hash blake3Hash
 
                 let mismatchedRoot =
                     LocalDirectoryVersion.CreateWithHashes
@@ -3929,13 +4158,94 @@ module LocalStateDbTests =
 
                 let mismatchedCommit =
                     Func<Task> (fun () ->
-                        LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ mismatchedRoot ] None target operation
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ mismatchedRoot ]
+                            completionDetails
+                            target
+                            operation
                         :> Task)
 
                 Assert.ThrowsAsync<ArgumentException>(mismatchedCommit)
                 |> ignore
 
                 use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directories;"
+                |> should equal 0
+
+                executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
+                |> should equal 0
+            })
+
+    /// Verifies repository and root identity mismatches reject completion before any durable local fact appears.
+    [<Test>]
+    let ``working directory update completion rejects direct repository and root mismatches`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "9")
+                let blake3Hash = Blake3Hash(String.replicate 64 "a")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 478L
+
+                let branchCompletion target =
+                    let previousBranchId = Guid.NewGuid()
+                    let selectedReferenceId = Guid.NewGuid()
+
+                    let operation =
+                        WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target
+                        |> requiredWorkingDirectoryUpdate
+
+                    let completionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(previousBranchId, selectedReferenceId)
+
+                    operation, completionDetails
+
+                let repositoryMismatchTarget =
+                    WorkingDirectoryUpdate.Target.create (Guid.NewGuid()) configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let repositoryMismatchOperation, repositoryMismatchCompletionDetails = branchCompletion repositoryMismatchTarget
+
+                let repositoryMismatchCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            repositoryMismatchCompletionDetails
+                            repositoryMismatchTarget
+                            repositoryMismatchOperation
+                        :> Task)
+
+                Assert.ThrowsAsync<ArgumentException>(repositoryMismatchCommit)
+                |> ignore
+
+                let rootMismatchTarget =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId (Guid.NewGuid()) sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let rootMismatchOperation, rootMismatchCompletionDetails = branchCompletion rootMismatchTarget
+
+                let rootMismatchCommit =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            rootMismatchCompletionDetails
+                            rootMismatchTarget
+                            rootMismatchOperation
+                        :> Task)
+
+                Assert.ThrowsAsync<ArgumentException>(rootMismatchCommit)
+                |> ignore
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarInt connection "SELECT COUNT(*) FROM status_directories;"
+                |> should equal 0
 
                 executeScalarInt connection "SELECT COUNT(*) FROM object_cache_directories;"
                 |> should equal 0
@@ -3959,32 +4269,69 @@ module LocalStateDbTests =
                     |> requiredWorkingDirectoryUpdate
 
                 let branchOperation () =
-                    WorkingDirectoryUpdate.Operation.branchSwitch (Guid.NewGuid()) (Guid.NewGuid()) target
-                    |> requiredWorkingDirectoryUpdate
+                    let previousBranchId = Guid.NewGuid()
+                    let selectedReferenceId = Guid.NewGuid()
 
-                let firstBranch = branchOperation ()
+                    let operation =
+                        WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target
+                        |> requiredWorkingDirectoryUpdate
+
+                    let completionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(previousBranchId, selectedReferenceId)
+
+                    operation, completionDetails
+
+                let firstBranch, firstBranchCompletionDetails = branchOperation ()
 
                 let watch =
                     WorkingDirectoryUpdate.Operation.watchReplay configuration.RepositoryId configuration.BranchId "watch-cursor-001"
                     |> requiredWorkingDirectoryUpdate
 
-                let! _ = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target firstBranch
+                let watchCompletionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.WatchFinalization "watch-cursor-001"
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        firstBranchCompletionDetails
+                        target
+                        firstBranch
 
                 do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target firstBranch
 
-                let! _ = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target watch
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        watchCompletionDetails
+                        target
+                        watch
 
                 do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target watch
 
-                let secondBranch = branchOperation ()
+                let secondBranch, secondBranchCompletionDetails = branchOperation ()
 
-                let! _ = LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target secondBranch
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        secondBranchCompletionDetails
+                        target
+                        secondBranch
 
-                let displacedPending = branchOperation ()
+                let displacedPending, displacedPendingCompletionDetails = branchOperation ()
 
                 let conflictingCommit =
                     Func<Task> (fun () ->
-                        LocalStateDb.commitWorkingDirectoryUpdateCompletion configuration.GraceStatusFile status [ rootDirectory ] None target displacedPending
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            displacedPendingCompletionDetails
+                            target
+                            displacedPending
                         :> Task)
 
                 Assert.ThrowsAsync<InvalidOperationException>(conflictingCommit)
@@ -4026,19 +4373,19 @@ module LocalStateDbTests =
                 |> should equal 2
             })
 
-    /// Verifies the development-only v9 database is replaced rather than migrated into the bounded completion schema.
+    /// Verifies the development-only v10 database is replaced rather than migrated into the bounded completion schema.
     [<Test>]
-    let ``working directory update schema v10 resets v9 completion data`` () =
+    let ``working directory update schema v11 resets v10 completion data`` () =
         withTempDir (fun _ configuration ->
             task {
                 do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
 
                 use seedConnection = openRawConnection configuration.GraceStatusFile
-                executeNonQuery seedConnection "UPDATE meta SET value = '9' WHERE key = 'schema_version';"
+                executeNonQuery seedConnection "UPDATE meta SET value = '10' WHERE key = 'schema_version';"
 
                 executeNonQuery
                     seedConnection
-                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, finalization_state, completed_at_unix_ticks) VALUES ('stale-operation', 'Branch', 'stale-target', 'Terminal', 1);"
+                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ('stale-operation', 'Branch', 'stale-target', 'repository', 'branch', 'root', 'sha256', 'blake3', 'previous-branch', 'selected-reference', NULL, 'Terminal', 1);"
 
                 seedConnection.Close()
                 LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
@@ -4047,7 +4394,7 @@ module LocalStateDbTests =
                 use connection = openRawConnection configuration.GraceStatusFile
 
                 executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                |> should equal "10"
+                |> should equal LocalStateDb.SchemaVersion
 
                 executeScalarInt connection "SELECT COUNT(*) FROM working_directory_update_completions;"
                 |> should equal 0
@@ -4137,7 +4484,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
 
                 let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                 statusMetaCount |> should equal 1
@@ -4167,7 +4516,9 @@ module LocalStateDbTests =
 
                 use connection = openRawConnection configuration.GraceStatusFile
                 let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                schemaVersion |> should equal "10"
+
+                schemaVersion
+                |> should equal LocalStateDb.SchemaVersion
             })
 
     /// Verifies non-Windows filesystems can initialize case-distinct local-state paths without rewriting the temp root.
@@ -4515,7 +4866,7 @@ module LocalStateDbTests =
                 do
                     use connection = openRawConnection configuration.GraceStatusFile
                     executeNonQuery connection "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
-                    executeNonQuery connection "INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '10');"
+                    executeNonQuery connection $"INSERT OR REPLACE INTO meta (key, value) VALUES ('schema_version', '{LocalStateDb.SchemaVersion}');"
 
                     executeNonQuery
                         connection
@@ -5530,7 +5881,9 @@ module LocalStateDbTests =
                     integrity.ToLowerInvariant() |> should equal "ok"
 
                     let schemaVersion = executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
-                    schemaVersion |> should equal "10"
+
+                    schemaVersion
+                    |> should equal LocalStateDb.SchemaVersion
 
                     let statusMetaCount = executeScalarInt connection "SELECT COUNT(*) FROM status_meta;"
                     statusMetaCount |> should equal 1

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -25,11 +25,11 @@
 		<None Include="instructions.md" />
 		<Compile Include="Log.CLI.fs" />
 		<Compile Include="Text.CLI.fs" />
+		<Compile Include="Command\WorkingDirectoryUpdate.CLI.fs" />
 		<Compile Include="LocalStateDb.CLI.fs" />
 		<Compile Include="SelectProjection.CLI.fs" />
 		<Compile Include="Command\Services.CLI.fs" />
 		<Compile Include="Command\Common.CLI.fs" />
-		<Compile Include="Command\WorkingDirectoryUpdate.CLI.fs" />
 		<Compile Include="Command\WorkingDirectoryUpdate.Coordination.CLI.fs" />
 		<Compile Include="Command\Auth.CLI.fs" />
 		<Compile Include="Command\Config.CLI.fs" />

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -21,7 +21,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let SchemaVersion = "10"
+    let SchemaVersion = "11"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -39,6 +39,21 @@ module LocalStateDb =
     type internal WorkingDirectoryUpdateCompletion =
         | Pending
         | Terminal
+
+    /// Carries the bounded caller facts that distinguish one pending finalization from another.
+    type internal WorkingDirectoryUpdateCompletionDetails =
+        | BranchFinalization of previousBranchId: BranchId * selectedReferenceId: ReferenceId
+        | WatchFinalization of eventCursor: string
+        | ConnectCompletion of initialCursor: string * localRootScope: WorkingDirectoryUpdate.LocalRootScope
+
+    /// Reconstructs one exact pending finalizer without creating a general completion-history surface.
+    type internal PendingWorkingDirectoryUpdateFinalization =
+        | PendingBranchFinalization of
+            target: WorkingDirectoryUpdate.Target *
+            operation: WorkingDirectoryUpdate.Operation *
+            previousBranchId: BranchId *
+            selectedReferenceId: ReferenceId
+        | PendingWatchFinalization of target: WorkingDirectoryUpdate.Target * operation: WorkingDirectoryUpdate.Operation * eventCursor: string
 
     [<Literal>]
     let private BusyTimeoutMs = 30000
@@ -238,7 +253,7 @@ module LocalStateDb =
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
             "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE TABLE IF NOT EXISTS remote_reference_boundaries (repository_id TEXT NOT NULL, branch_id TEXT NOT NULL, root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, event_cursor TEXT NOT NULL, PRIMARY KEY (repository_id, branch_id));"
-            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND branch_selected_reference_id IS NOT NULL AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_pending ON working_directory_update_completions(finalization_state) WHERE finalization_state = 'Pending';"
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_terminal_caller ON working_directory_update_completions(caller_kind) WHERE finalization_state = 'Terminal';"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
@@ -3055,7 +3070,7 @@ module LocalStateDb =
         (objectCacheDirectories: LocalDirectoryVersion array)
         (target: WorkingDirectoryUpdate.Target)
         (operation: WorkingDirectoryUpdate.Operation)
-        (connectIdentity: (string * WorkingDirectoryUpdate.LocalRootScope) option)
+        (completionDetails: WorkingDirectoryUpdateCompletionDetails)
         =
         if not (WorkingDirectoryUpdate.Operation.matchesTarget target operation) then
             invalidArg (nameof operation) "The Working Directory Update operation must match its target."
@@ -3092,15 +3107,27 @@ module LocalStateDb =
             ()
         | _ -> invalidArg (nameof objectCacheDirectories) "Working Directory Update object metadata must contain the exact target root once."
 
-        match WorkingDirectoryUpdate.Operation.callerKind operation, connectIdentity with
-        | WorkingDirectoryUpdate.CallerKind.Connect, Some (cursor, localRootScope) when not (String.IsNullOrWhiteSpace(cursor)) ->
+        let operationMatches expectedOperation = WorkingDirectoryUpdate.Operation.value expectedOperation = WorkingDirectoryUpdate.Operation.value operation
+
+        match WorkingDirectoryUpdate.Operation.callerKind operation, completionDetails with
+        | WorkingDirectoryUpdate.CallerKind.Branch, BranchFinalization (previousBranchId, selectedReferenceId) ->
+            match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
+            | Ok expectedOperation when operationMatches expectedOperation -> ()
+            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and selected Reference."
+        | WorkingDirectoryUpdate.CallerKind.Watch, WatchFinalization eventCursor ->
+            match
+                WorkingDirectoryUpdate.Operation.watchReplay
+                    (WorkingDirectoryUpdate.Target.repositoryId target)
+                    (WorkingDirectoryUpdate.Target.branchId target)
+                    eventCursor
+                with
+            | Ok expectedOperation when operationMatches expectedOperation -> ()
+            | _ -> invalidArg (nameof completionDetails) "Watch completion details must exactly match its target repository, branch, and event cursor."
+        | WorkingDirectoryUpdate.CallerKind.Connect, ConnectCompletion (cursor, localRootScope) ->
             match WorkingDirectoryUpdate.Operation.connectBootstrap target cursor localRootScope with
-            | Ok expectedOperation when WorkingDirectoryUpdate.Operation.value expectedOperation = WorkingDirectoryUpdate.Operation.value operation -> ()
-            | _ -> invalidArg (nameof operation) "Connect completion identity must exactly match its target, initial cursor, and local-root scope."
-        | WorkingDirectoryUpdate.CallerKind.Connect, _ ->
-            invalidArg (nameof connectIdentity) "Connect completion requires its exact initial cursor and local-root scope."
-        | _, None -> ()
-        | _ -> invalidArg (nameof connectIdentity) "Only Connect completion may persist a cursor and local-root scope."
+            | Ok expectedOperation when operationMatches expectedOperation -> ()
+            | _ -> invalidArg (nameof completionDetails) "Connect completion details must exactly match its target, initial cursor, and local-root scope."
+        | _ -> invalidArg (nameof completionDetails) "Working Directory Update completion details must match the operation caller."
 
     /// Coordinates local SQLite state for replace status snapshot, including Grace status, object cache, or watch metadata.
     let private replaceStatusSnapshotWithRevisionCore
@@ -3108,7 +3135,7 @@ module LocalStateDb =
         (graceStatus: GraceStatus)
         (boundary: ReferenceMaterializationBoundaryDto option)
         (objectCacheDirectories: LocalDirectoryVersion array)
-        (completion: (WorkingDirectoryUpdate.Target * WorkingDirectoryUpdate.Operation * (string * WorkingDirectoryUpdate.LocalRootScope) option) option)
+        (completion: (WorkingDirectoryUpdate.Target * WorkingDirectoryUpdate.Operation * WorkingDirectoryUpdateCompletionDetails) option)
         (cancellationToken: CancellationToken)
         (repairBaseline: LocalStateRepairBaseline option)
         (beforeWriteClaim: unit -> unit)
@@ -3131,8 +3158,8 @@ module LocalStateDb =
             | _ -> ()
 
             match completion with
-            | Some (target, operation, connectIdentity) ->
-                validateWorkingDirectoryUpdateCompletionInput graceStatus objectCacheDirectories target operation connectIdentity
+            | Some (target, operation, completionDetails) ->
+                validateWorkingDirectoryUpdateCompletionInput graceStatus objectCacheDirectories target operation completionDetails
             | None -> ()
 
             cancellationToken.ThrowIfCancellationRequested()
@@ -3311,7 +3338,7 @@ module LocalStateDb =
                             | None -> ()
 
                             match completion with
-                            | Some (target, operation, connectIdentity) ->
+                            | Some (target, operation, completionDetails) ->
                                 let operationValue = WorkingDirectoryUpdate.Operation.value operation
 
                                 let operationCallerKind = WorkingDirectoryUpdate.Operation.callerKind operation
@@ -3325,6 +3352,18 @@ module LocalStateDb =
 
                                 let targetCanonical = WorkingDirectoryUpdate.Target.canonical target
 
+                                let branchPreviousBranchId, branchSelectedReferenceId, watchEventCursor =
+                                    match completionDetails with
+                                    | BranchFinalization (previousBranchId, selectedReferenceId) ->
+                                        Some(previousBranchId.ToString()), Some(selectedReferenceId.ToString()), None
+                                    | WatchFinalization eventCursor -> None, None, Some eventCursor
+                                    | ConnectCompletion _ -> None, None, None
+
+                                let nullableText value =
+                                    value
+                                    |> Option.map box
+                                    |> Option.defaultValue (box DBNull.Value)
+
                                 use pendingCommand = connection.CreateCommand()
 
                                 pendingCommand.CommandText <-
@@ -3336,8 +3375,8 @@ module LocalStateDb =
                                 if not (isNull (pendingCommand.ExecuteScalar())) then
                                     invalidOp "A different Working Directory Update finalization is already pending."
 
-                                match connectIdentity with
-                                | Some (cursor, _) ->
+                                match completionDetails with
+                                | ConnectCompletion (cursor, _) ->
                                     executeNonQueryWithParams
                                         connection
                                         "INSERT OR REPLACE INTO remote_reference_boundaries (repository_id, branch_id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, event_cursor) VALUES ($repository_id, $branch_id, $root_id, $root_sha256_hash, $root_blake3_hash, $event_cursor);"
@@ -3367,7 +3406,8 @@ module LocalStateDb =
 
                                             parameters.AddWithValue("$event_cursor", cursor)
                                             |> ignore)
-                                | None -> ()
+                                | BranchFinalization _
+                                | WatchFinalization _ -> ()
 
                                 if operationCallerKind = WorkingDirectoryUpdate.CallerKind.Connect then
                                     executeNonQueryWithParams
@@ -3380,7 +3420,7 @@ module LocalStateDb =
                                 use completionCommand = connection.CreateCommand()
 
                                 completionCommand.CommandText <-
-                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
+                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $target_repository_id, $target_branch_id, $target_root_directory_version_id, $target_root_directory_sha256_hash, $target_root_directory_blake3_hash, $branch_previous_branch_id, $branch_selected_reference_id, $watch_event_cursor, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.target_repository_id = excluded.target_repository_id AND working_directory_update_completions.target_branch_id = excluded.target_branch_id AND working_directory_update_completions.target_root_directory_version_id = excluded.target_root_directory_version_id AND working_directory_update_completions.target_root_directory_sha256_hash = excluded.target_root_directory_sha256_hash AND working_directory_update_completions.target_root_directory_blake3_hash = excluded.target_root_directory_blake3_hash AND working_directory_update_completions.branch_previous_branch_id IS excluded.branch_previous_branch_id AND working_directory_update_completions.branch_selected_reference_id IS excluded.branch_selected_reference_id AND working_directory_update_completions.watch_event_cursor IS excluded.watch_event_cursor AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
 
                                 completionCommand.Parameters.AddWithValue("$operation_value", operationValue)
                                 |> ignore
@@ -3389,6 +3429,38 @@ module LocalStateDb =
                                 |> ignore
 
                                 completionCommand.Parameters.AddWithValue("$target_canonical", targetCanonical)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue(
+                                    "$target_repository_id",
+                                    WorkingDirectoryUpdate.Target.repositoryId target
+                                    |> string
+                                )
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue(
+                                    "$target_branch_id",
+                                    WorkingDirectoryUpdate.Target.branchId target
+                                    |> string
+                                )
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$target_root_directory_version_id", graceStatus.RootDirectoryId.ToString())
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$target_root_directory_sha256_hash", graceStatus.RootDirectorySha256Hash)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$target_root_directory_blake3_hash", getRootDirectoryBlake3Hash graceStatus)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$branch_previous_branch_id", nullableText branchPreviousBranchId)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$branch_selected_reference_id", nullableText branchSelectedReferenceId)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$watch_event_cursor", nullableText watchEventCursor)
                                 |> ignore
 
                                 completionCommand.Parameters.AddWithValue("$finalization_state", finalizationState)
@@ -3728,12 +3800,12 @@ module LocalStateDb =
             return ()
         }
 
-    /// Atomically stores exact local facts and a bounded completion after proving optional Connect cursor identity.
+    /// Atomically stores exact local facts and bounded caller-specific completion details.
     let internal commitWorkingDirectoryUpdateCompletion
         (dbPath: string)
         (graceStatus: GraceStatus)
         (objectCacheDirectories: IEnumerable<LocalDirectoryVersion>)
-        (connectIdentity: (string * WorkingDirectoryUpdate.LocalRootScope) option)
+        (completionDetails: WorkingDirectoryUpdateCompletionDetails)
         (target: WorkingDirectoryUpdate.Target)
         (operation: WorkingDirectoryUpdate.Operation)
         =
@@ -3748,18 +3820,18 @@ module LocalStateDb =
             graceStatus
             None
             directories
-            (Some(target, operation, connectIdentity))
+            (Some(target, operation, completionDetails))
             CancellationToken.None
             None
             ignore
             ignore
 
-    /// Commits update completion through an injected pre-commit seam used by deterministic rollback proof.
+    /// Commits exact caller-specific completion through an injected pre-commit seam used by deterministic rollback proof.
     let internal commitWorkingDirectoryUpdateCompletionWithBeforeCommit
         (dbPath: string)
         (graceStatus: GraceStatus)
         (objectCacheDirectories: IEnumerable<LocalDirectoryVersion>)
-        (connectIdentity: (string * WorkingDirectoryUpdate.LocalRootScope) option)
+        (completionDetails: WorkingDirectoryUpdateCompletionDetails)
         (target: WorkingDirectoryUpdate.Target)
         (operation: WorkingDirectoryUpdate.Operation)
         (beforeCommit: unit -> unit)
@@ -3775,11 +3847,83 @@ module LocalStateDb =
             graceStatus
             None
             directories
-            (Some(target, operation, connectIdentity))
+            (Some(target, operation, completionDetails))
             CancellationToken.None
             None
             ignore
             beforeCommit
+
+    /// Reads and validates the one pending Branch or Watch finalizer that survives process restart.
+    let internal readPendingWorkingDirectoryUpdateFinalization (dbPath: string) =
+        task {
+            do! ensureDbInitialized dbPath
+            use connection = openConnection dbPath
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor FROM working_directory_update_completions WHERE finalization_state = 'Pending' LIMIT 1;"
+
+            use reader = command.ExecuteReader()
+
+            if not (reader.Read()) then
+                return None
+            else
+                let requiredText ordinal columnName =
+                    if reader.IsDBNull(ordinal) then
+                        invalidOp $"Pending Working Directory Update finalization is missing '{columnName}'."
+                    else
+                        reader.GetString(ordinal)
+
+                let requiredGuid ordinal columnName =
+                    match Guid.TryParse(requiredText ordinal columnName) with
+                    | true, value -> value
+                    | false, _ -> invalidOp $"Pending Working Directory Update finalization has invalid '{columnName}'."
+
+                let operationValue = requiredText 0 "operation_value"
+                let callerKind = requiredText 1 "caller_kind"
+                let targetCanonical = requiredText 2 "target_canonical"
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create
+                        (requiredGuid 3 "target_repository_id")
+                        (requiredGuid 4 "target_branch_id")
+                        (requiredGuid 5 "target_root_directory_version_id")
+                        (requiredText 6 "target_root_directory_sha256_hash")
+                        (requiredText 7 "target_root_directory_blake3_hash")
+                    |> function
+                        | Ok value when WorkingDirectoryUpdate.Target.canonical value = targetCanonical -> value
+                        | Ok _ -> invalidOp "Pending Working Directory Update finalization target facts do not match their canonical target."
+                        | Error error -> invalidOp $"Pending Working Directory Update finalization target is invalid: {error}"
+
+                let operation, pendingFinalization =
+                    match callerKind with
+                    | "Branch" ->
+                        let previousBranchId = requiredGuid 8 "branch_previous_branch_id"
+                        let selectedReferenceId = requiredGuid 9 "branch_selected_reference_id"
+
+                        match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
+                        | Ok operation -> operation, PendingBranchFinalization(target, operation, previousBranchId, selectedReferenceId)
+                        | Error error -> invalidOp $"Pending Branch finalization is invalid: {error}"
+                    | "Watch" ->
+                        let eventCursor = requiredText 10 "watch_event_cursor"
+
+                        match
+                            WorkingDirectoryUpdate.Operation.watchReplay
+                                (WorkingDirectoryUpdate.Target.repositoryId target)
+                                (WorkingDirectoryUpdate.Target.branchId target)
+                                eventCursor
+                            with
+                        | Ok operation -> operation, PendingWatchFinalization(target, operation, eventCursor)
+                        | Error error -> invalidOp $"Pending Watch finalization is invalid: {error}"
+                    | "Connect" -> invalidOp "Connect completion must be terminal and cannot be a pending finalization."
+                    | value -> invalidOp $"Pending Working Directory Update finalization has invalid caller kind '{value}'."
+
+                if WorkingDirectoryUpdate.Operation.value operation
+                   <> operationValue then
+                    return raise (InvalidOperationException("Pending Working Directory Update finalization facts do not match their operation identity."))
+                else
+                    return Some pendingFinalization
+        }
 
     /// Reads the exact retained completion state for one caller operation and its complete target.
     let internal readWorkingDirectoryUpdateCompletion (dbPath: string) (target: WorkingDirectoryUpdate.Target) (operation: WorkingDirectoryUpdate.Operation) =

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -9,6 +9,7 @@ open System.Text
 open System.Text.RegularExpressions
 open System.Threading
 open System.Threading.Tasks
+open Grace.CLI.Command
 open Grace.Shared.Client.Configuration
 open Grace.Shared.Utilities
 open Grace.Types.Common
@@ -20,7 +21,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let SchemaVersion = "9"
+    let SchemaVersion = "10"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -33,6 +34,11 @@ module LocalStateDb =
     /// Keeps a bounded diagnostic tail of already-applied Watch journal rows.
     [<Literal>]
     let WatchJournalRetainedAppliedRows = 1024L
+
+    /// Represents the only durable local completion states retained for a Working Directory Update operation.
+    type internal WorkingDirectoryUpdateCompletion =
+        | Pending
+        | Terminal
 
     [<Literal>]
     let private BusyTimeoutMs = 30000
@@ -232,6 +238,9 @@ module LocalStateDb =
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
             "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE TABLE IF NOT EXISTS remote_reference_boundaries (repository_id TEXT NOT NULL, branch_id TEXT NOT NULL, root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, event_cursor TEXT NOT NULL, PRIMARY KEY (repository_id, branch_id));"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL);"
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_pending ON working_directory_update_completions(finalization_state) WHERE finalization_state = 'Pending';"
+            "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_terminal_caller ON working_directory_update_completions(caller_kind) WHERE finalization_state = 'Terminal';"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_version_id ON status_files(directory_version_id);"
             "CREATE INDEX IF NOT EXISTS ix_status_files_sha256 ON status_files(sha256_hash);"
@@ -252,6 +261,7 @@ module LocalStateDb =
             "status_directories"
             "status_files"
             "remote_reference_boundaries"
+            "working_directory_update_completions"
             "object_cache_directories"
             "object_cache_directory_children"
             "object_cache_directory_files"
@@ -269,6 +279,8 @@ module LocalStateDb =
             "ix_object_cache_directories_relative_path"
             "ix_object_cache_children_parent"
             "ix_object_cache_files_path_hash"
+            "ux_working_directory_update_completions_pending"
+            "ux_working_directory_update_completions_terminal_caller"
         |]
 
     /// Models read only local state inspection values passed between the parser and local state db handlers.
@@ -785,11 +797,6 @@ module LocalStateDb =
             | None -> false
         | _ -> false
 
-    /// Adds one nullable Watch journal column when migrating v6 databases without deleting pending rows.
-    let private addWatchJournalColumnIfMissing (connection: SqliteConnection) columnName columnDeclaration =
-        if not (columnExists connection "watch_journal" columnName) then
-            executeNonQuery connection $"ALTER TABLE watch_journal ADD COLUMN {columnDeclaration};"
-
     /// Adds the lifecycle diagnostics table that records Watch recovery decisions without replay payloads.
     let private ensureWatchLifecycleEventTable (connection: SqliteConnection) =
         executeNonQuery
@@ -798,25 +805,6 @@ module LocalStateDb =
 
         if not (columnExists connection "watch_lifecycle_events" "root_directory_sha256_hash") then
             executeNonQuery connection "ALTER TABLE watch_lifecycle_events ADD COLUMN root_directory_sha256_hash TEXT;"
-
-    /// Migrates the v6 Watch journal shape by preserving rows and adding identity plus quarantine metadata.
-    let private migrateWatchJournalV6ToV7 (connection: SqliteConnection) =
-        addWatchJournalColumnIfMissing connection "repository_id" "repository_id TEXT"
-        addWatchJournalColumnIfMissing connection "branch_id" "branch_id TEXT"
-        addWatchJournalColumnIfMissing connection "workspace_root" "workspace_root TEXT"
-        addWatchJournalColumnIfMissing connection "watch_root" "watch_root TEXT"
-        addWatchJournalColumnIfMissing connection "root_directory_version_id" "root_directory_version_id TEXT"
-        addWatchJournalColumnIfMissing connection "root_directory_sha256_hash" "root_directory_sha256_hash TEXT"
-        addWatchJournalColumnIfMissing connection "root_directory_blake3_hash" "root_directory_blake3_hash TEXT"
-        addWatchJournalColumnIfMissing connection "watch_mode" "watch_mode TEXT"
-        addWatchJournalColumnIfMissing connection "quarantined_at_unix_ticks" "quarantined_at_unix_ticks INTEGER"
-        addWatchJournalColumnIfMissing connection "quarantine_reason" "quarantine_reason TEXT"
-        ensureWatchLifecycleEventTable connection
-
-    /// Adds root SHA-256 identity to Watch journal and lifecycle records; preexisting incomplete rows remain replay-incompatible.
-    let private migrateWatchJournalV7ToV8 (connection: SqliteConnection) =
-        addWatchJournalColumnIfMissing connection "root_directory_sha256_hash" "root_directory_sha256_hash TEXT"
-        ensureWatchLifecycleEventTable connection
 
     /// Verifies that the Watch journal table can support ordered local recovery and retention operations.
     let private hasRequiredWatchJournalShape (connection: SqliteConnection) =
@@ -1640,28 +1628,6 @@ module LocalStateDb =
 
                                                 match tryGetMetaValue connection "schema_version" with
                                                 | Some version when version = SchemaVersion -> ()
-                                                | Some "6" ->
-                                                    if hasRequiredMetaKeyValueShape connection
-                                                       && tableExists connection "watch_journal" then
-                                                        try
-                                                            logTrace "migrating local state DB schema from v6 to v9"
-                                                            migrateWatchJournalV6ToV7 connection
-                                                            setMetaValue connection "schema_version" SchemaVersion
-                                                        with
-                                                        | :? SqliteException -> recreate <- true
-                                                    else
-                                                        recreate <- true
-                                                | Some "7" ->
-                                                    if hasRequiredMetaKeyValueShape connection
-                                                       && tableExists connection "watch_journal" then
-                                                        try
-                                                            logTrace "migrating local state DB schema from v7 to v9"
-                                                            migrateWatchJournalV7ToV8 connection
-                                                            setMetaValue connection "schema_version" SchemaVersion
-                                                        with
-                                                        | :? SqliteException -> recreate <- true
-                                                    else
-                                                        recreate <- true
                                                 | Some _ -> recreate <- true
                                                 | None ->
                                                     logTrace "meta schema_version missing; writing defaults"
@@ -2957,11 +2923,188 @@ module LocalStateDb =
                     return UnreadableLocalStateDatabase(file.Length, file.LastWriteTimeUtc)
         }
 
+    /// Applies object-cache directory metadata through the caller's already-open SQLite transaction.
+    let private upsertObjectCacheRows (connection: SqliteConnection) (directoriesToUpsert: LocalDirectoryVersion array) =
+        let knownDirectoryIds = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+
+        use knownDirectoryIdsCommand = connection.CreateCommand()
+        knownDirectoryIdsCommand.CommandText <- "SELECT directory_version_id FROM object_cache_directories;"
+
+        use knownDirectoryIdsReader = knownDirectoryIdsCommand.ExecuteReader()
+
+        while knownDirectoryIdsReader.Read() do
+            knownDirectoryIds.Add(knownDirectoryIdsReader.GetString(0))
+            |> ignore
+
+        knownDirectoryIdsReader.Close()
+
+        directoriesToUpsert
+        |> Array.iter (fun directory ->
+            let directoryVersionId = directory.DirectoryVersionId.ToString()
+
+            executeNonQueryWithParams
+                connection
+                "INSERT INTO object_cache_directories (directory_version_id, relative_path, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write) ON CONFLICT(directory_version_id) DO UPDATE SET relative_path = excluded.relative_path, sha256_hash = excluded.sha256_hash, blake3_hash = excluded.blake3_hash, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
+                (fun parameters ->
+                    parameters.AddWithValue("$directory_version_id", directoryVersionId)
+                    |> ignore
+
+                    parameters.AddWithValue("$relative_path", directory.RelativePath)
+                    |> ignore
+
+                    parameters.AddWithValue("$sha256_hash", directory.Sha256Hash)
+                    |> ignore
+
+                    parameters.AddWithValue("$blake3_hash", directory.Blake3Hash)
+                    |> ignore
+
+                    parameters.AddWithValue("$size_bytes", directory.Size)
+                    |> ignore
+
+                    parameters.AddWithValue("$created_at", directory.CreatedAt.ToUnixTimeTicks())
+                    |> ignore
+
+                    parameters.AddWithValue("$last_write", directory.LastWriteTimeUtc.Ticks)
+                    |> ignore)
+
+            knownDirectoryIds.Add(directoryVersionId)
+            |> ignore)
+
+        directoriesToUpsert
+        |> Array.iter (fun directory ->
+            let directoryVersionId = directory.DirectoryVersionId.ToString()
+
+            executeNonQueryWithParams
+                connection
+                "DELETE FROM object_cache_directory_children WHERE parent_directory_version_id = $directory_version_id;"
+                (fun parameters ->
+                    parameters.AddWithValue("$directory_version_id", directoryVersionId)
+                    |> ignore)
+
+            executeNonQueryWithParams
+                connection
+                "DELETE FROM object_cache_directory_files WHERE directory_version_id = $directory_version_id;"
+                (fun parameters ->
+                    parameters.AddWithValue("$directory_version_id", directoryVersionId)
+                    |> ignore)
+
+            directory.Directories
+            |> Seq.iteri (fun ordinal childDirectoryVersionId ->
+                let childId = childDirectoryVersionId.ToString()
+
+                if not (knownDirectoryIds.Contains(childId)) then
+                    invalidOp
+                        $"Cannot upsert object cache because child DirectoryVersionId {childDirectoryVersionId} is missing. Parent DirectoryVersionId: {directory.DirectoryVersionId}."
+
+                executeNonQueryWithParams
+                    connection
+                    "INSERT INTO object_cache_directory_children (parent_directory_version_id, child_directory_version_id, ordinal) VALUES ($parent_directory_version_id, $child_directory_version_id, $ordinal) ON CONFLICT(parent_directory_version_id, child_directory_version_id) DO UPDATE SET ordinal = excluded.ordinal;"
+                    (fun parameters ->
+                        parameters.AddWithValue("$parent_directory_version_id", directoryVersionId)
+                        |> ignore
+
+                        parameters.AddWithValue("$child_directory_version_id", childId)
+                        |> ignore
+
+                        parameters.AddWithValue("$ordinal", ordinal)
+                        |> ignore))
+
+            directory.Files
+            |> Seq.iter (fun file ->
+                executeNonQueryWithParams
+                    connection
+                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write) ON CONFLICT(directory_version_id, relative_path) DO UPDATE SET sha256_hash = excluded.sha256_hash, blake3_hash = excluded.blake3_hash, is_binary = excluded.is_binary, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, uploaded_to_object_storage = excluded.uploaded_to_object_storage, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
+                    (fun parameters ->
+                        parameters.AddWithValue("$directory_version_id", directoryVersionId)
+                        |> ignore
+
+                        parameters.AddWithValue("$relative_path", file.RelativePath)
+                        |> ignore
+
+                        parameters.AddWithValue("$sha256_hash", file.Sha256Hash)
+                        |> ignore
+
+                        parameters.AddWithValue("$blake3_hash", file.Blake3Hash)
+                        |> ignore
+
+                        parameters.AddWithValue("$is_binary", (if file.IsBinary then 1 else 0))
+                        |> ignore
+
+                        parameters.AddWithValue("$size_bytes", file.Size)
+                        |> ignore
+
+                        parameters.AddWithValue("$created_at", file.CreatedAt.ToUnixTimeTicks())
+                        |> ignore
+
+                        parameters.AddWithValue("$uploaded", (if file.UploadedToObjectStorage then 1 else 0))
+                        |> ignore
+
+                        parameters.AddWithValue("$last_write", file.LastWriteTimeUtc.Ticks)
+                        |> ignore)))
+
+    /// Converts one Working Directory Update caller kind into its bounded completion retention key.
+    let private workingDirectoryUpdateCallerKindValue callerKind =
+        match callerKind with
+        | WorkingDirectoryUpdate.CallerKind.Watch -> "Watch"
+        | WorkingDirectoryUpdate.CallerKind.Branch -> "Branch"
+        | WorkingDirectoryUpdate.CallerKind.Connect -> "Connect"
+
+    /// Verifies that completion input repeats one exact target through status, object metadata, and caller operation contracts.
+    let private validateWorkingDirectoryUpdateCompletionInput
+        (graceStatus: GraceStatus)
+        (objectCacheDirectories: LocalDirectoryVersion array)
+        (target: WorkingDirectoryUpdate.Target)
+        (operation: WorkingDirectoryUpdate.Operation)
+        (connectCursor: string option)
+        =
+        if not (WorkingDirectoryUpdate.Operation.matchesTarget target operation) then
+            invalidArg (nameof operation) "The Working Directory Update operation must match its target."
+
+        let statusTarget =
+            WorkingDirectoryUpdate.Target.create
+                (WorkingDirectoryUpdate.Target.repositoryId target)
+                (WorkingDirectoryUpdate.Target.branchId target)
+                graceStatus.RootDirectoryId
+                graceStatus.RootDirectorySha256Hash
+                (getRootDirectoryBlake3Hash graceStatus)
+
+        match statusTarget with
+        | Ok statusTarget when WorkingDirectoryUpdate.Target.canonical statusTarget = WorkingDirectoryUpdate.Target.canonical target -> ()
+        | _ -> invalidArg (nameof graceStatus) "The local status root must exactly match the Working Directory Update target."
+
+        let targetRepositoryId = WorkingDirectoryUpdate.Target.repositoryId target
+
+        if objectCacheDirectories
+           |> Array.exists (fun directory -> directory.RepositoryId <> targetRepositoryId) then
+            invalidArg (nameof objectCacheDirectories) "Working Directory Update object metadata must belong to the target repository."
+
+        let rootMetadata =
+            objectCacheDirectories
+            |> Array.filter (fun directory -> directory.DirectoryVersionId = graceStatus.RootDirectoryId)
+
+        match rootMetadata with
+        | [| root |] when
+            root.RepositoryId = targetRepositoryId
+            && root.RelativePath = Grace.Shared.Constants.RootDirectoryPath
+            && root.Sha256Hash = graceStatus.RootDirectorySha256Hash
+            && root.Blake3Hash = getRootDirectoryBlake3Hash graceStatus
+            ->
+            ()
+        | _ -> invalidArg (nameof objectCacheDirectories) "Working Directory Update object metadata must contain the exact target root once."
+
+        match WorkingDirectoryUpdate.Operation.callerKind operation, connectCursor with
+        | WorkingDirectoryUpdate.CallerKind.Connect, Some cursor when not (String.IsNullOrWhiteSpace(cursor)) -> ()
+        | WorkingDirectoryUpdate.CallerKind.Connect, _ -> invalidArg (nameof connectCursor) "Connect completion requires its exact initial cursor."
+        | _, None -> ()
+        | _ -> invalidArg (nameof connectCursor) "Only Connect completion may persist a cursor."
+
     /// Coordinates local SQLite state for replace status snapshot, including Grace status, object cache, or watch metadata.
     let private replaceStatusSnapshotWithRevisionCore
         (dbPath: string)
         (graceStatus: GraceStatus)
         (boundary: ReferenceMaterializationBoundaryDto option)
+        (objectCacheDirectories: LocalDirectoryVersion array)
+        (completion: (WorkingDirectoryUpdate.Target * WorkingDirectoryUpdate.Operation * string option) option)
         (cancellationToken: CancellationToken)
         (repairBaseline: LocalStateRepairBaseline option)
         (beforeWriteClaim: unit -> unit)
@@ -2982,6 +3125,11 @@ module LocalStateDb =
                 ->
                 invalidArg (nameof boundary) "The remote Reference boundary must match the complete persisted status root identity."
             | _ -> ()
+
+            match completion with
+            | Some (target, operation, connectCursor) ->
+                validateWorkingDirectoryUpdateCompletionInput graceStatus objectCacheDirectories target operation connectCursor
+            | None -> ()
 
             cancellationToken.ThrowIfCancellationRequested()
 
@@ -3131,6 +3279,8 @@ module LocalStateDb =
                                     fileCommand.Parameters["$last_write"].Value <- file.LastWriteTimeUtc.Ticks
                                     fileCommand.ExecuteNonQuery() |> ignore))
 
+                            upsertObjectCacheRows connection objectCacheDirectories
+
                             match boundary with
                             | Some boundary ->
                                 executeNonQueryWithParams
@@ -3154,6 +3304,99 @@ module LocalStateDb =
 
                                         parameters.AddWithValue("$event_cursor", boundary.EventCursor)
                                         |> ignore)
+                            | None -> ()
+
+                            match completion with
+                            | Some (target, operation, connectCursor) ->
+                                let operationValue = WorkingDirectoryUpdate.Operation.value operation
+
+                                let operationCallerKind = WorkingDirectoryUpdate.Operation.callerKind operation
+
+                                let callerKind = workingDirectoryUpdateCallerKindValue operationCallerKind
+
+                                let finalizationState =
+                                    match operationCallerKind with
+                                    | WorkingDirectoryUpdate.CallerKind.Connect -> "Terminal"
+                                    | _ -> "Pending"
+
+                                let targetCanonical = WorkingDirectoryUpdate.Target.canonical target
+
+                                use pendingCommand = connection.CreateCommand()
+
+                                pendingCommand.CommandText <-
+                                    "SELECT operation_value FROM working_directory_update_completions WHERE finalization_state = 'Pending' AND operation_value <> $operation_value LIMIT 1;"
+
+                                pendingCommand.Parameters.AddWithValue("$operation_value", operationValue)
+                                |> ignore
+
+                                if not (isNull (pendingCommand.ExecuteScalar())) then
+                                    invalidOp "A different Working Directory Update finalization is already pending."
+
+                                match connectCursor with
+                                | Some cursor ->
+                                    executeNonQueryWithParams
+                                        connection
+                                        "INSERT OR REPLACE INTO remote_reference_boundaries (repository_id, branch_id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, event_cursor) VALUES ($repository_id, $branch_id, $root_id, $root_sha256_hash, $root_blake3_hash, $event_cursor);"
+                                        (fun parameters ->
+                                            parameters.AddWithValue(
+                                                "$repository_id",
+                                                WorkingDirectoryUpdate.Target.repositoryId target
+                                                |> string
+                                            )
+                                            |> ignore
+
+                                            parameters.AddWithValue(
+                                                "$branch_id",
+                                                WorkingDirectoryUpdate.Target.branchId target
+                                                |> string
+                                            )
+                                            |> ignore
+
+                                            parameters.AddWithValue("$root_id", graceStatus.RootDirectoryId.ToString())
+                                            |> ignore
+
+                                            parameters.AddWithValue("$root_sha256_hash", graceStatus.RootDirectorySha256Hash)
+                                            |> ignore
+
+                                            parameters.AddWithValue("$root_blake3_hash", getRootDirectoryBlake3Hash graceStatus)
+                                            |> ignore
+
+                                            parameters.AddWithValue("$event_cursor", cursor)
+                                            |> ignore)
+                                | None -> ()
+
+                                if operationCallerKind = WorkingDirectoryUpdate.CallerKind.Connect then
+                                    executeNonQueryWithParams
+                                        connection
+                                        "DELETE FROM working_directory_update_completions WHERE caller_kind = $caller_kind AND finalization_state = 'Terminal';"
+                                        (fun parameters ->
+                                            parameters.AddWithValue("$caller_kind", callerKind)
+                                            |> ignore)
+
+                                use completionCommand = connection.CreateCommand()
+
+                                completionCommand.CommandText <-
+                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
+
+                                completionCommand.Parameters.AddWithValue("$operation_value", operationValue)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$caller_kind", callerKind)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$target_canonical", targetCanonical)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$finalization_state", finalizationState)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$completed_at", getCurrentInstant().ToUnixTimeTicks())
+                                |> ignore
+
+                                let rowsWritten = completionCommand.ExecuteNonQuery()
+
+                                if rowsWritten <> 1 then
+                                    invalidOp "The existing Working Directory Update completion does not match the requested finalization state."
                             | None -> ()
 
                             beforeCommit ()
@@ -3186,7 +3429,7 @@ module LocalStateDb =
         (boundary: ReferenceMaterializationBoundaryDto)
         (cancellationToken: CancellationToken)
         =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken None ignore ignore
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) Array.empty None cancellationToken None ignore ignore
 
     /// Refuses exact local-state repair when another SQLite connection currently owns the write claim.
     let ensureNoActiveWriterForLocalStateRepair (dbPath: string) =
@@ -3225,7 +3468,7 @@ module LocalStateDb =
         (cancellationToken: CancellationToken)
         (beforeCommit: unit -> unit)
         =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken None ignore beforeCommit
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) Array.empty None cancellationToken None ignore beforeCommit
 
     /// Replaces exact repair status only if no writer changed or owns the captured local-state generation.
     let replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepair
@@ -3235,7 +3478,7 @@ module LocalStateDb =
         (boundary: ReferenceMaterializationBoundaryDto)
         (cancellationToken: CancellationToken)
         =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken (Some baseline) ignore ignore
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) Array.empty None cancellationToken (Some baseline) ignore ignore
 
     /// Exposes the final repair write-claim seam so deterministic tests can race a real SQLite writer.
     let internal replaceStatusSnapshotWithRemoteReferenceBoundaryForLocalStateRepairWithBeforeWriteClaim
@@ -3246,11 +3489,11 @@ module LocalStateDb =
         (cancellationToken: CancellationToken)
         (beforeWriteClaim: unit -> unit)
         =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) cancellationToken (Some baseline) beforeWriteClaim ignore
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus (Some boundary) Array.empty None cancellationToken (Some baseline) beforeWriteClaim ignore
 
     /// Replaces status without changing any branch-scoped remote Reference boundary.
     let replaceStatusSnapshotWithRevision (dbPath: string) (graceStatus: GraceStatus) =
-        replaceStatusSnapshotWithRevisionCore dbPath graceStatus None CancellationToken.None None ignore ignore
+        replaceStatusSnapshotWithRevisionCore dbPath graceStatus None Array.empty None CancellationToken.None None ignore ignore
 
     /// Reads the boundary for one repository and branch without falling back to global metadata.
     let readRemoteReferenceBoundary (dbPath: string) repositoryId branchId =
@@ -3481,176 +3724,199 @@ module LocalStateDb =
             return ()
         }
 
-    /// Persists upsert object cache changes in the local SQLite state database.
-    let upsertObjectCache (dbPath: string) (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>) =
+    /// Atomically stores exact local status, object metadata, an optional Connect cursor, and its bounded update completion.
+    let internal commitWorkingDirectoryUpdateCompletion
+        (dbPath: string)
+        (graceStatus: GraceStatus)
+        (objectCacheDirectories: IEnumerable<LocalDirectoryVersion>)
+        (connectCursor: string option)
+        (target: WorkingDirectoryUpdate.Target)
+        (operation: WorkingDirectoryUpdate.Operation)
+        =
+        let directories =
+            if isNull (box objectCacheDirectories) then
+                invalidArg (nameof objectCacheDirectories) "Working Directory Update completion requires explicit object metadata."
+            else
+                objectCacheDirectories |> Seq.toArray
+
+        replaceStatusSnapshotWithRevisionCore
+            dbPath
+            graceStatus
+            None
+            directories
+            (Some(target, operation, connectCursor))
+            CancellationToken.None
+            None
+            ignore
+            ignore
+
+    /// Commits a pending update completion through an injected pre-commit seam used by deterministic rollback proof.
+    let internal commitWorkingDirectoryUpdateCompletionWithBeforeCommit
+        (dbPath: string)
+        (graceStatus: GraceStatus)
+        (objectCacheDirectories: IEnumerable<LocalDirectoryVersion>)
+        (connectCursor: string option)
+        (target: WorkingDirectoryUpdate.Target)
+        (operation: WorkingDirectoryUpdate.Operation)
+        (beforeCommit: unit -> unit)
+        =
+        let directories =
+            if isNull (box objectCacheDirectories) then
+                invalidArg (nameof objectCacheDirectories) "Working Directory Update completion requires explicit object metadata."
+            else
+                objectCacheDirectories |> Seq.toArray
+
+        replaceStatusSnapshotWithRevisionCore
+            dbPath
+            graceStatus
+            None
+            directories
+            (Some(target, operation, connectCursor))
+            CancellationToken.None
+            None
+            ignore
+            beforeCommit
+
+    /// Reads the exact retained completion state for one caller operation and its complete target.
+    let internal readWorkingDirectoryUpdateCompletion (dbPath: string) (target: WorkingDirectoryUpdate.Target) (operation: WorkingDirectoryUpdate.Operation) =
         task {
+            if not (WorkingDirectoryUpdate.Operation.matchesTarget target operation) then
+                invalidArg (nameof operation) "The Working Directory Update operation must match its target."
+
             do! ensureDbInitialized dbPath
-            let directoriesToUpsert = newDirectoryVersions |> Seq.toArray
+            use connection = openConnection dbPath
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT finalization_state FROM working_directory_update_completions WHERE operation_value = $operation_value AND caller_kind = $caller_kind AND target_canonical = $target_canonical LIMIT 1;"
+
+            command.Parameters.AddWithValue("$operation_value", WorkingDirectoryUpdate.Operation.value operation)
+            |> ignore
+
+            command.Parameters.AddWithValue(
+                "$caller_kind",
+                WorkingDirectoryUpdate.Operation.callerKind operation
+                |> workingDirectoryUpdateCallerKindValue
+            )
+            |> ignore
+
+            command.Parameters.AddWithValue("$target_canonical", WorkingDirectoryUpdate.Target.canonical target)
+            |> ignore
+
+            match command.ExecuteScalar() with
+            | :? string as "Pending" -> return Some WorkingDirectoryUpdateCompletion.Pending
+            | :? string as "Terminal" -> return Some WorkingDirectoryUpdateCompletion.Terminal
+            | null -> return None
+            | value -> return invalidOp $"Invalid Working Directory Update completion state '{value}'."
+        }
+
+    /// Marks one exact pending completion terminal while retaining only the latest terminal result for its caller kind.
+    let internal finalizeWorkingDirectoryUpdateCompletion
+        (dbPath: string)
+        (target: WorkingDirectoryUpdate.Target)
+        (operation: WorkingDirectoryUpdate.Operation)
+        =
+        task {
+            if not (WorkingDirectoryUpdate.Operation.matchesTarget target operation) then
+                invalidArg (nameof operation) "The Working Directory Update operation must match its target."
+
+            let operationValue = WorkingDirectoryUpdate.Operation.value operation
+
+            let callerKind =
+                WorkingDirectoryUpdate.Operation.callerKind operation
+                |> workingDirectoryUpdateCallerKindValue
+
+            let targetCanonical = WorkingDirectoryUpdate.Target.canonical target
+
+            do! ensureDbInitialized dbPath
 
             return!
                 executeWithRetry (fun () ->
                     task {
-                        let connection = openConnection dbPath
+                        use connection = openConnection dbPath
+                        executeNonQuery connection "BEGIN IMMEDIATE;"
 
                         try
-                            executeNonQuery connection "BEGIN IMMEDIATE;"
+                            use currentCommand = connection.CreateCommand()
 
-                            try
-                                let knownDirectoryIds = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                            currentCommand.CommandText <-
+                                "SELECT finalization_state FROM working_directory_update_completions WHERE operation_value = $operation_value AND caller_kind = $caller_kind AND target_canonical = $target_canonical LIMIT 1;"
 
-                                use knownDirectoryIdsCommand = connection.CreateCommand()
-                                knownDirectoryIdsCommand.CommandText <- "SELECT directory_version_id FROM object_cache_directories;"
+                            currentCommand.Parameters.AddWithValue("$operation_value", operationValue)
+                            |> ignore
 
-                                use knownDirectoryIdsReader = knownDirectoryIdsCommand.ExecuteReader()
+                            currentCommand.Parameters.AddWithValue("$caller_kind", callerKind)
+                            |> ignore
 
-                                while knownDirectoryIdsReader.Read() do
-                                    knownDirectoryIds.Add(knownDirectoryIdsReader.GetString(0))
-                                    |> ignore
+                            currentCommand.Parameters.AddWithValue("$target_canonical", targetCanonical)
+                            |> ignore
 
-                                use directoryCommand = connection.CreateCommand()
+                            match currentCommand.ExecuteScalar() with
+                            | :? string as "Terminal" ->
+                                executeNonQuery connection "COMMIT;"
+                                return ()
+                            | :? string as "Pending" ->
+                                executeNonQueryWithParams
+                                    connection
+                                    "DELETE FROM working_directory_update_completions WHERE caller_kind = $caller_kind AND finalization_state = 'Terminal';"
+                                    (fun parameters ->
+                                        parameters.AddWithValue("$caller_kind", callerKind)
+                                        |> ignore)
 
-                                directoryCommand.CommandText <-
-                                    "INSERT INTO object_cache_directories (directory_version_id, relative_path, sha256_hash, blake3_hash, size_bytes, created_at_unix_ticks, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $blake3_hash, $size_bytes, $created_at, $last_write) ON CONFLICT(directory_version_id) DO UPDATE SET relative_path = excluded.relative_path, sha256_hash = excluded.sha256_hash, blake3_hash = excluded.blake3_hash, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
+                                use updateCommand = connection.CreateCommand()
 
-                                directoryCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
+                                updateCommand.CommandText <-
+                                    "UPDATE working_directory_update_completions SET finalization_state = 'Terminal' WHERE operation_value = $operation_value AND caller_kind = $caller_kind AND target_canonical = $target_canonical AND finalization_state = 'Pending';"
+
+                                updateCommand.Parameters.AddWithValue("$operation_value", operationValue)
                                 |> ignore
 
-                                directoryCommand.Parameters.Add("$relative_path", SqliteType.Text)
+                                updateCommand.Parameters.AddWithValue("$caller_kind", callerKind)
                                 |> ignore
 
-                                directoryCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
+                                updateCommand.Parameters.AddWithValue("$target_canonical", targetCanonical)
                                 |> ignore
 
-                                directoryCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
-                                |> ignore
+                                let updated = updateCommand.ExecuteNonQuery()
 
-                                directoryCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$created_at", SqliteType.Integer)
-                                |> ignore
-
-                                directoryCommand.Parameters.Add("$last_write", SqliteType.Integer)
-                                |> ignore
-
-                                use deleteChildrenCommand = connection.CreateCommand()
-
-                                deleteChildrenCommand.CommandText <-
-                                    "DELETE FROM object_cache_directory_children WHERE parent_directory_version_id = $parent_directory_version_id;"
-
-                                deleteChildrenCommand.Parameters.Add("$parent_directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                use insertChildCommand = connection.CreateCommand()
-
-                                insertChildCommand.CommandText <-
-                                    "INSERT INTO object_cache_directory_children (parent_directory_version_id, child_directory_version_id, ordinal) VALUES ($parent_directory_version_id, $child_directory_version_id, $ordinal) ON CONFLICT(parent_directory_version_id, child_directory_version_id) DO UPDATE SET ordinal = excluded.ordinal;"
-
-                                insertChildCommand.Parameters.Add("$parent_directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                insertChildCommand.Parameters.Add("$child_directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                insertChildCommand.Parameters.Add("$ordinal", SqliteType.Integer)
-                                |> ignore
-
-                                use deleteFilesCommand = connection.CreateCommand()
-                                deleteFilesCommand.CommandText <- "DELETE FROM object_cache_directory_files WHERE directory_version_id = $directory_version_id;"
-
-                                deleteFilesCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                use insertFileCommand = connection.CreateCommand()
-
-                                insertFileCommand.CommandText <-
-                                    "INSERT INTO object_cache_directory_files (directory_version_id, relative_path, sha256_hash, blake3_hash, is_binary, size_bytes, created_at_unix_ticks, uploaded_to_object_storage, last_write_time_utc_ticks) VALUES ($directory_version_id, $relative_path, $sha256_hash, $blake3_hash, $is_binary, $size_bytes, $created_at, $uploaded, $last_write) ON CONFLICT(directory_version_id, relative_path) DO UPDATE SET sha256_hash = excluded.sha256_hash, blake3_hash = excluded.blake3_hash, is_binary = excluded.is_binary, size_bytes = excluded.size_bytes, created_at_unix_ticks = excluded.created_at_unix_ticks, uploaded_to_object_storage = excluded.uploaded_to_object_storage, last_write_time_utc_ticks = excluded.last_write_time_utc_ticks;"
-
-                                insertFileCommand.Parameters.Add("$directory_version_id", SqliteType.Text)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$relative_path", SqliteType.Text)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$sha256_hash", SqliteType.Text)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$blake3_hash", SqliteType.Text)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$is_binary", SqliteType.Integer)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$size_bytes", SqliteType.Integer)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$created_at", SqliteType.Integer)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$uploaded", SqliteType.Integer)
-                                |> ignore
-
-                                insertFileCommand.Parameters.Add("$last_write", SqliteType.Integer)
-                                |> ignore
-
-                                // Pass 1: Ensure all directory rows exist before adding any FK-dependent rows.
-                                directoriesToUpsert
-                                |> Seq.iter (fun directory ->
-                                    let directoryVersionId = directory.DirectoryVersionId.ToString()
-                                    directoryCommand.Parameters["$directory_version_id"].Value <- directoryVersionId
-                                    directoryCommand.Parameters["$relative_path"].Value <- directory.RelativePath
-                                    directoryCommand.Parameters["$sha256_hash"].Value <- directory.Sha256Hash
-                                    directoryCommand.Parameters["$blake3_hash"].Value <- directory.Blake3Hash
-                                    directoryCommand.Parameters["$size_bytes"].Value <- directory.Size
-                                    directoryCommand.Parameters["$created_at"].Value <- directory.CreatedAt.ToUnixTimeTicks()
-                                    directoryCommand.Parameters["$last_write"].Value <- directory.LastWriteTimeUtc.Ticks
-                                    directoryCommand.ExecuteNonQuery() |> ignore
-
-                                    knownDirectoryIds.Add(directoryVersionId)
-                                    |> ignore)
-
-                                // Pass 2: Refresh child and file links for each upserted directory.
-                                directoriesToUpsert
-                                |> Seq.iter (fun directory ->
-                                    deleteChildrenCommand.Parameters["$parent_directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
-                                    deleteChildrenCommand.ExecuteNonQuery() |> ignore
-
-                                    deleteFilesCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
-                                    deleteFilesCommand.ExecuteNonQuery() |> ignore
-
-                                    directory.Directories
-                                    |> Seq.iteri (fun index childId ->
-                                        let childDirectoryVersionId = childId.ToString()
-
-                                        if knownDirectoryIds.Contains(childDirectoryVersionId) then
-                                            insertChildCommand.Parameters["$parent_directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
-                                            insertChildCommand.Parameters["$child_directory_version_id"].Value <- childDirectoryVersionId
-                                            insertChildCommand.Parameters["$ordinal"].Value <- index
-                                            insertChildCommand.ExecuteNonQuery() |> ignore
-                                        else
-                                            invalidOp
-                                                $"Cannot upsert object cache because child DirectoryVersionId {childDirectoryVersionId} is missing. Parent DirectoryVersionId: {directory.DirectoryVersionId}.")
-
-                                    directory.Files
-                                    |> Seq.iter (fun file ->
-                                        insertFileCommand.Parameters["$directory_version_id"].Value <- directory.DirectoryVersionId.ToString()
-                                        insertFileCommand.Parameters["$relative_path"].Value <- file.RelativePath
-                                        insertFileCommand.Parameters["$sha256_hash"].Value <- file.Sha256Hash
-                                        insertFileCommand.Parameters["$blake3_hash"].Value <- file.Blake3Hash
-                                        insertFileCommand.Parameters["$is_binary"].Value <- if file.IsBinary then 1 else 0
-                                        insertFileCommand.Parameters["$size_bytes"].Value <- file.Size
-                                        insertFileCommand.Parameters["$created_at"].Value <- file.CreatedAt.ToUnixTimeTicks()
-                                        insertFileCommand.Parameters["$uploaded"].Value <- if file.UploadedToObjectStorage then 1 else 0
-                                        insertFileCommand.Parameters["$last_write"].Value <- file.LastWriteTimeUtc.Ticks
-                                        insertFileCommand.ExecuteNonQuery() |> ignore))
+                                if updated <> 1 then
+                                    invalidOp "The pending Working Directory Update completion changed before finalization."
 
                                 executeNonQuery connection "COMMIT;"
-                            with
-                            | ex ->
-                                executeNonQuery connection "ROLLBACK;"
-                                return raise ex
-                        finally
-                            connection.Dispose()
+                                return ()
+                            | null -> invalidOp "The Working Directory Update completion is missing."
+                            | value -> invalidOp $"Invalid Working Directory Update completion state '{value}'."
+                        with
+                        | ex ->
+                            executeNonQuery connection "ROLLBACK;"
+                            return raise ex
+                    })
+        }
+
+    /// Persists upsert object cache changes in the local SQLite state database.
+    let upsertObjectCache (dbPath: string) (newDirectoryVersions: IEnumerable<LocalDirectoryVersion>) =
+        task {
+            do! ensureDbInitialized dbPath
+
+            let directoriesToUpsert =
+                if isNull (box newDirectoryVersions) then
+                    invalidArg (nameof newDirectoryVersions) "Object-cache directory metadata must not be null."
+                else
+                    newDirectoryVersions |> Seq.toArray
+
+            return!
+                executeWithRetry (fun () ->
+                    task {
+                        use connection = openConnection dbPath
+                        executeNonQuery connection "BEGIN IMMEDIATE;"
+
+                        try
+                            upsertObjectCacheRows connection directoriesToUpsert
+                            executeNonQuery connection "COMMIT;"
+                        with
+                        | ex ->
+                            executeNonQuery connection "ROLLBACK;"
+                            return raise ex
                     })
         }
 

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -3055,7 +3055,7 @@ module LocalStateDb =
         (objectCacheDirectories: LocalDirectoryVersion array)
         (target: WorkingDirectoryUpdate.Target)
         (operation: WorkingDirectoryUpdate.Operation)
-        (connectCursor: string option)
+        (connectIdentity: (string * WorkingDirectoryUpdate.LocalRootScope) option)
         =
         if not (WorkingDirectoryUpdate.Operation.matchesTarget target operation) then
             invalidArg (nameof operation) "The Working Directory Update operation must match its target."
@@ -3092,11 +3092,15 @@ module LocalStateDb =
             ()
         | _ -> invalidArg (nameof objectCacheDirectories) "Working Directory Update object metadata must contain the exact target root once."
 
-        match WorkingDirectoryUpdate.Operation.callerKind operation, connectCursor with
-        | WorkingDirectoryUpdate.CallerKind.Connect, Some cursor when not (String.IsNullOrWhiteSpace(cursor)) -> ()
-        | WorkingDirectoryUpdate.CallerKind.Connect, _ -> invalidArg (nameof connectCursor) "Connect completion requires its exact initial cursor."
+        match WorkingDirectoryUpdate.Operation.callerKind operation, connectIdentity with
+        | WorkingDirectoryUpdate.CallerKind.Connect, Some (cursor, localRootScope) when not (String.IsNullOrWhiteSpace(cursor)) ->
+            match WorkingDirectoryUpdate.Operation.connectBootstrap target cursor localRootScope with
+            | Ok expectedOperation when WorkingDirectoryUpdate.Operation.value expectedOperation = WorkingDirectoryUpdate.Operation.value operation -> ()
+            | _ -> invalidArg (nameof operation) "Connect completion identity must exactly match its target, initial cursor, and local-root scope."
+        | WorkingDirectoryUpdate.CallerKind.Connect, _ ->
+            invalidArg (nameof connectIdentity) "Connect completion requires its exact initial cursor and local-root scope."
         | _, None -> ()
-        | _ -> invalidArg (nameof connectCursor) "Only Connect completion may persist a cursor."
+        | _ -> invalidArg (nameof connectIdentity) "Only Connect completion may persist a cursor and local-root scope."
 
     /// Coordinates local SQLite state for replace status snapshot, including Grace status, object cache, or watch metadata.
     let private replaceStatusSnapshotWithRevisionCore
@@ -3104,7 +3108,7 @@ module LocalStateDb =
         (graceStatus: GraceStatus)
         (boundary: ReferenceMaterializationBoundaryDto option)
         (objectCacheDirectories: LocalDirectoryVersion array)
-        (completion: (WorkingDirectoryUpdate.Target * WorkingDirectoryUpdate.Operation * string option) option)
+        (completion: (WorkingDirectoryUpdate.Target * WorkingDirectoryUpdate.Operation * (string * WorkingDirectoryUpdate.LocalRootScope) option) option)
         (cancellationToken: CancellationToken)
         (repairBaseline: LocalStateRepairBaseline option)
         (beforeWriteClaim: unit -> unit)
@@ -3127,8 +3131,8 @@ module LocalStateDb =
             | _ -> ()
 
             match completion with
-            | Some (target, operation, connectCursor) ->
-                validateWorkingDirectoryUpdateCompletionInput graceStatus objectCacheDirectories target operation connectCursor
+            | Some (target, operation, connectIdentity) ->
+                validateWorkingDirectoryUpdateCompletionInput graceStatus objectCacheDirectories target operation connectIdentity
             | None -> ()
 
             cancellationToken.ThrowIfCancellationRequested()
@@ -3307,7 +3311,7 @@ module LocalStateDb =
                             | None -> ()
 
                             match completion with
-                            | Some (target, operation, connectCursor) ->
+                            | Some (target, operation, connectIdentity) ->
                                 let operationValue = WorkingDirectoryUpdate.Operation.value operation
 
                                 let operationCallerKind = WorkingDirectoryUpdate.Operation.callerKind operation
@@ -3332,8 +3336,8 @@ module LocalStateDb =
                                 if not (isNull (pendingCommand.ExecuteScalar())) then
                                     invalidOp "A different Working Directory Update finalization is already pending."
 
-                                match connectCursor with
-                                | Some cursor ->
+                                match connectIdentity with
+                                | Some (cursor, _) ->
                                     executeNonQueryWithParams
                                         connection
                                         "INSERT OR REPLACE INTO remote_reference_boundaries (repository_id, branch_id, root_directory_version_id, root_directory_sha256_hash, root_directory_blake3_hash, event_cursor) VALUES ($repository_id, $branch_id, $root_id, $root_sha256_hash, $root_blake3_hash, $event_cursor);"
@@ -3724,12 +3728,12 @@ module LocalStateDb =
             return ()
         }
 
-    /// Atomically stores exact local status, object metadata, an optional Connect cursor, and its bounded update completion.
+    /// Atomically stores exact local facts and a bounded completion after proving optional Connect cursor identity.
     let internal commitWorkingDirectoryUpdateCompletion
         (dbPath: string)
         (graceStatus: GraceStatus)
         (objectCacheDirectories: IEnumerable<LocalDirectoryVersion>)
-        (connectCursor: string option)
+        (connectIdentity: (string * WorkingDirectoryUpdate.LocalRootScope) option)
         (target: WorkingDirectoryUpdate.Target)
         (operation: WorkingDirectoryUpdate.Operation)
         =
@@ -3744,18 +3748,18 @@ module LocalStateDb =
             graceStatus
             None
             directories
-            (Some(target, operation, connectCursor))
+            (Some(target, operation, connectIdentity))
             CancellationToken.None
             None
             ignore
             ignore
 
-    /// Commits a pending update completion through an injected pre-commit seam used by deterministic rollback proof.
+    /// Commits update completion through an injected pre-commit seam used by deterministic rollback proof.
     let internal commitWorkingDirectoryUpdateCompletionWithBeforeCommit
         (dbPath: string)
         (graceStatus: GraceStatus)
         (objectCacheDirectories: IEnumerable<LocalDirectoryVersion>)
-        (connectCursor: string option)
+        (connectIdentity: (string * WorkingDirectoryUpdate.LocalRootScope) option)
         (target: WorkingDirectoryUpdate.Target)
         (operation: WorkingDirectoryUpdate.Operation)
         (beforeCommit: unit -> unit)
@@ -3771,7 +3775,7 @@ module LocalStateDb =
             graceStatus
             None
             directories
-            (Some(target, operation, connectCursor))
+            (Some(target, operation, connectIdentity))
             CancellationToken.None
             None
             ignore

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -21,7 +21,7 @@ open SQLitePCL
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let SchemaVersion = "11"
+    let SchemaVersion = "10"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]


### PR DESCRIPTION
# Pull Request

## Linked issue

Related to #838

## Why this matters

The shared Working Directory Update transaction needs one local irreversible point. This slice keeps status, verified
object metadata, optional Connect cursor, and bounded completion aligned across crashes and restarts instead of leaving
callers to infer success from partially written state.

## Summary

- Replaces the development local-state schema with version 10 and adds bounded Working Directory Update completion.
- Commits exact status, verified root-object metadata, optional Connect cursor, and completion in one SQLite transaction.
- Retains one pending finalization plus the latest terminal row per caller; pending evidence is never pruned.
- Keeps Branch and Watch pending for later finalization while Connect cursor completion is terminal in the same commit.
- Proves pre-commit rollback, restart readback, strict identity, per-caller supersession, pending retention, and schema
  reset behavior.
- Moves the existing #837 contract compile item before local state so SQLite can consume the typed identity directly.

## Touched paths

- `src/Grace.CLI/Grace.CLI.fsproj`
- `src/Grace.CLI/LocalStateDb.CLI.fs`
- `src/Grace.CLI.Tests/LocalStateDb.Tests.fs`
- `src/Grace.CLI.Tests/Doctor.CLI.Tests.fs`

## Owned-path compliance

- [x] Changed paths match #838's corrected owned paths.
- [x] The project-file edit only moves the existing #837 contract before local state and preserves #839's ordering.
- [x] No caller, marker/lease, working-file mutation, public output, or migration/compatibility path changed.

## Validation profile and public-boundary evidence

- Validation profile: `domain-contract`
- Stable seam: private typed local-completion transaction and bounded readback APIs.
- RED: focused completion/restart proof failed before the schema and transaction API existed.
- GREEN: Release build passed and the complete LocalStateDb fixture passed 124 with one platform-only skip.

## Minimum detail gate evidence

- Invariant: exact repository/root/caller/operation/target status, object metadata, optional cursor, and completion commit
  together or not at all.
- Positive proof: atomic readback after a real-file restart, Connect cursor, one pending plus latest terminal retention.
- Negative proof: injected pre-commit failure leaves no partial facts; one-hash and exact-root mismatches reject.
- Regression proof: a new Branch terminal does not prune Watch; pending survives newer operations.
- Boundary proof: mismatched development schemas reset to v10; development data is not migrated or dual-read.
- Forbidden shapes: no running row, split cursor/completion write, pending prune, expiry, migration, marker, finalizer, or
  working-file mutation.

## State revalidation

- Source before decision: typed #837 target and operation plus verified exact root-object metadata.
- Revalidation point: complete operation/target and object identity are checked before the SQLite transaction commits.
- Abort state: validation or injected pre-commit failure rolls back the entire transaction.
- Retry/cleanup: restart reads the same bounded completion; no partial row or compatibility state is retained.

## Test coverage changes

- [x] LocalStateDb tests cover atomicity, restart, strict identity, retention, supersession, cursor, and reset boundaries.

## Docs impact

- [x] No public documentation change; this private enabling slice adds XML documentation for its new declarations.

## Local focused evidence

- [x] Fantomas is clean on touched F# files.
- [x] Release build passed with 0 warnings and 0 errors.
- [x] Complete LocalStateDb fixture passed 125, skipped 1 platform-only case, failed 0.
- [x] Both owned Doctor schema-diagnostic cases passed 1/1.
- [x] Staged diff check passed.

## Optional local broad preflight

- [x] Neither Fast nor Full was run; focused Release proof is the local gate and GitHub `Validate` is the broad
  current-head gate.

## Required CI evidence

- Current head SHA: `7e19639fc0cf69b6e1f4b7747b76438e41c84e62`
- GitHub `Validate` state: passed on attempt 2
- GitHub Actions run link: [Validate 31550280221 attempt 2](https://github.com/ScottArbeit/Grace/actions/runs/31550280221/attempts/2)
- [x] The result remains associated with the latest PR revision.

## Validation not run

None.

## Residual risks

The engine and caller leaves still own when to invoke this private transaction and how to finalize pending Branch/Watch
progress. This slice intentionally provides no general operation history or automatic recovery.

## Review Status

- Worker starts: 3/4.
- Current head SHA: `7e19639fc0cf69b6e1f4b7747b76438e41c84e62`
- Active worker: complete
- Fresh review subagent: session 3 approved, `gpt-5.6-sol`, high reasoning, Fast mode inherited from user configuration
- `dev-process/CODE_REVIEW.md` followed: yes
- Review verdict: approve, with no substantive findings
- Required checks: Validate 31550280221 attempt 2 passed
- [x] Review and required checks both completed successfully for the same head SHA.
- Finding dispositions: session-1 findings closed in `f46a00e4`; session-2 schema-number correction completed in
  `7e19639f`; session 3 approved the complete exact-head diff. Unrelated Watch and Server timing failures were not
  routed to this branch; the same-head rerun passed.

## Review/fix prevention

- Root-cause classes: incomplete restart payload, false-positive cursor atomicity proof, and schema propagation drift.
- Prevention: issue #838 now requires typed Branch/Watch pending reconstruction, a cursor-active Connect rollback plus
  reopened success proof, direct repository/root mismatch cases, schema diagnostics derived from version 10, and one
  clean v9-to-v10 replacement without intermediate unshipped generations.

## Rollback or recovery notes

No production data exists. Reverting the commit returns the development schema to version 9; the next local open resets
the development database according to the active schema contract.

## Docs follow-up required

None for this private storage slice; engine and caller issues own behavior documentation.
