### PR TITLE
[Superseded] Correct the Branch transaction contract after supersession

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,10 +24,10 @@ parity, and non-version SHA-256 uses that intentionally stay SHA-256.
 _Avoid_: FileContentHash, ChunkAddress, ContentBlockAddress, ManifestAddress
 
 **Working Directory Update**:
-The accepted, Plan-ready design for a Grace-controlled operation that will change indexed working-directory content and
-durable local state to match one selected server root, then commit caller-specific progress only after verifying that
-match. After implementation, Branch switching, Watch current-Reference replay, and Connect retrieval will use this
-shared operation while retaining their own admission and presentation policies.
+The accepted, Plan-ready Branch transaction that will change indexed working-directory content and durable local state
+to match one selected server root, then finalize Branch identity only after verifying that match. Its first private
+interface is Branch-derived; Watch current-Reference replay and Connect retrieval remain deferred until their separate
+work names their own admission and finalization rules.
 _Avoid_: WorkingDirectoryMaterialization, exact materialization, caller-owned filesystem transaction
 
 **FileManifest**:

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -69,7 +69,7 @@ contract, and this document does not describe their runtime shape as accepted.
 | DEC-004 | Reference finalization is repeatable from persisted typed facts. | Previous Branch applies once; the exact selected Branch is already applied; any third Branch rejects. | #871 |
 | DEC-005 | The plan covers the complete tracked topology. | It creates target directories, removes obsolete tracked empty directories, handles file/directory transitions before mutation, and preserves ignored content. | #870 |
 | DEC-006 | The public action token remains attached until mutation begins. | Admission, Save, resolution, preparation, lease wait, object publication, and the final pre-mutation boundary observe it; only post-mutation cancellation is deferred. | #870, #872 |
-| DEC-007 | The first deep module has a minimal Branch seam. | The caller supplies only typed selection, exact target graph, verified prepared content, and diagnostic correlation. | #870 |
+| DEC-007 | The first deep module has one exact Branch seam. | The caller supplies only sealed `AcceptedBranchPhase`, typed selection, exact target graph, immutable prepared content, and diagnostic correlation. | #870 |
 | DEC-008 | Phase proof is split by boundary. | Real filesystem and SQLite tests activate phase and recovery seams; built-command tests cover selector routing and bounded public projection. | #870–#872 |
 | DEC-009 | #841 is superseded as an implementation plan. | #868 corrects this contract; #869, #870, #871, and #872 deliver the sequential Branch work. | #868 |
 
@@ -92,7 +92,7 @@ proof of the graph.
 
 ### Accepted Branch phase
 
-Immediately after successful Save or no-Save admission, Branch constructs one immutable `AcceptedBranchPhase`. It holds
+Immediately after successful Save or no-Save admission, Branch constructs one opaque, sealed `AcceptedBranchPhase`. It holds
 the accepted SQLite revision, canonical fingerprint of the complete current Grace status graph, and the public action
 token for that command invocation. It does not hold or expose a mutable status graph, alternate local paths, or a
 selected-state reader.
@@ -121,26 +121,28 @@ that phase, but cannot alter its revision, fingerprint, or action token.
 
 The `WorkingDirectoryUpdate.run` entry accepts only the following Branch facts:
 
-1. The immutable `AcceptedBranchPhase`.
-2. The typed `Reference` or `DirectoryVersion` selection.
+1. The sealed `AcceptedBranchPhase`.
+2. The typed `Reference` or exact-root `DirectoryVersion` selection.
 3. The exact resolved target graph.
-4. Verified prepared content for that graph.
+4. Immutable prepared content for that graph.
 5. Diagnostic correlation.
 
 This is a narrow phase and interface, not a caller-supplied context bag. From the phase and canonical Branch
 configuration, the module derives the working root, object root, `.grace` directory, SQLite path, ignore-aware scan
-input, local-root scope, operation identity, pending and completion facts, marker disposition, and Branch finalization
-facts. It compares the phase's accepted revision and fingerprint with its own post-lease reread. A caller cannot
-provide alternate paths, a status graph, a selected-state reader, a finalizer, a filesystem writer, a mutation plan, or
-a database handle.
+input, local-root scope, operation identity, pending and completion facts, marker disposition, and typed Branch
+finalization facts from the same selection, target, canonical configuration, and persisted operation facts. It compares
+the phase's accepted revision and fingerprint with its own post-lease reread. A caller cannot provide alternate paths,
+a status graph, a selected-state reader, a finalizer or finalizer callback, a progress observer in place of diagnostic
+correlation, a filesystem writer, a mutation plan, a database handle, or a generic context bag.
 
 The one action token in `AcceptedBranchPhase` is observed before and during admission and Save, during target resolution
 and preparation, while waiting for the lease, during object publication, and immediately before the first
 working-tree mutation. Cancellation is deferred only after mutation begins.
 
-The module exposes `run` and the internal exact-finalization retry used by #871 and #842. It does not expose Watch or
-Connect construction. Any later caller requires its own accepted design and must not widen this Branch input by adding
-an arbitrary context record.
+The module exposes `run` and the internal exact-finalization retry used by #871 and #842. Retry reconstructs the same
+typed Branch finalization behavior from the persisted typed operation facts; it cannot accept a separately assembled
+finalization tuple or callback. The module does not expose Watch or Connect construction. Any later caller requires its
+own accepted design and must not widen this Branch input by adding an arbitrary context record.
 
 ## 7. Branch transaction and marker behavior
 

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -68,7 +68,7 @@ contract, and this document does not describe their runtime shape as accepted.
 | DEC-003 | Marker evidence is a typed disposition, not a Boolean. | Missing, exact, different-operation, malformed or unsupported, unreadable, and exact-cleanup-failed evidence retain distinct behavior. | #869, consumed by #870–#872 |
 | DEC-004 | Reference finalization is repeatable from persisted typed facts. | Previous Branch applies once; the exact selected Branch is already applied; any third Branch rejects. | #871 |
 | DEC-005 | The plan covers the complete tracked topology. | It creates target directories, removes obsolete tracked empty directories, handles file/directory transitions before mutation, and preserves ignored content. | #870 |
-| DEC-006 | The public action token remains attached until mutation begins. | Admission, Save, resolution, preparation, lease wait, object publication, and the final pre-mutation boundary observe it; only post-mutation cancellation is deferred. | #870, #872 |
+| DEC-006 | The public action token controls only before an irreversible side-effect boundary. | Before the first working-tree mutation, cancellation rejects without mutation or completion. After mutation starts, evidence—not cancellation—determines completion, cleanup, finalization, terminal recording, and outcome. Exact terminal replay is `Unchanged` despite a cancelled invocation token. Explicit finalization retry has the same rule at its first finalization side effect. | #870–#872, #842 |
 | DEC-007 | The first deep module has one exact Branch seam. | The caller supplies only sealed `AcceptedBranchPhase`, typed selection, exact target graph, immutable prepared content, and diagnostic correlation. | #870 |
 | DEC-008 | Phase proof is split by boundary. | Real filesystem and SQLite tests activate phase and recovery seams; built-command tests cover selector routing and bounded public projection. | #870–#872 |
 | DEC-009 | #841 is superseded as an implementation plan. | #868 corrects this contract; #869, #870, #871, and #872 deliver the sequential Branch work. | #868 |
@@ -137,7 +137,9 @@ correlation, a filesystem writer, a mutation plan, a database handle, or a gener
 
 The one action token in `AcceptedBranchPhase` is observed before and during admission and Save, during target resolution
 and preparation, while waiting for the lease, during object publication, and immediately before the first
-working-tree mutation. Cancellation is deferred only after mutation begins.
+working-tree mutation. Cancellation before that mutation returns `Rejected` without working-tree mutation or a new
+completion. Once mutation begins, the token is non-controlling through local completion, the Branch finalization
+attempt, exact marker cleanup, and terminal recording.
 
 The module exposes `run` and the internal exact-finalization retry used by #871 and #842. Retry reconstructs the same
 typed Branch finalization behavior from the persisted typed operation facts; it cannot accept a separately assembled
@@ -222,17 +224,26 @@ types independently of the selected root fields.
 ### Action token and outcomes
 
 The public action token is observed during admission, optional Save, target resolution, preparation, lease waiting,
-object publication, and immediately before the first working-tree mutation. Once mutation starts, cancellation is
-deferred until verified local completion or an unavoidable incomplete failure; it does not interrupt the local
-transaction half way through. It may apply again to finalization.
+object publication, and immediately before the first working-tree mutation. Cancellation before that mutation returns
+`Rejected` with no working-tree mutation and no new completion. Once mutation starts, cancellation is non-controlling
+through local completion, the finalization attempt, exact marker cleanup, and terminal recording. Actual filesystem,
+SQLite, marker, and Branch evidence alone determines `Updated`, `UpdateIncomplete`, or `FinalizationIncomplete`.
+
+An exact terminal replay returns `Unchanged` even when the replay invocation's action token is already cancelled. An
+explicit finalization retry may observe cancellation only before its first finalization side effect—exact marker cleanup
+or Branch publication, whichever occurs first. A cancellation there preserves the pending completion unchanged,
+returns `FinalizationIncomplete`, and retains the `grace doctor --repair-local-state` recommendation. After the first
+retry side effect begins, cancellation is non-controlling through terminal recording and actual evidence determines the
+result.
 
 | Condition | Durable result | Public outcome |
 | --- | --- | --- |
-| Existing matching terminal completion or exact no-mutation result | Matching terminal completion | `Unchanged` |
-| Complete verified root, local completion, marker cleanup, and finalization | Terminal completion | `Updated` |
-| Stale baseline, foreign or damaged pre-completion evidence, conflict, or cancellation before mutation | No new completion | `Rejected` |
-| Mutation started but local completion did not commit | No completion | `UpdateIncomplete` |
-| Local completion committed but cleanup, finalization, or terminal completion did not finish | Pending completion | `FinalizationIncomplete` |
+| Exact terminal replay, including an already-cancelled invocation token, or an exact no-mutation result | Matching terminal completion or no new mutation | `Unchanged` |
+| Cancellation observed before the first working-tree mutation | No new completion and no working-tree mutation | `Rejected` |
+| Complete verified root, local completion, exact marker cleanup, finalization, and terminal recording after mutation began | Terminal completion | `Updated` |
+| Mutation started but local completion did not commit, regardless of later cancellation | No completion | `UpdateIncomplete` |
+| Local completion committed but cleanup, finalization, or terminal recording did not finish, regardless of later cancellation | Pending completion | `FinalizationIncomplete` |
+| Explicit finalization retry cancelled before its first finalization side effect | Existing pending completion remains unchanged | `FinalizationIncomplete` |
 
 `FinalizationIncomplete` is nonzero, states that bytes were updated, and recommends
 `grace doctor --repair-local-state`. It is never reported as `UpdateIncomplete` after local completion.
@@ -257,7 +268,7 @@ the final audit owner, not a substitute for a row's delivery owner.
 | REQ-010 | Bounded pending and terminal completion state | #838 | #871 and #842 prove finalization and recovery retention. | Verify no caller adds a second pending state or retention path. |
 | REQ-011 | Idempotent finalization and blocking | #871 | #842 proves Doctor retry; #843 later adds Watch cursor finalization. | Verify finalizers use persisted exact facts and block different work. |
 | REQ-012 | Truthful five outcomes and public exit behavior | #871 | #870 proves hash projection; #872, #842, #843, and #845 add their real output cases. | Verify built human/JSON/schema/examples/exits agree. |
-| REQ-013 | Action-token cancellation through the last pre-mutation check | #870 | #872 adds Save-enabled admission; #844 and #845 later carry their Connect preparation. | Verify deterministic pre-mutation cancellation and deferred post-mutation behavior. |
+| REQ-013 | Deterministic action-token precedence at mutation, replay, and retry boundaries | #870 | #871 proves finalization/retry precedence; #872 adds Save-enabled admission; #842 proves Branch-only Doctor retry; #844 and #845 later carry Connect preparation. | Verify pre-mutation rejection, post-mutation evidence precedence, cancelled terminal replay, and retry's first-side-effect boundary. |
 | REQ-014 | Same-operation marker adoption with fresh planning | #869 | #870, #871, and #842 prove Branch and recovery replay. | Verify adoption never resumes an old plan or deletes foreign evidence. |
 | REQ-015 | Explicit Doctor recovery without working-file mutation | #842 | No later caller delivery; #846 only audits the completed recovery proof. | Verify exact pending retry and refusal evidence remain current. |
 | REQ-016 | Caller-specific ordering | #871 | #872 completes Save ordering; #843 and #845 add Watch and Connect ordering. | Verify each caller has one real ordering path through the transaction. |

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -53,7 +53,7 @@ does not create a generic request shape or a partly active constructor for eithe
 | Epic base `ff630513` | Branch still owns direct local mutation, status replacement, and Branch publication. | The first replacement path must remove that reachable direct route rather than wrap it. |
 | Closed #841 and superseded PR #854 at `bc9bd109` | The broad implementation mixed persistence, runtime, Save admission, finalization, public projection, and the full failure matrix. | Do not restore its generic request or all-caller shapes. Split the sequential Branch work below. |
 | Exact-head #854 review | Typed marker results were collapsed, Reference finalization was not repeatable, planning used pre-Save status, topology and cancellation rules were incomplete, and the executable phase matrix was absent. | These are explicit requirements, proof seams, and issue owners below. |
-| Accepted D1 | `Reference` and exact-root `DirectoryVersion` have different Branch semantics. | Persist and reconstruct the typed selection; hashes retain the current Branch. |
+| DEC-001 — typed Branch selection | `Reference` and exact-root `DirectoryVersion` have different Branch semantics. | Persist and reconstruct the typed selection; hashes retain the current Branch. |
 | #869–#872 | Four sequential source issues replace #841. | Each issue owns one primary invariant family and a complete vertical proof boundary. |
 
 The superseded commits are evidence and possible narrow test vectors only. They do not establish an implementation

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -3,638 +3,287 @@
 **Status:** Plan-ready\
 **Quality contract:** Product V1\
 **Canonical source:** `docs/Working Directory Update.md`\
