### PR TITLE
Persist exact Branch update selection and marker evidence

### DIFF
--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -177,6 +177,18 @@ module LocalStateDbTests =
         cmd.CommandText <- sql
         cmd.ExecuteNonQuery() |> ignore
 
+    /// Closes every SQLite handle so a pending-finalization assertion exercises the production restart reconstruction path.
+    let private assertPendingFinalizationReopenRejects (configuration: GraceConfiguration) expectedMessage =
+        SqliteConnection.ClearAllPools()
+        LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+
+        let corruptedRead = Func<Task>(fun () -> LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile :> Task)
+
+        let thrownException = Assert.ThrowsAsync<InvalidOperationException>(corruptedRead)
+
+        thrownException.Message
+        |> should equal expectedMessage
+
     /// Allocates Watch journal sequences without adding replay semantics beyond the schema scaffold.
     let private insertWatchJournalRows (connection: SqliteConnection) throughSequence =
         [| 1L .. throughSequence |]
@@ -3857,7 +3869,7 @@ module LocalStateDbTests =
                     WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
                     |> requiredWorkingDirectoryUpdate
 
-                let previousBranchId = Guid.NewGuid()
+                let previousBranchId = configuration.BranchId
                 let selectedReferenceId = Guid.NewGuid()
 
                 let branchOperation =
@@ -4002,6 +4014,48 @@ module LocalStateDbTests =
                 | _ -> failwith "Expected the persisted hash-selected Branch finalizer after restart."
             })
 
+    /// Proves persisted DirectoryVersion selections reject when their previous Branch no longer matches the exact target Branch.
+    [<Test>]
+    let ``working directory update pending DirectoryVersion Branch corruption rejects on reopen`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "e")
+                let blake3Hash = Blake3Hash(String.replicate 64 "f")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 225L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.branchSwitchWithSelection
+                        configuration.BranchId
+                        WorkingDirectoryUpdate.BranchSelection.DirectoryVersion
+                        target
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization configuration.BranchId)
+                        target
+                        operation
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+
+                    executeNonQuery
+                        connection
+                        $"UPDATE working_directory_update_completions SET branch_previous_branch_id = '{Guid.NewGuid()}' WHERE finalization_state = 'Pending';"
+
+                assertPendingFinalizationReopenRejects
+                    configuration
+                    "Pending Branch finalization is invalid: DirectoryVersion Branch selection must retain the current Branch."
+            })
+
     /// Proves impossible persisted selector and Reference combinations reject during strict pending-row reconstruction.
     [<Test>]
     let ``working directory update pending Branch selector corruption rejects on reopen`` () =
@@ -4016,7 +4070,7 @@ module LocalStateDbTests =
                     WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
                     |> requiredWorkingDirectoryUpdate
 
-                let previousBranchId = Guid.NewGuid()
+                let previousBranchId = configuration.BranchId
                 let selectedReferenceId = Guid.NewGuid()
 
                 let operation =
@@ -4040,13 +4094,74 @@ module LocalStateDbTests =
                         connection
                         "UPDATE working_directory_update_completions SET branch_selection_kind = 'DirectoryVersion' WHERE finalization_state = 'Pending';"
 
+                    executeNonQuery connection "PRAGMA ignore_check_constraints = OFF;"
+
                 SqliteConnection.ClearAllPools()
                 LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
 
-                let corruptedRead = Func<Task>(fun () -> LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile :> Task)
+                assertPendingFinalizationReopenRejects configuration "DirectoryVersion Branch finalization must not persist a Reference id."
+            })
 
-                Assert.ThrowsAsync<InvalidOperationException>(corruptedRead)
-                |> ignore
+    /// Proves restart validation rejects independently mutated target, operation, and caller facts from an otherwise valid pending row.
+    [<TestCase("target")>]
+    [<TestCase("operation")>]
+    [<TestCase("caller")>]
+    let ``working directory update pending finalization rejects each corrupted persisted identity fact`` (corruptedFact: string) =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "a")
+                let blake3Hash = Blake3Hash(String.replicate 64 "b")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 226L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.branchSwitchWithSelection
+                        configuration.BranchId
+                        WorkingDirectoryUpdate.BranchSelection.DirectoryVersion
+                        target
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization configuration.BranchId)
+                        target
+                        operation
+
+                let expectedMessage =
+                    use connection = openRawConnection configuration.GraceStatusFile
+
+                    match corruptedFact with
+                    | "target" ->
+                        executeNonQuery
+                            connection
+                            "UPDATE working_directory_update_completions SET target_root_directory_sha256_hash = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc' WHERE finalization_state = 'Pending';"
+
+                        "Pending Working Directory Update finalization target facts do not match their canonical target."
+                    | "operation" ->
+                        executeNonQuery
+                            connection
+                            "UPDATE working_directory_update_completions SET operation_value = 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc' WHERE finalization_state = 'Pending';"
+
+                        "Pending Working Directory Update finalization facts do not match their operation identity."
+                    | "caller" ->
+                        executeNonQuery connection "PRAGMA ignore_check_constraints = ON;"
+
+                        executeNonQuery
+                            connection
+                            "UPDATE working_directory_update_completions SET caller_kind = 'Connect' WHERE finalization_state = 'Pending';"
+
+                        executeNonQuery connection "PRAGMA ignore_check_constraints = OFF;"
+                        "Connect completion must be terminal and cannot be a pending finalization."
+                    | value -> failwith $"Unexpected persisted identity fact '{value}'."
+
+                assertPendingFinalizationReopenRejects configuration expectedMessage
             })
 
     /// Verifies Connect cursor progress and its terminal completion cannot commit separately from matching local facts.
@@ -4165,9 +4280,9 @@ module LocalStateDbTests =
                 |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
             })
 
-    /// Proves completion writes reject any Branch operation whose typed selector disagrees with persisted finalization details.
+    /// Proves completion writes reject selector disagreement and the impossible DirectoryVersion target/previous-Branch tuple.
     [<Test>]
-    let ``working directory update completion rejects mismatched Branch selector on write`` () =
+    let ``working directory update completion rejects mismatched Branch selector and DirectoryVersion Branch retention on write`` () =
         withTempDir (fun _ configuration ->
             task {
                 let rootId = Guid.NewGuid()
@@ -4179,7 +4294,7 @@ module LocalStateDbTests =
                     WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
                     |> requiredWorkingDirectoryUpdate
 
-                let previousBranchId = Guid.NewGuid()
+                let previousBranchId = configuration.BranchId
                 let selectedReferenceId = Guid.NewGuid()
 
                 let directoryVersionOperation =
@@ -4221,6 +4336,30 @@ module LocalStateDbTests =
 
                 Assert.ThrowsAsync<ArgumentException>(mismatchedDirectoryVersionWrite)
                 |> ignore
+
+                let otherBranchTarget =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId (Guid.NewGuid()) rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let referenceOperationForOtherBranch =
+                    WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId otherBranchTarget
+                    |> requiredWorkingDirectoryUpdate
+
+                let invalidDirectoryVersionWrite =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization previousBranchId)
+                            otherBranchTarget
+                            referenceOperationForOtherBranch
+                        :> Task)
+
+                let thrownException = Assert.ThrowsAsync<ArgumentException>(invalidDirectoryVersionWrite)
+
+                thrownException.Message
+                |> should equal "DirectoryVersion Branch completion must retain the current Branch. (Parameter 'completionDetails')"
             })
 
     /// Verifies an injected pre-commit failure rolls back every local fact in the update completion transaction.

--- a/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
+++ b/src/Grace.CLI.Tests/LocalStateDb.Tests.fs
@@ -264,7 +264,7 @@ module LocalStateDbTests =
 
         executeNonQuery
             connection
-            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND branch_selected_reference_id IS NOT NULL AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selection_kind TEXT NULL CHECK (branch_selection_kind IN ('Reference', 'DirectoryVersion')), branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND ((branch_selection_kind = 'Reference' AND branch_selected_reference_id IS NOT NULL) OR (branch_selection_kind = 'DirectoryVersion' AND branch_selected_reference_id IS NULL)) AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
 
         executeNonQuery
             connection
@@ -2222,6 +2222,41 @@ module LocalStateDbTests =
                 corruptAfter |> should equal (corruptBefore + 1)
             })
 
+    /// Proves a complete prior v10 database is replaced instead of being read through as the v11 typed-selector shape.
+    [<Test>]
+    let ``ensureDbInitialized cleanly recreates v10 local state for typed Branch selectors`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                seedSchemaVersionOnly configuration.GraceStatusFile "10"
+
+                let corruptBefore =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                use connection = openRawConnection configuration.GraceStatusFile
+
+                executeScalarString connection "SELECT value FROM meta WHERE key = 'schema_version';"
+                |> should equal "11"
+
+                let selectorColumn =
+                    use command = connection.CreateCommand()
+
+                    command.CommandText <-
+                        "SELECT COUNT(*) FROM pragma_table_info('working_directory_update_completions') WHERE name = 'branch_selection_kind';"
+
+                    command.ExecuteScalar() |> Convert.ToInt32
+
+                selectorColumn |> should equal 1
+
+                let corruptAfter =
+                    getCorruptBackups configuration.GraceStatusFile
+                    |> Array.length
+
+                corruptAfter |> should equal (corruptBefore + 1)
+            })
+
     /// Verifies that ensure db initialized recreates db when schema v6 has a malformed Watch journal table.
     [<Test>]
     let ``ensureDbInitialized recreates DB when schema v6 watch journal shape is malformed`` () =
