### PR TITLE
Repair cache enrollment across Orleans actor boundary

### DIFF
--- a/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
@@ -8,6 +8,7 @@ open Grace.Shared
 open Grace.Shared.Utilities
 open Grace.Types
 open Grace.Types.Common
+open Grace.Types.CacheRegistration
 open Grace.Types.ContentBlockMetadata
 open Grace.Types.Reminder
 open Grace.Types.UploadSession
@@ -16,6 +17,7 @@ open NodaTime
 open NodaTime.Text
 open NUnit.Framework
 open System
+open System.Collections.Generic
 open System.IO
 open System.Net
 open System.Net.Http
@@ -110,6 +112,44 @@ module private RestartDurabilityHelpers =
                 ()
 
             return repositoryId
+        }
+
+    /// Builds the public half of a static P-256 Cache identity key for HTTP enrollment requests.
+    let cacheIdentityPublicKey (privateKey: ECDsa) =
+        let parameters = privateKey.ExportParameters(false)
+        CacheIdentityPublicKey.Create(ArtifactGrant.Base64Url.encode parameters.Q.X, ArtifactGrant.Base64Url.encode parameters.Q.Y)
+
+    /// Sends a valid Cache enrollment request through the HTTP and Orleans actor boundary.
+    let enrollCacheAsync (privateKey: ECDsa) (repositoryId: string) (displayName: string) (endpoint: string) =
+        task {
+            let organization = Guid.Parse organizationId
+
+            let request =
+                {
+                    Class = nameof CacheEnrollmentRequest
+                    DisplayName = displayName
+                    BoundaryKind = CacheBoundaryKind.Organization
+                    OwnerId = Guid.Parse ownerId
+                    OrganizationId = Some organization
+                    RepositoryScopes =
+                        List<CacheRepositoryScope>(
+                            [
+                                CacheRepositoryScope.Create(organization, Guid.Parse repositoryId)
+                            ]
+                        )
+                    PublicKey = cacheIdentityPublicKey privateKey
+                    Endpoint = endpoint
+                    AllowHttpEndpoint = false
+                    Health = CacheHealthStatus.Healthy
+                    SoftwareVersion = "1.0.0"
+                    ProtocolVersion = "v1"
+                    PrefetchSupported = false
+                }
+
+            let! response = Client.PostAsync("/cache/enroll", createJsonContent request)
+            let! body = requireOkAsync response
+            let result = deserialize<GraceReturnValue<CacheRegistrationResult>> body
+            return request, result.ReturnValue
         }
 
     /// Gets owner from the running test server.
@@ -435,4 +475,45 @@ type RestartDurabilityServer() =
             Assert.That(reminderAfterRestart.ActorId, Is.EqualTo(reminderActorId))
             Assert.That(reminderAfterRestart.ReminderType, Is.EqualTo(ReminderTypes.Maintenance))
             Assert.That(reminderAfterRestart.ReminderTime, Is.EqualTo(reminderFireAt))
+        }
+
+    /// Verifies valid HTTP enrollment keeps every immutable request field through the Orleans actor call and persists before success.
+    [<Test>]
+    [<Order(3)>]
+    member _.CacheEnrollmentTransfersValidatedFieldsThroughTheActorBoundary() =
+        task {
+            let! invalidResponse = Client.PostAsync("/cache/enroll", createJsonContent Unchecked.defaultof<CacheEnrollmentRequest>)
+
+            Assert.That(invalidResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest))
+
+            use privateKey = ECDsa.Create(ECCurve.NamedCurves.nistP256)
+            let displayName = $"enrollment-transfer-{Guid.NewGuid():N}"
+            let endpoint = $"https://cache-{Guid.NewGuid():N}.example.test"
+            let! request, result = RestartDurabilityHelpers.enrollCacheAsync privateKey repositoryIds[0] displayName endpoint
+
+            let registration =
+                match result.Registration with
+                | Some value -> value
+                | None ->
+                    Assert.Fail("Successful Cache enrollment did not return the persisted registration.")
+                    Unchecked.defaultof<CacheRegistration>
+
+            Assert.Multiple(
+                Action (fun () ->
+                    Assert.That(result.Status, Is.EqualTo(CacheRegistrationRefreshStatus.Enrolled))
+                    Assert.That(registration.CacheId, Is.Not.EqualTo(Guid.Empty))
+                    Assert.That(registration.DisplayName, Is.EqualTo(request.DisplayName))
+                    Assert.That(registration.BoundaryKind, Is.EqualTo(request.BoundaryKind))
+                    Assert.That(registration.OwnerId, Is.EqualTo(request.OwnerId))
+                    Assert.That(registration.OrganizationId, Is.EqualTo(request.OrganizationId))
+                    Assert.That(registration.RepositoryScopes, Has.Length.EqualTo(request.RepositoryScopes.Count))
+                    Assert.That(registration.RepositoryScopes[0], Is.EqualTo(request.RepositoryScopes[0]))
+                    Assert.That(registration.PublicKey, Is.EqualTo(request.PublicKey))
+                    Assert.That(registration.Endpoint, Is.EqualTo(request.Endpoint))
+                    Assert.That(registration.AllowHttpEndpoint, Is.EqualTo(request.AllowHttpEndpoint))
+                    Assert.That(registration.Health, Is.EqualTo(request.Health))
+                    Assert.That(registration.SoftwareVersion, Is.EqualTo(request.SoftwareVersion))
+                    Assert.That(registration.ProtocolVersion, Is.EqualTo(request.ProtocolVersion))
+                    Assert.That(registration.PrefetchSupported, Is.EqualTo(request.PrefetchSupported)))
+            )
         }

