### PR TITLE
Stabilize upload-confirm race gate proof

### DIFF
--- a/src/Grace.Server.Tests/Storage.Server.Tests.fs
+++ b/src/Grace.Server.Tests/Storage.Server.Tests.fs
@@ -2139,9 +2139,9 @@ type StorageManifestUploadSessionRoutes() =
             )
         }
 
-    /// Verifies the confirm content block upload deletes final CAS when actor rejects after confirm race scenario.
+    /// Verifies the confirm content block upload rejects a racing confirm after finalization and retains final shared CAS.
     [<Test>]
-    member _.ConfirmContentBlockUploadDeletesFinalCasWhenActorRejectsAfterConfirmRace() =
+    member _.ConfirmContentBlockUploadRejectsRacingConfirmAndRetainsFinalSharedCas() =
         task {
             let repositoryId = repositoryIds[0]
             let correlationId = generateCorrelationId ()
@@ -2260,10 +2260,14 @@ type StorageManifestUploadSessionRoutes() =
             let! racingResponse = racingConfirmTask
             let! racingBody = racingResponse.Content.ReadAsStringAsync()
             Assert.That(racingResponse.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), racingBody)
-            Assert.That(racingBody, Does.Contain("RetentionPending"))
 
             let! finalBlockExists = finalContentBlockExistsByAddress racingUploadUri racingBlock.Address
-            Assert.That(finalBlockExists, Is.False)
+
+            match (deserialize<GraceError> racingBody).Error with
+            | "UploadSession is waiting for cleanup and cannot be changed by ConfirmBlockUploaded." -> Assert.That(finalBlockExists, Is.True)
+            | "UploadSession must be active before confirming a ContentBlock upload; current state is RetentionPending." ->
+                Assert.That(finalBlockExists, Is.False)
+            | error -> Assert.Fail($"Unexpected racing confirm error: {error}")
         }
 
     /// Verifies the confirm content block upload rejects terminal session before final CAS materialization scenario.


### PR DESCRIPTION
# Stabilize the upload-confirm race gate proof

## Why

The Full gate repeatedly failed because one integration test asserted stale upload-session internals. Current production
behavior has two supported race orderings and deliberately retains final CAS after actor rejection when content may be
shared.

Relates to #874.

## Changes

- Rename the confirm/finalize race test to describe rejection and conditional shared-CAS retention.
- Deserialize `GraceError.Error` and accept only the two exact existing cleanup-transition messages.
- Assert final CAS exists after actor rejection and remains absent when handler revalidation rejects before
  materialization.
- Preserve finalization lifecycle and HTTP 400 proof.

## Proof

- Targeted Fantomas passed.
- Matching nonincremental Release builds passed for Server.Tests and Server.Unit.Tests.
- Renamed hosted race test passed three sequential fresh-host runs.
- `ConfirmActorRejectionKeepsFinalCasPlacement` passed.
- `git diff --check` and Product V1 self-review passed.

## Scope

This PR changes one integration test. It does not alter production storage, upload-session, CAS, or Grace Cache
behavior.