@@ -3850,7 +3885,7 @@ module LocalStateDbTests =
                 | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingBranchFinalization (persistedTarget,
                                                                                                           persistedOperation,
                                                                                                           persistedPreviousBranchId,
-                                                                                                          persistedSelectedReferenceId)) ->
+                                                                                                          persistedSelection)) ->
                     WorkingDirectoryUpdate.Target.canonical persistedTarget
                     |> should equal (WorkingDirectoryUpdate.Target.canonical target)
 
@@ -3860,8 +3895,8 @@ module LocalStateDbTests =
                     persistedPreviousBranchId
                     |> should equal previousBranchId
 
-                    persistedSelectedReferenceId
-                    |> should equal selectedReferenceId
+                    persistedSelection
+                    |> should equal (WorkingDirectoryUpdate.BranchSelection.Reference selectedReferenceId)
                 | _ -> failwith "Expected the persisted Branch finalizer after restart."
 
                 do! LocalStateDb.finalizeWorkingDirectoryUpdateCompletion configuration.GraceStatusFile target branchOperation
@@ -3913,6 +3948,104 @@ module LocalStateDbTests =
                 let alteredRead = Func<Task>(fun () -> LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile :> Task)
 
                 Assert.ThrowsAsync<InvalidOperationException>(alteredRead)
+                |> ignore
+            })
+
+    /// Proves reopening a hash-selected Branch finalization retains its typed no-Reference selector.
+    [<Test>]
+    let ``working directory update pending finalization reconstructs DirectoryVersion Branch selection after restart`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "c")
+                let blake3Hash = Blake3Hash(String.replicate 64 "d")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 224L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let previousBranchId = configuration.BranchId
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion target
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization previousBranchId)
+                        target
+                        operation
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+                do! LocalStateDb.ensureDbInitialized configuration.GraceStatusFile
+
+                let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile
+
+                match pending with
+                | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingBranchFinalization (persistedTarget,
+                                                                                                          persistedOperation,
+                                                                                                          persistedPreviousBranchId,
+                                                                                                          WorkingDirectoryUpdate.BranchSelection.DirectoryVersion)) ->
+                    persistedPreviousBranchId
+                    |> should equal previousBranchId
+
+                    WorkingDirectoryUpdate.Target.canonical persistedTarget
+                    |> should equal (WorkingDirectoryUpdate.Target.canonical target)
+
+                    WorkingDirectoryUpdate.Operation.value persistedOperation
+                    |> should equal (WorkingDirectoryUpdate.Operation.value operation)
+                | _ -> failwith "Expected the persisted hash-selected Branch finalizer after restart."
+            })
+
+    /// Proves impossible persisted selector and Reference combinations reject during strict pending-row reconstruction.
+    [<Test>]
+    let ``working directory update pending Branch selector corruption rejects on reopen`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "e")
+                let blake3Hash = Blake3Hash(String.replicate 64 "f")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 225L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let previousBranchId = Guid.NewGuid()
+                let selectedReferenceId = Guid.NewGuid()
+
+                let operation =
+                    WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target
+                    |> requiredWorkingDirectoryUpdate
+
+                let! _ =
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        configuration.GraceStatusFile
+                        status
+                        [ rootDirectory ]
+                        (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(previousBranchId, selectedReferenceId))
+                        target
+                        operation
+
+                do
+                    use connection = openRawConnection configuration.GraceStatusFile
+                    executeNonQuery connection "PRAGMA ignore_check_constraints = ON;"
+
+                    executeNonQuery
+                        connection
+                        "UPDATE working_directory_update_completions SET branch_selection_kind = 'DirectoryVersion' WHERE finalization_state = 'Pending';"
+
+                SqliteConnection.ClearAllPools()
+                LocalStateDb.invalidateInitializationCacheForLocalStateRepair configuration.GraceStatusFile
+
+                let corruptedRead = Func<Task>(fun () -> LocalStateDb.readPendingWorkingDirectoryUpdateFinalization configuration.GraceStatusFile :> Task)
+
+                Assert.ThrowsAsync<InvalidOperationException>(corruptedRead)
                 |> ignore
             })
 
