### PR TITLE
[Superseded] Deliver Working Directory Update through grace switch

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -144,10 +144,10 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
 - Total leaf commands: `207`
-- JSON-ready routed commands: `186`
+- JSON-ready routed commands: `187`
 - Conditionally JSON-ready routed commands: `1`
 - Intentionally human-only commands: `0`
-- Deferred routed commands with explicit V2 scope: `11`
+- Deferred routed commands with explicit V2 scope: `10`
 - Source-only/unrouted commands: `9`
 - Deleted commands: `0`
 
@@ -174,7 +174,6 @@ metadata and V2 scope because their success paths still need migration before Gr
 
 - `branch.rebase`
 - `branch.status`
-- `branch.switch`
 - `diff.checkpoint`
 - `diff.commit`
 - `diff.directoryid`
@@ -231,20 +230,27 @@ grace --output Json doctor --select Status
 grace watch --check --select Mode
 ```
 
-## Planned Working Directory Update outcomes
+## Working Directory Update outcomes
 
-The Plan-ready [Working Directory Update specification](Working%20Directory%20Update.md) defines a typed local-update
-outcome for Branch switching, Connect retrieval, and Watch diagnostics. `Unchanged` and `Updated` return exit code `0`;
-`Rejected`, `UpdateIncomplete`, and `FinalizationIncomplete` return nonzero. `FinalizationIncomplete` states that the
-working directory was updated and includes `grace doctor --repair-local-state` as the recommended command.
+`grace branch switch` returns the normal `GraceReturnValue<string>` JSON envelope for `Updated` and `Unchanged`.
+Both return exit code `0`. `Rejected`, `UpdateIncomplete`, and `FinalizationIncomplete` return a `GraceError` JSON
+envelope and a nonzero exit code. The error text begins with the corresponding outcome name.
 
-When implemented, Connect output will distinguish successful repository configuration from its optional update result.
-`branch.switch` will leave the V2 deferral list only when its stable outcome DTO, schema, example, selection behavior,
-and exit-code proof are complete. Foreground Watch remains a continuous command; its existing check projection and
-human diagnostics will report blocked update state without emitting a second JSON document.
+`FinalizationIncomplete` means the working-directory bytes were updated, while the final Branch identity action did
+not complete. It always recommends this explicit recovery command:
 
-This is an accepted future contract. The inventory and deferral counts above remain the current executable inventory
-until implementation changes the command registry.
+```powershell
+grace doctor --repair-local-state
+```
+
+```bash
+grace doctor --repair-local-state
+```
+
+The Branch selection inputs remain unchanged: Branch or Reference selection can transition the active Branch after
+local completion; SHA-256 or BLAKE3 selection applies the selected exact root while keeping the current Branch active.
+Foreground Watch remains a continuous command; its existing check projection and human diagnostics report blocked
+update state without emitting a second JSON document.
 
 ## V2 Deferrals
 

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -73,7 +73,7 @@ remote retrieval, scheduling, and presentation policies where they belong.
 | `src/Grace.CLI/Command/Branch.CLI.fs` | Branch owns a workflow lease, Watch-clean preflight, marker handling, working-directory updates, local status, branch identity, and cache refresh. | Branch is the first public tracer and has a real post-update finalizer. | Current source around `runBranchSwitchWorkflowWithLease` and `updateWorkingDirectory`. |
 | `src/Grace.CLI/Command/Watch.CLI.fs` | Watch has private plan/apply clients, an object-cache apply path, marker sidecars, serialized replay, and cursor acknowledgement. | Watch supplies the most demanding ordering and retry scenarios. | Current source around `CurrentBranchRemoteMaterializationPlan`, `applyCurrentBranchMaterializationTargets`, and cursor replay. |
 | `src/Grace.CLI/Command/Connect.CLI.fs` | Connect writes configuration before optional retrieval, streams a server zip, writes working and object files together, and ignores undeclared zip files. | The design preserves zip retrieval while replacing extraction, verification, and outcome behavior. | Current source around `extractZipEntries` and `connectImpl`. |
-| `src/Grace.CLI/LocalStateDb.CLI.fs` | Schema version 9 stores status, object-cache metadata, and remote-reference boundaries. Boundary writes require complete root identity matching. | Schema replacement adds bounded update completion rows and extends atomic commit operations. | Current source around `replaceStatusSnapshotWithRevisionCore` and cursor operations. |
+| `src/Grace.CLI/LocalStateDb.CLI.fs` | Schema version 11 stores status, object-cache metadata, remote-reference boundaries, and bounded completion rows. Boundary writes require complete root identity matching. | A clean development-only schema replacement persists typed Branch selector facts and extends atomic commit operations. | Current source around `replaceStatusSnapshotWithRevisionCore` and cursor operations. |
 | `src/Grace.CLI/Command/Doctor.CLI.fs` | `--repair-local-state` proves an unchanged working tree against server root and branch history before atomic reconstruction. | Doctor is the sole explicit recovery gesture and will gain recorded-finalization retry. | Current source around `repairLocalState`. |
 | `src/Grace.Types/Reference.Types.fs` | `ReferenceMaterializationBoundaryDto` combines target root identity with an event cursor. | The internal update target must separate root identity from caller progress. | Current source at `ReferenceMaterializationBoundaryDto`. |
 | `src/Grace.CLI/Grace.CLI.fsproj` | Connect currently compiles before the shared module. | The new module and adapters must compile before Connect, Branch, Watch, and Doctor. | Current project file. |
@@ -127,6 +127,7 @@ termination and manual intervention when interrupted bytes match no known server
 | DEC-014 | architecture | accepted | The same deterministic operation may adopt a known orphaned marker after lease acquisition and fresh replanning. | Separate operation ID from random attempt token. | Same, different, malformed, and completed marker tests. |
 | DEC-015 | product | accepted | Incomplete outcomes use nonzero exit status; `FinalizationIncomplete` says bytes were updated and recommends Doctor. | Add typed human and machine projections. | Exit-code, JSON, and no-mixed-output proof. |
 | DEC-016 | proof | accepted | `grace switch` is the first value-bearing tracer. | Build the core module through one object-backed Branch path before Watch and Connect migration. | Public tracer proves the shared transaction and finalization. |
+| DEC-017 | product | accepted | A Branch request selected by branch name, branch ID, or Reference uses `Reference(referenceId)` and may transition branch identity. A request selected by SHA-256 or BLAKE3 uses `DirectoryVersion`, bound by its exact target root; it keeps the current branch identity and has no Reference ID. | Persist selector kind and the optional Reference ID, and reconstruct the same typed facts for retry. Replace the development-only local schema cleanly at version 11. | Prove both selector forms, including equivalent hash prefixes resolving to one operation and reopen of both persisted shapes. |
 
 ### Capability inventory
 
@@ -162,7 +163,9 @@ The deterministic caller-specific tuple that distinguishes retry, stale work, an
 canonical serialization of the tuple. Correlation IDs are diagnostic and do not affect idempotency.
 
 - Watch: caller kind, repository, branch, and exact event cursor.
-- Branch: caller kind, repository, previous branch, selected branch, selected Reference, and target root.
+- Branch `Reference(referenceId)`: caller kind, repository, previous branch, selected branch, selected Reference, and target root.
+- Branch `DirectoryVersion`: caller kind, repository, current branch, selector kind, and target root. SHA-256 and BLAKE3
+  prefixes that resolve to that same exact root are the same operation.
 - Connect: caller kind, repository, selected branch, target root, initial cursor, and local root scope.
 
 ### Attempt token
@@ -182,8 +185,10 @@ cursor when applicable, and the operation completion row. This is the irreversib
 
 ### Finalization
 
-An idempotent caller action performed after local completion while the lease remains held. Branch persists selected
-branch identity. Watch advances the exact cursor. Connect ordinarily has no separate finalization.
+An idempotent caller action performed after local completion while the lease remains held. A Reference-selected Branch
+persists the selected branch identity. A DirectoryVersion-selected Branch verifies that the current branch remains
+unchanged and never publishes branch identity. Watch advances the exact cursor. Connect ordinarily has no separate
+finalization.
 
 ### Local root scope
 
@@ -194,10 +199,13 @@ lease, marker, and sidecar files. It is not a DirectoryVersion identity.
 
 ### Successful Branch tracer
 
-Branch completes admission and content preparation, constructs a deterministic request, and calls `run`. The module
+Branch completes admission and content preparation, constructs a deterministic request, and calls `run`. A branch or
+Reference selection creates `Reference(referenceId)`; a SHA-256 or BLAKE3 selection creates `DirectoryVersion` bound
+to the resolved target root. The module
 acquires the lease, revalidates selection and clean local state, plans from current bytes, marks, applies from verified
 objects, verifies the target, commits local completion, removes the marker, and finalizes selected branch identity.
-The command returns `Updated` with exit code 0.
+The Reference form transitions branch identity. The DirectoryVersion form keeps the current branch identity. The command
+returns `Updated` with exit code 0.
 
 ### Already-matching target
 

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -212,6 +212,14 @@ returns `Updated` with exit code 0.
 If current working bytes and status already match the target, the module performs no filesystem mutation. The same
 operation returns its existing completion; a new operation receives its own local completion and finalization.
 
+### Branch outcome projection
+
+`grace branch switch` projects `Updated` and `Unchanged` as successful human text or a single
+`GraceReturnValue<string>` JSON envelope, with exit code `0`. `Rejected`, `UpdateIncomplete`, and
+`FinalizationIncomplete` project their outcome name and reason through the normal human error or `GraceError` JSON
+envelope, with a nonzero exit code. `FinalizationIncomplete` states that working-directory bytes were updated and
+recommends exactly `grace doctor --repair-local-state`.
+
 ### Watch replay
 
 Watch retains replay admission and server ordering. The module applies one selected Reference from verified object

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -11,6 +11,7 @@ open Grace.Shared.Utilities
 open Grace.Shared.Validation.Errors
 open Grace.Types.Annotation
 open Grace.Types.Common
+open Grace.Types.DirectoryVersion
 open Grace.Types.Reference
 open Microsoft.Data.Sqlite
 open NodaTime
@@ -174,23 +175,15 @@ module BranchCommandTests =
 
             deleteTempDirectory 10
 
-    /// Runs an in-process HTTP endpoint that responds to selector reads and records the production SDK requests.
-    let private withSwitchRequestCapture (currentBranch: Grace.Types.Branch.BranchDto) (action: (unit -> string list) -> unit) =
+    /// Runs a bounded in-process HTTP endpoint for production Branch switch parser and dispatch fixtures.
+    let private withSwitchRequestFixture (responseForRequest: string -> int * string * string) (action: (unit -> string list) -> unit) =
         use listener = new TcpListener(IPAddress.Loopback, 0)
         use cancellation = new CancellationTokenSource()
         listener.Start()
         let requests = ResizeArray<string>()
         let correlationId = "branch-switch-built-fixture"
 
-        let successfulBranch =
-            GraceReturnValue.Create currentBranch correlationId
-            |> serialize
-
-        let rejectedRequest =
-            GraceError.Create "fixture stops after selector dispatch" correlationId
-            |> serialize
-
-        /// Writes successful current-Branch reads and terminates the selected-version request after it is observed.
+        /// Writes one deterministic SDK response for each production request the fixture observes.
         let writeResponse (client: TcpClient) =
             task {
                 use client = client
@@ -213,10 +206,14 @@ module BranchCommandTests =
                 requests.Add(requestText)
 
                 let statusCode, reasonPhrase, body =
-                    if requestText.Contains("POST /branch/GetVersion", StringComparison.Ordinal) then
-                        400, "Bad Request", rejectedRequest
-                    else
-                        200, "OK", successfulBranch
+                    try
+                        responseForRequest requestText
+                    with
+                    | ex ->
+                        500,
+                        "Fixture Error",
+                        (GraceError.Create $"fixture response failed: {ex.Message}" correlationId
+                         |> serialize)
 
                 let bodyBytes = Encoding.UTF8.GetBytes(body)
 
@@ -228,11 +225,11 @@ module BranchCommandTests =
                 do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length, cancellation.Token)
             }
 
-        /// Serves one SDK request at a time until the fixture is disposed.
+        /// Serves a bounded sequence of SDK requests and shuts down without an unbounded accept loop.
         let rec serve requestNumber =
             task {
                 if not cancellation.IsCancellationRequested
-                   && requestNumber < 6 then
+                   && requestNumber < 16 then
                     try
                         let! client =
                             listener
@@ -263,6 +260,26 @@ module BranchCommandTests =
 
             if not (serverTask.Wait(TimeSpan.FromSeconds(5.0))) then
                 Assert.Fail("Timed out waiting for the branch switch HTTP fixture to stop.")
+
+    /// Records selector traffic and refuses after the selected-version request without allowing the update path to run.
+    let private withSwitchRequestCapture (currentBranch: Grace.Types.Branch.BranchDto) (action: (unit -> string list) -> unit) =
+        let correlationId = "branch-switch-built-fixture"
+
+        let successfulBranch =
+            GraceReturnValue.Create currentBranch correlationId
+            |> serialize
+
+        let rejectedRequest =
+            GraceError.Create "fixture stops after selector dispatch" correlationId
+            |> serialize
+
+        withSwitchRequestFixture
+            (fun requestText ->
+                if requestText.Contains("POST /branch/GetVersion", StringComparison.Ordinal) then
+                    400, "Bad Request", rejectedRequest
+                else
+                    200, "OK", successfulBranch)
+            action
 
     /// Drives the production CLI parser and dispatch through a selector until the fixture rejects the selected-version request.
     let private invokeSwitchSelector selectorArguments =
@@ -360,6 +377,167 @@ module BranchCommandTests =
 
                 selectedVersionRequest.Value
                 |> should contain hashPrefix))
+
+    /// Proves an explicit Reference crosses the production parser and dispatch path, commits its exact root, and only then changes Branch identity.
+    [<Test>]
+    [<Category("BranchSwitchSelectorFixture")>]
+    let ``built switch Reference selection applies the exact target then changes Branch identity`` () =
+        withTempBranchSwitchRepo (fun () ->
+            let targetBranchId = Guid.NewGuid()
+            let targetRootDirectoryId = Guid.NewGuid()
+            let targetReferenceId = Guid.NewGuid()
+
+            let targetRoot =
+                DirectoryVersion.CreateWithHashes
+                    targetRootDirectoryId
+                    ownerId
+                    organizationId
+                    repositoryId
+                    Constants.RootDirectoryPath
+                    (Grace.Shared.Services.computeSha256ForDirectoryEntries Constants.RootDirectoryPath Seq.empty)
+                    (Grace.Shared.Services.computeBlake3ForDirectory Constants.RootDirectoryPath Seq.empty)
+                    (List<DirectoryVersionId>())
+                    (List<FileVersion>())
+                    0L
+
+            let targetReference =
+                { ReferenceDto.Default with
+                    ReferenceId = targetReferenceId
+                    OwnerId = ownerId
+                    OrganizationId = organizationId
+                    RepositoryId = repositoryId
+                    BranchId = targetBranchId
+                    DirectoryId = targetRootDirectoryId
+                    Sha256Hash = targetRoot.Sha256Hash
+                    Blake3Hash = targetRoot.Blake3Hash
+                }
+
+            let currentBranch =
+                { Grace.Types.Branch.BranchDto.Default with
+                    OwnerId = ownerId
+                    OrganizationId = organizationId
+                    RepositoryId = repositoryId
+                    BranchId = branchId
+                    BranchName = Grace.Types.Common.BranchName "branch-switch-current"
+                    SaveEnabled = false
+                }
+
+            let targetBranch =
+                { currentBranch with
+                    BranchId = targetBranchId
+                    BranchName = Grace.Types.Common.BranchName "branch-switch-target"
+                    LatestReference = targetReference
+                }
+
+            let configuration = Current()
+            configuration.OwnerId <- ownerId
+            configuration.OrganizationId <- organizationId
+            configuration.RepositoryId <- repositoryId
+            configuration.BranchId <- branchId
+            configuration.BranchName <- "branch-switch-current"
+
+            LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            let initialRootDirectoryId = Guid.NewGuid()
+
+            let initialRoot =
+                LocalDirectoryVersion.CreateWithHashes
+                    initialRootDirectoryId
+                    ownerId
+                    organizationId
+                    repositoryId
+                    Constants.RootDirectoryPath
+                    targetRoot.Sha256Hash
+                    targetRoot.Blake3Hash
+                    (List<DirectoryVersionId>())
+                    (List<LocalFileVersion>())
+                    0L
+                    DateTime.UtcNow
+
+            let initialIndex = GraceIndex()
+
+            initialIndex.TryAdd(initialRootDirectoryId, initialRoot)
+            |> ignore
+
+            { GraceStatus.Default with
+                Index = initialIndex
+                RootDirectoryId = initialRootDirectoryId
+                RootDirectorySha256Hash = initialRoot.Sha256Hash
+                RootDirectoryBlake3Hash = initialRoot.Blake3Hash
+            }
+            |> LocalStateDb.replaceStatusSnapshot configuration.GraceStatusFile
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            writeBranchSwitchWatchStatus (Services.IpcFileName()) (branchSwitchWatchStatus ())
+            let correlationId = "branch-switch-built-fixture"
+            let mutable branchGetCount = 0
+
+            let response value =
+                GraceReturnValue.Create value correlationId
+                |> serialize
+
+            withSwitchRequestFixture
+                (fun request ->
+                    if request.Contains("POST /branch/GetReference", StringComparison.Ordinal) then
+                        200, "OK", response targetReference
+                    elif request.Contains("POST /branch/GetVersion", StringComparison.Ordinal) then
+                        200, "OK", response [| targetRootDirectoryId |]
+                    elif request.Contains("POST /directory/GetByDirectoryIds", StringComparison.Ordinal) then
+                        200, "OK", response [| { DirectoryVersionDto.Default with DirectoryVersion = targetRoot } |]
+                    elif request.Contains("POST /branch/Get", StringComparison.Ordinal) then
+                        branchGetCount <- branchGetCount + 1
+
+                        if branchGetCount = 1 then
+                            200, "OK", response currentBranch
+                        else
+                            200, "OK", response targetBranch
+                    else
+                        200, "OK", response currentBranch)
+                (fun getRequests ->
+                    let exitCode, output =
+                        captureOutput (fun () ->
+                            GraceCommand.main [| "branch"
+                                                 "switch"
+                                                 "--reference-id"
+                                                 targetReferenceId.ToString()
+                                                 "--output"
+                                                 "Normal" |])
+
+                    if exitCode <> 0 then
+                        Assert.Fail($"Expected the Reference switch fixture to complete, got: {output}")
+
+                    Current().BranchId |> should equal targetBranchId
+
+                    Current().BranchName
+                    |> should equal "branch-switch-target"
+
+                    let completedStatus =
+                        LocalStateDb.readStatusSnapshot configuration.GraceStatusFile
+                        |> fun task -> task.GetAwaiter().GetResult()
+
+                    completedStatus.RootDirectoryId
+                    |> should equal targetRootDirectoryId
+
+                    completedStatus.RootDirectorySha256Hash
+                    |> should equal targetRoot.Sha256Hash
+
+                    completedStatus.RootDirectoryBlake3Hash
+                    |> should equal targetRoot.Blake3Hash
+
+                    let requests = getRequests ()
+
+                    requests
+                    |> List.exists (fun request ->
+                        request.Contains("POST /branch/GetReference", StringComparison.Ordinal)
+                        && request.Contains(targetReferenceId.ToString(), StringComparison.Ordinal))
+                    |> should equal true
+
+                    requests
+                    |> List.exists (fun request ->
+                        request.Contains("POST /branch/GetVersion", StringComparison.Ordinal)
+                        && request.Contains(targetReferenceId.ToString(), StringComparison.Ordinal))
+                    |> should equal true))
 
     /// Wraps a status snapshot in the inspection shape consumed by branch switch preflight.
     let private branchSwitchWatchInspection persistedMode status =

--- a/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Branch.CLI.Tests.fs
@@ -12,13 +12,18 @@ open Grace.Shared.Validation.Errors
 open Grace.Types.Annotation
 open Grace.Types.Common
 open Grace.Types.Reference
+open Microsoft.Data.Sqlite
 open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
 open System.Collections.Generic
 open System.IO
+open System.Net
+open System.Net.Sockets
+open System.Text
 open System.Text.Json
+open System.Threading
 open System.Threading.Tasks
 
 /// Groups branch command coverage for the CLI test project.
@@ -156,10 +161,118 @@ module BranchCommandTests =
             resetConfiguration ()
             Services.parseResult <- originalParseResult
             Environment.CurrentDirectory <- originalDir
+            SqliteConnection.ClearAllPools()
 
-            if Directory.Exists(tempDir) then Directory.Delete(tempDir, true)
+            /// Retries deletion briefly while the local SQLite worker releases its test database handle.
+            let rec deleteTempDirectory remainingAttempts =
+                try
+                    if Directory.Exists(tempDir) then Directory.Delete(tempDir, true)
+                with
+                | :? IOException when remainingAttempts > 0 ->
+                    Thread.Sleep(100)
+                    deleteTempDirectory (remainingAttempts - 1)
 
-    /// Builds a trusted Watch IPC inspection snapshot for branch switch preflight tests.
+            deleteTempDirectory 10
+
+    /// Runs an in-process HTTP endpoint that responds to selector reads and records the production SDK requests.
+    let private withSwitchRequestCapture (currentBranch: Grace.Types.Branch.BranchDto) (action: (unit -> string list) -> unit) =
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        use cancellation = new CancellationTokenSource()
+        listener.Start()
+        let requests = ResizeArray<string>()
+        let correlationId = "branch-switch-built-fixture"
+
+        let successfulBranch =
+            GraceReturnValue.Create currentBranch correlationId
+            |> serialize
+
+        let rejectedRequest =
+            GraceError.Create "fixture stops after selector dispatch" correlationId
+            |> serialize
+
+        /// Writes successful current-Branch reads and terminates the selected-version request after it is observed.
+        let writeResponse (client: TcpClient) =
+            task {
+                use client = client
+                use stream = client.GetStream()
+                use requestBytes = new MemoryStream()
+                let buffer = Array.zeroCreate<byte> 8192
+                let mutable complete = false
+
+                while not complete do
+                    let! read = stream.ReadAsync(buffer, 0, buffer.Length, cancellation.Token)
+
+                    if read = 0 then
+                        complete <- true
+                    else
+                        requestBytes.Write(buffer, 0, read)
+                        let requestText = Encoding.UTF8.GetString(requestBytes.ToArray())
+                        complete <- requestText.Contains("\r\n\r\n", StringComparison.Ordinal)
+
+                let requestText = Encoding.UTF8.GetString(requestBytes.ToArray())
+                requests.Add(requestText)
+
+                let statusCode, reasonPhrase, body =
+                    if requestText.Contains("POST /branch/GetVersion", StringComparison.Ordinal) then
+                        400, "Bad Request", rejectedRequest
+                    else
+                        200, "OK", successfulBranch
+
+                let bodyBytes = Encoding.UTF8.GetBytes(body)
+
+                let headers =
+                    $"HTTP/1.1 {statusCode} {reasonPhrase}\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n"
+
+                let headerBytes = Encoding.ASCII.GetBytes(headers)
+                do! stream.WriteAsync(headerBytes, 0, headerBytes.Length, cancellation.Token)
+                do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length, cancellation.Token)
+            }
+
+        /// Serves one SDK request at a time until the fixture is disposed.
+        let rec serve requestNumber =
+            task {
+                if not cancellation.IsCancellationRequested
+                   && requestNumber < 6 then
+                    try
+                        let! client =
+                            listener
+                                .AcceptTcpClientAsync(cancellation.Token)
+                                .AsTask()
+
+                        do! writeResponse client
+                        return! serve (requestNumber + 1)
+                    with
+                    | :? OperationCanceledException -> return ()
+                    | :? ObjectDisposedException -> return ()
+            }
+
+        let serverTask = Task.Run(Func<Task>(fun () -> serve 0))
+        let endpoint = $"http://127.0.0.1:{(listener.LocalEndpoint :?> IPEndPoint).Port}"
+        let originalServerUri = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+
+        try
+            let configuration = Current()
+            configuration.ServerUri <- endpoint
+            updateConfiguration configuration
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri, endpoint)
+            action (fun () -> requests |> Seq.toList)
+        finally
+            Environment.SetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri, originalServerUri)
+            cancellation.Cancel()
+            listener.Stop()
+
+            if not (serverTask.Wait(TimeSpan.FromSeconds(5.0))) then
+                Assert.Fail("Timed out waiting for the branch switch HTTP fixture to stop.")
+
+    /// Drives the production CLI parser and dispatch through a selector until the fixture rejects the selected-version request.
+    let private invokeSwitchSelector selectorArguments =
+        GraceCommand.main (
+            Array.concat [ [| "branch"; "switch" |]
+                           selectorArguments
+                           [| "--output"; "Silent" |] ]
+        )
+
+    /// Builds a trusted Watch IPC snapshot needed by the production Branch switch admission path.
     let private branchSwitchWatchStatus () : GraceWatchStatus =
         let current = Current()
         let rootDirectoryId = Guid.NewGuid()
@@ -182,6 +295,72 @@ module BranchCommandTests =
             DirectoryIds = HashSet<DirectoryVersionId>([| rootDirectoryId |])
         }
 
+    /// Writes the production-compatible Watch IPC file that Branch switch reads before local mutation.
+    let private writeBranchSwitchWatchStatus (fileName: string) status =
+        Directory.CreateDirectory(Path.GetDirectoryName(fileName))
+        |> ignore
+
+        File.WriteAllText(fileName, serialize status)
+
+    /// Verifies SHA-256 and BLAKE3 selectors reach the production version lookup after current-Branch admission.
+    [<TestCase("--sha256-hash", "deadc0de")>]
+    [<TestCase("--blake3-hash", "beadfeed")>]
+    [<Category("BranchSwitchSelectorFixture")>]
+    let ``built switch selector dispatch preserves the supplied hash evidence`` optionName hashPrefix =
+        withTempBranchSwitchRepo (fun () ->
+            let configuration = Current()
+            configuration.OwnerId <- ownerId
+            configuration.OrganizationId <- organizationId
+            configuration.RepositoryId <- repositoryId
+            configuration.BranchId <- branchId
+
+            LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            writeBranchSwitchWatchStatus (Services.IpcFileName()) (branchSwitchWatchStatus ())
+
+            let currentBranch =
+                { Grace.Types.Branch.BranchDto.Default with
+                    RepositoryId = repositoryId
+                    BranchId = branchId
+                    BranchName = Grace.Types.Common.BranchName "branch-switch-current"
+                    SaveEnabled = false
+                }
+
+            let parsedSelector =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "branch"
+                        "switch"
+                        optionName
+                        hashPrefix
+                        "--output"
+                        "Silent"
+                    |]
+                )
+
+            parsedSelector.Errors.Count |> should equal 0
+
+            parsedSelector.GetValue<string>(optionName)
+            |> should equal hashPrefix
+
+            withSwitchRequestCapture currentBranch (fun getRequests ->
+                let exitCode =
+                    invokeSwitchSelector [| optionName
+                                            hashPrefix |]
+
+                exitCode |> should not' (equal 0)
+                let requests = getRequests ()
+
+                let selectedVersionRequest =
+                    requests
+                    |> List.tryFind (fun request -> request.Contains("POST /branch/GetVersion", StringComparison.Ordinal))
+
+                selectedVersionRequest.IsSome |> should equal true
+
+                selectedVersionRequest.Value
+                |> should contain hashPrefix))
+
     /// Wraps a status snapshot in the inspection shape consumed by branch switch preflight.
     let private branchSwitchWatchInspection persistedMode status =
         { Exists = true; Status = Some status; PersistedMode = persistedMode; SafetyFlags = status.SafetyFlags; ReadError = None }
@@ -189,13 +368,6 @@ module BranchCommandTests =
     /// Builds clean durable journal evidence for branch switch preflight tests.
     let private cleanPendingJournalSummary () : LocalStateDb.WatchJournalPendingWorkSummary =
         { DbPath = Current().GraceStatusFile; AppliedThroughSequence = 0L; PendingRowCount = 0L }
-
-    /// Writes a Watch IPC status snapshot for branch switch preflight tests.
-    let private writeBranchSwitchWatchStatus (fileName: string) status =
-        Directory.CreateDirectory(Path.GetDirectoryName(fileName))
-        |> ignore
-
-        File.WriteAllText(fileName, serialize status)
 
     /// Runs branch switch preflight with injected side effects and reports which effects occurred.
     let private runBranchSwitchPreflight markerExists inspection =

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -246,15 +246,14 @@ module CommandOutputContractRegistryTests =
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 186
+        |> should equal 187
 
         countBy ImmediateJsonErrorOnly |> should equal 0
 
         countBy ConditionalCheckStatusEnvelope
         |> should equal 1
 
-        countBy HumanProgressOnlySuccess
-        |> should equal 10
+        countBy HumanProgressOnlySuccess |> should equal 9
 
         countBy PartialManualSuccess |> should equal 0
         countBy ManualJsonUnenveloped |> should equal 0
@@ -297,10 +296,10 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 186
+        jsonReady |> should equal 187
         intentionallyHumanOnly |> should equal 0
         conditionalStatus |> should equal 1
-        deferredV2 |> should equal 11
+        deferredV2 |> should equal 10
         sourceOnly |> should equal 9
         deleted |> should equal 0
 
@@ -574,7 +573,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 186
+        commonEntries.Length |> should equal 187
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -592,7 +591,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 186
+        commonEntries.Length |> should equal 187
 
         let parserInvalidEntries =
             commonEntries
@@ -1054,7 +1053,7 @@ module CommandOutputContractRegistryTests =
                 | ConditionalGraceResultEnvelope _ -> true
                 | _ -> false)
 
-        eligibleEntries.Length |> should equal 187
+        eligibleEntries.Length |> should equal 188
 
         for entry in eligibleEntries do
             entry.ReturnValueContract.Status

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -264,7 +264,7 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND branch_selected_reference_id IS NOT NULL AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selection_kind TEXT NULL CHECK (branch_selection_kind IN ('Reference', 'DirectoryVersion')), branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND ((branch_selection_kind = 'Reference' AND branch_selected_reference_id IS NOT NULL) OR (branch_selection_kind = 'DirectoryVersion' AND branch_selected_reference_id IS NULL)) AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
 
         executeNonQuery
             connection
@@ -2222,6 +2222,41 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Proves a complete prior v10 database is replaced instead of being read through as the v11 typed-selector shape.
+    [<Test>]
+    let ``ensureDbInitialized cleanly recreates v10 local state for typed Branch selectors`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                seedSchemaVersionOnly configuration.GraceStatusFile "10"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                |> should equal "11"
+
+                let selectorColumn =
+                    use command = connection.CreateCommand()
+
+                    command.CommandText <-
+                        "SELECT COUNT(*) FROM pragma_table_info('working_directory_update_completions') WHERE name = 'branch_selection_kind';"
+
+                    command.ExecuteScalar() |> Convert.ToInt32
+
+                selectorColumn |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that ensure db initialized recreates db when schema v6 has a malformed Watch journal table.
     [<Test>]
     let ``ensureDbInitialized recreates DB when schema v6 watch journal shape is malformed`` () =