--- a/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
+++ b/src/Grace.Server.Tests/RestartDurability.Server.Tests.fs
@@ -139,11 +139,11 @@ module private RestartDurabilityHelpers =
                         )
                     PublicKey = cacheIdentityPublicKey privateKey
                     Endpoint = endpoint
-                    AllowHttpEndpoint = false
+                    AllowHttpEndpoint = true
                     Health = CacheHealthStatus.Healthy
                     SoftwareVersion = "1.0.0"
                     ProtocolVersion = "v1"
-                    PrefetchSupported = false
+                    PrefetchSupported = true
                 }
 
             let! response = Client.PostAsync("/cache/enroll", createJsonContent request)
@@ -488,7 +488,7 @@ type RestartDurabilityServer() =
 
             use privateKey = ECDsa.Create(ECCurve.NamedCurves.nistP256)
             let displayName = $"enrollment-transfer-{Guid.NewGuid():N}"
-            let endpoint = $"https://cache-{Guid.NewGuid():N}.example.test"
+            let endpoint = $"http://cache-{Guid.NewGuid():N}.example.test"
             let! request, result = RestartDurabilityHelpers.enrollCacheAsync privateKey repositoryIds[0] displayName endpoint
 
             let registration =

--- a/src/Grace.Types/CacheRegistration.Types.fs
+++ b/src/Grace.Types/CacheRegistration.Types.fs
@@ -40,10 +40,15 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheIdentityPublicKey =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             Algorithm: string
+            [<Id(2u)>]
             Curve: string
+            [<Id(3u)>]
             PublicKeyX: string
+            [<Id(4u)>]
             PublicKeyY: string
         }
         /// Builds a canonical Cache identity public key from base64url P-256 coordinates.
@@ -54,8 +59,11 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheRepositoryScope =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             OrganizationId: OrganizationId
+            [<Id(2u)>]
             RepositoryId: RepositoryId
         }
         /// Builds one explicit repository scope without permitting name-based or wildcard assignment.
@@ -66,10 +74,15 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheRequestProofPayload =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             CacheId: Guid
+            [<Id(2u)>]
             Operation: string
+            [<Id(3u)>]
             RequestDigest: string
+            [<Id(4u)>]
             IssuedAt: Instant
         }
         /// Builds a protocol-millisecond Cache proof payload for one exact operation and request digest.
@@ -86,8 +99,11 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type SignedCacheRequestProof =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             Payload: CacheRequestProofPayload
+            [<Id(2u)>]
             Signature: string
         }
         /// Builds the Cache proof envelope without exposing private-key material.
@@ -98,18 +114,31 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheEnrollmentRequest =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             DisplayName: string
+            [<Id(2u)>]
             BoundaryKind: CacheBoundaryKind
+            [<Id(3u)>]
             OwnerId: OwnerId
+            [<Id(4u)>]
             OrganizationId: OrganizationId option
+            [<Id(5u)>]
             RepositoryScopes: List<CacheRepositoryScope>
+            [<Id(6u)>]
             PublicKey: CacheIdentityPublicKey
+            [<Id(7u)>]
             Endpoint: string
+            [<Id(8u)>]
             AllowHttpEndpoint: bool
+            [<Id(9u)>]
             Health: CacheHealthStatus
+            [<Id(10u)>]
             SoftwareVersion: string
+            [<Id(11u)>]
             ProtocolVersion: string
+            [<Id(12u)>]
             PrefetchSupported: bool
         }
 
@@ -117,53 +146,107 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheRegistrationRefreshRequest =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             CacheId: Guid
+            [<Id(2u)>]
             Endpoint: string
+            [<Id(3u)>]
             Health: CacheHealthStatus
+            [<Id(4u)>]
             SoftwareVersion: string
+            [<Id(5u)>]
             ProtocolVersion: string
+            [<Id(6u)>]
             PrefetchSupported: bool
+            [<Id(7u)>]
             ObservedAt: Instant
+            [<Id(8u)>]
             Proof: SignedCacheRequestProof
         }
 
     /// Represents the administrator-authenticated replacement of the exact repository assignment set.
     [<CLIMutable; GenerateSerializer>]