@@ -4030,6 +4163,64 @@ module LocalStateDbTests =
 
                 completion
                 |> should equal (Some LocalStateDb.WorkingDirectoryUpdateCompletion.Terminal)
+            })
+
+    /// Proves completion writes reject any Branch operation whose typed selector disagrees with persisted finalization details.
+    [<Test>]
+    let ``working directory update completion rejects mismatched Branch selector on write`` () =
+        withTempDir (fun _ configuration ->
+            task {
+                let rootId = Guid.NewGuid()
+                let sha256Hash = Sha256Hash(String.replicate 64 "7")
+                let blake3Hash = Blake3Hash(String.replicate 64 "8")
+                let status, rootDirectory = completionStatus configuration rootId sha256Hash blake3Hash 344L
+
+                let target =
+                    WorkingDirectoryUpdate.Target.create configuration.RepositoryId configuration.BranchId rootId sha256Hash blake3Hash
+                    |> requiredWorkingDirectoryUpdate
+
+                let previousBranchId = Guid.NewGuid()
+                let selectedReferenceId = Guid.NewGuid()
+
+                let directoryVersionOperation =
+                    WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion target
+                    |> requiredWorkingDirectoryUpdate
+
+                let referenceOperation =
+                    WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target
+                    |> requiredWorkingDirectoryUpdate
+
+                let referenceDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(previousBranchId, selectedReferenceId)
+
+                let directoryVersionDetails = LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization previousBranchId
+
+                let mismatchedReferenceWrite =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            referenceDetails
+                            target
+                            directoryVersionOperation
+                        :> Task)
+
+                let mismatchedDirectoryVersionWrite =
+                    Func<Task> (fun () ->
+                        LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                            configuration.GraceStatusFile
+                            status
+                            [ rootDirectory ]
+                            directoryVersionDetails
+                            target
+                            referenceOperation
+                        :> Task)
+
+                Assert.ThrowsAsync<ArgumentException>(mismatchedReferenceWrite)
+                |> ignore
+
+                Assert.ThrowsAsync<ArgumentException>(mismatchedDirectoryVersionWrite)
+                |> ignore
             })
 
     /// Verifies an injected pre-commit failure rolls back every local fact in the update completion transaction.

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
@@ -114,32 +114,64 @@ module WorkingDirectoryUpdateContractsTests =
         |> Result.isError
         |> should equal true
 
-    /// Proves a hash-resolved target is a typed Branch operation without inventing a Reference identity.
+    /// Proves a hash-selected Branch operation keeps its exact target identity without inventing a Reference identity.
     [<Test>]
-    let ``DirectoryVersion Branch selection binds identity to the exact target rather than a hash prefix`` () =
+    let ``DirectoryVersion Branch selection binds identity to its exact target`` () =
         let selectedTarget = selectedTarget ()
-        let previousBranchId = Guid.Parse("2c461ab1-72a0-42c3-9c2e-ea9c0c3b83de")
+        let previousBranchId = branchId
 
-        let sha256PrefixOperation =
+        let selectedTargetOperation =
             WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion selectedTarget
             |> required
 
-        let blake3PrefixOperation =
-            WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion selectedTarget
+        let differentTarget =
+            target
+                repositoryId
+                branchId
+                (Guid.Parse("e71c392d-16a8-4ec1-a759-9f1b56fe5363"))
+                (Sha256Hash "50786b40bc5f3bc9070bf49f72bbf1f8b160bb952156e3c9894438c82d03dbd9")
+                (Blake3Hash "ec938391649e1c587adcf4ddfe0b06b7a6c47df9e9812c4bea6d01a7c9eab836")
+
+        let differentTargetOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion differentTarget
             |> required
 
         let referenceOperation =
             WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId (Guid.Parse("d9622ad2-552d-4ab1-996e-2d756af82047")) selectedTarget
             |> required
 
-        WorkingDirectoryUpdate.Operation.value sha256PrefixOperation
-        |> should equal (WorkingDirectoryUpdate.Operation.value blake3PrefixOperation)
+        WorkingDirectoryUpdate.Operation.matchesTarget selectedTarget selectedTargetOperation
+        |> should equal true
 
-        WorkingDirectoryUpdate.Operation.value sha256PrefixOperation
+        WorkingDirectoryUpdate.Operation.matchesTarget differentTarget selectedTargetOperation
+        |> should equal false
+
+        WorkingDirectoryUpdate.Operation.value selectedTargetOperation
+        |> should not' (equal (WorkingDirectoryUpdate.Operation.value differentTargetOperation))
+
+        WorkingDirectoryUpdate.Operation.value selectedTargetOperation
         |> should not' (equal (WorkingDirectoryUpdate.Operation.value referenceOperation))
 
         WorkingDirectoryUpdate.Operation.branchSwitch Guid.Empty (Guid.NewGuid()) selectedTarget
         |> Result.isError
