### PR TITLE
Implement durable usage-fact journal recovery

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Grace.Operations.fsproj" />
+    <ProjectReference Include="..\..\Grace.Shared\Grace.Shared.fsproj" />
     <ProjectReference Include="..\..\Grace.Types\Grace.Types.fsproj" />
   </ItemGroup>
 

--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -28,8 +28,10 @@
     <Compile Include="Migrations\20260709110000_AddPricingPlanRateAssignment.fs" />
     <Compile Include="Migrations\20260711090000_AddChargePreviewLines.fs" />
     <Compile Include="Migrations\20260812090000_AddBillingCompletenessCoordination.fs" />
+    <Compile Include="Migrations\20260812110000_AddUsageFactJournal.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
+    <Compile Include="OperationsUsageJournal.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -15,6 +15,22 @@ schema is intentionally narrow:
 The ingestion hot path still uses reviewed raw SQL for the durable insert and aggregate update. That path preserves the
 `UsageFactId` idempotency lock and the aggregate `MERGE ... WITH (HOLDLOCK)` behavior that the worker depends on.
 
+## Usage-Fact Journal
+
+`ops.UsageFactJournal` is the internal Operations source of truth for each supported fact before any Service Bus send.
+Appending an immutable, validated fact commits it as `Pending`; Service Bus then carries only a retryable signal with
+the same `UsageFactId`. A bounded dispatcher rescans pending rows after send uncertainty, expiry, terminal broker
+movement, or restart. Those broker outcomes never change journal state.
+
+For an exact owner, organization, repository, and UTC-month scope, billing completeness remains blocked while a journal
+row is `Pending` or `Rejected`. The worker rereads and compares the journal identity, payload, and scope inside its
+SQL mutation transaction. It atomically writes raw usage, its aggregate, and `Accepted`; duplicate delivery only sees
+the already accepted identity. A caller with a deterministic supported-fact decision can atomically write scoped
+rejection evidence and `Rejected`, which remains blocked until explicit same-payload processing repairs it.
+
+This internal seam does not create a repository-storage producer. #829 owns the first such producer and must append to
+the journal before sending any signal.
+
 ## Hot/Cold Raw Payload Archive
 
 Raw payloads stay hot in SQL only for the configured Operations archive retention window. When archive Blob settings

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -4,7 +4,7 @@
 schema is intentionally narrow:
 
 - `ops.RawUsageFact` stores immutable `UsageFact` rows with `UsageFactId` as the duplicate-delivery boundary and keeps
-  the exact accepted broker payload in `RawPayload` for replay and audit.
+  the canonical validated payload owned by the journal in `RawPayload` for replay and audit.
 - `ops.UsageAggregateMinute` stores one aggregate row per fact kind, Grace scope, storage pool, and UTC minute.
 - `ops.ChargePreviewLine` stores deterministic provisional owner charge lines rebuilt from compact immutable usage
   facts and complete effective pricing. A rebuild atomically replaces one owner/repository/half-open-period scope;