-    type CacheRepositoryAssignmentRequest = { Class: string; CacheId: Guid; RepositoryScopes: List<CacheRepositoryScope> }
+    type CacheRepositoryAssignmentRequest =
+        {
+            [<Id(0u)>]
+            Class: string
+            [<Id(1u)>]
+            CacheId: Guid
+            [<Id(2u)>]
+            RepositoryScopes: List<CacheRepositoryScope>
+        }
 
     /// Represents the administrator-authenticated terminal revocation of one Cache identity.
     [<CLIMutable; GenerateSerializer>]
-    type CacheRevocationRequest = { Class: string; CacheId: Guid }
+    type CacheRevocationRequest =
+        {
+            [<Id(0u)>]
+            Class: string
+            [<Id(1u)>]
+            CacheId: Guid
+        }
 
     /// Represents a current-key-proven Cache identity rotation. The server accepts the new public key before retiring the old key.
     [<CLIMutable; GenerateSerializer>]
-    type CacheKeyRotationRequest = { Class: string; CacheId: Guid; NewPublicKey: CacheIdentityPublicKey; Proof: SignedCacheRequestProof }
+    type CacheKeyRotationRequest =
+        {
+            [<Id(0u)>]
+            Class: string
+            [<Id(1u)>]
+            CacheId: Guid
+            [<Id(2u)>]
+            NewPublicKey: CacheIdentityPublicKey
+            [<Id(3u)>]
+            Proof: SignedCacheRequestProof
+        }
 
     /// Represents the server-owned durable registration for one Cache identity.
     [<CLIMutable; GenerateSerializer>]
     type CacheRegistration =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             CacheId: Guid
+            [<Id(2u)>]
             DisplayName: string
+            [<Id(3u)>]
             BoundaryKind: CacheBoundaryKind
+            [<Id(4u)>]
             OwnerId: OwnerId
+            [<Id(5u)>]
             OrganizationId: OrganizationId option
+            [<Id(6u)>]
             RepositoryScopes: CacheRepositoryScope array
+            [<Id(7u)>]
             PublicKey: CacheIdentityPublicKey
+            [<Id(8u)>]
             Endpoint: string
+            [<Id(9u)>]
             AllowHttpEndpoint: bool
+            [<Id(10u)>]
             Health: CacheHealthStatus
+            [<Id(11u)>]
             SoftwareVersion: string
+            [<Id(12u)>]
             ProtocolVersion: string
+            [<Id(13u)>]
             PrefetchSupported: bool
+            [<Id(14u)>]
             EnrolledBy: string
+            [<Id(15u)>]
             EnrolledAt: Instant
+            [<Id(16u)>]
             LastRefreshedAt: Instant
+            [<Id(17u)>]
             RefreshAfter: Instant
+            [<Id(18u)>]
             ExpiresAt: Instant
+            [<Id(19u)>]
             RotationDueAt: Instant
+            [<Id(20u)>]
             RevokedAt: Instant option
         }
 
@@ -183,9 +266,13 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheRegistrationResult =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             Status: CacheRegistrationRefreshStatus
+            [<Id(2u)>]
             Registration: CacheRegistration option
+            [<Id(3u)>]
             Message: string
         }
         /// Builds a Cache lifecycle result without leaking private key material.
@@ -196,8 +283,11 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheRegistrationSelectionQuery =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             RepositoryId: RepositoryId option
+            [<Id(2u)>]
             RequirePrefetch: bool
         }
         /// Builds a current-Cache selection query from stable repository identity.
@@ -211,7 +301,9 @@ module CacheRegistration =
     [<CLIMutable; GenerateSerializer>]
     type CacheRegistrationState =
         {
+            [<Id(0u)>]
             Class: string
+            [<Id(1u)>]
             Registrations: CacheRegistration array
         }
         /// Represents the empty durable Cache registration state.


### PR DESCRIPTION
# Repair cache enrollment across the Orleans actor boundary

## Why

A valid cache enrollment reached the Orleans actor with every record field replaced by its default value. The lifecycle
then failed before persistence, which blocked both static Product V1 enrollment and #855's required restart proof.

Relates to #861.

## Changes

- Add explicit Orleans field IDs to the existing cache actor request, result, state, registration, and nested records.
- Preserve the current public JSON contract and durable logical shape.
- Add a real HTTP-to-Orleans enrollment regression test that proves null-request rejection, successful enrollment, and
  exact immutable-field transfer.

## Proof

- Targeted Fantomas check passed.
- `Grace.Types.Tests` Release build passed with no warnings or errors.
- Focused cache-registration lifecycle suite passed 13/13.
- `Grace.Server.Tests` Release build passed with only the existing Aspire warning.
- Focused live HTTP enrollment test passed 1/1.
- Regenerated codec inspection confirmed all 13 enrollment fields are written.
- `git diff --check` and Product V1 self-review passed.

## Scope

This PR does not change enrollment meaning, public routes, validation, authorization, artifact-grant behavior, or add
recovery, retry, rotation, or new durable state.