+        |> should equal true
+
+    /// Proves DirectoryVersion selection retains the current Branch while Reference selection may transition Branches.
+    [<Test>]
+    let ``DirectoryVersion Branch selection rejects a target from another Branch`` () =
+        let selectedTarget = selectedTarget ()
+
+        let otherBranchTarget = target repositoryId (Guid.Parse("c9e1d511-13b0-4a65-b2f2-0f3e0c0cd690")) rootDirectoryVersionId sha256Hash blake3Hash
+
+        WorkingDirectoryUpdate.Operation.branchSwitchWithSelection branchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion otherBranchTarget
+        |> function
+            | Error message ->
+                message
+                |> should equal "DirectoryVersion Branch selection must retain the current Branch."
+            | Ok _ -> failwith "Expected DirectoryVersion selection to reject a target from another Branch."
+
+        WorkingDirectoryUpdate.Operation.branchSwitch branchId (Guid.Parse("d9622ad2-552d-4ab1-996e-2d756af82047")) otherBranchTarget
+        |> Result.isOk
         |> should equal true
 
         WorkingDirectoryUpdate.Target.create

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
@@ -114,6 +114,30 @@ module WorkingDirectoryUpdateContractsTests =
         |> Result.isError
         |> should equal true
 
+    /// Proves a hash-resolved target is a typed Branch operation without inventing a Reference identity.
+    [<Test>]
+    let ``DirectoryVersion Branch selection binds identity to the exact target rather than a hash prefix`` () =
+        let selectedTarget = selectedTarget ()
+        let previousBranchId = Guid.Parse("2c461ab1-72a0-42c3-9c2e-ea9c0c3b83de")
+
+        let sha256PrefixOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion selectedTarget
+            |> required
+
+        let blake3PrefixOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion selectedTarget
+            |> required
+
+        let referenceOperation =
+            WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId (Guid.Parse("d9622ad2-552d-4ab1-996e-2d756af82047")) selectedTarget
+            |> required
+
+        WorkingDirectoryUpdate.Operation.value sha256PrefixOperation
+        |> should equal (WorkingDirectoryUpdate.Operation.value blake3PrefixOperation)
+
+        WorkingDirectoryUpdate.Operation.value sha256PrefixOperation
+        |> should not' (equal (WorkingDirectoryUpdate.Operation.value referenceOperation))
+
         WorkingDirectoryUpdate.Operation.branchSwitch Guid.Empty (Guid.NewGuid()) selectedTarget
         |> Result.isError
         |> should equal true
@@ -164,7 +188,7 @@ module WorkingDirectoryUpdateContractsTests =
         |> should equal "sha256:66d663c833c8a6984092cbd243d78dd7c01518aae7fa3456f234e7c7339f94f2"
 
         branchValue
-        |> should equal "sha256:e08980617e39f55a9fd1272b848b88b871bca0b11680ff4b99c5d8209518f1c2"
+        |> should equal "sha256:8c706ec29cafceeb72203b736ac4bf16112413af8a48bddf2a112d287ad520e8"
 
         connectValue |> should equal expectedConnectValue
 

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Coordination.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Coordination.Tests.fs
@@ -315,7 +315,7 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.Adopt
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
 
             let differentRootDirectoryVersion =
                 targetWith
@@ -349,7 +349,7 @@ module WorkingDirectoryUpdateCoordinationTests =
                 ] do
                 WorkingDirectoryUpdateCoordination.Marker.inspect scope differentTarget operation
                 |> fun task -> task.GetAwaiter().GetResult()
-                |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+                |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
 
             let differentOperation =
                 WorkingDirectoryUpdate.Operation.watchReplay repositoryId branchId "different-cursor"
@@ -357,7 +357,7 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget differentOperation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
 
             let persistedMarker = File.ReadAllText(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
 
@@ -369,7 +369,7 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
 
             let unsupported = persistedMarker.Replace("\"schemaVersion\":1", "\"schemaVersion\":2", StringComparison.Ordinal)
 
@@ -382,13 +382,13 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported
 
             File.WriteAllText(WorkingDirectoryUpdateCoordination.Scope.markerPath scope, "{not-json")
 
             WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.RequiresDoctor)
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported)
 
     /// Proves cleanup rereads marker ownership and never removes a replacement attempt token.
     [<Test>]
@@ -423,14 +423,116 @@ module WorkingDirectoryUpdateCoordinationTests =
 
             WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope firstToken
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal false
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.DifferentOperationEvidence
 
             File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
             |> should equal true
 
             WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope secondToken
             |> fun task -> task.GetAwaiter().GetResult()
-            |> should equal true
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
 
             File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
             |> should equal false)
+
+    /// Proves missing, damaged, and unreadable cleanup evidence is never treated as successful cleanup.
+    [<Test>]
+    let ``marker cleanup distinguishes every non-successful evidence disposition`` () =
+        withTempRoot (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let selectedTarget = target repositoryId branchId
+            let operation = branchOperation selectedTarget
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let token = WorkingDirectoryUpdate.AttemptToken.create ()
+            let markerPath = WorkingDirectoryUpdateCoordination.Scope.markerPath scope
+
+            WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.Missing
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker
+
+            Directory.CreateDirectory(Path.GetDirectoryName(markerPath))
+            |> ignore
+
+            File.WriteAllText(markerPath, "{not-json")
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.MalformedOrUnsupportedEvidence
+
+            let marker =
+                WorkingDirectoryUpdateCoordination.Marker.create scope token selectedTarget operation
+                |> required
+
+            WorkingDirectoryUpdateCoordination.Marker.write scope marker
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            use markerHandle = new FileStream(markerPath, FileMode.Open, FileAccess.Read, FileShare.None)
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope token
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.UnreadableEvidence)
+
+    /// Proves an unreadable marker is preserved rather than treated as missing or adoptable evidence.
+    [<Test>]
+    let ``marker inspection distinguishes unreadable evidence`` () =
+        withTempRoot (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let selectedTarget = target repositoryId branchId
+            let operation = branchOperation selectedTarget
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let marker =
+                WorkingDirectoryUpdateCoordination.Marker.create scope (WorkingDirectoryUpdate.AttemptToken.create ()) selectedTarget operation
+                |> required
+
+            WorkingDirectoryUpdateCoordination.Marker.write scope marker
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            use markerHandle = new FileStream(WorkingDirectoryUpdateCoordination.Scope.markerPath scope, FileMode.Open, FileAccess.Read, FileShare.None)
+
+            WorkingDirectoryUpdateCoordination.Marker.inspect scope selectedTarget operation
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerInspection.Unreadable)
+
+    /// Proves a matching marker remains visible when exact-token cleanup cannot delete its current file.
+    [<Test>]
+    let ``marker cleanup distinguishes exact cleanup failure`` () =
+        withTempRoot (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let selectedTarget = target repositoryId branchId
+            let operation = branchOperation selectedTarget
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let token = WorkingDirectoryUpdate.AttemptToken.create ()
+
+            let marker =
+                WorkingDirectoryUpdateCoordination.Marker.create scope token selectedTarget operation
+                |> required
+
+            WorkingDirectoryUpdateCoordination.Marker.write scope marker
+            |> fun task -> task.GetAwaiter().GetResult()
+
+            WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwnedWithDelete scope token (fun _ ->
+                raise (IOException("forced portable marker deletion failure")))
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactCleanupFailed
+
+            File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
+            |> should equal true)

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
@@ -29,11 +29,22 @@ module internal WorkingDirectoryUpdateCoordination =
         interface IDisposable with
             member _.Dispose() = stream.Dispose()
 
