### PR TITLE
Generate exact Working Directory Update lifecycle projections

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,8 @@ The accepted, Plan-ready design for a Grace-controlled operation that will chang
 durable local state to match one selected server root, then commit caller-specific progress only after verifying that
 match. After implementation, Branch switching, Watch current-Reference replay, and Connect retrieval will use this
 shared operation while retaining their own admission and presentation policies.
+Its canonical lifecycle rows and nine generated consumer projections are checked as one exact offline packet before
+later implementation starts.
 _Avoid_: WorkingDirectoryMaterialization, exact materialization, caller-owned filesystem transaction
 
 **FileManifest**:

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -1,6 +1,6 @@
 # Working Directory Update
 
-**Status:** Design-ready; implementation projections pending
+**Status:** Plan-ready; exact lifecycle projection packet validated
 **Quality contract:** Product V1
 **Canonical source:** `docs/Working Directory Update.md`
 **Evidence current through:** 2026-08-12, epic base `ff6305130c6bf18c6db0aa1096a251e64a4041d5`
@@ -253,11 +253,30 @@ Each row has one primary implementation owner even when companion issues prove a
 
 Static validation parses the fenced JSON and its closed grammar, rejects unknown or malformed predicates, expands every
 Cartesian cell, rejects overlap, and verifies row, outcome, marker, and cancellation coverage. It also asserts every
-`FinalizationIncomplete` row has a nonzero exit and Doctor guidance. Issue #882 must consume these declarations without
-inventing wildcard or precedence rules. Behavioral proof must use production-reachable persisted facts and
+`FinalizationIncomplete` row has a nonzero exit and Doctor guidance. Issue #890 consumes these declarations through one
+exact assignment plan without inventing wildcard or precedence rules. Behavioral proof must use production-reachable persisted facts and
 deterministic seams; source-string assertions, sleeps, and impossible hand-built states are insufficient.
 
-The following consumers remain pending projections rather than competing authorities:
+<!-- grace:wdu-lifecycle-projection-plan:start -->
+```json
+{
+  "schema": "grace.wdu.lifecycle-projection-plan/v1",
+  "assignments": [
+    {"artifact":"adr-0011","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-023","WDU-LC-025","WDU-LC-026","WDU-LC-030","WDU-LC-033","WDU-LC-035","WDU-LC-036","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"],"proof":"Record the lasting Branch transaction lifecycle and reference canonical rows without copying their order."},
+    {"artifact":"epic-835","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-030","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"],"proof":"Keep the epic dependency and requirement packet aligned with the sole canonical lifecycle."},
+    {"artifact":"issue-842","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-100","WDU-LC-101","WDU-LC-102","WDU-LC-103","WDU-LC-104","WDU-LC-105","WDU-LC-106","WDU-LC-107","WDU-LC-108","WDU-LC-109","WDU-LC-115","WDU-LC-116","WDU-LC-110","WDU-LC-111","WDU-LC-112","WDU-LC-113","WDU-LC-114","WDU-LC-120","WDU-LC-121","WDU-LC-122","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-141","WDU-LC-142","WDU-LC-143","WDU-LC-003"],"proof":"Prove Branch-only Doctor retry, refusal, cancellation boundaries, terminal replay, and no working-file mutation."},
+    {"artifact":"issue-843","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-003","WDU-LC-100","WDU-LC-101","WDU-LC-103"],"proof":"Consume the completed Branch lifecycle while deferring the first real Watch producer and retry proof to this issue."},
+    {"artifact":"issue-846","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-030","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"],"proof":"Audit the completed 17/9 packet, public outcomes, Doctor guidance, and removal of competing lifecycle paths."},
+    {"artifact":"issue-869","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-203","WDU-LC-204","WDU-LC-205","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-211","WDU-LC-212","WDU-LC-010","WDU-LC-011","WDU-LC-012","WDU-LC-013","WDU-LC-014","WDU-LC-015","WDU-LC-100"],"proof":"Persist typed selection and marker facts that select canonical admission, refusal, cleanup, and retry rows."},
+    {"artifact":"issue-870","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-203","WDU-LC-204","WDU-LC-205","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-211","WDU-LC-212","WDU-LC-001","WDU-LC-005","WDU-LC-002","WDU-LC-004","WDU-LC-006","WDU-LC-010","WDU-LC-011","WDU-LC-012","WDU-LC-013","WDU-LC-014","WDU-LC-015","WDU-LC-026","WDU-LC-027","WDU-LC-036","WDU-LC-037","WDU-LC-100","WDU-LC-101","WDU-LC-102","WDU-LC-103","WDU-LC-115","WDU-LC-116","WDU-LC-140","WDU-LC-141","WDU-LC-142","WDU-LC-143","WDU-LC-003"],"proof":"Implement exact-root DirectoryVersion switching with fresh planning, mutation boundaries, retry, and current-Branch retention."},
+    {"artifact":"issue-871","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-020","WDU-LC-021","WDU-LC-022","WDU-LC-023","WDU-LC-024","WDU-LC-025","WDU-LC-030","WDU-LC-031","WDU-LC-032","WDU-LC-033","WDU-LC-034","WDU-LC-035","WDU-LC-100","WDU-LC-101","WDU-LC-102","WDU-LC-103","WDU-LC-104","WDU-LC-105","WDU-LC-106","WDU-LC-107","WDU-LC-108","WDU-LC-109","WDU-LC-110","WDU-LC-111","WDU-LC-112","WDU-LC-113","WDU-LC-114","WDU-LC-120","WDU-LC-121","WDU-LC-122","WDU-LC-123","WDU-LC-130","WDU-LC-003"],"proof":"Implement repeatable Reference previous, selected, and third-state finalization with truthful retry outcomes."},
+    {"artifact":"issue-872","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-211","WDU-LC-212","WDU-LC-001","WDU-LC-005","WDU-LC-002","WDU-LC-004","WDU-LC-006","WDU-LC-003"],"proof":"Prove Save and no-Save admission preserve one sealed baseline and action token through the final pre-mutation reread."}
+  ]
+}
+```
+<!-- grace:wdu-lifecycle-projection-plan:end -->
+
+The following consumers carry generated projections rather than competing lifecycle sequences:
 
 - #869 persists selection and marker predicates.
 - #870 proves initial-run and cancellation rows.
@@ -267,9 +286,9 @@ The following consumers remain pending projections rather than competing authori
 - #843–#845 later consume the transaction contract for Watch and Connect.
 - #846 audits public output, Doctor guidance, row references, and absence of retired paths.
 