@@ -3850,7 +3885,7 @@ module LocalStateDbTests =
                 | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingBranchFinalization (persistedTarget,
                                                                                                           persistedOperation,
                                                                                                           persistedPreviousBranchId,
-                                                                                                          persistedSelectedReferenceId)) ->
+                                                                                                          persistedSelection)) ->
                     WorkingDirectoryUpdate.Target.canonical persistedTarget
                     |> should equal (WorkingDirectoryUpdate.Target.canonical target)
 
@@ -3860,8 +3895,8 @@ module LocalStateDbTests =
                     persistedPreviousBranchId
                     |> should equal previousBranchId
 
-                    persistedSelectedReferenceId
-                    |> should equal selectedReferenceId
+                    persistedSelection
+                    |> should equal (WorkingDirectoryUpdate.BranchSelection.Reference selectedReferenceId)
                 | _ -> failwith "Expected the persisted Branch finalizer after restart."
 
                 do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target branchOperation
@@ -3914,6 +3949,57 @@ module LocalStateDbTests =
 
                 Assert.ThrowsAsync<InvalidOperationException>(alteredRead)
                 |> ignore
+            })
+
+    /// Proves reopening a hash-selected Branch finalization retains its typed no-Reference selector.
+    [<Test>]
+    let ``working directory update pending finalization reconstructs DirectoryVersion Branch selection after restart`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "c")
+                let blake3Hash = Blake3Hash(String.replicate 64 "d")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 224L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let previousBranchId = configuration.BranchId
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion target
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization previousBranchId)
+                        target
+                        operation
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile
+
+                match pending with
+                | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingBranchFinalization (persistedTarget,
+                                                                                                          persistedOperation,
+                                                                                                          persistedPreviousBranchId,
+                                                                                                          WorkingDirectoryUpdate.BranchSelection.DirectoryVersion)) ->
+                    persistedPreviousBranchId
+                    |> should equal previousBranchId
+
+                    WorkingDirectoryUpdate.Target.canonical persistedTarget
+                    |> should equal (WorkingDirectoryUpdate.Target.canonical target)
+
+                    WorkingDirectoryUpdate.Operation.value persistedOperation
+                    |> should equal (WorkingDirectoryUpdate.Operation.value operation)
+                | _ -> failwith "Expected the persisted hash-selected Branch finalizer after restart."
             })
 
     /// Verifies Connect cursor progress and its terminal completion cannot commit separately from matching local facts.

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
@@ -114,6 +114,30 @@ module WorkingDirectoryUpdateContractsTests =
         |> Result.isError
         |> should equal true
 
+    /// Proves a hash-resolved target is a typed Branch operation without inventing a Reference identity.
+    [<Test>]
+    let ``DirectoryVersion Branch selection binds identity to the exact target rather than a hash prefix`` () =
+        let selectedTarget = selectedTarget ()
+        let previousBranchId = Guid.Parse("2c461ab1-72a0-42c3-9c2e-ea9c0c3b83de")
+
+        let sha256PrefixOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion selectedTarget
+            |> required
+
+        let blake3PrefixOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion selectedTarget
+            |> required
+
+        let referenceOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId (Guid.Parse("d9622ad2-552d-4ab1-996e-2d756af82047")) selectedTarget
+            |> required
+
+        WorkingDirectoryUpdate.Operation.value sha256PrefixOperation
+        |> should equal (WorkingDirectoryUpdate.Operation.value blake3PrefixOperation)
+
+        WorkingDirectoryUpdate.Operation.value sha256PrefixOperation
+        |> should not' (equal (WorkingDirectoryUpdate.Operation.value referenceOperation))
+
         WorkingDirectoryUpdate.Operation.branchSwitch Guid.Empty (Guid.NewGuid()) selectedTarget
         |> Result.isError
         |> should equal true
@@ -164,7 +188,7 @@ module WorkingDirectoryUpdateContractsTests =
         |> should equal "sha256:66d663c833c8a6984092cbd243d78dd7c01518aae7fa3456f234e7c7339f94f2"
 
         branchValue
-        |> should equal "sha256:e08980617e39f55a9fd1272b848b88b871bca0b11680ff4b99c5d8209518f1c2"
+        |> should equal "sha256:8c706ec29cafceeb72203b736ac4bf16112413af8a48bddf2a112d287ad520e8"
 
         connectValue |> should equal expectedConnectValue
 

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Coordination.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Coordination.Tests.fs
@@ -315,7 +315,7 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.Adopt
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
 
             let differentRootDirectoryVersion =
                 targetWith
@@ -349,7 +349,7 @@ module WorkingDirectoryUpdateCoordinationTests =
                 ] do
                 WorkingDirectoryUpdateCoordination.Marker.inspect scope differentTarget operation
                 |> fun task -> task.GetAwaiter().GetResult()
-                |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+                |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
 
             let differentOperation =
                 WorkingDirectoryUpdate.Operation.watchReplay repositoryId branchId "different-cursor"
@@ -357,7 +357,7 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget differentOperation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
 
             let persistedMarker = File.ReadAllText(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
 
@@ -369,7 +369,7 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
 
             let unsupported = persistedMarker.Replace("\"schemaVersion\":1", "\"schemaVersion\":2", StringComparison.Ordinal)
 
@@ -382,13 +382,13 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported
 
             File.WriteAllText(WorkingDirectoryUpdateCoordination.Scope.markerPath scope, "{not-json")
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor)
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported)
 
     /// Proves cleanup rereads marker ownership and never removes a replacement attempt token.
     [<Test>]
@@ -423,14 +423,71 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope firstToken
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal false
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.DifferentOperationEvidence
 
             File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
             |> should equal true
 
             WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope secondToken
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal true
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
 
             File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
             |> should equal false)
+
+    /// Proves an unreadable marker is preserved rather than treated as missing or adoptable evidence.
+    [<Test>]
+    let ``marker inspection distinguishes unreadable evidence`` () =
+        withTempRoot (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let selectedTarget = target repositoryId branchId
+            let operation = branchOperation selectedTarget
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let marker =
+                WorkingDirectoryUpdateCoordination.Marker.create scope (WorkingDirectoryUpdate.AttemptToken.create ()) selectedTarget operation
+                |> required
+
+            WorkingDirectoryUpdateCoordination.Marker.write scope marker
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            use markerHandle = new FileStream(WorkingDirectoryUpdateCoordination.Scope.markerPath scope, FileMode.Open, FileAccess.Read, FileShare.None)
+
+            WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.Unreadable)
+
+    /// Proves a matching marker remains visible when exact-token cleanup cannot delete its current file.
+    [<Test>]
+    let ``marker cleanup distinguishes exact cleanup failure`` () =
+        withTempRoot (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let selectedTarget = target repositoryId branchId
+            let operation = branchOperation selectedTarget
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let token = WorkingDirectoryUpdate.AttemptToken.create ()
+
+            let marker =
+                WorkingDirectoryUpdateCoordination.Marker.create scope token selectedTarget operation
+                |> required
+
+            WorkingDirectoryUpdateCoordination.Marker.write scope marker
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            use markerHandle = new FileStream(WorkingDirectoryUpdateCoordination.Scope.markerPath scope, FileMode.Open, FileAccess.Read, FileShare.Read)
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactCleanupFailed
+
+            File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
+            |> should equal true)

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Coordination.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Coordination.Tests.fs
@@ -435,6 +435,52 @@ module WorkingDirectoryUpdateCoordinationTests =
             File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
             |> should equal false)
 
+    /// Proves missing, damaged, and unreadable cleanup evidence is never treated as successful cleanup.
+    [<Test>]
+    let ``marker cleanup distinguishes every non-successful evidence disposition`` () =
+        withTempRoot (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let selectedTarget = target repositoryId branchId
+            let operation = branchOperation selectedTarget
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let token = WorkingDirectoryUpdate.AttemptToken.create ()
+            let markerPath = WorkingDirectoryUpdateCoordination.Scope.markerPath scope
+
+            WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.Missing
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker
+
+            Directory.CreateDirectory(Path.GetDirectoryName(markerPath))
+            |> ignore
+
+            File.WriteAllText(markerPath, "{not-json")
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.MalformedOrUnsupportedEvidence
+
+            let marker =
+                WorkingDirectoryUpdateCoordination.Marker.create scope token selectedTarget operation
+                |> required
+
+            WorkingDirectoryUpdateCoordination.Marker.write scope marker
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            use markerHandle = new FileStream(markerPath, FileMode.Open, FileAccess.Read, FileShare.None)
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.UnreadableEvidence)
+
     /// Proves an unreadable marker is preserved rather than treated as missing or adoptable evidence.
     [<Test>]
     let ``marker inspection distinguishes unreadable evidence`` () =
@@ -483,9 +529,8 @@ module WorkingDirectoryUpdateCoordinationTests =
             WorkingDirectoryUpdateCoordination.Marker.write scope marker
             |> fun task -> task.GetAwaiter().GetResult()
 
-            use markerHandle = new FileStream(WorkingDirectoryUpdateCoordination.Scope.markerPath scope, FileMode.Open, FileAccess.Read, FileShare.Read)
-
-            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwnedWithDelete scope token (fun _ ->
+                raise (IOException("forced portable marker deletion failure")))
             |> fun task -> task.GetAwaiter().GetResult()
             |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactCleanupFailed
 

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -48,6 +48,32 @@ open System.CommandLine.Completions
 /// Groups the branch command parser, handlers, and output helpers.
 module Branch =
 
+    /// Supplies verified object-cache streams for the exact files declared by one selected Branch root.
+    type private BranchObjectCachePreparedReader(objectRoot: string, files: LocalFileVersion array) =
+        let filesByPath = Dictionary<string, LocalFileVersion>(StringComparer.OrdinalIgnoreCase)
+
+        do
+            files
+            |> Array.iter (fun file -> filesByPath[string file.RelativePath] <- file)
+
+        interface WorkingDirectoryUpdateContracts.IPreparedContentReader with
+            /// Lists only the selected root's canonical file paths for pre-lease byte validation.
+            member _.FilePaths = filesByPath.Keys :> seq<string>
+
+            /// Opens the verified object-cache source for one selected target file.
+            member _.OpenReadAsync(relativePath: RelativePath, cancellationToken: CancellationToken) =
+                cancellationToken.ThrowIfCancellationRequested()
+
+                match filesByPath.TryGetValue(string relativePath) with
+                | true, file ->
+                    let objectFileName = getLocalObjectCacheFileName file.RelativePath file.Sha256Hash file.Blake3Hash
+                    let objectPath = Path.Combine(objectRoot, string file.RelativePath, objectFileName)
+                    Task.FromResult<Stream>(File.Open(objectPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                | false, _ -> Task.FromException<Stream>(FileNotFoundException($"No selected object-cache file exists for '{relativePath}'."))
+
+            /// Does not own the cache files, so disposing the reader has no filesystem side effect.
+            member _.Dispose() = ()
+
     /// Derives the retry-stable child Rebase identity owned by one caller-selected Promotion identity.
     let internal buildPromotionRebaseReferenceId (promotionReferenceId: ReferenceId) =
         let seed = $"grace.branch.promote-rebase-reference.v1|{promotionReferenceId:N}"
@@ -3788,7 +3814,7 @@ module Branch =
                         }
 
                     /// 8. Update object cache and working directory.
-                    let updateWorkingDirectory
+                    let updateLegacyWorkingDirectory
                         (t: ProgressTask)
                         (showOutput,
                          parseResult: ParseResult,
@@ -3917,6 +3943,246 @@ module Branch =
                                 return Error(GraceError.Create $"{error}" (parseResult |> getCorrelationId))
                         }
 
+                    /// Routes every supported switch selector through the verified Branch transaction after remote preparation completes.
+                    let updateWorkingDirectory
+                        (t: ProgressTask)
+                        (showOutput,
+                         parseResult: ParseResult,
+                         parameters: SwitchParameters,
+                         currentBranch: BranchDto,
+                         newBranch: BranchDto,
+                         directoryIds: IEnumerable<DirectoryVersionId>)
+                        =
+                        task {
+                            t |> startProgressTask showOutput
+
+                            let missingDirectoryIds =
+                                directoryIds
+                                    .Where(fun directoryId ->
+                                        not
+                                        <| directoryIdsInNewGraceStatus.Contains(directoryId))
+                                    .ToList()
+
+                            match! getMissingDirectoryVersionsWithClosure missingDirectoryIds with
+                            | Error error -> return Error error
+                            | Ok newDirectoryVersionDtos ->
+                                let targetStatus = updateGraceStatusWithNewDirectoryVersionsFromServer newGraceStatus newDirectoryVersionDtos
+
+                                let getDownloadUriParameters =
+                                    Storage.GetDownloadUriParameters(
+                                        OwnerId = graceIds.OwnerIdString,
+                                        OwnerName = graceIds.OwnerName,
+                                        OrganizationId = graceIds.OrganizationIdString,
+                                        OrganizationName = graceIds.OrganizationName,
+                                        RepositoryId = graceIds.RepositoryIdString,
+                                        RepositoryName = graceIds.RepositoryName,
+                                        CorrelationId = graceIds.CorrelationId
+                                    )
+
+                                let mutable preparationFailure: string option = None
+
+                                for directoryVersionDto in newDirectoryVersionDtos do
+                                    if preparationFailure.IsNone then
+                                        match!
+                                            downloadFileVersionsFromObjectStorage
+                                                getDownloadUriParameters
+                                                directoryVersionDto.DirectoryVersion.Files
+                                                (getCorrelationId parseResult)
+                                            with
+                                        | Ok _ -> ()
+                                        | Error error -> preparationFailure <- Some error
+
+                                match preparationFailure with
+                                | Some error -> return Error(GraceError.Create error (getCorrelationId parseResult))
+                                | None ->
+                                    try
+                                        let configuration = Current()
+                                        let configurationSnapshot = captureOperationalConfigurationSnapshot "switch" configuration
+
+                                        let scanInput: Grace.CLI.Services.WorkingTreeScanInput =
+                                            {
+                                                RootDirectory = configuration.RootDirectory
+                                                GraceDirectory = configuration.GraceDirectory
+                                                GraceStatusFile = configuration.GraceStatusFile
+                                                DirectoryIgnoreEntries = Array.copy configuration.GraceDirectoryIgnoreEntries
+                                                FileIgnoreEntries = Array.copy configuration.GraceFileIgnoreEntries
+                                            }
+
+                                        let canonicalConfiguration = serialize configurationSnapshot
+
+                                        let acceptedConfiguration =
+                                            WorkingDirectoryUpdate.AcceptedConfiguration.create canonicalConfiguration scanInput
+                                            |> Result.defaultWith invalidOp
+
+                                        let localRootScope =
+                                            WorkingDirectoryUpdateContracts.LocalRootScope.create configuration.RootDirectory
+                                            |> Result.defaultWith invalidOp
+
+                                        let target =
+                                            WorkingDirectoryUpdateContracts.Target.create
+                                                newBranch.RepositoryId
+                                                newBranch.BranchId
+                                                targetStatus.RootDirectoryId
+                                                targetStatus.RootDirectorySha256Hash
+                                                targetStatus.RootDirectoryBlake3Hash
+                                            |> Result.defaultWith invalidOp
+
+                                        let branchSelection =
+                                            if
+                                                not (String.IsNullOrWhiteSpace switchParameters.Sha256Hash)
+                                                || not (String.IsNullOrWhiteSpace switchParameters.Blake3Hash)
+                                            then
+                                                WorkingDirectoryUpdateContracts.DirectoryVersion
+                                            else
+                                                let referenceId =
+                                                    if not (String.IsNullOrWhiteSpace switchParameters.ReferenceId) then
+                                                        Guid.Parse(switchParameters.ReferenceId)
+                                                    else
+                                                        newBranch.LatestReference.ReferenceId
+
+                                                if referenceId = Guid.Empty then
+                                                    invalidOp "Grace switch requires an exact Reference for a branch-selected update."
+
+                                                WorkingDirectoryUpdateContracts.Reference referenceId
+
+                                        let operation =
+                                            WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection currentBranch.BranchId branchSelection target
+                                            |> Result.defaultWith invalidOp
+
+                                        let manifestEntries =
+                                            targetStatus.Index.Values
+                                            |> Seq.collect (fun directory ->
+                                                seq {
+                                                    if directory.RelativePath
+                                                       <> Grace.Shared.Constants.RootDirectoryPath then
+                                                        yield WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory directory.RelativePath
+
+                                                    for file in directory.Files do
+                                                        yield
+                                                            WorkingDirectoryUpdateContracts.PreparedManifestEntry.File(
+                                                                file.RelativePath,
+                                                                file.Sha256Hash,
+                                                                file.Blake3Hash
+                                                            )
+                                                })
+                                            |> Seq.toArray
+
+                                        let manifest =
+                                            WorkingDirectoryUpdateContracts.PreparedManifest.create manifestEntries
+                                            |> Result.defaultWith invalidOp
+
+                                        let selectedFiles =
+                                            targetStatus.Index.Values
+                                            |> Seq.collect (fun directory -> directory.Files)
+                                            |> Seq.toArray
+
+                                        let! preparedContent =
+                                            WorkingDirectoryUpdateContracts.PreparedContent.create
+                                                manifest
+                                                (new BranchObjectCachePreparedReader(configuration.ObjectDirectory, selectedFiles))
+                                                CancellationToken.None
+
+                                        let preparedContent = preparedContent |> Result.defaultWith invalidOp
+                                        let! acceptedRevision = Grace.CLI.LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                                        let acceptedSelection =
+                                            WorkingDirectoryUpdate.AcceptedSelection.create target localRootScope acceptedConfiguration acceptedRevision
+                                            |> Result.defaultWith invalidOp
+
+                                        let applicationFacts =
+                                            WorkingDirectoryUpdate.BranchContext.create
+                                                target
+                                                configuration.RootDirectory
+                                                configuration.ObjectDirectory
+                                                configuration.GraceStatusFile
+                                                previousGraceStatus
+                                                targetStatus
+                                                (targetStatus.Index.Values |> Seq.toArray)
+                                            |> Result.defaultWith invalidOp
+
+                                        let selectedStateReader =
+                                            { new WorkingDirectoryUpdate.ISelectedStateReader with
+                                                /// Revalidates the canonical local configuration and status revision after the update lease is held.
+                                                member _.ReadAsync(cancellationToken: CancellationToken) =
+                                                    task {
+                                                        cancellationToken.ThrowIfCancellationRequested()
+                                                        requireOperationalConfigurationSnapshotCurrent "switch" (Current()) configurationSnapshot
+                                                        let! revision = Grace.CLI.LocalStateDb.readLocalStatusRevision configuration.GraceStatusFile
+
+                                                        return
+                                                            WorkingDirectoryUpdate.AcceptedSelection.create target localRootScope acceptedConfiguration revision
+                                                            |> Result.defaultWith invalidOp
+                                                    }
+                                            }
+
+                                        let finalizer =
+                                            { new WorkingDirectoryUpdate.IIdempotentFinalizer with
+                                                /// Publishes Branch identity only after the engine has committed the verified local root.
+                                                member _.FinalizeAsync(finalization, cancellationToken: CancellationToken) =
+                                                    task {
+                                                        cancellationToken.ThrowIfCancellationRequested()
+                                                        requireOperationalConfigurationSnapshotCurrent "switch" (Current()) configurationSnapshot
+
+                                                        match finalization with
+                                                        | WorkingDirectoryUpdate.BranchFinalization (previousBranchId,
+                                                                                                     WorkingDirectoryUpdateContracts.Reference _) ->
+                                                            let currentConfiguration = Current()
+
+                                                            if currentConfiguration.BranchId <> previousBranchId then
+                                                                invalidOp "Grace switch refused to publish a Branch identity that changed before finalization."
+
+                                                            currentConfiguration.BranchId <- newBranch.BranchId
+                                                            currentConfiguration.BranchName <- newBranch.BranchName
+                                                            updateConfiguration currentConfiguration
+                                                        | WorkingDirectoryUpdate.BranchFinalization (previousBranchId,
+                                                                                                     WorkingDirectoryUpdateContracts.DirectoryVersion) ->
+                                                            if Current().BranchId <> previousBranchId then
+                                                                invalidOp
+                                                                    "Grace switch refused a hash-selected update because the current Branch changed before finalization."
+                                                        | _ -> invalidOp "Grace switch received non-Branch finalization facts."
+                                                    }
+                                            }
+
+                                        let request =
+                                            WorkingDirectoryUpdate.Request.branchSwitch
+                                                acceptedSelection
+                                                applicationFacts
+                                                operation
+                                                preparedContent
+                                                (getCorrelationId parseResult)
+                                                selectedStateReader
+                                                currentBranch.BranchId
+                                                branchSelection
+                                                finalizer
+                                                None
+                                            |> Result.defaultWith invalidOp
+
+                                        let! outcome = WorkingDirectoryUpdate.run request CancellationToken.None
+
+                                        match outcome with
+                                        | WorkingDirectoryUpdateContracts.Updated _
+                                        | WorkingDirectoryUpdateContracts.Unchanged _ ->
+                                            newGraceStatus <- targetStatus
+                                            rootDirectoryId <- targetStatus.RootDirectoryId
+                                            rootDirectorySha256Hash <- targetStatus.RootDirectorySha256Hash
+                                            directoryIdsInNewGraceStatus <- targetStatus.Index.Keys.ToHashSet()
+                                            t |> setProgressTaskValue showOutput 100.0
+                                            return Ok(showOutput, parseResult, parameters, newBranch, "Working Directory Update completed.")
+                                        | WorkingDirectoryUpdateContracts.Rejected failure
+                                        | WorkingDirectoryUpdateContracts.UpdateIncomplete failure ->
+                                            return
+                                                Error(GraceError.Create (WorkingDirectoryUpdateContracts.Failure.value failure) (getCorrelationId parseResult))
+                                        | WorkingDirectoryUpdateContracts.FinalizationIncomplete (_, failure) ->
+                                            return
+                                                Error(
+                                                    GraceError.Create
+                                                        $"Working-directory bytes were updated, but Branch finalization is incomplete: {WorkingDirectoryUpdateContracts.Failure.value failure}. Run `grace doctor --repair-local-state`."
+                                                        (getCorrelationId parseResult)
+                                                )
+                                    with
+                                    | ex -> return Error(GraceError.Create ex.Message (getCorrelationId parseResult))
+                        }
+
                     /// Coordinates generate result behavior for this CLI command path.
                     let generateResult (progressTasks: ProgressTask array) =
                         task {
@@ -4018,47 +4284,19 @@ module Branch =
         /// Runs the asynchronous switch action when System.CommandLine dispatches the parsed command.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Tasks.Task<int> =
             task {
-                let updateMarkerFileName = updateInProgressFileName ()
-                let switchLeaseFileName = branchSwitchWorkflowLeaseFileName updateMarkerFileName
-                let switchLeaseText = $"`grace switch` workflow lease. Lease: {Guid.NewGuid():N}"
-
                 if parseResult |> verbose then printParseResult parseResult
 
                 let preflightOperations =
                     {
-                        UpdateMarkerExists = fun () -> File.Exists(updateMarkerFileName)
+                        UpdateMarkerExists = fun () -> false
                         InspectWatchStatus = inspectGraceWatchStatus
                         ReadPendingJournalSummary =
                             fun () -> Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck (Current().GraceStatusFile)
                     }
 
-                let! switchResult =
-                    runBranchSwitchWorkflowWithLease preflightOperations (getCorrelationId parseResult) switchLeaseFileName switchLeaseText (fun () ->
-                        task {
-                            let switchParameters = SwitchParameters()
+                let! preflightResult = runBranchSwitchWatchCleanPreflight preflightOperations (getCorrelationId parseResult)
 
-                            let toBranchId = parseResult.GetValue(Options.toBranchId)
-                            if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
-
-                            let toBranchName = parseResult.GetValue(Options.toBranchName)
-                            switchParameters.ToBranchName <- toBranchName
-
-                            let referenceId = parseResult.GetValue(Options.referenceId)
-
-                            if referenceId <> Guid.Empty then
-                                switchParameters.ReferenceId <- $"{referenceId}"
-
-                            let sha256Hash = getSha256HashPrefix parseResult
-                            switchParameters.Sha256Hash <- sha256Hash
-
-                            let blake3Hash = getBlake3HashPrefix parseResult
-                            switchParameters.Blake3Hash <- blake3Hash
-
-                            let! result = switchHandler parseResult switchParameters
-                            return result
-                        })
-
-                match switchResult with
+                match preflightResult with
                 | Error error ->
                     if parseResult |> verbose then
                         AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.ToString())}[/]")
@@ -4066,7 +4304,23 @@ module Branch =
                         AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.Error)}[/]")
 
                     return -1
-                | Ok result -> return result
+                | Ok () ->
+                    let switchParameters = SwitchParameters()
+
+                    let toBranchId = parseResult.GetValue(Options.toBranchId)
+                    if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
+
+                    let toBranchName = parseResult.GetValue(Options.toBranchName)
+                    switchParameters.ToBranchName <- toBranchName
+
+                    let referenceId = parseResult.GetValue(Options.referenceId)
+
+                    if referenceId <> Guid.Empty then
+                        switchParameters.ReferenceId <- $"{referenceId}"
+
+                    switchParameters.Sha256Hash <- getSha256HashPrefix parseResult
+                    switchParameters.Blake3Hash <- getBlake3HashPrefix parseResult
+                    return! switchHandler parseResult switchParameters
             }
 
     /// Routes the rebase command from parsed options through validation, the SDK call, and result rendering.

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3692,17 +3692,7 @@ module Branch =
                     let getVersionToSwitchTo (t: ProgressTask) (showOutput, parseResult: ParseResult, parameters: SwitchParameters, currentBranch: BranchDto) =
                         t |> startProgressTask showOutput
 
-                        if not
-                           <| String.IsNullOrEmpty(switchParameters.ToBranchId)
-                           || not
-                              <| String.IsNullOrEmpty(switchParameters.ToBranchName) then
-                            getVersionToSwitchToFromBranch t (showOutput, parseResult, parameters, currentBranch)
-                        elif
-                            not
-                            <| String.IsNullOrEmpty(switchParameters.ReferenceId)
-                        then
-                            getVersionToSwitchToFromReference t (showOutput, parseResult, parameters, currentBranch)
-                        elif
+                        if
                             not
                             <| String.IsNullOrEmpty(switchParameters.Sha256Hash)
                         then
@@ -3714,6 +3704,16 @@ module Branch =
                             <| String.IsNullOrEmpty(switchParameters.Blake3Hash)
                         then
                             getVersionToSwitchToFromHash String.Empty switchParameters.Blake3Hash t (showOutput, parseResult, parameters, currentBranch)
+                        elif
+                            not
+                            <| String.IsNullOrEmpty(switchParameters.ReferenceId)
+                        then
+                            getVersionToSwitchToFromReference t (showOutput, parseResult, parameters, currentBranch)
+                        elif not
+                             <| String.IsNullOrEmpty(switchParameters.ToBranchId)
+                             || not
+                                <| String.IsNullOrEmpty(switchParameters.ToBranchName) then
+                            getVersionToSwitchToFromBranch t (showOutput, parseResult, parameters, currentBranch)
                         else
                             Task.FromResult(
                                 Error(
@@ -3811,136 +3811,6 @@ module Branch =
                             match resultError with
                             | Some error -> return Error error
                             | None -> return Ok(fetchedDirectoryVersions.Values |> Seq.toArray :> IEnumerable<DirectoryVersionDto>)
-                        }
-
-                    /// 8. Update object cache and working directory.
-                    let updateLegacyWorkingDirectory
-                        (t: ProgressTask)
-                        (showOutput,
-                         parseResult: ParseResult,
-                         parameters: SwitchParameters,
-                         currentBranch: BranchDto,
-                         newBranch: BranchDto,
-                         directoryIds: IEnumerable<DirectoryVersionId>)
-                        =
-                        task {
-                            t |> startProgressTask showOutput
-
-                            let missingDirectoryIds =
-                                directoryIds
-                                    .Where(fun directoryId ->
-                                        not
-                                        <| directoryIdsInNewGraceStatus.Contains(directoryId))
-                                    .ToList()
-
-                            if parseResult |> verbose then
-                                logToAnsiConsole Colors.Verbose $"In updateWorkingDirectory: missingDirectoryIds.Count: {missingDirectoryIds.Count()}."
-
-                            match! getMissingDirectoryVersionsWithClosure missingDirectoryIds with
-                            | Ok newDirectoryVersionDtos ->
-                                // Create a new version of GraceStatus that includes the new DirectoryVersions.
-                                if parseResult |> verbose then
-                                    logToAnsiConsole Colors.Verbose $"In updateWorkingDirectory: newDirectoryVersions.Count: {newDirectoryVersionDtos.Count()}."
-
-                                let graceStatusWithNewDirectoryVersionsFromServer =
-                                    updateGraceStatusWithNewDirectoryVersionsFromServer newGraceStatus newDirectoryVersionDtos
-
-                                let mutable isError = false
-
-                                // Identify files that we don't already have in object cache and download them.
-                                let getDownloadUriParameters =
-                                    Storage.GetDownloadUriParameters(
-                                        OwnerId = graceIds.OwnerIdString,
-                                        OwnerName = graceIds.OwnerName,
-                                        OrganizationId = graceIds.OrganizationIdString,
-                                        OrganizationName = graceIds.OrganizationName,
-                                        RepositoryId = graceIds.RepositoryIdString,
-                                        RepositoryName = graceIds.RepositoryName,
-                                        CorrelationId = graceIds.CorrelationId
-                                    )
-
-                                for directoryVersionDto in newDirectoryVersionDtos do
-                                    match! (downloadFileVersionsFromObjectStorage
-                                                getDownloadUriParameters
-                                                directoryVersionDto.DirectoryVersion.Files
-                                                (getCorrelationId parseResult))
-                                        with
-                                    | Ok _ -> ()
-                                    | Error error ->
-                                        if parseResult |> verbose then
-                                            logToAnsiConsole
-                                                Colors.Verbose
-                                                $"Failed downloading files from object storage for {directoryVersionDto.DirectoryVersion.RelativePath}."
-
-                                        logToAnsiConsole Colors.Error $"{error}"
-                                        isError <- true
-
-                                if not <| isError then
-                                    let workingTreeUpdateMarkerFileName = updateInProgressFileName ()
-                                    let workingTreeUpdateMarkerText = $"`grace switch` is in progress. Lease: {Guid.NewGuid():N}"
-
-                                    let preflightOperations =
-                                        {
-                                            UpdateMarkerExists = fun () -> File.Exists(workingTreeUpdateMarkerFileName)
-                                            InspectWatchStatus = inspectGraceWatchStatus
-                                            ReadPendingJournalSummary =
-                                                fun () ->
-                                                    Grace.CLI.LocalStateDb.readWatchJournalPendingWorkSummaryForTransitionCheck (Current().GraceStatusFile)
-                                        }
-
-                                    let! workingTreeUpdateResult =
-                                        runBranchSwitchWorkingTreeUpdateWithMarker
-                                            preflightOperations
-                                            (getCorrelationId parseResult)
-                                            workingTreeUpdateMarkerFileName
-                                            workingTreeUpdateMarkerText
-                                            (fun () ->
-                                                task {
-                                                    //logToAnsiConsole Colors.Verbose $"Succeeded downloading files from object storage for {directoryVersion.RelativePath}."
-
-                                                    // Update working directory based on new GraceStatus.Index
-                                                    do!
-                                                        updateWorkingDirectory
-                                                            newGraceStatus
-                                                            graceStatusWithNewDirectoryVersionsFromServer
-                                                            newDirectoryVersionDtos
-                                                            (getCorrelationId parseResult)
-                                                    //logToAnsiConsole Colors.Verbose $"Succeeded calling updateWorkingDirectory."
-
-                                                    // Save the new Grace Status.
-                                                    do!
-                                                        applyBranchSwitchLocalState
-                                                            (fun () -> writeGraceStatusFile graceStatusWithNewDirectoryVersionsFromServer)
-                                                            (fun () ->
-                                                                let configuration = Current()
-                                                                configuration.BranchId <- newBranch.BranchId
-                                                                configuration.BranchName <- newBranch.BranchName
-                                                                updateConfiguration configuration)
-                                                            (fun () -> upsertObjectCache graceStatusWithNewDirectoryVersionsFromServer.Index.Values)
-
-                                                    t |> setProgressTaskValue showOutput 100.0
-                                                })
-
-                                    match workingTreeUpdateResult with
-                                    | Error error -> return Error error
-                                    | Ok () ->
-                                        newGraceStatus <- graceStatusWithNewDirectoryVersionsFromServer
-                                        rootDirectoryId <- newGraceStatus.RootDirectoryId
-                                        rootDirectorySha256Hash <- newGraceStatus.RootDirectorySha256Hash
-                                        directoryIdsInNewGraceStatus <- newGraceStatus.Index.Keys.ToHashSet()
-
-                                        if parseResult |> verbose then
-                                            logToAnsiConsole Colors.Verbose $"About to exit updateWorkingDirectory."
-
-                                        return Ok(showOutput, parseResult, parameters, newBranch, $"Save created after branch switch.")
-                                else
-                                    return Error(GraceError.Create $"Failed downloading files from object storage." (parseResult |> getCorrelationId))
-                            | Error error ->
-                                if parseResult |> verbose then
-                                    logToAnsiConsole Colors.Verbose $"Failed retrieving directory versions for switch."
-
-                                logToAnsiConsole Colors.Error $"{error}"
-                                return Error(GraceError.Create $"{error}" (parseResult |> getCorrelationId))
                         }
 
                     /// Routes every supported switch selector through the verified Branch transaction after remote preparation completes.
@@ -4310,8 +4180,13 @@ module Branch =
                     let toBranchId = parseResult.GetValue(Options.toBranchId)
                     if toBranchId <> Guid.Empty then switchParameters.ToBranchId <- $"{toBranchId}"
 
-                    let toBranchName = parseResult.GetValue(Options.toBranchName)
-                    switchParameters.ToBranchName <- toBranchName
+                    let toBranchNameResult = parseResult.GetResult(Options.toBranchName)
+
+                    if
+                        not (isNull toBranchNameResult)
+                        && not toBranchNameResult.Implicit
+                    then
+                        switchParameters.ToBranchName <- parseResult.GetValue(Options.toBranchName)
 
                     let referenceId = parseResult.GetValue(Options.referenceId)
 
@@ -4320,6 +4195,7 @@ module Branch =
 
                     switchParameters.Sha256Hash <- getSha256HashPrefix parseResult
                     switchParameters.Blake3Hash <- getBlake3HashPrefix parseResult
+
                     return! switchHandler parseResult switchParameters
             }
 
@@ -5262,7 +5138,7 @@ module Branch =
             new Command(
                 "switch",
                 Description =
-                    "Switches your current branch to another branch, or to a specific reference or Sha256Hash. If a Sha256Hash is provided, the current branch will be set to the version with that hash."
+                    "Materializes a selected branch, Reference, SHA-256, or BLAKE3 root through a verified Working Directory Update. Branch and Reference selection update the active branch after local completion; hash selection keeps the current branch active while applying the exact selected root."
             )
             |> addOption Options.toBranchId
             |> addOption Options.toBranchName

--- a/src/Grace.CLI/Command/Branch.CLI.fs
+++ b/src/Grace.CLI/Command/Branch.CLI.fs
@@ -3281,6 +3281,8 @@ module Branch =
                     let mutable rootDirectoryId = DirectoryVersionId.Empty
                     /// The SHA-256 hash of the root directory version.
                     let mutable rootDirectorySha256Hash = Sha256Hash String.Empty
+                    /// The truthful terminal Working Directory Update classification rendered by the Branch command.
+                    let mutable workingDirectoryOutcomeText = String.Empty
                     /// The set of DirectoryIds in the working directory after the current version is saved.
                     let mutable directoryIdsInNewGraceStatus: HashSet<DirectoryVersionId> = null
 
@@ -4030,23 +4032,41 @@ module Branch =
                                         let! outcome = WorkingDirectoryUpdate.run request CancellationToken.None
 
                                         match outcome with
-                                        | WorkingDirectoryUpdateContracts.Updated _
+                                        | WorkingDirectoryUpdateContracts.Updated _ ->
+                                            newGraceStatus <- targetStatus
+                                            rootDirectoryId <- targetStatus.RootDirectoryId
+                                            rootDirectorySha256Hash <- targetStatus.RootDirectorySha256Hash
+                                            directoryIdsInNewGraceStatus <- targetStatus.Index.Keys.ToHashSet()
+                                            t |> setProgressTaskValue showOutput 100.0
+                                            workingDirectoryOutcomeText <- "Updated: Working Directory Update completed."
+                                            return Ok(showOutput, parseResult, parameters, newBranch, workingDirectoryOutcomeText)
                                         | WorkingDirectoryUpdateContracts.Unchanged _ ->
                                             newGraceStatus <- targetStatus
                                             rootDirectoryId <- targetStatus.RootDirectoryId
                                             rootDirectorySha256Hash <- targetStatus.RootDirectorySha256Hash
                                             directoryIdsInNewGraceStatus <- targetStatus.Index.Keys.ToHashSet()
                                             t |> setProgressTaskValue showOutput 100.0
-                                            return Ok(showOutput, parseResult, parameters, newBranch, "Working Directory Update completed.")
-                                        | WorkingDirectoryUpdateContracts.Rejected failure
+                                            workingDirectoryOutcomeText <- "Unchanged: Working Directory Update already matches the selected root."
+                                            return Ok(showOutput, parseResult, parameters, newBranch, workingDirectoryOutcomeText)
+                                        | WorkingDirectoryUpdateContracts.Rejected failure ->
+                                            return
+                                                Error(
+                                                    GraceError.Create
+                                                        $"Rejected: {WorkingDirectoryUpdateContracts.Failure.value failure}"
+                                                        (getCorrelationId parseResult)
+                                                )
                                         | WorkingDirectoryUpdateContracts.UpdateIncomplete failure ->
                                             return
-                                                Error(GraceError.Create (WorkingDirectoryUpdateContracts.Failure.value failure) (getCorrelationId parseResult))
+                                                Error(
+                                                    GraceError.Create
+                                                        $"UpdateIncomplete: {WorkingDirectoryUpdateContracts.Failure.value failure}"
+                                                        (getCorrelationId parseResult)
+                                                )
                                         | WorkingDirectoryUpdateContracts.FinalizationIncomplete (_, failure) ->
                                             return
                                                 Error(
                                                     GraceError.Create
-                                                        $"Working-directory bytes were updated, but Branch finalization is incomplete: {WorkingDirectoryUpdateContracts.Failure.value failure}. Run `grace doctor --repair-local-state`."
+                                                        $"FinalizationIncomplete: Working-directory bytes were updated, but Branch finalization is incomplete: {WorkingDirectoryUpdateContracts.Failure.value failure}. Run `grace doctor --repair-local-state`."
                                                         (getCorrelationId parseResult)
                                                 )
                                     with
@@ -4071,14 +4091,17 @@ module Branch =
                                 >>=! createSaveReference progressTasks[9]
 
                             match result with
-                            | Ok _ -> return 0
-                            | Error error ->
-                                if parseResult |> verbose then
-                                    AnsiConsole.MarkupLine($"[{Colors.Error}]{error}[/]")
-                                else
-                                    AnsiConsole.MarkupLine($"[{Colors.Error}]{error.Error}[/]")
+                            | Ok _ ->
+                                let message = workingDirectoryOutcomeText
 
-                                return -1
+                                if parseResult |> normal then
+                                    AnsiConsole.MarkupLine($"[{Colors.Highlighted}]{Markup.Escape(message)}[/]")
+
+                                return
+                                    GraceReturnValue.Create message (getCorrelationId parseResult)
+                                    |> Ok
+                                    |> renderOutput parseResult
+                            | Error error -> return Error error |> renderOutput parseResult
                         }
 
                     if showOutput then
@@ -4145,10 +4168,10 @@ module Branch =
                                               emptyTask |]
                 with
                 | ex ->
-                    logToConsole $"{ExceptionResponse.Create ex}"
-                    logToAnsiConsole Colors.Error (Markup.Escape($"{ExceptionResponse.Create ex}"))
-                    logToAnsiConsole Colors.Important $"CorrelationId: {(parseResult |> getCorrelationId)}"
-                    return -1
+                    return
+                        GraceError.Create $"{ExceptionResponse.Create ex}" (parseResult |> getCorrelationId)
+                        |> Error
+                        |> renderOutput parseResult
             }
 
         /// Runs the asynchronous switch action when System.CommandLine dispatches the parsed command.
@@ -4167,13 +4190,7 @@ module Branch =
                 let! preflightResult = runBranchSwitchWatchCleanPreflight preflightOperations (getCorrelationId parseResult)
 
                 match preflightResult with
-                | Error error ->
-                    if parseResult |> verbose then
-                        AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.ToString())}[/]")
-                    else
-                        AnsiConsole.MarkupLine($"[{Colors.Error}]{Markup.Escape(error.Error)}[/]")
-
-                    return -1
+                | Error error -> return Error error |> renderOutput parseResult
                 | Ok () ->
                     let switchParameters = SwitchParameters()
 

--- a/src/Grace.CLI/Command/Services.CLI.fs
+++ b/src/Grace.CLI/Command/Services.CLI.fs
@@ -64,6 +64,7 @@ module Services =
             RootDirectory: string
             GraceDirectory: string
             GraceStatusFile: string
+            ObjectDirectory: string
             GraceFileIgnoreEntries: string array
             GraceDirectoryIgnoreEntries: string array
         }
@@ -95,6 +96,7 @@ module Services =
             RootDirectory = Path.GetFullPath(configuration.RootDirectory)
             GraceDirectory = Path.GetFullPath(configuration.GraceDirectory)
             GraceStatusFile = Path.GetFullPath(configuration.GraceStatusFile)
+            ObjectDirectory = Path.GetFullPath(configuration.ObjectDirectory)
             GraceFileIgnoreEntries = Array.copy configuration.GraceFileIgnoreEntries
             GraceDirectoryIgnoreEntries = Array.copy configuration.GraceDirectoryIgnoreEntries
         }
@@ -123,6 +125,7 @@ module Services =
         && samePath actual.RootDirectory expected.RootDirectory
         && samePath actual.GraceDirectory expected.GraceDirectory
         && samePath actual.GraceStatusFile expected.GraceStatusFile
+        && samePath actual.ObjectDirectory expected.ObjectDirectory
         && actual.GraceFileIgnoreEntries.Length = expected.GraceFileIgnoreEntries.Length
         && Array.forall2 (=) actual.GraceFileIgnoreEntries expected.GraceFileIgnoreEntries
         && actual.GraceDirectoryIgnoreEntries.Length = expected.GraceDirectoryIgnoreEntries.Length

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -724,9 +724,17 @@ module internal WorkingDirectoryUpdate =
 
                     fileIndex <- fileIndex + 1
 
+                let expectedDirectSize =
+                    if directory.Files.Count = 0
+                       && directory.Size = Grace.Shared.Constants.InitialDirectorySize then
+                        0L
+                    else
+                        directory.Size
+
                 match fileError with
                 | Some error -> return Error error
-                | None when directSize <> directory.Size -> return Error $"Directory '{directory.RelativePath}' has an unexpected direct-file size."
+                | None when directSize <> expectedDirectSize ->
+                    return Error $"Directory '{directory.RelativePath}' has an unexpected direct-file size: expected {expectedDirectSize}, found {directSize}."
                 | None ->
                     let childIds = directory.Directories |> Seq.toArray
                     let mutable childIndex = 0

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -1,5 +1,1087 @@
 namespace Grace.CLI.Command
 
+open Grace.CLI
+open Grace.Shared.Services
+open Grace.Shared.Utilities
+open Grace.Types.Common
+open System
+open System.Collections.Generic
+open System.IO
+open System.Threading
+open System.Threading.Tasks
+
 /// Owns the verified local working-directory update transaction after its private contracts and storage seams exist.
 module internal WorkingDirectoryUpdate =
-    ()
+    module Contracts = WorkingDirectoryUpdateContracts
+    open Contracts
+
+    /// Names bounded, internal interruption points used only by the integration fixture.
+    type internal FailurePoint =
+        | BeforeObjectPublication
+        | AfterWorkingMutation
+        | BeforeLocalCompletion
+        | AfterLocalCompletionBeforeSidecar
+        | BeforeFinalization
+        | BeforeTerminalCompletion
+
+    /// Captures the caller-approved configuration and repository scan inputs without exposing mutable configuration objects.
+    type internal AcceptedConfiguration = private AcceptedConfiguration of canonical: string * scanInput: Services.WorkingTreeScanInput
+
+    /// Binds the selected root, stable local-root scope, and exact SQLite revision that must remain current after leasing.
+    type internal AcceptedSelection =
+        private | AcceptedSelection of
+            target: Contracts.Target *
+            localRootScope: Contracts.LocalRootScope *
+            configuration: AcceptedConfiguration *
+            localStatusRevision: int64
+
+    /// Carries defensively copied local paths and complete target status facts required by the one atomic completion write.
+    type internal BranchContext =
+        private | BranchContext of
+            localRoot: string *
+            objectRoot: string *
+            localStateDbPath: string *
+            priorStatus: GraceStatus *
+            targetStatus: GraceStatus *
+            objectMetadata: LocalDirectoryVersion array
+
+    /// Clones one directory and its mutable child collections so an accepted status cannot change through caller aliases.
+    let private copyDirectory (directory: LocalDirectoryVersion) =
+        let copy = LocalDirectoryVersion()
+        copy.Class <- directory.Class
+        copy.DirectoryVersionId <- directory.DirectoryVersionId
+        copy.OwnerId <- directory.OwnerId
+        copy.OrganizationId <- directory.OrganizationId
+        copy.RepositoryId <- directory.RepositoryId
+        copy.RelativePath <- directory.RelativePath
+        copy.Sha256Hash <- directory.Sha256Hash
+        copy.Blake3Hash <- directory.Blake3Hash
+        copy.Directories <- List<DirectoryVersionId>(directory.Directories)
+        copy.Files <- List<LocalFileVersion>(directory.Files)
+        copy.Size <- directory.Size
+        copy.CreatedAt <- directory.CreatedAt
+        copy.LastWriteTimeUtc <- directory.LastWriteTimeUtc
+        copy
+
+    /// Copies a status graph into a private index before request construction can expose it to caller mutation.
+    let private freezeStatus (status: GraceStatus) =
+        if isNull (box status) || isNull status.Index then
+            Error "Working Directory Update requires a complete target status graph."
+        else
+            try
+                let index = GraceIndex()
+
+                let directories =
+                    status.Index.Values
+                    |> Seq.map copyDirectory
+                    |> Seq.toArray
+
+                let mutable duplicate = false
+                let mutable directoryIndex = 0
+
+                while directoryIndex < directories.Length do
+                    let directory = directories[directoryIndex]
+
+                    if not (index.TryAdd(directory.DirectoryVersionId, directory)) then
+                        duplicate <- true
+
+                    directoryIndex <- directoryIndex + 1
+
+                if duplicate then
+                    Error "Working Directory Update target status graph contains duplicate directory identities."
+                else
+                    Ok({ status with Index = index })
+            with
+            | ex -> Error $"Working Directory Update could not freeze the target status graph: {ex.Message}"
+
+    /// Creates immutable application facts before leasing and rejects incomplete or cross-inconsistent root facts.
+    module BranchContext =
+        /// Creates facts only when all paths are absolute and exactly one target root metadata record agrees with status.
+        let create
+            (target: Contracts.Target)
+            localRoot
+            objectRoot
+            localStateDbPath
+            (priorStatus: GraceStatus)
+            (targetStatus: GraceStatus)
+            (objectMetadata: LocalDirectoryVersion array)
+            =
+            let requiredPath name path =
+                if
+                    String.IsNullOrWhiteSpace(path)
+                    || not (Path.IsPathFullyQualified(path))
+                then
+                    Error $"Working Directory Update requires an absolute {name}."
+                else
+                    Ok(Path.GetFullPath(path))
+
+            match requiredPath "local root" localRoot,
+                  requiredPath "object root" objectRoot,
+                  requiredPath "local-state database path" localStateDbPath,
+                  freezeStatus priorStatus,
+                  freezeStatus targetStatus
+                with
+            | Ok normalizedLocalRoot, Ok normalizedObjectRoot, Ok normalizedDatabasePath, Ok frozenPriorStatus, Ok frozenTargetStatus when
+                not (isNull (box objectMetadata))
+                ->
+                let copiedMetadata = objectMetadata |> Array.map copyDirectory
+
+                let matchesTargetStatus status =
+                    status.RootDirectoryId = Contracts.Target.rootDirectoryVersionId target
+                    && status.RootDirectorySha256Hash = Contracts.Target.sha256Hash target
+                    && status.RootDirectoryBlake3Hash = Contracts.Target.blake3Hash target
+
+                let matchingRoots =
+                    copiedMetadata
+                    |> Array.filter (fun (directory: LocalDirectoryVersion) ->
+                        directory.DirectoryVersionId = Contracts.Target.rootDirectoryVersionId target
+                        && directory.RelativePath = Grace.Shared.Constants.RootDirectoryPath
+                        && directory.Sha256Hash = Contracts.Target.sha256Hash target
+                        && directory.Blake3Hash = Contracts.Target.blake3Hash target
+                        && directory.RepositoryId = Contracts.Target.repositoryId target)
+
+                let metadataMatchesTargetGraph =
+                    copiedMetadata.Length = frozenTargetStatus.Index.Count
+                    && copiedMetadata
+                       |> Array.forall (fun directory ->
+                           let mutable expected = LocalDirectoryVersion.Default
+
+                           frozenTargetStatus.Index.TryGetValue(directory.DirectoryVersionId, &expected)
+                           && expected.Equals(directory))
+
+                if not (matchesTargetStatus frozenTargetStatus) then
+                    Error "Working Directory Update target status does not match the selected target."
+                elif LocalStateDb.validateCompleteStatusTree frozenTargetStatus
+                     |> Result.isError then
+                    Error "Working Directory Update target status must be one complete canonical root graph."
+                elif matchingRoots.Length <> 1 then
+                    Error "Working Directory Update requires exactly one target root metadata record."
+                elif not metadataMatchesTargetGraph then
+                    Error "Working Directory Update object metadata must exactly match the frozen target status graph."
+                else
+                    Ok(BranchContext(normalizedLocalRoot, normalizedObjectRoot, normalizedDatabasePath, frozenPriorStatus, frozenTargetStatus, copiedMetadata))
+            | Error error, _, _, _, _ -> Error error
+            | _, Error error, _, _, _ -> Error error
+            | _, _, Error error, _, _ -> Error error
+            | _, _, _, Error error, _ -> Error error
+            | _, _, _, _, Error error -> Error error
+            | _ -> Error "Working Directory Update requires complete object metadata."
+
+    /// Supplies construction and comparison functions for the immutable selected-state snapshot.
+    module AcceptedConfiguration =
+        /// Copies configuration and scan arrays so later caller mutation cannot change a leased plan.
+        let create canonical (scanInput: Services.WorkingTreeScanInput) =
+            if
+                String.IsNullOrWhiteSpace(canonical)
+                || isNull (box scanInput)
+            then
+                Error "Working Directory Update requires a canonical configuration snapshot."
+            elif not (Path.IsPathFullyQualified(scanInput.RootDirectory)) then
+                Error "Working Directory Update scan root must be absolute."
+            else
+                Ok(
+                    AcceptedConfiguration(
+                        canonical,
+                        { scanInput with
+                            RootDirectory = Path.GetFullPath(scanInput.RootDirectory)
+                            GraceDirectory = Path.GetFullPath(scanInput.GraceDirectory)
+                            GraceStatusFile = Path.GetFullPath(scanInput.GraceStatusFile)
+                            DirectoryIgnoreEntries = Array.copy scanInput.DirectoryIgnoreEntries
+                            FileIgnoreEntries = Array.copy scanInput.FileIgnoreEntries
+                        }
+                    )
+                )
+
+    /// Supplies construction functions for accepted state facts.
+    module AcceptedSelection =
+        /// Captures exactly the target, local-root scope, configuration, and status revision accepted by a caller.
+        let create target localRootScope (configuration as AcceptedConfiguration (_, scanInput)) localStatusRevision =
+            if
+                isNull (box target) || isNull (box localRootScope)
+                || isNull (box configuration)
+            then
+                Error "Working Directory Update requires complete selected target, root scope, and configuration facts."
+            elif localStatusRevision < 0L then
+                Error "Working Directory Update local status revision must be non-negative."
+            else
+                match Contracts.LocalRootScope.create scanInput.RootDirectory with
+                | Ok expectedScope when expectedScope = localRootScope -> Ok(AcceptedSelection(target, localRootScope, configuration, localStatusRevision))
+                | _ -> Error "Working Directory Update selected root scope does not match the frozen scan root."
+
+        /// Returns the frozen local revision for focused stale-selection proof without exposing mutable caller state.
+        let internal localStatusRevision (AcceptedSelection (_, _, _, localStatusRevision)) = localStatusRevision
+
+    /// Rejects a request whose selected scope or frozen scan root could target a different local transaction location.
+    let private selectionMatchesBranchContext
+        (AcceptedSelection (_, selectedScope, AcceptedConfiguration (_, scanInput), _))
+        (BranchContext (localRoot, _, _, _, _, _))
+        =
+        match Contracts.LocalRootScope.create localRoot with
+        | Ok localRootScope ->
+            localRootScope = selectedScope
+            && String.Equals(Path.GetFullPath(scanInput.RootDirectory), localRoot, StringComparison.OrdinalIgnoreCase)
+        | Error _ -> false
+
+    /// Validates the branch tuple by regenerating its deterministic operation identity from every repeated caller fact.
+    let private matchesBranchOperation target operation previousBranchId selection =
+        match Contracts.Operation.branchSwitchWithSelection previousBranchId selection target with
+        | Ok expected -> Contracts.Operation.value expected = Contracts.Operation.value operation
+        | Error _ -> false
+
+    /// Validates the Watch tuple by regenerating its deterministic operation identity from its exact replay cursor.
+    let private matchesWatchOperation target operation eventCursor =
+        match Contracts.Operation.watchReplay (Contracts.Target.repositoryId target) (Contracts.Target.branchId target) eventCursor with
+        | Ok expected -> Contracts.Operation.value expected = Contracts.Operation.value operation
+        | Error _ -> false
+
+    /// Validates the Connect tuple by regenerating its deterministic operation identity from the selected scope and cursor.
+    let private matchesConnectOperation target operation localRootScope initialCursor =
+        match Contracts.Operation.connectBootstrap target initialCursor localRootScope with
+        | Ok expected -> Contracts.Operation.value expected = Contracts.Operation.value operation
+        | Error _ -> false
+
+    /// Verifies that frozen prepared content declares exactly the target status graph before the lease can be acquired.
+    let private preparedContentMatchesTargetStatus (BranchContext (_, _, _, _, targetStatus, _)) preparedContent =
+        let expectedDirectories = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        let expectedFiles = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.OrdinalIgnoreCase)
+        let mutable valid = true
+
+        targetStatus.Index.Values
+        |> Seq.iter (fun directory ->
+            if directory.RelativePath
+               <> Grace.Shared.Constants.RootDirectoryPath then
+                valid <-
+                    valid
+                    && expectedDirectories.Add(string directory.RelativePath)
+
+            directory.Files
+            |> Seq.iter (fun file ->
+                valid <-
+                    valid
+                    && not (expectedFiles.ContainsKey(string file.RelativePath))
+
+                expectedFiles[string file.RelativePath] <- (file.Sha256Hash, file.Blake3Hash)))
+
+        let manifestDirectories = HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        let manifestFiles = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.OrdinalIgnoreCase)
+
+        Contracts.PreparedManifest.entries (Contracts.PreparedContent.manifest preparedContent)
+        |> Seq.iter (function
+            | Contracts.PreparedManifestEntry.Directory path -> valid <- valid && manifestDirectories.Add(string path)
+            | Contracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) ->
+                valid <-
+                    valid
+                    && not (manifestFiles.ContainsKey(string path))
+
+                manifestFiles[string path] <- (sha256Hash, blake3Hash))
+
+        valid
+        && manifestDirectories.SetEquals(expectedDirectories)
+        && manifestFiles.Count = expectedFiles.Count
+        && (expectedFiles
+            |> Seq.forall (fun entry ->
+                match manifestFiles.TryGetValue(entry.Key) with
+                | true, hashes -> hashes = entry.Value
+                | false, _ -> false))
+
+    /// Returns only current immutable selection facts after the engine owns the stable repository/local-root lease.
+    type internal ISelectedStateReader =
+        /// Rereads caller-selected target, normalized root scope, and canonical configuration without planning or mutation access.
+        abstract member ReadAsync: CancellationToken -> Task<AcceptedSelection>
+
+    /// Carries the only caller-progress actions that may run after verified local completion.
+    type internal FinalizationFacts =
+        | BranchFinalization of previousBranchId: BranchId * selection: Contracts.BranchSelection
+        | WatchFinalization of eventCursor: string
+        | ConnectFinalization
+
+    /// Observes coarse engine stages without participating in update ordering or failure classification.
+    type internal ProgressObserver = Progress -> unit
+
+    /// Performs the one idempotent caller acknowledgement after the local update is durably pending.
+    type internal IIdempotentFinalizer =
+        /// Acknowledges only the typed Branch or Watch fact; implementations receive no working-file or SQLite access.
+        abstract member FinalizeAsync: FinalizationFacts * CancellationToken -> Task
+
+    /// Holds the private accepted request tuple while preserving caller-specific constructors and disallowing plans or writer callbacks.
+    type internal Request =
+        private | Request of
+            selection: AcceptedSelection *
+            applicationFacts: BranchContext *
+            operation: Contracts.Operation *
+            preparedContent: Contracts.PreparedContent *
+            correlationId: CorrelationId *
+            selectedStateReader: ISelectedStateReader *
+            completionDetails: LocalStateDb.WorkingDirectoryUpdateCompletionDetails *
+            finalization: FinalizationFacts *
+            finalizer: IIdempotentFinalizer option *
+            progress: ProgressObserver option
+
+    /// Holds only durable recovery facts; deliberately excludes prepared bytes, roots, and file operations.
+    type internal FinalizationRequest =
+        private | FinalizationRequest of
+            selection: AcceptedSelection *
+            operation: Contracts.Operation *
+            localStateDbPath: string *
+            correlationId: CorrelationId *
+            selectedStateReader: ISelectedStateReader *
+            finalization: FinalizationFacts *
+            finalizer: IIdempotentFinalizer *
+            progress: ProgressObserver option
+
+    /// Creates caller-specific normalized requests with no generic transaction hooks.
+    module Request =
+        /// Returns the private prepared-snapshot lifetime count for focused engine proof without exposing its bytes or ownership.
+        let internal preparedContentDisposalCountForTests (Request (_, _, _, preparedContent, _, _, _, _, _, _)) =
+            Contracts.PreparedContent.disposalCount preparedContent
+
+        /// Returns the constructed logical operation identity for caller-bound correlation proof without exposing request internals.
+        let internal operationValueForTests (Request (_, _, operation, _, _, _, _, _, _, _)) = Contracts.Operation.value operation
+
+        /// Captures a Branch-selected target and its idempotent post-completion branch facts.
+        let branchSwitch selection facts operation preparedContent correlationId reader previousBranchId branchSelection finalizer progress =
+            if
+                isNull (box preparedContent)
+                || isNull (box reader)
+                || isNull (box finalizer)
+            then
+                Error "Working Directory Update Branch request requires prepared content, selected state, and a finalizer."
+            elif previousBranchId = Guid.Empty then
+                Error "Working Directory Update Branch request requires a non-empty previous branch identity."
+            else
+                let (AcceptedSelection (target, _, _, _)) = selection
+
+                if
+                    not (selectionMatchesBranchContext selection facts)
+                    || not (matchesBranchOperation target operation previousBranchId branchSelection)
+                    || not (preparedContentMatchesTargetStatus facts preparedContent)
+                then
+                    Error "Working Directory Update Branch request facts do not bind one accepted operation, complete target graph, and local scope."
+                else
+                    Ok(
+                        Request(
+                            selection,
+                            facts,
+                            operation,
+                            preparedContent,
+                            correlationId,
+                            reader,
+                            (match branchSelection with
+                             | Contracts.Reference selectedReferenceId -> LocalStateDb.BranchFinalization(previousBranchId, selectedReferenceId)
+                             | Contracts.DirectoryVersion -> LocalStateDb.BranchDirectoryVersionFinalization previousBranchId),
+                            BranchFinalization(previousBranchId, branchSelection),
+                            Some finalizer,
+                            progress
+                        )
+                    )
+
+        /// Captures a Watch replay target and its exact cursor acknowledgement fact.
+        let watchReplay selection facts operation preparedContent correlationId reader eventCursor finalizer progress =
+            if
+                isNull (box preparedContent)
+                || isNull (box reader)
+                || isNull (box finalizer)
+                || String.IsNullOrWhiteSpace(eventCursor)
+            then
+                Error "Working Directory Update Watch request requires prepared content, selected state, a cursor, and a finalizer."
+            else
+                let (AcceptedSelection (target, _, _, _)) = selection
+
+                if
+                    not (selectionMatchesBranchContext selection facts)
+                    || not (matchesWatchOperation target operation eventCursor)
+                    || not (preparedContentMatchesTargetStatus facts preparedContent)
+                then
+                    Error "Working Directory Update Watch request facts do not bind one accepted operation, complete target graph, and local scope."
+                else
+                    Ok(
+                        Request(
+                            selection,
+                            facts,
+                            operation,
+                            preparedContent,
+                            correlationId,
+                            reader,
+                            LocalStateDb.WatchFinalization eventCursor,
+                            WatchFinalization eventCursor,
+                            Some finalizer,
+                            progress
+                        )
+                    )
+
+        /// Captures a Connect target, which has no separate finalizer once local completion commits.
+        let connectBootstrap
+            (selection as AcceptedSelection (_, localRootScope, _, _))
+            facts
+            operation
+            preparedContent
+            correlationId
+            reader
+            initialCursor
+            progress
+            =
+            if
+                isNull (box preparedContent)
+                || isNull (box reader)
+                || String.IsNullOrWhiteSpace(initialCursor)
+            then
+                Error "Working Directory Update Connect request requires prepared content, selected state, and an initial cursor."
+            else
+                let (AcceptedSelection (target, _, _, _)) = selection
+
+                if
+                    not (selectionMatchesBranchContext selection facts)
+                    || not (matchesConnectOperation target operation localRootScope initialCursor)
+                    || not (preparedContentMatchesTargetStatus facts preparedContent)
+                then
+                    Error "Working Directory Update Connect request facts do not bind one accepted operation, complete target graph, and local scope."
+                else
+                    Ok(
+                        Request(
+                            selection,
+                            facts,
+                            operation,
+                            preparedContent,
+                            correlationId,
+                            reader,
+                            LocalStateDb.ConnectCompletion(initialCursor, localRootScope),
+                            ConnectFinalization,
+                            None,
+                            progress
+                        )
+                    )
+
+    /// Creates recovery-only requests after the caller has retained exact Branch or Watch finalization facts.
+    module FinalizationRequest =
+        /// Captures a Branch retry without allowing the retry path to access prepared or working-file state.
+        let branchSwitch selection operation localStateDbPath correlationId reader previousBranchId branchSelection finalizer progress =
+            if isNull (box reader)
+               || isNull (box finalizer)
+               || String.IsNullOrWhiteSpace(localStateDbPath)
+               || previousBranchId = Guid.Empty then
+                Error "Working Directory Update Branch finalization requires selected state, database path, and finalizer."
+            else
+                let (AcceptedSelection (target, _, _, _)) = selection
+
+                if not (matchesBranchOperation target operation previousBranchId branchSelection) then
+                    Error "Working Directory Update Branch finalization facts do not bind the recorded operation."
+                else
+                    Ok(
+                        FinalizationRequest(
+                            selection,
+                            operation,
+                            Path.GetFullPath(localStateDbPath),
+                            correlationId,
+                            reader,
+                            BranchFinalization(previousBranchId, branchSelection),
+                            finalizer,
+                            progress
+                        )
+                    )
+
+        /// Captures a Watch retry without allowing the retry path to access prepared or working-file state.
+        let watchReplay selection operation localStateDbPath correlationId reader eventCursor finalizer progress =
+            if
+                isNull (box reader)
+                || isNull (box finalizer)
+                || String.IsNullOrWhiteSpace(localStateDbPath)
+                || String.IsNullOrWhiteSpace(eventCursor)
+            then
+                Error "Working Directory Update Watch finalization requires selected state, database path, cursor, and finalizer."
+            else
+                let (AcceptedSelection (target, _, _, _)) = selection
+
+                if not (matchesWatchOperation target operation eventCursor) then
+                    Error "Working Directory Update Watch finalization facts do not bind the recorded operation."
+                else
+                    Ok(
+                        FinalizationRequest(
+                            selection,
+                            operation,
+                            Path.GetFullPath(localStateDbPath),
+                            correlationId,
+                            reader,
+                            WatchFinalization eventCursor,
+                            finalizer,
+                            progress
+                        )
+                    )
+
+    /// Holds the process-local finite seam selected by an integration test, never by a caller request.
+    let mutable private failurePointForTests = None
+
+    /// Selects an internal finite seam for a serialized integration test.
+    let internal setFailurePointForTests failurePoint = failurePointForTests <- failurePoint
+
+    /// Reports progress best-effort so observers cannot change transaction ordering or outcomes.
+    let private report progress stage =
+        match progress with
+        | Some observer ->
+            try
+                observer stage
+            with
+            | _ -> ()
+        | None -> ()
+
+    /// Produces a classified failure without leaking mutable engine state to callers.
+    let private failure reason =
+        Contracts.Failure.create reason
+        |> function
+            | Ok value -> value
+            | Error error -> invalidOp error
+
+    /// Produces a receipt only after the operation and target are known to match.
+    let private receipt target operation bytesChanged =
+        Contracts.Receipt.create target operation bytesChanged
+        |> function
+            | Ok value -> value
+            | Error error -> invalidOp error
+
+    /// Throws at exactly one finite integration-test seam without providing a generic failure callback.
+    let private throwAt expected =
+        match failurePointForTests with
+        | Some actual when actual = expected -> invalidOp $"Injected Working Directory Update failure at {expected}."
+        | _ -> ()
+
+    /// Resolves a relative path below a normalized root and rejects traversal before any file operation.
+    let private pathUnderRoot root (relativePath: RelativePath) =
+        let fullRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root))
+        let candidate = Path.GetFullPath(Path.Combine(fullRoot, string relativePath))
+        let prefix = fullRoot + string Path.DirectorySeparatorChar
+
+        if candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) then
+            candidate
+        else
+            invalidOp "Working Directory Update rejected a path outside its local root."
+
+    /// Computes required content hashes from a real file immediately before crossing an object or working-file boundary.
+    let private computeHashes path =
+        task {
+            use stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read)
+            return! computeHashesForFile stream (RelativePath(Path.GetFileName(path)))
+        }
+
+    /// Requires a real file to retain its exact prepared SHA-256 and BLAKE3 bytes.
+    let private verifyFile path sha256Hash blake3Hash =
+        task {
+            if not (File.Exists(path)) then
+                return Error "Required prepared file is missing."
+            else
+                let! actualSha256Hash, actualBlake3Hash = computeHashes path
+
+                if actualSha256Hash <> sha256Hash then
+                    return Error "File bytes do not match the prepared SHA-256 hash."
+                elif actualBlake3Hash <> blake3Hash then
+                    return Error "File bytes do not match the prepared BLAKE3 hash."
+                else
+                    return Ok()
+        }
+
+    /// Avoids a working-file rewrite when its actual bytes already equal the verified object declaration.
+    let private requiresWorkingCopy path sha256Hash blake3Hash =
+        task {
+            match! verifyFile path sha256Hash blake3Hash with
+            | Ok () -> return false
+            | Error _ -> return true
+        }
+
+    /// Publishes one verified object atomically before any working-file mutation and re-verifies the final object path.
+    let private publishObject preparedContent objectRoot relativePath sha256Hash blake3Hash =
+        task {
+            let objectFileName = Services.getLocalObjectCacheFileName relativePath sha256Hash blake3Hash
+            let objectPath = pathUnderRoot objectRoot (RelativePath(Path.Combine(string relativePath, objectFileName)))
+            let objectDirectory = Path.GetDirectoryName(objectPath)
+
+            Directory.CreateDirectory(objectDirectory)
+            |> ignore
+
+            let temporaryPath = Path.Combine(objectDirectory, $".{objectFileName}.{Guid.NewGuid():N}.tmp")
+
+            try
+                match! verifyFile objectPath sha256Hash blake3Hash with
+                | Ok () -> return Ok()
+                | Error _ ->
+                    match Contracts.PreparedContent.openRead preparedContent relativePath with
+                    | Error error -> return Error error
+                    | Ok source ->
+                        use source = source
+                        use destination = File.Open(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)
+                        do! source.CopyToAsync(destination)
+                        destination.Flush(true)
+                        destination.Dispose()
+
+                        match! verifyFile temporaryPath sha256Hash blake3Hash with
+                        | Error error -> return Error error
+                        | Ok () ->
+                            File.Move(temporaryPath, objectPath, true)
+                            return! verifyFile objectPath sha256Hash blake3Hash
+            finally
+                if File.Exists(temporaryPath) then File.Delete(temporaryPath)
+        }
+
+    /// Builds a target-only plan only after supported ignore-aware scanning has verified the accepted baseline.
+    let private buildPlan (scanInput: Services.WorkingTreeScanInput) localRoot (baselineStatus: GraceStatus) preparedContent =
+        task {
+            match! Services.scanWorkingTreeForDifferencesReadOnly scanInput baselineStatus with
+            | Error error -> return Error error
+            | Ok differences when differences.Count > 0 ->
+                let changedPaths =
+                    differences
+                    |> Seq.map (fun difference -> string difference.RelativePath)
+                    |> Seq.distinct
+                    |> String.concat ", "
+
+                return Error $"Working Directory Update rejected relevant working-tree content that changed after selection: {changedPaths}."
+            | Ok _ ->
+                let targetFiles =
+                    Contracts.PreparedManifest.entries (Contracts.PreparedContent.manifest preparedContent)
+                    |> Seq.choose (function
+                        | Contracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) -> Some(path, sha256Hash, blake3Hash)
+                        | Contracts.PreparedManifestEntry.Directory _ -> None)
+                    |> Seq.toArray
+
+                let targetPaths =
+                    HashSet<string>(
+                        targetFiles
+                        |> Seq.map (fun (path, _, _) -> string path),
+                        StringComparer.OrdinalIgnoreCase
+                    )
+
+                let deletions =
+                    baselineStatus.Index.Values
+                    |> Seq.collect (fun directory -> directory.Files)
+                    |> Seq.map (fun file -> file.RelativePath)
+                    |> Seq.filter (fun path -> not (targetPaths.Contains(string path)))
+                    |> Seq.toArray
+
+                return Ok(targetFiles, deletions)
+        }
+
+    /// Resolves a status-directory path under the working root, including the canonical root-directory entry.
+    let private directoryPathUnderRoot localRoot (relativePath: RelativePath) =
+        if relativePath = Grace.Shared.Constants.RootDirectoryPath then
+            Path.GetFullPath(localRoot)
+        else
+            pathUnderRoot localRoot relativePath
+
+    /// Creates every directory declared by the frozen target graph before final-root verification.
+    let private materializeTargetDirectories localRoot (statusToCommit: GraceStatus) =
+        task {
+            let directories =
+                statusToCommit.Index.Values
+                |> Seq.map (fun directory -> directory.RelativePath)
+                |> Seq.sortBy (fun relativePath -> string relativePath)
+                |> Seq.toArray
+
+            let mutable directoryIndex = 0
+            let mutable created = false
+
+            while directoryIndex < directories.Length do
+                let directoryPath = directoryPathUnderRoot localRoot directories[directoryIndex]
+
+                if not (Directory.Exists(directoryPath)) then
+                    Directory.CreateDirectory(directoryPath) |> ignore
+
+                    created <- true
+
+                directoryIndex <- directoryIndex + 1
+
+            return created
+        }
+
+    /// Recomputes one on-disk directory identity from verified direct files and recursively verified children.
+    let rec private verifyCompleteDirectory localRoot (statusToCommit: GraceStatus) directoryId =
+        task {
+            let mutable directory = LocalDirectoryVersion.Default
+
+            if not (statusToCommit.Index.TryGetValue(directoryId, &directory)) then
+                return Error $"Working Directory Update final verification is missing directory {directoryId}."
+            elif not (Directory.Exists(directoryPathUnderRoot localRoot directory.RelativePath)) then
+                return Error $"Working Directory Update final verification is missing directory '{directory.RelativePath}'."
+            else
+                let entries = ResizeArray<Grace.Shared.Services.DirectoryVersionPreimageEntry>()
+                let files = directory.Files |> Seq.toArray
+                let mutable fileIndex = 0
+                let mutable fileError = None
+                let mutable directSize = 0L
+
+                while fileIndex < files.Length
+                      && Option.isNone fileError do
+                    let file = files[fileIndex]
+                    let filePath = pathUnderRoot localRoot file.RelativePath
+
+                    match! verifyFile filePath file.Sha256Hash file.Blake3Hash with
+                    | Error error -> fileError <- Some error
+                    | Ok () ->
+                        let actualSize = FileInfo(filePath).Length
+
+                        if actualSize <> file.Size then
+                            fileError <- Some $"File '{file.RelativePath}' has an unexpected size."
+                        else
+                            directSize <- directSize + actualSize
+
+                            entries.Add(Grace.Shared.Services.DirectoryVersionPreimageEntry.File file.RelativePath actualSize file.Blake3Hash file.Sha256Hash)
+
+                    fileIndex <- fileIndex + 1
+
+                match fileError with
+                | Some error -> return Error error
+                | None when directSize <> directory.Size -> return Error $"Directory '{directory.RelativePath}' has an unexpected direct-file size."
+                | None ->
+                    let childIds = directory.Directories |> Seq.toArray
+                    let mutable childIndex = 0
+                    let mutable childError = None
+
+                    while childIndex < childIds.Length
+                          && Option.isNone childError do
+                        let! child = verifyCompleteDirectory localRoot statusToCommit childIds[childIndex]
+
+                        match child with
+                        | Error error -> childError <- Some error
+                        | Ok (childPath, childSize, childSha256Hash, childBlake3Hash) ->
+                            entries.Add(Grace.Shared.Services.DirectoryVersionPreimageEntry.Directory childPath childSize childBlake3Hash childSha256Hash)
+
+                        childIndex <- childIndex + 1
+
+                    match childError with
+                    | Some error -> return Error error
+                    | None ->
+                        let actualSha256Hash = Grace.Shared.Services.computeSha256ForDirectoryEntries directory.RelativePath entries
+
+                        let actualBlake3Hash = Grace.Shared.Services.computeBlake3ForDirectory directory.RelativePath entries
+
+                        if actualSha256Hash <> directory.Sha256Hash then
+                            return Error $"Directory '{directory.RelativePath}' does not match its SHA-256 hash."
+                        elif actualBlake3Hash <> directory.Blake3Hash then
+                            return Error $"Directory '{directory.RelativePath}' does not match its BLAKE3 hash."
+                        else
+                            return Ok(directory.RelativePath, directSize, actualSha256Hash, actualBlake3Hash)
+        }
+
+    /// Verifies the full eligible final tree and exact target tuple before the atomic local completion commit.
+    let private verifySelectedRoot localRoot scanInput (statusToCommit: GraceStatus) target =
+        task {
+            if LocalStateDb.validateCompleteStatusTree statusToCommit
+               |> Result.isError then
+                return Error "Working Directory Update final status is not one complete canonical root graph."
+            elif statusToCommit.RootDirectoryId
+                 <> Contracts.Target.rootDirectoryVersionId target
+                 || statusToCommit.RootDirectorySha256Hash
+                    <> Contracts.Target.sha256Hash target
+                 || statusToCommit.RootDirectoryBlake3Hash
+                    <> Contracts.Target.blake3Hash target then
+                return Error "Working Directory Update final status does not match the selected target."
+            else
+                match! Services.scanWorkingTreeForDifferencesReadOnly scanInput statusToCommit with
+                | Error error -> return Error $"Working Directory Update final tree scan failed: {error}"
+                | Ok differences when differences.Count > 0 ->
+                    return Error "Working Directory Update final tree contains missing or unexpected eligible entries."
+                | Ok _ ->
+                    match! verifyCompleteDirectory localRoot statusToCommit statusToCommit.RootDirectoryId with
+                    | Error error -> return Error $"Working Directory Update final verification failed: {error}"
+                    | Ok (_, _, rootSha256Hash, rootBlake3Hash) when
+                        rootSha256Hash = Contracts.Target.sha256Hash target
+                        && rootBlake3Hash = Contracts.Target.blake3Hash target
+                        ->
+                        return Ok()
+                    | Ok _ -> return Error "Working Directory Update final root does not match the selected target."
+        }
+
+    /// Validates both accepted status revision and baseline root tuple after lease acquisition.
+    let private matchesBaseline actual expected =
+        actual.RootDirectoryId = expected.RootDirectoryId
+        && actual.RootDirectorySha256Hash = expected.RootDirectorySha256Hash
+        && actual.RootDirectoryBlake3Hash = expected.RootDirectoryBlake3Hash
+
+    /// Runs the typed finalizer before the only pending-to-terminal SQLite transition.
+    let private finalize localStateDbPath target operation (finalization: FinalizationFacts) (finalizer: IIdempotentFinalizer) cancellationToken =
+        task {
+            throwAt BeforeFinalization
+            do! finalizer.FinalizeAsync(finalization, cancellationToken)
+
+            throwAt BeforeTerminalCompletion
+            do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion localStateDbPath target operation
+        }
+
+    /// Reconciles a same-operation pending completion without touching working files.
+    let private finishPending localStateDbPath target operation finalization finalizer cancellationToken =
+        task {
+            try
+                do! finalize localStateDbPath target operation finalization finalizer cancellationToken
+                return Unchanged(receipt target operation false)
+            with
+            | ex -> return FinalizationIncomplete(receipt target operation false, failure ex.Message)
+        }
+
+    /// Applies one verified local update under the repository/local-root lease and returns only the five terminal outcomes.
+    let run
+        (Request (selection,
+                  BranchContext (localRoot, objectRoot, localStateDbPath, priorStatus, targetStatus, objectMetadata),
+                  operation,
+                  preparedContent,
+                  _,
+                  selectedStateReader,
+                  completionDetails,
+                  finalization,
+                  finalizer,
+                  progress))
+        cancellationToken
+        =
+        task {
+            use preparedContentLifetime =
+                { new IDisposable with
+                    member _.Dispose() = Contracts.PreparedContent.dispose preparedContent
+                }
+
+            let (AcceptedSelection (target, localRootScope, AcceptedConfiguration (_, scanInput), acceptedRevision)) = selection
+            let mutable mutated = false
+            let mutable locallyCompleted = false
+            let mutable ownedToken = None
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create (Contracts.Target.repositoryId target) localRoot
+                |> function
+                    | Ok value -> value
+                    | Error error -> invalidOp error
+
+            /// Clears only the current attempt's exact marker while the scope lease remains held.
+            let complete outcome =
+                task {
+                    match ownedToken with
+                    | Some token ->
+                        let! _ = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+                        ownedToken <- None
+                    | None -> ()
+
+                    return outcome
+                }
+
+            try
+                if not (Contracts.Operation.matchesTarget target operation) then
+                    return! complete (Rejected(failure "Working Directory Update operation does not match its accepted target."))
+                else
+                    report progress Preparing
+
+                    report progress Waiting
+                    use! heldLease = WorkingDirectoryUpdateCoordination.Lease.acquire scope cancellationToken
+                    cancellationToken.ThrowIfCancellationRequested()
+                    let! selectedAfterLease = selectedStateReader.ReadAsync(cancellationToken)
+                    let! currentRevision = LocalStateDb.readLocalStatusRevision localStateDbPath
+                    let! currentStatus = LocalStateDb.readStatusSnapshot localStateDbPath
+                    let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization localStateDbPath
+                    let! completion = LocalStateDb.readWorkingDirectoryUpdateCompletion localStateDbPath target operation
+
+                    if selectedAfterLease <> selection then
+                        return! complete (Rejected(failure "Working Directory Update selected state changed while waiting for the lease."))
+                    else
+                        match pending, completion with
+                        | Some _, Some LocalStateDb.WorkingDirectoryUpdateCompletion.Pending ->
+                            let! _ = WorkingDirectoryUpdateCoordination.Marker.tryRemoveMatchingCompletion scope target operation
+
+                            match finalizer with
+                            | Some value ->
+                                let! outcome = finishPending localStateDbPath target operation finalization value cancellationToken
+                                return! complete outcome
+                            | None -> return! complete (Rejected(failure "Connect cannot retain a pending finalization."))
+                        | Some _, _ -> return! complete (Rejected(failure "A different Working Directory Update finalization is pending."))
+                        | None, Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal ->
+                            let! _ = WorkingDirectoryUpdateCoordination.Marker.tryRemoveMatchingCompletion scope target operation
+                            return! complete (Unchanged(receipt target operation false))
+                        | None, Some LocalStateDb.WorkingDirectoryUpdateCompletion.Pending ->
+                            match finalizer with
+                            | Some value ->
+                                let! outcome = finishPending localStateDbPath target operation finalization value cancellationToken
+                                return! complete outcome
+                            | None -> return! complete (Rejected(failure "Connect cannot retain a pending finalization."))
+                        | None, None when
+                            currentRevision <> acceptedRevision
+                            || not (matchesBaseline currentStatus priorStatus)
+                            ->
+                            return! complete (Rejected(failure "Working Directory Update local status changed while waiting for the lease."))
+                        | None, None ->
+                            match! WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation with
+                            | WorkingDirectoryUpdateCoordination.DifferentOperation
+                            | WorkingDirectoryUpdateCoordination.MalformedOrUnsupported
+                            | WorkingDirectoryUpdateCoordination.Unreadable ->
+                                return! complete (Rejected(failure "Working Directory Update marker requires `grace doctor --repair-local-state` recovery."))
+                            | WorkingDirectoryUpdateCoordination.ExactMatch ->
+                                return!
+                                    complete (
+                                        Rejected(
+                                            failure
+                                                "Working Directory Update found matching incomplete marker evidence; run `grace doctor --repair-local-state`."
+                                        )
+                                    )
+                            | WorkingDirectoryUpdateCoordination.Missing ->
+                                match! buildPlan scanInput localRoot priorStatus preparedContent with
+                                | Error error -> return! complete (Rejected(failure error))
+                                | Ok (targetFiles, deletions) ->
+                                    let token = Contracts.AttemptToken.create ()
+
+                                    let marker =
+                                        WorkingDirectoryUpdateCoordination.Marker.create scope token target operation
+                                        |> function
+                                            | Ok value -> value
+                                            | Error error -> invalidOp error
+
+                                    do! WorkingDirectoryUpdateCoordination.Marker.write scope marker
+                                    ownedToken <- Some token
+                                    cancellationToken.ThrowIfCancellationRequested()
+                                    throwAt BeforeObjectPublication
+
+                                    let mutable objectIndex = 0
+
+                                    while objectIndex < targetFiles.Length do
+                                        let relativePath, sha256Hash, blake3Hash = targetFiles[objectIndex]
+
+                                        match! publishObject preparedContent objectRoot relativePath sha256Hash blake3Hash with
+                                        | Ok () -> ()
+                                        | Error error -> invalidOp error
+
+                                        objectIndex <- objectIndex + 1
+
+                                    report progress Applying
+
+                                    let mutable applicationIndex = 0
+
+                                    while applicationIndex < targetFiles.Length do
+                                        let relativePath, sha256Hash, blake3Hash = targetFiles[applicationIndex]
+                                        let objectFileName = Services.getLocalObjectCacheFileName relativePath sha256Hash blake3Hash
+                                        let objectPath = pathUnderRoot objectRoot (RelativePath(Path.Combine(string relativePath, objectFileName)))
+
+                                        match! verifyFile objectPath sha256Hash blake3Hash with
+                                        | Error error -> invalidOp error
+                                        | Ok () ->
+                                            let workingPath = pathUnderRoot localRoot relativePath
+                                            let! workingCopyRequired = requiresWorkingCopy workingPath sha256Hash blake3Hash
+
+                                            if workingCopyRequired then
+                                                Directory.CreateDirectory(Path.GetDirectoryName(workingPath))
+                                                |> ignore
+
+                                                mutated <- true
+                                                File.Copy(objectPath, workingPath, true)
+
+                                        applicationIndex <- applicationIndex + 1
+
+                                    let! createdDirectories = materializeTargetDirectories localRoot targetStatus
+
+                                    if createdDirectories then mutated <- true
+
+                                    let mutable deletionIndex = 0
+
+                                    while deletionIndex < deletions.Length do
+                                        let relativePath = deletions[deletionIndex]
+                                        let path = pathUnderRoot localRoot relativePath
+
+                                        if File.Exists(path) then
+                                            mutated <- true
+                                            File.Delete(path)
+
+                                        deletionIndex <- deletionIndex + 1
+
+                                    throwAt AfterWorkingMutation
+                                    report progress Verifying
+
+                                    match! verifySelectedRoot localRoot scanInput targetStatus target with
+                                    | Error error -> return! complete (UpdateIncomplete(failure error))
+                                    | Ok () ->
+                                        throwAt BeforeLocalCompletion
+                                        report progress Committing
+
+                                        let! _ =
+                                            LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                                                localStateDbPath
+                                                targetStatus
+                                                objectMetadata
+                                                completionDetails
+                                                target
+                                                operation
+
+                                        locallyCompleted <- true
+                                        throwAt AfterLocalCompletionBeforeSidecar
+
+                                        do! WorkingDirectoryUpdateCoordination.Sidecar.write scope operation
+
+                                        match ownedToken with
+                                        | Some token ->
+                                            let! _ = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+                                            ownedToken <- None
+                                            ()
+                                        | None -> ()
+
+                                        match finalizer with
+                                        | None ->
+                                            return!
+                                                complete (
+                                                    if mutated then
+                                                        Updated(receipt target operation true)
+                                                    else
+                                                        Unchanged(receipt target operation false)
+                                                )
+                                        | Some value ->
+                                            try
+                                                do! finalize localStateDbPath target operation finalization value cancellationToken
+
+                                                return!
+                                                    complete (
+                                                        if mutated then
+                                                            Updated(receipt target operation true)
+                                                        else
+                                                            Unchanged(receipt target operation false)
+                                                    )
+                                            with
+                                            | ex -> return! complete (FinalizationIncomplete(receipt target operation mutated, failure ex.Message))
+            with
+            | :? OperationCanceledException when not mutated ->
+                return! complete (Rejected(failure "Working Directory Update was cancelled before working-file mutation."))
+            | ex when locallyCompleted ->
+                match finalizer with
+                | Some _ -> return! complete (FinalizationIncomplete(receipt target operation mutated, failure ex.Message))
+                | None ->
+                    return!
+                        complete (
+                            if mutated then
+                                Updated(receipt target operation true)
+                            else
+                                Unchanged(receipt target operation false)
+                        )
+            | ex when mutated -> return! complete (UpdateIncomplete(failure ex.Message))
+            | ex -> return! complete (Rejected(failure ex.Message))
+        }
+
+    /// Retries only recorded typed finalization after lease and selected-state revalidation; it never accesses working files.
+    let retryFinalization
+        (FinalizationRequest (selection, operation, localStateDbPath, _, selectedStateReader, finalization, finalizer, progress))
+        cancellationToken
+        =
+        task {
+            let (AcceptedSelection (target, localRootScope, _, _)) = selection
+
+            try
+                report progress Waiting
+
+                let scope =
+                    WorkingDirectoryUpdateCoordination.Scope.createFromLocalRootScope (Contracts.Target.repositoryId target) localRootScope
+                    |> function
+                        | Ok value -> value
+                        | Error error -> invalidOp error
+
+                use! heldLease = WorkingDirectoryUpdateCoordination.Lease.acquire scope cancellationToken
+                cancellationToken.ThrowIfCancellationRequested()
+                let! selectedAfterLease = selectedStateReader.ReadAsync(cancellationToken)
+
+                if selectedAfterLease <> selection then
+                    return Rejected(failure "Working Directory Update selected state changed before finalization retry.")
+                else
+                    let! completion = LocalStateDb.readWorkingDirectoryUpdateCompletion localStateDbPath target operation
+
+                    match completion with
+                    | Some LocalStateDb.WorkingDirectoryUpdateCompletion.Pending ->
+                        return! finishPending localStateDbPath target operation finalization finalizer cancellationToken
+                    | Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal -> return Unchanged(receipt target operation false)
+                    | None -> return Rejected(failure "Working Directory Update finalization is not pending for this operation.")
+            with
+            | :? OperationCanceledException -> return Rejected(failure "Working Directory Update finalization retry was cancelled.")
+            | ex -> return Rejected(failure ex.Message)
+        }

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -904,15 +904,9 @@ module internal WorkingDirectoryUpdate =
                             | WorkingDirectoryUpdateCoordination.MalformedOrUnsupported
                             | WorkingDirectoryUpdateCoordination.Unreadable ->
                                 return! complete (Rejected(failure "Working Directory Update marker requires `grace doctor --repair-local-state` recovery."))
+                            | WorkingDirectoryUpdateCoordination.Missing
                             | WorkingDirectoryUpdateCoordination.ExactMatch ->
-                                return!
-                                    complete (
-                                        Rejected(
-                                            failure
-                                                "Working Directory Update found matching incomplete marker evidence; run `grace doctor --repair-local-state`."
-                                        )
-                                    )
-                            | WorkingDirectoryUpdateCoordination.Missing ->
+                                // An exact orphaned marker is adopted only after the complete post-lease reread above; the fresh marker below owns this attempt.
                                 match! buildPlan scanInput localRoot priorStatus preparedContent with
                                 | Error error -> return! complete (Rejected(failure error))
                                 | Ok (targetFiles, deletions) ->

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
@@ -256,6 +256,14 @@ module internal WorkingDirectoryUpdateCoordination =
                     let rootScope = WorkingDirectoryUpdate.LocalRootScope.value localRootScope
                     Scope(repositoryId, rootScope, Services.workingDirectoryUpdateTempDirectory repositoryId rootScope))
 
+        /// Rebuilds the stable lease location from the immutable root scope retained by a recovery-only request.
+        let createFromLocalRootScope repositoryId localRootScope =
+            if repositoryId = Guid.Empty then
+                Error "Working Directory Update coordination requires a repository id."
+            else
+                let rootScope = WorkingDirectoryUpdate.LocalRootScope.value localRootScope
+                Ok(Scope(repositoryId, rootScope, Services.workingDirectoryUpdateTempDirectory repositoryId rootScope))
+
         /// Returns the lower-case SHA-256 local-root component of a scope.
         let value (scope: Scope) = scopeValue scope
 
@@ -411,6 +419,32 @@ module internal WorkingDirectoryUpdateCoordination =
 
         /// Removes a marker only after its currently persisted token exactly matches this attempt and reports every refusal distinctly.
         let tryRemoveOwned scope attemptToken = tryRemoveOwnedWithDelete scope attemptToken File.Delete
+
+        /// Removes only marker evidence that exactly identifies an already completed operation.
+        let tryRemoveMatchingCompletion scope expectedTarget operation =
+            task {
+                let path = Scope.markerPath scope
+
+                if not (File.Exists(path)) then
+                    return false
+                else
+                    try
+                        let content = File.ReadAllText(path)
+
+                        match tryReadMarkerDocument scope content with
+                        | Ok marker when
+                            marker.OperationId = WorkingDirectoryUpdate.Operation.value operation
+                            && marker.Target = WorkingDirectoryUpdate.Target.canonical expectedTarget
+                            && marker.CallerKind = (WorkingDirectoryUpdate.Operation.callerKind operation
+                                                    |> callerKindText)
+                            ->
+                            File.Delete(path)
+                            return true
+                        | _ -> return false
+                    with
+                    | :? IOException
+                    | :? UnauthorizedAccessException -> return false
+            }
 
     /// Supplies derived sidecar creation without changing or deleting marker evidence.
     module Sidecar =

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
@@ -383,8 +383,8 @@ module internal WorkingDirectoryUpdateCoordination =
                         | :? UnauthorizedAccessException -> return Unreadable
             }
 
-        /// Removes a marker only after its currently persisted token exactly matches this attempt and reports every refusal distinctly.
-        let tryRemoveOwned scope attemptToken =
+        /// Removes a marker with an injected deletion action so portable focused proofs can force the exact cleanup-failure boundary.
+        let tryRemoveOwnedWithDelete scope attemptToken deleteMarker =
             task {
                 let path = Scope.markerPath scope
 
@@ -397,7 +397,7 @@ module internal WorkingDirectoryUpdateCoordination =
                         match tryReadMarkerDocument scope content with
                         | Ok marker when marker.AttemptToken = WorkingDirectoryUpdate.AttemptToken.value attemptToken ->
                             try
-                                File.Delete(path)
+                                deleteMarker path
                                 return ExactMatchCleaned
                             with
                             | :? IOException
@@ -408,6 +408,9 @@ module internal WorkingDirectoryUpdateCoordination =
                     | :? IOException
                     | :? UnauthorizedAccessException -> return UnreadableEvidence
             }
+
+        /// Removes a marker only after its currently persisted token exactly matches this attempt and reports every refusal distinctly.
+        let tryRemoveOwned scope attemptToken = tryRemoveOwnedWithDelete scope attemptToken File.Delete
 
     /// Supplies derived sidecar creation without changing or deleting marker evidence.
     module Sidecar =

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
@@ -29,11 +29,22 @@ module internal WorkingDirectoryUpdateCoordination =
         interface IDisposable with
             member _.Dispose() = stream.Dispose()
 
-    /// Names the only marker inspection outcomes callers may use before planning a fresh update.
+    /// Names every persisted marker disposition that decides whether an update may plan, adopt, or must preserve evidence.
     type MarkerInspection =
         | Missing
-        | Adopt
-        | RequiresDoctor
+        | ExactMatch
+        | DifferentOperation
+        | MalformedOrUnsupported
+        | Unreadable
+
+    /// Names the exact cleanup result so callers never mistake foreign or damaged evidence for successful removal.
+    type MarkerCleanup =
+        | NoMarker
+        | ExactMatchCleaned
+        | DifferentOperationEvidence
+        | MalformedOrUnsupportedEvidence
+        | UnreadableEvidence
+        | ExactCleanupFailed
 
     /// Holds one versioned marker record written only while its scope lease is held.
     type internal MarkerDocument =
@@ -343,11 +354,11 @@ module internal WorkingDirectoryUpdateCoordination =
                 File.WriteAllText(Scope.markerPath scope, serialized)
             }
 
-        /// Classifies a marker as adoptable only when its complete target, caller kind, and operation exactly match the retry.
+        /// Classifies every marker state so a caller can adopt only exact evidence and preserve all Doctor-required evidence.
         let inspect scope expectedTarget operation =
             task {
                 if not (WorkingDirectoryUpdate.Operation.matchesTarget expectedTarget operation) then
-                    return RequiresDoctor
+                    return DifferentOperation
                 else
                     let path = Scope.markerPath scope
 
@@ -364,33 +375,38 @@ module internal WorkingDirectoryUpdateCoordination =
                                 && marker.CallerKind = (WorkingDirectoryUpdate.Operation.callerKind operation
                                                         |> callerKindText)
                                 ->
-                                return Adopt
-                            | Ok _ -> return RequiresDoctor
-                            | Error _ -> return RequiresDoctor
+                                return ExactMatch
+                            | Ok _ -> return DifferentOperation
+                            | Error _ -> return MalformedOrUnsupported
                         with
                         | :? IOException
-                        | :? UnauthorizedAccessException -> return RequiresDoctor
+                        | :? UnauthorizedAccessException -> return Unreadable
             }
 
-        /// Removes a marker only after its currently persisted token exactly matches this attempt token.
+        /// Removes a marker only after its currently persisted token exactly matches this attempt and reports every refusal distinctly.
         let tryRemoveOwned scope attemptToken =
             task {
                 let path = Scope.markerPath scope
 
                 if not (File.Exists(path)) then
-                    return false
+                    return NoMarker
                 else
                     try
                         let content = File.ReadAllText(path)
 
                         match tryReadMarkerDocument scope content with
                         | Ok marker when marker.AttemptToken = WorkingDirectoryUpdate.AttemptToken.value attemptToken ->
-                            File.Delete(path)
-                            return true
-                        | _ -> return false
+                            try
+                                File.Delete(path)
+                                return ExactMatchCleaned
+                            with
+                            | :? IOException
+                            | :? UnauthorizedAccessException -> return ExactCleanupFailed
+                        | Ok _ -> return DifferentOperationEvidence
+                        | Error _ -> return MalformedOrUnsupportedEvidence
                     with
                     | :? IOException
-                    | :? UnauthorizedAccessException -> return false
+                    | :? UnauthorizedAccessException -> return UnreadableEvidence
             }
 
     /// Supplies derived sidecar creation without changing or deleting marker evidence.

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -66,7 +66,7 @@ module internal WorkingDirectoryUpdateContracts =
         abstract member OpenReadAsync: RelativePath * CancellationToken -> Task<Stream>
 
     /// Represents immutable dual-hash-verified bytes for a future update engine.
-    type PreparedContent = private PreparedContent of PreparedManifest * Dictionary<string, byte array> * disposed: bool ref
+    type PreparedContent = private PreparedContent of PreparedManifest * Dictionary<string, byte array> * disposed: bool ref * disposalCount: int ref
 
     /// Holds validated update inputs without exposing a mutation plan, writer, or transaction callback.
     type Request = private Request of Target * Operation * PreparedContent * CorrelationId
@@ -233,6 +233,15 @@ module internal WorkingDirectoryUpdateContracts =
 
         /// Returns the branch selected by this target.
         let branchId (Target (_, branchId, _, _, _, _)) = branchId
+
+        /// Returns the exact root directory version that the completed working tree must represent.
+        let rootDirectoryVersionId (Target (_, _, rootDirectoryVersionId, _, _, _)) = rootDirectoryVersionId
+
+        /// Returns the selected root SHA-256 that binds the status graph to the target.
+        let sha256Hash (Target (_, _, _, sha256Hash, _, _)) = sha256Hash
+
+        /// Returns the selected root BLAKE3 that binds the status graph to the target.
+        let blake3Hash (Target (_, _, _, _, blake3Hash, _)) = blake3Hash
 
         /// Returns the canonical target encoding included in caller operation tuples.
         let canonical (Target (_, _, _, _, _, canonical)) = canonical
@@ -522,13 +531,16 @@ module internal WorkingDirectoryUpdateContracts =
 
                             match byteError with
                             | Some error -> return Error error
-                            | None -> return Ok(PreparedContent(manifest, bytesByPath, ref false))
+                            | None -> return Ok(PreparedContent(manifest, bytesByPath, ref false, ref 0))
                     finally
                         reader.Dispose()
             }
 
+        /// Returns the immutable manifest that defines every path the update may materialize.
+        let manifest (PreparedContent (manifest, _, _, _)) = manifest
+
         /// Opens a read-only stream over verified bytes for one declared file.
-        let openRead (PreparedContent (_, bytesByPath, disposed)) path =
+        let openRead (PreparedContent (_, bytesByPath, disposed, _)) path =
             match normalizeRelativePath path with
             | Error error -> Error error
             | Ok path when !disposed -> Error "Prepared-content has already been disposed."
@@ -538,13 +550,17 @@ module internal WorkingDirectoryUpdateContracts =
                 | false, _ -> Error $"Prepared-content has no declared file '{path}'."
 
         /// Clears verified bytes when the owning update operation reaches a terminal path.
-        let dispose (PreparedContent (_, bytesByPath, disposed)) =
+        let dispose (PreparedContent (_, bytesByPath, disposed, disposalCount)) =
             if not !disposed then
                 bytesByPath.Values
                 |> Seq.iter (fun bytes -> Array.Clear(bytes, 0, bytes.Length))
 
                 bytesByPath.Clear()
                 disposed := true
+                disposalCount := !disposalCount + 1
+
+        /// Returns how often the private verified-byte snapshot has been disposed for focused lifetime proof.
+        let internal disposalCount (PreparedContent (_, _, _, disposalCount)) = !disposalCount
 
     /// Supplies construction and access functions for private update requests.
     module Request =

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -33,6 +33,11 @@ module internal WorkingDirectoryUpdateContracts =
     /// Represents the path-derived Connect scope that separates local working roots.
     type LocalRootScope = private LocalRootScope of string
 
+    /// States whether a Branch update may publish a selected Reference or must preserve the current branch identity.
+    type BranchSelection =
+        | Reference of ReferenceId
+        | DirectoryVersion
+
     /// Represents one deterministic caller-specific logical update identity.
     type Operation = private Operation of callerKind: CallerKind * target: Target option * repositoryId: RepositoryId * branchId: BranchId * value: string
 
@@ -287,25 +292,42 @@ module internal WorkingDirectoryUpdateContracts =
 
                 create Watch None repositoryId branchId canonical
 
-        /// Creates the Branch identity from branch transition, Reference, and selected target facts.
-        let branchSwitch previousBranchId selectedReferenceId target =
-            match requireId "PreviousBranchId" previousBranchId, requireId "SelectedReferenceId" selectedReferenceId with
-            | Ok previousBranchId, Ok selectedReferenceId ->
+        /// Creates the Branch identity from an exact transition Reference or an exact hash-selected target root.
+        let branchSwitchWithSelection previousBranchId selection target =
+            match requireId "PreviousBranchId" previousBranchId with
+            | Ok previousBranchId ->
                 let repositoryId = Target.repositoryId target
                 let branchId = Target.branchId target
 
-                let canonical =
-                    "grace.working-directory-update.operation.v1\n"
-                    + canonicalField "caller" "branch"
-                    + canonicalField "repository" (guidText repositoryId)
-                    + canonicalField "previous-branch" (guidText previousBranchId)
-                    + canonicalField "selected-branch" (guidText branchId)
-                    + canonicalField "selected-reference" (guidText selectedReferenceId)
-                    + canonicalField "target" (Target.canonical target)
+                let selectionCanonical =
+                    match selection with
+                    | Reference selectedReferenceId ->
+                        match requireId "SelectedReferenceId" selectedReferenceId with
+                        | Ok selectedReferenceId ->
+                            Ok(
+                                canonicalField "branch-selection" "reference"
+                                + canonicalField "selected-reference" (guidText selectedReferenceId)
+                            )
+                        | Error error -> Error error
+                    | DirectoryVersion -> Ok(canonicalField "branch-selection" "directory-version")
 
-                create Branch (Some target) repositoryId branchId canonical
-            | Error error, _ -> Error error
-            | _, Error error -> Error error
+                match selectionCanonical with
+                | Error error -> Error error
+                | Ok selectionCanonical ->
+                    let canonical =
+                        "grace.working-directory-update.operation.v1\n"
+                        + canonicalField "caller" "branch"
+                        + canonicalField "repository" (guidText repositoryId)
+                        + canonicalField "previous-branch" (guidText previousBranchId)
+                        + canonicalField "selected-branch" (guidText branchId)
+                        + selectionCanonical
+                        + canonicalField "target" (Target.canonical target)
+
+                    create Branch (Some target) repositoryId branchId canonical
+            | Error error -> Error error
+
+        /// Retains the existing private Reference-selected construction shorthand while callers migrate to typed selection.
+        let branchSwitch previousBranchId selectedReferenceId target = branchSwitchWithSelection previousBranchId (Reference selectedReferenceId) target
 
         /// Creates the Connect identity from target, initial cursor, and local-root scope.
         let connectBootstrap target initialCursor localRootScope =

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -596,3 +596,6 @@ module internal WorkingDirectoryUpdateContracts =
                 Error "Working Directory Update failure reason must not be empty."
             else
                 Ok(Failure reason)
+
+        /// Returns the classified terminal reason for caller-owned human and machine output projection.
+        let value (Failure reason) = reason

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -682,6 +682,7 @@ module CommandOutputContract =
         | "branch.get-tags" -> typeof<Grace.Types.Branch.BranchDto * Grace.Types.Reference.ReferenceDto array>
         | "branch.get-recursive-size" -> typeof<int64>
         | "branch.list-contents" -> typeof<IEnumerable<Grace.Types.DirectoryVersion.DirectoryVersionDto>>
+        | "branch.switch" -> typeof<string>
         | "candidate.attestations" -> typeof<Grace.Shared.Parameters.Review.CandidateAttestationsResult>
         | "candidate.cancel"
         | "candidate.gate.rerun"
@@ -1199,7 +1200,7 @@ module CommandOutputContract =
             row [ "branch" ] "set-name" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "set-promotion-mode" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "status" true false human_progress_only_success read_list_search composite_local_server RequiresCliDto
-            row [ "branch" ] "switch" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
+            row [ "branch" ] "switch" true true common_renderOutput_envelope progress_local_workflow composite_local_server RequiresCliDto
             row [ "branch" ] "tag" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "update-parent-branch" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate" ] "attestations" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -23,7 +23,7 @@ module WorkingDirectoryUpdate = WorkingDirectoryUpdateContracts
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let SchemaVersion = "10"
+    let SchemaVersion = "11"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -45,6 +45,7 @@ module LocalStateDb =
     /// Carries the bounded caller facts that distinguish one pending finalization from another.
     type internal WorkingDirectoryUpdateCompletionDetails =
         | BranchFinalization of previousBranchId: BranchId * selectedReferenceId: ReferenceId
+        | BranchDirectoryVersionFinalization of previousBranchId: BranchId
         | WatchFinalization of eventCursor: string
         | ConnectCompletion of initialCursor: string * localRootScope: WorkingDirectoryUpdate.LocalRootScope
 
@@ -54,7 +55,7 @@ module LocalStateDb =
             target: WorkingDirectoryUpdate.Target *
             operation: WorkingDirectoryUpdate.Operation *
             previousBranchId: BranchId *
-            selectedReferenceId: ReferenceId
+            selection: WorkingDirectoryUpdate.BranchSelection
         | PendingWatchFinalization of target: WorkingDirectoryUpdate.Target * operation: WorkingDirectoryUpdate.Operation * eventCursor: string
 
     [<Literal>]
@@ -255,7 +256,7 @@ module LocalStateDb =
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
             "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE TABLE IF NOT EXISTS remote_reference_boundaries (repository_id TEXT NOT NULL, branch_id TEXT NOT NULL, root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, event_cursor TEXT NOT NULL, PRIMARY KEY (repository_id, branch_id));"
-            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND branch_selected_reference_id IS NOT NULL AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selection_kind TEXT NULL CHECK (branch_selection_kind IN ('Reference', 'DirectoryVersion')), branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND ((branch_selection_kind = 'Reference' AND branch_selected_reference_id IS NOT NULL) OR (branch_selection_kind = 'DirectoryVersion' AND branch_selected_reference_id IS NULL)) AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_pending ON working_directory_update_completions(finalization_state) WHERE finalization_state = 'Pending';"
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_terminal_caller ON working_directory_update_completions(caller_kind) WHERE finalization_state = 'Terminal';"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
@@ -1543,6 +1544,8 @@ module LocalStateDb =
         && columnExists connection "status_files" "blake3_hash"
         && columnExists connection "object_cache_directories" "blake3_hash"
         && columnExists connection "object_cache_directory_files" "blake3_hash"
+        && columnExists connection "working_directory_update_completions" "branch_selection_kind"
+        && columnExists connection "working_directory_update_completions" "branch_selected_reference_id"
         && tableExists connection "watch_journal"
         && tableExists connection "watch_lifecycle_events"
         && hasRequiredWatchJournalShape connection
@@ -3115,7 +3118,12 @@ module LocalStateDb =
         | WorkingDirectoryUpdate.CallerKind.Branch, BranchFinalization (previousBranchId, selectedReferenceId) ->
             match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
             | Ok expectedOperation when operationMatches expectedOperation -> ()
-            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and selected Reference."
+            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and typed selector."
+        | WorkingDirectoryUpdate.CallerKind.Branch, BranchDirectoryVersionFinalization previousBranchId ->
+            match WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion target
+                with
+            | Ok expectedOperation when operationMatches expectedOperation -> ()
+            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and typed selector."
         | WorkingDirectoryUpdate.CallerKind.Watch, WatchFinalization eventCursor ->
             match
                 WorkingDirectoryUpdate.Operation.watchReplay
@@ -3354,12 +3362,14 @@ module LocalStateDb =
 
                                 let targetCanonical = WorkingDirectoryUpdate.Target.canonical target
 
-                                let branchPreviousBranchId, branchSelectedReferenceId, watchEventCursor =
+                                let branchPreviousBranchId, branchSelectionKind, branchSelectedReferenceId, watchEventCursor =
                                     match completionDetails with
                                     | BranchFinalization (previousBranchId, selectedReferenceId) ->
-                                        Some(previousBranchId.ToString()), Some(selectedReferenceId.ToString()), None
-                                    | WatchFinalization eventCursor -> None, None, Some eventCursor
-                                    | ConnectCompletion _ -> None, None, None
+                                        Some(previousBranchId.ToString()), Some "Reference", Some(selectedReferenceId.ToString()), None
+                                    | BranchDirectoryVersionFinalization previousBranchId ->
+                                        Some(previousBranchId.ToString()), Some "DirectoryVersion", None, None
+                                    | WatchFinalization eventCursor -> None, None, None, Some eventCursor
+                                    | ConnectCompletion _ -> None, None, None, None
 
                                 let nullableText value =
                                     value
@@ -3409,6 +3419,7 @@ module LocalStateDb =
                                             parameters.AddWithValue("$event_cursor", cursor)
                                             |> ignore)
                                 | BranchFinalization _
+                                | BranchDirectoryVersionFinalization _
                                 | WatchFinalization _ -> ()
 
                                 if operationCallerKind = WorkingDirectoryUpdate.CallerKind.Connect then
@@ -3422,7 +3433,7 @@ module LocalStateDb =
                                 use completionCommand = connection.CreateCommand()
 
                                 completionCommand.CommandText <-
-                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $target_repository_id, $target_branch_id, $target_root_directory_version_id, $target_root_directory_sha256_hash, $target_root_directory_blake3_hash, $branch_previous_branch_id, $branch_selected_reference_id, $watch_event_cursor, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.target_repository_id = excluded.target_repository_id AND working_directory_update_completions.target_branch_id = excluded.target_branch_id AND working_directory_update_completions.target_root_directory_version_id = excluded.target_root_directory_version_id AND working_directory_update_completions.target_root_directory_sha256_hash = excluded.target_root_directory_sha256_hash AND working_directory_update_completions.target_root_directory_blake3_hash = excluded.target_root_directory_blake3_hash AND working_directory_update_completions.branch_previous_branch_id IS excluded.branch_previous_branch_id AND working_directory_update_completions.branch_selected_reference_id IS excluded.branch_selected_reference_id AND working_directory_update_completions.watch_event_cursor IS excluded.watch_event_cursor AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
+                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selection_kind, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $target_repository_id, $target_branch_id, $target_root_directory_version_id, $target_root_directory_sha256_hash, $target_root_directory_blake3_hash, $branch_previous_branch_id, $branch_selection_kind, $branch_selected_reference_id, $watch_event_cursor, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.target_repository_id = excluded.target_repository_id AND working_directory_update_completions.target_branch_id = excluded.target_branch_id AND working_directory_update_completions.target_root_directory_version_id = excluded.target_root_directory_version_id AND working_directory_update_completions.target_root_directory_sha256_hash = excluded.target_root_directory_sha256_hash AND working_directory_update_completions.target_root_directory_blake3_hash = excluded.target_root_directory_blake3_hash AND working_directory_update_completions.branch_previous_branch_id IS excluded.branch_previous_branch_id AND working_directory_update_completions.branch_selection_kind IS excluded.branch_selection_kind AND working_directory_update_completions.branch_selected_reference_id IS excluded.branch_selected_reference_id AND working_directory_update_completions.watch_event_cursor IS excluded.watch_event_cursor AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
 
                                 completionCommand.Parameters.AddWithValue("$operation_value", operationValue)
                                 |> ignore
@@ -3457,6 +3468,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 completionCommand.Parameters.AddWithValue("$branch_previous_branch_id", nullableText branchPreviousBranchId)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$branch_selection_kind", nullableText branchSelectionKind)
                                 |> ignore
 
                                 completionCommand.Parameters.AddWithValue("$branch_selected_reference_id", nullableText branchSelectedReferenceId)
@@ -3863,7 +3877,7 @@ module LocalStateDb =
             use command = connection.CreateCommand()
 
             command.CommandText <-
-                "SELECT operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor FROM working_directory_update_completions WHERE finalization_state = 'Pending' LIMIT 1;"
+                "SELECT operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selection_kind, branch_selected_reference_id, watch_event_cursor FROM working_directory_update_completions WHERE finalization_state = 'Pending' LIMIT 1;"
 
             use reader = command.ExecuteReader()
 
@@ -3901,13 +3915,21 @@ module LocalStateDb =
                     match callerKind with
                     | "Branch" ->
                         let previousBranchId = requiredGuid 8 "branch_previous_branch_id"
-                        let selectedReferenceId = requiredGuid 9 "branch_selected_reference_id"
 
-                        match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
-                        | Ok operation -> operation, PendingBranchFinalization(target, operation, previousBranchId, selectedReferenceId)
+                        let selection =
+                            match requiredText 9 "branch_selection_kind" with
+                            | "Reference" ->
+                                requiredGuid 10 "branch_selected_reference_id"
+                                |> WorkingDirectoryUpdate.BranchSelection.Reference
+                            | "DirectoryVersion" when reader.IsDBNull(10) -> WorkingDirectoryUpdate.BranchSelection.DirectoryVersion
+                            | "DirectoryVersion" -> invalidOp "DirectoryVersion Branch finalization must not persist a Reference id."
+                            | value -> invalidOp $"Pending Branch finalization has invalid selector kind '{value}'."
+
+                        match WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId selection target with
+                        | Ok operation -> operation, PendingBranchFinalization(target, operation, previousBranchId, selection)
                         | Error error -> invalidOp $"Pending Branch finalization is invalid: {error}"
                     | "Watch" ->
-                        let eventCursor = requiredText 10 "watch_event_cursor"
+                        let eventCursor = requiredText 11 "watch_event_cursor"
 
                         match
                             WorkingDirectoryUpdate.Operation.watchReplay


### PR DESCRIPTION
# Why this matters

`grace switch` must update working files, local status, and selected Branch identity as one trustworthy transaction.
This pull request is the active implementation record for the first real caller tracer, replacing the superseded
private-only engine design.

Relates to #841.

Parent epic: #835.

## Current checkpoint

The first coherent slice replaces Boolean marker handling with explicit inspection and cleanup outcomes:

- missing evidence;
- exact matching evidence;
- different-operation evidence;
- malformed or unsupported evidence;
- unreadable evidence;
- exact cleanup success, non-matching evidence, and cleanup failure.

The built Branch tracer is not complete at this head. `Branch.CLI.fs` still owns its prior direct mutation and status
path, and `WorkingDirectoryUpdate.CLI.fs` remains a shell. The next worker must implement the Branch-specific immutable
context, post-lease rereads, complete-root verifier, durable ordering, output projection, and built-command proof before
this PR can merge.

Owner decision D1 is accepted: hash-selected switching remains supported. A hash identifies an exact
`RootDirectoryVersion`, keeps the current branch active, and performs no branch-identity transition. The implementation
uses a typed `Reference` or `DirectoryVersion` selection and never invents a Reference ID.

## Design correction preserved

- No generic repeated-facts request or independently supplied local/object/scan/SQLite paths.
- No planning from a caller-supplied pre-lease status graph.
- No Boolean replay classification.
- No Watch, Connect, or Doctor behavior.
- No wholesale reuse of closed PR #851 behavioral commits.

## Current validation

- Targeted Fantomas passed.
- Release `Grace.CLI.Tests` build passed.
- The live PR head's Ubuntu cleanup-failure test was platform-dependent. Local commit `cb8a01e3` replaces it with a
  deterministic seam and expands `WorkingDirectoryUpdateCoordinationTests` to 9 passed, 0 failed; it is not pushed yet.
- `git diff --check` passed.

## Review status

- Quality contract: Product V1.
- Implementation workers: 3/4 used. Worker 4/4 is the final authorized implementation start; no worker 5 is authorized.
- Current live head is an incomplete foundation checkpoint and its Validate run failed the now-repaired portable-test
  issue plus one unrelated Watch filesystem case.
- Owner decision D1: accepted and propagated to #841, #842, #846, and the epic record.
- Fresh exact-head review and GitHub Validate: required after worker 4/4 pushes the complete tracer.
- Merge readiness: blocked until the full #841 tracer and all issue proof are present.