-    /// Names the only marker inspection outcomes callers may use before planning a fresh update.
+    /// Names every persisted marker disposition that decides whether an update may plan, adopt, or must preserve evidence.
     type MarkerInspection =
         | Missing
-        | Adopt
-        | RequiresDoctor
+        | ExactMatch
+        | DifferentOperation
+        | MalformedOrUnsupported
+        | Unreadable
+
+    /// Names the exact cleanup result so callers never mistake foreign or damaged evidence for successful removal.
+    type MarkerCleanup =
+        | NoMarker
+        | ExactMatchCleaned
+        | DifferentOperationEvidence
+        | MalformedOrUnsupportedEvidence
+        | UnreadableEvidence
+        | ExactCleanupFailed
 
     /// Holds one versioned marker record written only while its scope lease is held.
     type internal MarkerDocument =
@@ -343,11 +354,11 @@ module internal WorkingDirectoryUpdateCoordination =
                 File.WriteAllText(Scope.markerPath scope, serialized)
             }
 
-        /// Classifies a marker as adoptable only when its complete target, caller kind, and operation exactly match the retry.
+        /// Classifies every marker state so a caller can adopt only exact evidence and preserve all Doctor-required evidence.
         let inspect scope expectedTarget operation =
             task {
                 if not (WorkingDirectoryUpdate.Operation.matchesTarget expectedTarget operation) then
-                    return RequiresDoctor
+                    return DifferentOperation
                 else
                     let path = Scope.markerPath scope
 
@@ -364,34 +375,42 @@ module internal WorkingDirectoryUpdateCoordination =
                                 && marker.CallerKind = (WorkingDirectoryUpdate.Operation.callerKind operation
                                                         |> callerKindText)
                                 ->
-                                return Adopt
-                            | Ok _ -> return RequiresDoctor
-                            | Error _ -> return RequiresDoctor
+                                return ExactMatch
+                            | Ok _ -> return DifferentOperation
+                            | Error _ -> return MalformedOrUnsupported
                         with
                         | :? IOException
-                        | :? UnauthorizedAccessException -> return RequiresDoctor
+                        | :? UnauthorizedAccessException -> return Unreadable
             }
 
-        /// Removes a marker only after its currently persisted token exactly matches this attempt token.
-        let tryRemoveOwned scope attemptToken =
+        /// Removes a marker with an injected deletion action so portable focused proofs can force the exact cleanup-failure boundary.
+        let tryRemoveOwnedWithDelete scope attemptToken deleteMarker =
             task {
                 let path = Scope.markerPath scope
 
                 if not (File.Exists(path)) then
-                    return false
+                    return NoMarker
                 else
                     try
                         let content = File.ReadAllText(path)
 
                         match tryReadMarkerDocument scope content with
                         | Ok marker when marker.AttemptToken = WorkingDirectoryUpdate.AttemptToken.value attemptToken ->
-                            File.Delete(path)
-                            return true
-                        | _ -> return false
+                            try
+                                deleteMarker path
+                                return ExactMatchCleaned
+                            with
+                            | :? IOException
+                            | :? UnauthorizedAccessException -> return ExactCleanupFailed
+                        | Ok _ -> return DifferentOperationEvidence
+                        | Error _ -> return MalformedOrUnsupportedEvidence
                     with
                     | :? IOException
-                    | :? UnauthorizedAccessException -> return false
+                    | :? UnauthorizedAccessException -> return UnreadableEvidence
             }
+
+        /// Removes a marker only after its currently persisted token exactly matches this attempt and reports every refusal distinctly.
+        let tryRemoveOwned scope attemptToken = tryRemoveOwnedWithDelete scope attemptToken File.Delete
 
     /// Supplies derived sidecar creation without changing or deleting marker evidence.
     module Sidecar =

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -309,7 +309,8 @@ module internal WorkingDirectoryUpdateContracts =
                                 + canonicalField "selected-reference" (guidText selectedReferenceId)
                             )
                         | Error error -> Error error
-                    | DirectoryVersion -> Ok(canonicalField "branch-selection" "directory-version")
+                    | DirectoryVersion when branchId = previousBranchId -> Ok(canonicalField "branch-selection" "directory-version")
+                    | DirectoryVersion -> Error "DirectoryVersion Branch selection must retain the current Branch."
 
                 match selectionCanonical with
                 | Error error -> Error error

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -33,6 +33,11 @@ module internal WorkingDirectoryUpdateContracts =
     /// Represents the path-derived Connect scope that separates local working roots.
     type LocalRootScope = private LocalRootScope of string
 
+    /// States whether a Branch update may publish a selected Reference or must preserve the current branch identity.
+    type BranchSelection =
+        | Reference of ReferenceId
+        | DirectoryVersion
+
     /// Represents one deterministic caller-specific logical update identity.
     type Operation = private Operation of callerKind: CallerKind * target: Target option * repositoryId: RepositoryId * branchId: BranchId * value: string
 
@@ -287,25 +292,42 @@ module internal WorkingDirectoryUpdateContracts =
 
                 create Watch None repositoryId branchId canonical
 
-        /// Creates the Branch identity from branch transition, Reference, and selected target facts.
-        let branchSwitch previousBranchId selectedReferenceId target =
-            match requireId "PreviousBranchId" previousBranchId, requireId "SelectedReferenceId" selectedReferenceId with
-            | Ok previousBranchId, Ok selectedReferenceId ->
+        /// Creates the Branch identity from an exact transition Reference or an exact hash-selected target root.
+        let branchSwitchWithSelection previousBranchId selection target =
+            match requireId "PreviousBranchId" previousBranchId with
+            | Ok previousBranchId ->
                 let repositoryId = Target.repositoryId target
                 let branchId = Target.branchId target
 