-ADR 0011 and active issue bodies remain contextual consumers until their #882 projections cite row IDs. They must not be
-treated as lifecycle ordering authority. This document returns to Plan-ready only after those projections validate
-against the machine-readable block.
+ADR 0011 and active issue bodies remain contextual consumers. The #890 checker validates only their exact
+marker-delimited projections and ignores surrounding Markdown or prose. This document is Plan-ready after the complete
+exported packet validates against the compiled canonical block.
 
 The bounded Product V1 residual risk remains interruption after working-tree mutation but before SQLite local
 completion. `WDU-LC-002` requires truthful `UpdateIncomplete` and fresh revalidation; Grace does not guess, roll back,

--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -1,6 +1,6 @@
 # Working Directory Update
 
-**Status:** Plan-ready; exact lifecycle projection packet validated
+**Status:** Plan-ready; structural and projection proof boundaries declared
 **Quality contract:** Product V1
 **Canonical source:** `docs/Working Directory Update.md`
 **Evidence current through:** 2026-08-12, epic base `ff6305130c6bf18c6db0aa1096a251e64a4041d5`
@@ -64,9 +64,8 @@ in lifecycle evidence.
 ## 4. Normative Branch lifecycle table
 
 This fenced JSON block is the sole normative lifecycle ordering contract. Human prose, ADRs, implementation issues, and
-tests cite `WDU-LC-*` row IDs; they must not restate or reorder the transition sequence. Its `machineGrammar` closes the
-predicate language; consumers such as #882 parse that grammar and must not infer aliases, wildcard behavior, or row
-precedence.
+tests cite `WDU-LC-*` row IDs; they must not restate or reorder the transition sequence. #889 checks its closed
+structural grammar, graph, and canonical digest; consumers must not infer aliases, wildcard behavior, or row precedence.
 
 <!-- grace:wdu-lifecycle-contract:start -->
 ```json
@@ -251,11 +250,11 @@ Each row has one primary implementation owner even when companion issues prove a
 
 ## 6. Proof, propagation, and readiness
 
-Static validation parses the fenced JSON and its closed grammar, rejects unknown or malformed predicates, expands every
-Cartesian cell, rejects overlap, and verifies row, outcome, marker, and cancellation coverage. It also asserts every
-`FinalizationIncomplete` row has a nonzero exit and Doctor guidance. Issue #890 consumes these declarations through one
-exact assignment plan without inventing wildcard or precedence rules. Behavioral proof must use production-reachable persisted facts and
-deterministic seams; source-string assertions, sleeps, and impossible hand-built states are insufficient.
+Issue #889 checks the closed structural grammar, graph, and canonical digest. Issue #890 checks exact generated projections and
+required packet membership without inventing wildcard or precedence rules. Neither tool establishes lifecycle meaning;
+normal review and later runtime proof remain responsible for the behavior of outcomes, marker handling, cancellation,
+and Doctor guidance. Behavioral proof must use production-reachable persisted facts and deterministic seams;
+source-string assertions, sleeps, and impossible hand-built states are insufficient.
 
 <!-- grace:wdu-lifecycle-projection-plan:start -->
 ```json
@@ -287,8 +286,9 @@ The following consumers carry generated projections rather than competing lifecy
 - #846 audits public output, Doctor guidance, row references, and absence of retired paths.
 
 ADR 0011 and active issue bodies remain contextual consumers. The #890 checker validates only their exact
-marker-delimited projections and ignores surrounding Markdown or prose. This document is Plan-ready after the complete
-exported packet validates against the compiled canonical block.
+marker-delimited projections and required packet membership, ignoring surrounding Markdown or prose. The Plan-ready
+boundary is the closed structural proof from #889 plus the exact-projection proof from #890; normal review and later
+runtime proof establish lifecycle meaning.
 
 The bounded Product V1 residual risk remains interruption after working-tree mutation but before SQLite local
 completion. `WDU-LC-002` requires truthful `UpdateIncomplete` and fresh revalidation; Grace does not guess, roll back,

--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -57,6 +57,53 @@ justify three local-integrity implementations.
 The complete requirements, state model, propagation map, and proof contract are in
 [Working Directory Update](../Working%20Directory%20Update.md).
 
+## Lifecycle projection
+
+<!-- grace:wdu-lifecycle-projection:start -->
+```json
+{
+  "schema": "grace.wdu.lifecycle-projection/v1",
+  "artifact": "adr-0011",
+  "canonical": "docs/Working Directory Update.md#normative-branch-lifecycle-table",
+  "canonicalContentDigest": "901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7",
+  "rowIds": [
+    "WDU-LC-200",
+    "WDU-LC-201",
+    "WDU-LC-202",
+    "WDU-LC-206",
+    "WDU-LC-207",
+    "WDU-LC-208",
+    "WDU-LC-209",
+    "WDU-LC-210",
+    "WDU-LC-212",
+    "WDU-LC-006",
+    "WDU-LC-010",
+    "WDU-LC-015",
+    "WDU-LC-020",
+    "WDU-LC-023",
+    "WDU-LC-025",
+    "WDU-LC-026",
+    "WDU-LC-030",
+    "WDU-LC-033",
+    "WDU-LC-035",
+    "WDU-LC-036",
+    "WDU-LC-100",
+    "WDU-LC-101",
+    "WDU-LC-103",
+    "WDU-LC-110",
+    "WDU-LC-114",
+    "WDU-LC-120",
+    "WDU-LC-123",
+    "WDU-LC-130",
+    "WDU-LC-140",
+    "WDU-LC-143",
+    "WDU-LC-003"
+  ],
+  "proof": "Record the lasting Branch transaction lifecycle and reference canonical rows without copying their order."
+}
+```
+<!-- grace:wdu-lifecycle-projection:end -->
+
 ## Consequences
 
 The module becomes deep: a small typed interface hides cross-process serialization, stale-state rejection, fresh

--- a/scripts/check-wdu-lifecycle-projections.ps1
+++ b/scripts/check-wdu-lifecycle-projections.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param(
+    [string] $CanonicalPath = (Join-Path $PSScriptRoot '../docs/Working Directory Update.md'),
+    [Parameter(Mandatory, ValueFromRemainingArguments)][ValidateNotNullOrEmpty()][string[]] $ArtifactPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'modules/WduLifecycleProjection.psm1') -Force
+Test-WduLifecycleProjection -CanonicalPath $CanonicalPath -ArtifactPath $ArtifactPath

--- a/scripts/get-wdu-lifecycle-projection.ps1
+++ b/scripts/get-wdu-lifecycle-projection.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param(
+    [string] $CanonicalPath = (Join-Path $PSScriptRoot '../docs/Working Directory Update.md'),
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Artifact
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'modules/WduLifecycleProjection.psm1') -Force
+Write-Output (New-WduLifecycleProjection -CanonicalPath $CanonicalPath -Artifact $Artifact)