-**Evidence current through:** 2026-08-11, `main` at `c477d09529b1bf0cc789d512c9e8c43731cda6f1`
+**Evidence current through:** 2026-08-12, epic base `ff6305130c6bf18c6db0aa1096a251e64a4041d5`
 
 ## 1. Outcome
 
-Working Directory Update is the Grace-controlled operation that makes an indexed working directory and its durable
-local state match one selected server root. Branch switching, Watch current-Reference replay, and Connect retrieval use
-one deep internal module for serialization, stale-state rejection, content verification, filesystem mutation, local
-commit, cleanup, and truthful outcomes.
-
-The module commits caller-specific progress only after it proves the selected root. Branch and Watch then perform an
-idempotent finalization step. Connect commits its initial event cursor with the matching local status and object-cache
-metadata.
-
-## 2. Intent, scope, and non-goals
-
-### Why this matters
-
-Grace currently spreads working-directory mutation across large Branch, Watch, and Connect command implementations.
-The shared `WorkingDirectoryMaterialization` module serializes arbitrary callbacks but does not own the transaction it
-names. The result is duplicated planning, marker, verification, cancellation, and persistence behavior at the highest
-local-integrity risk surface in the CLI.
-
-Working Directory Update gives those callers one coherent contract while leaving their admission, target selection,
-remote retrieval, scheduling, and presentation policies where they belong.
-
-### Supported actors, workflows, and environments
-
-- `grace switch` changing the selected branch and its working-directory root.
-- `grace watch` replaying one current-branch Reference from server-ordered events.
-- `grace connect` optionally retrieving its selected branch through the existing zip download.
-- `grace doctor --repair-local-state` explicitly resolving a recorded incomplete finalization or reconstructing exact
-  local state without changing working-directory content.
-- Grace CLI on its currently supported local filesystem and SQLite environment. Windows path comparison remains
-  supported; implementation must preserve existing platform abstractions for other supported systems.
-
-### Required now
-
-- One internal `WorkingDirectoryUpdate` module with `run` and `retryFinalization` operations.
-- Caller-specific request constructors over one private normalized request.
-- Object-cache, Connect zip, and deterministic prepared-content adapters.
-- Repository-and-working-root scoped cross-process lease, marker, and completion sidecar.
-- Exact selected-target and local-state revalidation after lease acquisition.
-- Fresh planning, filesystem mutation, dual-hash verification, final-root verification, and one canonical SQLite
-  completion transaction.
-- The five outcomes `Unchanged`, `Updated`, `Rejected`, `UpdateIncomplete`, and `FinalizationIncomplete`.
-- Idempotent Branch and Watch finalization, blocking while finalization is incomplete, and Doctor recovery.
-- Human and machine-readable result projection with truthful nonzero exit status for incomplete outcomes.
-
-### Deferred, rejected, and out of scope
-
-- Automatic recovery for every interrupted phase.
-- Filesystem rollback after mutation starts.
-- Durable per-file planning or mutation journals.
-- Multiple queued incomplete finalizations for one working directory.
-- Hostile-local-process defense beyond file-lease and ownership-token correctness.
-- Availability, failover, load, multi-host coordination, or broad cross-platform hardening beyond supported CLI use.
-- Network reads while the update lease is held.
-- Unbounded completion history or time-based record expiry.
-- Compatibility, migration, or backfill for development-only local SQLite data. The schema may be replaced cleanly.
-- A public planning or preview interface.
-- A generic transaction-participant or SQL-callback extension mechanism.
-
-## 3. Current-state evidence
-
-| Evidence | Current behavior or contract | Relevance | Confidence or verification |
-| -------- | ---------------------------- | --------- | -------------------------- |
-| `src/Grace.CLI/Command/WorkingDirectoryMaterialization.CLI.fs` | A 75-line module provides an in-process lane and exclusive file lease around arbitrary callbacks. | The replacement must deepen this module rather than preserve the callback seam. | Current source. |
-| `src/Grace.CLI/Command/Branch.CLI.fs` | Branch owns a workflow lease, Watch-clean preflight, marker handling, working-directory updates, local status, branch identity, and cache refresh. | Branch is the first public tracer and has a real post-update finalizer. | Current source around `runBranchSwitchWorkflowWithLease` and `updateWorkingDirectory`. |
-| `src/Grace.CLI/Command/Watch.CLI.fs` | Watch has private plan/apply clients, an object-cache apply path, marker sidecars, serialized replay, and cursor acknowledgement. | Watch supplies the most demanding ordering and retry scenarios. | Current source around `CurrentBranchRemoteMaterializationPlan`, `applyCurrentBranchMaterializationTargets`, and cursor replay. |
-| `src/Grace.CLI/Command/Connect.CLI.fs` | Connect writes configuration before optional retrieval, streams a server zip, writes working and object files together, and ignores undeclared zip files. | The design preserves zip retrieval while replacing extraction, verification, and outcome behavior. | Current source around `extractZipEntries` and `connectImpl`. |
-| `src/Grace.CLI/LocalStateDb.CLI.fs` | Schema version 9 stores status, object-cache metadata, and remote-reference boundaries. Boundary writes require complete root identity matching. | Schema replacement adds bounded update completion rows and extends atomic commit operations. | Current source around `replaceStatusSnapshotWithRevisionCore` and cursor operations. |
-| `src/Grace.CLI/Command/Doctor.CLI.fs` | `--repair-local-state` proves an unchanged working tree against server root and branch history before atomic reconstruction. | Doctor is the sole explicit recovery gesture and will gain recorded-finalization retry. | Current source around `repairLocalState`. |
-| `src/Grace.Types/Reference.Types.fs` | `ReferenceMaterializationBoundaryDto` combines target root identity with an event cursor. | The internal update target must separate root identity from caller progress. | Current source at `ReferenceMaterializationBoundaryDto`. |
-| `src/Grace.CLI/Grace.CLI.fsproj` | Connect currently compiles before the shared module. | The new module and adapters must compile before Connect, Branch, Watch, and Doctor. | Current project file. |
-| ADR 0009 and ADR 0010 | Watch branch-transition refresh and current-branch materialization define existing caller-specific trust rules. | Working Directory Update must preserve and centralize their local mutation invariants without erasing caller policy. | Accepted repository decisions. |
-
-The intended design deliberately supersedes current callback-based and Connect extraction behavior. It does not describe
-those changes as already implemented.
-
-## 4. Quality contract and accepted risk
-
-The active profile is Product V1.
-
-- **Data and compatibility:** Grace is not in production. Local schema replacement and fixture regeneration are
-  allowed; no migration, dual read, or compatibility layer is required.
-- **Integrity:** Working-directory bytes, object-cache bytes, selected root, local status, cursor, and completion state
-  must never claim success without dual-hash and ordering proof.
-- **Concurrency:** Branch, Watch, and Connect updates affecting the same local directory serialize across processes.
-- **Recovery:** Exact same-operation retry, finalization-only retry, and explicit Doctor recovery are required. General
-  rollback and automatic phase recovery are not.
-- **Threat model:** Ordinary local process races, crashes, malformed prepared content, and stale selections are in
-  scope. A malicious local process intentionally replacing coordination files is not.
-- **Availability and scale:** No multi-host availability or load promises are added. Completion storage remains
-  bounded.
-- **Review and proof:** Real temporary filesystems and SQLite are required at the module seam. Public CLI output,
-  ordering, cancellation, restart, and cleanup receive focused proof.
-- **Complexity stop:** Do not add a durable running-operation state, per-file journal, rollback engine, generic plugin
-  protocol, or recovery scheduler to satisfy this specification.
-
-Accepted Product V1 risks include a random prepared zip remaining in the system temp directory after abrupt process
-termination and manual intervention when interrupted bytes match no known server root.
-
-## 5. Decisions and capability inventory
-
-### Decision ledger
+Working Directory Update is the bounded local transaction used by `grace switch` to make a Grace-indexed working
+directory and its local SQLite state match one exact selected root. It verifies prepared objects, applies only the
+tracked plan, proves the complete final root, commits local completion, and then completes the Branch-specific
+finalization.
 
-| ID | Lane | Status | Accepted decision | Implementation impact | Proof impact |
-| -- | ---- | ------ | ----------------- | --------------------- | ------------ |
-| DEC-001 | domain | accepted | Name the operation Working Directory Update. | Rename and deepen the shared module; add the term to `CONTEXT.md`. | Public and contributor docs use one term. |
-| DEC-002 | scope | accepted | Product V1 is the quality contract; rollback, journals, broad automatic recovery, and hardening remain out of scope. | Keep the state machine bounded. | Prove selected V1 failure and restart paths only. |
-| DEC-003 | architecture | accepted | Use a hybrid interface: generic `run` and `retryFinalization` operations with caller-specific request constructors. | One private engine serves Branch, Watch, and Connect. | All callers cross the same stable module seam. |
-| DEC-004 | domain | accepted | Target identity is repository, branch, root DirectoryVersion, SHA-256, and BLAKE3; caller operation identity is separate and deterministic. | Do not use the event-boundary DTO as the internal target. | Same target/same operation and same target/new operation receive distinct proof. |
-| DEC-005 | architecture | accepted | Prepared adapters expose immutable manifest entries and readable bytes, never mutation plans. | Zip, object-cache, and deterministic adapters share one content contract. | Adapter contract suites plus real module integration. |
-| DEC-006 | architecture | accepted | Lease, marker, and sidecar use repository ID plus a normalized local-root-path hash, excluding branch identity. | Add a stable repository/root temp-scope helper. | Separate local roots do not block; branch changes do not move evidence. |
-| DEC-007 | architecture | accepted | SQLite local completion is the irreversible point; the sidecar is derived Watch notification evidence. | Commit matching status, cache metadata, Connect cursor, and completion row atomically. | Crash tests at every commit and cleanup edge. |
-| DEC-008 | product | accepted | `FinalizationIncomplete` blocks different updates until exact retry or Doctor recovery. | Persist one pending finalization and reject later operations. | Ordering and blocking tests across processes. |
-| DEC-009 | architecture | accepted | SQLite stores no pre-completion operation state and retains only the latest terminal row per caller plus one pending row. | No running row, operation log, or expiry clock. | Retention and supersession proof. |
-| DEC-010 | product | accepted | Doctor first retries recorded finalization without filesystem mutation, then may perform exact reconstruction. | Persist minimum typed finalization facts and extend Doctor. | Branch, Watch, unknown-marker, and refusal cases. |
-| DEC-011 | product | accepted | Connect keeps zip download, stages locally, validates exact manifest coverage, writes verified objects first, and performs no network reads under lease. | Replace `extractZipEntries`; add zip adapter and local staging. | Per-file triple-location dual-hash and malformed-archive proof. |
-| DEC-012 | product | accepted | Connect `--force` replaces conflicts only at target paths and never deletes unrelated eligible content. | Caller admission supplies approved target conflicts; module rejects unexpected paths. | Force, no-force, unrelated, ignored, and path-type tests. |
-| DEC-013 | product | accepted | Connect configuration persists before optional retrieval and output reports configuration separately from update result. | Preserve config ordering; extend Connect result projection. | Retrieval-disabled and failed-update behavior. |
-| DEC-014 | architecture | accepted | The same deterministic operation may adopt a known orphaned marker after lease acquisition and fresh replanning. | Separate operation ID from random attempt token. | Same, different, malformed, and completed marker tests. |
-| DEC-015 | product | accepted | Incomplete outcomes use nonzero exit status; `FinalizationIncomplete` says bytes were updated and recommends Doctor. | Add typed human and machine projections. | Exit-code, JSON, and no-mixed-output proof. |
-| DEC-016 | proof | accepted | `grace switch` is the first value-bearing tracer. | Build the core module through one object-backed Branch path before Watch and Connect migration. | Public tracer proves the shared transaction and finalization. |
+The first replacement path is deliberately Branch-only. Watch and Connect remain deferred callers; this specification
+does not create a generic request shape or a partly active constructor for either one.
 
-### Capability inventory
+## 2. Scope and non-goals
 
-| Capability | Disposition | User-visible outcome | Surfaces | Intrinsic obligations | Complexity impact | Reason |
-| ---------- | ----------- | -------------------- | -------- | --------------------- | ----------------- | ------ |
-| Shared update transaction | Required now | Three callers report the same truthful outcomes. | CLI internals, filesystem, SQLite | Serialization, revalidation, integrity, cleanup | Replaces duplicated logic | Core value. |
-| Branch finalization | Required now | Selected branch identity follows verified bytes. | Branch CLI, config, SQLite | Idempotency and blocking | Small typed finalizer | Required by tracer. |
-| Watch finalization | Required now | Cursor advances only after verified bytes. | Watch replay, SQLite, IPC status | Ordered replay and idempotency | Small typed finalizer | Required current behavior. |
-| Connect zip adapter | Required now | Existing zip retrieval produces verified object and working bytes. | Connect CLI, temp zip, object cache | Exact manifest and dual hashes | Dedicated adapter | Required current workflow. |
-| Doctor recovery | Required now | One documented command resolves exact recoverable states. | Doctor CLI, SQLite, marker | No file mutation, exact proof | Extends existing repair | Required operator path. |
-| Filesystem rollback | Rejected | None promised. | Not applicable | Would require durable inverse plans | High | Outside Product V1. |
-| Per-file durable journal | Rejected | None promised. | Not applicable | Restart and compaction lifecycle | High | Marker plus exact retry is sufficient. |
-| Automatic general recovery | Deferred | Manual Doctor remains required for ambiguous states. | Future maintenance | Classification and scheduling | High | No V1 value beyond selected paths. |
-| Temp-file scavenging after crashes | Deferred | Handled exits clean up; abrupt exits may leave random zip files. | System temp | Age, ownership, and deletion safety | Moderate | Accepted Product V1 risk. |
-| Hostile local coordination-file defense | Out of scope | No promise. | Local temp files | Identity and access hardening | High | Not in current threat model. |
-| Public update-planning interface | Rejected | No preview or plan manipulation. | CLI/API | Stable plan format and compatibility | High | Would make the module shallow. |
+### Required Branch behavior
 