-                let canonical =
-                    "grace.working-directory-update.operation.v1\n"
-                    + canonicalField "caller" "branch"
-                    + canonicalField "repository" (guidText repositoryId)
-                    + canonicalField "previous-branch" (guidText previousBranchId)
-                    + canonicalField "selected-branch" (guidText branchId)
-                    + canonicalField "selected-reference" (guidText selectedReferenceId)
-                    + canonicalField "target" (Target.canonical target)
+                let selectionCanonical =
+                    match selection with
+                    | Reference selectedReferenceId ->
+                        match requireId "SelectedReferenceId" selectedReferenceId with
+                        | Ok selectedReferenceId ->
+                            Ok(
+                                canonicalField "branch-selection" "reference"
+                                + canonicalField "selected-reference" (guidText selectedReferenceId)
+                            )
+                        | Error error -> Error error
+                    | DirectoryVersion -> Ok(canonicalField "branch-selection" "directory-version")
 
-                create Branch (Some target) repositoryId branchId canonical
-            | Error error, _ -> Error error
-            | _, Error error -> Error error
+                match selectionCanonical with
+                | Error error -> Error error
+                | Ok selectionCanonical ->
+                    let canonical =
+                        "grace.working-directory-update.operation.v1\n"
+                        + canonicalField "caller" "branch"
+                        + canonicalField "repository" (guidText repositoryId)
+                        + canonicalField "previous-branch" (guidText previousBranchId)
+                        + canonicalField "selected-branch" (guidText branchId)
+                        + selectionCanonical
+                        + canonicalField "target" (Target.canonical target)
+
+                    create Branch (Some target) repositoryId branchId canonical
+            | Error error -> Error error
+
+        /// Retains the existing private Reference-selected construction shorthand while callers migrate to typed selection.
+        let branchSwitch previousBranchId selectedReferenceId target = branchSwitchWithSelection previousBranchId (Reference selectedReferenceId) target
 
         /// Creates the Connect identity from target, initial cursor, and local-root scope.
         let connectBootstrap target initialCursor localRootScope =

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -3115,6 +3115,11 @@ module LocalStateDb =
         let operationMatches expectedOperation = WorkingDirectoryUpdate.Operation.value expectedOperation = WorkingDirectoryUpdate.Operation.value operation
 
         match WorkingDirectoryUpdate.Operation.callerKind operation, completionDetails with
+        | WorkingDirectoryUpdate.CallerKind.Branch, BranchDirectoryVersionFinalization previousBranchId when
+            WorkingDirectoryUpdate.Target.branchId target
+            <> previousBranchId
+            ->
+            invalidArg (nameof completionDetails) "DirectoryVersion Branch completion must retain the current Branch."
         | WorkingDirectoryUpdate.CallerKind.Branch, BranchFinalization (previousBranchId, selectedReferenceId) ->
             match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
             | Ok expectedOperation when operationMatches expectedOperation -> ()

--- a/src/Grace.CLI/LocalStateDb.CLI.fs
+++ b/src/Grace.CLI/LocalStateDb.CLI.fs
@@ -23,7 +23,7 @@ module WorkingDirectoryUpdate = WorkingDirectoryUpdateContracts
 /// Groups the local state db command parser, handlers, and output helpers.
 module LocalStateDb =
     [<Literal>]
-    let SchemaVersion = "10"
+    let SchemaVersion = "11"
 
     /// Identifies the single local Watch journal metadata row that records applied-through progress.
     [<Literal>]
@@ -45,6 +45,7 @@ module LocalStateDb =
     /// Carries the bounded caller facts that distinguish one pending finalization from another.
     type internal WorkingDirectoryUpdateCompletionDetails =
         | BranchFinalization of previousBranchId: BranchId * selectedReferenceId: ReferenceId
+        | BranchDirectoryVersionFinalization of previousBranchId: BranchId
         | WatchFinalization of eventCursor: string
         | ConnectCompletion of initialCursor: string * localRootScope: WorkingDirectoryUpdate.LocalRootScope
 
@@ -54,7 +55,7 @@ module LocalStateDb =
             target: WorkingDirectoryUpdate.Target *
             operation: WorkingDirectoryUpdate.Operation *
             previousBranchId: BranchId *
-            selectedReferenceId: ReferenceId
+            selection: WorkingDirectoryUpdate.BranchSelection
         | PendingWatchFinalization of target: WorkingDirectoryUpdate.Target * operation: WorkingDirectoryUpdate.Operation * eventCursor: string
 
     [<Literal>]
@@ -255,7 +256,7 @@ module LocalStateDb =
             "CREATE UNIQUE INDEX IF NOT EXISTS ix_status_directories_directory_version_id ON status_directories(directory_version_id);"
             "CREATE TABLE IF NOT EXISTS status_files (relative_path TEXT PRIMARY KEY, directory_path TEXT NOT NULL, directory_version_id TEXT NOT NULL, sha256_hash TEXT NOT NULL, blake3_hash TEXT NOT NULL, is_binary INTEGER NOT NULL, size_bytes INTEGER NOT NULL, created_at_unix_ticks INTEGER NOT NULL, uploaded_to_object_storage INTEGER NOT NULL, last_write_time_utc_ticks INTEGER NOT NULL, FOREIGN KEY (directory_version_id) REFERENCES status_directories(directory_version_id) ON DELETE CASCADE);"
             "CREATE TABLE IF NOT EXISTS remote_reference_boundaries (repository_id TEXT NOT NULL, branch_id TEXT NOT NULL, root_directory_version_id TEXT NOT NULL, root_directory_sha256_hash TEXT NOT NULL, root_directory_blake3_hash TEXT NOT NULL, event_cursor TEXT NOT NULL, PRIMARY KEY (repository_id, branch_id));"
