### PR TITLE
Compile the canonical Working Directory Update lifecycle block

### DIFF
--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -68,6 +68,7 @@ tests cite `WDU-LC-*` row IDs; they must not restate or reorder the transition s
 predicate language; consumers such as #882 parse that grammar and must not infer aliases, wildcard behavior, or row
 precedence.
 
+<!-- grace:wdu-lifecycle-contract:start -->
 ```json
 {
   "schema": "grace.wdu.branch-lifecycle/v1",
@@ -215,6 +216,7 @@ precedence.
   ]
 }
 ```
+<!-- grace:wdu-lifecycle-contract:end -->
 
 Rows `WDU-LC-200`–`WDU-LC-212` own pre-local marker admission, exact adoption, refusal, cleanup, fresh planning, and the
 final pre-mutation reread. Rows `WDU-LC-010`–`WDU-LC-015` prohibit Branch publication for every disallowed marker

--- a/scripts/modules/WduLifecycleContract.psm1
+++ b/scripts/modules/WduLifecycleContract.psm1
@@ -9,15 +9,30 @@ function Fail-Contract {
     throw "WDU lifecycle contract '$Path': $Reason"
 }
 
+function Test-ExactDictionaryKey {
+    param([System.Collections.IDictionary] $Value, [string] $Name)
+    foreach ($key in $Value.Keys) {
+        if ([string] $key -ceq $Name) { return $true }
+    }
+    return $false
+}
+
+function Assert-AllowedObjectProperties {
+    param([object] $Value, [string[]] $AllowedNames, [string[]] $RequiredNames, [string] $Path, [string] $SourcePath)
+    if ($Value -isnot [System.Collections.IDictionary]) { Fail-Contract $SourcePath "$Path must be a JSON object" }
+    $allowed = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($name in $AllowedNames) { $null = $allowed.Add($name) }
+    foreach ($name in $Value.Keys) {
+        if (-not $allowed.Contains([string] $name)) { Fail-Contract $SourcePath "$Path has unknown property '$name'" }
+    }
+    foreach ($name in $RequiredNames) {
+        if (-not (Test-ExactDictionaryKey $Value $name)) { Fail-Contract $SourcePath "$Path is missing property '$name'" }
+    }
+}
+
 function Assert-ExactObject {
     param([object] $Value, [string[]] $Names, [string] $Path, [string] $SourcePath)
-    if ($Value -isnot [System.Collections.IDictionary]) { Fail-Contract $SourcePath "$Path must be a JSON object" }
-    foreach ($name in $Value.Keys) {
-        if ($Names -notcontains $name) { Fail-Contract $SourcePath "$Path has unknown property '$name'" }
-    }
-    foreach ($name in $Names) {
-        if (-not $Value.Contains($name)) { Fail-Contract $SourcePath "$Path is missing property '$name'" }
-    }
+    Assert-AllowedObjectProperties $Value $Names $Names $Path $SourcePath
 }
 
 function Assert-StringValue {
@@ -74,20 +89,26 @@ function Assert-NoDuplicateProperties {
 
 function Get-DeclaredEnumValues {
     param([System.Collections.IDictionary] $Enums, [string] $Name, [string] $SourcePath)
-    if (-not $Enums.Contains($Name)) { Fail-Contract $SourcePath "machineGrammar.concreteEnums is missing '$Name'" }
+    if (-not (Test-ExactDictionaryKey $Enums $Name)) { Fail-Contract $SourcePath "machineGrammar.concreteEnums is missing '$Name'" }
     return @(Assert-StringArray $Enums[$Name] "machineGrammar.concreteEnums.$Name" $SourcePath)
 }
 
 function Expand-Predicate {
     param(
-        [System.Collections.IDictionary] $Predicate,
+        [object] $Predicate,
         [string] $Axis,
         [System.Collections.IDictionary] $ConcreteEnums,
         [System.Collections.IDictionary] $Aggregates,
         [string] $RowPath,
         [string] $SourcePath
     )
-    if ($Predicate -isnot [System.Collections.IDictionary] -or -not $Predicate.Contains('kind')) {
+    if ($Predicate -isnot [System.Collections.IDictionary]) {
+        Fail-Contract $SourcePath "$RowPath.$Axis must be a predicate object with kind"
+    }
+    if (-not (Test-ExactDictionaryKey $Predicate 'kind')) {
+        foreach ($name in $Predicate.Keys) {
+            if ([string] $name -ieq 'kind') { Fail-Contract $SourcePath "$RowPath.$Axis has unknown property '$name'" }
+        }
         Fail-Contract $SourcePath "$RowPath.$Axis must be a predicate object with kind"
     }
     $values = Get-DeclaredEnumValues $ConcreteEnums $Axis $SourcePath
@@ -106,11 +127,11 @@ function Expand-Predicate {
         'aggregate' {
             Assert-ExactObject $Predicate @('kind', 'name') "$RowPath.$Axis" $SourcePath
             Assert-StringValue $Predicate['name'] "$RowPath.$Axis.name" $SourcePath
-            if (-not $Aggregates.Contains($Axis) -or $Aggregates[$Axis] -isnot [System.Collections.IDictionary]) {
+            if (-not (Test-ExactDictionaryKey $Aggregates $Axis) -or $Aggregates[$Axis] -isnot [System.Collections.IDictionary]) {
                 Fail-Contract $SourcePath "$RowPath.$Axis aggregate is not declared for this axis"
             }
             $axisAggregates = $Aggregates[$Axis]
-            if (-not $axisAggregates.Contains($Predicate['name'])) {
+            if (-not (Test-ExactDictionaryKey $axisAggregates $Predicate['name'])) {
                 Fail-Contract $SourcePath "$RowPath.$Axis aggregate '$($Predicate['name'])' is not declared"
             }
             $expanded = @(Assert-StringArray $axisAggregates[$Predicate['name']] "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath)
@@ -145,6 +166,10 @@ function Read-WduLifecycleContract {
     try {
         if ($document.RootElement.ValueKind -ne [Text.Json.JsonValueKind]::Object) { Fail-Contract $sourcePath 'marked payload must be a JSON object' }
         Assert-NoDuplicateProperties $document.RootElement '$' $sourcePath
+        $rawRows = @($document.RootElement.EnumerateObject() | Where-Object { $_.Name -ceq 'rows' })
+        if ($rawRows.Count -eq 1 -and $rawRows[0].Value.ValueKind -ne [Text.Json.JsonValueKind]::Array) {
+            Fail-Contract $sourcePath 'rows must be a JSON array'
+        }
     }
     finally { $document.Dispose() }
     try { $contract = $json | ConvertFrom-Json -AsHashtable -Depth 100 }
@@ -198,19 +223,22 @@ function Read-WduLifecycleContract {
     foreach ($name in @('rule', 'routing')) { Assert-StringValue $grammar['overlap'][$name] "machineGrammar.overlap.$name" $sourcePath }
     foreach ($name in $grammar['terminalReplay'].Keys) { Assert-StringValue $grammar['terminalReplay'][$name] "machineGrammar.terminalReplay.$name" $sourcePath }
 
-    if ($contract['rows'] -is [string] -or $contract['rows'] -isnot [System.Collections.IEnumerable]) { Fail-Contract $sourcePath 'rows must be a JSON array' }
+    if ($contract['rows'] -is [string] -or $contract['rows'] -is [System.Collections.IDictionary] -or $contract['rows'] -isnot [System.Collections.IEnumerable]) {
+        Fail-Contract $sourcePath 'rows must be a JSON array'
+    }
     $rows = @($contract['rows']); if ($rows.Count -eq 0) { Fail-Contract $sourcePath 'rows must not be empty' }
-    $rowIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    $rowLookup = [ordered]@{}
+    $rowIds = [Collections.Generic.List[string]]::new()
+    $rowIdUniqueness = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    $rowsById = [Collections.Generic.Dictionary[string, object]]::new([StringComparer]::Ordinal)
     $keyOwners = [Collections.Generic.Dictionary[string, string]]::new([StringComparer]::Ordinal)
     foreach ($row in $rows) {
         $rowPath = 'rows[]'
         $allowed = @('id', 'match', 'firstApplicableRetryWrite', 'requiredActions', 'workingFiles', 'branchIdentity', 'durableResult', 'outcome', 'exitClass', 'doctorGuidance', 'resultingMarker', 'nextRows')
-        if ($row -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath "$rowPath must be a JSON object" }
-        foreach ($name in $row.Keys) { if ($allowed -notcontains $name) { Fail-Contract $sourcePath "$rowPath has unknown property '$name'" } }
-        foreach ($name in $allowed[0..9]) { if (-not $row.Contains($name)) { Fail-Contract $sourcePath "$rowPath is missing property '$name'" } }
+        Assert-AllowedObjectProperties $row $allowed @($allowed[0..9]) $rowPath $sourcePath
         Assert-StringValue $row['id'] "$rowPath.id" $sourcePath
-        if (-not $rowIds.Add($row['id'])) { Fail-Contract $sourcePath "duplicate row ID '$($row['id'])'" }
+        if (-not $rowIdUniqueness.Add($row['id'])) { Fail-Contract $sourcePath "duplicate row ID '$($row['id'])'" }
+        if (-not $rowsById.TryAdd($row['id'], $row)) { Fail-Contract $sourcePath "duplicate row ID '$($row['id'])'" }
+        $rowIds.Add($row['id'])
         $rowPath = "row $($row['id'])"
         Assert-ExactObject $row['match'] $axes "$rowPath.match" $sourcePath
         $expandedAxes = foreach ($axis in $axes) { ,@(Expand-Predicate $row['match'][$axis] $axis $enums $aggregates $rowPath $sourcePath) }
@@ -225,8 +253,8 @@ function Read-WduLifecycleContract {
         Assert-NullableString $row['exitClass'] "$rowPath.exitClass" $sourcePath
         if ($null -ne $row['exitClass'] -and (Get-DeclaredEnumValues $enums 'exitClass' $sourcePath) -cnotcontains $row['exitClass']) { Fail-Contract $sourcePath "$rowPath.exitClass is not declared" }
         Assert-NullableBoolean $row['doctorGuidance'] "$rowPath.doctorGuidance" $sourcePath
-        if ($row.Contains('resultingMarker')) { Assert-StringValue $row['resultingMarker'] "$rowPath.resultingMarker" $sourcePath }
-        if ($row.Contains('nextRows')) {
+        if (Test-ExactDictionaryKey $row 'resultingMarker') { Assert-StringValue $row['resultingMarker'] "$rowPath.resultingMarker" $sourcePath }
+        if (Test-ExactDictionaryKey $row 'nextRows') {
             $nextRows = @(Assert-StringArray $row['nextRows'] "$rowPath.nextRows" $sourcePath)
             if ($null -ne $row['outcome']) { Fail-Contract $sourcePath "$rowPath routing row must not have an outcome" }
         }
@@ -248,15 +276,15 @@ function Read-WduLifecycleContract {
             if ($keyOwners.ContainsKey($key)) { Fail-Contract $sourcePath "duplicate applicability key for rows '$($keyOwners[$key])' and '$($row['id'])'" }
             $keyOwners.Add($key, $row['id'])
         }
-        $null = $rowLookup[$row['id']] = $row
     }
+    if ($rows.Count -ne $rowIds.Count -or $rows.Count -ne $rowsById.Count) { Fail-Contract $sourcePath 'row identity counts are inconsistent' }
     foreach ($row in $rows) {
-        if ($row.Contains('nextRows')) {
-            foreach ($target in $row['nextRows']) { if (-not $rowLookup.Contains($target)) { Fail-Contract $sourcePath "row '$($row['id'])' has dangling nextRows target '$target'" } }
+        if (Test-ExactDictionaryKey $row 'nextRows') {
+            foreach ($target in $row['nextRows']) { if (-not $rowsById.ContainsKey($target)) { Fail-Contract $sourcePath "row '$($row['id'])' has dangling nextRows target '$target'" } }
         }
     }
     $digestBytes = [Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($json))
-    return [pscustomobject]@{ Digest = [Convert]::ToHexString($digestBytes).ToLowerInvariant(); RowIds = @($rowLookup.Keys); ApplicabilityKeys = @($keyOwners.Keys); RowsById = $rowLookup }
+    return [pscustomobject]@{ Digest = [Convert]::ToHexString($digestBytes).ToLowerInvariant(); RowIds = @($rowIds); ApplicabilityKeys = @($keyOwners.Keys); RowsById = $rowsById }
 }
 
 Export-ModuleMember -Function Read-WduLifecycleContract

--- a/scripts/modules/WduLifecycleContract.psm1
+++ b/scripts/modules/WduLifecycleContract.psm1
@@ -1,0 +1,262 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:StartMarker = '<!-- grace:wdu-lifecycle-contract:start -->'
+$script:EndMarker = '<!-- grace:wdu-lifecycle-contract:end -->'
+
+function Fail-Contract {
+    param([string] $Path, [string] $Reason)
+    throw "WDU lifecycle contract '$Path': $Reason"
+}
+
+function Assert-ExactObject {
+    param([object] $Value, [string[]] $Names, [string] $Path, [string] $SourcePath)
+    if ($Value -isnot [System.Collections.IDictionary]) { Fail-Contract $SourcePath "$Path must be a JSON object" }
+    foreach ($name in $Value.Keys) {
+        if ($Names -notcontains $name) { Fail-Contract $SourcePath "$Path has unknown property '$name'" }
+    }
+    foreach ($name in $Names) {
+        if (-not $Value.Contains($name)) { Fail-Contract $SourcePath "$Path is missing property '$name'" }
+    }
+}
+
+function Assert-StringValue {
+    param([object] $Value, [string] $Path, [string] $SourcePath)
+    if ($Value -isnot [string]) { Fail-Contract $SourcePath "$Path must be a JSON string" }
+}
+
+function Assert-StringArray {
+    param([object] $Value, [string] $Path, [string] $SourcePath, [bool] $AllowEmpty = $false)
+    if ($Value -is [string] -or $Value -isnot [System.Collections.IEnumerable] -or $Value -is [System.Collections.IDictionary]) {
+        Fail-Contract $SourcePath "$Path must be a JSON array of strings"
+    }
+    $values = @($Value)
+    if (-not $AllowEmpty -and $values.Count -eq 0) { Fail-Contract $SourcePath "$Path must not be empty" }
+    foreach ($item in $values) { Assert-StringValue $item "$Path[]" $SourcePath }
+    return $values
+}
+
+function Assert-UniqueStrings {
+    param([string[]] $Values, [string] $Path, [string] $SourcePath)
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($value in $Values) {
+        if (-not $seen.Add($value)) { Fail-Contract $SourcePath "$Path contains duplicate value '$value'" }
+    }
+}
+
+function Assert-NullableString {
+    param([object] $Value, [string] $Path, [string] $SourcePath)
+    if ($null -ne $Value) { Assert-StringValue $Value $Path $SourcePath }
+}
+
+function Assert-NullableBoolean {
+    param([object] $Value, [string] $Path, [string] $SourcePath)
+    if ($null -ne $Value -and $Value -isnot [bool]) { Fail-Contract $SourcePath "$Path must be a JSON boolean or null" }
+}
+
+function Assert-NoDuplicateProperties {
+    param([System.Text.Json.JsonElement] $Element, [string] $Path, [string] $SourcePath)
+    if ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Object) {
+        $names = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($property in $Element.EnumerateObject()) {
+            if (-not $names.Add($property.Name)) { Fail-Contract $SourcePath "$Path has duplicate case-equivalent property '$($property.Name)'" }
+            Assert-NoDuplicateProperties $property.Value "$Path.$($property.Name)" $SourcePath
+        }
+    }
+    elseif ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
+        $index = 0
+        foreach ($item in $Element.EnumerateArray()) {
+            Assert-NoDuplicateProperties $item "$Path[$index]" $SourcePath
+            $index++
+        }
+    }
+}
+
+function Get-DeclaredEnumValues {
+    param([System.Collections.IDictionary] $Enums, [string] $Name, [string] $SourcePath)
+    if (-not $Enums.Contains($Name)) { Fail-Contract $SourcePath "machineGrammar.concreteEnums is missing '$Name'" }
+    return @(Assert-StringArray $Enums[$Name] "machineGrammar.concreteEnums.$Name" $SourcePath)
+}
+
+function Expand-Predicate {
+    param(
+        [System.Collections.IDictionary] $Predicate,
+        [string] $Axis,
+        [System.Collections.IDictionary] $ConcreteEnums,
+        [System.Collections.IDictionary] $Aggregates,
+        [string] $RowPath,
+        [string] $SourcePath
+    )
+    if ($Predicate -isnot [System.Collections.IDictionary] -or -not $Predicate.Contains('kind')) {
+        Fail-Contract $SourcePath "$RowPath.$Axis must be a predicate object with kind"
+    }
+    $values = Get-DeclaredEnumValues $ConcreteEnums $Axis $SourcePath
+    $kind = $Predicate['kind']; Assert-StringValue $kind "$RowPath.$Axis.kind" $SourcePath
+    switch ($kind) {
+        'one' {
+            Assert-ExactObject $Predicate @('kind', 'value') "$RowPath.$Axis" $SourcePath
+            Assert-StringValue $Predicate['value'] "$RowPath.$Axis.value" $SourcePath
+            $expanded = @($Predicate['value'])
+        }
+        'set' {
+            Assert-ExactObject $Predicate @('kind', 'values') "$RowPath.$Axis" $SourcePath
+            $expanded = @(Assert-StringArray $Predicate['values'] "$RowPath.$Axis.values" $SourcePath)
+            Assert-UniqueStrings $expanded "$RowPath.$Axis.values" $SourcePath
+        }
+        'aggregate' {
+            Assert-ExactObject $Predicate @('kind', 'name') "$RowPath.$Axis" $SourcePath
+            Assert-StringValue $Predicate['name'] "$RowPath.$Axis.name" $SourcePath
+            if (-not $Aggregates.Contains($Axis) -or $Aggregates[$Axis] -isnot [System.Collections.IDictionary]) {
+                Fail-Contract $SourcePath "$RowPath.$Axis aggregate is not declared for this axis"
+            }
+            $axisAggregates = $Aggregates[$Axis]
+            if (-not $axisAggregates.Contains($Predicate['name'])) {
+                Fail-Contract $SourcePath "$RowPath.$Axis aggregate '$($Predicate['name'])' is not declared"
+            }
+            $expanded = @(Assert-StringArray $axisAggregates[$Predicate['name']] "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath)
+            Assert-UniqueStrings $expanded "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath
+        }
+        default { Fail-Contract $SourcePath "$RowPath.$Axis has unknown predicate kind '$kind'" }
+    }
+    foreach ($value in $expanded) {
+        if ($values -cnotcontains $value) { Fail-Contract $SourcePath "$RowPath.$Axis value '$value' is not declared" }
+    }
+    return $expanded
+}
+
+function Read-WduLifecycleContract {
+    param([Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Path)
+
+    $sourcePath = [IO.Path]::GetFullPath($Path)
+    $text = [IO.File]::ReadAllText($sourcePath)
+    $lines = @($text -split "`r`n|`n|`r")
+    $starts = @($lines | Where-Object { $_ -ceq $script:StartMarker })
+    $ends = @($lines | Where-Object { $_ -ceq $script:EndMarker })
+    if ($starts.Count -ne 1 -or $ends.Count -ne 1) { Fail-Contract $sourcePath 'requires one exact lifecycle marker pair' }
+    $start = [Array]::IndexOf($lines, $script:StartMarker)
+    $end = [Array]::IndexOf($lines, $script:EndMarker)
+    if ($start -ge $end) { Fail-Contract $sourcePath 'lifecycle markers are reversed' }
+    $marked = [string]::Join("`n", @($lines[($start + 1)..($end - 1)]))
+    $match = [regex]::Match($marked, '(?s)\A\s*```json[ \t]*\n(?<json>\{.*\})\n```[ \t]*\s*\z')
+    if (-not $match.Success) { Fail-Contract $sourcePath 'marked payload must be one fenced JSON object' }
+    $json = $match.Groups['json'].Value.Replace("`r`n", "`n").Replace("`r", "`n")
+    try { $document = [Text.Json.JsonDocument]::Parse($json) }
+    catch { Fail-Contract $sourcePath "marked JSON is malformed: $($_.Exception.Message)" }
+    try {
+        if ($document.RootElement.ValueKind -ne [Text.Json.JsonValueKind]::Object) { Fail-Contract $sourcePath 'marked payload must be a JSON object' }
+        Assert-NoDuplicateProperties $document.RootElement '$' $sourcePath
+    }
+    finally { $document.Dispose() }
+    try { $contract = $json | ConvertFrom-Json -AsHashtable -Depth 100 }
+    catch { Fail-Contract $sourcePath "marked JSON cannot be decoded: $($_.Exception.Message)" }
+
+    Assert-ExactObject $contract @('schema', 'boundaries', 'retryAdmission', 'doctorCommand', 'order', 'machineGrammar', 'rows') '$' $sourcePath
+    if ($contract['schema'] -cne 'grace.wdu.branch-lifecycle/v1') { Fail-Contract $sourcePath 'schema must be grace.wdu.branch-lifecycle/v1' }
+    Assert-ExactObject $contract['boundaries'] @('firstWorkingTreeMutation', 'sqliteLocalCompletion', 'firstApplicableRetryWrite') 'boundaries' $sourcePath
+    foreach ($name in $contract['boundaries'].Keys) { Assert-StringValue $contract['boundaries'][$name] "boundaries.$name" $sourcePath }
+    Assert-ExactObject $contract['retryAdmission'] @('source', 'requiredActions', 'staleEvidenceAction') 'retryAdmission' $sourcePath
+    Assert-StringValue $contract['retryAdmission']['source'] 'retryAdmission.source' $sourcePath
+    Assert-StringArray $contract['retryAdmission']['requiredActions'] 'retryAdmission.requiredActions' $sourcePath | Out-Null
+    Assert-StringValue $contract['retryAdmission']['staleEvidenceAction'] 'retryAdmission.staleEvidenceAction' $sourcePath
+    Assert-StringValue $contract['doctorCommand'] 'doctorCommand' $sourcePath
+    Assert-StringArray $contract['order'] 'order' $sourcePath | Out-Null
+
+    $grammar = $contract['machineGrammar']
+    Assert-ExactObject $grammar @('predicateAxes', 'encoding', 'concreteEnums', 'aggregates', 'expansion', 'overlap', 'terminalReplay') 'machineGrammar' $sourcePath
+    $axes = @(Assert-StringArray $grammar['predicateAxes'] 'machineGrammar.predicateAxes' $sourcePath); Assert-UniqueStrings $axes 'machineGrammar.predicateAxes' $sourcePath
+    Assert-ExactObject $grammar['encoding'] @('one', 'set', 'aggregate') 'machineGrammar.encoding' $sourcePath
+    foreach ($kind in @('one', 'set', 'aggregate')) {
+        Assert-ExactObject $grammar['encoding'][$kind] @('jsonShape', 'meaning') "machineGrammar.encoding.$kind" $sourcePath
+        $shapeNames = if ($kind -eq 'one') { @('kind', 'value') } elseif ($kind -eq 'set') { @('kind', 'values') } else { @('kind', 'name') }
+        $shape = $grammar['encoding'][$kind]['jsonShape']
+        Assert-ExactObject $shape $shapeNames "machineGrammar.encoding.$kind.jsonShape" $sourcePath
+        Assert-StringValue $shape['kind'] "machineGrammar.encoding.$kind.jsonShape.kind" $sourcePath
+        if ($shape['kind'] -cne $kind) { Fail-Contract $sourcePath "machineGrammar.encoding.$kind must declare kind '$kind'" }
+        if ($kind -eq 'set') { Assert-StringArray $shape['values'] "machineGrammar.encoding.$kind.jsonShape.values" $sourcePath | Out-Null }
+        else { Assert-StringValue $shape[$shapeNames[1]] "machineGrammar.encoding.$kind.jsonShape.$($shapeNames[1])" $sourcePath }
+        Assert-StringValue $grammar['encoding'][$kind]['meaning'] "machineGrammar.encoding.$kind.meaning" $sourcePath
+    }
+    $enums = $grammar['concreteEnums']; if ($enums -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath 'machineGrammar.concreteEnums must be an object' }
+    foreach ($name in $enums.Keys) { $members = @(Assert-StringArray $enums[$name] "machineGrammar.concreteEnums.$name" $sourcePath); Assert-UniqueStrings $members "machineGrammar.concreteEnums.$name" $sourcePath }
+    foreach ($axis in $axes) { Get-DeclaredEnumValues $enums $axis $sourcePath | Out-Null }
+    $aggregates = $grammar['aggregates']; if ($aggregates -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath 'machineGrammar.aggregates must be an object' }
+    foreach ($axis in $aggregates.Keys) {
+        if ($axes -cnotcontains $axis -or $aggregates[$axis] -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath "machineGrammar.aggregates.$axis is not an axis aggregate object" }
+        foreach ($name in $aggregates[$axis].Keys) {
+            $members = @(Assert-StringArray $aggregates[$axis][$name] "machineGrammar.aggregates.$axis.$name" $sourcePath)
+            Assert-UniqueStrings $members "machineGrammar.aggregates.$axis.$name" $sourcePath
+            $declared = Get-DeclaredEnumValues $enums $axis $sourcePath
+            foreach ($member in $members) { if ($declared -cnotcontains $member) { Fail-Contract $sourcePath "machineGrammar.aggregates.$axis.$name has undeclared member '$member'" } }
+        }
+    }
+    Assert-ExactObject $grammar['expansion'] @('rule', 'setMembers', 'aggregateMembers', 'example') 'machineGrammar.expansion' $sourcePath
+    Assert-ExactObject $grammar['overlap'] @('applicabilityKey', 'rule', 'routing') 'machineGrammar.overlap' $sourcePath
+    $keyAxes = @(Assert-StringArray $grammar['overlap']['applicabilityKey'] 'machineGrammar.overlap.applicabilityKey' $sourcePath)
+    if (@(Compare-Object $axes $keyAxes -SyncWindow 0).Count -ne 0) { Fail-Contract $sourcePath 'machineGrammar.overlap.applicabilityKey must name the predicate axes' }
+    Assert-ExactObject $grammar['terminalReplay'] @('row', 'selectionExpansion', 'markerExpansion', 'effects') 'machineGrammar.terminalReplay' $sourcePath
+    foreach ($name in $grammar['expansion'].Keys) { Assert-StringValue $grammar['expansion'][$name] "machineGrammar.expansion.$name" $sourcePath }
+    foreach ($name in @('rule', 'routing')) { Assert-StringValue $grammar['overlap'][$name] "machineGrammar.overlap.$name" $sourcePath }
+    foreach ($name in $grammar['terminalReplay'].Keys) { Assert-StringValue $grammar['terminalReplay'][$name] "machineGrammar.terminalReplay.$name" $sourcePath }
+
+    if ($contract['rows'] -is [string] -or $contract['rows'] -isnot [System.Collections.IEnumerable]) { Fail-Contract $sourcePath 'rows must be a JSON array' }
+    $rows = @($contract['rows']); if ($rows.Count -eq 0) { Fail-Contract $sourcePath 'rows must not be empty' }
+    $rowIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $rowLookup = [ordered]@{}
+    $keyOwners = [Collections.Generic.Dictionary[string, string]]::new([StringComparer]::Ordinal)
+    foreach ($row in $rows) {
+        $rowPath = 'rows[]'
+        $allowed = @('id', 'match', 'firstApplicableRetryWrite', 'requiredActions', 'workingFiles', 'branchIdentity', 'durableResult', 'outcome', 'exitClass', 'doctorGuidance', 'resultingMarker', 'nextRows')
+        if ($row -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath "$rowPath must be a JSON object" }
+        foreach ($name in $row.Keys) { if ($allowed -notcontains $name) { Fail-Contract $sourcePath "$rowPath has unknown property '$name'" } }
+        foreach ($name in $allowed[0..9]) { if (-not $row.Contains($name)) { Fail-Contract $sourcePath "$rowPath is missing property '$name'" } }
+        Assert-StringValue $row['id'] "$rowPath.id" $sourcePath
+        if (-not $rowIds.Add($row['id'])) { Fail-Contract $sourcePath "duplicate row ID '$($row['id'])'" }
+        $rowPath = "row $($row['id'])"
+        Assert-ExactObject $row['match'] $axes "$rowPath.match" $sourcePath
+        $expandedAxes = foreach ($axis in $axes) { ,@(Expand-Predicate $row['match'][$axis] $axis $enums $aggregates $rowPath $sourcePath) }
+        for ($i = 0; $i -lt $expandedAxes[0].Count; $i++) { }
+        $first = $row['firstApplicableRetryWrite']; Assert-StringValue $first "$rowPath.firstApplicableRetryWrite" $sourcePath
+        if ((Get-DeclaredEnumValues $enums 'firstApplicableRetryWrite' $sourcePath) -cnotcontains $first) { Fail-Contract $sourcePath "$rowPath.firstApplicableRetryWrite is not declared" }
+        Assert-StringArray $row['requiredActions'] "$rowPath.requiredActions" $sourcePath $true | Out-Null
+        Assert-StringValue $row['workingFiles'] "$rowPath.workingFiles" $sourcePath
+        Assert-StringValue $row['branchIdentity'] "$rowPath.branchIdentity" $sourcePath
+        Assert-NullableString $row['durableResult'] "$rowPath.durableResult" $sourcePath
+        Assert-NullableString $row['outcome'] "$rowPath.outcome" $sourcePath
+        Assert-NullableString $row['exitClass'] "$rowPath.exitClass" $sourcePath
+        if ($null -ne $row['exitClass'] -and (Get-DeclaredEnumValues $enums 'exitClass' $sourcePath) -cnotcontains $row['exitClass']) { Fail-Contract $sourcePath "$rowPath.exitClass is not declared" }
+        Assert-NullableBoolean $row['doctorGuidance'] "$rowPath.doctorGuidance" $sourcePath
+        if ($row.Contains('resultingMarker')) { Assert-StringValue $row['resultingMarker'] "$rowPath.resultingMarker" $sourcePath }
+        if ($row.Contains('nextRows')) {
+            $nextRows = @(Assert-StringArray $row['nextRows'] "$rowPath.nextRows" $sourcePath)
+            if ($null -ne $row['outcome']) { Fail-Contract $sourcePath "$rowPath routing row must not have an outcome" }
+        }
+        else {
+            if ($null -eq $row['outcome']) { Fail-Contract $sourcePath "$rowPath terminal row must have an outcome" }
+        }
+        $combinations = [Collections.Generic.List[object]]::new()
+        $combinations.Add([string[]]@())
+        foreach ($values in $expandedAxes) {
+            $next = [Collections.Generic.List[object]]::new()
+            foreach ($prefixObject in $combinations) {
+                [string[]] $prefix = $prefixObject
+                foreach ($value in $values) { $next.Add([string[]]@($prefix + [string]$value)) }
+            }
+            $combinations = $next
+        }
+        foreach ($combination in $combinations) {
+            $key = [string]::Join([char]31, [string[]]$combination)
+            if ($keyOwners.ContainsKey($key)) { Fail-Contract $sourcePath "duplicate applicability key for rows '$($keyOwners[$key])' and '$($row['id'])'" }
+            $keyOwners.Add($key, $row['id'])
+        }
+        $null = $rowLookup[$row['id']] = $row
+    }
+    foreach ($row in $rows) {
+        if ($row.Contains('nextRows')) {
+            foreach ($target in $row['nextRows']) { if (-not $rowLookup.Contains($target)) { Fail-Contract $sourcePath "row '$($row['id'])' has dangling nextRows target '$target'" } }
+        }
+    }
+    $digestBytes = [Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes($json))
+    return [pscustomobject]@{ Digest = [Convert]::ToHexString($digestBytes).ToLowerInvariant(); RowIds = @($rowLookup.Keys); ApplicabilityKeys = @($keyOwners.Keys); RowsById = $rowLookup }
+}
+
+Export-ModuleMember -Function Read-WduLifecycleContract

--- a/scripts/modules/WduLifecycleContract.psm1
+++ b/scripts/modules/WduLifecycleContract.psm1
@@ -9,10 +9,36 @@ function Fail-Contract {
     throw "WDU lifecycle contract '$Path': $Reason"
 }
 
+function Test-OrdinalStringEquals {
+    param([string] $Left, [string] $Right)
+    return [StringComparer]::Ordinal.Equals($Left, $Right)
+}
+
+function Test-OrdinalIgnoreCaseStringEquals {
+    param([string] $Left, [string] $Right)
+    return [StringComparer]::OrdinalIgnoreCase.Equals($Left, $Right)
+}
+
+function Test-OrdinalStringInCollection {
+    param([string[]] $Values, [string] $Expected)
+    foreach ($value in $Values) {
+        if (Test-OrdinalStringEquals $value $Expected) { return $true }
+    }
+    return $false
+}
+
+function Find-OrdinalStringIndex {
+    param([string[]] $Values, [string] $Expected)
+    for ($index = 0; $index -lt $Values.Count; $index++) {
+        if (Test-OrdinalStringEquals $Values[$index] $Expected) { return $index }
+    }
+    return -1
+}
+
 function Test-ExactDictionaryKey {
     param([System.Collections.IDictionary] $Value, [string] $Name)
     foreach ($key in $Value.Keys) {
-        if ([string] $key -ceq $Name) { return $true }
+        if (Test-OrdinalStringEquals ([string] $key) $Name) { return $true }
     }
     return $false
 }
@@ -107,40 +133,38 @@ function Expand-Predicate {
     }
     if (-not (Test-ExactDictionaryKey $Predicate 'kind')) {
         foreach ($name in $Predicate.Keys) {
-            if ([string] $name -ieq 'kind') { Fail-Contract $SourcePath "$RowPath.$Axis has unknown property '$name'" }
+            if (Test-OrdinalIgnoreCaseStringEquals ([string] $name) 'kind') { Fail-Contract $SourcePath "$RowPath.$Axis has unknown property '$name'" }
         }
         Fail-Contract $SourcePath "$RowPath.$Axis must be a predicate object with kind"
     }
     $values = Get-DeclaredEnumValues $ConcreteEnums $Axis $SourcePath
     $kind = $Predicate['kind']; Assert-StringValue $kind "$RowPath.$Axis.kind" $SourcePath
-    switch ($kind) {
-        'one' {
-            Assert-ExactObject $Predicate @('kind', 'value') "$RowPath.$Axis" $SourcePath
-            Assert-StringValue $Predicate['value'] "$RowPath.$Axis.value" $SourcePath
-            $expanded = @($Predicate['value'])
-        }
-        'set' {
-            Assert-ExactObject $Predicate @('kind', 'values') "$RowPath.$Axis" $SourcePath
-            $expanded = @(Assert-StringArray $Predicate['values'] "$RowPath.$Axis.values" $SourcePath)
-            Assert-UniqueStrings $expanded "$RowPath.$Axis.values" $SourcePath
-        }
-        'aggregate' {
-            Assert-ExactObject $Predicate @('kind', 'name') "$RowPath.$Axis" $SourcePath
-            Assert-StringValue $Predicate['name'] "$RowPath.$Axis.name" $SourcePath
-            if (-not (Test-ExactDictionaryKey $Aggregates $Axis) -or $Aggregates[$Axis] -isnot [System.Collections.IDictionary]) {
-                Fail-Contract $SourcePath "$RowPath.$Axis aggregate is not declared for this axis"
-            }
-            $axisAggregates = $Aggregates[$Axis]
-            if (-not (Test-ExactDictionaryKey $axisAggregates $Predicate['name'])) {
-                Fail-Contract $SourcePath "$RowPath.$Axis aggregate '$($Predicate['name'])' is not declared"
-            }
-            $expanded = @(Assert-StringArray $axisAggregates[$Predicate['name']] "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath)
-            Assert-UniqueStrings $expanded "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath
-        }
-        default { Fail-Contract $SourcePath "$RowPath.$Axis has unknown predicate kind '$kind'" }
+    if (Test-OrdinalStringEquals $kind 'one') {
+        Assert-ExactObject $Predicate @('kind', 'value') "$RowPath.$Axis" $SourcePath
+        Assert-StringValue $Predicate['value'] "$RowPath.$Axis.value" $SourcePath
+        $expanded = @($Predicate['value'])
     }
+    elseif (Test-OrdinalStringEquals $kind 'set') {
+        Assert-ExactObject $Predicate @('kind', 'values') "$RowPath.$Axis" $SourcePath
+        $expanded = @(Assert-StringArray $Predicate['values'] "$RowPath.$Axis.values" $SourcePath)
+        Assert-UniqueStrings $expanded "$RowPath.$Axis.values" $SourcePath
+    }
+    elseif (Test-OrdinalStringEquals $kind 'aggregate') {
+        Assert-ExactObject $Predicate @('kind', 'name') "$RowPath.$Axis" $SourcePath
+        Assert-StringValue $Predicate['name'] "$RowPath.$Axis.name" $SourcePath
+        if (-not (Test-ExactDictionaryKey $Aggregates $Axis) -or $Aggregates[$Axis] -isnot [System.Collections.IDictionary]) {
+            Fail-Contract $SourcePath "$RowPath.$Axis aggregate is not declared for this axis"
+        }
+        $axisAggregates = $Aggregates[$Axis]
+        if (-not (Test-ExactDictionaryKey $axisAggregates $Predicate['name'])) {
+            Fail-Contract $SourcePath "$RowPath.$Axis aggregate '$($Predicate['name'])' is not declared"
+        }
+        $expanded = @(Assert-StringArray $axisAggregates[$Predicate['name']] "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath)
+        Assert-UniqueStrings $expanded "machineGrammar.aggregates.$Axis.$($Predicate['name'])" $SourcePath
+    }
+    else { Fail-Contract $SourcePath "$RowPath.$Axis has unknown predicate kind '$kind'" }
     foreach ($value in $expanded) {
-        if ($values -cnotcontains $value) { Fail-Contract $SourcePath "$RowPath.$Axis value '$value' is not declared" }
+        if (-not (Test-OrdinalStringInCollection $values $value)) { Fail-Contract $SourcePath "$RowPath.$Axis value '$value' is not declared" }
     }
     return $expanded
 }
@@ -151,11 +175,11 @@ function Read-WduLifecycleContract {
     $sourcePath = [IO.Path]::GetFullPath($Path)
     $text = [IO.File]::ReadAllText($sourcePath)
     $lines = @($text -split "`r`n|`n|`r")
-    $starts = @($lines | Where-Object { $_ -ceq $script:StartMarker })
-    $ends = @($lines | Where-Object { $_ -ceq $script:EndMarker })
+    $starts = @($lines | Where-Object { Test-OrdinalStringEquals $_ $script:StartMarker })
+    $ends = @($lines | Where-Object { Test-OrdinalStringEquals $_ $script:EndMarker })
     if ($starts.Count -ne 1 -or $ends.Count -ne 1) { Fail-Contract $sourcePath 'requires one exact lifecycle marker pair' }
-    $start = [Array]::IndexOf($lines, $script:StartMarker)
-    $end = [Array]::IndexOf($lines, $script:EndMarker)
+    $start = Find-OrdinalStringIndex $lines $script:StartMarker
+    $end = Find-OrdinalStringIndex $lines $script:EndMarker
     if ($start -ge $end) { Fail-Contract $sourcePath 'lifecycle markers are reversed' }
     $marked = [string]::Join("`n", @($lines[($start + 1)..($end - 1)]))
     $match = [regex]::Match($marked, '(?s)\A\s*```json[ \t]*\n(?<json>\{.*\})\n```[ \t]*\s*\z')
@@ -166,7 +190,7 @@ function Read-WduLifecycleContract {
     try {
         if ($document.RootElement.ValueKind -ne [Text.Json.JsonValueKind]::Object) { Fail-Contract $sourcePath 'marked payload must be a JSON object' }
         Assert-NoDuplicateProperties $document.RootElement '$' $sourcePath
-        $rawRows = @($document.RootElement.EnumerateObject() | Where-Object { $_.Name -ceq 'rows' })
+        $rawRows = @($document.RootElement.EnumerateObject() | Where-Object { Test-OrdinalStringEquals $_.Name 'rows' })
         if ($rawRows.Count -eq 1 -and $rawRows[0].Value.ValueKind -ne [Text.Json.JsonValueKind]::Array) {
             Fail-Contract $sourcePath 'rows must be a JSON array'
         }
@@ -176,7 +200,7 @@ function Read-WduLifecycleContract {
     catch { Fail-Contract $sourcePath "marked JSON cannot be decoded: $($_.Exception.Message)" }
 
     Assert-ExactObject $contract @('schema', 'boundaries', 'retryAdmission', 'doctorCommand', 'order', 'machineGrammar', 'rows') '$' $sourcePath
-    if ($contract['schema'] -cne 'grace.wdu.branch-lifecycle/v1') { Fail-Contract $sourcePath 'schema must be grace.wdu.branch-lifecycle/v1' }
+    if (-not (Test-OrdinalStringEquals $contract['schema'] 'grace.wdu.branch-lifecycle/v1')) { Fail-Contract $sourcePath 'schema must be grace.wdu.branch-lifecycle/v1' }
     Assert-ExactObject $contract['boundaries'] @('firstWorkingTreeMutation', 'sqliteLocalCompletion', 'firstApplicableRetryWrite') 'boundaries' $sourcePath
     foreach ($name in $contract['boundaries'].Keys) { Assert-StringValue $contract['boundaries'][$name] "boundaries.$name" $sourcePath }
     Assert-ExactObject $contract['retryAdmission'] @('source', 'requiredActions', 'staleEvidenceAction') 'retryAdmission' $sourcePath
@@ -192,12 +216,12 @@ function Read-WduLifecycleContract {
     Assert-ExactObject $grammar['encoding'] @('one', 'set', 'aggregate') 'machineGrammar.encoding' $sourcePath
     foreach ($kind in @('one', 'set', 'aggregate')) {
         Assert-ExactObject $grammar['encoding'][$kind] @('jsonShape', 'meaning') "machineGrammar.encoding.$kind" $sourcePath
-        $shapeNames = if ($kind -eq 'one') { @('kind', 'value') } elseif ($kind -eq 'set') { @('kind', 'values') } else { @('kind', 'name') }
+        $shapeNames = if (Test-OrdinalStringEquals $kind 'one') { @('kind', 'value') } elseif (Test-OrdinalStringEquals $kind 'set') { @('kind', 'values') } else { @('kind', 'name') }
         $shape = $grammar['encoding'][$kind]['jsonShape']
         Assert-ExactObject $shape $shapeNames "machineGrammar.encoding.$kind.jsonShape" $sourcePath
         Assert-StringValue $shape['kind'] "machineGrammar.encoding.$kind.jsonShape.kind" $sourcePath
-        if ($shape['kind'] -cne $kind) { Fail-Contract $sourcePath "machineGrammar.encoding.$kind must declare kind '$kind'" }
-        if ($kind -eq 'set') { Assert-StringArray $shape['values'] "machineGrammar.encoding.$kind.jsonShape.values" $sourcePath | Out-Null }
+        if (-not (Test-OrdinalStringEquals $shape['kind'] $kind)) { Fail-Contract $sourcePath "machineGrammar.encoding.$kind must declare kind '$kind'" }
+        if (Test-OrdinalStringEquals $kind 'set') { Assert-StringArray $shape['values'] "machineGrammar.encoding.$kind.jsonShape.values" $sourcePath | Out-Null }
         else { Assert-StringValue $shape[$shapeNames[1]] "machineGrammar.encoding.$kind.jsonShape.$($shapeNames[1])" $sourcePath }
         Assert-StringValue $grammar['encoding'][$kind]['meaning'] "machineGrammar.encoding.$kind.meaning" $sourcePath
     }
@@ -206,18 +230,23 @@ function Read-WduLifecycleContract {
     foreach ($axis in $axes) { Get-DeclaredEnumValues $enums $axis $sourcePath | Out-Null }
     $aggregates = $grammar['aggregates']; if ($aggregates -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath 'machineGrammar.aggregates must be an object' }
     foreach ($axis in $aggregates.Keys) {
-        if ($axes -cnotcontains $axis -or $aggregates[$axis] -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath "machineGrammar.aggregates.$axis is not an axis aggregate object" }
+        if (-not (Test-OrdinalStringInCollection $axes $axis) -or $aggregates[$axis] -isnot [System.Collections.IDictionary]) { Fail-Contract $sourcePath "machineGrammar.aggregates.$axis is not an axis aggregate object" }
         foreach ($name in $aggregates[$axis].Keys) {
             $members = @(Assert-StringArray $aggregates[$axis][$name] "machineGrammar.aggregates.$axis.$name" $sourcePath)
             Assert-UniqueStrings $members "machineGrammar.aggregates.$axis.$name" $sourcePath
             $declared = Get-DeclaredEnumValues $enums $axis $sourcePath
-            foreach ($member in $members) { if ($declared -cnotcontains $member) { Fail-Contract $sourcePath "machineGrammar.aggregates.$axis.$name has undeclared member '$member'" } }
+            foreach ($member in $members) { if (-not (Test-OrdinalStringInCollection $declared $member)) { Fail-Contract $sourcePath "machineGrammar.aggregates.$axis.$name has undeclared member '$member'" } }
         }
     }
     Assert-ExactObject $grammar['expansion'] @('rule', 'setMembers', 'aggregateMembers', 'example') 'machineGrammar.expansion' $sourcePath
     Assert-ExactObject $grammar['overlap'] @('applicabilityKey', 'rule', 'routing') 'machineGrammar.overlap' $sourcePath
     $keyAxes = @(Assert-StringArray $grammar['overlap']['applicabilityKey'] 'machineGrammar.overlap.applicabilityKey' $sourcePath)
-    if (@(Compare-Object $axes $keyAxes -SyncWindow 0).Count -ne 0) { Fail-Contract $sourcePath 'machineGrammar.overlap.applicabilityKey must name the predicate axes' }
+    if ($axes.Count -ne $keyAxes.Count) { Fail-Contract $sourcePath 'machineGrammar.overlap.applicabilityKey must name the predicate axes in declared order' }
+    for ($index = 0; $index -lt $axes.Count; $index++) {
+        if (-not (Test-OrdinalStringEquals $axes[$index] $keyAxes[$index])) {
+            Fail-Contract $sourcePath 'machineGrammar.overlap.applicabilityKey must name the predicate axes in declared order'
+        }
+    }
     Assert-ExactObject $grammar['terminalReplay'] @('row', 'selectionExpansion', 'markerExpansion', 'effects') 'machineGrammar.terminalReplay' $sourcePath
     foreach ($name in $grammar['expansion'].Keys) { Assert-StringValue $grammar['expansion'][$name] "machineGrammar.expansion.$name" $sourcePath }
     foreach ($name in @('rule', 'routing')) { Assert-StringValue $grammar['overlap'][$name] "machineGrammar.overlap.$name" $sourcePath }
@@ -242,16 +271,15 @@ function Read-WduLifecycleContract {
         $rowPath = "row $($row['id'])"
         Assert-ExactObject $row['match'] $axes "$rowPath.match" $sourcePath
         $expandedAxes = foreach ($axis in $axes) { ,@(Expand-Predicate $row['match'][$axis] $axis $enums $aggregates $rowPath $sourcePath) }
-        for ($i = 0; $i -lt $expandedAxes[0].Count; $i++) { }
         $first = $row['firstApplicableRetryWrite']; Assert-StringValue $first "$rowPath.firstApplicableRetryWrite" $sourcePath
-        if ((Get-DeclaredEnumValues $enums 'firstApplicableRetryWrite' $sourcePath) -cnotcontains $first) { Fail-Contract $sourcePath "$rowPath.firstApplicableRetryWrite is not declared" }
+        if (-not (Test-OrdinalStringInCollection (Get-DeclaredEnumValues $enums 'firstApplicableRetryWrite' $sourcePath) $first)) { Fail-Contract $sourcePath "$rowPath.firstApplicableRetryWrite is not declared" }
         Assert-StringArray $row['requiredActions'] "$rowPath.requiredActions" $sourcePath $true | Out-Null
         Assert-StringValue $row['workingFiles'] "$rowPath.workingFiles" $sourcePath
         Assert-StringValue $row['branchIdentity'] "$rowPath.branchIdentity" $sourcePath
         Assert-NullableString $row['durableResult'] "$rowPath.durableResult" $sourcePath
         Assert-NullableString $row['outcome'] "$rowPath.outcome" $sourcePath
         Assert-NullableString $row['exitClass'] "$rowPath.exitClass" $sourcePath
-        if ($null -ne $row['exitClass'] -and (Get-DeclaredEnumValues $enums 'exitClass' $sourcePath) -cnotcontains $row['exitClass']) { Fail-Contract $sourcePath "$rowPath.exitClass is not declared" }
+        if ($null -ne $row['exitClass'] -and -not (Test-OrdinalStringInCollection (Get-DeclaredEnumValues $enums 'exitClass' $sourcePath) $row['exitClass'])) { Fail-Contract $sourcePath "$rowPath.exitClass is not declared" }
         Assert-NullableBoolean $row['doctorGuidance'] "$rowPath.doctorGuidance" $sourcePath
         if (Test-ExactDictionaryKey $row 'resultingMarker') { Assert-StringValue $row['resultingMarker'] "$rowPath.resultingMarker" $sourcePath }
         if (Test-ExactDictionaryKey $row 'nextRows') {

--- a/scripts/tests/WduLifecycleContract.Tests.ps1
+++ b/scripts/tests/WduLifecycleContract.Tests.ps1
@@ -82,6 +82,8 @@ try {
         [IO.File]::Copy($canonicalPath, $copy, $true)
         $contract = Read-WduLifecycleContract -Path $copy
         Assert-True ($contract.RowIds.Count -eq 67) 'the canonical lifecycle has 67 rows'
+        Assert-True ($contract.RowsById.Count -eq 67) 'the row index has one exact entry for every parsed row'
+        Assert-True ($contract.RowIds.Count -eq $contract.RowsById.Count) 'the returned row IDs and row index have equal cardinality'
         Assert-True ($contract.ApplicabilityKeys.Count -eq 254) 'the canonical lifecycle has 254 disjoint applicability keys'
         Assert-True ($contract.Digest -match '^[0-9a-f]{64}$') 'the normalized digest is lowercase SHA-256'
     }
@@ -147,12 +149,39 @@ try {
         }
     }
 
+    Invoke-Case 'rejects a rows object that PowerShell could enumerate' {
+        $copy = New-CanonicalCopy 'rows-object'
+        $text = [regex]::Replace((Get-TestText $copy), '(?s)"rows":\s*\[.*?\]\s*\n\}', '"rows": {"id":"not-an-array"}' + "`n}", 1)
+        Set-TestText $copy $text
+        try { Read-WduLifecycleContract $copy | Out-Null }
+        catch {
+            Assert-True $_.Exception.Message.Contains($copy, [StringComparison]::Ordinal) 'rows diagnostic includes the canonical path'
+            Assert-True $_.Exception.Message.Contains('rows must be a JSON array', [StringComparison]::Ordinal) 'rows diagnostic names the raw array requirement'
+            return
+        }
+        throw 'Expected a rows-object failure'
+    }
+
     foreach ($mutation in @(
         @{ Name = 'unknown root property'; Old = '"schema": "grace.wdu.branch-lifecycle/v1",'; New = '"schema": "grace.wdu.branch-lifecycle/v1", "unknown": true,'; Reason = 'unknown property' },
         @{ Name = 'wrong token kind'; Old = '"doctorCommand": "grace doctor --repair-local-state"'; New = '"doctorCommand": true'; Reason = 'doctorCommand must be a JSON string' },
         @{ Name = 'duplicate case property'; Old = '"schema": "grace.wdu.branch-lifecycle/v1",'; New = '"schema": "grace.wdu.branch-lifecycle/v1", "Schema": "x",'; Reason = 'duplicate case-equivalent' },
         @{ Name = 'nested duplicate case property'; Old = '"invocation":{"kind":"one","value":"initial"}'; New = '"invocation":{"kind":"one","Kind":"one","value":"initial"}'; Reason = 'duplicate case-equivalent' },
         @{ Name = 'grammar shape wrong token kind'; Old = '"kind":"one","value":"<concrete-enum-member>"'; New = '"kind":"one","value":true'; Reason = 'jsonShape.value must be a JSON string' }
+    )) {
+        Invoke-Case $mutation.Name {
+            $copy = New-CanonicalCopy $mutation.Name.Replace(' ', '-')
+            Set-TestText $copy (Replace-Once (Get-TestText $copy) $mutation.Old $mutation.New)
+            Assert-Fails { Read-WduLifecycleContract $copy } $mutation.Reason
+        }
+    }
+
+    foreach ($mutation in @(
+        @{ Name = 'wrong-case root property'; Old = '"schema": "grace.wdu.branch-lifecycle/v1"'; New = '"Schema": "grace.wdu.branch-lifecycle/v1"'; Reason = "unknown property 'Schema'" },
+        @{ Name = 'wrong-case row property'; Old = '"id":"WDU-LC-200"'; New = '"Id":"WDU-LC-200"'; Reason = "unknown property 'Id'" },
+        @{ Name = 'wrong-case predicate property'; Old = '"invocation":{"kind":"one","value":"initial"}'; New = '"invocation":{"Kind":"one","value":"initial"}'; Reason = "unknown property 'Kind'" },
+        @{ Name = 'wrong-case optional resulting marker'; Old = '"resultingMarker":"exact"'; New = '"ResultingMarker":"exact"'; Reason = "unknown property 'ResultingMarker'" },
+        @{ Name = 'wrong-case optional next rows'; Old = '"nextRows":["WDU-LC-207","WDU-LC-208"'; New = '"NextRows":["WDU-LC-207","WDU-LC-208"'; Reason = "unknown property 'NextRows'" }
     )) {
         Invoke-Case $mutation.Name {
             $copy = New-CanonicalCopy $mutation.Name.Replace(' ', '-')
@@ -180,7 +209,9 @@ try {
     foreach ($mutation in @(
         @{ Name = 'duplicate applicability'; Old = '"trigger":{"kind":"one","value":"exactSameOperationAdoption"},"marker":{"kind":"one","value":"exact"}'; New = '"trigger":{"kind":"one","value":"missingMarkerFreshAdmission"},"marker":{"kind":"one","value":"missing"}'; Reason = "rows 'WDU-LC-200' and 'WDU-LC-201'" },
         @{ Name = 'duplicate row ID'; Old = '"id":"WDU-LC-201"'; New = '"id":"WDU-LC-200"'; Reason = "duplicate row ID 'WDU-LC-200'" },
+        @{ Name = 'case-equivalent row ID'; Old = '"id":"WDU-LC-201"'; New = '"id":"wdu-lc-200"'; Reason = "duplicate row ID 'wdu-lc-200'" },
         @{ Name = 'dangling graph target'; Old = '"WDU-LC-207","WDU-LC-208"'; New = '"WDU-LC-missing","WDU-LC-208"'; Reason = 'dangling nextRows target' },
+        @{ Name = 'wrong-case graph target'; Old = '"WDU-LC-207","WDU-LC-208"'; New = '"wdu-lc-207","WDU-LC-208"'; Reason = 'dangling nextRows target' },
         @{ Name = 'routing terminal result'; Old = '"outcome":null,"exitClass":null,"doctorGuidance":null,"resultingMarker":"exact","nextRows"'; New = '"outcome":"Updated","exitClass":null,"doctorGuidance":null,"resultingMarker":"exact","nextRows"'; Reason = 'routing row must not have an outcome' },
         @{ Name = 'routing without successor'; Old = '"doctorGuidance":null,"resultingMarker":"exact","nextRows":["WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-211","WDU-LC-212"]'; New = '"doctorGuidance":null,"resultingMarker":"exact"'; Reason = 'terminal row must have an outcome' },
         @{ Name = 'terminal successor'; Old = '"doctorGuidance":true},'; New = '"doctorGuidance":true,"nextRows":["WDU-LC-203"]},'; Reason = 'routing row must not have an outcome' }
@@ -189,6 +220,20 @@ try {
             $copy = New-CanonicalCopy $mutation.Name.Replace(' ', '-')
             Set-TestText $copy (Replace-Once (Get-TestText $copy) $mutation.Old $mutation.New)
             Assert-Fails { Read-WduLifecycleContract $copy } $mutation.Reason
+        }
+    }
+
+    foreach ($predicateToken in @('true', '[]', '"initial"', 'null')) {
+        Invoke-Case "wrapper reports a scoped non-object predicate $predicateToken" {
+            $copy = New-CanonicalCopy ('predicate-token-' + [guid]::NewGuid().ToString('N'))
+            Set-TestText $copy (Replace-Once (Get-TestText $copy) '"invocation":{"kind":"one","value":"initial"}' ('"invocation":' + $predicateToken))
+            $wrapper = Join-Path $repositoryRoot 'scripts/validate-wdu-lifecycle-contract.ps1'
+            $diagnostic = & pwsh -NoProfile -File $wrapper -Path $copy 2>&1
+            Assert-True ($LASTEXITCODE -ne 0) 'wrapper exits nonzero for a non-object predicate'
+            $message = $diagnostic -join "`n"
+            Assert-True ($message.Contains($copy, [StringComparison]::Ordinal)) 'wrapper diagnostic includes the file path'
+            Assert-True ($message.Contains('row WDU-LC-200.invocation', [StringComparison]::Ordinal)) 'wrapper diagnostic includes the row and axis'
+            Assert-True ($message.Contains('must be a predicate object with kind', [StringComparison]::Ordinal)) 'wrapper diagnostic includes the reason'
         }
     }
 

--- a/scripts/tests/WduLifecycleContract.Tests.ps1
+++ b/scripts/tests/WduLifecycleContract.Tests.ps1
@@ -1,0 +1,211 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$modulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleContract.psm1'
+$canonicalPath = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
+
+Import-Module $modulePath -Force
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw "Assertion failed: $Message" }
+}
+
+function Invoke-Case {
+    param([string] $Name, [scriptblock] $Body)
+    try {
+        & $Body
+        $script:Passed++
+        Write-Host "PASS $Name"
+    }
+    catch {
+        $script:Failed++
+        Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+function Write-TestDocument {
+    param([string] $Path, [string] $Content)
+    [IO.File]::WriteAllText($Path, $Content, [Text.UTF8Encoding]::new($false))
+}
+
+function New-CanonicalCopy {
+    param([string] $Name)
+    $path = Join-Path $script:TestRoot "$Name.md"
+    [IO.File]::Copy($canonicalPath, $path, $true)
+    return $path
+}
+
+function Get-TestText {
+    param([string] $Path)
+    return [IO.File]::ReadAllText($Path)
+}
+
+function Set-TestText {
+    param([string] $Path, [string] $Text)
+    Write-TestDocument $Path $Text
+}
+
+function Replace-Once {
+    param([string] $Text, [string] $Old, [string] $New)
+    $index = $Text.IndexOf($Old, [StringComparison]::Ordinal)
+    if ($index -lt 0) { throw "Test anchor not found: $Old" }
+    return $Text.Remove($index, $Old.Length).Insert($index, $New)
+}
+
+function Assert-Fails {
+    param([scriptblock] $Body, [string] $Contains)
+    try { & $Body | Out-Null }
+    catch {
+        Assert-True $_.Exception.Message.Contains($Contains, [StringComparison]::Ordinal) "failure should contain '$Contains'"
+        return
+    }
+    throw "Expected failure containing '$Contains'"
+}
+
+$script:Passed = 0
+$script:Failed = 0
+$script:TestRoot = Join-Path ([IO.Path]::GetTempPath()) ("wdu-lifecycle-contract-" + [guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($script:TestRoot) | Out-Null
+
+try {
+    Invoke-Case 'exports only the contract reader' {
+        $exports = @(Get-Command -Module WduLifecycleContract | Select-Object -ExpandProperty Name)
+        Assert-True ($exports.Count -eq 1 -and $exports[0] -ceq 'Read-WduLifecycleContract') 'module exports only Read-WduLifecycleContract'
+    }
+
+    Invoke-Case 'compiles the canonical contract through a path with spaces and Unicode' {
+        $directory = Join-Path $script:TestRoot 'path with spaces é'
+        [IO.Directory]::CreateDirectory($directory) | Out-Null
+        $copy = Join-Path $directory 'canonical lifecycle.md'
+        [IO.File]::Copy($canonicalPath, $copy, $true)
+        $contract = Read-WduLifecycleContract -Path $copy
+        Assert-True ($contract.RowIds.Count -eq 67) 'the canonical lifecycle has 67 rows'
+        Assert-True ($contract.ApplicabilityKeys.Count -eq 254) 'the canonical lifecycle has 254 disjoint applicability keys'
+        Assert-True ($contract.Digest -match '^[0-9a-f]{64}$') 'the normalized digest is lowercase SHA-256'
+    }
+
+    Invoke-Case 'normalizes LF and CRLF only for the digest' {
+        $lf = New-CanonicalCopy 'lf'; $crlf = New-CanonicalCopy 'crlf'
+        $text = (Get-TestText $lf).Replace("`r`n", "`n").Replace("`r", "`n")
+        Set-TestText $lf $text
+        Set-TestText $crlf $text.Replace("`n", "`r`n")
+        Assert-True ((Read-WduLifecycleContract $lf).Digest -ceq (Read-WduLifecycleContract $crlf).Digest) 'line ending variants have one digest'
+    }
+
+    Invoke-Case 'a structurally valid semantic edit compiles and changes the digest' {
+        $copy = New-CanonicalCopy 'semantic-edit'
+        $original = Read-WduLifecycleContract $copy
+        Set-TestText $copy (Replace-Once (Get-TestText $copy) 'retainMarkerEvidence' 'retainedMarkerEvidence')
+        $changed = Read-WduLifecycleContract $copy
+        Assert-True ($changed.Digest -cne $original.Digest) 'semantic data change changes the digest'
+        Assert-True ($changed.RowIds.Count -eq 67) 'semantic data change remains structurally compilable'
+    }
+
+    Invoke-Case 'ignores unrelated fenced JSON values and malformed samples' {
+        $copy = New-CanonicalCopy 'unrelated-json'
+        $samples = @(
+            ('```json' + "`n" + '[]' + "`n" + '```'), ('```json' + "`n" + '42' + "`n" + '```'),
+            ('```json' + "`n" + 'null' + "`n" + '```'), ('```json' + "`n" + '{' + "`n" + '```'),
+            ('```json' + "`n" + '{"schema":"grace.wdu.branch-lifecycle/v1"}' + "`n" + '```'), ('```json' + "`n`n" + '```')
+        )
+        Set-TestText $copy ((Get-TestText $copy) + "`n# Unicode outside block: é`n" + ($samples -join "`n"))
+        $contract = Read-WduLifecycleContract $copy
+        Assert-True ($contract.ApplicabilityKeys.Count -eq 254) 'unrelated JSON never participates in object parsing'
+    }
+
+    Invoke-Case 'leaves input bytes unchanged on success and failure' {
+        $success = New-CanonicalCopy 'read-only-success'; $failure = New-CanonicalCopy 'read-only-failure'
+        $beforeSuccess = (Get-FileHash -LiteralPath $success -Algorithm SHA256).Hash
+        Read-WduLifecycleContract $success | Out-Null
+        Assert-True ($beforeSuccess -ceq (Get-FileHash -LiteralPath $success -Algorithm SHA256).Hash) 'success is read-only'
+        Set-TestText $failure ((Get-TestText $failure).Replace('<!-- grace:wdu-lifecycle-contract:end -->', ''))
+        $beforeFailure = (Get-FileHash -LiteralPath $failure -Algorithm SHA256).Hash
+        Assert-Fails { Read-WduLifecycleContract $failure } 'marker pair'
+        Assert-True ($beforeFailure -ceq (Get-FileHash -LiteralPath $failure -Algorithm SHA256).Hash) 'failure is read-only'
+    }
+
+    foreach ($markerCase in @(
+        @{ Name = 'missing markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-contract:start -->', '') }; Reason = 'marker pair' },
+        @{ Name = 'duplicate markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-contract:start -->', "<!-- grace:wdu-lifecycle-contract:start -->`n<!-- grace:wdu-lifecycle-contract:start -->") }; Reason = 'marker pair' },
+        @{ Name = 'reversed markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-contract:start -->', '<!-- temporary marker -->').Replace('<!-- grace:wdu-lifecycle-contract:end -->', '<!-- grace:wdu-lifecycle-contract:start -->').Replace('<!-- temporary marker -->', '<!-- grace:wdu-lifecycle-contract:end -->') }; Reason = 'markers are reversed' }
+    )) {
+        Invoke-Case $markerCase.Name {
+            $copy = New-CanonicalCopy $markerCase.Name.Replace(' ', '-')
+            Set-TestText $copy (& $markerCase.Mutate (Get-TestText $copy))
+            Assert-Fails { Read-WduLifecycleContract $copy } $markerCase.Reason
+        }
+    }
+
+    foreach ($payload in @('[]', '42', 'null', '{')) {
+        Invoke-Case "rejects marked non-object or malformed JSON $payload" {
+            $copy = New-CanonicalCopy ('payload-' + [guid]::NewGuid().ToString('N'))
+            $text = [regex]::Replace((Get-TestText $copy), '(?s)(?<=```json\n)\{.*?(?=\n```)', $payload, 1)
+            Set-TestText $copy $text
+            Assert-Fails { Read-WduLifecycleContract $copy } 'marked'
+        }
+    }
+
+    foreach ($mutation in @(
+        @{ Name = 'unknown root property'; Old = '"schema": "grace.wdu.branch-lifecycle/v1",'; New = '"schema": "grace.wdu.branch-lifecycle/v1", "unknown": true,'; Reason = 'unknown property' },
+        @{ Name = 'wrong token kind'; Old = '"doctorCommand": "grace doctor --repair-local-state"'; New = '"doctorCommand": true'; Reason = 'doctorCommand must be a JSON string' },
+        @{ Name = 'duplicate case property'; Old = '"schema": "grace.wdu.branch-lifecycle/v1",'; New = '"schema": "grace.wdu.branch-lifecycle/v1", "Schema": "x",'; Reason = 'duplicate case-equivalent' },
+        @{ Name = 'nested duplicate case property'; Old = '"invocation":{"kind":"one","value":"initial"}'; New = '"invocation":{"kind":"one","Kind":"one","value":"initial"}'; Reason = 'duplicate case-equivalent' },
+        @{ Name = 'grammar shape wrong token kind'; Old = '"kind":"one","value":"<concrete-enum-member>"'; New = '"kind":"one","value":true'; Reason = 'jsonShape.value must be a JSON string' }
+    )) {
+        Invoke-Case $mutation.Name {
+            $copy = New-CanonicalCopy $mutation.Name.Replace(' ', '-')
+            Set-TestText $copy (Replace-Once (Get-TestText $copy) $mutation.Old $mutation.New)
+            Assert-Fails { Read-WduLifecycleContract $copy } $mutation.Reason
+        }
+    }
+
+    foreach ($mutation in @(
+        @{ Name = 'unknown predicate value'; Old = '"value":"initial"'; New = '"value":"unknown"'; Reason = 'is not declared' },
+        @{ Name = 'unknown predicate kind'; Old = '"invocation":{"kind":"one","value":"initial"}'; New = '"invocation":{"kind":"wildcard","value":"initial"}'; Reason = 'unknown predicate kind' },
+        @{ Name = 'empty predicate set'; Old = '"values":["differentOperation","malformed","unsupported","unreadable","exactCleanupFailed"]'; New = '"values":[]'; Reason = 'must not be empty' },
+        @{ Name = 'duplicate predicate set'; Old = '"values":["differentOperation","malformed","unsupported","unreadable","exactCleanupFailed"]'; New = '"values":["differentOperation","differentOperation"]'; Reason = 'duplicate value' },
+        @{ Name = 'cross axis aggregate'; Old = '"marker":{"kind":"aggregate","name":"none"}'; New = '"marker":{"kind":"aggregate","name":"persisted"}'; Reason = 'is not declared' },
+        @{ Name = 'missing aggregate'; Old = '"marker":{"kind":"aggregate","name":"none"}'; New = '"marker":{"kind":"aggregate","name":"missing"}'; Reason = 'is not declared' },
+        @{ Name = 'malformed predicate shape'; Old = '"invocation":{"kind":"one","value":"initial"}'; New = '"invocation":{"kind":"one","values":["initial"]}'; Reason = 'unknown property' }
+    )) {
+        Invoke-Case $mutation.Name {
+            $copy = New-CanonicalCopy $mutation.Name.Replace(' ', '-')
+            Set-TestText $copy (Replace-Once (Get-TestText $copy) $mutation.Old $mutation.New)
+            Assert-Fails { Read-WduLifecycleContract $copy } $mutation.Reason
+        }
+    }
+
+    foreach ($mutation in @(
+        @{ Name = 'duplicate applicability'; Old = '"trigger":{"kind":"one","value":"exactSameOperationAdoption"},"marker":{"kind":"one","value":"exact"}'; New = '"trigger":{"kind":"one","value":"missingMarkerFreshAdmission"},"marker":{"kind":"one","value":"missing"}'; Reason = "rows 'WDU-LC-200' and 'WDU-LC-201'" },
+        @{ Name = 'duplicate row ID'; Old = '"id":"WDU-LC-201"'; New = '"id":"WDU-LC-200"'; Reason = "duplicate row ID 'WDU-LC-200'" },
+        @{ Name = 'dangling graph target'; Old = '"WDU-LC-207","WDU-LC-208"'; New = '"WDU-LC-missing","WDU-LC-208"'; Reason = 'dangling nextRows target' },
+        @{ Name = 'routing terminal result'; Old = '"outcome":null,"exitClass":null,"doctorGuidance":null,"resultingMarker":"exact","nextRows"'; New = '"outcome":"Updated","exitClass":null,"doctorGuidance":null,"resultingMarker":"exact","nextRows"'; Reason = 'routing row must not have an outcome' },
+        @{ Name = 'routing without successor'; Old = '"doctorGuidance":null,"resultingMarker":"exact","nextRows":["WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-211","WDU-LC-212"]'; New = '"doctorGuidance":null,"resultingMarker":"exact"'; Reason = 'terminal row must have an outcome' },
+        @{ Name = 'terminal successor'; Old = '"doctorGuidance":true},'; New = '"doctorGuidance":true,"nextRows":["WDU-LC-203"]},'; Reason = 'routing row must not have an outcome' }
+    )) {
+        Invoke-Case $mutation.Name {
+            $copy = New-CanonicalCopy $mutation.Name.Replace(' ', '-')
+            Set-TestText $copy (Replace-Once (Get-TestText $copy) $mutation.Old $mutation.New)
+            Assert-Fails { Read-WduLifecycleContract $copy } $mutation.Reason
+        }
+    }
+
+    Invoke-Case 'thin wrapper returns a success model and a nonzero diagnostic' {
+        $wrapper = Join-Path $repositoryRoot 'scripts/validate-wdu-lifecycle-contract.ps1'
+        $success = & pwsh -NoProfile -File $wrapper -Path $canonicalPath 2>&1
+        Assert-True ($LASTEXITCODE -eq 0) 'wrapper succeeds for canonical contract'
+        Assert-True (($success -join "`n").Contains('WDU-LC-200', [StringComparison]::Ordinal)) 'wrapper projects the model'
+        $failure = New-CanonicalCopy 'wrapper-failure'; Set-TestText $failure ((Get-TestText $failure).Replace('<!-- grace:wdu-lifecycle-contract:end -->', ''))
+        $diagnostic = & pwsh -NoProfile -File $wrapper -Path $failure 2>&1
+        Assert-True ($LASTEXITCODE -ne 0) 'wrapper exits nonzero for invalid contract'
+        Assert-True (($diagnostic -join "`n").Contains('marker pair', [StringComparison]::Ordinal)) 'wrapper projects concise diagnostic'
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $script:TestRoot) { Remove-Item -LiteralPath $script:TestRoot -Recurse -Force }
+}
+
+Write-Host "Result: $script:Passed passed; $script:Failed failed"
+if ($script:Failed -ne 0) { exit 1 }

--- a/scripts/tests/WduLifecycleContract.Tests.ps1
+++ b/scripts/tests/WduLifecycleContract.Tests.ps1
@@ -206,6 +206,32 @@ try {
         }
     }
 
+    Invoke-Case 'rejects a wrong-case predicate kind with the canonical predicate location' {
+        $copy = New-CanonicalCopy 'wrong-case-predicate-kind'
+        Set-TestText $copy (Replace-Once (Get-TestText $copy) '"invocation":{"kind":"one","value":"initial"}' '"invocation":{"kind":"One","value":"initial"}')
+        try { Read-WduLifecycleContract $copy | Out-Null }
+        catch {
+            Assert-True $_.Exception.Message.Contains($copy, [StringComparison]::Ordinal) 'predicate-kind diagnostic includes the canonical path'
+            Assert-True $_.Exception.Message.Contains('row WDU-LC-200.invocation', [StringComparison]::Ordinal) 'predicate-kind diagnostic includes the row and axis'
+            Assert-True $_.Exception.Message.Contains("unknown predicate kind 'One'", [StringComparison]::Ordinal) 'predicate-kind diagnostic names the exact discriminator'
+            return
+        }
+        throw 'Expected a wrong-case predicate-kind failure'
+    }
+
+    Invoke-Case 'rejects a wrong-case ordered applicability axis with the canonical overlap location' {
+        $copy = New-CanonicalCopy 'wrong-case-applicability-axis'
+        Set-TestText $copy (Replace-Once (Get-TestText $copy) '"applicabilityKey": ["invocation"' '"applicabilityKey": ["Invocation"')
+        try { Read-WduLifecycleContract $copy | Out-Null }
+        catch {
+            Assert-True $_.Exception.Message.Contains($copy, [StringComparison]::Ordinal) 'applicability-axis diagnostic includes the canonical path'
+            Assert-True $_.Exception.Message.Contains('machineGrammar.overlap.applicabilityKey', [StringComparison]::Ordinal) 'applicability-axis diagnostic includes the overlap declaration'
+            Assert-True $_.Exception.Message.Contains('predicate axes', [StringComparison]::Ordinal) 'applicability-axis diagnostic names the ordered-axis requirement'
+            return
+        }
+        throw 'Expected a wrong-case applicability-axis failure'
+    }
+
     foreach ($mutation in @(
         @{ Name = 'duplicate applicability'; Old = '"trigger":{"kind":"one","value":"exactSameOperationAdoption"},"marker":{"kind":"one","value":"exact"}'; New = '"trigger":{"kind":"one","value":"missingMarkerFreshAdmission"},"marker":{"kind":"one","value":"missing"}'; Reason = "rows 'WDU-LC-200' and 'WDU-LC-201'" },
         @{ Name = 'duplicate row ID'; Old = '"id":"WDU-LC-201"'; New = '"id":"WDU-LC-200"'; Reason = "duplicate row ID 'WDU-LC-200'" },

--- a/scripts/validate-wdu-lifecycle-contract.ps1
+++ b/scripts/validate-wdu-lifecycle-contract.ps1
@@ -1,0 +1,12 @@
+[CmdletBinding()]
+param([Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Path)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'modules/WduLifecycleContract.psm1') -Force
+try { Read-WduLifecycleContract -Path $Path }
+catch {
+    [Console]::Error.WriteLine($_.Exception.Message)
+    exit 1
+}


### PR DESCRIPTION
# Summary

Compile and structurally lint the one canonical Working Directory Update lifecycle JSON block without duplicating its product semantics.

This gives later Branch implementation work a deterministic mechanical input while leaving semantic specification changes to normal review and runtime proof.

## Changes

- Add exact lifecycle-block markers to the canonical specification.
- Add a read-only `Read-WduLifecycleContract` PowerShell module interface.
- Add a thin validation command.
- Add focused proof for markers, JSON structure, declared grammar, predicate expansion, graph shape, unrelated JSON content, deterministic digest, and read-only behavior.

## Quality contract

Product V1 development tooling. The compiler intentionally does not interpret action, outcome, cleanup, publication, Branch, working-file, exit, or repair semantics. Projection generation remains #890.

## Validation

- Focused compiler suite: 32/32.
- PowerShell parse: module, wrapper, and tests pass.
- Direct canonical result: 67 rows and 254 unique applicability keys.
- MarkdownLint: 0 errors.
- Local links: 0 local links, 0 failures.
- `git diff --check`: clean.
- Root user-owned documentation state: preserved.

## Scope

Four declared paths changed. No ADR, `CONTEXT.md`, runtime source, projection behavior, prose scanning, file output, network access, or tracker mutation was added.

## Review status

- Head: `c48c5ba60f363493ed0751ad08dcce0447a34271`.
- Fresh exact-head review and GitHub Validate will run concurrently.
- First implementation worker; first-pass self-review reported ready.

Part of #889 and epic #835.