-## 6. Domain language and model
+- `grace switch` routes every supported Reference, SHA-256, and BLAKE3 selector through one private
+  `WorkingDirectoryUpdate` module.
+- `Reference` selection may change the active Branch only after verified local completion.
+- Exact-root `DirectoryVersion` selection keeps the current Branch active. It does not invent a Reference ID.
+- One successful pre-switch Save establishes the only accepted current-version baseline for a Save-enabled switch.
+- The module derives its repository configuration, local paths, scan input, current-state binding, operation identity,
+  completion facts, marker facts, and Branch finalization facts.
+- The result is one of `Unchanged`, `Updated`, `Rejected`, `UpdateIncomplete`, or `FinalizationIncomplete`.
 
-### Canonical operation term
+### Deferred callers and work
 
-A Grace-controlled operation that changes indexed working-directory content and durable local state to match one
-selected server root, then commits caller-specific progress only after verifying that match.
+- Watch replay and finalization are deferred to their named later epic work. They must not add a request constructor,
+  callback, or policy branch to the Branch module during #869–#872.
+- Connect retrieval, zip staging, target-only `--force`, and cache policy are deferred to their named later epic work.
+- Doctor remains the explicit recovery command. #842 consumes the exact pending Branch facts after the Branch sequence;
+  it does not make Working Directory Update a generic all-caller engine.
 
-### Selected target
+### Product V1 limits
 
-The immutable tuple of RepositoryId, BranchId, root DirectoryVersionId, root SHA-256, and root BLAKE3 selected by the
-caller. An event cursor is not part of the target.
+- No filesystem rollback, durable per-file journal, automatic recovery scheduler, migration, compatibility layer, or
+  additional durable update state.
+- No network access while the local update lease is held.
+- No public planning interface, arbitrary path bag, database callback, caller-supplied mutation plan, or generic
+  finalizer callback.
+- No new public outcome, server route, SDK surface, OpenAPI shape, or generated artifact.
 
-### Operation identity
+## 3. Current evidence and supersession
 
-The deterministic caller-specific tuple that distinguishes retry, stale work, and a new operation. Grace hashes a
-canonical serialization of the tuple. Correlation IDs are diagnostic and do not affect idempotency.
+| Evidence | Finding | Planning consequence |
+| --- | --- | --- |
+| Epic base `ff630513` | Branch still owns direct local mutation, status replacement, and Branch publication. | The first replacement path must remove that reachable direct route rather than wrap it. |
+| Closed #841 and superseded PR #854 at `bc9bd109` | The broad implementation mixed persistence, runtime, Save admission, finalization, public projection, and the full failure matrix. | Do not restore its generic request or all-caller shapes. Split the sequential Branch work below. |
+| Exact-head #854 review | Typed marker results were collapsed, Reference finalization was not repeatable, planning used pre-Save status, topology and cancellation rules were incomplete, and the executable phase matrix was absent. | These are explicit requirements, proof seams, and issue owners below. |
+| Accepted D1 | `Reference` and exact-root `DirectoryVersion` have different Branch semantics. | Persist and reconstruct the typed selection; hashes retain the current Branch. |
+| #869–#872 | Four sequential source issues replace #841. | Each issue owns one primary invariant family and a complete vertical proof boundary. |
 
-- Watch: caller kind, repository, branch, and exact event cursor.
-- Branch: caller kind, repository, previous branch, selected branch, selected Reference, and target root.
-- Connect: caller kind, repository, selected branch, target root, initial cursor, and local root scope.
+The superseded commits are evidence and possible narrow test vectors only. They do not establish an implementation
+contract, and this document does not describe their runtime shape as accepted.
 
-### Attempt token
+## 4. Accepted decisions
 
-A random token identifying one execution attempt. It owns one marker instance and is never used as logical operation
-identity.
+| ID | Decision | Lasting consequence | Replacement owner |
+| --- | --- | --- | --- |
+| DEC-001 | Branch selection is typed as `Reference` or exact-root `DirectoryVersion`. | A Reference has its selected Reference ID. A DirectoryVersion has no Reference ID and uses the current Branch as previous and selected Branch. | #869 |
+| DEC-002 | The successful pre-switch Save is the sole accepted baseline. | Bind the saved complete status graph by SQLite revision and canonical full-status fingerprint; reread that binding under the lease before planning. | #872 |
+| DEC-003 | Marker evidence is a typed disposition, not a Boolean. | Missing, exact, different-operation, malformed or unsupported, unreadable, and exact-cleanup-failed evidence retain distinct behavior. | #869, consumed by #870–#872 |
+| DEC-004 | Reference finalization is repeatable from persisted typed facts. | Previous Branch applies once; the exact selected Branch is already applied; any third Branch rejects. | #871 |
+| DEC-005 | The plan covers the complete tracked topology. | It creates target directories, removes obsolete tracked empty directories, handles file/directory transitions before mutation, and preserves ignored content. | #870 |
+| DEC-006 | The public action token remains attached until mutation begins. | Admission, Save, resolution, preparation, lease wait, object publication, and the final pre-mutation boundary observe it; only post-mutation cancellation is deferred. | #870, #872 |
+| DEC-007 | The first deep module has a minimal Branch seam. | The caller supplies only typed selection, exact target graph, verified prepared content, and diagnostic correlation. | #870 |
+| DEC-008 | Phase proof is split by boundary. | Real filesystem and SQLite tests activate phase and recovery seams; built-command tests cover selector routing and bounded public projection. | #870–#872 |
+| DEC-009 | #841 is superseded as an implementation plan. | #868 corrects this contract; #869, #870, #871, and #872 deliver the sequential Branch work. | #868 |
 
-### Prepared content
+No product decision is open. The rows above refine the accepted Product V1 behavior exposed by the #854 review; they do
+not add another state, outcome, recovery mode, or caller.
 
-An immutable target manifest plus readable uncompressed file bytes. Its adapter owns zip, object-cache, or test
-resources and is disposed by the module. It cannot supply a mutation plan.
+## 5. Domain language
 
-### Local completion
+### Typed Branch selection
 
-The SQLite transaction that atomically records matching status, required object-cache metadata, Connect's initial
-cursor when applicable, and the operation completion row. This is the irreversible point.
+`Reference` contains the current Branch, selected Branch, and required selected Reference ID. `DirectoryVersion`
+contains the current Branch and exact target root with no Reference ID. Hash prefixes that resolve to the same target
+root are the same DirectoryVersion operation; a Reference remains a distinct exact selection.
 
-### Finalization
+### Exact target graph
 
-An idempotent caller action performed after local completion while the lease remains held. Branch persists selected
-branch identity. Watch advances the exact cursor. Connect ordinarily has no separate finalization.
+The immutable complete selected directory graph contains the root DirectoryVersion identity, SHA-256 and BLAKE3 roots,
+declared files, declared directories including empty directories, and their canonical paths. Root fields alone are not
+proof of the graph.
 
-### Local root scope
+### Accepted local baseline
 
-The lowercase SHA-256 of the normalized absolute working-directory path, combined with repository identity to scope
-lease, marker, and sidecar files. It is not a DirectoryVersion identity.
+The immutable binding created by the successful current-version Save, or by supported no-Save admission, contains the
+SQLite revision and canonical fingerprint of the complete current Grace status graph. It is not a caller-supplied
+prior-status graph. The post-lease reread must equal it before a plan can be built.
 
-## 7. Supported scenarios and workflows
+### Operation and attempt
 
-### Successful Branch tracer
+The deterministic operation binds repository, previous and selected Branch, typed selection and optional Reference,
+exact target root, and local-root scope. Diagnostic correlation is not part of operation identity. A random attempt
+token identifies one owned marker instance and never substitutes for that identity.
 
-Branch completes admission and content preparation, constructs a deterministic request, and calls `run`. The module
-acquires the lease, revalidates selection and clean local state, plans from current bytes, marks, applies from verified
-objects, verifies the target, commits local completion, removes the marker, and finalizes selected branch identity.
-The command returns `Updated` with exit code 0.
+### Local completion and finalization
 
-### Already-matching target
+Local completion is the atomic SQLite commit of verified status, required object metadata, and the pending or terminal
+Branch operation. It is the irreversible local point. Finalization occurs only after local completion using the same
+persisted typed operation; it changes Branch configuration only for `Reference`.
 
-If current working bytes and status already match the target, the module performs no filesystem mutation. The same
-operation returns its existing completion; a new operation receives its own local completion and finalization.
+## 6. Minimal Branch module contract
 
-### Watch replay
+The private Branch entry to `WorkingDirectoryUpdate.run` accepts exactly four caller-provided facts:
 
-Watch retains replay admission and server ordering. The module applies one selected Reference from verified object
-content. Only after local completion does the finalizer advance the expected cursor to the accepted cursor. A newer
-event selecting the same root is a new operation and still finalizes its cursor.
+1. The typed `Reference` or `DirectoryVersion` selection.
+2. The exact resolved target graph.
+3. Verified prepared content for that graph.
+4. Diagnostic correlation.
 
-### Connect retrieval
+From these facts and canonical Branch configuration, the module derives the working root, object root, `.grace`
+directory, SQLite path, ignore-aware scan input, local-root scope, accepted revision and complete-status fingerprint,
+operation identity, pending and completion facts, marker disposition, and Branch finalization facts. A caller cannot
+provide alternate paths, a selected-state reader, an old status graph, a finalizer, a filesystem writer, a mutation
+plan, or a database handle.
 
-Connect persists valid configuration, resolves target and cursor, downloads the complete zip locally, validates exact
-manifest coverage and hashes, and calls `run`. Under the lease, the module verifies or creates object files first,
-copies verified objects into approved target paths, verifies the final root, and commits status, cache metadata, initial
-cursor, and completion together.
+The module exposes `run` and the internal exact-finalization retry used by #871 and #842. It does not expose Watch or
+Connect construction. Any later caller requires its own accepted design and must not widen this Branch input by adding
+an arbitrary context record.
 
-### Connect without retrieval
+## 7. Branch transaction and marker behavior
 