-            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND branch_selected_reference_id IS NOT NULL AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
+            "CREATE TABLE IF NOT EXISTS working_directory_update_completions (operation_value TEXT PRIMARY KEY, caller_kind TEXT NOT NULL CHECK (caller_kind IN ('Watch', 'Branch', 'Connect')), target_canonical TEXT NOT NULL, target_repository_id TEXT NOT NULL, target_branch_id TEXT NOT NULL, target_root_directory_version_id TEXT NOT NULL, target_root_directory_sha256_hash TEXT NOT NULL, target_root_directory_blake3_hash TEXT NOT NULL, branch_previous_branch_id TEXT NULL, branch_selection_kind TEXT NULL CHECK (branch_selection_kind IN ('Reference', 'DirectoryVersion')), branch_selected_reference_id TEXT NULL, watch_event_cursor TEXT NULL, finalization_state TEXT NOT NULL CHECK (finalization_state IN ('Pending', 'Terminal')), completed_at_unix_ticks INTEGER NOT NULL, CHECK ((caller_kind = 'Branch' AND branch_previous_branch_id IS NOT NULL AND ((branch_selection_kind = 'Reference' AND branch_selected_reference_id IS NOT NULL) OR (branch_selection_kind = 'DirectoryVersion' AND branch_selected_reference_id IS NULL)) AND watch_event_cursor IS NULL) OR (caller_kind = 'Watch' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NOT NULL) OR (caller_kind = 'Connect' AND branch_previous_branch_id IS NULL AND branch_selection_kind IS NULL AND branch_selected_reference_id IS NULL AND watch_event_cursor IS NULL)));"
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_pending ON working_directory_update_completions(finalization_state) WHERE finalization_state = 'Pending';"
             "CREATE UNIQUE INDEX IF NOT EXISTS ux_working_directory_update_completions_terminal_caller ON working_directory_update_completions(caller_kind) WHERE finalization_state = 'Terminal';"
             "CREATE INDEX IF NOT EXISTS ix_status_files_directory_path ON status_files(directory_path);"
@@ -1543,6 +1544,8 @@ module LocalStateDb =
         && columnExists connection "status_files" "blake3_hash"
         && columnExists connection "object_cache_directories" "blake3_hash"
         && columnExists connection "object_cache_directory_files" "blake3_hash"
+        && columnExists connection "working_directory_update_completions" "branch_selection_kind"
+        && columnExists connection "working_directory_update_completions" "branch_selected_reference_id"
         && tableExists connection "watch_journal"
         && tableExists connection "watch_lifecycle_events"
         && hasRequiredWatchJournalShape connection
@@ -3115,7 +3118,12 @@ module LocalStateDb =
         | WorkingDirectoryUpdate.CallerKind.Branch, BranchFinalization (previousBranchId, selectedReferenceId) ->
             match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
             | Ok expectedOperation when operationMatches expectedOperation -> ()
-            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and selected Reference."
+            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and typed selector."
+        | WorkingDirectoryUpdate.CallerKind.Branch, BranchDirectoryVersionFinalization previousBranchId ->
+            match WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId WorkingDirectoryUpdate.BranchSelection.DirectoryVersion target
+                with
+            | Ok expectedOperation when operationMatches expectedOperation -> ()
+            | _ -> invalidArg (nameof completionDetails) "Branch completion details must exactly match its target, previous branch, and typed selector."
         | WorkingDirectoryUpdate.CallerKind.Watch, WatchFinalization eventCursor ->
             match
                 WorkingDirectoryUpdate.Operation.watchReplay
@@ -3354,12 +3362,14 @@ module LocalStateDb =
 
                                 let targetCanonical = WorkingDirectoryUpdate.Target.canonical target
 
-                                let branchPreviousBranchId, branchSelectedReferenceId, watchEventCursor =
+                                let branchPreviousBranchId, branchSelectionKind, branchSelectedReferenceId, watchEventCursor =
                                     match completionDetails with
                                     | BranchFinalization (previousBranchId, selectedReferenceId) ->
-                                        Some(previousBranchId.ToString()), Some(selectedReferenceId.ToString()), None
-                                    | WatchFinalization eventCursor -> None, None, Some eventCursor
-                                    | ConnectCompletion _ -> None, None, None
+                                        Some(previousBranchId.ToString()), Some "Reference", Some(selectedReferenceId.ToString()), None
+                                    | BranchDirectoryVersionFinalization previousBranchId ->
+                                        Some(previousBranchId.ToString()), Some "DirectoryVersion", None, None
+                                    | WatchFinalization eventCursor -> None, None, None, Some eventCursor
+                                    | ConnectCompletion _ -> None, None, None, None
 
                                 let nullableText value =
                                     value
@@ -3409,6 +3419,7 @@ module LocalStateDb =
                                             parameters.AddWithValue("$event_cursor", cursor)
                                             |> ignore)
                                 | BranchFinalization _
+                                | BranchDirectoryVersionFinalization _
                                 | WatchFinalization _ -> ()
 
                                 if operationCallerKind = WorkingDirectoryUpdate.CallerKind.Connect then
@@ -3422,7 +3433,7 @@ module LocalStateDb =
                                 use completionCommand = connection.CreateCommand()
 
                                 completionCommand.CommandText <-