--- a/scripts/modules/WduLifecycleProjection.psm1
+++ b/scripts/modules/WduLifecycleProjection.psm1
@@ -1,0 +1,280 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'WduLifecycleContract.psm1') -Force
+
+$script:PlanStartMarker = '<!-- grace:wdu-lifecycle-projection-plan:start -->'
+$script:PlanEndMarker = '<!-- grace:wdu-lifecycle-projection-plan:end -->'
+$script:ProjectionStartMarker = '<!-- grace:wdu-lifecycle-projection:start -->'
+$script:ProjectionEndMarker = '<!-- grace:wdu-lifecycle-projection:end -->'
+$script:PlanSchema = 'grace.wdu.lifecycle-projection-plan/v1'
+$script:ProjectionSchema = 'grace.wdu.lifecycle-projection/v1'
+
+function Fail-Projection {
+    param([string] $Subject, [string] $Reason)
+    throw "WDU lifecycle projection '$Subject': $Reason"
+}
+
+function Normalize-LineEndings {
+    param([string] $Text)
+    return $Text.Replace("`r`n", "`n").Replace("`r", "`n")
+}
+
+function Get-OrdinalIndexes {
+    param([string] $Text, [string] $Value)
+    $indexes = [Collections.Generic.List[int]]::new()
+    $offset = 0
+    while ($offset -le ($Text.Length - $Value.Length)) {
+        $index = $Text.IndexOf($Value, $offset, [StringComparison]::Ordinal)
+        if ($index -lt 0) { break }
+        $indexes.Add($index)
+        $offset = $index + $Value.Length
+    }
+    return @($indexes)
+}
+
+function Get-SingleMarkedBlock {
+    param([string] $Text, [string] $StartMarker, [string] $EndMarker, [string] $Subject)
+    $starts = @(Get-OrdinalIndexes $Text $StartMarker)
+    $ends = @(Get-OrdinalIndexes $Text $EndMarker)
+    if ($starts.Count -ne 1 -or $ends.Count -ne 1) {
+        Fail-Projection $Subject 'requires one exact projection marker pair'
+    }
+    $contentStart = $starts[0] + $StartMarker.Length
+    if ($ends[0] -le $contentStart) { Fail-Projection $Subject 'projection markers are reversed' }
+    return [pscustomobject]@{
+        Block = $Text.Substring($starts[0], ($ends[0] + $EndMarker.Length) - $starts[0])
+        Content = $Text.Substring($contentStart, $ends[0] - $contentStart)
+    }
+}
+
+function Get-FencedJson {
+    param([string] $Content, [string] $Subject)
+    $trimmed = $Content.Trim()
+    $prefix = '```json' + "`n"
+    $suffix = "`n" + '```'
+    if (-not $trimmed.StartsWith($prefix, [StringComparison]::Ordinal) -or -not $trimmed.EndsWith($suffix, [StringComparison]::Ordinal)) {
+        Fail-Projection $Subject 'marked payload must be one exact fenced JSON object'
+    }
+    return $trimmed.Substring($prefix.Length, $trimmed.Length - $prefix.Length - $suffix.Length)
+}
+
+function Assert-NoDuplicateJsonProperties {
+    param([string] $Json, [string] $Subject)
+    try { $document = [Text.Json.JsonDocument]::Parse($Json) }
+    catch { Fail-Projection $Subject "marked JSON is malformed: $($_.Exception.Message)" }
+    try {
+        $visit = $null
+        $visit = {
+            param([Text.Json.JsonElement] $Element, [string] $Location)
+            if ($Element.ValueKind -eq [Text.Json.JsonValueKind]::Object) {
+                $names = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+                foreach ($property in $Element.EnumerateObject()) {
+                    if (-not $names.Add($property.Name)) {
+                        Fail-Projection $Subject "$Location has duplicate case-equivalent property '$($property.Name)'"
+                    }
+                    & $visit $property.Value "$Location.$($property.Name)"
+                }
+            }
+            elseif ($Element.ValueKind -eq [Text.Json.JsonValueKind]::Array) {
+                $index = 0
+                foreach ($item in $Element.EnumerateArray()) {
+                    & $visit $item "$Location[$index]"
+                    $index++
+                }
+            }
+        }
+        & $visit $document.RootElement '$'
+        if ($document.RootElement.ValueKind -ne [Text.Json.JsonValueKind]::Object) {
+            Fail-Projection $Subject 'marked JSON must be an object'
+        }
+    }
+    finally { $document.Dispose() }
+}
+
+function ConvertFrom-ExactJsonObject {
+    param([string] $Content, [string] $Subject)
+    $json = Get-FencedJson $Content $Subject
+    Assert-NoDuplicateJsonProperties $json $Subject
+    try { return $json | ConvertFrom-Json -AsHashtable -Depth 32 }
+    catch { Fail-Projection $Subject "marked JSON cannot be decoded: $($_.Exception.Message)" }
+}
+
+function Test-ExactKey {
+    param([System.Collections.IDictionary] $Value, [string] $Name)
+    foreach ($key in $Value.Keys) {
+        if ([StringComparer]::Ordinal.Equals([string] $key, $Name)) { return $true }
+    }
+    return $false
+}
+
+function Assert-ExactObjectProperties {
+    param([object] $Value, [string[]] $Names, [string] $Location, [string] $Subject)
+    if ($Value -isnot [System.Collections.IDictionary]) { Fail-Projection $Subject "$Location must be a JSON object" }
+    $expected = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($name in $Names) { $null = $expected.Add($name) }
+    foreach ($key in $Value.Keys) {
+        if (-not $expected.Contains([string] $key)) { Fail-Projection $Subject "$Location has unknown property '$key'" }
+    }
+    foreach ($name in $Names) {
+        if (-not (Test-ExactKey $Value $name)) { Fail-Projection $Subject "$Location is missing property '$name'" }
+    }
+}
+
+function Assert-NonBlankString {
+    param([object] $Value, [string] $Location, [string] $Subject)
+    if ($Value -isnot [string] -or [string]::IsNullOrWhiteSpace($Value)) {
+        Fail-Projection $Subject "$Location must be a nonblank JSON string"
+    }
+}
+
+function Test-LowercaseSha256 {
+    param([string] $Value)
+    if ($Value.Length -ne 64) { return $false }
+    foreach ($character in $Value.ToCharArray()) {
+        if (($character -lt '0' -or $character -gt '9') -and ($character -lt 'a' -or $character -gt 'f')) { return $false }
+    }
+    return $true
+}
+
+function Get-StringArray {
+    param([object] $Value, [string] $Location, [string] $Subject)
+    if ($Value -is [string] -or $Value -is [System.Collections.IDictionary] -or $Value -isnot [System.Collections.IEnumerable]) {
+        Fail-Projection $Subject "$Location must be a nonempty JSON array of strings"
+    }
+    $values = @($Value)
+    if ($values.Count -eq 0) { Fail-Projection $Subject "$Location must be a nonempty JSON array of strings" }
+    foreach ($value in $values) { Assert-NonBlankString $value "$Location[]" $Subject }
+    return [string[]] $values
+}
+
+function Find-Assignment {
+    param([object[]] $Assignments, [string] $Artifact, [string] $Subject)
+    foreach ($assignment in $Assignments) {
+        if ([StringComparer]::Ordinal.Equals($assignment.Artifact, $Artifact)) { return $assignment }
+    }
+    Fail-Projection $Subject "has unexpected artifact '$Artifact'"
+}
+
+function Read-WduLifecycleProjectionPlan {
+    param([string] $CanonicalPath, [object] $Compiled)
+    $resolved = [IO.Path]::GetFullPath($CanonicalPath)
+    $text = Normalize-LineEndings ([IO.File]::ReadAllText($resolved))
+    $marked = Get-SingleMarkedBlock $text $script:PlanStartMarker $script:PlanEndMarker $resolved
+    $plan = ConvertFrom-ExactJsonObject $marked.Content $resolved
+    Assert-ExactObjectProperties $plan @('schema', 'assignments') '$' $resolved
+    Assert-NonBlankString $plan['schema'] '$.schema' $resolved
+    if (-not [StringComparer]::Ordinal.Equals($plan['schema'], $script:PlanSchema)) {
+        Fail-Projection $resolved "$.schema must equal '$script:PlanSchema'"
+    }
+    if ($plan['assignments'] -is [string] -or $plan['assignments'] -is [System.Collections.IDictionary] -or $plan['assignments'] -isnot [System.Collections.IEnumerable]) {
+        Fail-Projection $resolved '$.assignments must be a JSON array'
+    }
+    $rawAssignments = @($plan['assignments'])
+    if ($rawAssignments.Count -ne 9) { Fail-Projection $resolved '$.assignments must contain the complete nine-artifact packet' }
+    $knownRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($rowId in $Compiled.RowIds) { $null = $knownRows.Add($rowId) }
+    $coveredRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $artifacts = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $assignments = [Collections.Generic.List[object]]::new()
+    foreach ($raw in $rawAssignments) {
+        Assert-ExactObjectProperties $raw @('artifact', 'canonical', 'canonicalContentDigest', 'rowIds', 'proof') '$.assignments[]' $resolved
+        foreach ($name in @('artifact', 'canonical', 'canonicalContentDigest', 'proof')) {
+            Assert-NonBlankString $raw[$name] "$.assignments[].$name" $resolved
+        }
+        if (-not $artifacts.Add($raw['artifact'])) { Fail-Projection $resolved "$.assignments contains duplicate artifact '$($raw['artifact'])'" }
+        if (-not (Test-LowercaseSha256 $raw['canonicalContentDigest'])) {
+            Fail-Projection $resolved '$.assignments[].canonicalContentDigest must be a lowercase SHA-256 digest'
+        }
+        if (-not [StringComparer]::Ordinal.Equals($raw['canonicalContentDigest'], $Compiled.Digest)) {
+            Fail-Projection $resolved "$.assignments[].canonicalContentDigest is stale for '$($raw['artifact'])'"
+        }
+        $rowIds = @(Get-StringArray $raw['rowIds'] '$.assignments[].rowIds' $resolved)
+        $assignedRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+        foreach ($rowId in $rowIds) {
+            if (-not $knownRows.Contains($rowId)) { Fail-Projection $resolved "$.assignments[] has unknown row ID '$rowId'" }
+            if (-not $assignedRows.Add($rowId)) { Fail-Projection $resolved "$.assignments[] has duplicate row ID '$rowId'" }
+            $null = $coveredRows.Add($rowId)
+        }
+        $assignments.Add([pscustomobject]@{
+                Artifact = [string] $raw['artifact']
+                Canonical = [string] $raw['canonical']
+                CanonicalContentDigest = [string] $raw['canonicalContentDigest']
+                RowIds = [string[]] $rowIds
+                Proof = [string] $raw['proof']
+            })
+    }
+    foreach ($rowId in $Compiled.RowIds) {
+        if (-not $coveredRows.Contains($rowId)) { Fail-Projection $resolved "$.assignments does not cover canonical row ID '$rowId'" }
+    }
+    return @($assignments)
+}
+
+function New-ProjectionText {
+    param([object] $Assignment)
+    $projection = [ordered]@{
+        schema = $script:ProjectionSchema
+        artifact = $Assignment.Artifact
+        canonical = $Assignment.Canonical
+        canonicalContentDigest = $Assignment.CanonicalContentDigest
+        rowIds = @($Assignment.RowIds)
+        proof = $Assignment.Proof
+    }
+    $json = $projection | ConvertTo-Json -Depth 4
+    return $script:ProjectionStartMarker + "`n" + '```json' + "`n$json`n" + '```' + "`n" + $script:ProjectionEndMarker
+}
+
+function Get-ProjectionArtifact {
+    param([string] $Content, [string] $Subject)
+    $projection = ConvertFrom-ExactJsonObject $Content $Subject
+    if ($projection -isnot [System.Collections.IDictionary] -or -not (Test-ExactKey $projection 'artifact')) {
+        Fail-Projection $Subject "projection is missing property 'artifact'"
+    }
+    Assert-NonBlankString $projection['artifact'] '$.artifact' $Subject
+    return [string] $projection['artifact']
+}
+
+function New-WduLifecycleProjection {
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $CanonicalPath,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Artifact
+    )
+    $compiled = Read-WduLifecycleContract -Path $CanonicalPath
+    $assignments = @(Read-WduLifecycleProjectionPlan -CanonicalPath $CanonicalPath -Compiled $compiled)
+    $assignment = Find-Assignment $assignments $Artifact $CanonicalPath
+    return New-ProjectionText $assignment
+}
+
+function Test-WduLifecycleProjection {
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $CanonicalPath,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]] $ArtifactPath
+    )
+    $compiled = Read-WduLifecycleContract -Path $CanonicalPath
+    $assignments = @(Read-WduLifecycleProjectionPlan -CanonicalPath $CanonicalPath -Compiled $compiled)
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $pathsByArtifact = [Collections.Generic.Dictionary[string, string]]::new([StringComparer]::Ordinal)
+    foreach ($path in $ArtifactPath) {
+        $resolved = [IO.Path]::GetFullPath($path)
+        $text = Normalize-LineEndings ([IO.File]::ReadAllText($resolved))
+        $marked = Get-SingleMarkedBlock $text $script:ProjectionStartMarker $script:ProjectionEndMarker $resolved
+        $artifact = Get-ProjectionArtifact $marked.Content $resolved
+        if (-not $seen.Add($artifact)) { Fail-Projection $resolved "packet contains duplicate artifact '$artifact'" }
+        $assignment = Find-Assignment $assignments $artifact $resolved
+        $expected = Normalize-LineEndings (New-ProjectionText $assignment)
+        if (-not [StringComparer]::Ordinal.Equals($marked.Block, $expected)) {
+            Fail-Projection $resolved "artifact '$artifact' does not equal its exact generated projection"
+        }
+        $pathsByArtifact.Add($artifact, $resolved)
+    }
+    foreach ($assignment in $assignments) {
+        if (-not $seen.Contains($assignment.Artifact)) {
+            Fail-Projection $CanonicalPath "packet is missing required artifact '$($assignment.Artifact)'"
+        }
+    }
+    foreach ($assignment in $assignments) {
+        [pscustomobject]@{ Artifact = $assignment.Artifact; Path = $pathsByArtifact[$assignment.Artifact]; Result = 'ExactMatch' }
+    }
+}
+
+Export-ModuleMember -Function New-WduLifecycleProjection, Test-WduLifecycleProjection