-`--retrieve-default-branch false` persists configuration and does not call the module, establish a materialized root,
-or record an event cursor.
-
-### Local conflict
-
-Without `--force`, Connect rejects a mismatching selected target path before mutation. With `--force`, it may replace
-that path. Eligible content outside the target is always rejected. Ignored content remains untouched.
-
-### Failure after mutation
-
-After the first filesystem mutation, cancellation is deferred. If verified local completion cannot be reached, the
-module returns `UpdateIncomplete`, records no completion row, and removes only its owned marker on handled failure.
-A retry revalidates and creates a new plan.
-
-### Finalization failure
-
-The module commits local completion, writes derived notification evidence, removes its marker, and attempts finalization.
-Failure returns `FinalizationIncomplete`, a nonzero exit, and a Doctor recommendation. A different update is blocked.
-
-### Same-operation restart
-
-After acquiring the lease, the same deterministic operation may adopt a known orphaned marker. It never continues an
-old plan; it validates content and current state and plans again. A different or unrecognized marker is rejected and
-requires Doctor.
-
-### Doctor recovery
-
-Doctor acquires the update lease. For a pending finalization, it proves the recorded target and retries only the typed
-idempotent finalizer. If that is not applicable, Doctor may use its existing exact working-tree reconstruction path.
-It never changes working-directory content and preserves evidence when proof fails.
-
-## 8. Functional requirements and invariants
-
-### REQ-001 — One deep internal module
-
-- Branch, Watch, and Connect must cross `WorkingDirectoryUpdate.run` for working-directory mutation.
-- Finalization-only recovery must cross `WorkingDirectoryUpdate.retryFinalization`.
-- Callers retain admission, target selection, remote access, scheduling, and rendering.
-- Callers must not pass mutation plans, filesystem writers, database handles, or transaction callbacks.
-
-### REQ-002 — Complete target and operation identity
-
-- Target identity must contain repository, branch, root DirectoryVersion, SHA-256, and BLAKE3.
-- Operation identity must be deterministic from the accepted caller tuple.
-- Marker attempt tokens must be random and independent from operation identity.
-- Empty, incomplete, mismatched, or noncanonical identity must be rejected before mutation.
-
-### REQ-003 — Exact prepared content
-
-- Prepared content must cover every target file exactly once and no undeclared non-directory content.
-- Paths must be normalized, relative, representable, contained, and collision-free under active path comparison.
-- Each uncompressed file must match its declared SHA-256 and BLAKE3 before lease acquisition.
-- The adapter must be disposed on every terminal path.
-
-### REQ-004 — Stable serialization scope
-
-- The lease, marker, and sidecar must use repository identity plus local root scope and exclude branch identity.
-- Only one update may hold the scope lease.
-- A caller must revalidate selected target, configuration, local status, pending finalization, and relevant filesystem
-  state after acquiring the lease and before mutation.
-
-### REQ-005 — Versioned owned marker
-
-- The marker must contain schema version, attempt token, caller kind, operation identity, repository and branch facts,
-  target root, start time, and diagnostic process ID.
-- It must not contain credentials, zip URLs, or unnecessary absolute paths.
-- Cleanup must remove only the marker matching the current attempt token.
-- Malformed, unsupported, or different-operation markers require Doctor.
-
-### REQ-006 — Fresh plan and local-content safety
-
-- The module must build the mutation plan only after lease acquisition and revalidation.
-- The plan may delete only paths proven by accepted prior status to be Grace-tracked and absent from the target.
-- Unexpected eligible content must reject the operation.
-- Connect `--force` may replace only conflicts at selected target paths.
-- Ignored content must remain untouched and outside selected-root comparison.
-
-### REQ-007 — Verified object-first application
-
-- Connect must complete its zip download and validation before lease acquisition.
-- No remote access may occur while the lease is held.
-- Every object file must be dual-hash verified before use; a mismatched existing object must be replaced from validated
-  content through an atomic local-file publication step.
-- Working files must be copied only from verified objects and verified again after copy.
-
-### REQ-008 — Final-root verification
-
-- The module must independently verify retained paths, applied files, directory structure, and both final root hashes.
-- The selected DirectoryVersion identity must be used only when computed root hashes match the selected target.
-- No durable status or completion record may be written for an unverified root.
-
-### REQ-009 — Canonical local completion
-
-- One SQLite transaction must commit matching status, required cache metadata, Connect's initial cursor when present,
-  and the operation completion row.
-- No SQLite operation row may exist before this transaction.
-- The sidecar is derived notification evidence and cannot override SQLite truth.
-- A crash after commit must remain discoverable as locally complete even if sidecar or marker cleanup did not finish.
-
-### REQ-010 — Bounded completion state
-
-- The table must retain the single pending finalization and the latest terminal row per caller kind.
-- Pending finalization must never be pruned or superseded.
-- A newer terminal operation may prune the older terminal row for the same caller.
-- No time-based expiry or unbounded history is allowed.
-
-### REQ-011 — Idempotent finalization and blocking
-
-- Branch and Watch finalizers must be idempotent for the operation identity.
-- Initial finalization occurs while the lease remains held.
-- A pending finalization blocks every different update in the same scope.
-- Finalization retry must reacquire the lease, prove the same target, perform no filesystem mutation, and retry only the
-  finalizer.
-
-### REQ-012 — Truthful outcomes and exit status
-
-- `Unchanged` and `Updated` are success outcomes with exit code 0.
-- `Rejected`, `UpdateIncomplete`, and `FinalizationIncomplete` are nonzero outcomes.
-- `FinalizationIncomplete` must state that working-directory bytes were updated and recommend
-  `grace doctor --repair-local-state`.
-- Human and JSON output must distinguish configured Connect identity from update outcome.
-- Parse, authentication, and transport errors remain normal `GraceError` failures rather than update outcomes.
-
-### REQ-013 — Cancellation and progress
-
-- Cancellation is honored during admission, download, preparation, lease waiting, and before first mutation.
-- After first mutation, cancellation is deferred until verified local completion or unavoidable update failure.
-- Cancellation may apply again during finalization and produce `FinalizationIncomplete`.
-- Progress is coarse: preparing, waiting, applying, verifying, committing, and finalizing.
-- Progress failure cannot control or fail the transaction.
-
-### REQ-014 — Same-operation marker adoption
-
-- Adoption is allowed only after acquiring the lease and matching marker schema, operation identity, scope, and target.
-- A matching completion row routes to cleanup and finalization-only retry.
-- No completion row routes to complete revalidation and fresh planning.
-- Adoption replaces the old attempt token; it never resumes an old plan.
-
-### REQ-015 — Explicit Doctor recovery
-
-- Doctor must use the same update lease and refuse active competing work.
-- It must first attempt an exact filesystem-free retry of a recorded pending finalization.
-- Fallback reconstruction must preserve current bytes and prove a complete known server root and event boundary.
-- Doctor must not guess targets, resume archive extraction, roll back content, or delete unrecognized evidence without
-  exact reconciliation.
-
-### REQ-016 — Caller-specific ordering
-
-- Branch must not publish selected branch identity before local completion.
-- Watch must not advance its cursor before local completion and must preserve ordered replay.
-- Connect must not write an initial cursor without matching status and root.
-- Connect configuration remains independently valid when retrieval is not requested or does not complete.
-
-### REQ-017 — Public and contributor documentation
-
-- The canonical specification and ADR must define the current intended contract.
-- CLI help, Doctor documentation, machine-readable output documentation, Watch documentation, and `CONTEXT.md` must be
-  updated with implementation.
-- Design-only cross-references must not claim behavior is already implemented.
-
-## 9. Interfaces, contracts, and propagation
-
-### Internal interface shape
-
-The implementation may refine names while preserving this shape:
-
-```fsharp
-module internal WorkingDirectoryUpdate =
-    type Target = private Target of repositoryId: RepositoryId * branchId: BranchId * root: RootIdentity
-    type Operation = private Operation of string
-    type Request = private Request
-    type FinalizationRequest = private FinalizationRequest
-
-    type Outcome =
-        | Unchanged of Receipt
-        | Updated of Receipt
-        | Rejected of Failure
-        | UpdateIncomplete of Failure
-        | FinalizationIncomplete of Receipt * Failure
-
-    val run: Request -> CancellationToken -> Task<Outcome>
-    val retryFinalization: FinalizationRequest -> CancellationToken -> Task<Outcome>
-```
-
-`Request.branchSwitch`, `Request.watchReplay`, and `Request.connectBootstrap` are constructors, not separate transaction
-implementations. `IPreparedContent`, selected-target reading, and idempotent finalization are the only caller-facing
-variation seams.
-
-### Contract propagation matrix
-
-| Surface | Owner or artifact | Accepted and rejected values | Persistence impact | Compatibility posture | Disposition | Proof |
-| ------- | ----------------- | ---------------------------- | ------------------ | --------------------- | ----------- | ----- |
-| Internal module | New `WorkingDirectoryUpdate*.CLI.fs` files | Private typed requests and five outcomes; reject incomplete identity and arbitrary callbacks | None directly | Clean replacement | Updated | Shared integration suite. |
-| F# compile order | `Grace.CLI.fsproj` | Core and adapters precede all consumers | None | No compatibility concern | Updated | Release build. |
-| SQLite | `LocalStateDb.CLI.fs` | Bounded completion rows and typed finalization facts | Schema replacement from development schema 9 | No migration or dual read | Updated | Real SQLite schema, transaction, restart, and retention tests. |
-| Coordination files | Services and update module | Versioned known marker; reject malformed or conflicting marker | Temp lease, marker, sidecar | Replace branch-scoped marker | Updated | Cross-process and restart tests. |
-| Branch CLI | `Branch.CLI.fs`, output DTO/registry | Typed update outcomes; Branch finalizer | Selected branch follows local completion | Current behavior replaced cleanly | Updated | `grace switch` tracer, JSON, exit-code tests. |
-| Watch | `Watch.CLI.fs`, existing check projection | Internal outcomes; foreground Watch remains continuous | Cursor finalization and existing IPC status | Preserve existing event and check shapes unless proof requires additive reason text | Updated | Ordered replay, same-root event, blocked status, restart tests. |
-| Connect CLI | `Connect.CLI.fs`, `ConnectDto` or replacement projection | Exact zip; target-only `--force`; optional retrieval | Config separate; status/cache/cursor/completion atomic | Clean current-contract replacement | Updated | Zip, force, no-retrieval, JSON, and exit-code tests. |
-| Doctor CLI | `Doctor.CLI.fs`, `DoctorReportDto` | Exact finalization retry or exact reconstruction only | Finalized/recovered completion status | Extend current explicit option | Updated | Pending Branch/Watch, refusal, and JSON tests. |
-| Machine output registry | `CommandOutputContract.CLI.fs` | Stable outcome DTOs; invalid command shape remains `GraceError` | None | `branch.switch` leaves current V2 deferral when implementation lands | Updated | Schema, example, select, single-document, and exit tests. |
-| Shared Types and SDK | `Grace.Types`, `Grace.SDK` | Existing server target and cursor DTOs remain | None | No change | Unchanged with reason | Build and scoped diff. |
-| HTTP/OpenAPI/generated clients | Server routes and generated artifacts | No new route or wire behavior | None | No change | Not applicable with reason | Generated freshness and scoped diff. |
-| Configuration | Grace local config | Connect identity may exist without retrieved root | Existing config file | Preserve supported no-retrieval behavior | Updated documentation; runtime ordering preserved | Connect scenarios. |
-| Documentation | This specification, ADR 0011, context and user docs | One canonical term and planned/current distinction | None | Update with implementation | Updated | MarkdownLint and review. |
-
-## 10. Source, identity, state, time, and outcomes
-
-### Source and identity model
-
-| Concern | Contract |
-| ------- | -------- |
-| Selected target source | Caller-selected immutable server Reference/root facts, reread through the caller's typed selected-target seam. |
-| Current local source | Fresh configuration snapshot, SQLite status and completion rows, held scope lease, marker, and actual filesystem bytes. |
-| Same operation | Equal deterministic caller tuple within the same repository/root scope. |
-| Same target, new operation | Equal target tuple but different deterministic operation tuple; no file mutation, new completion/finalization. |
-| Stale work | Selected target, configuration, prior status, expected cursor, or branch facts differ at post-lease revalidation. |
-| Conflicting work | Another pending finalization, a different known marker, or unexpected eligible filesystem content. |
-| Attempt ownership | Held lease plus exact random token in the current marker. Process ID is diagnostic only. |
-| Revalidation point | After lease acquisition and again immediately before mutation or finalization-only commit. |
-
-### State model
-
-| State | Entry condition | Durable truth | Allowed transitions | Terminal? | Restart behavior | Published result |
-| ----- | --------------- | ------------- | ------------------- | --------- | ---------------- | ---------------- |
-| Preparing | Caller is selecting and preparing content. | No update row. | Waiting, Rejected | No | Caller restarts preparation. | Coarse progress only. |
-| Waiting | Valid request is waiting for scope lease. | No update row. | Applying, Rejected | No | Caller resubmits. | Coarse progress only. |
-| Applying | Lease held, revalidation passed, owned marker written, first mutation may occur. | Marker only. | Verifying, UpdateIncomplete | No | Same operation may adopt known marker and replan. | No success publication. |
-| Verifying | Planned writes completed; content and root are being proven. | Marker only. | Committing, UpdateIncomplete | No | Same as Applying. | No success publication. |
-| Committing | Verified root is entering canonical SQLite transaction. | Marker; row appears only on successful commit. | FinalizationPending, UpdateIncomplete | No | Presence of completion row decides the path. | No success publication. |
-| FinalizationPending | Local completion transaction committed. | Completion row with finalization pending. | Finalized, RecoveredByDoctor, FinalizationIncomplete | No | Retry only finalization after exact proof. | Incomplete result if finalizer fails. |
-| Finalized | Required finalization completed. | Latest terminal row for caller plus caller progress. | Superseded by newer same-caller terminal row | Yes | Same operation returns existing completion. | `Updated` or `Unchanged`. |
-| RecoveredByDoctor | Doctor explicitly reconciled exact local state. | Terminal recovery row and exact local state. | Superseded by newer same-caller terminal row | Yes | Normal later operations may proceed. | Doctor recovery result. |
-| Rejected | No mutation began. | No update row. | Caller fixes reason and resubmits. | Yes | Nothing to recover unless foreign marker remains. | `Rejected`. |
-| UpdateIncomplete | Mutation began but local completion did not commit. | No completion row; handled marker removed, crash marker may remain. | Fresh same-operation retry or Doctor | Yes | Revalidate and replan. | `UpdateIncomplete`. |
-| FinalizationIncomplete | Local completion committed but caller progress did not finish. | Pending completion row. | Same-operation finalization retry or Doctor | Yes | Blocks different operations. | `FinalizationIncomplete`. |
-
-No state has an expiry timer. Timestamps use UTC for diagnostics and completion evidence; they do not decide operation
-ownership, adoption, or pruning.
-
-### Side-effect ordering
+### Side-effect order
 
 ```text
-prepare and validate content
-→ acquire scope lease
-→ inspect completion and marker state
-→ revalidate target and local state
-→ build fresh plan
-→ create or adopt owned marker
-→ verify or publish object files atomically
-→ mutate approved working-directory paths
-→ verify applied files and final root
-→ atomically commit status + cache metadata + Connect cursor + completion row
-→ write derived completion sidecar
-→ remove owned marker
-→ run idempotent Branch or Watch finalization
-→ mark completion terminal
-→ release lease
-→ dispose prepared content
+admission and optional current-version Save
+→ bind accepted revision plus complete-status fingerprint
+→ resolve target and verify prepared content
+→ acquire repository/local-root lease
+→ reread configuration, SQLite revision, complete status, completion, marker, and relevant filesystem state
+→ require the accepted baseline and inspect marker disposition
+→ build a fresh tracked plan
+→ publish and reverify dual-hash objects
+→ final action-token check
+→ mutate tracked paths
+→ independently verify complete graph and both final root hashes
+→ atomically commit local completion
+→ clean only exact owned marker evidence
+→ Branch finalization
+→ mark terminal completion and release the lease
 ```
 
-### Failure and outcome matrix
+Target resolution and prepared-content work finish before the lease. Planning always consumes the complete state
+reread under that lease, never the earlier in-memory status or a separately assembled prior graph.
 
-| Outcome | Filesystem mutation | Durable truth | Retry | Cleanup and user result |
-| ------- | ------------------- | ------------- | ----- | ----------------------- |
-| `Unchanged` | None | Matching terminal completion and caller progress | Safe same-operation replay | Exit 0. |
-| `Updated` | Completed and verified | Matching terminal completion and caller progress | Safe same-operation replay | Exit 0. |
-| `Rejected` | None | No completion row | Fix classified reason; Doctor for unrecognized marker | Remove only owned marker; nonzero. |
-| `UpdateIncomplete` | Began or may have begun | No completion row | Revalidate and replan; same operation may adopt crash marker | Nonzero; never claim matching root. |
-| `FinalizationIncomplete` | Completed and verified | Pending completion row | Finalization-only retry or Doctor | Nonzero; say bytes updated and recommend Doctor. |
+### Marker inspection and cleanup table
 
-### Cancellation and cleanup
+The pending completion row is the durable local source after local completion. Marker evidence never overrides it and
+unknown evidence is never deleted.
 