-                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $target_repository_id, $target_branch_id, $target_root_directory_version_id, $target_root_directory_sha256_hash, $target_root_directory_blake3_hash, $branch_previous_branch_id, $branch_selected_reference_id, $watch_event_cursor, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.target_repository_id = excluded.target_repository_id AND working_directory_update_completions.target_branch_id = excluded.target_branch_id AND working_directory_update_completions.target_root_directory_version_id = excluded.target_root_directory_version_id AND working_directory_update_completions.target_root_directory_sha256_hash = excluded.target_root_directory_sha256_hash AND working_directory_update_completions.target_root_directory_blake3_hash = excluded.target_root_directory_blake3_hash AND working_directory_update_completions.branch_previous_branch_id IS excluded.branch_previous_branch_id AND working_directory_update_completions.branch_selected_reference_id IS excluded.branch_selected_reference_id AND working_directory_update_completions.watch_event_cursor IS excluded.watch_event_cursor AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
+                                    "INSERT INTO working_directory_update_completions (operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selection_kind, branch_selected_reference_id, watch_event_cursor, finalization_state, completed_at_unix_ticks) VALUES ($operation_value, $caller_kind, $target_canonical, $target_repository_id, $target_branch_id, $target_root_directory_version_id, $target_root_directory_sha256_hash, $target_root_directory_blake3_hash, $branch_previous_branch_id, $branch_selection_kind, $branch_selected_reference_id, $watch_event_cursor, $finalization_state, $completed_at) ON CONFLICT(operation_value) DO UPDATE SET completed_at_unix_ticks = excluded.completed_at_unix_ticks WHERE working_directory_update_completions.caller_kind = excluded.caller_kind AND working_directory_update_completions.target_canonical = excluded.target_canonical AND working_directory_update_completions.target_repository_id = excluded.target_repository_id AND working_directory_update_completions.target_branch_id = excluded.target_branch_id AND working_directory_update_completions.target_root_directory_version_id = excluded.target_root_directory_version_id AND working_directory_update_completions.target_root_directory_sha256_hash = excluded.target_root_directory_sha256_hash AND working_directory_update_completions.target_root_directory_blake3_hash = excluded.target_root_directory_blake3_hash AND working_directory_update_completions.branch_previous_branch_id IS excluded.branch_previous_branch_id AND working_directory_update_completions.branch_selection_kind IS excluded.branch_selection_kind AND working_directory_update_completions.branch_selected_reference_id IS excluded.branch_selected_reference_id AND working_directory_update_completions.watch_event_cursor IS excluded.watch_event_cursor AND working_directory_update_completions.finalization_state = excluded.finalization_state;"
 
                                 completionCommand.Parameters.AddWithValue("$operation_value", operationValue)
                                 |> ignore
@@ -3457,6 +3468,9 @@ module LocalStateDb =
                                 |> ignore
 
                                 completionCommand.Parameters.AddWithValue("$branch_previous_branch_id", nullableText branchPreviousBranchId)
+                                |> ignore
+
+                                completionCommand.Parameters.AddWithValue("$branch_selection_kind", nullableText branchSelectionKind)
                                 |> ignore
 
                                 completionCommand.Parameters.AddWithValue("$branch_selected_reference_id", nullableText branchSelectedReferenceId)
@@ -3863,7 +3877,7 @@ module LocalStateDb =
             use command = connection.CreateCommand()
 
             command.CommandText <-
-                "SELECT operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selected_reference_id, watch_event_cursor FROM working_directory_update_completions WHERE finalization_state = 'Pending' LIMIT 1;"
+                "SELECT operation_value, caller_kind, target_canonical, target_repository_id, target_branch_id, target_root_directory_version_id, target_root_directory_sha256_hash, target_root_directory_blake3_hash, branch_previous_branch_id, branch_selection_kind, branch_selected_reference_id, watch_event_cursor FROM working_directory_update_completions WHERE finalization_state = 'Pending' LIMIT 1;"
 
             use reader = command.ExecuteReader()
 
@@ -3901,13 +3915,21 @@ module LocalStateDb =
                     match callerKind with
                     | "Branch" ->
                         let previousBranchId = requiredGuid 8 "branch_previous_branch_id"
-                        let selectedReferenceId = requiredGuid 9 "branch_selected_reference_id"
 
-                        match WorkingDirectoryUpdate.Operation.branchSwitch previousBranchId selectedReferenceId target with
-                        | Ok operation -> operation, PendingBranchFinalization(target, operation, previousBranchId, selectedReferenceId)
+                        let selection =
+                            match requiredText 9 "branch_selection_kind" with
+                            | "Reference" ->
+                                requiredGuid 10 "branch_selected_reference_id"
+                                |> WorkingDirectoryUpdate.BranchSelection.Reference
+                            | "DirectoryVersion" when reader.IsDBNull(10) -> WorkingDirectoryUpdate.BranchSelection.DirectoryVersion
+                            | "DirectoryVersion" -> invalidOp "DirectoryVersion Branch finalization must not persist a Reference id."
+                            | value -> invalidOp $"Pending Branch finalization has invalid selector kind '{value}'."
+
+                        match WorkingDirectoryUpdate.Operation.branchSwitchWithSelection previousBranchId selection target with
+                        | Ok operation -> operation, PendingBranchFinalization(target, operation, previousBranchId, selection)
                         | Error error -> invalidOp $"Pending Branch finalization is invalid: {error}"
                     | "Watch" ->
-                        let eventCursor = requiredText 10 "watch_event_cursor"
+                        let eventCursor = requiredText 11 "watch_event_cursor"
 
                         match
                             WorkingDirectoryUpdate.Operation.watchReplay


### PR DESCRIPTION
# WDU-05B: Persist exact Branch update selection and marker evidence

Part of #869 and epic #835.

## Why this matters

Later Branch update and recovery slices must reconstruct the exact selected work without inventing a Reference or
collapsing damaged marker evidence into success. This leaf makes those persisted and filesystem facts trustworthy
before any runtime mutation path consumes them.

## Summary

- Adds typed `Reference` versus exact-root `DirectoryVersion` Branch selection and deterministic operation identities.
- Advances the development-only local schema to 11 with clean mismatch recreation and no migration path.
- Persists and strictly reconstructs selector kind, optional Reference ID, target, operation, and typed finalization facts.
- Keeps marker inspection and cleanup outcomes explicit, preserving malformed, foreign, unreadable, and cleanup-failed evidence.
- Adds real SQLite close/reopen, persisted-corruption, selector mismatch, and portable cleanup-failure proof.

## Scope

Six declared source/test paths changed. No runtime engine, Branch command migration, public output, Watch, Connect,
Doctor, SDK, API, generated contract, migration, or documentation behavior was added.

## Validation

- Fantomas on all touched F# files.
- Release `Grace.CLI.Tests` build: 0 warnings, 0 errors.
- Working Directory Update contracts: 6/6 passed.
- Working Directory Update coordination: 9/9 passed.
- LocalStateDb: 129 passed, 1 documented non-Windows skip.
- Fresh live nine-artifact #890 projection packet: 9/9 `ExactMatch`.
- `git diff --check`: passed.

## Review status

- Implementation worker: #869 worker 1, `gpt-5.6-terra` high.
- Head: `82032bacb22740691824836790aed09c592ea9e6`.
- First-pass worker self-review: ready; no forbidden lifecycle or caller scope entered.
- Current-head fresh review and GitHub Validate: pending.

## Residual risk and later ownership

This leaf intentionally produces exact persisted and marker facts only. #870, #871, and #842 own runtime application,
Branch finalization, and Doctor recovery. No rollback or development-data migration is promised.