--- a/scripts/modules/WduLifecycleProjection.psm1
+++ b/scripts/modules/WduLifecycleProjection.psm1
@@ -9,6 +9,17 @@ $script:ProjectionStartMarker = '<!-- grace:wdu-lifecycle-projection:start -->'
 $script:ProjectionEndMarker = '<!-- grace:wdu-lifecycle-projection:end -->'
 $script:PlanSchema = 'grace.wdu.lifecycle-projection-plan/v1'
 $script:ProjectionSchema = 'grace.wdu.lifecycle-projection/v1'
+$script:RequiredArtifactIds = @(
+    'adr-0011',
+    'epic-835',
+    'issue-842',
+    'issue-843',
+    'issue-846',
+    'issue-869',
+    'issue-870',
+    'issue-871',
+    'issue-872'
+)
 
 function Fail-Projection {
     param([string] $Subject, [string] $Reason)
@@ -177,12 +188,17 @@ function Read-WduLifecycleProjectionPlan {
     $coveredRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
     $artifacts = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
     $assignments = [Collections.Generic.List[object]]::new()
+    $assignmentIndex = 0
     foreach ($raw in $rawAssignments) {
         Assert-ExactObjectProperties $raw @('artifact', 'canonical', 'canonicalContentDigest', 'rowIds', 'proof') '$.assignments[]' $resolved
         foreach ($name in @('artifact', 'canonical', 'canonicalContentDigest', 'proof')) {
             Assert-NonBlankString $raw[$name] "$.assignments[].$name" $resolved
         }
         if (-not $artifacts.Add($raw['artifact'])) { Fail-Projection $resolved "$.assignments contains duplicate artifact '$($raw['artifact'])'" }
+        $requiredArtifact = $script:RequiredArtifactIds[$assignmentIndex]
+        if (-not [StringComparer]::Ordinal.Equals($raw['artifact'], $requiredArtifact)) {
+            Fail-Projection $resolved "$.assignments must declare required artifact '$requiredArtifact' at ordinal $($assignmentIndex + 1), not '$($raw['artifact'])'"
+        }
         if (-not (Test-LowercaseSha256 $raw['canonicalContentDigest'])) {
             Fail-Projection $resolved '$.assignments[].canonicalContentDigest must be a lowercase SHA-256 digest'
         }
@@ -203,6 +219,7 @@ function Read-WduLifecycleProjectionPlan {
                 RowIds = [string[]] $rowIds
                 Proof = [string] $raw['proof']
             })
+        $assignmentIndex++
     }
     foreach ($rowId in $Compiled.RowIds) {
         if (-not $coveredRows.Contains($rowId)) { Fail-Projection $resolved "$.assignments does not cover canonical row ID '$rowId'" }

--- a/scripts/tests/WduLifecycleProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleProjection.Tests.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet('All', 'PlanCore', 'PlanNegativeA', 'PlanNegativeB', 'PlanNegativeC', 'PlanMarkers', 'Marker', 'DriftA', 'DriftB', 'DriftC', 'PacketA', 'PacketB')]
+    [ValidateSet('All', 'PlanCore', 'PlanNegativeA', 'PlanNegativeB', 'PlanNegativeC', 'RequiredPacket', 'PlanMarkers', 'Marker', 'DriftA', 'DriftB', 'DriftC', 'PacketA', 'PacketAEmpty', 'PacketB', 'PacketBReadOnly', 'PacketBCommands')]
     [string] $Group = 'All'
 )
 