-Cancellation is active through preparation, lease wait, and the final pre-mutation check. Once the first filesystem
-mutation begins, the module defers cancellation until it reaches verified local completion or unavoidable failure. The
-token may apply again to finalization. Prepared content is disposed after lease release on every handled path. Marker
-and sidecar deletion never erase SQLite completion truth.
+| Phase | Evidence or cleanup result | Required Branch behavior | Result when the step cannot continue |
+| --- | --- | --- | --- |
+| Before local completion | No marker | Create the owned current-attempt marker after fresh revalidation and plan. | Continue normally. |
+| Before local completion | Exact matching marker | Adopt only the matching operation, discard its old attempt token, reread all facts, and build a new plan. | Reject if the fresh binding no longer matches. |
+| Before local completion | Different operation | Preserve the marker. Do not mutate or replace it. | `Rejected`. |
+| Before local completion | Malformed or unsupported marker | Preserve the marker. Do not infer ownership. | `Rejected`. |
+| Before local completion | Unreadable marker | Preserve the marker and do not treat absence as proof. | `Rejected`. |
+| Before local completion | Exact-marker cleanup fails while handling a pre-commit failure | Preserve the readable exact marker. The update remains non-successful; a later exact operation must revalidate and replan. | `Rejected` before mutation, otherwise `UpdateIncomplete`. |
+| After local completion | No marker | Use the matching pending completion row; no working-file mutation is permitted. | Continue only with exact finalization facts. |
+| After local completion | Exact matching marker | Clean only that marker, then finalize from the pending row. | Cleanup failure remains pending. |
+| After local completion | Different operation | Preserve the marker and do not finalize through ambiguous evidence. | `FinalizationIncomplete`. |
+| After local completion | Malformed or unsupported marker | Preserve the marker and do not reduce it to missing. | `FinalizationIncomplete`. |
+| After local completion | Unreadable marker | Preserve the evidence and do not continue as if cleanup succeeded. | `FinalizationIncomplete`. |
+| After local completion | Exact cleanup failure | Preserve the exact marker and pending completion; do not claim terminal success. | `FinalizationIncomplete` with `grace doctor --repair-local-state`. |
 
-## 11. Non-functional, security, durability, and operations
+Only missing or exact-cleaned evidence may advance the applicable phase. A different, malformed, unsupported,
+unreadable, or cleanup-failed result is retained for the exact replay or Doctor path; it never becomes success through a
+Boolean conversion.
 
-- Hash every accepted uncompressed file with SHA-256 and BLAKE3 during preparation, object publication, and final
-  working-file verification as applicable.
-- Publish object files through temporary files and atomic local replacement so no reader observes partially written
-  content at its expected object filename.
-- Do not log file contents, credentials, signed download URLs, or unnecessary absolute paths.
-- Keep remote access outside the update lease. Target rereads required for pre-mutation validation must be bounded and
-  occur before the marker or first mutation; if the caller cannot perform that reread, reject rather than use stale
-  selection.
-- Use real exclusive file handles for cross-process serialization and the existing in-process lane only as a local
-  efficiency measure.
-- Treat progress as optional presentation. Progress callbacks cannot change ordering or outcomes.
-- Preserve one JSON document on stdout in JSON mode; human progress and diagnostics stay off JSON stdout.
-- Development databases and test fixtures may reset for the new schema. Documentation must not promise migration.
-- Operational recovery is explicit. Doctor refuses when exact proof cannot be established and preserves evidence.
+### Branch finalization
 
-## 12. Proof strategy
+For a pending `Reference` completion, the module reads the canonical current Branch under the same lease:
 
-| Invariant | RED evidence | Positive proof | Negative and boundary proof | Stable seam |
-| --------- | ------------ | -------------- | --------------------------- | ----------- |
-| One shared transaction | Current callers bypass the callback-only module. | Branch tracer, Watch, and Connect all call `run`. | Scoped source test rejects direct mutation entry points after retirement. | Internal module plus public caller tests. |
-| Post-lease revalidation | Current preparation and mutation checks are distributed. | Target and local facts reread after held lease. | Change selection, status, marker, path, or cursor while waiting; assert no mutation. | Real temp filesystem and SQLite. |
-| Prepared-content integrity | Current Connect ignores extra entries and does not verify object bytes. | Exact zip and object adapters pass dual hashes. | Missing, extra, duplicate, unsafe, corrupt, case-colliding, file/directory-swap content rejects. | Adapter contract suite. |
-| Object-first verified apply | Current Connect writes working and object paths together. | Objects verify before working copies. | Corrupt existing object, interrupted object write, changed object before copy. | Zip adapter plus real files. |
-| Final-root truth | Current callers use different verification paths. | Every caller commits selected dual-hash root. | Mutate retained/applied file before commit; assert no completion row. | Module integration. |
-| Atomic local completion | Completion row does not exist today. | Status, cache, Connect cursor, and completion appear together. | Failure before commit leaves none; crash after commit remains locally complete. | Real SQLite restart tests. |
-| Finalization blocking | No shared pending-finalization state exists today. | Same operation retries idempotently. | Different caller and operation reject while pending; finalizer success before row update safely repeats. | Module and Doctor integration. |
-| Marker adoption | Current markers are text and branch-scoped. | Same operation adopts after lease and replans. | Different target, operation, token, schema, or malformed file requires Doctor. | Cross-process lease tests. |
-| Cancellation | Current Connect checks cancellation after extraction. | Pre-mutation cancellation stops cleanly; post-mutation cancellation defers. | Cancel at object, first working write, verification, commit, and finalization seams. | Deterministic failure seams around real operations. |
-| Doctor recovery | Current Doctor reconstructs only current configured branch state. | Recorded Branch and Watch finalization retries without file mutation. | Changed bytes, config, target, active Watch, unknown marker, or SQLite generation refuses. | Doctor CLI integration. |
-| CLI truth | Current Branch JSON remains deferred and no shared DTO exists. | Outcome DTOs, exit codes, and Doctor recommendation match. | No mixed JSON output; transport errors remain `GraceError`; Watch continuous mode unchanged. | Built executable help/schema/examples and CLI tests. |
-| Retention | No completion rows exist today. | Latest terminal per caller retained. | Pending never pruned; newer same-caller terminal removes only older terminal. | SQLite tests. |
+| Current Branch state | Finalizer behavior |
+| --- | --- |
+| Equals the persisted previous Branch | Publish the persisted selected Branch once, then continue to terminal completion. |
+| Equals the persisted selected Branch | Treat publication as already complete and continue to terminal completion without working-file mutation. |
+| Any third Branch or inconsistent configuration | Preserve pending evidence and reject finalization; do not alter configuration or terminal state. |
 
-The repository's focused Release build/test profile is the expected implementation proof. Broad Fast or Full validation
-is selected only under repository guidance; required pull-request `Validate` remains the broad current-revision gate.
+For `DirectoryVersion`, previous and selected Branch are the same current Branch. Finalization proves that branch is
+still active and never resolves, invents, or publishes a Reference ID.
 
-## 13. Requirements traceability ledger
+### Topology and content plan
 
-| ID | Requirement | Source | Type | Status | Implementation seam | Proof seam | Candidate planning owner | Residual risk |
-| -- | ----------- | ------ | ---- | ------ | ------------------- | ---------- | ------------------------ | ------------- |
-| REQ-001 | One deep internal module | DEC-003 | behavior | Required | `WorkingDirectoryUpdate.CLI.fs` | Branch/Watch/Connect integration | Core/tracer slice | Interface could regain callback breadth. |
-| REQ-002 | Complete target and operation identity | DEC-004, DEC-014 | contract | Required | Request constructors and marker serializer | Identity and replay tests | Core/tracer slice | Canonical tuple encoding must be stable. |
-| REQ-003 | Exact prepared content | DEC-005, DEC-011 | security | Required | Prepared adapters | Shared adapter contract tests | Adapter slices | Zip format assumptions require source fixtures. |
-| REQ-004 | Stable serialization scope | DEC-006 | non-functional | Required | Services scope helper and lease | Cross-process scope tests | Core/tracer slice | Platform path normalization drift. |
-| REQ-005 | Versioned owned marker | DEC-006, DEC-014 | behavior | Required | Marker store | Ownership, schema, crash tests | Core/tracer slice | Filesystem notification ordering differs by platform. |
-| REQ-006 | Fresh plan and local-content safety | DEC-012 | security | Required | Planner and caller admission facts | Conflict, race, delete-scope tests | Core/tracer and Connect slices | Existing ignore semantics are complex. |
-| REQ-007 | Verified object-first application | DEC-011 | behavior | Required | Zip/object adapters and apply engine | Corrupt object and copy tests | Connect slice | Triple hashing costs local I/O. |
-| REQ-008 | Final-root verification | DEC-004, DEC-007 | behavior | Required | Verifier | Changed retained/applied path tests | Core/tracer slice | Large-tree test cost. |
-| REQ-009 | Canonical local completion | DEC-007, DEC-009 | contract | Required | `LocalStateDb` transaction | Atomicity and restart tests | Core/tracer slice | SQLite schema fans into many tests. |
-| REQ-010 | Bounded completion state | DEC-009 | non-functional | Required | Completion row retention | Retention tests | Core/tracer slice | Latest-per-caller assumption depends on caller ordering. |
-| REQ-011 | Idempotent finalization and blocking | DEC-008, DEC-010 | behavior | Required | Finalizer and completion store | Branch/Watch retry and blocking tests | Branch, Watch, Doctor slices | Finalizer reconstruction facts must stay minimal. |
-| REQ-012 | Truthful outcomes and exit status | DEC-015 | contract | Required | Common DTOs, renderers, registry | JSON, human, exit, schema tests | Output/Doctor slice | Current Branch JSON deferral must be removed coherently. |
-| REQ-013 | Cancellation and progress | DEC-002 | behavior | Required | Core engine | Phase cancellation tests | Core/tracer slice | Timing seams can become over-injected. |
-| REQ-014 | Same-operation marker adoption | DEC-014 | workflow | Required | Core engine and marker store | Crash/adoption tests | Core/tracer slice | Adoption must never skip fresh planning. |
-| REQ-015 | Explicit Doctor recovery | DEC-010 | workflow | Required | Doctor and retry interface | Exact recovery/refusal tests | Doctor slice | Ambiguous bytes remain manual by design. |
-| REQ-016 | Caller-specific ordering | DEC-007, DEC-008, DEC-013 | behavior | Required | Branch, Watch, Connect constructors/finalizers | Caller ordering tests | Caller slices | Existing caller code is large and intertwined. |
-| REQ-017 | Public and contributor documentation | DEC-001, DEC-015 | documentation | Required | Approved docs | MarkdownLint and review | Final audit slice | Docs can drift during staged migration. |
+The fresh plan considers every tracked path and target entry. It removes tracked file blockers and obsolete tracked
+empty directories deepest-first, creates required target directories shallowest-first, and applies verified files only
+from independently verified objects. File-to-directory and directory-to-file transitions are either planned in that
+safe order or rejected before the first mutation. Declared empty directories are materialized and verified as part of
+the complete target graph. Ignored content remains untouched; unexpected eligible content rejects before mutation.
 
-No required row lacks an implementation or proof seam.
+Immediately before local completion, a separate verification recomputes the full recursive target graph and both root
+hashes from actual filesystem bytes. It proves retained and applied files, directories, empty directories, and path
+types independently of the selected root fields.
 
-## 14. Implementation-planning handoff
+### Action token and outcomes
 
-### Value-bearing tracer
+The public action token is observed during admission, optional Save, target resolution, preparation, lease waiting,
+object publication, and immediately before the first working-tree mutation. Once mutation starts, cancellation is
+deferred until verified local completion or an unavoidable incomplete failure; it does not interrupt the local
+transaction half way through. It may apply again to finalization.
 
-The first tracer is `grace switch` between two branches when required target objects are already prepared. It must cross
-the public command, generic request, lease and marker, real filesystem, SQLite completion, selected-branch finalizer,
-typed output, and focused proof. A controlled finalizer failure must prove blocking and Doctor recovery before the
-tracer is considered complete.
+| Condition | Durable result | Public outcome |
+| --- | --- | --- |
+| Existing matching terminal completion or exact no-mutation result | Matching terminal completion | `Unchanged` |
+| Complete verified root, local completion, marker cleanup, and finalization | Terminal completion | `Updated` |
+| Stale baseline, foreign or damaged pre-completion evidence, conflict, or cancellation before mutation | No new completion | `Rejected` |
+| Mutation started but local completion did not commit | No completion | `UpdateIncomplete` |
+| Local completion committed but cleanup, finalization, or terminal completion did not finish | Pending completion | `FinalizationIncomplete` |
 
-### Likely vertical slices and dependencies
+`FinalizationIncomplete` is nonzero, states that bytes were updated, and recommends
+`grace doctor --repair-local-state`. It is never reported as `UpdateIncomplete` after local completion.
 
-1. **Core plus Branch tracer:** schema replacement, compile-order scaffold, shared module, object adapter, stable
-   coordination scope, Branch request/finalizer, five outcomes, and tracer proof.
-1. **Watch integration:** replace current-reference plan/apply internals with the shared module while preserving replay,
-   IPC, SignalR, and cursor policy.
-1. **Connect integration:** local zip staging, exact adapter validation, object-first apply, target-only `--force`,
-   configuration/result separation, and atomic initial cursor.
-1. **Doctor and public output:** finalization retry, exact fallback recovery, outcome DTOs, help, schema/examples, exit
-   behavior, and Watch blocked diagnostics.
-1. **Consolidation and audit:** remove superseded helpers and internal-hook tests after parity, finish docs, run contract
-   propagation review, and record final proof.
+## 8. Requirements and proof contract
 