@@ -46,7 +46,8 @@ usage-facts/v1/observedYear=<yyyy>/observedMonth=<MM>/ownerId=<owner-guid>/organ
 ```
 
 Each Blob contains one gzip-compressed JSONL record with archive schema version, usage fact identity, Grace scope,
-storage pool, quantity, observed UTC timestamp, and the exact accepted broker payload as base64. SQL stores:
+storage pool, quantity, observed UTC timestamp, and the canonical validated payload owned by the journal as base64.
+SQL stores:
 
 - `ArchiveState`, where `0` is hot, `1` is Blob-verified with hot payload retained, and `2` is archived with hot
   payload cleared.

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812110000_AddUsageFactJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812110000_AddUsageFactJournal.fs
@@ -1,26 +1,81 @@
-namespace Grace.Operations.Data
+namespace Grace.Operations.Data.Migrations
 
+open Grace.Operations.Data
 open Microsoft.EntityFrameworkCore
-open Microsoft.EntityFrameworkCore.Design
-open Microsoft.EntityFrameworkCore.Infrastructure
 open Microsoft.EntityFrameworkCore.Migrations
 open Microsoft.EntityFrameworkCore.Metadata.Builders
-open Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
 open System
 
-/// Configures the Operations EF Core model without opening a database connection.
-[<RequireQualifiedAccess>]
-module OperationsModel =
+/// Adds the immutable pre-send journal that keeps supported usage visible when Service Bus delivery is delayed or lost.
+[<Microsoft.EntityFrameworkCore.Infrastructure.DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260812110000_AddUsageFactJournal")>]
+type AddUsageFactJournal() =
+    inherit Migration()
 
-    /// Configures the raw fact and minute aggregate tables that form the Operations usage foundation.
-    let configure (modelBuilder: ModelBuilder) =
-        modelBuilder.HasDefaultSchema(OperationsUsageSql.SchemaName)
+    /// Creates the one journal row per immutable fact, including the indexes used by dispatch and exact-scope completeness.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+CREATE TABLE ops.UsageFactJournal
+(
+    UsageFactId uniqueidentifier NOT NULL,
+    RawPayload varbinary(max) NOT NULL,
+    CorrelationId nvarchar(200) NOT NULL,
+    FactKind int NOT NULL,
+    OwnerId uniqueidentifier NOT NULL,
+    OrganizationId uniqueidentifier NOT NULL,
+    RepositoryId uniqueidentifier NOT NULL,
+    StoragePoolId nvarchar(256) COLLATE Latin1_General_100_BIN2 NOT NULL,
+    Quantity bigint NOT NULL,
+    ObservedAtUtc datetime2(7) NOT NULL,
+    State int NOT NULL,
+    CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_UsageFactJournal_CreatedAtUtc DEFAULT (SYSUTCDATETIME()),
+    TerminalAtUtc datetime2(7) NULL,
+    CONSTRAINT PK_ops_UsageFactJournal PRIMARY KEY (UsageFactId),
+    CONSTRAINT CK_ops_UsageFactJournal_Identity CHECK
+    (
+        UsageFactId <> '00000000-0000-0000-0000-000000000000'
+        AND OwnerId <> '00000000-0000-0000-0000-000000000000'
+        AND OrganizationId <> '00000000-0000-0000-0000-000000000000'
+        AND RepositoryId <> '00000000-0000-0000-0000-000000000000'
+        AND LEN(LTRIM(RTRIM(CorrelationId))) > 0
+        AND LEN(LTRIM(RTRIM(StoragePoolId))) > 0
+        AND DATALENGTH(RawPayload) > 0
+    ),
+    CONSTRAINT CK_ops_UsageFactJournal_State CHECK
+    (
+        (State = 0 AND TerminalAtUtc IS NULL)
+        OR (State IN (1, 2) AND TerminalAtUtc IS NOT NULL)
+    )
+);
+
+CREATE INDEX IX_ops_UsageFactJournal_ScopeState
+    ON ops.UsageFactJournal(OwnerId, OrganizationId, RepositoryId, ObservedAtUtc, State, UsageFactId);
+
+CREATE INDEX IX_ops_UsageFactJournal_PendingDispatch
+    ON ops.UsageFactJournal(State, CreatedAtUtc, UsageFactId);
+"""
+        )
         |> ignore
+
+    /// Removes only the journal introduced by this slice.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.DropTable("UsageFactJournal", "ops")
+        |> ignore
+
+    /// Rebuilds the complete model at this reviewed migration point.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        // Deliberately keep this snapshot frozen with literals so future runtime model edits
+        // cannot change the latest reviewed migration point before a new migration updates it.
+        modelBuilder.HasDefaultSchema("ops") |> ignore
 
         let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
 
-        rawFact.ToTable(OperationsUsageSql.RawUsageFactTableName, OperationsUsageSql.SchemaName)
-        |> ignore
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
 
         rawFact
             .HasKey([| "UsageFactId" |])
@@ -40,7 +95,7 @@ module OperationsModel =
 
         rawFact
             .Property<string>("CorrelationId")
-            .HasMaxLength(OperationsUsageSql.CorrelationIdMaxLength)
+            .HasMaxLength(200)
             .IsRequired()
         |> ignore
 
@@ -67,8 +122,8 @@ module OperationsModel =
 
         rawFact
             .Property<string>("StoragePoolId")
-            .HasMaxLength(OperationsUsageSql.StoragePoolIdMaxLength)
-            .UseCollation(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation)
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
         |> ignore
 
@@ -86,43 +141,43 @@ module OperationsModel =
 
         rawFact
             .Property<string>("ArchiveBlobName")
-            .HasMaxLength(OperationsUsageSql.ArchiveBlobNameMaxLength)
+            .HasMaxLength(512)
         |> ignore
 
         rawFact
             .Property<string>("ArchiveChecksumSha256Hex")
-            .HasMaxLength(OperationsUsageSql.ArchiveChecksumSha256HexLength)
+            .HasMaxLength(64)
             .IsFixedLength()
             .IsUnicode(false)
         |> ignore
 
         rawFact
-            .Property<Nullable<int64>>("ArchiveByteLength")
+            .Property<System.Nullable<int64>>("ArchiveByteLength")
             .HasColumnType("bigint")
         |> ignore
 
         rawFact
-            .Property<Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .Property<System.Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
         rawFact
-            .Property<Nullable<System.DateTime>>("ArchivedAtUtc")
+            .Property<System.Nullable<System.DateTime>>("ArchivedAtUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
         rawFact
-            .Property<Nullable<System.DateTime>>("RehydrationExpiresAtUtc")
+            .Property<System.Nullable<System.DateTime>>("RehydrationExpiresAtUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
         rawFact
             .Property<string>("LastArchiveFailureReason")
-            .HasMaxLength(OperationsUsageSql.ArchiveFailureReasonMaxLength)
+            .HasMaxLength(400)
         |> ignore
 
         rawFact
-            .Property<Nullable<System.DateTime>>("LastArchiveFailureAtUtc")
+            .Property<System.Nullable<System.DateTime>>("LastArchiveFailureAtUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
@@ -132,7 +187,7 @@ module OperationsModel =
         |> ignore
 
         rawFact
-            .Property<Nullable<System.DateTime>>("ArchiveRetiredAtUtc")
+            .Property<System.Nullable<System.DateTime>>("ArchiveRetiredAtUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
@@ -169,7 +224,7 @@ module OperationsModel =
 
         rawFact
             .HasIndex([| "RehydrationExpiresAtUtc" |])
-            .HasDatabaseName(OperationsUsageSql.TemporaryHotCleanupExpiryIndexName)
+            .HasDatabaseName("IX_ops_RawUsageFact_RehydrationExpiresAtUtc")
             .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
         |> ignore
 
@@ -177,7 +232,7 @@ module OperationsModel =
 
         rejection.ToTable(
             "UsageFactRejection",
-            OperationsUsageSql.SchemaName,
+            "ops",
             fun (table: TableBuilder<UsageFactRejectionEntity>) ->
                 table.HasCheckConstraint(
                     "CK_ops_UsageFactRejection_SuppliedGuids",
@@ -238,7 +293,7 @@ module OperationsModel =
 
         rejection
             .Property<string>("Reason")
-            .HasMaxLength(OperationsUsageSql.ArchiveFailureReasonMaxLength)
+            .HasMaxLength(400)
             .IsRequired()
         |> ignore
 
@@ -289,7 +344,7 @@ module OperationsModel =
 
         let journal = modelBuilder.Entity<UsageFactJournalEntity>()
 
-        journal.ToTable(OperationsUsageSql.UsageFactJournalTableName, OperationsUsageSql.SchemaName)
+        journal.ToTable("UsageFactJournal", "ops")
         |> ignore
 
         journal
@@ -311,7 +366,7 @@ module OperationsModel =
 
         journal
             .Property<string>("CorrelationId")
-            .HasMaxLength(OperationsUsageSql.CorrelationIdMaxLength)
+            .HasMaxLength(200)
             .IsRequired()
         |> ignore
 
@@ -332,8 +387,8 @@ module OperationsModel =
 
         journal
             .Property<string>("StoragePoolId")
-            .HasMaxLength(OperationsUsageSql.StoragePoolIdMaxLength)
-            .UseCollation(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation)
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
         |> ignore
 
@@ -388,7 +443,7 @@ module OperationsModel =
 
         let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
 
-        aggregate.ToTable(OperationsUsageSql.UsageAggregateMinuteTableName, OperationsUsageSql.SchemaName)
+        aggregate.ToTable("UsageAggregateMinute", "ops")
         |> ignore
 
         aggregate
@@ -428,8 +483,8 @@ module OperationsModel =
 
         aggregate
             .Property<string>("StoragePoolId")
-            .HasMaxLength(OperationsUsageSql.StoragePoolIdMaxLength)
-            .UseCollation(OperationsUsageSql.CaseSensitiveStoragePoolIdCollation)
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
         |> ignore
 
@@ -464,7 +519,7 @@ module OperationsModel =
 
         let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
 
-        pricingPlan.ToTable(OperationsPricingSql.PricingPlanTableName, OperationsUsageSql.SchemaName)
+        pricingPlan.ToTable("PricingPlan", "ops")
         |> ignore
 
         pricingPlan
@@ -480,13 +535,13 @@ module OperationsModel =
 
         pricingPlan
             .Property<string>("PlanCode")
-            .HasMaxLength(OperationsPricingSql.PlanCodeMaxLength)
+            .HasMaxLength(128)
             .IsRequired()
         |> ignore
 
         pricingPlan
             .Property<string>("DisplayName")
-            .HasMaxLength(OperationsPricingSql.DisplayNameMaxLength)
+            .HasMaxLength(200)
             .IsRequired()
         |> ignore
 
@@ -497,7 +552,7 @@ module OperationsModel =
         |> ignore
 
         pricingPlan
-            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
@@ -516,7 +571,7 @@ module OperationsModel =
 
         let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
 
-        mapping.ToTable(OperationsPricingSql.BillableUsageKindMappingTableName, OperationsUsageSql.SchemaName)
+        mapping.ToTable("BillableUsageKindMapping", "ops")
         |> ignore
 
         mapping
@@ -540,7 +595,7 @@ module OperationsModel =
 
         mapping
             .Property<string>("DisplayName")
-            .HasMaxLength(OperationsPricingSql.DisplayNameMaxLength)
+            .HasMaxLength(200)
             .IsRequired()
         |> ignore
 
@@ -551,7 +606,7 @@ module OperationsModel =
         |> ignore
 
         mapping
-            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
@@ -576,12 +631,12 @@ module OperationsModel =
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName(OperationsPricingSql.BillableUsageKindMappingEffectiveIndexName)
+            .HasDatabaseName("IX_ops_BillableUsageKindMapping_FactKindEffective")
         |> ignore
 
         let pricingRate = modelBuilder.Entity<PricingRateEntity>()
 
-        pricingRate.ToTable(OperationsPricingSql.PricingRateTableName, OperationsUsageSql.SchemaName)
+        pricingRate.ToTable("PricingRate", "ops")
         |> ignore
 
         pricingRate
@@ -609,7 +664,7 @@ module OperationsModel =
         pricingRate
             .Property<string>("CurrencyCode")
             .HasColumnType("varchar(3)")
-            .HasMaxLength(OperationsPricingSql.CurrencyCodeLength)
+            .HasMaxLength(3)
             .IsUnicode(false)
             .UseCollation("Latin1_General_100_BIN2")
             .IsRequired()
@@ -617,7 +672,7 @@ module OperationsModel =
 
         pricingRate
             .Property<string>("UnitName")
-            .HasMaxLength(OperationsPricingSql.UnitNameMaxLength)
+            .HasMaxLength(64)
             .IsRequired()
         |> ignore
 
@@ -638,7 +693,7 @@ module OperationsModel =
         |> ignore
 
         pricingRate
-            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
@@ -670,7 +725,7 @@ module OperationsModel =
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName(OperationsPricingSql.PricingRateEffectiveIndexName)
+            .HasDatabaseName("IX_ops_PricingRate_PlanUsageKindEffective")
         |> ignore
 
         pricingRate
@@ -683,7 +738,7 @@ module OperationsModel =
 
         let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
 
-        assignment.ToTable(OperationsPricingSql.PricingAssignmentTableName, OperationsUsageSql.SchemaName)
+        assignment.ToTable("PricingAssignment", "ops")
         |> ignore
 
         assignment
@@ -728,7 +783,7 @@ module OperationsModel =
         |> ignore
 
         assignment
-            .Property<Nullable<System.DateTime>>("EffectiveToUtc")
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
             .HasColumnType("datetime2(7)")
         |> ignore
 
@@ -741,7 +796,7 @@ module OperationsModel =
 
         assignment
             .HasIndex([| "PricingPlanId" |])
-            .HasDatabaseName(OperationsPricingSql.PricingAssignmentPricingPlanIndexName)
+            .HasDatabaseName("IX_PricingAssignment_PricingPlanId")
         |> ignore
 
         assignment
@@ -767,7 +822,7 @@ module OperationsModel =
                     "EffectiveToUtc"
                 |]
             )
-            .HasDatabaseName(OperationsPricingSql.PricingAssignmentScopeIndexName)
+            .HasDatabaseName("IX_ops_PricingAssignment_ScopeEffective")
         |> ignore
 
         assignment
@@ -778,168 +833,142 @@ module OperationsModel =
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
 
-        OperationsChargePreviewModel.configure modelBuilder
+        let line = modelBuilder.Entity<ChargePreviewLineEntity>()
 
-/// Owns the EF Core model for Grace Operations SQL Server schema evolution.
-type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
-    inherit DbContext(options)
+        line.ToTable(
+            "ChargePreviewLine",
+            "ops",
+            fun (table: TableBuilder<ChargePreviewLineEntity>) ->
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_PeriodRange", "[PeriodFromUtc] < [PeriodToUtc]")
+                |> ignore
 
-    /// Exposes immutable usage facts for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private rawUsageFacts: DbSet<RawUsageFactEntity>
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_EffectiveRange",
+                    "[PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc]"
+                )
+                |> ignore
 
-    /// Exposes UTC minute aggregates for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private usageAggregateMinutes: DbSet<UsageAggregateMinuteEntity>
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_UnitQuantity", "[UnitQuantity] > 0")
+                |> ignore
 
-    /// Exposes durable scoped and partial usage rejection evidence for migrations and SQL inspection.
-    [<DefaultValue>]
-    val mutable private usageFactRejections: DbSet<UsageFactRejectionEntity>
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_Amounts", "[UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0 AND [ChargeMicros] >= 0")
+                |> ignore
 
-    /// Exposes immutable pending and terminal journal rows for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private usageFactJournal: DbSet<UsageFactJournalEntity>
-
-    /// Exposes pricing plans for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private pricingPlans: DbSet<PricingPlanEntity>
-
-    /// Exposes billable usage-kind mappings for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private billableUsageKindMappings: DbSet<BillableUsageKindMappingEntity>
-
-    /// Exposes pricing rates for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private pricingRates: DbSet<PricingRateEntity>
-
-    /// Exposes owner-scoped pricing assignments for EF migrations and schema inspection.
-    [<DefaultValue>]
-    val mutable private pricingAssignments: DbSet<PricingAssignmentEntity>
-
-    /// Provides EF access to provisional charge-preview lines.
-    [<DefaultValue>]
-    val mutable private chargePreviewLines: DbSet<ChargePreviewLineEntity>
-
-    /// Provides the EF set for immutable usage fact rows.
-    member this.RawUsageFacts
-        with get () = this.rawUsageFacts
-        and set value = this.rawUsageFacts <- value
-
-    /// Provides the EF set for repository resource minute aggregate rows.
-    member this.UsageAggregateMinutes
-        with get () = this.usageAggregateMinutes
-        and set value = this.usageAggregateMinutes <- value
-
-    /// Provides the EF set for active and repaired usage rejection records.
-    member this.UsageFactRejections
-        with get () = this.usageFactRejections
-        and set value = this.usageFactRejections <- value
-
-    /// Provides the EF set for immutable usage-fact journal rows.
-    member this.UsageFactJournal
-        with get () = this.usageFactJournal
-        and set value = this.usageFactJournal <- value
-
-    /// Provides the EF set for effective-dated pricing plans.
-    member this.PricingPlans
-        with get () = this.pricingPlans
-        and set value = this.pricingPlans <- value
-
-    /// Provides the EF set for billable usage-kind mappings.
-    member this.BillableUsageKindMappings
-        with get () = this.billableUsageKindMappings
-        and set value = this.billableUsageKindMappings <- value
-
-    /// Provides the EF set for effective-dated pricing rates.
-    member this.PricingRates
-        with get () = this.pricingRates
-        and set value = this.pricingRates <- value
-
-    /// Provides the EF set for owner-scoped pricing assignments.
-    member this.PricingAssignments
-        with get () = this.pricingAssignments
-        and set value = this.pricingAssignments <- value
-
-    /// Provides the EF set for provisional charge-preview lines.
-    member this.ChargePreviewLines
-        with get () = this.chargePreviewLines
-        and set value = this.chargePreviewLines <- value
-
-    /// Configures the Operations SQL Server schema shape that migrations must preserve.
-    override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder
-
-/// Ensures EF-generated scripts create the Operations schema before SQL Server receives history-table DDL.
-type OperationsSqlServerHistoryRepository(dependencies: HistoryRepositoryDependencies) =
-    inherit SqlServerHistoryRepository(dependencies)
-
-    let withOpsSchemaPreamble (script: string) =
-        if String.IsNullOrWhiteSpace script then
-            script
-        else
-            $"{OperationsUsageSql.CreateSchemaIfMissing.Trim()}{Environment.NewLine}{Environment.NewLine}{script}"
-
-    /// Creates the Operations schema before EF creates `[ops].[__EFMigrationsHistory]` in non-idempotent scripts.
-    override _.GetCreateScript() = base.GetCreateScript() |> withOpsSchemaPreamble
-
-    /// Creates the Operations schema before EF creates `[ops].[__EFMigrationsHistory]` in idempotent scripts and bundles.
-    override _.GetCreateIfNotExistsScript() =
-        base.GetCreateIfNotExistsScript()
-        |> withOpsSchemaPreamble
-
-/// Builds configured Operations EF contexts for runtime schema migration and tests.
-[<RequireQualifiedAccess>]
-module OperationsDbContextFactory =
-
-    /// Provides the SQL Server connection string used when EF tooling builds migrations without opening the database.
-    let private defaultDesignTimeConnectionString = "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsDesignTime;Integrated Security=true;"
-
-    /// Names the documented Operations SQL environment variable shared with `Grace.Operations.Worker`.
-    let private documentedSqlConnectionStringEnvironmentVariable = "grace__operations__sql__connectionstring"
-
-    /// Names the legacy design-time SQL environment variable retained for local developer compatibility.
-    let private legacySqlConnectionStringEnvironmentVariable = "GRACE_OPERATIONS_SQL_CONNECTION_STRING"
-
-    /// Reads the first non-empty environment variable from the supplied precedence order.
-    let private firstEnvironmentConnectionString variableNames =
-        variableNames
-        |> Seq.map Environment.GetEnvironmentVariable
-        |> Seq.tryFind (fun value -> not (String.IsNullOrWhiteSpace value))
-
-    /// Resolves the design-time SQL Server connection string from EF command arguments, environment, or LocalDB.
-    let designTimeConnectionString (args: string array) =
-        match args
-              |> Array.tryFind (fun value -> not (String.IsNullOrWhiteSpace value))
-            with
-        | Some connectionString -> connectionString
-        | None ->
-            [|
-                documentedSqlConnectionStringEnvironmentVariable
-                legacySqlConnectionStringEnvironmentVariable
-            |]
-            |> firstEnvironmentConnectionString
-            |> Option.defaultValue defaultDesignTimeConnectionString
-
-    /// Creates EF Core options for the Operations SQL Server database.
-    let options (connectionString: string) =
-        DbContextOptionsBuilder<OperationsDbContext>()
-            .ReplaceService<IHistoryRepository, OperationsSqlServerHistoryRepository>()
-            .UseSqlServer(
-            connectionString,
-            System.Action<SqlServerDbContextOptionsBuilder> (fun sql ->
-                sql.MigrationsHistoryTable("__EFMigrationsHistory", OperationsUsageSql.SchemaName)
-                |> ignore)
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
         )
-            .Options
+        |> ignore
 
-    /// Creates a configured Operations EF context for the supplied SQL Server connection string.
-    let create connectionString = new OperationsDbContext(options connectionString)
+        line
+            .HasKey([| "ChargePreviewLineId" |])
+            .HasName("PK_ops_ChargePreviewLine")
+        |> ignore
 
-/// Provides the discoverable EF Core design-time factory used by `dotnet ef migrations add`.
-type OperationsDesignTimeDbContextFactory() =
+        line
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
 
-    interface IDesignTimeDbContextFactory<OperationsDbContext> with
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillableUsageKindMappingId"
+                "PricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            line
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
 
-        /// Creates an Operations context without relying on F# module discovery.
-        member _.CreateDbContext(args: string array) =
-            OperationsDbContextFactory.designTimeConnectionString args
-            |> OperationsDbContextFactory.create
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            line
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        line.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        line
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            line.Property<int64>(name).IsRequired() |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_ChargePreviewLine_Scope")
+        |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                    "FactKind"
+                    "BillableUsageKindMappingId"
+                    "BillableUsageKind"
+                    "PricingAssignmentId"
+                    "PricingPlanId"
+                    "PricingRateId"
+                    "CurrencyCode"
+                    "UnitName"
+                    "UnitQuantity"
+                    "UnitPriceMicros"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
+            .IsUnique()
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812110000_AddUsageFactJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812110000_AddUsageFactJournal.fs
@@ -34,18 +34,18 @@ CREATE TABLE ops.UsageFactJournal
     CONSTRAINT PK_ops_UsageFactJournal PRIMARY KEY (UsageFactId),
     CONSTRAINT CK_ops_UsageFactJournal_Identity CHECK
     (
-        UsageFactId <> '00000000-0000-0000-0000-000000000000'
-        AND OwnerId <> '00000000-0000-0000-0000-000000000000'
-        AND OrganizationId <> '00000000-0000-0000-0000-000000000000'
-        AND RepositoryId <> '00000000-0000-0000-0000-000000000000'
-        AND LEN(LTRIM(RTRIM(CorrelationId))) > 0
-        AND LEN(LTRIM(RTRIM(StoragePoolId))) > 0
-        AND DATALENGTH(RawPayload) > 0
+        [UsageFactId] <> '00000000-0000-0000-0000-000000000000'
+        AND [OwnerId] <> '00000000-0000-0000-0000-000000000000'
+        AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000'
+        AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000'
+        AND LEN(LTRIM(RTRIM([CorrelationId]))) > 0
+        AND LEN(LTRIM(RTRIM([StoragePoolId]))) > 0
+        AND DATALENGTH([RawPayload]) > 0
     ),
     CONSTRAINT CK_ops_UsageFactJournal_State CHECK
     (
-        (State = 0 AND TerminalAtUtc IS NULL)
-        OR (State IN (1, 2) AND TerminalAtUtc IS NOT NULL)
+        ([State] = 0 AND [TerminalAtUtc] IS NULL)
+        OR ([State] IN (1, 2) AND [TerminalAtUtc] IS NOT NULL)
     )
 );
 
@@ -344,7 +344,22 @@ CREATE INDEX IX_ops_UsageFactJournal_PendingDispatch
 
         let journal = modelBuilder.Entity<UsageFactJournalEntity>()
 
-        journal.ToTable("UsageFactJournal", "ops")
+        journal.ToTable(
+            "UsageFactJournal",
+            "ops",
+            fun (table: TableBuilder<UsageFactJournalEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_Identity",
+                    "[UsageFactId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([CorrelationId]))) > 0 AND LEN(LTRIM(RTRIM([StoragePoolId]))) > 0 AND DATALENGTH([RawPayload]) > 0"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_State",
+                    "([State] = 0 AND [TerminalAtUtc] IS NULL) OR ([State] IN (1, 2) AND [TerminalAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
         |> ignore
 
         journal

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -289,6 +289,105 @@ type OperationsDbContextModelSnapshot() =
             .HasDatabaseName("IX_ops_UsageFactRejection_ActiveScope")
         |> ignore
 
+        let journal = modelBuilder.Entity<UsageFactJournalEntity>()
+
+        journal.ToTable("UsageFactJournal", "ops")
+        |> ignore
+
+        journal
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_UsageFactJournal")
+        |> ignore
+
+        journal
+            .Property<Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        journal
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+            .IsRequired()
+        |> ignore
+
+        journal
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            journal
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        journal
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        journal
+            .Property<DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int>("State").IsRequired()
+        |> ignore
+
+        journal
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        journal
+            .Property<Nullable<DateTime>>("TerminalAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        journal
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "ObservedAtUtc"
+                    "State"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactJournal_ScopeState")
+        |> ignore
+
+        journal
+            .HasIndex(
+                [|
+                    "State"
+                    "CreatedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactJournal_PendingDispatch")
+        |> ignore
+
         let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
 
         aggregate.ToTable("UsageAggregateMinute", "ops")

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -291,7 +291,22 @@ type OperationsDbContextModelSnapshot() =
 
         let journal = modelBuilder.Entity<UsageFactJournalEntity>()
 
-        journal.ToTable("UsageFactJournal", "ops")
+        journal.ToTable(
+            "UsageFactJournal",
+            "ops",
+            fun (table: TableBuilder<UsageFactJournalEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_Identity",
+                    "[UsageFactId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([CorrelationId]))) > 0 AND LEN(LTRIM(RTRIM([StoragePoolId]))) > 0 AND DATALENGTH([RawPayload]) > 0"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_State",
+                    "([State] = 0 AND [TerminalAtUtc] IS NULL) OR ([State] IN (1, 2) AND [TerminalAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
         |> ignore
 
         journal

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -181,6 +181,7 @@ module UsageFactRejection =
 type BillingCompletenessResult =
     | Complete
     | BlockedByActiveScopedRejection
+    | BlockedByUnresolvedUsageFactJournal
 
 /// Identifies one UTC minute aggregate row in `ops.UsageAggregateMinute`.
 type UsageAggregateMinuteKey =
@@ -707,6 +708,9 @@ type IOperationsUsageTransaction =
     /// Reads active scoped rejection evidence while the caller holds the central scope lock.
     abstract HasActiveScopedUsageFactRejectionAsync: scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task<bool>
 
+    /// Reads exact-scope Pending or Rejected journal rows while the caller holds the central scope lock.
+    abstract HasUnresolvedUsageFactJournalAsync: scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task<bool>
+
 /// Runs operations usage mutations inside one storage transaction boundary.
 type IOperationsUsageTransactionScope =
 
@@ -965,6 +969,16 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
             task {
                 use command = createCommand OperationsUsageSql.HasActiveScopedUsageFactRejection
                 addBillingCompletenessScopeParameters command scope
+                let! result = command.ExecuteScalarAsync cancellationToken
+                return Convert.ToBoolean result
+            }
+
+        member _.HasUnresolvedUsageFactJournalAsync(scope, cancellationToken) =
+            task {
+                use command = createCommand OperationsUsageSql.HasUnresolvedUsageFactJournal
+                addBillingCompletenessScopeParameters command scope
+                addParameter command "@PendingState" SqlDbType.Int 0
+                addParameter command "@RejectedState" SqlDbType.Int 2
                 let! result = command.ExecuteScalarAsync cancellationToken
                 return Convert.ToBoolean result
             }
@@ -1872,7 +1886,12 @@ type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
                 task {
                     do! transaction.AcquireBillingCompletenessScopeAsync(validScope, operationCancellationToken)
                     let! blocked = transaction.HasActiveScopedUsageFactRejectionAsync(validScope, operationCancellationToken)
-                    return if blocked then BlockedByActiveScopedRejection else Complete
+                    let! journalBlocked = transaction.HasUnresolvedUsageFactJournalAsync(validScope, operationCancellationToken)
+
+                    return
+                        if blocked then BlockedByActiveScopedRejection
+                        elif journalBlocked then BlockedByUnresolvedUsageFactJournal
+                        else Complete
                 }
 
             transactionScope.ExecuteAsync(operation, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -2,6 +2,7 @@ namespace Grace.Operations.Data
 
 open Grace.Types.Common
 open Grace.Types.Usage
+open Grace.Shared
 open Microsoft.EntityFrameworkCore
 open Microsoft.Data.SqlClient
 open NodaTime
@@ -675,6 +676,11 @@ module UsageFactPersistencePlan =
                     }
 
                 Ok { RawFact = rawFact; Aggregate = aggregate }
+
+    /// Validates a supported fact and serializes it with the shared options used by the worker parser.
+    let tryCreateCanonical (fact: UsageFact) =
+        let rawPayload = JsonSerializer.SerializeToUtf8Bytes<UsageFact>(fact, Constants.JsonSerializerOptions)
+        tryCreate fact rawPayload
 
 /// Represents the commands available inside one durable operations usage transaction.
 type IOperationsUsageTransaction =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -289,7 +289,22 @@ module OperationsModel =
 
         let journal = modelBuilder.Entity<UsageFactJournalEntity>()
 
-        journal.ToTable(OperationsUsageSql.UsageFactJournalTableName, OperationsUsageSql.SchemaName)
+        journal.ToTable(
+            OperationsUsageSql.UsageFactJournalTableName,
+            OperationsUsageSql.SchemaName,
+            fun (table: TableBuilder<UsageFactJournalEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_Identity",
+                    "[UsageFactId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([CorrelationId]))) > 0 AND LEN(LTRIM(RTRIM([StoragePoolId]))) > 0 AND DATALENGTH([RawPayload]) > 0"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_State",
+                    "([State] = 0 AND [TerminalAtUtc] IS NULL) OR ([State] IN (1, 2) AND [TerminalAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
         |> ignore
 
         journal

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -106,6 +106,39 @@ type UsageFactRejectionEntity() =
     /// Stores SQL-created ordering evidence for diagnostics.
     member val CreatedAtUtc = DateTime.MinValue with get, set
 
+/// Represents the immutable SQL source of truth for a supported fact before any Service Bus signal is sent.
+[<AllowNullLiteral>]
+type UsageFactJournalEntity() =
+
+    /// Stores the stable fact identity shared by journal, broker message, raw usage, and rejection evidence.
+    member val UsageFactId = Guid.Empty with get, set
+
+    /// Stores the canonical immutable fact bytes compared on append and processing replay.
+    member val RawPayload: byte array = Array.empty with get, set
+
+    /// Stores the correlation lineage without using it as a journal identity.
+    member val CorrelationId = String.Empty with get, set
+
+    /// Stores the persisted usage-fact kind.
+    member val FactKind = 0 with get, set
+
+    /// Stores the complete billing scope and resource identity carried by the immutable fact.
+    member val OwnerId = Guid.Empty with get, set
+    member val OrganizationId = Guid.Empty with get, set
+    member val RepositoryId = Guid.Empty with get, set
+    member val StoragePoolId = String.Empty with get, set
+    member val Quantity = 0L with get, set
+    member val ObservedAtUtc = DateTime.MinValue with get, set
+
+    /// Stores Pending, Accepted, or Rejected; sending and settlement never change this state.
+    member val State = 0 with get, set
+
+    /// Stores when the immutable journal row became durable.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+    /// Stores when a terminal state was durably recorded.
+    member val TerminalAtUtc = Nullable<DateTime>() with get, set
+
 /// Represents one repository resource aggregate row for a UTC minute.
 [<AllowNullLiteral>]
 type UsageAggregateMinuteEntity() =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -1,0 +1,491 @@
+namespace Grace.Operations.Data
+
+open Grace.Types.Usage
+open Grace.Types.Common
+open Microsoft.Data.SqlClient
+open NodaTime
+open System
+open System.Data
+open System.Threading
+open System.Threading.Tasks
+
+/// Represents the only durable lifecycle for a supported fact before and during Operations ingestion.
+type UsageFactJournalState =
+    | Pending = 0
+    | Accepted = 1
+    | Rejected = 2
+
+/// Carries the immutable journal payload and exact identity read by dispatch immediately before send.
+type UsageFactJournalEntry =
+    {
+        UsageFactId: UsageFactId
+        RawPayload: byte array
+        CorrelationId: CorrelationId
+        FactKind: UsageFactKind
+        OwnerId: OwnerId
+        OrganizationId: OrganizationId
+        RepositoryId: RepositoryId
+        StoragePoolId: StoragePoolId
+        Quantity: int64
+        ObservedAt: Instant
+        State: UsageFactJournalState
+    }
+
+/// Reports whether an append created durable pre-send journal truth or repeated the same immutable fact.
+type UsageFactJournalAppendResult =
+    | AppendedPending
+    | AlreadyPending
+    | AlreadyTerminal of UsageFactJournalState
+
+/// Reports how a delivered signal interacted with current journal truth.
+type UsageFactJournalProcessResult =
+    | AcceptedFromJournal
+    | AlreadyAccepted
+    | MissingJournal
+    | JournalConflict
+
+/// Reports how an explicit deterministic supported-fact rejection interacted with current journal truth.
+type UsageFactJournalRejectResult =
+    | RejectedFromJournal
+    | AlreadyRejected
+    | RejectMissingJournal
+    | RejectJournalConflict
+    | RejectAlreadyAccepted
+
+/// Owns the internal Operations append, dispatch scan, and transactionally verified journal processing seam.
+type IOperationsUsageJournalStore =
+
+    /// Commits a complete supported fact as immutable Pending truth before any broker send.
+    abstract AppendAsync:
+        fact: UsageFact * rawPayload: byte array * cancellationToken: CancellationToken -> Task<Result<UsageFactJournalAppendResult, string list>>
+
+    /// Reads a bounded stable set of currently Pending immutable facts for retryable Service Bus signalling.
+    abstract ListPendingAsync: batchSize: int * cancellationToken: CancellationToken -> Task<UsageFactJournalEntry list>
+
+    /// Rechecks the matching immutable journal row inside the raw, aggregate, and state transaction before accepting it.
+    abstract ProcessAsync: fact: UsageFact * rawPayload: byte array * cancellationToken: CancellationToken -> Task<UsageFactJournalProcessResult>
+
+    /// Atomically records scoped rejection evidence and the Rejected state for an already journaled supported fact.
+    abstract RejectAsync: fact: UsageFact * rawPayload: byte array * reason: string * cancellationToken: CancellationToken -> Task<UsageFactJournalRejectResult>
+
+/// Stores immutable usage facts in the SQL journal and treats Service Bus delivery as a retryable signal only.
+type SqlOperationsUsageJournalStore(connectionString: string) =
+
+    /// Opens the SQL connection used by one append, scan, or processing transaction.
+    let openConnectionAsync cancellationToken =
+        task {
+            let connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            return connection
+        }
+
+    /// Converts an instant to the UTC database timestamp representation used by Operations usage tables.
+    let toUtcDateTime (instant: Instant) = instant.ToDateTimeUtc()
+
+    /// Converts a database timestamp back to the immutable Operations instant representation.
+    let toInstant (dateTime: DateTime) =
+        DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+        |> Instant.FromDateTimeUtc
+
+    /// Adds a scalar parameter to a transaction-bound SQL command.
+    let addParameter (command: SqlCommand) name sqlDbType value =
+        let parameter = command.Parameters.Add(name, sqlDbType)
+        parameter.Value <- value
+
+    /// Adds a bounded string parameter to a transaction-bound SQL command.
+    let addStringParameter (command: SqlCommand) name length (value: string) =
+        let parameter = command.Parameters.Add(name, SqlDbType.NVarChar, length)
+        parameter.Value <- value
+
+    /// Creates a command that remains inside the supplied SQL transaction.
+    let createCommand (connection: SqlConnection) (transaction: SqlTransaction) commandText =
+        let command = connection.CreateCommand()
+        command.Transaction <- transaction
+        command.CommandType <- CommandType.Text
+        command.CommandText <- commandText
+        command
+
+    /// Acquires #877's exact scope lock before a completeness-affecting journal mutation.
+    let acquireScopeAsync connection transaction (scope: BillingCompletenessScope) cancellationToken =
+        task {
+            use command = createCommand connection transaction OperationsUsageSql.AcquireBillingCompletenessScopeLock
+            addStringParameter command "@BillingCompletenessLockResource" 255 (BillingCompletenessScope.databaseLockIdentity scope)
+            addParameter command "@BillingCompletenessLockTimeoutMilliseconds" SqlDbType.Int 30000
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Adds an immutable fact's complete identity, payload, and resource fields to the supplied command.
+    let addFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
+        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+        let payload = command.Parameters.Add("@RawPayload", SqlDbType.VarBinary, -1)
+        payload.Value <- Array.copy rawFact.RawPayload
+        addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
+        addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
+        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength rawFact.StoragePoolId
+        addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
+        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
+
+    /// Builds the exact completeness scope for a fact that has already passed supported fact validation.
+    let scopeFor (rawFact: RawUsageFact) : BillingCompletenessScope =
+        BillingCompletenessScope.tryCreate rawFact.OwnerId rawFact.OrganizationId rawFact.RepositoryId rawFact.ObservedAt
+        |> Result.defaultWith (fun errors -> invalidOp (String.Join("; ", errors)))
+
+    /// Reads a full journal row while an append or worker transaction keeps update locks on its identity.
+    let readJournalForUpdateAsync (connection: SqlConnection) (transaction: SqlTransaction) (usageFactId: UsageFactId) (cancellationToken: CancellationToken) =
+        task {
+            use command =
+                createCommand
+                    connection
+                    transaction
+                    """
+SELECT UsageFactId, RawPayload, CorrelationId, FactKind, OwnerId, OrganizationId, RepositoryId, StoragePoolId, Quantity, ObservedAtUtc, State
+FROM ops.UsageFactJournal WITH (UPDLOCK, HOLDLOCK)
+WHERE UsageFactId = @UsageFactId;
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            use! reader = command.ExecuteReaderAsync cancellationToken
+            let! hasRow = reader.ReadAsync cancellationToken
+
+            if not hasRow then
+                return None
+            else
+                return
+                    Some
+                        {
+                            UsageFactId = reader.GetGuid 0
+                            RawPayload = reader.GetFieldValue<byte array> 1
+                            CorrelationId = reader.GetString 2
+                            FactKind = enum<UsageFactKind> (reader.GetInt32 3)
+                            OwnerId = reader.GetGuid 4
+                            OrganizationId = reader.GetGuid 5
+                            RepositoryId = reader.GetGuid 6
+                            StoragePoolId = reader.GetString 7
+                            Quantity = reader.GetInt64 8
+                            ObservedAt = reader.GetDateTime 9 |> toInstant
+                            State = enum<UsageFactJournalState> (reader.GetInt32 10)
+                        }
+        }
+
+    /// Compares every immutable fact field so same-ID replay cannot cross scope or silently replace payload truth.
+    let matches (rawFact: RawUsageFact) (entry: UsageFactJournalEntry) =
+        entry.UsageFactId = rawFact.UsageFactId
+        && entry.CorrelationId = rawFact.CorrelationId
+        && entry.FactKind = rawFact.FactKind
+        && entry.OwnerId = rawFact.OwnerId
+        && entry.OrganizationId = rawFact.OrganizationId
+        && entry.RepositoryId = rawFact.RepositoryId
+        && entry.StoragePoolId = rawFact.StoragePoolId
+        && entry.Quantity = rawFact.Quantity
+        && entry.ObservedAt = rawFact.ObservedAt
+        && entry
+            .RawPayload
+            .AsSpan()
+            .SequenceEqual(rawFact.RawPayload)
+
+    /// Inserts a validated complete fact as Pending without deriving journal state from any send result.
+    let insertPendingAsync (connection: SqlConnection) (transaction: SqlTransaction) (rawFact: RawUsageFact) (cancellationToken: CancellationToken) =
+        task {
+            use command =
+                createCommand
+                    connection
+                    transaction
+                    """
+INSERT INTO ops.UsageFactJournal
+    (UsageFactId, RawPayload, CorrelationId, FactKind, OwnerId, OrganizationId, RepositoryId, StoragePoolId, Quantity, ObservedAtUtc, State)
+VALUES
+    (@UsageFactId, @RawPayload, @CorrelationId, @FactKind, @OwnerId, @OrganizationId, @RepositoryId, @StoragePoolId, @Quantity, @ObservedAtUtc, 0);
+"""
+
+            addFactParameters command rawFact
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Adds the accepted fact to raw usage only when a prior durable raw identity does not already exist.
+    let tryInsertRawAsync (connection: SqlConnection) (transaction: SqlTransaction) (rawFact: RawUsageFact) (cancellationToken: CancellationToken) =
+        task {
+            use command = createCommand connection transaction OperationsUsageSql.TryInsertRawUsageFact
+            addFactParameters command rawFact
+            let! rows = command.ExecuteNonQueryAsync cancellationToken
+            return rows = 1
+        }
+
+    /// Adds the newly accepted quantity to the minute aggregate under the same journal processing transaction.
+    let addAggregateAsync (connection: SqlConnection) (transaction: SqlTransaction) (aggregate: UsageAggregateMinute) (cancellationToken: CancellationToken) =
+        task {
+            use command = createCommand connection transaction OperationsUsageSql.AddToUsageAggregateMinute
+            addParameter command "@FactKind" SqlDbType.Int (int aggregate.Key.FactKind)
+            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier aggregate.Key.OwnerId
+            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier aggregate.Key.OrganizationId
+            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier aggregate.Key.RepositoryId
+            addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength aggregate.Key.StoragePoolId
+            addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (toUtcDateTime aggregate.Key.BucketStart)
+            addParameter command "@Quantity" SqlDbType.BigInt aggregate.Quantity
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Marks one still-unresolved matching journal row Accepted only after raw and aggregate persistence succeeded.
+    let markAcceptedAsync (connection: SqlConnection) (transaction: SqlTransaction) (usageFactId: UsageFactId) (cancellationToken: CancellationToken) =
+        task {
+            use command =
+                createCommand
+                    connection
+                    transaction
+                    """
+UPDATE ops.UsageFactJournal
+SET State = 1, TerminalAtUtc = SYSUTCDATETIME()
+WHERE UsageFactId = @UsageFactId AND State IN (0, 2);
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Marks one still-unresolved matching journal row Rejected only after its scoped rejection evidence is durable.
+    let markRejectedAsync (connection: SqlConnection) (transaction: SqlTransaction) (usageFactId: UsageFactId) (cancellationToken: CancellationToken) =
+        task {
+            use command =
+                createCommand
+                    connection
+                    transaction
+                    """
+UPDATE ops.UsageFactJournal
+SET State = 2, TerminalAtUtc = COALESCE(TerminalAtUtc, SYSUTCDATETIME())
+WHERE UsageFactId = @UsageFactId AND State = 0;
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Records exact-scope rejection evidence using the #877 uniqueness and accepted-row guard inside this journal transaction.
+    let recordScopedRejectionAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (usageFactId: UsageFactId)
+        (scope: BillingCompletenessScope)
+        (reason: string)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            if String.IsNullOrWhiteSpace reason then
+                invalidArg (nameof reason) "A deterministic rejection reason is required."
+
+            let boundedReason =
+                if reason.Length
+                   <= OperationsUsageSql.ArchiveFailureReasonMaxLength then
+                    reason
+                else
+                    reason.Substring(0, OperationsUsageSql.ArchiveFailureReasonMaxLength)
+
+            use command = createCommand connection transaction OperationsUsageSql.RecordScopedUsageFactRejection
+            addParameter command "@RejectionId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
+            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier scope.OrganizationId
+            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier scope.RepositoryId
+            addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
+            addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
+            addStringParameter command "@Reason" OperationsUsageSql.ArchiveFailureReasonMaxLength boundedReason
+            use! reader = command.ExecuteReaderAsync cancellationToken
+            let! hasRow = reader.ReadAsync cancellationToken
+
+            if not hasRow then
+                invalidOp "A Pending journal fact cannot become Rejected after accepted raw usage already exists."
+        }
+
+    /// Releases rejected completeness evidence only inside the same successful accepted processing transaction.
+    let resolveRejectionAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (usageFactId: UsageFactId)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use command = createCommand connection transaction OperationsUsageSql.ResolveScopedUsageFactRejection
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
+            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier scope.OrganizationId
+            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier scope.RepositoryId
+            addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
+            addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Rolls back a failed processing transaction without replacing its original error.
+    let rollbackIgnoringFailuresAsync (transaction: SqlTransaction) =
+        task {
+            try
+                do! transaction.RollbackAsync CancellationToken.None
+            with
+            | _ -> ()
+        }
+
+    /// Runs one journal operation inside a SQL transaction and preserves all-or-nothing journal truth.
+    let executeAsync operation cancellationToken =
+        task {
+            use! connection = openConnectionAsync cancellationToken
+            let! databaseTransaction = connection.BeginTransactionAsync cancellationToken
+            use transaction = databaseTransaction :?> SqlTransaction
+
+            try
+                let! result = operation connection transaction cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return result
+            with
+            | ex ->
+                do! rollbackIgnoringFailuresAsync transaction
+                return raise ex
+        }
+
+    /// Appends one supported fact with immutable-idempotence semantics before a dispatcher can observe it.
+    member _.AppendAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            | Error errors -> return Error errors
+            | Ok plan ->
+                let! result =
+                    executeAsync
+                        (fun connection transaction operationCancellationToken ->
+                            task {
+                                let scope = scopeFor plan.RawFact
+                                do! acquireScopeAsync connection transaction scope operationCancellationToken
+                                let! existing = readJournalForUpdateAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+
+                                match existing with
+                                | Some entry when not (matches plan.RawFact entry) ->
+                                    return raise (InvalidOperationException("UsageFactId is already bound to a different immutable journal payload or scope."))
+                                | Some entry when entry.State = UsageFactJournalState.Pending -> return AlreadyPending
+                                | Some entry -> return AlreadyTerminal entry.State
+                                | None ->
+                                    do! insertPendingAsync connection transaction plan.RawFact operationCancellationToken
+                                    return AppendedPending
+                            })
+                        cancellationToken
+
+                return Ok result
+        }
+
+    /// Lists current Pending rows in a stable bounded order; a later transaction still rechecks state before sending.
+    member _.ListPendingAsync(batchSize: int, cancellationToken: CancellationToken) =
+        task {
+            if batchSize <= 0 then
+                invalidArg (nameof batchSize) "Journal dispatch batch size must be greater than zero."
+
+            use! connection = openConnectionAsync cancellationToken
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+
+            command.CommandText <-
+                """
+SELECT TOP (@BatchSize) UsageFactId, RawPayload, CorrelationId, FactKind, OwnerId, OrganizationId, RepositoryId, StoragePoolId, Quantity, ObservedAtUtc, State
+FROM ops.UsageFactJournal WITH (READCOMMITTEDLOCK)
+WHERE State = 0
+ORDER BY CreatedAtUtc ASC, UsageFactId ASC;
+"""
+
+            addParameter command "@BatchSize" SqlDbType.Int batchSize
+            use! reader = command.ExecuteReaderAsync cancellationToken
+            let rows = ResizeArray<UsageFactJournalEntry>()
+
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+
+                if hasRow then
+                    rows.Add(
+                        {
+                            UsageFactId = reader.GetGuid 0
+                            RawPayload = reader.GetFieldValue<byte array> 1
+                            CorrelationId = reader.GetString 2
+                            FactKind = enum<UsageFactKind> (reader.GetInt32 3)
+                            OwnerId = reader.GetGuid 4
+                            OrganizationId = reader.GetGuid 5
+                            RepositoryId = reader.GetGuid 6
+                            StoragePoolId = reader.GetString 7
+                            Quantity = reader.GetInt64 8
+                            ObservedAt = reader.GetDateTime 9 |> toInstant
+                            State = enum<UsageFactJournalState> (reader.GetInt32 10)
+                        }
+                    )
+                else
+                    reading <- false
+
+            return rows |> Seq.toList
+        }
+
+    /// Processes only a matching journalled fact and atomically commits raw, aggregate, rejection repair, and Accepted.
+    member _.ProcessAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            | Error errors -> return raise (InvalidOperationException(String.Join("; ", errors)))
+            | Ok plan ->
+                return!
+                    executeAsync
+                        (fun connection transaction operationCancellationToken ->
+                            task {
+                                let scope = scopeFor plan.RawFact
+                                do! acquireScopeAsync connection transaction scope operationCancellationToken
+                                let! journal = readJournalForUpdateAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+
+                                match journal with
+                                | None -> return MissingJournal
+                                | Some entry when not (matches plan.RawFact entry) -> return JournalConflict
+                                | Some entry when entry.State = UsageFactJournalState.Accepted -> return AlreadyAccepted
+                                | Some _ ->
+                                    let! inserted = tryInsertRawAsync connection transaction plan.RawFact operationCancellationToken
+
+                                    if inserted then
+                                        do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
+
+                                    do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
+                                    do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+                                    return AcceptedFromJournal
+                            })
+                        cancellationToken
+        }
+
+    /// Marks an existing matching Pending journal row Rejected with its exact-scope evidence in one transaction.
+    member _.RejectAsync(fact: UsageFact, rawPayload: byte array, reason: string, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            | Error errors -> return raise (InvalidOperationException(String.Join("; ", errors)))
+            | Ok plan ->
+                return!
+                    executeAsync
+                        (fun connection transaction operationCancellationToken ->
+                            task {
+                                let scope = scopeFor plan.RawFact
+                                do! acquireScopeAsync connection transaction scope operationCancellationToken
+                                let! journal = readJournalForUpdateAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+
+                                match journal with
+                                | None -> return RejectMissingJournal
+                                | Some entry when not (matches plan.RawFact entry) -> return RejectJournalConflict
+                                | Some entry when entry.State = UsageFactJournalState.Accepted -> return RejectAlreadyAccepted
+                                | Some entry when entry.State = UsageFactJournalState.Rejected -> return AlreadyRejected
+                                | Some _ ->
+                                    do! recordScopedRejectionAsync connection transaction plan.RawFact.UsageFactId scope reason operationCancellationToken
+                                    do! markRejectedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+                                    return RejectedFromJournal
+                            })
+                        cancellationToken
+        }
+
+    interface IOperationsUsageJournalStore with
+
+        member this.AppendAsync(fact, rawPayload, cancellationToken) = this.AppendAsync(fact, rawPayload, cancellationToken)
+        member this.ListPendingAsync(batchSize, cancellationToken) = this.ListPendingAsync(batchSize, cancellationToken)
+        member this.ProcessAsync(fact, rawPayload, cancellationToken) = this.ProcessAsync(fact, rawPayload, cancellationToken)
+        member this.RejectAsync(fact, rawPayload, reason, cancellationToken) = this.RejectAsync(fact, rawPayload, reason, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -53,6 +53,19 @@ type UsageFactJournalRejectResult =
     | RejectJournalConflict
     | RejectAlreadyAccepted
 
+/// Pauses a ProcessAsync transaction only after its raw and aggregate mutations have been staged for deterministic rollback proof.
+type internal IOperationsUsageJournalTransactionInterleaving =
+
+    /// Observes the transaction-local point immediately before journal acceptance can commit.
+    abstract AfterRawAndAggregateStagedAsync: cancellationToken: CancellationToken -> Task
+
+/// Leaves production journal transactions uninterrupted when no deterministic proof interleaving is supplied.
+type private NoOperationsUsageJournalTransactionInterleaving() =
+
+    interface IOperationsUsageJournalTransactionInterleaving with
+
+        member _.AfterRawAndAggregateStagedAsync(_cancellationToken) = Task.CompletedTask
+
 /// Owns the internal Operations append, dispatch scan, and transactionally verified journal processing seam.
 type IOperationsUsageJournalStore =
 
@@ -75,7 +88,7 @@ type IOperationsUsageJournalStore =
     abstract RepairAsync: fact: UsageFact * cancellationToken: CancellationToken -> Task<UsageFactJournalProcessResult>
 
 /// Stores immutable usage facts in the SQL journal and treats Service Bus delivery as a retryable signal only.
-type SqlOperationsUsageJournalStore(connectionString: string) =
+type SqlOperationsUsageJournalStore private (connectionString: string, transactionInterleaving: IOperationsUsageJournalTransactionInterleaving) =
 
     /// Opens the SQL connection used by one append, scan, or processing transaction.
     let openConnectionAsync cancellationToken =
@@ -354,6 +367,13 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
                 return raise ex
         }
 
+    /// Creates the production journal store with no test interleaving in its transaction path.
+    new(connectionString: string) =
+        SqlOperationsUsageJournalStore(connectionString, NoOperationsUsageJournalTransactionInterleaving() :> IOperationsUsageJournalTransactionInterleaving)
+
+    /// Creates an internal deterministic proof store that pauses only a transaction-local test interleaving point.
+    static member internal CreateForTest(connectionString, transactionInterleaving) = SqlOperationsUsageJournalStore(connectionString, transactionInterleaving)
+
     /// Appends one supported fact with immutable-idempotence semantics before a dispatcher can observe it.
     member _.AppendAsync(fact: UsageFact, cancellationToken: CancellationToken) =
         task {
@@ -494,6 +514,7 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
                                     if inserted then
                                         do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
 
+                                    do! transactionInterleaving.AfterRawAndAggregateStagedAsync(operationCancellationToken)
                                     do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
                                     do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
                                     return AcceptedFromJournal

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -41,6 +41,7 @@ type UsageFactJournalAppendResult =
 type UsageFactJournalProcessResult =
     | AcceptedFromJournal
     | AlreadyAccepted
+    | AlreadyRejected
     | MissingJournal
     | JournalConflict
 
@@ -55,18 +56,23 @@ type UsageFactJournalRejectResult =
 /// Owns the internal Operations append, dispatch scan, and transactionally verified journal processing seam.
 type IOperationsUsageJournalStore =
 
-    /// Commits a complete supported fact as immutable Pending truth before any broker send.
-    abstract AppendAsync:
-        fact: UsageFact * rawPayload: byte array * cancellationToken: CancellationToken -> Task<Result<UsageFactJournalAppendResult, string list>>
+    /// Commits a complete supported fact as immutable canonical Pending truth before any broker send.
+    abstract AppendAsync: fact: UsageFact * cancellationToken: CancellationToken -> Task<Result<UsageFactJournalAppendResult, string list>>
 
     /// Reads a bounded stable set of currently Pending immutable facts for retryable Service Bus signalling.
     abstract ListPendingAsync: batchSize: int * cancellationToken: CancellationToken -> Task<UsageFactJournalEntry list>
+
+    /// Rereads one candidate immediately before send and returns it only while its durable state remains Pending.
+    abstract TryGetPendingAsync: usageFactId: UsageFactId * cancellationToken: CancellationToken -> Task<UsageFactJournalEntry option>
 
     /// Rechecks the matching immutable journal row inside the raw, aggregate, and state transaction before accepting it.
     abstract ProcessAsync: fact: UsageFact * rawPayload: byte array * cancellationToken: CancellationToken -> Task<UsageFactJournalProcessResult>
 
     /// Atomically records scoped rejection evidence and the Rejected state for an already journaled supported fact.
     abstract RejectAsync: fact: UsageFact * rawPayload: byte array * reason: string * cancellationToken: CancellationToken -> Task<UsageFactJournalRejectResult>
+
+    /// Explicitly replays one matching Rejected fact into accepted raw and aggregate storage.
+    abstract RepairAsync: fact: UsageFact * cancellationToken: CancellationToken -> Task<UsageFactJournalProcessResult>
 
 /// Stores immutable usage facts in the SQL journal and treats Service Bus delivery as a retryable signal only.
 type SqlOperationsUsageJournalStore(connectionString: string) =
@@ -349,9 +355,9 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
         }
 
     /// Appends one supported fact with immutable-idempotence semantics before a dispatcher can observe it.
-    member _.AppendAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
+    member _.AppendAsync(fact: UsageFact, cancellationToken: CancellationToken) =
         task {
-            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            match UsageFactPersistencePlan.tryCreateCanonical fact with
             | Error errors -> return Error errors
             | Ok plan ->
                 let! result =
@@ -425,10 +431,48 @@ ORDER BY CreatedAtUtc ASC, UsageFactId ASC;
             return rows |> Seq.toList
         }
 
+    /// Rereads a selected identity immediately before Service Bus send so stale scans cannot signal a terminal row.
+    member _.TryGetPendingAsync(usageFactId: UsageFactId, cancellationToken: CancellationToken) =
+        task {
+            use! connection = openConnectionAsync cancellationToken
+            use command = connection.CreateCommand()
+            command.CommandType <- CommandType.Text
+
+            command.CommandText <-
+                """
+SELECT UsageFactId, RawPayload, CorrelationId, FactKind, OwnerId, OrganizationId, RepositoryId, StoragePoolId, Quantity, ObservedAtUtc, State
+FROM ops.UsageFactJournal WITH (READCOMMITTEDLOCK)
+WHERE UsageFactId = @UsageFactId AND State = 0;
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            use! reader = command.ExecuteReaderAsync cancellationToken
+            let! hasRow = reader.ReadAsync cancellationToken
+
+            if not hasRow then
+                return None
+            else
+                return
+                    Some
+                        {
+                            UsageFactId = reader.GetGuid 0
+                            RawPayload = reader.GetFieldValue<byte array> 1
+                            CorrelationId = reader.GetString 2
+                            FactKind = enum<UsageFactKind> (reader.GetInt32 3)
+                            OwnerId = reader.GetGuid 4
+                            OrganizationId = reader.GetGuid 5
+                            RepositoryId = reader.GetGuid 6
+                            StoragePoolId = reader.GetString 7
+                            Quantity = reader.GetInt64 8
+                            ObservedAt = reader.GetDateTime 9 |> toInstant
+                            State = enum<UsageFactJournalState> (reader.GetInt32 10)
+                        }
+        }
+
     /// Processes only a matching journalled fact and atomically commits raw, aggregate, rejection repair, and Accepted.
     member _.ProcessAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
         task {
-            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            match UsageFactPersistencePlan.tryCreateCanonical fact with
             | Error errors -> return raise (InvalidOperationException(String.Join("; ", errors)))
             | Ok plan ->
                 return!
@@ -443,6 +487,39 @@ ORDER BY CreatedAtUtc ASC, UsageFactId ASC;
                                 | None -> return MissingJournal
                                 | Some entry when not (matches plan.RawFact entry) -> return JournalConflict
                                 | Some entry when entry.State = UsageFactJournalState.Accepted -> return AlreadyAccepted
+                                | Some entry when entry.State = UsageFactJournalState.Rejected -> return UsageFactJournalProcessResult.AlreadyRejected
+                                | Some _ ->
+                                    let! inserted = tryInsertRawAsync connection transaction plan.RawFact operationCancellationToken
+
+                                    if inserted then
+                                        do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
+
+                                    do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
+                                    do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+                                    return AcceptedFromJournal
+                            })
+                        cancellationToken
+        }
+
+    /// Explicitly repairs a matching Rejected fact by resolving its evidence and accepting it in one transaction.
+    member _.RepairAsync(fact: UsageFact, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactPersistencePlan.tryCreateCanonical fact with
+            | Error errors -> return raise (InvalidOperationException(String.Join("; ", errors)))
+            | Ok plan ->
+                return!
+                    executeAsync
+                        (fun connection transaction operationCancellationToken ->
+                            task {
+                                let scope = scopeFor plan.RawFact
+                                do! acquireScopeAsync connection transaction scope operationCancellationToken
+                                let! journal = readJournalForUpdateAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
+
+                                match journal with
+                                | None -> return MissingJournal
+                                | Some entry when not (matches plan.RawFact entry) -> return JournalConflict
+                                | Some entry when entry.State = UsageFactJournalState.Accepted -> return AlreadyAccepted
+                                | Some entry when entry.State = UsageFactJournalState.Pending -> return JournalConflict
                                 | Some _ ->
                                     let! inserted = tryInsertRawAsync connection transaction plan.RawFact operationCancellationToken
 
@@ -459,7 +536,7 @@ ORDER BY CreatedAtUtc ASC, UsageFactId ASC;
     /// Marks an existing matching Pending journal row Rejected with its exact-scope evidence in one transaction.
     member _.RejectAsync(fact: UsageFact, rawPayload: byte array, reason: string, cancellationToken: CancellationToken) =
         task {
-            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            match UsageFactPersistencePlan.tryCreateCanonical fact with
             | Error errors -> return raise (InvalidOperationException(String.Join("; ", errors)))
             | Ok plan ->
                 return!
@@ -485,7 +562,9 @@ ORDER BY CreatedAtUtc ASC, UsageFactId ASC;
 
     interface IOperationsUsageJournalStore with
 
-        member this.AppendAsync(fact, rawPayload, cancellationToken) = this.AppendAsync(fact, rawPayload, cancellationToken)
+        member this.AppendAsync(fact, cancellationToken) = this.AppendAsync(fact, cancellationToken)
         member this.ListPendingAsync(batchSize, cancellationToken) = this.ListPendingAsync(batchSize, cancellationToken)
+        member this.TryGetPendingAsync(usageFactId, cancellationToken) = this.TryGetPendingAsync(usageFactId, cancellationToken)
         member this.ProcessAsync(fact, rawPayload, cancellationToken) = this.ProcessAsync(fact, rawPayload, cancellationToken)
         member this.RejectAsync(fact, rawPayload, reason, cancellationToken) = this.RejectAsync(fact, rawPayload, reason, cancellationToken)
+        member this.RepairAsync(fact, cancellationToken) = this.RepairAsync(fact, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -20,6 +20,14 @@ module OperationsUsageSql =
     [<Literal>]
     let UsageFactRejectionTable = "ops.UsageFactRejection"
 
+    /// Names the immutable pre-send fact journal used by dispatch and billing completeness.
+    [<Literal>]
+    let UsageFactJournalTable = "ops.UsageFactJournal"
+
+    /// Names the journal table without schema qualification for EF migrations.
+    [<Literal>]
+    let UsageFactJournalTableName = "UsageFactJournal"
+
     /// Names the minute aggregate table without schema qualification for EF migrations.
     [<Literal>]
     let UsageAggregateMinuteTableName = "UsageAggregateMinute"
@@ -163,6 +171,17 @@ WHERE UsageFactId = @UsageFactId AND OwnerId = @OwnerId AND OrganizationId = @Or
 SELECT CASE WHEN EXISTS (SELECT 1 FROM ops.UsageFactRejection WITH (UPDLOCK, HOLDLOCK)
                          WHERE OwnerId = @OwnerId AND OrganizationId = @OrganizationId AND RepositoryId = @RepositoryId
                            AND MonthStartUtc = @MonthStartUtc AND IsActive = 1)
+THEN CAST(1 AS bit) ELSE CAST(0 AS bit) END;
+"""
+
+    /// Reads unresolved journal truth only after the caller owns the matching completeness lock.
+    [<Literal>]
+    let HasUnresolvedUsageFactJournal =
+        """
+SELECT CASE WHEN EXISTS (SELECT 1 FROM ops.UsageFactJournal WITH (UPDLOCK, HOLDLOCK)
+                         WHERE OwnerId = @OwnerId AND OrganizationId = @OrganizationId AND RepositoryId = @RepositoryId
+                           AND ObservedAtUtc >= @MonthStartUtc AND ObservedAtUtc < @NextMonthStartUtc
+                           AND State IN (@PendingState, @RejectedState))
 THEN CAST(1 AS bit) ELSE CAST(0 AS bit) END;
 """
 

--- a/src/Grace.Operations/Grace.Operations.ProofHost/Grace.Operations.ProofHost.fsproj
+++ b/src/Grace.Operations/Grace.Operations.ProofHost/Grace.Operations.ProofHost.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <OutputType>Exe</OutputType>
+    <Description>Test-only executable that enters Operations usage-fact append through its production data boundary.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <OtherFlags>--test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen</OtherFlags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
+    <ProjectReference Include="..\Grace.Operations.fsproj" />
+    <ProjectReference Include="..\..\Grace.Shared\Grace.Shared.fsproj" />
+    <ProjectReference Include="..\..\Grace.Types\Grace.Types.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/Grace.Operations/Grace.Operations.ProofHost/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.ProofHost/Program.fs
@@ -1,0 +1,54 @@
+namespace Grace.Operations.ProofHost
+
+open Grace.Operations.Data
+open Grace.Shared
+open Grace.Types.Usage
+open System
+open System.Text.Json
+open System.Threading
+
+/// Runs the internal Operations append seam from an isolated process used only by AppHost integration proof.
+module Program =
+
+    /// Appends one serialized fact through the production journal store without exposing a product route or test SQL shortcut.
+    let private append connectionString encodedFact =
+        let factBytes = Convert.FromBase64String encodedFact
+        let fact = JsonSerializer.Deserialize<UsageFact>(factBytes, Constants.JsonSerializerOptions)
+
+        if isNull (box fact) then
+            invalidArg (nameof encodedFact) "The usage fact payload is required."
+
+        let store = SqlOperationsUsageJournalStore(connectionString)
+
+        store
+            .AppendAsync(fact, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult()
+
+    /// Provides the test-only executable entry point used by the graph-independent AppHost tracer.
+    [<EntryPoint>]
+    let main arguments =
+        if arguments.Length <> 2 then
+            Console.Error.WriteLine("Usage: Grace.Operations.ProofHost <operations-sql-connection-string> <base64-usage-fact-json>")
+            64
+        else
+            try
+                let result = append arguments[0] arguments[1]
+
+                match result with
+                | Ok AppendedPending ->
+                    Console.Out.WriteLine("appended-pending")
+                    0
+                | Ok AlreadyPending ->
+                    Console.Out.WriteLine("already-pending")
+                    0
+                | Ok (AlreadyTerminal state) ->
+                    Console.Out.WriteLine($"already-terminal:{state}")
+                    0
+                | Error errors ->
+                    Console.Error.WriteLine(String.Join("; ", errors))
+                    1
+            with
+            | ex ->
+                Console.Error.WriteLine(ex.ToString())
+                1

--- a/src/Grace.Operations/Grace.Operations.ProofHost/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.ProofHost/Program.fs
@@ -10,14 +10,19 @@ open System.Threading
 /// Runs the internal Operations append seam from an isolated process used only by AppHost integration proof.
 module Program =
 
-    /// Appends one serialized fact through the production journal store without exposing a product route or test SQL shortcut.
-    let private append connectionString encodedFact =
+    /// Deserializes the complete supplied fact once for Operations-only proof commands.
+    let private deserializeFact encodedFact =
         let factBytes = Convert.FromBase64String encodedFact
         let fact = JsonSerializer.Deserialize<UsageFact>(factBytes, Constants.JsonSerializerOptions)
 
         if isNull (box fact) then
             invalidArg (nameof encodedFact) "The usage fact payload is required."
 
+        fact
+
+    /// Appends one serialized fact through the production journal store without exposing a product route or test SQL shortcut.
+    let private append connectionString encodedFact =
+        let fact = deserializeFact encodedFact
         let store = SqlOperationsUsageJournalStore(connectionString)
 
         store
@@ -25,29 +30,61 @@ module Program =
             .GetAwaiter()
             .GetResult()
 
+    /// Evaluates the fact's exact scope through the production completeness store, preserving the root/Operations graph boundary.
+    let private evaluateCompleteness connectionString encodedFact =
+        let fact = deserializeFact encodedFact
+
+        let scope =
+            match UsageFactPersistencePlan.tryCreateCanonical fact with
+            | Ok plan ->
+                BillingCompletenessScope.tryCreate plan.RawFact.OwnerId plan.RawFact.OrganizationId plan.RawFact.RepositoryId plan.RawFact.ObservedAt
+                |> Result.defaultWith (fun errors -> invalidOp (String.Join("; ", errors)))
+            | Error errors -> invalidOp (String.Join("; ", errors))
+
+        OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+            .EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+            .GetAwaiter()
+            .GetResult()
+
     /// Provides the test-only executable entry point used by the graph-independent AppHost tracer.
     [<EntryPoint>]
     let main arguments =
-        if arguments.Length <> 2 then
-            Console.Error.WriteLine("Usage: Grace.Operations.ProofHost <operations-sql-connection-string> <base64-usage-fact-json>")
+        if arguments.Length <> 3 then
+            Console.Error.WriteLine("Usage: Grace.Operations.ProofHost <append|completeness> <operations-sql-connection-string> <base64-usage-fact-json>")
             64
         else
             try
-                let result = append arguments[0] arguments[1]
+                match arguments[0] with
+                | "append" ->
+                    let result = append arguments[1] arguments[2]
 
-                match result with
-                | Ok AppendedPending ->
-                    Console.Out.WriteLine("appended-pending")
-                    0
-                | Ok AlreadyPending ->
-                    Console.Out.WriteLine("already-pending")
-                    0
-                | Ok (AlreadyTerminal state) ->
-                    Console.Out.WriteLine($"already-terminal:{state}")
-                    0
-                | Error errors ->
-                    Console.Error.WriteLine(String.Join("; ", errors))
-                    1
+                    match result with
+                    | Ok AppendedPending ->
+                        Console.Out.WriteLine("appended-pending")
+                        0
+                    | Ok AlreadyPending ->
+                        Console.Out.WriteLine("already-pending")
+                        0
+                    | Ok (AlreadyTerminal state) ->
+                        Console.Out.WriteLine($"already-terminal:{state}")
+                        0
+                    | Error errors ->
+                        Console.Error.WriteLine(String.Join("; ", errors))
+                        1
+                | "completeness" ->
+                    match evaluateCompleteness arguments[1] arguments[2] with
+                    | BlockedByUnresolvedUsageFactJournal ->
+                        Console.Out.WriteLine("blocked-by-unresolved-usage-fact-journal")
+                        0
+                    | Complete ->
+                        Console.Out.WriteLine("complete")
+                        0
+                    | state ->
+                        Console.Out.WriteLine($"other-completeness:{state}")
+                        1
+                | command ->
+                    Console.Error.WriteLine($"Unknown proof command '{command}'.")
+                    64
             with
             | ex ->
                 Console.Error.WriteLine(ex.ToString())

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -1382,8 +1382,8 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 let journal = SqlOperationsUsageJournalStore(connectionString)
                 let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
 
-                let! firstAppend = journal.AppendAsync(usageFact, rawPayload, CancellationToken.None)
-                let! secondAppend = journal.AppendAsync(usageFact, rawPayload, CancellationToken.None)
+                let! firstAppend = journal.AppendAsync(usageFact, CancellationToken.None)
+                let! secondAppend = journal.AppendAsync(usageFact, CancellationToken.None)
                 let! blocked = completeness.EvaluateBillingCompletenessAsync(exactScope, CancellationToken.None)
                 let! unrelated = completeness.EvaluateBillingCompletenessAsync(unrelatedScope, CancellationToken.None)
                 let! firstProcess = journal.ProcessAsync(usageFact, rawPayload, CancellationToken.None)
@@ -1419,7 +1419,7 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 )
             })
 
-    /// Proves deterministic rejection writes exact-scope evidence and Rejected atomically, then explicit same-payload processing repairs it.
+    /// Proves normal delivery leaves Rejected truth intact and only explicit same-payload replay repairs it.
     [<Test>]
     member _.JournalRejectionIsAtomicAndAcceptanceRepairsOnlyMatchingEvidence() =
         withDatabaseAsync (fun connectionString ->
@@ -1434,7 +1434,7 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 let journal = SqlOperationsUsageJournalStore(connectionString)
                 let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
 
-                let! appended = journal.AppendAsync(usageFact, rawPayload, CancellationToken.None)
+                let! appended = journal.AppendAsync(usageFact, CancellationToken.None)
                 let! rejected = journal.RejectAsync(usageFact, rawPayload, "deterministic policy rejection", CancellationToken.None)
                 let! blockedByRejected = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
 
@@ -1448,7 +1448,13 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         connectionString
                         $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND State = 2;"
 
-                let! accepted = journal.ProcessAsync(usageFact, rawPayload, CancellationToken.None)
+                let! normalDelivery = journal.ProcessAsync(usageFact, rawPayload, CancellationToken.None)
+                let! rejectedAfterNormalDelivery = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+
+                let! rawCountAfterNormalDelivery =
+                    executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                let! accepted = journal.RepairAsync(usageFact, CancellationToken.None)
                 let! completeAfterRepair = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
 
                 let! activeRejectionCount =
@@ -1471,6 +1477,9 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         Assert.That(blockedByRejected, Is.EqualTo(BlockedByActiveScopedRejection))
                         Assert.That(rejectionCount, Is.EqualTo(1))
                         Assert.That(rejectedJournalCount, Is.EqualTo(1))
+                        Assert.That(normalDelivery, Is.EqualTo(UsageFactJournalProcessResult.AlreadyRejected))
+                        Assert.That(rejectedAfterNormalDelivery, Is.EqualTo(BlockedByActiveScopedRejection))
+                        Assert.That(rawCountAfterNormalDelivery, Is.Zero)
                         Assert.That(accepted, Is.EqualTo(AcceptedFromJournal))
                         Assert.That(completeAfterRepair, Is.EqualTo(Complete))
                         Assert.That(activeRejectionCount, Is.Zero)

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -54,6 +54,8 @@ type private ObservedOperationsUsageTransaction
 
         member _.HasActiveScopedUsageFactRejectionAsync(scope, cancellationToken) = inner.HasActiveScopedUsageFactRejectionAsync(scope, cancellationToken)
 
+        member _.HasUnresolvedUsageFactJournalAsync(scope, cancellationToken) = inner.HasUnresolvedUsageFactJournalAsync(scope, cancellationToken)
+
 /// Wraps a real SQL transaction scope with deterministic lock-grant callbacks used only by concurrency proofs.
 type private ObservedOperationsUsageTransactionScope
     (
@@ -1363,3 +1365,115 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                     Is.True
                 ))
         )
+
+    /// Proves a durable Pending fact blocks only its exact scope before dispatch and becomes Accepted exactly once after processing.
+    [<Test>]
+    member _.JournalAppendBlocksOnlyItsScopeAndProcessesExactlyOnce() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let rawPayload = payloadFor usageFact
+                let exactScope = scopeFor ownerId organizationId repositoryId observedAt
+                let unrelatedScope = scopeFor ownerId organizationId (Guid.NewGuid()) observedAt
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+
+                let! firstAppend = journal.AppendAsync(usageFact, rawPayload, CancellationToken.None)
+                let! secondAppend = journal.AppendAsync(usageFact, rawPayload, CancellationToken.None)
+                let! blocked = completeness.EvaluateBillingCompletenessAsync(exactScope, CancellationToken.None)
+                let! unrelated = completeness.EvaluateBillingCompletenessAsync(unrelatedScope, CancellationToken.None)
+                let! firstProcess = journal.ProcessAsync(usageFact, rawPayload, CancellationToken.None)
+                let! duplicateProcess = journal.ProcessAsync(usageFact, rawPayload, CancellationToken.None)
+                let! completed = completeness.EvaluateBillingCompletenessAsync(exactScope, CancellationToken.None)
+
+                let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                let! aggregateCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                let! acceptedJournalCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND State = 1;"
+
+                match firstAppend, secondAppend with
+                | Ok AppendedPending, Ok AlreadyPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append results: first={firstAppend}; second={secondAppend}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(blocked, Is.EqualTo(BlockedByUnresolvedUsageFactJournal))
+                        Assert.That(unrelated, Is.EqualTo(Complete))
+                        Assert.That(firstProcess, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(duplicateProcess, Is.EqualTo(AlreadyAccepted))
+                        Assert.That(completed, Is.EqualTo(Complete))
+                        Assert.That(rawCount, Is.EqualTo(1))
+                        Assert.That(aggregateCount, Is.EqualTo(1))
+                        Assert.That(acceptedJournalCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves deterministic rejection writes exact-scope evidence and Rejected atomically, then explicit same-payload processing repairs it.
+    [<Test>]
+    member _.JournalRejectionIsAtomicAndAcceptanceRepairsOnlyMatchingEvidence() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let rawPayload = payloadFor usageFact
+                let scope = scopeFor ownerId organizationId repositoryId observedAt
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+
+                let! appended = journal.AppendAsync(usageFact, rawPayload, CancellationToken.None)
+                let! rejected = journal.RejectAsync(usageFact, rawPayload, "deterministic policy rejection", CancellationToken.None)
+                let! blockedByRejected = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+
+                let! rejectionCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND IsActive = 1;"
+
+                let! rejectedJournalCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND State = 2;"
+
+                let! accepted = journal.ProcessAsync(usageFact, rawPayload, CancellationToken.None)
+                let! completeAfterRepair = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+
+                let! activeRejectionCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND IsActive = 1;"
+
+                let! acceptedJournalCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND State = 1;"
+
+                match appended with
+                | Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append result: {appended}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                        Assert.That(blockedByRejected, Is.EqualTo(BlockedByActiveScopedRejection))
+                        Assert.That(rejectionCount, Is.EqualTo(1))
+                        Assert.That(rejectedJournalCount, Is.EqualTo(1))
+                        Assert.That(accepted, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(completeAfterRepair, Is.EqualTo(Complete))
+                        Assert.That(activeRejectionCount, Is.Zero)
+                        Assert.That(acceptedJournalCount, Is.EqualTo(1)))
+                )
+            })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Operations.Tests
 
 open Grace.Operations.Data
+open Grace.Operations.Worker
 open Grace.Shared
 open Grace.Types.Common
 open Grace.Types.Usage
@@ -77,6 +78,69 @@ type private ObservedOperationsUsageTransactionScope
                         operationCancellationToken),
                 cancellationToken
             )
+
+/// Pauses a real ProcessAsync transaction after raw and aggregate SQL writes have been staged, then lets cancellation abort it.
+type private CancellationAfterJournalStageInterleaving() =
+    let staged = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+    /// Completes only after the transaction owns staged raw and aggregate mutations.
+    member _.Staged = staged.Task
+
+    /// Releases a non-cancelled test path without retaining any durable state.
+    member _.Release() = release.TrySetResult(()) |> ignore
+
+    interface IOperationsUsageJournalTransactionInterleaving with
+
+        member _.AfterRawAndAggregateStagedAsync(cancellationToken) =
+            task {
+                staged.TrySetResult(()) |> ignore
+                do! release.Task.WaitAsync(cancellationToken)
+            }
+            :> Task
+
+/// Pauses the production dispatcher loop after selection and before its per-row current-state reread.
+type private PauseAfterPendingScanInterleaving() =
+    let selected = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let selectedUsageFactIds = ResizeArray<UsageFactId>()
+
+    /// Completes when the production loop has a stale candidate that it must reread before sending.
+    member _.Selected = selected.Task
+
+    /// Returns the candidates selected before the required production reread.
+    member _.SelectedUsageFactIds = selectedUsageFactIds |> Seq.toList
+
+    /// Allows the production loop to continue to its per-row reread.
+    member _.Release() = release.TrySetResult(()) |> ignore
+
+    interface IOperationsUsageJournalDispatchInterleaving with
+
+        member _.AfterPendingScanAsync(entries, cancellationToken) =
+            task {
+                entries
+                |> List.iter (fun entry -> selectedUsageFactIds.Add(entry.UsageFactId))
+
+                selected.TrySetResult(()) |> ignore
+                do! release.Task.WaitAsync(cancellationToken)
+            }
+            :> Task
+
+/// Records production dispatch send decisions without inserting a broker substitute into the SQL proof.
+type private RecordingOperationsUsageJournalSignalSender() =
+    let sent = ResizeArray<UsageFactJournalEntry>()
+
+    /// Returns immutable identities the production dispatcher decided to signal.
+    member _.SentUsageFactIds =
+        sent
+        |> Seq.map (fun entry -> entry.UsageFactId)
+        |> Seq.toList
+
+    interface IOperationsUsageJournalSignalSender with
+
+        member _.SendAsync(entry, _cancellationToken) =
+            sent.Add(entry)
+            Task.CompletedTask
 
 /// Proves the owner-month completeness coordination boundary against isolated real SQL Server databases.
 [<TestFixture>]
@@ -1663,6 +1727,75 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 )
             })
 
+    /// Proves cancellation after ProcessAsync stages raw and aggregate SQL mutations rolls every journal-side effect back to Pending truth.
+    [<Test>]
+    member _.JournalProcessCancellationAfterStagedRawAndAggregateRollsBackToPendingTruth() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let scope = scopeFor ownerId organizationId repositoryId observedAt
+                let interleaving = CancellationAfterJournalStageInterleaving()
+
+                let journal = SqlOperationsUsageJournalStore.CreateForTest(connectionString, interleaving :> IOperationsUsageJournalTransactionInterleaving)
+
+                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+                let! appended = journal.AppendAsync(usageFact, CancellationToken.None)
+                use cancellation = new CancellationTokenSource()
+                let processing = journal.ProcessAsync(usageFact, payloadFor usageFact, cancellation.Token)
+
+                try
+                    do! interleaving.Staged.WaitAsync(TimeSpan.FromSeconds(10.0))
+                    cancellation.Cancel()
+
+                    let! cancelled =
+                        task {
+                            try
+                                let! _ = processing
+                                return false
+                            with
+                            | :? OperationCanceledException -> return true
+                        }
+
+                    let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! aggregateCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                    let! pendingJournalCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND State = 0;"
+
+                    let! rejectionEvidenceCount =
+                        executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! completenessAfterCancellation = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+
+                    let appendedPending =
+                        match appended with
+                        | Ok AppendedPending -> true
+                        | _ -> false
+
+                    Assert.Multiple(
+                        Action (fun () ->
+                            Assert.That(appendedPending, Is.True)
+                            Assert.That(cancelled, Is.True)
+                            Assert.That(rawCount, Is.Zero)
+                            Assert.That(aggregateCount, Is.Zero)
+                            Assert.That(pendingJournalCount, Is.EqualTo(1))
+                            Assert.That(rejectionEvidenceCount, Is.Zero)
+                            Assert.That(completenessAfterCancellation, Is.EqualTo(BlockedByUnresolvedUsageFactJournal)))
+                    )
+                finally
+                    interleaving.Release()
+            })
+
     /// Proves stale dispatch rereads skip a rejected row and concurrent explicit repairs converge without duplicate aggregate state.
     [<Test>]
     member _.JournalStaleDispatchAndConflictingRepairPreserveTerminalTruth() =
@@ -1677,8 +1810,31 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 let journal = SqlOperationsUsageJournalStore(connectionString)
                 let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
                 let! _ = journal.AppendAsync(usageFact, CancellationToken.None)
-                let! staleSelection = journal.ListPendingAsync(10, CancellationToken.None)
-                let! rejected = journal.RejectAsync(usageFact, payloadFor usageFact, "deterministic rejection", CancellationToken.None)
+                let pause = PauseAfterPendingScanInterleaving()
+                let sender = RecordingOperationsUsageJournalSignalSender()
+
+                let dispatch =
+                    OperationsUsageJournalDispatcher.dispatchCurrentPendingAsync
+                        (journal :> IOperationsUsageJournalStore)
+                        10
+                        (pause :> IOperationsUsageJournalDispatchInterleaving)
+                        (sender :> IOperationsUsageJournalSignalSender)
+                        CancellationToken.None
+
+                let! rejected =
+                    task {
+                        try
+                            do! pause.Selected.WaitAsync(TimeSpan.FromSeconds(10.0))
+
+                            let! result = journal.RejectAsync(usageFact, payloadFor usageFact, "deterministic rejection", CancellationToken.None)
+
+                            pause.Release()
+                            return result
+                        finally
+                            pause.Release()
+                    }
+
+                do! dispatch
                 let! pendingAfterRejection = journal.TryGetPendingAsync(usageFact.UsageFactId, CancellationToken.None)
                 let! normal = journal.ProcessAsync(usageFact, payloadFor usageFact, CancellationToken.None)
                 let firstRepair = journal.RepairAsync(usageFact, CancellationToken.None)
@@ -1701,13 +1857,14 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 Assert.Multiple(
                     Action (fun () ->
                         Assert.That(
-                            staleSelection
-                            |> List.exists (fun entry -> entry.UsageFactId = usageFact.UsageFactId),
+                            pause.SelectedUsageFactIds
+                            |> List.contains usageFact.UsageFactId,
                             Is.True
                         )
 
                         Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
                         Assert.That(pendingAfterRejection, Is.EqualTo(None))
+                        Assert.That(sender.SentUsageFactIds, Is.Empty)
                         Assert.That(normal, Is.EqualTo(UsageFactJournalProcessResult.AlreadyRejected))
 
                         Assert.That(

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -9,6 +9,7 @@ open NodaTime
 open NUnit.Framework
 open System
 open System.Data
+open System.Text
 open System.Text.Json
 open System.Threading
 open System.Threading.Tasks
@@ -150,6 +151,19 @@ type OperationsBillingCompletenessTests() =
             observedAt
         )
 
+    /// Builds a valid fact with an explicit immutable quantity for same-identity conflict proofs.
+    let factWithQuantity usageFactId ownerId organizationId repositoryId quantity observedAt =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            CorrelationId $"billing-completeness-{usageFactId}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            StoragePoolId "billing-completeness-pool",
+            quantity,
+            observedAt
+        )
+
     /// Serializes a UsageFact payload exactly as the production Operations storage boundary receives it.
     let payloadFor usageFact = JsonSerializer.SerializeToUtf8Bytes(usageFact, Constants.JsonSerializerOptions)
 
@@ -187,6 +201,17 @@ type OperationsBillingCompletenessTests() =
             command.CommandText <- commandText
             let! value = command.ExecuteScalarAsync CancellationToken.None
             return Convert.ToInt32 value
+        }
+
+    /// Reads one binary value from the isolated Operations database for canonical-byte persistence assertions.
+    let executeBytesAsync connectionString commandText =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- commandText
+            let! value = command.ExecuteScalarAsync CancellationToken.None
+            return value :?> byte array
         }
 
     /// Reads whether SQL Server reports the named production operation has a waiting application-lock request.
@@ -1484,5 +1509,224 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         Assert.That(completeAfterRepair, Is.EqualTo(Complete))
                         Assert.That(activeRejectionCount, Is.Zero)
                         Assert.That(acceptedJournalCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves a UsageFactId cannot be rebound to a different immutable payload or exact scope, and processing persists canonical bytes once.
+    [<Test>]
+    member _.JournalConflictsPreserveExistingScopeAndCanonicalProcessingIgnoresBrokerByteVariation() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let usageFactId = Guid.NewGuid()
+                let usageFact = fact usageFactId ownerId organizationId repositoryId observedAt
+                let changedPayload = factWithQuantity usageFactId ownerId organizationId repositoryId 8192L observedAt
+                let changedScope = fact usageFactId ownerId organizationId (Guid.NewGuid()) observedAt
+                let exactScope = scopeFor ownerId organizationId repositoryId observedAt
+                let changedScopeValue = scopeFor ownerId organizationId changedScope.Scope.RepositoryId observedAt
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+
+                let! appended = journal.AppendAsync(usageFact, CancellationToken.None)
+
+                let! payloadConflict =
+                    task {
+                        try
+                            let! _ = journal.AppendAsync(changedPayload, CancellationToken.None)
+                            return false
+                        with
+                        | :? InvalidOperationException -> return true
+                    }
+
+                let! scopeConflict =
+                    task {
+                        try
+                            let! _ = journal.AppendAsync(changedScope, CancellationToken.None)
+                            return false
+                        with
+                        | :? InvalidOperationException -> return true
+                    }
+
+                let noncanonicalBrokerBytes = Encoding.UTF8.GetBytes($"  \n{JsonSerializer.Serialize(usageFact, Constants.JsonSerializerOptions)}\n  ")
+                let! processed = journal.ProcessAsync(usageFact, noncanonicalBrokerBytes, CancellationToken.None)
+                let! exactCompleteness = completeness.EvaluateBillingCompletenessAsync(exactScope, CancellationToken.None)
+                let! changedCompleteness = completeness.EvaluateBillingCompletenessAsync(changedScopeValue, CancellationToken.None)
+                let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFactId:D}';"
+
+                let! canonicalRawPayload = executeBytesAsync connectionString $"SELECT RawPayload FROM ops.RawUsageFact WHERE UsageFactId = '{usageFactId:D}';"
+
+                let! journalCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFactId:D}' AND Quantity = 4096 AND RepositoryId = '{repositoryId:D}' AND State = 1;"
+
+                let! aggregateQuantity =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                match appended with
+                | Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append result: {appended}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(payloadConflict, Is.True)
+                        Assert.That(scopeConflict, Is.True)
+                        Assert.That(processed, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(exactCompleteness, Is.EqualTo(Complete))
+                        Assert.That(changedCompleteness, Is.EqualTo(Complete))
+                        Assert.That(rawCount, Is.EqualTo(1))
+                        Assert.That(Convert.ToBase64String(canonicalRawPayload), Is.EqualTo(Convert.ToBase64String(payloadFor usageFact)))
+                        Assert.That(journalCount, Is.EqualTo(1))
+                        Assert.That(aggregateQuantity, Is.EqualTo(4096)))
+                )
+            })
+
+    /// Proves deterministic SQL failures after staged rejection or raw/aggregate work roll back all journal transition effects.
+    [<Test>]
+    member _.JournalTransactionFailuresLeavePendingTruthAndCompletenessBlocked() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let rejectionFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let processingFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let scope = scopeFor ownerId organizationId repositoryId observedAt
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+                let! _ = journal.AppendAsync(rejectionFact, CancellationToken.None)
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        "CREATE TRIGGER ops.ThrowAfterRejectionEvidence ON ops.UsageFactRejection AFTER INSERT AS BEGIN THROW 51000, 'deterministic rejection evidence failure', 1; END;"
+
+                let! rejectionFailed =
+                    task {
+                        try
+                            let! _ = journal.RejectAsync(rejectionFact, payloadFor rejectionFact, "deterministic rejection", CancellationToken.None)
+                            return false
+                        with
+                        | :? SqlException -> return true
+                    }
+
+                do! executeNonQueryAsync connectionString "DROP TRIGGER ops.ThrowAfterRejectionEvidence;"
+                let! _ = journal.AppendAsync(processingFact, CancellationToken.None)
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        "CREATE TRIGGER ops.ThrowAfterAggregate ON ops.UsageAggregateMinute AFTER INSERT AS BEGIN THROW 51001, 'deterministic aggregate failure', 1; END;"
+
+                let! processingFailed =
+                    task {
+                        try
+                            let! _ = journal.ProcessAsync(processingFact, payloadFor processingFact, CancellationToken.None)
+                            return false
+                        with
+                        | :? SqlException -> return true
+                    }
+
+                let! rejectionState =
+                    executeInt32Async connectionString $"SELECT State FROM ops.UsageFactJournal WHERE UsageFactId = '{rejectionFact.UsageFactId:D}';"
+
+                let! processingState =
+                    executeInt32Async connectionString $"SELECT State FROM ops.UsageFactJournal WHERE UsageFactId = '{processingFact.UsageFactId:D}';"
+
+                let! evidenceCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId IN ('{rejectionFact.UsageFactId:D}', '{processingFact.UsageFactId:D}');"
+
+                let! rawCount =
+                    executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{processingFact.UsageFactId:D}';"
+
+                let! aggregateCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}';"
+                let! blocked = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(rejectionFailed, Is.True)
+                        Assert.That(processingFailed, Is.True)
+                        Assert.That(rejectionState, Is.Zero)
+                        Assert.That(processingState, Is.Zero)
+                        Assert.That(evidenceCount, Is.Zero)
+                        Assert.That(rawCount, Is.Zero)
+                        Assert.That(aggregateCount, Is.Zero)
+                        Assert.That(blocked, Is.EqualTo(BlockedByUnresolvedUsageFactJournal)))
+                )
+            })
+
+    /// Proves stale dispatch rereads skip a rejected row and concurrent explicit repairs converge without duplicate aggregate state.
+    [<Test>]
+    member _.JournalStaleDispatchAndConflictingRepairPreserveTerminalTruth() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let scope = scopeFor ownerId organizationId repositoryId observedAt
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+                let! _ = journal.AppendAsync(usageFact, CancellationToken.None)
+                let! staleSelection = journal.ListPendingAsync(10, CancellationToken.None)
+                let! rejected = journal.RejectAsync(usageFact, payloadFor usageFact, "deterministic rejection", CancellationToken.None)
+                let! pendingAfterRejection = journal.TryGetPendingAsync(usageFact.UsageFactId, CancellationToken.None)
+                let! normal = journal.ProcessAsync(usageFact, payloadFor usageFact, CancellationToken.None)
+                let firstRepair = journal.RepairAsync(usageFact, CancellationToken.None)
+                let secondRepair = journal.RepairAsync(usageFact, CancellationToken.None)
+                let! repairs = Task.WhenAll(firstRepair, secondRepair)
+                let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                let! aggregateQuantity =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                let! activeEvidence =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND IsActive = 1;"
+
+                let! completed = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            staleSelection
+                            |> List.exists (fun entry -> entry.UsageFactId = usageFact.UsageFactId),
+                            Is.True
+                        )
+
+                        Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                        Assert.That(pendingAfterRejection, Is.EqualTo(None))
+                        Assert.That(normal, Is.EqualTo(UsageFactJournalProcessResult.AlreadyRejected))
+
+                        Assert.That(
+                            repairs
+                            |> Array.filter ((=) AcceptedFromJournal)
+                            |> Array.length,
+                            Is.EqualTo(1)
+                        )
+
+                        Assert.That(
+                            repairs
+                            |> Array.filter ((=) AlreadyAccepted)
+                            |> Array.length,
+                            Is.EqualTo(1)
+                        )
+
+                        Assert.That(rawCount, Is.EqualTo(1))
+                        Assert.That(aggregateQuantity, Is.EqualTo(4096))
+                        Assert.That(activeEvidence, Is.Zero)
+                        Assert.That(completed, Is.EqualTo(Complete)))
                 )
             })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -244,7 +244,7 @@ type OperationsChargePreviewTests() =
                 "..",
                 "Grace.Operations.Data",
                 "Migrations",
-                "20260812090000_AddBillingCompletenessCoordination.fs"
+                "20260812110000_AddUsageFactJournal.fs"
             )
             |> Path.GetFullPath
 
@@ -274,7 +274,7 @@ type OperationsChargePreviewTests() =
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewModel;Integrated Security=true;"
         let runtime = context.GetService<IDesignTimeModel>().Model
         let snapshot = OperationsDbContextModelSnapshot().Model
-        let migration = AddBillingCompletenessCoordination().TargetModel
+        let migration = AddUsageFactJournal().TargetModel
 
         let modelShape (model: Microsoft.EntityFrameworkCore.Metadata.IModel) =
             model.GetEntityTypes()
@@ -342,6 +342,8 @@ type OperationsChargePreviewTests() =
             Assert.That(snapshotModelSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
             Assert.That(targetModelSource, Does.Contain("let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()"))
             Assert.That(snapshotModelSource, Does.Contain("let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()"))
+            Assert.That(targetModelSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
+            Assert.That(snapshotModelSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
             Assert.That(rejection, Is.Not.Null)
             Assert.That((migrationShape = snapshotShape), Is.True)
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsSkeleton.Tests.fs
@@ -157,6 +157,7 @@ type ``Operations skeleton project graph``() =
             [|
                 "Grace.Operations.fsproj"
                 "Grace.Operations.Data/Grace.Operations.Data.fsproj"
+                "Grace.Operations.ProofHost/Grace.Operations.ProofHost.fsproj"
                 "Grace.Operations.Tests/Grace.Operations.Tests.fsproj"
                 "Grace.Operations.Worker/Grace.Operations.Worker.fsproj"
             |]

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -164,6 +164,10 @@ type private InMemoryOperationsUsageTransactionScope() =
                         member _.HasActiveScopedUsageFactRejectionAsync(_scope, readCancellationToken) =
                             readCancellationToken.ThrowIfCancellationRequested()
                             Task.FromResult false
+
+                        member _.HasUnresolvedUsageFactJournalAsync(_scope, readCancellationToken) =
+                            readCancellationToken.ThrowIfCancellationRequested()
+                            Task.FromResult false
                     }
 
                 let! result = operation transaction cancellationToken

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsWorkerIngestion.Tests.fs
@@ -281,8 +281,14 @@ type OperationsWorkerIngestionTests() =
         let events = List<string>()
 
         let store =
-            OperationsUsageStore(FailingOperationsUsageTransactionScope())
-            |> OperationsUsageFactStoreAdapter
+            StubUsageFactStore(
+                (fun _ _ _ ->
+                    Task.FromResult(
+                        Error [ "CorrelationId exceeds the Operations SQL storage limit."
+                                "Resource.StoragePoolId exceeds the Operations SQL storage limit." ]
+                    )),
+                events
+            )
 
         let logger =
             NullLogger<OperationsUsageIngestionProcessor>
@@ -1890,7 +1896,7 @@ type OperationsWorkerIngestionTests() =
 
             Assert.Multiple(
                 Action (fun () ->
-                    Assert.That(eventText events, Is.EqualTo("dead-letter"))
+                    Assert.That(eventText events, Is.EqualTo("store|dead-letter"))
                     Assert.That(settlementText actions.Settlements, Is.EqualTo("dead-letter:InvalidUsageFact")))
             )
         }

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -95,6 +95,8 @@ type OperationsUsageFactStoreAdapter(journal: IOperationsUsageJournalStore) =
                     match result with
                     | AcceptedFromJournal -> Ok { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = fact.UsageFactId; Aggregate = None }
                     | AlreadyAccepted -> Ok { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
+                    | UsageFactJournalProcessResult.AlreadyRejected ->
+                        Ok { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
                     | MissingJournal -> Error [ "Unsupported UsageFact message has no matching journal row." ]
                     | JournalConflict -> Error [ "Unsupported UsageFact message conflicts with its immutable journal row." ]
             }
@@ -2409,7 +2411,12 @@ type OperationsUsageJournalDispatcherService
 
                             while index < pending.Length do
                                 let entry = pending[index]
-                                do! sender.SendMessageAsync(createMessage entry, cancellationToken)
+                                let! currentEntry = journal.TryGetPendingAsync(entry.UsageFactId, cancellationToken)
+
+                                match currentEntry with
+                                | Some pendingEntry -> do! sender.SendMessageAsync(createMessage pendingEntry, cancellationToken)
+                                | None -> ()
+
                                 index <- index + 1
 
                             do! Task.Delay(retryDelay, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -82,12 +82,22 @@ type IOperationsUsageFactStore =
     abstract StoreUsageFactAsync:
         fact: UsageFact * rawPayload: byte array * cancellationToken: CancellationToken -> Task<Result<UsageFactPersistenceResult, string list>>
 
-/// Adapts the concrete operations data store to the worker's fakeable ingestion dependency.
-type OperationsUsageFactStoreAdapter(store: OperationsUsageStore) =
+/// Adapts the journal processor to the worker's fakeable ingestion dependency without letting a broker message create a fact.
+type OperationsUsageFactStoreAdapter(journal: IOperationsUsageJournalStore) =
 
     interface IOperationsUsageFactStore with
 
-        member _.StoreUsageFactAsync(fact, rawPayload, cancellationToken) = store.StoreUsageFactAsync(fact, rawPayload, cancellationToken)
+        member _.StoreUsageFactAsync(fact, rawPayload, cancellationToken) =
+            task {
+                let! result = journal.ProcessAsync(fact, rawPayload, cancellationToken)
+
+                return
+                    match result with
+                    | AcceptedFromJournal -> Ok { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = fact.UsageFactId; Aggregate = None }
+                    | AlreadyAccepted -> Ok { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = fact.UsageFactId; Aggregate = None }
+                    | MissingJournal -> Error [ "Unsupported UsageFact message has no matching journal row." ]
+                    | JournalConflict -> Error [ "Unsupported UsageFact message conflicts with its immutable journal row." ]
+            }
 
 /// Carries deterministic compressed JSONL bytes and the Blob authority they must verify against.
 type OperationsUsageArchiveBlob = { Pointer: RawUsageFactArchivePointer; Content: byte array }
@@ -2334,3 +2344,124 @@ type OperationsUsageWorkerService
 
         /// Stops operational usage ingestion.
         member _.StopAsync(cancellationToken: CancellationToken) = stopBackgroundProcessingAsync cancellationToken
+
+/// Repeatedly sends currently Pending immutable journal rows as retryable Service Bus signals without persisting delivery state.
+type OperationsUsageJournalDispatcherService
+    (
+        settings: OperationsWorkerSettings,
+        schema: IOperationsUsageSchemaInitializer,
+        journal: IOperationsUsageJournalStore,
+        logger: ILogger<OperationsUsageJournalDispatcherService>
+    ) =
+
+    /// Keeps each SQL dispatch scan bounded so one retry pass cannot monopolize the worker process.
+    let dispatchBatchSize = 100
+
+    /// Uses the same fixed cadence as worker dependency retry while retaining SQL as the only retry source of truth.
+    let retryDelay = TimeSpan.FromSeconds(5.0)
+    let credential = lazy (DefaultAzureCredential() :> TokenCredential)
+    let mutable cancellation: CancellationTokenSource option = None
+    let mutable dispatchTask: Task option = None
+    let mutable serviceBusClient: ServiceBusClient option = None
+
+    /// Builds the configured sender client from the explicit connection string or managed identity namespace.
+    let createClient () =
+        match settings.ServiceBusConnectionString, settings.ServiceBusFullyQualifiedNamespace with
+        | Some connectionString, _ -> ServiceBusClient(connectionString)
+        | None, Some fullyQualifiedNamespace -> ServiceBusClient(fullyQualifiedNamespace, credential.Value)
+        | None, None -> invalidOp "Azure Service Bus connection string or namespace must be configured."
+
+    /// Creates the retryable delivery signal whose MessageId mirrors, but does not replace, SQL journal identity.
+    let createMessage (entry: UsageFactJournalEntry) =
+        let message = ServiceBusMessage(BinaryData(entry.RawPayload))
+        message.MessageId <- entry.UsageFactId.ToString("D")
+        message.CorrelationId <- entry.CorrelationId
+        message.Subject <- OperationalFactEnvelope.UsageFactSubject
+
+        message.ApplicationProperties[
+            OperationalFactEnvelope.UsageFactMessageTypeProperty
+        ] <- OperationalFactEnvelope.UsageFactMessageType
+
+        message.ApplicationProperties[
+            OperationalFactEnvelope.UsageFactKindProperty
+        ] <- entry.FactKind.ToString()
+
+        message
+
+    /// Repeats bounded scans so a crash, expiry, uncertain send, or terminal broker movement leaves Pending work discoverable.
+    let runAsync (cancellationToken: CancellationToken) =
+        task {
+            while not cancellationToken.IsCancellationRequested do
+                try
+                    do! schema.EnsureCreatedAsync cancellationToken
+                    use client = createClient ()
+                    serviceBusClient <- Some client
+                    use sender = client.CreateSender(settings.TopicName)
+
+                    let mutable scan = true
+
+                    while scan
+                          && not cancellationToken.IsCancellationRequested do
+                        try
+                            let! pending = journal.ListPendingAsync(dispatchBatchSize, cancellationToken)
+
+                            let mutable index = 0
+
+                            while index < pending.Length do
+                                let entry = pending[index]
+                                do! sender.SendMessageAsync(createMessage entry, cancellationToken)
+                                index <- index + 1
+
+                            do! Task.Delay(retryDelay, cancellationToken)
+                        with
+                        | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> ()
+                        | ex ->
+                            logger.LogWarning(ex, "Operations usage journal dispatch scan failed; Pending SQL rows remain the retry source of truth.")
+                            scan <- false
+                with
+                | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> ()
+                | ex -> logger.LogWarning(ex, "Operations usage journal dispatcher startup failed; Pending SQL rows remain the retry source of truth.")
+
+                serviceBusClient <- None
+
+                if not cancellationToken.IsCancellationRequested then
+                    do! Task.Delay(retryDelay, cancellationToken)
+        }
+
+    interface IHostedService with
+
+        /// Starts journal dispatch independently from broker receive processing so Pending recovery survives a worker restart.
+        member _.StartAsync(cancellationToken: CancellationToken) =
+            if dispatchTask
+               |> Option.exists (fun task -> not task.IsCompleted) then
+                Task.CompletedTask
+            else
+                let source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                cancellation <- Some source
+                dispatchTask <- Some(Task.Run(Func<Task>(fun () -> runAsync source.Token)))
+                Task.CompletedTask
+
+        /// Stops dispatch after cancelling its retry cadence and disposes its short-lived Service Bus client.
+        member _.StopAsync(cancellationToken: CancellationToken) =
+            task {
+                match cancellation with
+                | Some source -> source.Cancel()
+                | None -> ()
+
+                match dispatchTask with
+                | Some task ->
+                    try
+                        do! task.WaitAsync(cancellationToken)
+                    with
+                    | :? OperationCanceledException -> ()
+                    | ex -> logger.LogWarning(ex, "Operations usage journal dispatcher stopped after an unexpected task fault.")
+                | None -> ()
+
+                match cancellation with
+                | Some source -> source.Dispose()
+                | None -> ()
+
+                cancellation <- None
+                dispatchTask <- None
+                serviceBusClient <- None
+            }

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -2347,6 +2347,52 @@ type OperationsUsageWorkerService
         /// Stops operational usage ingestion.
         member _.StopAsync(cancellationToken: CancellationToken) = stopBackgroundProcessingAsync cancellationToken
 
+/// Sends one journal entry through a retryable signal transport without making the transport a source of truth.
+type internal IOperationsUsageJournalSignalSender =
+
+    /// Sends the immutable Pending entry that was reread immediately before this call.
+    abstract SendAsync: entry: UsageFactJournalEntry * cancellationToken: CancellationToken -> Task
+
+/// Observes the narrow gap between one Pending scan and its per-row production reread for deterministic stale-scan proof.
+type internal IOperationsUsageJournalDispatchInterleaving =
+
+    /// Runs after a bounded scan and before the production loop rereads each selected identity.
+    abstract AfterPendingScanAsync: entries: UsageFactJournalEntry list * cancellationToken: CancellationToken -> Task
+
+/// Keeps normal dispatch free of test interleavings while retaining the production loop as the proof seam.
+type private NoOperationsUsageJournalDispatchInterleaving() =
+
+    interface IOperationsUsageJournalDispatchInterleaving with
+
+        member _.AfterPendingScanAsync(_entries, _cancellationToken) = Task.CompletedTask
+
+/// Runs the bounded production journal dispatch loop with a current-state reread immediately before every signal send.
+module internal OperationsUsageJournalDispatcher =
+
+    /// Sends only rows that remain Pending after a scan-to-send interleaving, so stale candidates cannot signal terminal truth.
+    let dispatchCurrentPendingAsync
+        (journal: IOperationsUsageJournalStore)
+        batchSize
+        (interleaving: IOperationsUsageJournalDispatchInterleaving)
+        (sender: IOperationsUsageJournalSignalSender)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            let! pending = journal.ListPendingAsync(batchSize, cancellationToken)
+            do! interleaving.AfterPendingScanAsync(pending, cancellationToken)
+            let mutable index = 0
+
+            while index < pending.Length do
+                let entry = pending[index]
+                let! currentEntry = journal.TryGetPendingAsync(entry.UsageFactId, cancellationToken)
+
+                match currentEntry with
+                | Some pendingEntry -> do! sender.SendAsync(pendingEntry, cancellationToken)
+                | None -> ()
+
+                index <- index + 1
+        }
+
 /// Repeatedly sends currently Pending immutable journal rows as retryable Service Bus signals without persisting delivery state.
 type OperationsUsageJournalDispatcherService
     (
@@ -2390,6 +2436,15 @@ type OperationsUsageJournalDispatcherService
 
         message
 
+    /// Adapts one Azure Service Bus sender to the production loop's observable signal boundary.
+    let createSignalSender (sender: ServiceBusSender) =
+        { new IOperationsUsageJournalSignalSender with
+            member _.SendAsync(entry, cancellationToken) = sender.SendMessageAsync(createMessage entry, cancellationToken)
+        }
+
+    /// Uses the inert default outside deterministic tests so dispatch runtime behavior has no test-only pause.
+    let dispatchInterleaving = NoOperationsUsageJournalDispatchInterleaving() :> IOperationsUsageJournalDispatchInterleaving
+
     /// Repeats bounded scans so a crash, expiry, uncertain send, or terminal broker movement leaves Pending work discoverable.
     let runAsync (cancellationToken: CancellationToken) =
         task {
@@ -2405,19 +2460,15 @@ type OperationsUsageJournalDispatcherService
                     while scan
                           && not cancellationToken.IsCancellationRequested do
                         try
-                            let! pending = journal.ListPendingAsync(dispatchBatchSize, cancellationToken)
+                            let signalSender = createSignalSender sender
 
-                            let mutable index = 0
-
-                            while index < pending.Length do
-                                let entry = pending[index]
-                                let! currentEntry = journal.TryGetPendingAsync(entry.UsageFactId, cancellationToken)
-
-                                match currentEntry with
-                                | Some pendingEntry -> do! sender.SendMessageAsync(createMessage pendingEntry, cancellationToken)
-                                | None -> ()
-
-                                index <- index + 1
+                            do!
+                                OperationsUsageJournalDispatcher.dispatchCurrentPendingAsync
+                                    journal
+                                    dispatchBatchSize
+                                    dispatchInterleaving
+                                    signalSender
+                                    cancellationToken
 
                             do! Task.Delay(retryDelay, cancellationToken)
                         with

--- a/src/Grace.Operations/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/Program.fs
@@ -48,10 +48,12 @@ module Program =
         services.AddSingleton<IHealthCheckPublisher, OperationsUsageReadinessHealthCheckPublisher>()
         |> ignore
 
-        services.AddSingleton<IOperationsUsageFactStore> (fun _ ->
-            let transactionScope = SqlOperationsUsageTransactionScope(settings.SqlConnectionString)
-            let store = OperationsUsageStore transactionScope
-            OperationsUsageFactStoreAdapter(store) :> IOperationsUsageFactStore)
+        services.AddSingleton<IOperationsUsageJournalStore> (fun _ ->
+            SqlOperationsUsageJournalStore(settings.SqlConnectionString) :> IOperationsUsageJournalStore)
+        |> ignore
+
+        services.AddSingleton<IOperationsUsageFactStore> (fun serviceProvider ->
+            OperationsUsageFactStoreAdapter(serviceProvider.GetRequiredService<IOperationsUsageJournalStore>()) :> IOperationsUsageFactStore)
         |> ignore
 
         services.AddSingleton<IOperationsUsageArchiveStore> (fun _ ->
@@ -73,6 +75,9 @@ module Program =
         |> ignore
 
         services.AddHostedService<OperationsUsageWorkerService>()
+        |> ignore
+
+        services.AddHostedService<OperationsUsageJournalDispatcherService>()
         |> ignore
 
         services.AddHostedService<OperationsUsageTemporaryHotCleanupWorkerService>()

--- a/src/Grace.Operations/Grace.Operations.slnx
+++ b/src/Grace.Operations/Grace.Operations.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="Grace.Operations.fsproj" />
   <Project Path="Grace.Operations.Data/Grace.Operations.Data.fsproj" />
+  <Project Path="Grace.Operations.ProofHost/Grace.Operations.ProofHost.fsproj" />
   <Project Path="Grace.Operations.Tests/Grace.Operations.Tests.fsproj" />
   <Project Path="Grace.Operations.Worker/Grace.Operations.Worker.fsproj" />
 </Solution>

--- a/src/Grace.Server.Tests/AspireTestHost.fs
+++ b/src/Grace.Server.Tests/AspireTestHost.fs
@@ -74,7 +74,7 @@ module AspireTestHost =
 
     let private defaultWaitTimeout = getTimeout (TimeSpan.FromMinutes(5.0)) (TimeSpan.FromMinutes(3.0))
 
-    let private latestOperationsMigrationId = "20260709110000_AddPricingPlanRateAssignment"
+    let private latestOperationsMigrationId = "20260812110000_AddUsageFactJournal"
 
     /// Defines log progress behavior for the surrounding tests used by the server integration aspire Test Host scenario.
     let private logProgress (message: string) =
@@ -1472,6 +1472,56 @@ SELECT
                 do! waitForResourceHealthyAsync notificationService state.App graceServerResourceName cts.Token
                 do! waitForGraceServerHttpReadyAsync state.Client cts.Token
                 Console.WriteLine("Grace.Server Aspire project resource restart completed.")
+            finally
+                sharedStateLock.Release() |> ignore
+        }
+
+    /// Stops the Operations worker resource so a test can preserve journal state before exercising restart recovery.
+    let stopOperationsWorkerAsync (app: DistributedApplication) =
+        task {
+            do! sharedStateLock.WaitAsync()
+
+            try
+                Console.WriteLine("Stopping Operations worker Aspire project resource...")
+                let commandService = app.Services.GetRequiredService<ResourceCommandService>()
+                use cts = new CancellationTokenSource(defaultWaitTimeout)
+
+                let! result = commandService.ExecuteCommandAsync(operationsWorkerResourceName, KnownResourceCommands.StopCommand, cts.Token)
+
+                if not result.Success then
+                    let errorMessage =
+                        if not (String.IsNullOrWhiteSpace result.Message) then result.Message
+                        elif result.Canceled then "Stop command was canceled."
+                        else "Stop command failed without details."
+
+                    raise (InvalidOperationException($"Operations worker stop failed: {errorMessage}"))
+            finally
+                sharedStateLock.Release() |> ignore
+        }
+
+    /// Starts the Operations worker resource and waits until it is healthy after a test-controlled recovery interruption.
+    let startOperationsWorkerAsync (app: DistributedApplication) =
+        task {
+            do! sharedStateLock.WaitAsync()
+
+            try
+                Console.WriteLine("Starting Operations worker Aspire project resource...")
+                let commandService = app.Services.GetRequiredService<ResourceCommandService>()
+                use cts = new CancellationTokenSource(defaultWaitTimeout)
+
+                let! result = commandService.ExecuteCommandAsync(operationsWorkerResourceName, KnownResourceCommands.StartCommand, cts.Token)
+
+                if not result.Success then
+                    let errorMessage =
+                        if not (String.IsNullOrWhiteSpace result.Message) then result.Message
+                        elif result.Canceled then "Start command was canceled."
+                        else "Start command failed without details."
+
+                    raise (InvalidOperationException($"Operations worker start failed: {errorMessage}"))
+
+                let notificationService = app.Services.GetRequiredService<ResourceNotificationService>()
+                do! waitForResourceHealthyAsync notificationService app operationsWorkerResourceName cts.Token
+                Console.WriteLine("Operations worker Aspire project resource start completed.")
             finally
                 sharedStateLock.Release() |> ignore
         }

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -71,6 +71,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj" />
+    <ProjectReference Include="..\Grace.Operations\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
     <ProjectReference Include="..\Grace.Server\Grace.Server.fsproj" />
   </ItemGroup>

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -71,7 +71,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj" />
-    <ProjectReference Include="..\Grace.Operations\Grace.Operations.Data\Grace.Operations.Data.fsproj" />
     <ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
     <ProjectReference Include="..\Grace.Server\Grace.Server.fsproj" />
   </ItemGroup>

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -11,6 +11,7 @@ open NUnit.Framework
 open System
 open System.Data
 open System.Diagnostics
+open System.IO
 open System.Text
 open System.Text.Json
 open System.Threading
@@ -91,33 +92,43 @@ type OperationsTracerBulletServerTests() =
 
         message
 
-    /// Inserts a canonical Pending journal fact through the AppHost SQL boundary before the hosted dispatcher emits its Service Bus signal.
+    /// Invokes the Operations-owned test executable so the AppHost tracer enters canonical production append without a root-to-Operations project reference.
     let appendJournalFactAsync (fact: UsageFact) =
         task {
-            use connection = new SqlConnection(operationsSqlConnectionString)
-            do! connection.OpenAsync()
-            use command = connection.CreateCommand()
+            let projectPath =
+                Path.GetFullPath(
+                    Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Operations", "Grace.Operations.ProofHost", "Grace.Operations.ProofHost.fsproj")
+                )
 
-            command.CommandText <-
-                $"""
-INSERT INTO {operationsUsageFactJournalTable}
-    (UsageFactId, RawPayload, CorrelationId, FactKind, OwnerId, OrganizationId, RepositoryId, StoragePoolId, Quantity, ObservedAtUtc, State)
-VALUES
-    (@UsageFactId, @RawPayload, @CorrelationId, @FactKind, @OwnerId, @OrganizationId, @RepositoryId, @StoragePoolId, @Quantity, @ObservedAtUtc, 0);
-"""
+            let startInfo = ProcessStartInfo("dotnet")
+            startInfo.UseShellExecute <- false
+            startInfo.RedirectStandardOutput <- true
+            startInfo.RedirectStandardError <- true
+            startInfo.ArgumentList.Add("run")
+            startInfo.ArgumentList.Add("--configuration")
+            startInfo.ArgumentList.Add("Release")
+            startInfo.ArgumentList.Add("--project")
+            startInfo.ArgumentList.Add(projectPath)
+            startInfo.ArgumentList.Add("--no-launch-profile")
+            startInfo.ArgumentList.Add("--")
+            startInfo.ArgumentList.Add(operationsSqlConnectionString)
+            startInfo.ArgumentList.Add(Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)))
 
-            command.Parameters.Add("@UsageFactId", SqlDbType.UniqueIdentifier).Value <- fact.UsageFactId
-            command.Parameters.Add("@RawPayload", SqlDbType.VarBinary, -1).Value <- JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
-            command.Parameters.Add("@CorrelationId", SqlDbType.NVarChar, 200).Value <- fact.CorrelationId
-            command.Parameters.Add("@FactKind", SqlDbType.Int).Value <- int fact.FactKind
-            command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- fact.Scope.OwnerId
-            command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- fact.Scope.OrganizationId
-            command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- fact.Scope.RepositoryId
-            command.Parameters.Add("@StoragePoolId", SqlDbType.NVarChar, operationsStoragePoolIdMaxLength).Value <- fact.Resource.StoragePoolId
-            command.Parameters.Add("@Quantity", SqlDbType.BigInt).Value <- fact.Quantity
-            command.Parameters.Add("@ObservedAtUtc", SqlDbType.DateTime2).Value <- fact.ObservedAt.ToDateTimeUtc()
-            let! _ = command.ExecuteNonQueryAsync()
-            return ()
+            use child = Process.Start(startInfo)
+
+            if isNull child then
+                failwith "The Operations append proof executable did not start."
+
+            use timeout = new CancellationTokenSource(proofTimeout)
+            let! output = child.StandardOutput.ReadToEndAsync(timeout.Token)
+            let! error = child.StandardError.ReadToEndAsync(timeout.Token)
+            do! child.WaitForExitAsync(timeout.Token)
+
+            if
+                child.ExitCode <> 0
+                || not (output.Contains("appended-pending", StringComparison.Ordinal))
+            then
+                failwith $"The Operations append proof executable failed with exit code {child.ExitCode}. Output: {output}. Error: {error}"
         }
 
     /// Sends one raw message directly to the operational facts topic for duplicate and invalid-payload proof.

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -92,8 +92,8 @@ type OperationsTracerBulletServerTests() =
 
         message
 
-    /// Invokes the Operations-owned test executable so the AppHost tracer enters canonical production append without a root-to-Operations project reference.
-    let appendJournalFactAsync (fact: UsageFact) =
+    /// Invokes one Operations-owned proof command without adding a root-to-Operations project reference.
+    let runOperationsProofCommandAsync command (fact: UsageFact) =
         task {
             let projectPath =
                 Path.GetFullPath(
@@ -111,6 +111,7 @@ type OperationsTracerBulletServerTests() =
             startInfo.ArgumentList.Add(projectPath)
             startInfo.ArgumentList.Add("--no-launch-profile")
             startInfo.ArgumentList.Add("--")
+            startInfo.ArgumentList.Add(command)
             startInfo.ArgumentList.Add(operationsSqlConnectionString)
             startInfo.ArgumentList.Add(Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)))
 
@@ -124,12 +125,23 @@ type OperationsTracerBulletServerTests() =
             let! error = child.StandardError.ReadToEndAsync(timeout.Token)
             do! child.WaitForExitAsync(timeout.Token)
 
-            if
-                child.ExitCode <> 0
-                || not (output.Contains("appended-pending", StringComparison.Ordinal))
-            then
-                failwith $"The Operations append proof executable failed with exit code {child.ExitCode}. Output: {output}. Error: {error}"
+            if child.ExitCode <> 0 then
+                failwith $"The Operations '{command}' proof executable failed with exit code {child.ExitCode}. Output: {output}. Error: {error}"
+
+            return output.Trim()
         }
+
+    /// Appends through the Operations-owned production journal boundary and requires the durable Pending result.
+    let appendJournalFactAsync (fact: UsageFact) =
+        task {
+            let! output = runOperationsProofCommandAsync "append" fact
+
+            if not (String.Equals(output, "appended-pending", StringComparison.Ordinal)) then
+                failwith $"The Operations append proof executable returned unexpected output: {output}"
+        }
+
+    /// Reads exact-scope billing completeness through the Operations production store and checks its machine-readable result.
+    let evaluateBillingCompletenessAsync (fact: UsageFact) = runOperationsProofCommandAsync "completeness" fact
 
     /// Sends one raw message directly to the operational facts topic for duplicate and invalid-payload proof.
     let sendOperationalMessageAsync (message: ServiceBusMessage) =
@@ -537,18 +549,28 @@ WHERE FactKind = @FactKind
 
             Assert.That(fact.CorrelationId, Is.Not.EqualTo(fact.UsageFactId.ToString("D")))
 
-            do! appendJournalFactAsync fact
-            do! waitForUsageStateAsync "Initial published fact" 1L 4096L fact
-            do! waitForJournalStateAsync "Initial published fact" 1 fact
-
-            let restartFact = usageFact (Guid.Parse("53153153-3531-4531-8531-531531531531")) (CorrelationId "ops6-worker-restart-pending-correlation")
-
-            let finalDeliveryFact = usageFact (Guid.Parse("53153153-4531-4531-8531-531531531531")) (CorrelationId "ops6-final-delivery-pending-correlation")
-
             let app =
                 match App with
                 | Some runningApp -> runningApp
                 | None -> failwith "The shared Aspire test host was not available for Operations worker recovery proof."
+
+            do! AspireTestHost.stopOperationsWorkerAsync app
+            do! appendJournalFactAsync fact
+            do! waitForJournalStateAsync "Stopped worker leaves the first append pending before dispatch" 0 fact
+            let! blockedBeforeDispatch = evaluateBillingCompletenessAsync fact
+
+            Assert.That(blockedBeforeDispatch, Is.EqualTo("blocked-by-unresolved-usage-fact-journal"))
+
+            do! AspireTestHost.startOperationsWorkerAsync app
+            do! waitForUsageStateAsync "Initial published fact" 1L 4096L fact
+            do! waitForJournalStateAsync "Initial published fact" 1 fact
+            let! completeAfterAcceptance = evaluateBillingCompletenessAsync fact
+
+            Assert.That(completeAfterAcceptance, Is.EqualTo("complete"))
+
+            let restartFact = usageFact (Guid.Parse("53153153-3531-4531-8531-531531531531")) (CorrelationId "ops6-worker-restart-pending-correlation")
+
+            let finalDeliveryFact = usageFact (Guid.Parse("53153153-4531-4531-8531-531531531531")) (CorrelationId "ops6-final-delivery-pending-correlation")
 
             do! AspireTestHost.stopOperationsWorkerAsync app
             do! appendJournalFactAsync restartFact

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -1,7 +1,6 @@
 namespace Grace.Server.Tests
 
 open Azure.Messaging.ServiceBus
-open Grace.Operations.Data
 open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Types.Common
@@ -92,20 +91,33 @@ type OperationsTracerBulletServerTests() =
 
         message
 
-    /// Appends the supported immutable fact through the production Operations seam before the hosted dispatcher emits its Service Bus signal.
+    /// Inserts a canonical Pending journal fact through the AppHost SQL boundary before the hosted dispatcher emits its Service Bus signal.
     let appendJournalFactAsync (fact: UsageFact) =
         task {
-            let payload = JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
-            let journal = SqlOperationsUsageJournalStore(operationsSqlConnectionString)
-            let! result = journal.AppendAsync(fact, payload, CancellationToken.None)
+            use connection = new SqlConnection(operationsSqlConnectionString)
+            do! connection.OpenAsync()
+            use command = connection.CreateCommand()
 
-            match result with
-            | Ok AppendedPending
-            | Ok AlreadyPending -> return ()
-            | Ok terminal -> return invalidOp $"Tracer journal fact unexpectedly reached terminal state {terminal} before dispatch."
-            | Error errors ->
-                let details = String.Join("; ", errors)
-                return invalidOp $"Tracer journal append failed: {details}"
+            command.CommandText <-
+                $"""
+INSERT INTO {operationsUsageFactJournalTable}
+    (UsageFactId, RawPayload, CorrelationId, FactKind, OwnerId, OrganizationId, RepositoryId, StoragePoolId, Quantity, ObservedAtUtc, State)
+VALUES
+    (@UsageFactId, @RawPayload, @CorrelationId, @FactKind, @OwnerId, @OrganizationId, @RepositoryId, @StoragePoolId, @Quantity, @ObservedAtUtc, 0);
+"""
+
+            command.Parameters.Add("@UsageFactId", SqlDbType.UniqueIdentifier).Value <- fact.UsageFactId
+            command.Parameters.Add("@RawPayload", SqlDbType.VarBinary, -1).Value <- JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
+            command.Parameters.Add("@CorrelationId", SqlDbType.NVarChar, 200).Value <- fact.CorrelationId
+            command.Parameters.Add("@FactKind", SqlDbType.Int).Value <- int fact.FactKind
+            command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- fact.Scope.OwnerId
+            command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- fact.Scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- fact.Scope.RepositoryId
+            command.Parameters.Add("@StoragePoolId", SqlDbType.NVarChar, operationsStoragePoolIdMaxLength).Value <- fact.Resource.StoragePoolId
+            command.Parameters.Add("@Quantity", SqlDbType.BigInt).Value <- fact.Quantity
+            command.Parameters.Add("@ObservedAtUtc", SqlDbType.DateTime2).Value <- fact.ObservedAt.ToDateTimeUtc()
+            let! _ = command.ExecuteNonQueryAsync()
+            return ()
         }
 
     /// Sends one raw message directly to the operational facts topic for duplicate and invalid-payload proof.

--- a/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
+++ b/src/Grace.Server.Tests/OperationsTracerBullet.Server.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Server.Tests
 
 open Azure.Messaging.ServiceBus
+open Grace.Operations.Data
 open Grace.Server.Tests.Services
 open Grace.Shared
 open Grace.Types.Common
@@ -52,6 +53,10 @@ type OperationsTracerBulletServerTests() =
     [<Literal>]
     let operationsUsageAggregateMinuteTable = "ops.UsageAggregateMinute"
 
+    /// Operations journal table verified when proving dispatch recovery from durable Pending state.
+    [<Literal>]
+    let operationsUsageFactJournalTable = "ops.UsageFactJournal"
+
     /// Storage pool identifier width enforced by the operations database schema.
     [<Literal>]
     let operationsStoragePoolIdMaxLength = 256
@@ -86,6 +91,22 @@ type OperationsTracerBulletServerTests() =
         message.ApplicationProperties[ usageFactKindProperty ] <- fact.FactKind.ToString()
 
         message
+
+    /// Appends the supported immutable fact through the production Operations seam before the hosted dispatcher emits its Service Bus signal.
+    let appendJournalFactAsync (fact: UsageFact) =
+        task {
+            let payload = JsonSerializer.SerializeToUtf8Bytes(fact, Constants.JsonSerializerOptions)
+            let journal = SqlOperationsUsageJournalStore(operationsSqlConnectionString)
+            let! result = journal.AppendAsync(fact, payload, CancellationToken.None)
+
+            match result with
+            | Ok AppendedPending
+            | Ok AlreadyPending -> return ()
+            | Ok terminal -> return invalidOp $"Tracer journal fact unexpectedly reached terminal state {terminal} before dispatch."
+            | Error errors ->
+                let details = String.Join("; ", errors)
+                return invalidOp $"Tracer journal append failed: {details}"
+        }
 
     /// Sends one raw message directly to the operational facts topic for duplicate and invalid-payload proof.
     let sendOperationalMessageAsync (message: ServiceBusMessage) =
@@ -213,6 +234,21 @@ type OperationsTracerBulletServerTests() =
             return Convert.ToInt64 scalar
         }
 
+    /// Reads the durable journal state for one usage-fact identity.
+    let journalStateAsync usageFactId =
+        task {
+            use! connection = openOperationsSqlAsync ()
+            use command = connection.CreateCommand()
+            command.CommandText <- $"SELECT State FROM {operationsUsageFactJournalTable} WHERE UsageFactId = @UsageFactId;"
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
+            let! scalar = command.ExecuteScalarAsync()
+
+            return
+                match scalar with
+                | :? DBNull -> None
+                | value -> Some(Convert.ToInt32 value)
+        }
+
     /// Reads the minute aggregate quantity for the fact's repository resource and UTC bucket.
     let aggregateQuantityAsync (fact: UsageFact) =
         task {
@@ -288,6 +324,45 @@ WHERE FactKind = @FactKind
                 )
         }
 
+    /// Waits for the requested durable journal state while retaining SQL and broker diagnostics on timeout.
+    let waitForJournalStateAsync description expectedState fact =
+        task {
+            let stopwatch = Stopwatch.StartNew()
+            let mutable matched = false
+            let mutable lastState = None
+            let mutable lastError = String.Empty
+
+            while not matched && stopwatch.Elapsed < proofTimeout do
+                try
+                    let! state = journalStateAsync fact.UsageFactId
+                    lastState <- state
+                    lastError <- String.Empty
+
+                    if state = Some expectedState then
+                        matched <- true
+                    else
+                        do! Task.Delay(TimeSpan.FromSeconds(1.0))
+                with
+                | ex ->
+                    lastError <- ex.Message
+                    do! Task.Delay(TimeSpan.FromSeconds(1.0))
+
+            if not matched then
+                let! serviceBusDiagnostics = operationsServiceBusDiagnosticsAsync ()
+
+                let errorSuffix =
+                    if String.IsNullOrWhiteSpace lastError then
+                        ""
+                    else
+                        $" Last SQL error: {lastError}"
+
+                raise (
+                    TimeoutException(
+                        $"{description} did not reach journal state {expectedState}. Actual state={lastState}.{errorSuffix}{Environment.NewLine}{serviceBusDiagnostics}"
+                    )
+                )
+        }
+
     /// Waits until the operations worker has removed one expected message from its durable subscription.
     let waitForOperationalMessageSettledAsync description messageId =
         task {
@@ -328,6 +403,67 @@ WHERE FactKind = @FactKind
                         $"{description} message '{messageId}' was not settled by the operations worker before timeout.{Environment.NewLine}{activeDiagnostics}{Environment.NewLine}{deadLetterDiagnostics}"
                     )
                 )
+        }
+
+    /// Abandons one locked signal until the emulator applies its configured final-delivery movement.
+    let abandonOperationalMessageThroughFinalDeliveryAsync messageId =
+        task {
+            let client = ServiceBusClient(serviceBusConnectionString)
+            use _client = client
+
+            let receiver =
+                client.CreateReceiver(
+                    operationalFactsTopic,
+                    operationsProcessorSubscriptionName,
+                    ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock)
+                )
+
+            use _receiver = receiver
+            let mutable delivery = 0
+
+            while delivery < 10 do
+                let! message = receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5.0))
+
+                if isNull message then
+                    raise (TimeoutException($"Timed out receiving final-delivery signal '{messageId}' at delivery {delivery + 1}."))
+
+                if not (String.Equals(message.MessageId, messageId, StringComparison.Ordinal)) then
+                    raise (InvalidOperationException($"Expected final-delivery signal '{messageId}', received '{message.MessageId}'."))
+
+                do! receiver.AbandonMessageAsync(message)
+                delivery <- delivery + 1
+        }
+
+    /// Receives the expected broker-terminal signal and returns the broker's terminal reason.
+    let receiveTerminalOperationalMessageReasonAsync messageId =
+        task {
+            let client = ServiceBusClient(serviceBusConnectionString)
+            use _client = client
+
+            let receiver =
+                client.CreateReceiver(
+                    operationalFactsTopic,
+                    operationsProcessorSubscriptionName,
+                    ServiceBusReceiverOptions(SubQueue = SubQueue.DeadLetter, ReceiveMode = ServiceBusReceiveMode.ReceiveAndDelete)
+                )
+
+            use _receiver = receiver
+            let stopwatch = Stopwatch.StartNew()
+            let mutable terminalReason = None
+
+            while terminalReason.IsNone
+                  && stopwatch.Elapsed < proofTimeout do
+                let! message = receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(1.0))
+
+                if
+                    not (isNull message)
+                    && String.Equals(message.MessageId, messageId, StringComparison.Ordinal)
+                then
+                    terminalReason <- Some message.DeadLetterReason
+
+            return
+                terminalReason
+                |> Option.defaultWith (fun () -> raise (TimeoutException($"Timed out waiting for terminal signal '{messageId}' in the dead-letter subqueue.")))
         }
 
     /// Waits for an invalid operational message to reach the worker's dead-letter queue.
@@ -378,15 +514,46 @@ WHERE FactKind = @FactKind
 
             Assert.That(fact.CorrelationId, Is.Not.EqualTo(fact.UsageFactId.ToString("D")))
 
-            do! sendOperationalMessageAsync (usageFactMessage (fact.UsageFactId.ToString("D")) fact)
+            do! appendJournalFactAsync fact
             do! waitForUsageStateAsync "Initial published fact" 1L 4096L fact
+            do! waitForJournalStateAsync "Initial published fact" 1 fact
+
+            let restartFact = usageFact (Guid.Parse("53153153-3531-4531-8531-531531531531")) (CorrelationId "ops6-worker-restart-pending-correlation")
+
+            let finalDeliveryFact = usageFact (Guid.Parse("53153153-4531-4531-8531-531531531531")) (CorrelationId "ops6-final-delivery-pending-correlation")
+
+            let app =
+                match App with
+                | Some runningApp -> runningApp
+                | None -> failwith "The shared Aspire test host was not available for Operations worker recovery proof."
+
+            do! AspireTestHost.stopOperationsWorkerAsync app
+            do! appendJournalFactAsync restartFact
+            do! waitForJournalStateAsync "Stopped worker leaves journal append pending" 0 restartFact
+
+            do! appendJournalFactAsync finalDeliveryFact
+            do! waitForJournalStateAsync "Final-delivery journal append remains pending" 0 finalDeliveryFact
+
+            let finalDeliveryMessageId = $"{finalDeliveryFact.UsageFactId:D}-terminal"
+            do! sendOperationalMessageAsync (usageFactMessage finalDeliveryMessageId finalDeliveryFact)
+            do! abandonOperationalMessageThroughFinalDeliveryAsync finalDeliveryMessageId
+            let! finalDeliveryReason = receiveTerminalOperationalMessageReasonAsync finalDeliveryMessageId
+
+            Assert.That(finalDeliveryReason, Is.Not.Empty)
+            do! waitForJournalStateAsync "Broker terminal movement leaves journal fact pending" 0 finalDeliveryFact
+
+            do! AspireTestHost.startOperationsWorkerAsync app
+            do! waitForUsageStateAsync "Restarted worker dispatches pending journal fact" 1L 12288L restartFact
+            do! waitForJournalStateAsync "Restarted worker accepts pending journal fact" 1 restartFact
+            do! waitForUsageStateAsync "Terminal broker movement is redispatched from SQL journal" 1L 12288L finalDeliveryFact
+            do! waitForJournalStateAsync "Terminal broker movement journal fact is accepted" 1 finalDeliveryFact
 
             let duplicateMessageId = $"{fact.UsageFactId:D}-redelivery"
             let duplicateDelivery = usageFactMessage duplicateMessageId fact
 
             do! sendOperationalMessageAsync duplicateDelivery
             do! waitForOperationalMessageSettledAsync "Duplicate UsageFactId delivery" duplicateMessageId
-            do! waitForUsageStateAsync "Duplicate UsageFactId delivery" 1L 4096L fact
+            do! waitForUsageStateAsync "Duplicate UsageFactId delivery" 1L 12288L fact
 
             let futureFact = usageFact (Guid.Parse("53153153-2531-4531-8531-531531531531")) (CorrelationId "ops6-future-kind-correlation")
 


### PR DESCRIPTION
# Purpose

Make every supported Operations usage fact durable before broker delivery so billing completeness remains truthful
through broker retries, terminal movement, process restart, duplicate sends, and settlement uncertainty.

Related to #879. Parent replacement mini-epic: #863. Epic chain: #554 -> #560 -> #576.

## Product V1 behavior

- Commits one immutable exact-scope SQL journal row as `Pending` before any Service Bus signal.
- Treats Service Bus as a retryable signal; broker state never clears or replaces journal truth.
- Dispatches bounded pending rows with `MessageId = UsageFactId` and retries startup/setup failures.
- Requires the production worker to verify the matching journal row before supported processing.
- Atomically commits raw fact, aggregate, and `Accepted`, or scoped rejection evidence and `Rejected`.
- Keeps `Accepted` monotonic and rejects same-ID payload or exact-scope conflicts.
- Includes unresolved exact-scope `Pending` and `Rejected` rows in #877's transaction-locked completeness decision.
- Keeps the first real repository-storage producer in #829; this PR adds no public append route or actor-to-SQL coupling.

## Changed surfaces

- Operations journal model, SQL commands, transaction service, migration, snapshot, and migration documentation.
- Operations worker journal adapter, bounded dispatcher, startup retry, and runtime registration.
- Operations SQL/worker/migration tests.
- Narrow AppHost-backed Server Tests bridge and lifecycle controls for the real Service Bus emulator tracer.

## Validation

- Exact-head GitHub `Validate` run `31642417599` passed.
- Targeted Fantomas passed.
- Release builds passed with zero warnings and errors.
- Isolated real-SQL journal tests passed 6/6 with zero skips.
- Post-hook cancellation and stale-dispatcher SQL tests passed 2/2 with zero skips.
- Migration/model proof passed 1/1; worker ingestion passed 44/44; AppHost production tracer passed 1/1.
- Full local validation passed across the root and Operations suites; the Operations broad run had 18 expected
  no-SQL-environment skips, while the required isolated SQL cases ran separately with zero skips.
- MarkdownLint and `git diff --check` passed.

The real-emulator tracer proves journal-first append, exact-scope completeness blocked before acceptance and complete
thereafter, terminal movement after ten abandons, restart redispatch, atomic `Accepted` plus raw/aggregate exactly once,
duplicate idempotence, and unsupported or malformed signal handling.

## Review status

- Implementation/fix workers started: **5**.
- Exact head: `f953fdf109206cafb4e8849221bc4656c7b29520`.
- Exact-head GitHub `Validate`: **passed**.
- Fresh exact-head review 4: **approved with no substantive findings or blocking proof gaps**.
- Earlier findings and proof gaps are closed on the final revision.
- The supersession rule is not triggered; PR #894 is merge-ready.

## Proof-environment limitations

- The local Service Bus emulator ignored per-message TTL and closed live management SDK requests, so accelerated live
  expiry could not be driven. Production code has no broker TTL, sequence, delivery-count, or broker-state fields in
  journal transitions, and `Pending`/`Rejected` have no automatic expiry or cleanup path.
- The AppHost uses the emulator backing SQL container for Operations SQL, so it cannot isolate only the Operations SQL
  outage while keeping the broker alive. The real terminal-delivery and restart flow proves the same durable omission
  boundary without claiming an isolated-outage proof.

## Documentation impact

`Grace.Operations.Data/MIGRATIONS.md` now documents journal lifecycle, Service Bus signal semantics, exact-scope
completeness, restart behavior, and #829's producer boundary. No public API, CLI, SDK, or generated contract changes.

## Residual risk

The first production measurement caller remains deferred to #829. Until then, the implemented internal append seam and
real-emulator tracer establish the accepted journal/worker foundation without claiming repository-storage production
coverage.