@@ -140,6 +140,24 @@ try {
             Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } $case.Reason
         }
     }
+
+    }
+
+    if ($Group -in @('All', 'RequiredPacket')) {
+    Invoke-Case 'rejects a renamed required assignment artifact' {
+        $packet = New-Packet 'renamed-required-assignment-artifact'
+        Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-872"' '"artifact":"issue-999"')
+        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-872'"
+    }
+
+    Invoke-Case 'rejects reordered required assignment artifacts' {
+        $packet = New-Packet 'reordered-required-assignment-artifacts'
+        $reordered = Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-870"' '"artifact":"temporary-ordering-artifact"'
+        $reordered = Replace-Once $reordered '"artifact":"issue-871"' '"artifact":"issue-870"'
+        $reordered = Replace-Once $reordered '"artifact":"temporary-ordering-artifact"' '"artifact":"issue-871"'
+        Write-TestText $packet.Canonical $reordered
+        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-870'"
+    }
     }
 
     if ($Group -in @('All', 'PlanMarkers')) {
@@ -215,6 +233,9 @@ try {
         Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths + $unexpected) } 'unexpected artifact'
     }
 
+    }
+
+    if ($Group -in @('All', 'PacketAEmpty')) {
     Invoke-Case 'accepts empty content outside the exact projection markers' {
         $packet = New-Packet 'empty outside content'
         foreach ($path in $packet.Paths) {
@@ -230,7 +251,7 @@ try {
 
     }
 
-    if ($Group -in @('All', 'PacketB')) {
+    if ($Group -in @('All', 'PacketB', 'PacketBReadOnly')) {
 
     Invoke-Case 'leaves every input byte unchanged on success and failure' {
         $packet = New-Packet 'read only packet'
@@ -251,6 +272,9 @@ try {
         }
     }
 
+    }
+
+    if ($Group -in @('All', 'PacketB', 'PacketBCommands')) {
     Invoke-Case 'thin commands generate byte-identical stdout and check a complete offline packet' {
         $packet = New-Packet 'thin commands packet'
         $first = Join-Path $packet.Root 'first stdout.bin'

--- a/scripts/tests/WduLifecycleProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleProjection.Tests.ps1
@@ -1,0 +1,273 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('All', 'PlanCore', 'PlanNegativeA', 'PlanNegativeB', 'PlanNegativeC', 'PlanMarkers', 'Marker', 'DriftA', 'DriftB', 'DriftC', 'PacketA', 'PacketB')]
+    [string] $Group = 'All'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$modulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleProjection.psm1'
+$canonicalSource = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
+$getCommand = Join-Path $repositoryRoot 'scripts/get-wdu-lifecycle-projection.ps1'
+$checkCommand = Join-Path $repositoryRoot 'scripts/check-wdu-lifecycle-projections.ps1'
+$artifactIds = @('adr-0011', 'epic-835', 'issue-842', 'issue-843', 'issue-846', 'issue-869', 'issue-870', 'issue-871', 'issue-872')
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw "Assertion failed: $Message" }
+}
+
+function Assert-Fails {
+    param([scriptblock] $Body, [string] $Contains)
+    try { & $Body | Out-Null }
+    catch {
+        Assert-True $_.Exception.Message.Contains($Contains, [StringComparison]::Ordinal) "failure should contain '$Contains': $($_.Exception.Message)"
+        return
+    }
+    throw "Expected failure containing '$Contains'"
+}
+
+function Invoke-Case {
+    param([string] $Name, [scriptblock] $Body)
+    try {
+        & $Body
+        $script:Passed++
+        Write-Host "PASS $Name"
+    }
+    catch {
+        $script:Failed++
+        Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+function Write-TestText {
+    param([string] $Path, [string] $Text)
+    [IO.File]::WriteAllText($Path, $Text, [Text.UTF8Encoding]::new($false))
+}
+
+function Get-TestText {
+    param([string] $Path)
+    return [IO.File]::ReadAllText($Path)
+}
+
+function Replace-Once {
+    param([string] $Text, [string] $Old, [string] $New)
+    $index = $Text.IndexOf($Old, [StringComparison]::Ordinal)
+    if ($index -lt 0) { throw "Test anchor not found: $Old" }
+    return $Text.Remove($index, $Old.Length).Insert($index, $New)
+}
+
+function New-Packet {
+    param([string] $Name, [switch] $CrLf)
+    $root = Join-Path $script:TestRoot $Name
+    [IO.Directory]::CreateDirectory($root) | Out-Null
+    $canonical = Join-Path $root 'canonical lifecycle.md'
+    [IO.File]::Copy($canonicalSource, $canonical, $true)
+    $paths = [Collections.Generic.List[string]]::new()
+    foreach ($artifact in $artifactIds) {
+        $path = Join-Path $root "$artifact body.md"
+        $outside = "# arbitrary $artifact é`n`n" + '<div data-lifecycle="not interpreted">outside</div>' + "`n`n" + '```json' + "`n" + '[false, 42, {"artifact":"outside"}]' + "`n" + '```' + "`n`n" + '```text' + "`ncontradictory prose is ignored`n" + '```' + "`n"
+        $text = "$outside`n$(New-WduLifecycleProjection -CanonicalPath $canonical -Artifact $artifact)`n`n$outside"
+        if ($CrLf) { $text = $text.Replace("`r`n", "`n").Replace("`r", "`n").Replace("`n", "`r`n") }
+        Write-TestText $path $text
+        $paths.Add($path)
+    }
+    return [pscustomobject]@{ Root = $root; Canonical = $canonical; Paths = @($paths) }
+}
+
+function Get-Hashes {
+    param([string[]] $Paths)
+    return @($Paths | ForEach-Object { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
+}
+
+Import-Module $modulePath -Force
+$script:Passed = 0
+$script:Failed = 0
+$script:TestRoot = Join-Path ([IO.Path]::GetTempPath()) ('wdu-lifecycle-projection-' + [guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($script:TestRoot) | Out-Null
+
+try {
+    if ($Group -in @('All', 'PlanCore')) {
+    Invoke-Case 'exports exactly the two projection functions' {
+        $exports = @(Get-Command -Module WduLifecycleProjection | Select-Object -ExpandProperty Name | Sort-Object)
+        Assert-True (($exports -join '|') -ceq ('New-WduLifecycleProjection|Test-WduLifecycleProjection')) 'module exports only the two public functions'
+    }
+
+    Invoke-Case 'generates one deterministic ADR projection from the compiled canonical plan' {
+        $first = New-WduLifecycleProjection -CanonicalPath $canonicalSource -Artifact 'adr-0011'
+        $second = New-WduLifecycleProjection -CanonicalPath $canonicalSource -Artifact 'adr-0011'
+        Assert-True ($first -ceq $second) 'repeated in-process generation is byte-identical'
+        Assert-True $first.StartsWith('<!-- grace:wdu-lifecycle-projection:start -->', [StringComparison]::Ordinal) 'generated block starts with its exact marker'
+        Assert-True $first.EndsWith('<!-- grace:wdu-lifecycle-projection:end -->', [StringComparison]::Ordinal) 'generated block ends with its exact marker'
+        Assert-True $first.Contains('"artifact": "adr-0011"', [StringComparison]::Ordinal) 'generated block carries its artifact ID'
+    }
+
+    Invoke-Case 'checks a complete packet with paths containing spaces and Unicode in arbitrary input order' {
+        $packet = New-Packet 'paths with spaces é'
+        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths[8..0]))
+        Assert-True ($result.Count -eq 9) 'complete packet returns one scoped result per assignment'
+        Assert-True (($result | Select-Object -ExpandProperty Artifact) -join '|' -ceq ($artifactIds -join '|')) 'results are in canonical assignment order'
+    }
+
+    Invoke-Case 'normalizes LF and CRLF only while checking exact blocks' {
+        $packet = New-Packet 'crlf packet' -CrLf
+        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
+        Assert-True ($result.Count -eq 9) 'CRLF packet succeeds under the documented normalization'
+    }
+
+    }
+
+    if ($Group -in @('All', 'PlanNegativeA', 'PlanNegativeB', 'PlanNegativeC')) {
+    $planNegativeCases = @(
+            @{ Name = 'duplicate artifact assignment'; Old = '"artifact":"issue-843"'; New = '"artifact":"issue-842"'; Reason = 'duplicate artifact' },
+            @{ Name = 'duplicate assignment row ID'; Old = '"rowIds":["WDU-LC-003","WDU-LC-100","WDU-LC-101","WDU-LC-103"]'; New = '"rowIds":["WDU-LC-003","WDU-LC-100","WDU-LC-100","WDU-LC-103"]'; Reason = 'duplicate row ID' },
+            @{ Name = 'unknown assignment row ID'; Old = '"WDU-LC-027","WDU-LC-036","WDU-LC-037","WDU-LC-100"'; New = '"WDU-LC-027","WDU-LC-036","WDU-LC-999","WDU-LC-100"'; Reason = 'unknown row ID' },
+            @{ Name = 'blank assignment proof'; Old = '"proof":"Consume the completed Branch lifecycle while deferring the first real Watch producer and retry proof to this issue."'; New = '"proof":""'; Reason = 'must be a nonblank' },
+            @{ Name = 'malformed assignment digest'; Old = '901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7'; New = '901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7'; Reason = 'lowercase SHA-256' },
+            @{ Name = 'unknown assignment property'; Old = '"schema": "grace.wdu.lifecycle-projection-plan/v1",'; New = '"schema": "grace.wdu.lifecycle-projection-plan/v1", "extra": true,'; Reason = 'unknown property' },
+            @{ Name = 'incomplete assignment row coverage'; Old = ',"WDU-LC-037","WDU-LC-100"'; New = ',"WDU-LC-100"'; Reason = 'does not cover canonical row ID' }
+        )
+    $planNegativeSelected = if ($Group -eq 'PlanNegativeA') { @($planNegativeCases[0..2]) }
+    elseif ($Group -eq 'PlanNegativeB') { @($planNegativeCases[3..5]) }
+    elseif ($Group -eq 'PlanNegativeC') { @($planNegativeCases[6]) }
+    else { $planNegativeCases }
+    foreach ($case in $planNegativeSelected) {
+        Invoke-Case "rejects $($case.Name)" {
+            $packet = New-Packet ($case.Name.Replace(' ', '-'))
+            Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) $case.Old $case.New)
+            Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } $case.Reason
+        }
+    }
+    }
+
+    if ($Group -in @('All', 'PlanMarkers')) {
+    foreach ($case in @(
+            @{ Name = 'missing assignment plan marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection-plan:start -->', '') }; Reason = 'marker pair' },
+            @{ Name = 'duplicate assignment plan marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection-plan:start -->', "<!-- grace:wdu-lifecycle-projection-plan:start -->`n<!-- grace:wdu-lifecycle-projection-plan:start -->") }; Reason = 'marker pair' },
+            @{ Name = 'reversed assignment plan markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection-plan:start -->', '<!-- temporary marker -->').Replace('<!-- grace:wdu-lifecycle-projection-plan:end -->', '<!-- grace:wdu-lifecycle-projection-plan:start -->').Replace('<!-- temporary marker -->', '<!-- grace:wdu-lifecycle-projection-plan:end -->') }; Reason = 'markers are reversed' }
+        )) {
+        Invoke-Case "rejects $($case.Name)" {
+            $packet = New-Packet ($case.Name.Replace(' ', '-'))
+            Write-TestText $packet.Canonical (& $case.Mutate (Get-TestText $packet.Canonical))
+            Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } $case.Reason
+        }
+    }
+    }
+
+    if ($Group -in @('All', 'Marker')) {
+    foreach ($case in @(
+            @{ Name = 'missing projection marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection:start -->', '') }; Reason = 'marker pair' },
+            @{ Name = 'duplicate projection marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection:start -->', "<!-- grace:wdu-lifecycle-projection:start -->`n<!-- grace:wdu-lifecycle-projection:start -->") }; Reason = 'marker pair' },
+            @{ Name = 'reversed projection markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection:start -->', '<!-- temporary marker -->').Replace('<!-- grace:wdu-lifecycle-projection:end -->', '<!-- grace:wdu-lifecycle-projection:start -->').Replace('<!-- temporary marker -->', '<!-- grace:wdu-lifecycle-projection:end -->') }; Reason = 'markers are reversed' }
+        )) {
+        Invoke-Case "rejects $($case.Name)" {
+            $packet = New-Packet ($case.Name.Replace(' ', '-'))
+            Write-TestText $packet.Paths[0] (& $case.Mutate (Get-TestText $packet.Paths[0]))
+            Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths } $case.Reason
+        }
+    }
+    }
+
+    if ($Group -in @('All', 'DriftA', 'DriftB', 'DriftC')) {
+    $driftCases = @(
+            @{ Name = 'stale projection digest'; Old = '901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7'; New = '001fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7'; Reason = 'does not equal' },
+            @{ Name = 'wrong projection artifact'; Old = '"artifact": "issue-842"'; New = '"artifact": "unexpected"'; Reason = 'unexpected artifact' },
+            @{ Name = 'wrong projection anchor'; Old = 'docs/Working Directory Update.md#normative-branch-lifecycle-table'; New = 'docs/Working Directory Update.md#wrong-anchor'; Reason = 'does not equal' },
+            @{ Name = 'changed projection proof'; Old = 'Prove Branch-only Doctor retry, refusal, cancellation boundaries, terminal replay, and no working-file mutation.'; New = 'changed proof'; Reason = 'does not equal' },
+            @{ Name = 'missing projection row'; Old = "    `"WDU-LC-100`",`r`n"; New = ''; Reason = 'does not equal' },
+            @{ Name = 'extra projection row'; Old = "    `"WDU-LC-100`",`r`n"; New = "    `"WDU-LC-extra`",`r`n    `"WDU-LC-100`",`r`n"; Reason = 'does not equal' },
+            @{ Name = 'reordered projection row'; Old = "`"WDU-LC-100`",`r`n    `"WDU-LC-101`""; New = "`"WDU-LC-101`",`r`n    `"WDU-LC-100`""; Reason = 'does not equal' },
+            @{ Name = 'extra projection property'; Old = '"schema": "grace.wdu.lifecycle-projection/v1",'; New = '"schema": "grace.wdu.lifecycle-projection/v1", "extra": true,'; Reason = 'does not equal' }
+        )
+    $driftSelected = if ($Group -eq 'DriftA') { @($driftCases[0..2]) }
+    elseif ($Group -eq 'DriftB') { @($driftCases[3..5]) }
+    elseif ($Group -eq 'DriftC') { @($driftCases[6..7]) }
+    else { $driftCases }
+    foreach ($case in $driftSelected) {
+        Invoke-Case "rejects $($case.Name)" {
+            $packet = New-Packet ($case.Name.Replace(' ', '-'))
+            $target = $packet.Paths[2]
+            Write-TestText $target (Replace-Once (Get-TestText $target) $case.Old $case.New)
+            Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths } $case.Reason
+        }
+    }
+
+    }
+
+    if ($Group -in @('All', 'PacketA')) {
+
+    Invoke-Case 'requires complete packet membership before success' {
+        $packet = New-Packet 'missing packet artifact'
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths[0..7] } 'packet is missing required artifact'
+    }
+
+    Invoke-Case 'rejects a duplicate packet artifact before success' {
+        $packet = New-Packet 'duplicate packet artifact'
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths + $packet.Paths[0]) } 'duplicate artifact'
+    }
+
+    Invoke-Case 'rejects an unexpected packet artifact before success' {
+        $packet = New-Packet 'unexpected packet artifact'
+        $unexpected = Join-Path $packet.Root 'unexpected.md'
+        Write-TestText $unexpected (Replace-Once (Get-TestText $packet.Paths[2]) '"artifact": "issue-842"' '"artifact": "unexpected"')
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths + $unexpected) } 'unexpected artifact'
+    }
+
+    Invoke-Case 'accepts empty content outside the exact projection markers' {
+        $packet = New-Packet 'empty outside content'
+        foreach ($path in $packet.Paths) {
+            $text = Get-TestText $path
+            $start = $text.IndexOf('<!-- grace:wdu-lifecycle-projection:start -->', [StringComparison]::Ordinal)
+            $end = $text.IndexOf('<!-- grace:wdu-lifecycle-projection:end -->', [StringComparison]::Ordinal)
+            $block = $text.Substring($start, ($end + '<!-- grace:wdu-lifecycle-projection:end -->'.Length) - $start)
+            Write-TestText $path $block
+        }
+        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
+        Assert-True ($result.Count -eq 9) 'empty surrounding content is ignored'
+    }
+
+    }
+
+    if ($Group -in @('All', 'PacketB')) {
+
+    Invoke-Case 'leaves every input byte unchanged on success and failure' {
+        $packet = New-Packet 'read only packet'
+        $all = @($packet.Canonical) + $packet.Paths
+        $before = Get-Hashes $all
+        Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths | Out-Null
+        Assert-True ((Get-Hashes $all) -join '|' -ceq ($before -join '|')) 'successful check is read-only'
+        Write-TestText $packet.Paths[0] ((Get-TestText $packet.Paths[0]).Replace('<!-- grace:wdu-lifecycle-projection:end -->', ''))
+        $beforeFailure = Get-Hashes $all
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths } 'marker pair'
+        Assert-True ((Get-Hashes $all) -join '|' -ceq ($beforeFailure -join '|')) 'failed check is read-only'
+    }
+
+    Invoke-Case 'has no output-path parameter on the module or thin commands' {
+        foreach ($command in @('New-WduLifecycleProjection', 'Test-WduLifecycleProjection', $getCommand, $checkCommand)) {
+            $parameters = if ($command -like '*.ps1') { (Get-Command $command).Parameters.Keys } else { (Get-Command $command).Parameters.Keys }
+            Assert-True (-not ($parameters | Where-Object { $_ -match 'output|render|stage|publish' })) "$command has no output or publication parameter"
+        }
+    }
+
+    Invoke-Case 'thin commands generate byte-identical stdout and check a complete offline packet' {
+        $packet = New-Packet 'thin commands packet'
+        $first = Join-Path $packet.Root 'first stdout.bin'
+        $second = Join-Path $packet.Root 'second stdout.bin'
+        & pwsh -NoProfile -File $getCommand -CanonicalPath $packet.Canonical -Artifact 'adr-0011' > $first
+        Assert-True ($LASTEXITCODE -eq 0) 'first generator invocation succeeds'
+        & pwsh -NoProfile -File $getCommand -CanonicalPath $packet.Canonical -Artifact 'adr-0011' > $second
+        Assert-True ($LASTEXITCODE -eq 0) 'second generator invocation succeeds'
+        Assert-True ([Convert]::ToHexString([IO.File]::ReadAllBytes($first)) -ceq [Convert]::ToHexString([IO.File]::ReadAllBytes($second))) 'stdout generation is byte-identical'
+        $checked = @(& $checkCommand -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
+        Assert-True ($checked.Count -eq 9) 'thin checker returns the nine scoped results'
+    }
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $script:TestRoot) { Remove-Item -LiteralPath $script:TestRoot -Recurse -Force }
+}
+
+Write-Host "Result: $script:Passed passed; $script:Failed failed"
+if ($script:Failed -ne 0) { exit 1 }