-The first slice may include a small compile-item scaffold before semantic work, but it must still deliver the complete
-Branch tracer rather than stopping at abstractions.
+| ID | Requirement | Implementation owner | Independent proof |
+| --- | --- | --- | --- |
+| REQ-001 | Persist and reconstruct exact typed `Reference` and `DirectoryVersion` selection; a hash retains the current Branch and exact root. | #869 | Real SQLite close/reopen for both kinds; equivalent SHA-256 and BLAKE3 prefixes map to one exact-root operation. |
+| REQ-002 | Reject impossible selector combinations and preserve exact marker dispositions. | #869 | Real marker files cover missing, exact, different, malformed or unsupported, unreadable, and portable exact-cleanup failure. |
+| REQ-003 | The Branch module receives only selection, exact target graph, prepared content, and correlation. | #870 | Construction tests show config, paths, scan, revision, fingerprint, operation, completion, marker, and finalization facts are derived. |
+| REQ-004 | Plan only after the post-lease complete-status reread equals the accepted baseline. | #870, #872 | Deterministically change config, revision, fingerprint, relevant file, target, or pending row while waiting; each rejects before mutation. |
+| REQ-005 | Publish and reverify objects before copying tracked working files. | #870 | Real object corruption and final-tree mismatch cases leave no local completion. |
+| REQ-006 | Plan and verify files, directories, empty directories, and path-type transitions while preserving ignored content. | #870 | Real filesystem nested addition/removal, empty directory, file/directory, directory/file, ignored-content, and unexpected-eligible cases. |
+| REQ-007 | Observe the action token through every pre-mutation stage and defer it after mutation begins. | #870, #872 | Deterministic cancellation at lease wait, object publication, final pre-mutation, and post-mutation boundaries. |
+| REQ-008 | Reference finalization accepts previous and exact-selected states, but rejects a third state. | #871 | Fail terminal completion after successful publication, reopen, retry without file changes, and assert all three Branch states. |
+| REQ-009 | Cleanup and finalization after local completion remain pending on every non-success disposition. | #871 | Real completion/reopen cases for foreign, malformed, unsupported, unreadable, finalizer, and exact-cleanup failures. |
+| REQ-010 | A successful pre-switch Save supplies the only accepted current baseline. | #872 | Built Save-enabled switch proves saved graph, revision, and full-status fingerprint are reread under lease; post-Save drift rejects. |
+| REQ-011 | All supported selectors use the transaction and project five truthful outcomes. | #870–#872 | Built `grace switch` fixtures cover Reference, SHA-256, BLAKE3, representative human/JSON/exits, and repair guidance. |
+| REQ-012 | Recovery is exact and does not mutate working files. | #842 | Built Doctor retry proves typed pending facts and leaves working bytes and timestamps unchanged. |
 
-### High-conflict and shared surfaces
+Every phase failure must be deterministically activated somewhere. Module tests use real filesystem and SQLite state for
+lease, mutation, local-completion, marker, replay, finalizer, disposal, and release behavior. Built-command tests remain
+bounded: they prove selector routing and the corresponding public output rather than trying to inject every internal
+phase failure through the command process.
 
-- `src/Grace.CLI/Grace.CLI.fsproj`
-- `src/Grace.CLI/LocalStateDb.CLI.fs`
-- `src/Grace.CLI/Command/Services.CLI.fs`
-- `src/Grace.CLI/Command/Common.CLI.fs`
-- Shared CLI test project files and helpers
-- This specification and ADR 0011
+## 9. Propagation and traceability
 
-Slices touching these surfaces should be serialized or intentionally integrated. Watch and Connect migration should
-not overlap when both edit the shared module or SQLite schema.
+| Surface | Disposition | Owner and proof |
+| --- | --- | --- |
+| Private Branch selection, pending row, and marker records | Updated with typed selection and explicit dispositions. | #869; contract, SQLite, and marker tests. |
+| `WorkingDirectoryUpdate` Branch module | Updated as one deep Branch-only transaction. | #870; real filesystem/SQLite phase matrix. |
+| `grace switch` Reference and hash dispatch | Updated; no direct mutation/status/finalization bypass. | #870–#872; built selector fixtures. |
+| Local schema | Clean development replacement for the typed pending selection. | #869; schema reset and reopen tests. |
+| Branch output, schema, examples, and current behavior docs | Updated only as the replacement selectors and outcomes become executable. | #870–#872; built human/JSON/exit checks and MarkdownLint. |
+| Doctor `--repair-local-state` | Deferred until exact pending Branch facts exist. | #842; filesystem-free retry proof. |
+| Watch and Connect | Deferred; no Branch-side request construction or policy is added. | Later named epic work; scoped-diff review. |
+| Server, SDK, OpenAPI, and generated artifacts | Not applicable: this local Branch contract changes no wire shape. | Scoped diff and review. |
+| This specification and ADR 0011 | Updated by #868 before source work resumes. | MarkdownLint, local links, traceability and lifecycle audit. |
 
-### Contract propagation obligations
+## 10. Replacement implementation handoff
 
-- Promote `branch.switch` from its current machine-output deferral only when its stable outcome DTO is implemented.
-- Keep server, SDK, static OpenAPI, and generated clients unchanged unless current implementation evidence reveals a
-  genuine cross-project dependency.
-- Replace the local SQLite schema cleanly and regenerate fixtures; do not add migration code.
-- Update help and current-behavior docs in the same slice that changes their command behavior.
-- Preserve ADR 0009 and ADR 0010 caller-specific decisions and link them to ADR 0011.
+The replacement sequence is intentionally serial because the modules, Branch command, local completion, and proof
+fixtures share a high-risk write set.
 
-### Owner-interruption triggers
+1. **#868 — contract correction:** make this specification and ADR Plan-ready; remove the superseded all-caller request
+   model and assign every requirement to one replacement owner.
+2. **#869 — typed persistence and markers:** deliver schema-11 typed selection reconstruction and explicit marker
+   inspection and cleanup results. Stop before runtime or caller behavior.
+3. **#870 — exact-root hash tracer:** deliver both hash selectors through the real Branch transaction, with current
+   Branch retention, complete planning, cancellation, replay, and real phase proof.
+4. **#871 — Reference finalization:** extend the proven tracer with Reference publication, repeatable finalization,
+   pending recovery behavior, and the remaining public outcome contract.
+5. **#872 — Save-enabled admission:** bind the successful Save graph as the accepted baseline and complete the
+   Save-enabled built-command regression.
 
-Return to the owner before adding:
+Issue #842 follows #871 and completes the exact Doctor recovery path after the #872 Branch checkpoint. Watch and Connect are
+not admissible implementation work in this sequence.
 
-- Any sixth public outcome or another durable update state.
-- More than one pending finalization per working directory.
-- A new public command, flag, server route, SDK method, or OpenAPI shape.
-- Filesystem rollback, a per-file journal, automatic recovery scheduling, or time-based expiry.
-- Permission for `--force` to delete unrelated content.
-- Network I/O under the update lease.
-- A quality-contract change from Product V1.
+## 11. Completion and review gate
 
-## 15. Completion semantics and self-critique
+The Branch checkpoint is complete only when the source issue owning each requirement has a current exact-head review
+and `Validate` proof. A green build, an output registry entry, or a private helper is not a substitute for the required
+real module or built-command evidence.
 
-The feature is complete only when every required traceability row is implemented and proven or explicitly returned to
-the owner. A partially migrated caller does not satisfy the specification merely because the shared module exists.
+Before a source issue is reviewed, its self-review records one status for every requirement it owns: implemented and
+proven, implemented but proof incomplete, waived with reason, out of scope with reason, or not applicable with reason.
+No status may hide a failure seam in helper-only proof. The final traceability audit confirms that every row above has
+one owner, no Watch or Connect behavior slipped into the Branch interface, and no superseded generic request remains.
 
-- **Strongest design element:** SQLite local completion cleanly separates verified bytes from caller finalization and
-  makes `FinalizationIncomplete` truthful and recoverable.
-- **Most likely wrong assumption:** The latest terminal row per caller may prove insufficient if a caller later permits
-  out-of-order operations. Current Branch and Watch ordering forbids that behavior.
-- **Highest-risk dependency:** Existing Watch and Branch code combines policy, mutation, tests, and mutable process state
-  in large files. Migration can accidentally move caller policy into the shared module.
-- **Easiest way to overbuild:** Add a durable running-operation ledger, generalized recovery engine, or public plan
-  format.
-- **Easiest way to under-test:** Mock filesystem and SQLite behavior or prove only final hashes without failures between
-  mutation, commit, marker cleanup, and finalization.
-- **Simpler alternative considered:** Keep only the current serialization wrapper and align callers informally. It was
-  rejected because it provides no leverage over the ordering and failure semantics this work exists to centralize.
-- **Residual Product V1 risk:** Abrupt termination can leave a prepared zip or a partially updated working directory
-  that matches no known root. Grace preserves evidence and requires explicit user action rather than guessing.
-
-This specification is ready for `dev-process` spec-to-plan compilation. It does not create issues, branches, or
-implementation work.
+The remaining Product V1 risk is intentionally bounded: interruption after working-tree mutation but before local
+completion can leave bytes that require exact revalidation. Grace preserves evidence rather than guessing, rolling back,
+or introducing a broader recovery system.

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -24,8 +24,9 @@ does not create a generic request shape or a partly active constructor for eithe
 - `Reference` selection may change the active Branch only after verified local completion.
 - Exact-root `DirectoryVersion` selection keeps the current Branch active. It does not invent a Reference ID.
 - One successful pre-switch Save establishes the only accepted current-version baseline for a Save-enabled switch.
-- The module derives its repository configuration, local paths, scan input, current-state binding, operation identity,
-  completion facts, marker facts, and Branch finalization facts.
+- The module derives its repository configuration, local paths, scan input, operation identity, completion facts,
+  marker facts, and Branch finalization facts; its immutable admission phase carries and validates the current-state
+  binding.
 - The result is one of `Unchanged`, `Updated`, `Rejected`, `UpdateIncomplete`, or `FinalizationIncomplete`.
 
 ### Deferred callers and work
@@ -89,11 +90,16 @@ The immutable complete selected directory graph contains the root DirectoryVersi
 declared files, declared directories including empty directories, and their canonical paths. Root fields alone are not
 proof of the graph.
 
-### Accepted local baseline
+### Accepted Branch phase
 
-The immutable binding created by the successful current-version Save, or by supported no-Save admission, contains the
-SQLite revision and canonical fingerprint of the complete current Grace status graph. It is not a caller-supplied
-prior-status graph. The post-lease reread must equal it before a plan can be built.
+Immediately after successful Save or no-Save admission, Branch constructs one immutable `AcceptedBranchPhase`. It holds
+the accepted SQLite revision, canonical fingerprint of the complete current Grace status graph, and the public action
+token for that command invocation. It does not hold or expose a mutable status graph, alternate local paths, or a
+selected-state reader.
+
+Target resolution and preparation receive that same phase unchanged. `WorkingDirectoryUpdate.run` uses its scalar
+revision and fingerprint only to compare its post-lease reread with the accepted baseline before planning. A caller
+cannot replace either value or supply a separately assembled prior-status graph after admission.
 
 ### Operation and attempt
 
@@ -109,18 +115,28 @@ persisted typed operation; it changes Branch configuration only for `Reference`.
 
 ## 6. Minimal Branch module contract
 
-The private Branch entry to `WorkingDirectoryUpdate.run` accepts exactly four caller-provided facts:
+The private Branch flow has one executable admission phase and one update entry. Admission returns the opaque
+`AcceptedBranchPhase` described above immediately after Save or no-Save admission. Resolution and preparation can carry
+that phase, but cannot alter its revision, fingerprint, or action token.
 
-1. The typed `Reference` or `DirectoryVersion` selection.
-2. The exact resolved target graph.
-3. Verified prepared content for that graph.
-4. Diagnostic correlation.
+The `WorkingDirectoryUpdate.run` entry accepts only the following Branch facts:
 
-From these facts and canonical Branch configuration, the module derives the working root, object root, `.grace`
-directory, SQLite path, ignore-aware scan input, local-root scope, accepted revision and complete-status fingerprint,
-operation identity, pending and completion facts, marker disposition, and Branch finalization facts. A caller cannot
-provide alternate paths, a selected-state reader, an old status graph, a finalizer, a filesystem writer, a mutation
-plan, or a database handle.
+1. The immutable `AcceptedBranchPhase`.
+2. The typed `Reference` or `DirectoryVersion` selection.
+3. The exact resolved target graph.
+4. Verified prepared content for that graph.
+5. Diagnostic correlation.
+
+This is a narrow phase and interface, not a caller-supplied context bag. From the phase and canonical Branch
+configuration, the module derives the working root, object root, `.grace` directory, SQLite path, ignore-aware scan
+input, local-root scope, operation identity, pending and completion facts, marker disposition, and Branch finalization
+facts. It compares the phase's accepted revision and fingerprint with its own post-lease reread. A caller cannot
+provide alternate paths, a status graph, a selected-state reader, a finalizer, a filesystem writer, a mutation plan, or
+a database handle.
+
+The one action token in `AcceptedBranchPhase` is observed before and during admission and Save, during target resolution
+and preparation, while waiting for the lease, during object publication, and immediately before the first
+working-tree mutation. Cancellation is deferred only after mutation begins.
 
 The module exposes `run` and the internal exact-finalization retry used by #871 and #842. It does not expose Watch or
 Connect construction. Any later caller requires its own accepted design and must not widen this Branch input by adding
@@ -148,8 +164,9 @@ admission and optional current-version Save
 → mark terminal completion and release the lease
 ```
 
-Target resolution and prepared-content work finish before the lease. Planning always consumes the complete state
-reread under that lease, never the earlier in-memory status or a separately assembled prior graph.
+Target resolution and prepared-content work finish before the lease while retaining the same immutable
+`AcceptedBranchPhase`. Planning always consumes the complete state reread under that lease, never the earlier in-memory
+status or a separately assembled prior graph.
 
 ### Marker inspection and cleanup table
 
@@ -220,37 +237,52 @@ transaction half way through. It may apply again to finalization.
 
 ## 8. Requirements and proof contract
 
-| ID | Requirement | Implementation owner | Independent proof |
-| --- | --- | --- | --- |
-| REQ-001 | Persist and reconstruct exact typed `Reference` and `DirectoryVersion` selection; a hash retains the current Branch and exact root. | #869 | Real SQLite close/reopen for both kinds; equivalent SHA-256 and BLAKE3 prefixes map to one exact-root operation. |
-| REQ-002 | Reject impossible selector combinations and preserve exact marker dispositions. | #869 | Real marker files cover missing, exact, different, malformed or unsupported, unreadable, and portable exact-cleanup failure. |
-| REQ-003 | The Branch module receives only selection, exact target graph, prepared content, and correlation. | #870 | Construction tests show config, paths, scan, revision, fingerprint, operation, completion, marker, and finalization facts are derived. |
-| REQ-004 | Plan only after the post-lease complete-status reread equals the accepted baseline. | #870, #872 | Deterministically change config, revision, fingerprint, relevant file, target, or pending row while waiting; each rejects before mutation. |
-| REQ-005 | Publish and reverify objects before copying tracked working files. | #870 | Real object corruption and final-tree mismatch cases leave no local completion. |
-| REQ-006 | Plan and verify files, directories, empty directories, and path-type transitions while preserving ignored content. | #870 | Real filesystem nested addition/removal, empty directory, file/directory, directory/file, ignored-content, and unexpected-eligible cases. |
-| REQ-007 | Observe the action token through every pre-mutation stage and defer it after mutation begins. | #870, #872 | Deterministic cancellation at lease wait, object publication, final pre-mutation, and post-mutation boundaries. |
-| REQ-008 | Reference finalization accepts previous and exact-selected states, but rejects a third state. | #871 | Fail terminal completion after successful publication, reopen, retry without file changes, and assert all three Branch states. |
-| REQ-009 | Cleanup and finalization after local completion remain pending on every non-success disposition. | #871 | Real completion/reopen cases for foreign, malformed, unsupported, unreadable, finalizer, and exact-cleanup failures. |
-| REQ-010 | A successful pre-switch Save supplies the only accepted current baseline. | #872 | Built Save-enabled switch proves saved graph, revision, and full-status fingerprint are reread under lease; post-Save drift rejects. |
-| REQ-011 | All supported selectors use the transaction and project five truthful outcomes. | #870–#872 | Built `grace switch` fixtures cover Reference, SHA-256, BLAKE3, representative human/JSON/exits, and repair guidance. |
-| REQ-012 | Recovery is exact and does not mutate working files. | #842 | Built Doctor retry proves typed pending facts and leaves working bytes and timestamps unchanged. |
+This is the canonical 17-row ledger for epic #835. Every row has exactly one primary delivery owner. Companion issues
+consume, extend, or prove that requirement at their own caller seam; they do not become a second primary owner. #846 is
+the final audit owner, not a substitute for a row's delivery owner.
+
+| ID | Requirement | Primary delivery owner | Companion proof, extension, or disposition | #846 final-audit disposition |
+| --- | --- | --- | --- | --- |
+| REQ-001 | One deep transaction module | #870 | #871 and #872 extend Branch; #843 and #845 add their real callers. | Verify every caller crosses the one module and no bypass remains. |
+| REQ-002 | Exact target and operation identity | #869 | #870, #871, #842, #843, and #845 consume persisted identity. | Verify no caller rebuilds a contradictory tuple. |
+| REQ-003 | Exact prepared content | #837 | #870 consumes verified Branch objects; #844 owns the deferred Connect zip adapter. | Verify every active adapter satisfies the exact-content contract. |
+| REQ-004 | Stable repository/local-root serialization scope | #839 | #870 proves Branch use; #843 and #845 later consume the same scope. | Verify no caller creates an alternate lease scope. |
+| REQ-005 | Typed, versioned owned marker evidence | #869 | #870, #871, and #842 consume all dispositions; #843 and #845 defer their caller adoption. | Verify no Boolean replay or cleanup reduction remains. |
+| REQ-006 | Fresh planning and local-content safety | #870 | #872 adds the Save baseline; #845 applies the proven plan to Connect. | Verify no direct caller plan or unsafe local mutation remains. |
+| REQ-007 | Verified object-first application | #870 | #844 proves Connect zip preparation; #845 consumes the prepared adapter. | Verify active callers copy only verified objects. |
+| REQ-008 | Complete final-root verification | #870 | #871, #872, #843, and #845 prove their caller ordering. | Verify no completion can precede independent complete-root proof. |
+| REQ-009 | Canonical atomic local completion | #838 | #870, #871, #872, and #845 consume the transaction. | Verify all committed caller facts share the one local completion path. |
+| REQ-010 | Bounded pending and terminal completion state | #838 | #871 and #842 prove finalization and recovery retention. | Verify no caller adds a second pending state or retention path. |
+| REQ-011 | Idempotent finalization and blocking | #871 | #842 proves Doctor retry; #843 later adds Watch cursor finalization. | Verify finalizers use persisted exact facts and block different work. |
+| REQ-012 | Truthful five outcomes and public exit behavior | #871 | #870 proves hash projection; #872, #842, #843, and #845 add their real output cases. | Verify built human/JSON/schema/examples/exits agree. |
+| REQ-013 | Action-token cancellation through the last pre-mutation check | #870 | #872 adds Save-enabled admission; #844 and #845 later carry their Connect preparation. | Verify deterministic pre-mutation cancellation and deferred post-mutation behavior. |
+| REQ-014 | Same-operation marker adoption with fresh planning | #869 | #870, #871, and #842 prove Branch and recovery replay. | Verify adoption never resumes an old plan or deletes foreign evidence. |
+| REQ-015 | Explicit Doctor recovery without working-file mutation | #842 | No later caller delivery; #846 only audits the completed recovery proof. | Verify exact pending retry and refusal evidence remain current. |
+| REQ-016 | Caller-specific ordering | #871 | #872 completes Save ordering; #843 and #845 add Watch and Connect ordering. | Verify each caller has one real ordering path through the transaction. |
+| REQ-017 | Current public and contributor documentation | #846 | #868 establishes the Plan-ready contract; #870–#872, #843, #844, and #845 update behavior docs when executable. | Publish the completed 17-row implementation/proof ledger and remove stale planned wording. |
 
 Every phase failure must be deterministically activated somewhere. Module tests use real filesystem and SQLite state for
 lease, mutation, local-completion, marker, replay, finalizer, disposal, and release behavior. Built-command tests remain
 bounded: they prove selector routing and the corresponding public output rather than trying to inject every internal
-phase failure through the command process.
+phase failure through the command process. #870 proves deterministic construction of `AcceptedBranchPhase` for no-Save
+admission. #872 proves the Save-enabled built command, including a deterministic tracked edit made after the phase is
+captured while target preparation is still in progress; the post-lease revision/fingerprint comparison must reject
+before target mutation.
 
 ## 9. Propagation and traceability
 
 | Surface | Disposition | Owner and proof |
 | --- | --- | --- |
 | Private Branch selection, pending row, and marker records | Updated with typed selection and explicit dispositions. | #869; contract, SQLite, and marker tests. |
-| `WorkingDirectoryUpdate` Branch module | Updated as one deep Branch-only transaction. | #870; real filesystem/SQLite phase matrix. |
+| `WorkingDirectoryUpdate` Branch module | Updated as one deep Branch-only transaction with immutable admission phase and action token. | #870; construction and real filesystem/SQLite phase matrix. |
 | `grace switch` Reference and hash dispatch | Updated; no direct mutation/status/finalization bypass. | #870–#872; built selector fixtures. |
 | Local schema | Clean development replacement for the typed pending selection. | #869; schema reset and reopen tests. |
 | Branch output, schema, examples, and current behavior docs | Updated only as the replacement selectors and outcomes become executable. | #870–#872; built human/JSON/exit checks and MarkdownLint. |
 | Doctor `--repair-local-state` | Deferred until exact pending Branch facts exist. | #842; filesystem-free retry proof. |
-| Watch and Connect | Deferred; no Branch-side request construction or policy is added. | Later named epic work; scoped-diff review. |
+| Watch replay and cursor finalization | Deferred; no Branch-side Watch constructor or policy is added. | #843; ordered replay and built Watch proof. |
+| Connect zip preparation | Deferred; no Branch-side zip adapter or target-conflict policy is added. | #844; exact staged-content proof. |
+| Connect retrieval and cursor completion | Deferred; no Branch-side Connect constructor or policy is added. | #845; retrieval, completion, and output proof. |
+| Retired-path removal and completed ledger | Deferred final audit; it adds no new behavior. | #846; source-boundary, built-command, documentation, and canonical 17-row audit. |
 | Server, SDK, OpenAPI, and generated artifacts | Not applicable: this local Branch contract changes no wire shape. | Scoped diff and review. |
 | This specification and ADR 0011 | Updated by #868 before source work resumes. | MarkdownLint, local links, traceability and lifecycle audit. |
 

--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -51,7 +51,15 @@ supported: they select an exact root without a Reference and keep the current Br
   preserves ignored content. It verifies dual-hash objects before use and independently verifies the complete final
   graph and both root hashes before local completion.
 - The public action token in the phase applies through admission, Save, resolution, preparation, lease waiting, object
-  publication, and the final pre-mutation check. It is deferred only after working-tree mutation starts.
+  publication, and the final pre-mutation check. Cancellation before the first working-tree mutation returns `Rejected`
+  without mutation or a new completion. After mutation starts, the token is non-controlling through local completion,
+  finalization attempt, exact marker cleanup, and terminal recording; actual evidence determines `Updated`,
+  `UpdateIncomplete`, or `FinalizationIncomplete`.
+- Exact terminal replay returns `Unchanged` even when the new invocation token is already cancelled. Explicit
+  finalization retry may observe cancellation only before its first finalization side effect, preserving the pending
+  completion unchanged and returning `FinalizationIncomplete`. After that side effect starts, cancellation is
+  non-controlling through terminal recording. Cancellation never suppresses the
+  `grace doctor --repair-local-state` recommendation for `FinalizationIncomplete`.
 - SQLite local completion remains the irreversible local point. `Reference` finalization occurs afterward while the
   lease is held: previous Branch applies once, exact selected Branch is already applied, and any third Branch rejects.
   `DirectoryVersion` finalization proves the current Branch remains active and changes no Branch identity.

--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -1,114 +1,103 @@
 ---
 status: accepted
-date: 2026-08-11
+date: 2026-08-12
 decision-makers:
   - Scott Arbeit
 consulted:
   - Codex
 ---
 
-# Use one verified Working Directory Update transaction
+# Use one Branch-derived Working Directory Update transaction
 
-Grace will route Branch switching, Watch current-Reference replay, and Connect retrieval through one deep internal
-`WorkingDirectoryUpdate` module. The module owns the ordering-sensitive local transaction while each caller retains
-admission, target selection, remote retrieval, scheduling, and presentation.
+Grace will first route `grace switch` through one deep, private Branch-derived `WorkingDirectoryUpdate` transaction.
+The module owns local ordering, verification, completion, marker handling, and Branch finalization. Watch and Connect
+are deferred callers; they do not justify a generic request model before their own work is ready.
 
 ## Context
 
-The current `WorkingDirectoryMaterialization` module serializes arbitrary callbacks but does not own planning, marker
-behavior, filesystem mutation, content verification, durable local state, finalization, or failure classification.
-Branch and Watch each implement substantial private mutation workflows, while Connect extracts a server zip directly
-into working and object paths without the same lease or marker contract.
+The earlier all-caller planning and PR #854 combined typed selection persistence, filesystem planning, finalization,
+Save admission, output, and phase proof in one implementation slice. Exact-head review showed that a broad private
+request made core Branch rules implicit: typed marker evidence could be lost, Reference finalization could not repeat,
+planning could use a pre-Save graph, path topology was incomplete, and cancellation was detached from the public action.
 
-These paths can change the same local directory and SQLite state. Their differences are real—Watch advances an ordered
-cursor, Branch publishes selected branch identity, and Connect preserves zip retrieval—but those differences do not
-justify three local-integrity implementations.
+The replacement sequence needs one real Branch path with a small input and explicit durable facts. Hash selectors remain
+supported: they select an exact root without a Reference and keep the current Branch active.
 
 ## Decision
 
-- The internal module exposes one generic `run` operation and one `retryFinalization` operation. Caller-specific
-  constructors create private normalized requests.
-- Target identity contains repository, branch, root DirectoryVersion, SHA-256, and BLAKE3. Caller operation identity is
-  separate and deterministic. Each execution attempt receives a separate random marker token.
-- Prepared-content adapters expose exact immutable manifests and readable uncompressed bytes. They never provide
-  mutation plans or database callbacks.
-- A repository ID plus normalized local-root-path hash scopes the exclusive file lease, versioned marker, and completion
-  sidecar. Branch identity is excluded from the physical scope.
-- The module rereads selected target and local state after acquiring the lease, builds a fresh plan, mutates only proven
-  paths, verifies object and working bytes with SHA-256 and BLAKE3, and proves the final selected root.
-- SQLite local completion is the irreversible point. One transaction records matching status, required object-cache
-  metadata, Connect's initial cursor when present, and a bounded update completion row.
-- SQLite stores no running operation. It retains the latest terminal row per caller and one unresolved pending
-  finalization.
-- The completion sidecar is derived Watch notification evidence. It cannot override SQLite completion truth.
-- Branch and Watch finalization is idempotent and runs after local completion while the lease remains held. A failed
-  finalization blocks every different update in that local scope.
-- The five outcomes are `Unchanged`, `Updated`, `Rejected`, `UpdateIncomplete`, and `FinalizationIncomplete`.
-  Incomplete outcomes return nonzero. `FinalizationIncomplete` says the working directory was updated and recommends
+- The first private `WorkingDirectoryUpdate.run` input is Branch-only. Its caller provides only typed Branch selection,
+  exact target graph, verified prepared content, and diagnostic correlation.
+- The module derives canonical configuration, working/object/SQLite paths, scan input, current revision and complete
+  status fingerprint, operation identity, completion facts, marker disposition, and typed Branch finalization facts.
+  It does not accept an arbitrary path or context bag, old status graph, selected-state reader, finalizer callback,
+  mutation plan, or database handle.
+- Branch selection is typed. `Reference` carries the required selected Reference ID. Hash-selected `DirectoryVersion`
+  carries no Reference ID, binds the operation to its exact selected root, and retains the current Branch as both
+  previous and selected Branch.
+- A successful current-version Save produces the only accepted local baseline for a Save-enabled switch: its SQLite
+  revision plus a canonical fingerprint of the complete status graph. After acquiring the lease, the module rereads and
+  requires that binding before planning.
+- The module inspects and cleans markers through explicit dispositions. Missing or exact-cleaned evidence may advance
+  the relevant phase. Different-operation, malformed or unsupported, unreadable, and exact-cleanup-failed evidence is
+  preserved and never converted into success.
+- The module plans the complete tracked topology, including empty directories and file/directory transitions; it
+  preserves ignored content. It verifies dual-hash objects before use and independently verifies the complete final
+  graph and both root hashes before local completion.
+- The public action token applies through admission, Save, resolution, preparation, lease waiting, object publication,
+  and the final pre-mutation check. It is deferred only after working-tree mutation starts.
+- SQLite local completion remains the irreversible local point. `Reference` finalization occurs afterward while the
+  lease is held: previous Branch applies once, exact selected Branch is already applied, and any third Branch rejects.
+  `DirectoryVersion` finalization proves the current Branch remains active and changes no Branch identity.
+- The existing five outcomes remain unchanged. A post-local-completion cleanup or finalization failure is
+  `FinalizationIncomplete`, is nonzero, says that bytes were updated, and recommends
   `grace doctor --repair-local-state`.
-- The same deterministic operation may adopt a known orphaned marker only after acquiring the lease and performing
-  complete revalidation and replanning. Different or unrecognized markers require Doctor.
-- Doctor first attempts a filesystem-free retry of recorded finalization, then may use exact local-state reconstruction.
-  Doctor never rolls back or guesses working-directory content.
-- Connect keeps its zip download. It stages and validates the zip before lease acquisition, performs no network reads
-  under the lease, verifies objects before populating the working directory, and limits `--force` to conflicting target
-  paths.
+- Real filesystem and SQLite tests prove phase and recovery behavior. Bounded built-command tests prove selector routing
+  and public output. Every failure seam is deterministically activated by one of those proof boundaries.
 
-The complete requirements, state model, propagation map, and proof contract are in
+The complete requirement ownership, phase table, and proof contract are in
 [Working Directory Update](../Working%20Directory%20Update.md).
 
 ## Consequences
 
-The module becomes deep: a small typed interface hides cross-process serialization, stale-state rejection, fresh
-planning, marker ownership, object publication, working-directory mutation, verification, SQLite commit, cleanup,
-finalization, cancellation, and outcome classification.
+The module becomes deep without becoming generic. Branch callers are small and cannot assemble contradictory local
+facts, while the module owns the current Branch transaction end to end. Issue #869 persists typed facts and marker
+evidence; #870 delivers the hash-selected tracer; #871 adds repeatable Reference finalization; #872 adds Save-enabled
+baseline binding. Issue #842 later uses the same exact pending Branch facts for Doctor recovery without working-file
+mutation.
 
-Callers remain locally understandable because their policy stays outside the module. A new prepared content form can
-reuse the local transaction, but a new caller kind or finalization rule requires an explicit design decision.
+Watch and Connect stay outside this interface until a later accepted design names their independent admission and
+finalization rules. This avoids treating one future caller's callback or path needs as a current Branch contract.
 
-Product V1 recovery is deliberate rather than comprehensive. Exact same-operation retry and Doctor recovery are
-supported; rollback, durable per-file journals, automatic general recovery, hostile-local-process defense, and
-multi-host coordination are not.
-
-The local SQLite schema can be replaced without migration because Grace has no production local data contract. Public
-CLI output changes with implementation, while server DTOs, HTTP routes, SDK facades, OpenAPI, and generated clients are
-expected to remain unchanged.
+Product V1 still excludes rollback, durable per-file journals, automatic general recovery, migration, compatibility,
+and network access under the lease. Local schema replacement remains allowed because Grace has no production local-data
+compatibility obligation.
 
 ## Rejected alternatives
 
-### Keep the callback-only serialization wrapper
+### Restore the generic all-caller request
 
-A lease around arbitrary caller callbacks leaves the critical plan, mutation, verification, commit, and recovery order
-duplicated and unprovable as one contract.
+An interface that permits callers to supply alternate local paths, prior status, selected-state reading, or finalization
+returns the trust boundary to callers. It recreates the shape superseded after PR #854 rather than solving its review
+findings.
 
-### Expose separate Branch, Watch, and Connect transaction operations
+### Treat hash selection as a Reference
 
-Caller-oriented entries are ergonomic but make today's caller taxonomy the architecture. Private request constructors
-provide the same ergonomics without three transaction implementations.
+A selected root can have no Reference or more than one Reference. Inventing one would change Branch identity semantics
+and make persisted recovery facts false. `DirectoryVersion` keeps the exact root and current Branch instead.
 
-### Expose generic transaction participants
+### Plan from the pre-Save status
 
-Pluggable local commits, SQL callbacks, or caller-supplied mutation plans would move the hardest invariants back into
-callers and make the module shallow.
+After a successful Save, the earlier graph no longer names the accepted current version. Using it would make the
+subsequent plan stale by construction.
 
-### Use only the completion sidecar
+### Collapse marker evidence to cleanup succeeded or failed
 
-A sidecar written after status commit leaves an uncertain crash gap and cannot atomically identify the completed
-operation. SQLite completion closes that gap; the sidecar remains notification evidence only.
-
-### Hold the lease while reading the remote zip
-
-Remote reads can stall, retry, or outlive signed access. Local staging keeps the mutation phase bounded to local
-filesystem and SQLite work.
-
-### Add rollback or a durable per-file journal
-
-Those capabilities add inverse planning, restart state, compaction, abandonment, and recovery policy beyond the Product
-V1 contract. Exact retry and explicit Doctor recovery provide the selected value without that machinery.
+Different, malformed, unsupported, unreadable, and exact-cleanup-failed evidence have distinct recovery implications.
+A Boolean cannot preserve enough information to make finalization or Doctor behavior truthful.
 
 ## Related decisions
 
-- [ADR 0009](0009-refresh-watch-signalr-subscriptions-at-branch-transition.md) defines Watch subscription refresh after
-  Branch finalization.
-- [ADR 0010](0010-current-branch-materialization-trust-boundary.md) defines Watch's ordered current-Reference replay and
-  cursor rules, which become caller policy around this shared local transaction.
+- [ADR 0009](0009-refresh-watch-signalr-subscriptions-at-branch-transition.md) remains the accepted Watch refresh
+  decision; Watch integration is deferred from this Branch transaction.
+- [ADR 0010](0010-current-branch-materialization-trust-boundary.md) remains the accepted Watch replay boundary; it does
+  not create a Watch request constructor in the current Branch slice.

--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -25,16 +25,19 @@ supported: they select an exact root without a Reference and keep the current Br
 
 ## Decision
 
-- Immediately after successful Save or no-Save admission, Branch constructs an immutable `AcceptedBranchPhase` holding
+- Immediately after successful Save or no-Save admission, Branch constructs an opaque, sealed `AcceptedBranchPhase` holding
   the accepted SQLite revision, canonical complete-status fingerprint, and public action token. It holds no status graph,
   alternate path, selected-state reader, or mutable callback.
-- The first private `WorkingDirectoryUpdate.run` input is Branch-only. Its caller provides the unchanged
-  `AcceptedBranchPhase`, typed Branch selection, exact target graph, verified prepared content, and diagnostic
-  correlation.
+- The private `WorkingDirectoryUpdate.run` interface has exactly five inputs. Its Branch caller provides the unchanged
+  sealed `AcceptedBranchPhase`, typed `Reference` or exact-root `DirectoryVersion` selection, exact resolved target graph,
+  immutable prepared content, and diagnostic correlation.
 - The module derives canonical configuration, working/object/SQLite paths, scan input, operation identity, completion
-  facts, marker disposition, and typed Branch finalization facts. It rereads current revision and complete status under
-  the lease, then compares them with the immutable phase. It does not accept an arbitrary path or context bag, old
-  status graph, selected-state reader, finalizer callback, mutation plan, or database handle.
+  facts, marker disposition, and typed Branch finalization facts from the same selection, target, canonical
+  configuration, and persisted operation facts. It rereads current revision and complete status under the lease, then
+  compares them with the immutable phase. It does not accept an arbitrary path or generic context bag, old status graph,
+  selected-state reader, finalizer or finalizer callback, progress observer standing in for correlation, mutation plan,
+  or database handle. Finalization retry reconstructs from the persisted typed operation facts rather than accepting a
+  separately assembled tuple or callback.
 - Branch selection is typed. `Reference` carries the required selected Reference ID. Hash-selected `DirectoryVersion`
   carries no Reference ID, binds the operation to its exact selected root, and retains the current Branch as both
   previous and selected Branch.

--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -25,26 +25,30 @@ supported: they select an exact root without a Reference and keep the current Br
 
 ## Decision
 
-- The first private `WorkingDirectoryUpdate.run` input is Branch-only. Its caller provides only typed Branch selection,
-  exact target graph, verified prepared content, and diagnostic correlation.
-- The module derives canonical configuration, working/object/SQLite paths, scan input, current revision and complete
-  status fingerprint, operation identity, completion facts, marker disposition, and typed Branch finalization facts.
-  It does not accept an arbitrary path or context bag, old status graph, selected-state reader, finalizer callback,
-  mutation plan, or database handle.
+- Immediately after successful Save or no-Save admission, Branch constructs an immutable `AcceptedBranchPhase` holding
+  the accepted SQLite revision, canonical complete-status fingerprint, and public action token. It holds no status graph,
+  alternate path, selected-state reader, or mutable callback.
+- The first private `WorkingDirectoryUpdate.run` input is Branch-only. Its caller provides the unchanged
+  `AcceptedBranchPhase`, typed Branch selection, exact target graph, verified prepared content, and diagnostic
+  correlation.
+- The module derives canonical configuration, working/object/SQLite paths, scan input, operation identity, completion
+  facts, marker disposition, and typed Branch finalization facts. It rereads current revision and complete status under
+  the lease, then compares them with the immutable phase. It does not accept an arbitrary path or context bag, old
+  status graph, selected-state reader, finalizer callback, mutation plan, or database handle.
 - Branch selection is typed. `Reference` carries the required selected Reference ID. Hash-selected `DirectoryVersion`
   carries no Reference ID, binds the operation to its exact selected root, and retains the current Branch as both
   previous and selected Branch.
 - A successful current-version Save produces the only accepted local baseline for a Save-enabled switch: its SQLite
-  revision plus a canonical fingerprint of the complete status graph. After acquiring the lease, the module rereads and
-  requires that binding before planning.
+  revision plus a canonical fingerprint of the complete status graph. The same phase carries that binding through target
+  resolution and preparation. After acquiring the lease, the module rereads and requires it before planning.
 - The module inspects and cleans markers through explicit dispositions. Missing or exact-cleaned evidence may advance
   the relevant phase. Different-operation, malformed or unsupported, unreadable, and exact-cleanup-failed evidence is
   preserved and never converted into success.
 - The module plans the complete tracked topology, including empty directories and file/directory transitions; it
   preserves ignored content. It verifies dual-hash objects before use and independently verifies the complete final
   graph and both root hashes before local completion.
-- The public action token applies through admission, Save, resolution, preparation, lease waiting, object publication,
-  and the final pre-mutation check. It is deferred only after working-tree mutation starts.
+- The public action token in the phase applies through admission, Save, resolution, preparation, lease waiting, object
+  publication, and the final pre-mutation check. It is deferred only after working-tree mutation starts.
 - SQLite local completion remains the irreversible local point. `Reference` finalization occurs afterward while the
   lease is held: previous Branch applies once, exact selected Branch is already applied, and any third Branch rejects.
   `DirectoryVersion` finalization proves the current Branch remains active and changes no Branch identity.
@@ -64,6 +68,10 @@ facts, while the module owns the current Branch transaction end to end. Issue #8
 evidence; #870 delivers the hash-selected tracer; #871 adds repeatable Reference finalization; #872 adds Save-enabled
 baseline binding. Issue #842 later uses the same exact pending Branch facts for Doctor recovery without working-file
 mutation.
+
+The phase is executable rather than descriptive: #870 proves deterministic no-Save construction and phase consumption;
+issue #872 proves Save-enabled construction and a tracked edit during preparation that the post-lease comparison rejects
+before target mutation. This preserves the one deep module seam without allowing an arbitrary caller status graph.
 
 Watch and Connect stay outside this interface until a later accepted design names their independent admission and
 finalization rules. This avoids treating one future caller's callback or path needs as a current Branch contract.


### PR DESCRIPTION
# Summary

Correct the canonical Working Directory Update contract after PR #854 supersession and make the replacement Branch
sequence Plan-ready.

Related to #868. This PR targets the epic integration branch, so the issue will be closed manually after merge.

## Why this matters

The previous Branch tracer combined too many invariant families and left key transition rules implicit. The corrected
contract gives #869–#872 small, explicit implementation and proof responsibilities without reopening accepted product
semantics.

## Changes

- Record typed Reference versus exact-root DirectoryVersion selection.
- Define the successful pre-switch Save result as the accepted current baseline with revision and full-status fingerprint.
- Add exhaustive marker and cleanup dispositions across transaction phases.
- Define repeatable Reference finalization states.
- Specify tracked directory and file/directory transition ordering.
- Assign cancellation through the final pre-mutation check.
- Replace the broad request model with a small Branch seam and internally derived facts.
- Separate real module phase proof from bounded built-command proof.
- Replace #841 traceability with #868–#872 and amend ADR 0011 with lasting architecture only.

## Quality contract

Product V1. No source, schema implementation, outcome, durable state, migration, rollback, journal, or automatic recovery
is added by this docs-only slice.

## Changed paths

- `CONTEXT.md`
- `docs/Working Directory Update.md`
- `docs/adr/0011-working-directory-update-transaction.md`

## Validation

- MarkdownLint: 3/3 files passed.
- Local Markdown links resolved.
- Traceability audit: 17 requirements and nine accepted decisions, with one primary owner per requirement.
- Superseded request-shape audit passed.
- Scope, base, root-preservation, `git diff --check`, and clean-worktree checks passed.

## Residual risk

This PR changes only the canonical contract. Runtime implementation and executable proof remain explicitly assigned to
issues #869–#872.