### PR DESCRIPTION
# Summary

Generate and check exact marker-delimited Working Directory Update lifecycle projections from the compiled canonical contract.

This keeps the epic, ADR, and implementation issues mechanically aligned without interpreting arbitrary Markdown or duplicating lifecycle semantics.

## Changes

- Add one exact assignment plan to the canonical specification.
- Add a projection module with exactly two exported functions.
- Add one stdout generator and one read-only packet checker.
- Add the generated ADR projection and truthful readiness status.
- Add focused proof for plan shape, deterministic output, projection drift, packet completeness, line-ending normalization, read-only behavior, and ignored outside content.

## Quality contract

Product V1 development tooling. The tool consumes #889’s structural compiler and deliberately does not interpret lifecycle meaning, scan prose, publish files, call GitHub, or change runtime behavior.

## Validation

- Focused projection suite: 32/32.
- Prepared nine-artifact replacement packet: 9/9.
- Fresh export of the current live packet: 9/9.
- Repeated stdout generation: byte-identical.
- PowerShell parse: clean.
- MarkdownLint over the three changed Markdown files: 0 errors.
- Diff and scope checks: clean.
- Main root’s ten user-owned documentation entries: preserved.

## Scope

Seven declared paths changed. No `src/**`, compiler modification, lifecycle semantic table, prose scanner, output directory, staging/publishing behavior, network access, or tracker mutation is present.

## Tracker publication

The worker prepared complete replacement bodies and individual fragments outside the repository. The orchestrator will publish them after the fresh review starts, re-export all eight live bodies, and run the exact nine-artifact packet gate on this PR head.

## Review status

- Head: `dbbfb688dd962004dcd0c3f49fcd8010f846a719`.
- Implementation worker: 1.
- Fresh exact-head review and GitHub Validate will run concurrently.

Part of #890 and epic #835.
