### PR TITLE
GC-15R1B: Add cache enrollment and status commands

### DIFF
--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -120,6 +120,31 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
   #857 owns signed refreshes that remain `Unhealthy`; #625 publishes `Healthy` only after serving readiness is proven.
   R1A adds neither serving, rotation, reconciliation, non-Linux support, nor CacheStore behavior.
 
+### R1B: repository-independent enrollment and status commands (#887)
+
+- **Status classification:** `implementation leaf`.
+- **Required result:** `grace cache enroll` validates local inputs and state, resolves one existing bearer before key
+  staging, sends one selected-server request, and publishes ready only after the accepted configuration commits.
+  `grace cache status` reads local state only and returns a redacted result with an enrolled exit code only for a valid
+  ready identity.
+- **Propagation:** CLI root dispatch bypasses repository configuration and invocation history; the narrow SDK facade
+  accepts the selected URI and resolved bearer directly. Server routes, DTOs, OpenAPI, generated clients, cache host,
+  liveness, storage, retries, and reconciliation are unchanged.
+- **Proof:** The focused Linux CLI root-command suite passes 18 cases: parser registration, inert help/schema/examples,
+  complete-buffer JSON parsing, pure repository-independent status, ready/weak/corrupt redaction and exit codes, PAT
+  success/rejection/invalid input, M2M success/acquisition failure, missing and expired interactive results,
+  cancellation before and after staging, malformed nominal success, and forced local-commit failure. The bounded
+  internal test dependencies default to the production credential resolver and ready commit, then exercise controlled
+  outcomes through actual root command dispatch. The suite records exact M2M token and enrollment request counts, PAT
+  bearer forwarding, protected ready publication, failure cleanup, redacted JSON, and no repository `.grace` state. A
+  separate unprivileged Linux executable run observes inaccessible state as redacted `invalid`/`inaccessible` JSON with
+  exit code `1`.
+- **Interactive proof composition:** Existing Auth tests cover normal producer selection and invalid token behavior.
+  Cache root-command tests consume one resolved stored interactive bearer and one expired interactive error through the
+  same production command path. The available Linux SDK image has no dbus or libsecret service, so it cannot execute a
+  real secure-store-backed login. This is an environment limitation, not a cache product branch; hosted Linux may add
+  that exercise only when its documented secure-store dependencies are available.
+
 ### R2: registration liveness (#857)
 
 - **Status classification:** `planned`.

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -42,8 +42,8 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
 | [Issues #622](https://github.com/ScottArbeit/Grace/issues/622) and [#724](https://github.com/ScottArbeit/Grace/issues/724) | Closed and not planned. | Do not resume as cache work. |
 | [Issue #855](https://github.com/ScottArbeit/Grace/issues/855) | Complete R0 static-contract pruning. | Required predecessor completed. |
 | [Issue #856](https://github.com/ScottArbeit/Grace/issues/856) | Superseded by the narrower #886 and #887 R1 sequence. | Do not resume its mixed server, command, and status scope. |
-| [Issue #886](https://github.com/ScottArbeit/Grace/issues/886) and [PR #888](https://github.com/ScottArbeit/Grace/pull/888) | R1A static enrollment identity is implemented on the current PR head; focused proof and current-head Linux validation remain required before merge. | Owns only static enrollment state, protected local identity, and their focused proof. |
-| [Issue #887](https://github.com/ScottArbeit/Grace/issues/887) | Open R1B follow-on for repository-independent cache enrollment and status commands. | Starts after #886 integrates; owns no R1A implementation detail. |
+| [Issue #886](https://github.com/ScottArbeit/Grace/issues/886) and [PR #888](https://github.com/ScottArbeit/Grace/pull/888) | R1A static enrollment identity merged to the integration branch. | Owns only static enrollment state, protected local identity, and their focused proof. |
+| [Issue #887](https://github.com/ScottArbeit/Grace/issues/887) and [PR #896](https://github.com/ScottArbeit/Grace/pull/896) | R1B repository-independent enrollment and status commands are implemented in the current pull request. | Consumes R1A without owning protected-identity implementation detail. |
 | [Issue #857](https://github.com/ScottArbeit/Grace/issues/857) | Open R2: bounded registration liveness. | Starts after R1 and its liveness research gate. |
 | [Issue #835](https://github.com/ScottArbeit/Grace/issues/835) | Open. Later local materialization is blocked until it merges to `main` and Epic #597 is refreshed. | Required sequence for #628 to #630 and #634. |
 
@@ -202,9 +202,10 @@ The final Epic #597 release candidate requires all of the following:
 5. Current-head validation and a fresh review complete for every relevant pull request.
 6. The final `epic/597` to `main` pull request receives explicit maintainer approval at that reviewed, validated head.
 
-## R1A validation status
+## R1 validation status
 
-The R1A source, contract, generated-artifact, and focused-proof changes are in PR #888. Its required evidence is
+The R1A source, contract, generated-artifact, and focused-proof changes merged through PR #888. The R1B command and
+output work is implemented in PR #896. Required evidence is
 targeted F# formatting, affected Release builds and tests, OpenAPI/generated freshness, MarkdownLint, `git diff --check`,
 and a passing current-head GitHub `Validate` run that executes the Linux permission and inaccessible-state cases.
 Windows focused identity proof skips those Linux-only cases, so it cannot replace hosted Linux evidence.

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -130,7 +130,7 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
 - **Propagation:** CLI root dispatch bypasses repository configuration and invocation history; the narrow SDK facade
   accepts the selected URI and resolved bearer directly. Server routes, DTOs, OpenAPI, generated clients, cache host,
   liveness, storage, retries, and reconciliation are unchanged.
-- **Proof:** The focused Linux CLI root-command suite passes 18 cases: parser registration, inert help/schema/examples,
+- **Proof:** The focused Linux CLI root-command suite passes the registered Cache cases: parser registration, inert help/schema/examples,
   complete-buffer JSON parsing, pure repository-independent status, ready/weak/corrupt redaction and exit codes, PAT
   success/rejection/invalid input, M2M success/acquisition failure, missing and expired interactive results,
   cancellation before and after staging, malformed nominal success, and forced local-commit failure. The bounded
@@ -139,11 +139,10 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
   bearer forwarding, protected ready publication, failure cleanup, redacted JSON, and no repository `.grace` state. A
   separate unprivileged Linux executable run observes inaccessible state as redacted `invalid`/`inaccessible` JSON with
   exit code `1`.
-- **Interactive proof composition:** Existing Auth tests cover normal producer selection and invalid token behavior.
-  Cache root-command tests consume one resolved stored interactive bearer and one expired interactive error through the
-  same production command path. The available Linux SDK image has no dbus or libsecret service, so it cannot execute a
-  real secure-store-backed login. This is an environment limitation, not a cache product branch; hosted Linux may add
-  that exercise only when its documented secure-store dependencies are available.
+- **Interactive proof composition:** The Linux secure-store harness provisions an ephemeral D-Bus session, GNOME
+  Keyring, libsecret, and unlocked collection. It drives normal device login and production Cache root dispatch for a
+  valid stored bearer and an expired stored bearer: 2/2 pass. Existing Auth tests continue to cover producer selection
+  and invalid token behavior.
 
 ### R2: registration liveness (#857)
 
@@ -217,4 +216,5 @@ npx --yes markdownlint-cli2 "docs/Grace Cache.md" "docs/Grace Cache implementati
 git diff --check
 ```
 
-This status does not claim R1B commands, R2 liveness, serving, rotation, reconciliation, non-Linux support, or CacheStore behavior.
+This status claims the R1B enrollment and status commands only. It excludes R2 liveness, serving, rotation,
+reconciliation, non-Linux support, and CacheStore behavior.

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -605,8 +605,10 @@ sequencing, and owner interruption rules are explicit. The recovery topology may
 
 This verdict does not make R0, R1, R2, or later semantic work ready to code. The portable specification contract says
 Plan-ready supports implementation planning, while `dev-process` requires each issue to complete Tier-2 research and
-the issue-level Implementation Readiness Gate. The R1 inactive-orphan proof and R2 exact liveness table are intentionally
-leaf-level gates with defined stop outcomes, not hidden assumptions in this document.
+the issue-level Implementation Readiness Gate. The R1 inactive-orphan readiness question is resolved: after an ambiguous
+enrollment outcome, an inactive accepted server record remains an approved Product V1 risk under the existing server
+expiration rule. R2 exact liveness still has a leaf-level gate with a defined stop outcome, not a hidden assumption in
+this document.
 
 ### Passed criteria
 
@@ -620,8 +622,9 @@ leaf-level gates with defined stop outcomes, not hidden assumptions in this docu
 
 - The requested project specification profile is absent at the required starting commit. Its absence is recorded for
   later repository restoration; this document does not infer missing profile rules.
-- R1 has no current proof that inactive orphan enrollment is unselectable and does not block manual re-enrollment. This
-  is a stop condition before R1 code, not an accepted behavior claim.
+- The R1 inactive-orphan readiness question is resolved. An inactive accepted server record after an ambiguous enrollment
+  outcome remains an approved Product V1 risk; this leaf does not add reconciliation or change the existing server
+  expiration rule.
 - R2 still needs exact current server liveness response classes, timestamps, and selection timing on its branch head.
 - Cache host, SQLite/filesystem implementation, artifact route execution, and the local Working Directory Update seam
   do not exist on this epic head. They are planned work, not present behavior.
@@ -632,7 +635,6 @@ leaf-level gates with defined stop outcomes, not hidden assumptions in this docu
 
 Return to the owner before expanding scope when:
 
-- R1's current-contract proof shows an inactive orphan can become selectable or block fresh manual re-enrollment.
 - R0 shows that pruning rotation changes the server source-of-truth model, needs a new durable object/state machine, or
   reveals a real deployed compatibility obligation.
 - R2 needs a second scheduler/state machine, durable recovery workflow, new server source of truth, or generalized

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -433,6 +433,47 @@ to establish the static Product V1 shape.
 | Artifact fetch or validation fails | Incomplete staging is not committed as hit | Mode-specific unavailable or failure result | Hash/size/partial-store proof |
 | Unknown artifact-grant key | One advertised refresh attempt, then fail closed | No cache artifact served | Grant-key rollover proof |
 
+### Static enrollment commands
+
+`grace cache enroll` and `grace cache status` are repository-independent commands for the supported Linux x64 systemd
+profile. They run as the system-managed `grace-cache` account against the protected `/var/lib/grace-cache` root.
+Neither command reads, creates, or records repository `.grace` state.
+
+Enrollment validates its explicit boundary, repository assignments, endpoint, protocol version, configured absolute
+`GRACE_SERVER_URI`, and protected root before it obtains one normal Grace credential. It supports the existing
+interactive login, M2M configuration, and `GRACE_TOKEN` PAT producers. The selected bearer is forwarded unchanged to
+one non-retrying `POST /cache/enroll` request. Only an accepted server response followed by a protected ready commit
+reports enrollment. Rejection, cancellation, unknown response, and local commit failure do not publish ready state.
+
+Status is a pure local observation. Its JSON and human output expose only `class`, `enrollment`, `key`, and, for a
+valid ready identity, `cacheId`, `endpoint`, `boundaryKind`, and `repositoryCount`. It returns `0` only for an enrolled
+ready identity and otherwise returns `1`.
+
+Cache V1 has no implicit reset or re-enrollment. After a server-side revocation or invalid local identity, an operator
+uses the existing registration administration workflow to revoke the registration, stops the cache service, applies
+the local recovery procedure for the protected root, and runs `grace cache enroll` again. The command never discovers,
+reconciles, or replaces a prior registration by itself.
+
+PowerShell:
+
+```powershell
+sudo install -d -o grace-cache -g grace-cache -m 0700 /var/lib/grace-cache
+sudo -iu grace-cache pwsh -NoProfile
+$env:GRACE_SERVER_URI = "https://grace.example.test"
+grace cache enroll --display-name "Seattle cache" --endpoint "https://cache.example.test" --boundary organization --owner-id "<owner-id>" --organization-id "<organization-id>" --repository-organization-id "<organization-id>" --repository-id "<repository-id>"
+grace --output Json cache status
+```
+
+bash / zsh:
+
+```bash
+sudo install -d -o grace-cache -g grace-cache -m 0700 /var/lib/grace-cache
+sudo -iu grace-cache
+export GRACE_SERVER_URI="https://grace.example.test"
+grace cache enroll --display-name "Seattle cache" --endpoint "https://cache.example.test" --boundary organization --owner-id "<owner-id>" --organization-id "<organization-id>" --repository-organization-id "<organization-id>" --repository-id "<repository-id>"
+grace --output Json cache status
+```
+
 ## 11. Non-functional, security, durability, and operations
 
 - The listener binds only the exact enrolled endpoint after the process guard and local validation succeed.
@@ -443,8 +484,8 @@ to establish the static Product V1 shape.
   abandoned staging and incomplete commits; scheduled retention is absent.
 - Grant verification supports the already-advertised validation-key rollover. Cache service identity remains static;
   these key lifecycles have separate names, data, routes, and tests.
-- Status is an operational contract. It must reflect current local protected state and current server liveness, not a
-  historical successful run.
+- `grace cache status` is an operational contract for current local protected state. It performs no liveness request;
+  registration liveness belongs to R2.
 - The supported profile is one Linux x64 systemd deployment. The implementation rejects or declines unsupported host
   profiles instead of implying Windows or macOS support.
 

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -77,8 +77,8 @@ artifact retrieval.
 | [Issue #622](https://github.com/ScottArbeit/Grace/issues/622) and [issue #724](https://github.com/ScottArbeit/Grace/issues/724) | Closed and not planned for Product V1. | Neither is a future implementation container. |
 | [Issue #855](https://github.com/ScottArbeit/Grace/issues/855) | R0 static-contract pruning is complete. | Static cache identity is the current source contract. |
 | [Issue #856](https://github.com/ScottArbeit/Grace/issues/856) | Superseded by the narrower R1A and R1B sequence. | Do not resume its mixed scope. |
-| [Issue #886](https://github.com/ScottArbeit/Grace/issues/886) and [PR #888](https://github.com/ScottArbeit/Grace/pull/888) | R1A static enrollment identity is the current implementation leaf. | It owns protected local identity and its focused proof. |
-| [Issue #887](https://github.com/ScottArbeit/Grace/issues/887) | R1B follows R1A with repository-independent enrollment and status commands. | It is not implemented by this leaf. |
+| [Issue #886](https://github.com/ScottArbeit/Grace/issues/886) and [PR #888](https://github.com/ScottArbeit/Grace/pull/888) | R1A static enrollment identity merged to the integration branch. | It owns protected local identity and its focused proof. |
+| [Issue #887](https://github.com/ScottArbeit/Grace/issues/887) and [PR #896](https://github.com/ScottArbeit/Grace/pull/896) | R1B repository-independent enrollment and status commands are implemented in the current pull request. | It consumes R1A without changing protected-identity scope. |
 | [Issue #857](https://github.com/ScottArbeit/Grace/issues/857) | R2 registration liveness remains planned. | It follows the R1 sequence. |
 | [Issue #835](https://github.com/ScottArbeit/Grace/issues/835) | Open. `WorkingDirectoryUpdate.run` is not available to this epic until #835 merges to `main` and Epic #597 is refreshed. | Hard sequencing gate for #628 to #630 and #634. |
 | `src/Grace.Types/MaterializationExecutionMode.Types.fs` (`MaterializationExecutionMode`) | Defines `Direct`, `CachePreferred`, and `CacheRequired`. | Existing public execution-mode contract. |

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -15,6 +15,7 @@ The contract version is `cli-json-v1`. The charter is recorded in
 - Human text, progress, prompts, and diagnostics must not be mixed into JSON stdout.
 - `--schema` and `--examples` are inert introspection options. They do not run the selected command.
 - `--select` projects fields from `ReturnValue` only. It does not read envelope metadata.
+- `cache status` returns only redacted local enrollment facts and never contacts Grace Server.
 
 PowerShell:
 
@@ -24,6 +25,7 @@ grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
+grace --output Json cache status
 ```
 
 bash / zsh:
@@ -34,6 +36,7 @@ grace authenticate logout --schema
 grace authenticate logout --examples
 grace --output Json maintenance stats --select DirectoryCount
 grace --output Json doctor --select Status
+grace --output Json cache status
 ```
 
 ## Output Envelopes
@@ -129,8 +132,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `206`
-- JSON-ready routed commands: `185`
+- Total leaf commands: `208`
+- JSON-ready routed commands: `187`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`
@@ -173,6 +176,10 @@ starting the watcher.
 
 `doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
 supports `--schema`, `--examples`, and `--select`.
+
+`cache enroll` and `cache status` are included in the JSON-ready routed count. Their successful return value contains
+only `Class`, `Enrollment`, `Key`, and, for an enrolled ready identity, `CacheId`, `Endpoint`, `BoundaryKind`, and
+`RepositoryCount`. JSON stdout is one complete document with no progress or repository-configuration text.
 
 ## Agent Recipes
 

--- a/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
@@ -1,0 +1,62 @@
+namespace Grace.CLI.Tests
+
+open Grace.CLI
+open NUnit.Framework
+open System
+open System.Text.Json
+
+/// Covers pure parser and complete-document JSON requirements for cache commands.
+[<TestFixture>]
+module CacheCliParsingTests =
+
+    /// Parses one full JSON buffer and disposes its document before the assertion returns.
+    let private parsesCompleteDocument (value: string) : JsonValueKind =
+        use document = JsonDocument.Parse(value)
+        document.RootElement.ValueKind
+
+    /// Proves a complete-buffer parser rejects any non-document framing without assuming its concrete parser exception subtype.
+    let private rejectsCompleteDocument (value: string) =
+        let error = Assert.Catch(Action(fun () -> parsesCompleteDocument value |> ignore))
+
+        Assert.That(error, Is.Not.Null)
+
+    /// Verifies cache command names are accepted by the root parser without repository configuration.
+    [<Test>]
+    let ``cache command parser accepts enroll and status`` () =
+        for arguments in
+            [|
+                [| "cache"; "status" |]
+                [|
+                    "cache"
+                    "enroll"
+                    "--display-name"
+                    "test"
+                    "--endpoint"
+                    "https://cache.example.test"
+                    "--boundary"
+                    "owner"
+                    "--owner-id"
+                    "11111111-1111-1111-1111-111111111111"
+                    "--repository-organization-id"
+                    "22222222-2222-2222-2222-222222222222"
+                    "--repository-id"
+                    "33333333-3333-3333-3333-333333333333"
+                |]
+            |] do
+            let result = GraceCommand.rootCommand.Parse(arguments)
+            Assert.That(result.Errors.Count, Is.Zero)
+
+    /// Verifies inert enrollment examples do not validate or execute administrator-supplied enrollment inputs.
+    [<Test>]
+    let ``cache enrollment examples are inert without required inputs`` () =
+        let result = GraceCommand.rootCommand.Parse([| "cache"; "enroll"; "--examples" |])
+        Assert.That(result.Errors.Count, Is.Zero)
+
+    /// Verifies the JSON proof parses the complete buffer and rejects extra values or non-whitespace framing.
+    [<Test>]
+    let ``complete JSON output proof rejects prefix suffix and second documents`` () =
+        Assert.That(parsesCompleteDocument "\n{\n  \"ReturnValue\": { \"Enrollment\": \"notEnrolled\" }\n}\n", Is.EqualTo(JsonValueKind.Object))
+
+        rejectsCompleteDocument "prefix { }"
+        rejectsCompleteDocument "{ } suffix"
+        rejectsCompleteDocument "{ } { }"

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -9,6 +9,7 @@ open Grace.Types.CacheRegistration
 open Grace.Types.Common
 open NodaTime
 open NUnit.Framework
+open Spectre.Console
 open System
 open System.Collections.Concurrent
 open System.IO
@@ -99,7 +100,16 @@ module CacheCliTests =
                 requests.Enqueue(recorded)
                 let statusCode, body = respond recorded
                 let bodyBytes = Encoding.UTF8.GetBytes(body)
-                let headers = $"HTTP/1.1 {statusCode} Test\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n"
+
+                let redirect =
+                    if statusCode >= 300 && statusCode < 400 then
+                        "Location: /cache/redirected\r\n"
+                    else
+                        String.Empty
+
+                let headers =
+                    $"HTTP/1.1 {statusCode} Test\r\n{redirect}Content-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n"
+
                 let headerBytes = Encoding.ASCII.GetBytes(headers)
                 do! stream.WriteAsync(headerBytes, 0, headerBytes.Length)
                 do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length)
@@ -216,6 +226,12 @@ module CacheCliTests =
             CacheCommand.setEnrollmentDependenciesForTests (previous)
             |> ignore
 
+    /// Redirects Spectre.Console to the writer that captures one serialized root-command invocation.
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
     /// Invokes a cache command from a fresh non-repository directory and restores console and directory process state.
     let private invokeOutsideRepository arguments =
         let temporaryDirectory = Path.Combine(Path.GetTempPath(), $"grace-cache-cli-tests-{Guid.NewGuid():N}")
@@ -229,10 +245,12 @@ module CacheCliTests =
 
             Environment.CurrentDirectory <- temporaryDirectory
             Console.SetOut(output)
+            setAnsiConsoleOutput output
             let exitCode = GraceCommand.main arguments
             exitCode, output.ToString(), Directory.Exists(Path.Combine(temporaryDirectory, ".grace"))
         finally
             Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
             Environment.CurrentDirectory <- originalDirectory
 
             if Directory.Exists(temporaryDirectory) then
@@ -763,6 +781,258 @@ module CacheCliTests =
                             Has.Length.EqualTo(1)
                         )
 
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))
+
+    /// Proves stale staged state survives failed credential resolution and is recovered only after one bearer resolves.
+    [<Test>]
+    let ``Linux stale attempt survives failed credentials then recovers into one enrollment request`` () =
+        let validToken = PersonalAccessToken.formatToken "cache-recovery" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            Assert.That(
+                Grace.Cache.CacheIdentity.createAttempt root
+                |> Result.isOk,
+                Is.True
+            )
+
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some "not-a-grace-pat") None None None) (fun () ->
+                        let failedExit, failedOutput, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(failedExit, Is.Not.EqualTo(0))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.True)
+                        Assert.That(requests.IsEmpty, Is.True)
+                        use failedDocument = JsonDocument.Parse(failedOutput)
+
+                        Assert.That(
+                            failedDocument
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))
+
+                    withEnvironment (credentialEnvironment serverUri (Some validToken) None None None) (fun () ->
+                        let recoveredExit, recoveredOutput, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(recoveredExit, Is.EqualTo(0))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.True)
+                        Assert.That(requests.ToArray(), Has.Length.EqualTo(1))
+                        use recoveredDocument = JsonDocument.Parse(recoveredOutput)
+
+                        Assert.That(
+                            recoveredDocument
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Enrollment")
+                                .GetString(),
+                            Is.EqualTo("enrolled")
+                        ))))
+
+    /// Proves an enrollment redirect is rejected without issuing a second request or publishing ready state.
+    [<Test>]
+    let ``Linux enrollment redirect sends one POST and returns one safe JSON error`` () =
+        let token = PersonalAccessToken.formatToken "cache-redirect" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 307, "{}" else 500, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
+                        let exitCode, output, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(requests.ToArray(), Has.Length.EqualTo(1))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(output, Does.Not.Contain(token))
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))
+
+    /// Proves raw OIDC discovery failures are reduced to a stable Cache credential error document.
+    [<Test>]
+    let ``Linux unavailable OIDC discovery emits a redacted Cache JSON error`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    if request.Target = "/authenticate/oidc/config" then
+                        500, "raw discovery failure at /private/path"
+                    else
+                        404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        let exitCode, output, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.exists (fun request -> request.Target = "/cache/enroll"),
+                            Is.False
+                        )
+
+                        Assert.That(output, Does.Not.Contain("raw discovery failure"))
+                        Assert.That(output, Does.Not.Contain("/private/path"))
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Does.Not.Contain("http")
+                        ))))
+
+    /// Proves normal interactive login stores one Linux keyring credential that production Cache enrollment later resolves with only GRACE_SERVER_URI.
+    [<Test>]
+    let ``Linux secure-store interactive login enrolls through production credential resolution`` () =
+        if String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS")) then
+            Assert.Ignore("Requires a Linux D-Bus session and libsecret keyring; the focused Docker harness provides both.")
+
+        let mutable authority = String.Empty
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    match request.Target with
+                    | "/authenticate/oidc/config" ->
+                        200,
+                        $"{{\"ReturnValue\":{{\"Authority\":\"{authority}\",\"Audience\":\"test-audience\",\"CliClientId\":\"test-client\"}},\"EventTime\":\"2026-01-01T00:00:00Z\",\"CorrelationId\":\"test\",\"Properties\":{{}}}}"
+                    | "/oauth/device/code" ->
+                        200,
+                        "{\"device_code\":\"test-device\",\"user_code\":\"test-user\",\"verification_uri\":\"https://login.example.test\",\"expires_in\":60,\"interval\":1}"
+                    | "/oauth/token" ->
+                        200,
+                        "{\"access_token\":\"interactive-bearer\",\"refresh_token\":\"interactive-refresh\",\"expires_in\":3600,\"token_type\":\"Bearer\",\"scope\":\"openid offline_access\"}"
+                    | "/cache/enroll" -> 200, enrolledResponse ()
+                    | _ -> 404, "{}")
+                (fun serverUri requests ->
+                    authority <- serverUri
+
+                    withEnvironment
+                        (credentialEnvironment serverUri None None None None
+                         @ [
+                             Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri
+                             Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "test-audience"
+                             Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "test-client"
+                         ])
+                        (fun () ->
+                            let loginExitCode, _, _ =
+                                invokeOutsideRepository [| "authenticate"
+                                                           "login"
+                                                           "--auth"
+                                                           "device" |]
+
+                            Assert.That(loginExitCode, Is.EqualTo(0)))
+
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        let enrollExitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(enrollExitCode, Is.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.True)
+                        let recorded = requests.ToArray()
+
+                        Assert.That(
+                            recorded
+                            |> Array.filter (fun request -> request.Target = "/cache/enroll"),
+                            Has.Length.EqualTo(1)
+                        )
+
+                        Assert.That(
+                            (recorded
+                             |> Array.find (fun request -> request.Target = "/cache/enroll"))
+                                .Authorization,
+                            Is.EqualTo(Some "Bearer interactive-bearer")
+                        )
+
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Enrollment")
+                                .GetString(),
+                            Is.EqualTo("enrolled")
+                        ))))
+
+    /// Proves an expired normal Linux keyring credential attempts one refresh, then fails before Cache enrollment mutates or posts.
+    [<Test>]
+    let ``Linux secure-store expired interactive credential performs no enrollment request or local mutation`` () =
+        if String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DBUS_SESSION_BUS_ADDRESS")) then
+            Assert.Ignore("Requires a Linux D-Bus session and libsecret keyring; the focused Docker harness provides both.")
+
+        let mutable authority = String.Empty
+        let mutable tokenRequests = 0
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    match request.Target with
+                    | "/authenticate/oidc/config" ->
+                        200,
+                        $"{{\"ReturnValue\":{{\"Authority\":\"{authority}\",\"Audience\":\"test-audience\",\"CliClientId\":\"test-client\"}},\"EventTime\":\"2026-01-01T00:00:00Z\",\"CorrelationId\":\"test\",\"Properties\":{{}}}}"
+                    | "/oauth/device/code" ->
+                        200,
+                        "{\"device_code\":\"test-device\",\"user_code\":\"test-user\",\"verification_uri\":\"https://login.example.test\",\"expires_in\":60,\"interval\":1}"
+                    | "/oauth/token" ->
+                        tokenRequests <- tokenRequests + 1
+
+                        if tokenRequests = 1 then
+                            200,
+                            "{\"access_token\":\"expired-interactive-bearer\",\"refresh_token\":\"interactive-refresh\",\"expires_in\":0,\"token_type\":\"Bearer\",\"scope\":\"openid offline_access\"}"
+                        else
+                            500, "{\"error\":\"invalid_grant\",\"error_description\":\"raw refresh detail\"}"
+                    | "/cache/enroll" -> 500, "{}"
+                    | _ -> 404, "{}")
+                (fun serverUri requests ->
+                    authority <- serverUri
+
+                    withEnvironment
+                        (credentialEnvironment serverUri None None None None
+                         @ [
+                             Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri
+                             Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "test-audience"
+                             Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "test-client"
+                         ])
+                        (fun () ->
+                            let loginExitCode, _, _ =
+                                invokeOutsideRepository [| "authenticate"
+                                                           "login"
+                                                           "--auth"
+                                                           "device" |]
+
+                            Assert.That(loginExitCode, Is.EqualTo(0)))
+
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        let enrollExitCode, output, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(enrollExitCode, Is.Not.EqualTo(0))
+                        Assert.That(tokenRequests, Is.EqualTo(2))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.exists (fun request -> request.Target = "/cache/enroll"),
+                            Is.False
+                        )
+
+                        Assert.That(output, Does.Not.Contain("raw refresh detail"))
                         use document = JsonDocument.Parse(output)
 
                         Assert.That(

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -7,17 +7,20 @@ open Grace.Shared
 open Grace.Types
 open Grace.Types.CacheRegistration
 open Grace.Types.Common
+open Json.Schema
 open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
 open System.Collections.Concurrent
+open System.CommandLine
 open System.Diagnostics
 open System.IO
 open System.Net
 open System.Net.Sockets
 open System.Text
 open System.Text.Json
+open System.Text.Json.Nodes
 open System.Threading
 open System.Threading.Tasks
 
@@ -234,7 +237,7 @@ module CacheCliTests =
         AnsiConsole.Console <- AnsiConsole.Create(settings)
 
     /// Invokes a cache command from a fresh non-repository directory and captures both standard streams.
-    let private invokeOutsideRepositoryWithStreams arguments =
+    let private invokeOutsideRepositoryWithStreamsUsing arguments (invoke: unit -> int) =
         let temporaryDirectory = Path.Combine(Path.GetTempPath(), $"grace-cache-cli-tests-{Guid.NewGuid():N}")
         let originalDirectory = Environment.CurrentDirectory
         let originalOut = Console.Out
@@ -250,7 +253,7 @@ module CacheCliTests =
             Console.SetOut(output)
             Console.SetError(error)
             setAnsiConsoleOutput output
-            let exitCode = GraceCommand.main arguments
+            let exitCode = invoke ()
             exitCode, output.ToString(), error.ToString(), Directory.Exists(Path.Combine(temporaryDirectory, ".grace"))
         finally
             Console.SetOut(originalOut)
@@ -260,6 +263,19 @@ module CacheCliTests =
 
             if Directory.Exists(temporaryDirectory) then
                 Directory.Delete(temporaryDirectory, true)
+
+    /// Invokes a cache command from a fresh non-repository directory and captures both standard streams.
+    let private invokeOutsideRepositoryWithStreams arguments = invokeOutsideRepositoryWithStreamsUsing arguments (fun () -> GraceCommand.main arguments)
+
+    /// Invokes one parsed root Cache command with a supplied action cancellation token.
+    let private invokeOutsideRepositoryWithCancellation (arguments: string array) (cancellationToken: CancellationToken) =
+        invokeOutsideRepositoryWithStreamsUsing arguments (fun () ->
+            GraceCommand
+                .rootCommand
+                .Parse(arguments)
+                .InvokeAsync(InvocationConfiguration(), cancellationToken)
+                .GetAwaiter()
+                .GetResult())
 
     /// Invokes a cache command from a fresh non-repository directory while retaining the existing stdout-only test shape.
     let private invokeOutsideRepository arguments =
@@ -464,7 +480,7 @@ module CacheCliTests =
                 .EnumerateArray()
             |> Seq.toArray
 
-        Assert.That(variants, Has.Length.EqualTo(2))
+        Assert.That(variants, Has.Length.EqualTo(3))
 
         let readyVariant =
             variants
@@ -496,40 +512,122 @@ module CacheCliTests =
             Is.True
         )
 
-        let nonReadyVariant =
+        let notEnrolledVariant =
             variants
             |> Array.find (fun variant ->
-                let hasNot, _ =
+                let enrollment =
                     variant
                         .GetProperty("properties")
                         .GetProperty("Enrollment")
-                        .TryGetProperty("not")
+                        .GetProperty("const")
+                        .GetString()
 
-                hasNot)
+                enrollment = "notEnrolled")
 
-        let nonReadyRequired =
-            nonReadyVariant
+        let notEnrolledRequired =
+            notEnrolledVariant
                 .GetProperty("required")
                 .EnumerateArray()
             |> Seq.map (fun value -> value.GetString())
             |> Set.ofSeq
 
         Assert.That(
-            (nonReadyRequired = Set.ofList [ "Class"
-                                             "Enrollment"
-                                             "Key" ]),
+            (notEnrolledRequired = Set.ofList [ "Class"
+                                                "Enrollment"
+                                                "Key" ]),
             Is.True
         )
 
-        let nonReadyProperties =
-            nonReadyVariant
-                .GetProperty("properties")
-                .EnumerateObject()
-            |> Seq.map (fun property -> property.Name)
-            |> Set.ofSeq
+        let nonReadyVariants =
+            variants
+            |> Array.filter (fun variant ->
+                let enrollment =
+                    variant
+                        .GetProperty("properties")
+                        .GetProperty("Enrollment")
+                        .GetProperty("const")
+                        .GetString()
 
-        for field in readyOnlyStatusFields do
-            Assert.That(Set.contains field nonReadyProperties, Is.False, $"The non-ready Cache status schema must omit {field}.")
+                enrollment <> "enrolled")
+
+        for nonReadyVariant in nonReadyVariants do
+            Assert.That(
+                nonReadyVariant
+                    .GetProperty("additionalProperties")
+                    .GetBoolean(),
+                Is.False
+            )
+
+            let nonReadyProperties =
+                nonReadyVariant
+                    .GetProperty("properties")
+                    .EnumerateObject()
+                |> Seq.map (fun property -> property.Name)
+                |> Set.ofSeq
+
+            for field in readyOnlyStatusFields do
+                Assert.That(Set.contains field nonReadyProperties, Is.False, $"The non-ready Cache status schema must omit {field}.")
+
+        Assert.That(
+            readyVariant
+                .GetProperty("additionalProperties")
+                .GetBoolean(),
+            Is.False
+        )
+
+        let cacheStatusSchema = JsonSchema.FromText(returnValueSchema.GetRawText())
+
+        let statusDocument (enrollment: string) (key: string) includeReadyFields =
+            let document = JsonObject()
+            document["Class"] <- JsonValue.Create("Grace.Cache.Status")
+            document["Enrollment"] <- JsonValue.Create(enrollment)
+            document["Key"] <- JsonValue.Create(key)
+
+            if includeReadyFields then
+                document["CacheId"] <- JsonValue.Create("11111111-1111-1111-1111-111111111111")
+                document["Endpoint"] <- JsonValue.Create("https://cache.example.test")
+                document["BoundaryKind"] <- JsonValue.Create("Organization")
+                document["RepositoryCount"] <- JsonValue.Create(1)
+
+            document
+
+        let schemaAccepts (document: JsonObject) =
+            use parsedDocument = JsonDocument.Parse(document.ToJsonString())
+
+            cacheStatusSchema
+                .Evaluate(
+                    parsedDocument.RootElement
+                )
+                .IsValid
+
+        let acceptedDocuments =
+            [
+                statusDocument "enrolled" "available" true
+                statusDocument "notEnrolled" "missing" false
+                statusDocument "notEnrolled" "available" false
+                statusDocument "invalid" "invalid" false
+                statusDocument "invalid" "inaccessible" false
+            ]
+
+        for document in acceptedDocuments do
+            Assert.That(schemaAccepts document, Is.True, $"Expected accepted Cache status document: {document}")
+
+        let nonReadyWithReadyField = statusDocument "notEnrolled" "missing" false
+        nonReadyWithReadyField["Endpoint"] <- JsonValue.Create("https://cache.example.test")
+        let unknownEnrollment = statusDocument "pending" "available" false
+        let unknownKey = statusDocument "invalid" "pending" false
+        let invalidCombination = statusDocument "notEnrolled" "inaccessible" false
+        let incompleteReady = statusDocument "enrolled" "available" false
+
+        for document in
+            [
+                nonReadyWithReadyField
+                unknownEnrollment
+                unknownKey
+                invalidCombination
+                incompleteReady
+            ] do
+            Assert.That(schemaAccepts document, Is.False, $"Expected rejected Cache status document: {document}")
 
         let examplesExitCode, examplesOutput, examplesCreatedGraceDirectory =
             invokeOutsideRepository [| "cache"
@@ -539,6 +637,14 @@ module CacheCliTests =
         Assert.That(examplesExitCode, Is.EqualTo(0))
         Assert.That(examplesCreatedGraceDirectory, Is.False)
         use examplesDocument = JsonDocument.Parse(examplesOutput)
+
+        Assert.That(
+            examplesDocument
+                .RootElement
+                .GetProperty("Examples")
+                .GetArrayLength(),
+            Is.EqualTo(3)
+        )
 
         let exampleStatus =
             examplesDocument.RootElement.GetProperty("Examples").[0]
@@ -553,6 +659,34 @@ module CacheCliTests =
         )
 
         assertReadyOnlyStatusFields true exampleStatus
+
+        let nonReadyExampleStatus =
+            examplesDocument.RootElement.GetProperty("Examples").[1]
+                .GetProperty("Document")
+                .GetProperty("ReturnValue")
+
+        Assert.That(
+            examplesDocument.RootElement.GetProperty("Examples").[1]
+                .GetProperty("Name")
+                .GetString(),
+            Is.EqualTo("not-enrolled-envelope-shape")
+        )
+
+        Assert.That(
+            nonReadyExampleStatus
+                .GetProperty("Enrollment")
+                .GetString(),
+            Is.EqualTo("notEnrolled")
+        )
+
+        Assert.That(
+            nonReadyExampleStatus
+                .GetProperty("Key")
+                .GetString(),
+            Is.EqualTo("missing")
+        )
+
+        assertReadyOnlyStatusFields false nonReadyExampleStatus
 
         let helpExitCode, helpOutput, helpCreatedGraceDirectory =
             invokeOutsideRepository [| "cache"
@@ -1086,6 +1220,63 @@ module CacheCliTests =
                                 Assert.That(createdGraceDirectory, Is.False)
                                 Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
                                 Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                                Assert.That(requests.IsEmpty, Is.True)
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("Error")
+                                        .GetString(),
+                                    Does.Contain("cancelled")
+                                )))))
+
+    /// Proves cancellation after a successful credential result preserves a prior attempt without acquiring a claim or contacting the server.
+    [<Test>]
+    let ``Linux cancellation after credential acquisition preserves existing staged attempt`` () =
+        withLinuxCacheRoot (fun root ->
+            Assert.That(
+                Grace.Cache.CacheIdentity.createAttempt root
+                |> Result.isOk,
+                Is.True
+            )
+
+            let claimPath = Path.Combine(root, ".enrollment.lock")
+            File.Delete(claimPath)
+            use credentialEntered = new ManualResetEventSlim(false)
+            use releaseCredential = new ManualResetEventSlim(false)
+            use cancellation = new CancellationTokenSource()
+
+            withLoopbackServer
+                (fun _ -> 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies ->
+                                { dependencies with
+                                    ResolveBearer =
+                                        fun () ->
+                                            task {
+                                                credentialEntered.Set()
+                                                releaseCredential.Wait()
+                                                return Ok(Some "delayed-cancellation-bearer")
+                                            }
+                                })
+                            (fun () ->
+                                let invocation = Task.Run(fun () -> invokeOutsideRepositoryWithCancellation enrollmentArguments cancellation.Token)
+
+                                Assert.That(credentialEntered.Wait(TimeSpan.FromSeconds(5.0)), Is.True)
+                                cancellation.Cancel()
+                                releaseCredential.Set()
+
+                                let exitCode, output, errorOutput, createdGraceDirectory = invocation.GetAwaiter().GetResult()
+
+                                Assert.That(exitCode, Is.Not.EqualTo(0))
+                                Assert.That(errorOutput, Is.Empty)
+                                Assert.That(createdGraceDirectory, Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.True)
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                                Assert.That(File.Exists(claimPath), Is.False)
                                 Assert.That(requests.IsEmpty, Is.True)
                                 use document = JsonDocument.Parse(output)
 

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -12,6 +12,7 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.Collections.Concurrent
+open System.Diagnostics
 open System.IO
 open System.Net
 open System.Net.Sockets
@@ -27,6 +28,9 @@ module CacheCliTests =
 
     /// Records only the target and bearer header needed to prove selected-server enrollment transport behavior.
     type private RecordedRequest = { Target: string; Authorization: string option }
+
+    let private claimHolderRootVariable = "GRACE_CACHE_TEST_CLAIM_HOLDER_ROOT"
+    let private claimHolderSignalVariable = "GRACE_CACHE_TEST_CLAIM_HOLDER_SIGNAL"
 
     /// Runs one callback with the supplied environment values and restores every changed variable in a finally block.
     let private withEnvironment (values: (string * string option) list) (action: unit -> 'T) =
@@ -256,6 +260,43 @@ module CacheCliTests =
             if Directory.Exists(temporaryDirectory) then
                 Directory.Delete(temporaryDirectory, true)
 
+    /// Starts a separate test-host process that holds the production Linux claim until the callback verifies loser behavior.
+    let private withExternalClaimHolder root action =
+        let signalPath = Path.Combine(Path.GetTempPath(), $"grace-cache-claim-held-{Guid.NewGuid():N}")
+        use holder = new Process()
+        holder.StartInfo.FileName <- "dotnet"
+        holder.StartInfo.UseShellExecute <- false
+        holder.StartInfo.CreateNoWindow <- true
+        holder.StartInfo.ArgumentList.Add("vstest")
+
+        holder.StartInfo.ArgumentList.Add(
+            System
+                .Reflection
+                .Assembly
+                .GetExecutingAssembly()
+                .Location
+        )
+
+        holder.StartInfo.ArgumentList.Add("--Tests:internal Linux Cache claim holder")
+        holder.StartInfo.Environment[ claimHolderRootVariable ] <- root
+        holder.StartInfo.Environment[ claimHolderSignalVariable ] <- signalPath
+
+        try
+            Assert.That(holder.Start(), Is.True)
+            let deadline = DateTime.UtcNow.AddSeconds(10.0)
+
+            while not (File.Exists(signalPath))
+                  && DateTime.UtcNow < deadline do
+                Thread.Sleep(50)
+
+            Assert.That(File.Exists(signalPath), Is.True, "The external Cache claim holder did not report an acquired lock.")
+            action ()
+        finally
+            if not holder.HasExited then holder.Kill(true)
+            holder.WaitForExit(10000) |> ignore
+
+            if File.Exists(signalPath) then File.Delete(signalPath)
+
     /// Verifies the root command dispatches pure cache status without repository discovery or invocation history.
     [<Test>]
     let ``cache status is repository independent and emits one JSON envelope`` () =
@@ -283,6 +324,25 @@ module CacheCliTests =
 
         Assert.That(commandIds, Does.Contain("cache.enroll"))
         Assert.That(commandIds, Does.Contain("cache.status"))
+
+    /// Holds the production claim in the child test host used by the root-command cross-process proof.
+    [<Test>]
+    let ``internal Linux Cache claim holder`` () =
+        let root = Environment.GetEnvironmentVariable(claimHolderRootVariable)
+        let signalPath = Environment.GetEnvironmentVariable(claimHolderSignalVariable)
+
+        if
+            not (String.IsNullOrWhiteSpace(root))
+            && not (String.IsNullOrWhiteSpace(signalPath))
+        then
+            match Grace.Cache.CacheIdentity.tryAcquireEnrollmentClaim root with
+            | Error error -> Assert.Fail($"The external Cache claim holder could not acquire its protected root: {error}")
+            | Ok claim ->
+                try
+                    File.WriteAllText(signalPath, "held")
+                    Thread.Sleep(30000)
+                finally
+                    Grace.Cache.CacheIdentity.releaseEnrollmentClaim claim
 
     /// Verifies PAT enrollment uses one root-command POST with the exact resolved bearer and no repository state.
     [<Test>]
@@ -314,6 +374,40 @@ module CacheCliTests =
                         Assert.That(recorded, Has.Length.EqualTo(1))
                         Assert.That(recorded[0].Target, Is.EqualTo("/cache/enroll"))
                         Assert.That(recorded[0].Authorization, Is.EqualTo(Some $"Bearer {token}")))))
+
+    /// Proves an external process claim blocks one root command without a POST, then dies and releases the next enrollment.
+    [<Test>]
+    let ``Linux external claim blocks root enrollment then process exit releases it`` () =
+        let token = PersonalAccessToken.formatToken "cache-claim" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
+                        withExternalClaimHolder root (fun () ->
+                            let exitCode, output, _ = invokeOutsideRepository enrollmentArguments
+                            Assert.That(exitCode, Is.Not.EqualTo(0))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                            Assert.That(requests.IsEmpty, Is.True)
+                            use document = JsonDocument.Parse(output)
+
+                            Assert.That(
+                                document
+                                    .RootElement
+                                    .GetProperty("Error")
+                                    .GetString(),
+                                Is.Not.Empty
+                            ))
+
+                        let winnerExitCode, _, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(winnerExitCode, Is.EqualTo(0))
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.filter (fun request -> request.Target = "/cache/enroll"),
+                            Has.Length.EqualTo(1)
+                        ))))
 
     /// Verifies root status observes a ready identity, then reports weak and corrupt state without leaking private facts.
     [<Test>]
@@ -790,6 +884,43 @@ module CacheCliTests =
                                 .GetString(),
                             Is.Not.Empty
                         ))))
+
+    /// Proves a replacement staged attempt cannot be posted or removed by the invocation that created the prior key.
+    [<Test>]
+    let ``Linux replaced staged attempt prevents POST and preserves replacement state`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies ->
+                                { dependencies with
+                                    ResolveBearer = (fun () -> Task.FromResult(Ok(Some "replacement-bearer")))
+                                    AfterAttemptCreated =
+                                        (fun () ->
+                                            let attempt = Path.Combine(root, "attempt")
+
+                                            Directory.Delete(attempt, true)
+
+                                            Grace.Cache.CacheIdentity.createAttempt root
+                                            |> Result.iter ignore)
+                                })
+                            (fun () ->
+                                let exitCode, output, _ = invokeOutsideRepository enrollmentArguments
+                                Assert.That(exitCode, Is.Not.EqualTo(0))
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.True)
+                                Assert.That(requests.IsEmpty, Is.True)
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("Error")
+                                        .GetString(),
+                                    Is.Not.Empty
+                                )))))
 
     /// Proves stale staged state survives failed credential resolution and is recovered only after one bearer resolves.
     [<Test>]

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -29,9 +29,6 @@ module CacheCliTests =
     /// Records only the target and bearer header needed to prove selected-server enrollment transport behavior.
     type private RecordedRequest = { Target: string; Authorization: string option }
 
-    let private claimHolderRootVariable = "GRACE_CACHE_TEST_CLAIM_HOLDER_ROOT"
-    let private claimHolderSignalVariable = "GRACE_CACHE_TEST_CLAIM_HOLDER_SIGNAL"
-
     /// Runs one callback with the supplied environment values and restores every changed variable in a finally block.
     let private withEnvironment (values: (string * string option) list) (action: unit -> 'T) =
         let originals =
@@ -236,12 +233,14 @@ module CacheCliTests =
         settings.Out <- AnsiConsoleOutput(writer)
         AnsiConsole.Console <- AnsiConsole.Create(settings)
 
-    /// Invokes a cache command from a fresh non-repository directory and restores console and directory process state.
-    let private invokeOutsideRepository arguments =
+    /// Invokes a cache command from a fresh non-repository directory and captures both standard streams.
+    let private invokeOutsideRepositoryWithStreams arguments =
         let temporaryDirectory = Path.Combine(Path.GetTempPath(), $"grace-cache-cli-tests-{Guid.NewGuid():N}")
         let originalDirectory = Environment.CurrentDirectory
         let originalOut = Console.Out
+        let originalError = Console.Error
         use output = new StringWriter()
+        use error = new StringWriter()
 
         try
             Directory.CreateDirectory(temporaryDirectory)
@@ -249,53 +248,142 @@ module CacheCliTests =
 
             Environment.CurrentDirectory <- temporaryDirectory
             Console.SetOut(output)
+            Console.SetError(error)
             setAnsiConsoleOutput output
             let exitCode = GraceCommand.main arguments
-            exitCode, output.ToString(), Directory.Exists(Path.Combine(temporaryDirectory, ".grace"))
+            exitCode, output.ToString(), error.ToString(), Directory.Exists(Path.Combine(temporaryDirectory, ".grace"))
         finally
             Console.SetOut(originalOut)
+            Console.SetError(originalError)
             setAnsiConsoleOutput originalOut
             Environment.CurrentDirectory <- originalDirectory
 
             if Directory.Exists(temporaryDirectory) then
                 Directory.Delete(temporaryDirectory, true)
 
-    /// Starts a separate test-host process that holds the production Linux claim until the callback verifies loser behavior.
-    let private withExternalClaimHolder root action =
-        let signalPath = Path.Combine(Path.GetTempPath(), $"grace-cache-claim-held-{Guid.NewGuid():N}")
-        use holder = new Process()
-        holder.StartInfo.FileName <- "dotnet"
-        holder.StartInfo.UseShellExecute <- false
-        holder.StartInfo.CreateNoWindow <- true
-        holder.StartInfo.ArgumentList.Add("vstest")
+    /// Invokes a cache command from a fresh non-repository directory while retaining the existing stdout-only test shape.
+    let private invokeOutsideRepository arguments =
+        let exitCode, output, _, createdGraceDirectory = invokeOutsideRepositoryWithStreams arguments
+        exitCode, output, createdGraceDirectory
 
-        holder.StartInfo.ArgumentList.Add(
-            System
-                .Reflection
-                .Assembly
-                .GetExecutingAssembly()
-                .Location
-        )
+    /// Lists the ready-only JSON property names that must be absent from every non-ready Cache status result.
+    let private readyOnlyStatusFields =
+        Set.ofList [ "CacheId"
+                     "Endpoint"
+                     "BoundaryKind"
+                     "RepositoryCount" ]
 
-        holder.StartInfo.ArgumentList.Add("--Tests:internal Linux Cache claim holder")
-        holder.StartInfo.Environment[ claimHolderRootVariable ] <- root
-        holder.StartInfo.Environment[ claimHolderSignalVariable ] <- signalPath
+    /// Asserts the exact presence or omission of ready-only Cache status properties in a parsed command envelope.
+    let private assertReadyOnlyStatusFields (shouldBePresent: bool) (status: JsonElement) =
+        let presentFields =
+            status.EnumerateObject()
+            |> Seq.map (fun property -> property.Name)
+            |> Set.ofSeq
 
+        for field in readyOnlyStatusFields do
+            Assert.That(Set.contains field presentFields = shouldBePresent, Is.True, $"Unexpected Cache status field presence for {field}.")
+
+    /// Locates the test-only direct claim-holder executable built by the test project dependency.
+    let private tryFindClaimHolderCommand () =
         try
-            Assert.That(holder.Start(), Is.True)
-            let deadline = DateTime.UtcNow.AddSeconds(10.0)
+            let assemblyDirectory =
+                DirectoryInfo(
+                    Path.GetDirectoryName(
+                        System
+                            .Reflection
+                            .Assembly
+                            .GetExecutingAssembly()
+                            .Location
+                    )
+                )
 
-            while not (File.Exists(signalPath))
-                  && DateTime.UtcNow < deadline do
-                Thread.Sleep(50)
+            let configuration = assemblyDirectory.Parent.Name
+            let targetFramework = assemblyDirectory.Name
+            let mutable current = assemblyDirectory
+            let mutable sourceDirectory = Unchecked.defaultof<DirectoryInfo>
+            let mutable found = false
 
-            Assert.That(File.Exists(signalPath), Is.True, "The external Cache claim holder did not report an acquired lock.")
-            action ()
-        finally
-            if not holder.HasExited then holder.Kill(true)
-            holder.WaitForExit(10000) |> ignore
+            while not found && not (isNull current) do
+                if Directory.Exists(Path.Combine(current.FullName, "Grace.Cache.ClaimHolder")) then
+                    sourceDirectory <- current
+                    found <- true
+                else
+                    current <- current.Parent
 
-            if File.Exists(signalPath) then File.Delete(signalPath)
+            if not found then
+                None
+            else
+                let holderBinDirectory = Path.Combine(sourceDirectory.FullName, "Grace.Cache.ClaimHolder", "bin", configuration, targetFramework)
+                let executablePath = Path.Combine(holderBinDirectory, "Grace.Cache.ClaimHolder.exe")
+                let libraryPath = Path.Combine(holderBinDirectory, "Grace.Cache.ClaimHolder.dll")
+
+                if
+                    OperatingSystem.IsWindows()
+                    && File.Exists(executablePath)
+                then
+                    Some(executablePath, None)
+                elif File.Exists(libraryPath) then
+                    Some("dotnet", Some libraryPath)
+                else
+                    None
+        with
+        | _ -> None
+
+    /// Starts the direct claim-holder process, verifies its held signal, then terminates that exact descriptor owner.
+    let private withDirectClaimHolder root action =
+        let signalPath = Path.Combine(Path.GetTempPath(), $"grace-cache-claim-held-{Guid.NewGuid():N}")
+
+        match tryFindClaimHolderCommand () with
+        | None -> Assert.Fail("The direct Cache claim-holder executable was not built.")
+        | Some (fileName, libraryPath) ->
+            use holder = new Process()
+            holder.StartInfo.FileName <- fileName
+            holder.StartInfo.UseShellExecute <- false
+            holder.StartInfo.CreateNoWindow <- true
+            holder.StartInfo.RedirectStandardOutput <- true
+            holder.StartInfo.RedirectStandardError <- true
+
+            libraryPath
+            |> Option.iter holder.StartInfo.ArgumentList.Add
+
+            holder.StartInfo.ArgumentList.Add(root)
+            holder.StartInfo.ArgumentList.Add(signalPath)
+            let mutable started = false
+
+            try
+                started <- holder.Start()
+                Assert.That(started, Is.True)
+                let deadline = DateTime.UtcNow.AddSeconds(10.0)
+
+                while not (File.Exists(signalPath))
+                      && DateTime.UtcNow < deadline do
+                    Thread.Sleep(50)
+
+                Assert.That(File.Exists(signalPath), Is.True, "The direct Cache claim holder did not report an acquired claim.")
+                action ()
+            finally
+                if started then
+                    if not holder.HasExited then holder.Kill()
+
+                    let exited = holder.WaitForExit(10000)
+                    let standardOutput = holder.StandardOutput.ReadToEnd()
+                    let standardError = holder.StandardError.ReadToEnd()
+
+                    Assert.That(
+                        exited,
+                        Is.True,
+                        $"Timed out waiting for the direct Cache claim holder to exit. stdout: {standardOutput}; stderr: {standardError}"
+                    )
+
+                    Assert.That(holder.HasExited, Is.True, "The direct Cache claim holder remained alive after termination.")
+
+                    Assert.That(
+                        holder.ExitCode,
+                        Is.Not.EqualTo(0),
+                        $"The terminated direct Cache claim holder unexpectedly returned success. stdout: {standardOutput}; stderr: {standardError}"
+                    )
+
+                if File.Exists(signalPath) then File.Delete(signalPath)
 
     /// Verifies the root command dispatches pure cache status without repository discovery or invocation history.
     [<Test>]
@@ -314,6 +402,31 @@ module CacheCliTests =
         let status = document.RootElement.GetProperty("ReturnValue")
         Assert.That(status.GetProperty("Enrollment").GetString(), Is.Not.EqualTo("enrolled"))
         Assert.That(status.GetProperty("Key").GetString(), Is.Not.Null)
+        assertReadyOnlyStatusFields false status
+
+    /// Verifies a staged local identity has one complete non-ready JSON shape with no ready-only identity facts.
+    [<Test>]
+    let ``cache status omits ready-only JSON fields for staging state`` () =
+        withLinuxCacheRoot (fun root ->
+            Assert.That(
+                Grace.Cache.CacheIdentity.createAttempt root
+                |> Result.isOk,
+                Is.True
+            )
+
+            let exitCode, output, createdGraceDirectory =
+                invokeOutsideRepository [| "--output"
+                                           "Json"
+                                           "cache"
+                                           "status" |]
+
+            Assert.That(exitCode, Is.EqualTo(1))
+            Assert.That(createdGraceDirectory, Is.False)
+            use document = JsonDocument.Parse(output)
+            let status = document.RootElement.GetProperty("ReturnValue")
+            Assert.That(status.GetProperty("Enrollment").GetString(), Is.EqualTo("notEnrolled"))
+            Assert.That(status.GetProperty("Key").GetString(), Is.EqualTo("available"))
+            assertReadyOnlyStatusFields false status)
 
     /// Verifies cache leaves participate in the shared command inventory used by schema and examples introspection.
     [<Test>]
@@ -325,24 +438,131 @@ module CacheCliTests =
         Assert.That(commandIds, Does.Contain("cache.enroll"))
         Assert.That(commandIds, Does.Contain("cache.status"))
 
-    /// Holds the production claim in the child test host used by the root-command cross-process proof.
+    /// Verifies Cache status introspection promises ready-only identity facts only in the enrolled schema variant.
     [<Test>]
-    let ``internal Linux Cache claim holder`` () =
-        let root = Environment.GetEnvironmentVariable(claimHolderRootVariable)
-        let signalPath = Environment.GetEnvironmentVariable(claimHolderSignalVariable)
+    let ``cache status schema examples and help describe conditional ready facts`` () =
+        let schemaExitCode, schemaOutput, schemaCreatedGraceDirectory =
+            invokeOutsideRepository [| "cache"
+                                       "status"
+                                       "--schema" |]
 
-        if
-            not (String.IsNullOrWhiteSpace(root))
-            && not (String.IsNullOrWhiteSpace(signalPath))
-        then
-            match Grace.Cache.CacheIdentity.tryAcquireEnrollmentClaim root with
-            | Error error -> Assert.Fail($"The external Cache claim holder could not acquire its protected root: {error}")
-            | Ok claim ->
-                try
-                    File.WriteAllText(signalPath, "held")
-                    Thread.Sleep(30000)
-                finally
-                    Grace.Cache.CacheIdentity.releaseEnrollmentClaim claim
+        Assert.That(schemaExitCode, Is.EqualTo(0))
+        Assert.That(schemaCreatedGraceDirectory, Is.False)
+        use schemaDocument = JsonDocument.Parse(schemaOutput)
+
+        let returnValueSchema =
+            schemaDocument
+                .RootElement
+                .GetProperty("Schema")
+                .GetProperty("SuccessSchema")
+                .GetProperty("properties")
+                .GetProperty("ReturnValue")
+
+        let variants =
+            returnValueSchema
+                .GetProperty("oneOf")
+                .EnumerateArray()
+            |> Seq.toArray
+
+        Assert.That(variants, Has.Length.EqualTo(2))
+
+        let readyVariant =
+            variants
+            |> Array.find (fun variant ->
+                let enrollment =
+                    variant
+                        .GetProperty("properties")
+                        .GetProperty("Enrollment")
+                        .GetProperty("const")
+                        .GetString()
+
+                enrollment = "enrolled")
+
+        let readyRequired =
+            readyVariant
+                .GetProperty("required")
+                .EnumerateArray()
+            |> Seq.map (fun value -> value.GetString())
+            |> Set.ofSeq
+
+        Assert.That(
+            (readyRequired = Set.ofList [ "Class"
+                                          "Enrollment"
+                                          "CacheId"
+                                          "Endpoint"
+                                          "BoundaryKind"
+                                          "RepositoryCount"
+                                          "Key" ]),
+            Is.True
+        )
+
+        let nonReadyVariant =
+            variants
+            |> Array.find (fun variant ->
+                let hasNot, _ =
+                    variant
+                        .GetProperty("properties")
+                        .GetProperty("Enrollment")
+                        .TryGetProperty("not")
+
+                hasNot)
+
+        let nonReadyRequired =
+            nonReadyVariant
+                .GetProperty("required")
+                .EnumerateArray()
+            |> Seq.map (fun value -> value.GetString())
+            |> Set.ofSeq
+
+        Assert.That(
+            (nonReadyRequired = Set.ofList [ "Class"
+                                             "Enrollment"
+                                             "Key" ]),
+            Is.True
+        )
+
+        let nonReadyProperties =
+            nonReadyVariant
+                .GetProperty("properties")
+                .EnumerateObject()
+            |> Seq.map (fun property -> property.Name)
+            |> Set.ofSeq
+
+        for field in readyOnlyStatusFields do
+            Assert.That(Set.contains field nonReadyProperties, Is.False, $"The non-ready Cache status schema must omit {field}.")
+
+        let examplesExitCode, examplesOutput, examplesCreatedGraceDirectory =
+            invokeOutsideRepository [| "cache"
+                                       "status"
+                                       "--examples" |]
+
+        Assert.That(examplesExitCode, Is.EqualTo(0))
+        Assert.That(examplesCreatedGraceDirectory, Is.False)
+        use examplesDocument = JsonDocument.Parse(examplesOutput)
+
+        let exampleStatus =
+            examplesDocument.RootElement.GetProperty("Examples").[0]
+                .GetProperty("Document")
+                .GetProperty("ReturnValue")
+
+        Assert.That(
+            exampleStatus
+                .GetProperty("Enrollment")
+                .GetString(),
+            Is.EqualTo("enrolled")
+        )
+
+        assertReadyOnlyStatusFields true exampleStatus
+
+        let helpExitCode, helpOutput, helpCreatedGraceDirectory =
+            invokeOutsideRepository [| "cache"
+                                       "status"
+                                       "--help" |]
+
+        Assert.That(helpExitCode, Is.EqualTo(0))
+        Assert.That(helpCreatedGraceDirectory, Is.False)
+        Assert.That(helpOutput, Does.Contain("--schema"))
+        Assert.That(helpOutput, Does.Contain("--examples"))
 
     /// Verifies PAT enrollment uses one root-command POST with the exact resolved bearer and no repository state.
     [<Test>]
@@ -385,7 +605,7 @@ module CacheCliTests =
                 (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
                 (fun serverUri requests ->
                     withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
-                        withExternalClaimHolder root (fun () ->
+                        withDirectClaimHolder root (fun () ->
                             let exitCode, output, _ = invokeOutsideRepository enrollmentArguments
                             Assert.That(exitCode, Is.Not.EqualTo(0))
                             Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
@@ -400,8 +620,12 @@ module CacheCliTests =
                                 Is.Not.Empty
                             ))
 
-                        let winnerExitCode, _, _ = invokeOutsideRepository enrollmentArguments
-                        Assert.That(winnerExitCode, Is.EqualTo(0))
+                        let winnerExitCode, winnerOutput, winnerError, _ = invokeOutsideRepositoryWithStreams enrollmentArguments
+
+                        Assert.That(winnerExitCode, Is.EqualTo(0), $"The enrollment retry failed. stdout: {winnerOutput}; stderr: {winnerError}")
+
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.True)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
 
                         Assert.That(
                             requests.ToArray()
@@ -409,7 +633,7 @@ module CacheCliTests =
                             Has.Length.EqualTo(1)
                         ))))
 
-    /// Verifies root status observes a ready identity, then reports weak and corrupt state without leaking private facts.
+    /// Verifies root status exposes ready-only facts only for ready state and omits them for invalid and inaccessible state.
     [<Test>]
     let ``Linux cache status is redacted for ready weak and corrupt identities`` () =
         let token = PersonalAccessToken.formatToken "cache-status" (Guid.NewGuid()) (Array.zeroCreate 32)
@@ -440,17 +664,41 @@ module CacheCliTests =
                             |> Seq.map (fun property -> property.Name)
                             |> Set.ofSeq
 
+                        let readyFieldNames = String.Join(", ", readyFields)
+
                         Assert.That(
-                            Set.isSubset
-                                readyFields
-                                (Set.ofList [ "Class"
-                                              "Enrollment"
-                                              "CacheId"
-                                              "Endpoint"
-                                              "BoundaryKind"
-                                              "RepositoryCount"
-                                              "Key" ]),
+                            (readyFields = Set.ofList [ "Class"
+                                                        "Enrollment"
+                                                        "CacheId"
+                                                        "Endpoint"
+                                                        "BoundaryKind"
+                                                        "RepositoryCount"
+                                                        "Key" ]),
+                            Is.True,
+                            $"Unexpected ready Cache status fields: {readyFieldNames}"
+                        )
+
+                        assertReadyOnlyStatusFields true (readyDocument.RootElement.GetProperty("ReturnValue"))
+
+                        Assert.That(
+                            Guid.TryParse(
+                                readyDocument
+                                    .RootElement
+                                    .GetProperty("ReturnValue")
+                                    .GetProperty("CacheId")
+                                    .GetString()
+                            )
+                            |> fst,
                             Is.True
+                        )
+
+                        Assert.That(
+                            readyDocument
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Endpoint")
+                                .GetString(),
+                            Is.Not.Empty
                         )
 
                         let readyDirectory = Path.Combine(root, "ready")
@@ -477,6 +725,38 @@ module CacheCliTests =
                             let weakStatus = weakDocument.RootElement.GetProperty("ReturnValue")
                             Assert.That(weakStatus.GetProperty("Enrollment").GetString(), Is.EqualTo("invalid"))
                             Assert.That(weakStatus.GetProperty("Key").GetString(), Is.EqualTo("invalid"))
+                            assertReadyOnlyStatusFields false weakStatus
+                        finally
+                            File.SetUnixFileMode(
+                                readyDirectory,
+                                UnixFileMode.UserRead
+                                ||| UnixFileMode.UserWrite
+                                ||| UnixFileMode.UserExecute
+                            )
+
+                        try
+                            File.SetUnixFileMode(readyDirectory, UnixFileMode.UserWrite)
+
+                            let inaccessibleExitCode, inaccessibleOutput, inaccessibleCreatedGraceDirectory =
+                                invokeOutsideRepository [| "--output"
+                                                           "Json"
+                                                           "cache"
+                                                           "status" |]
+
+                            Assert.That(inaccessibleExitCode, Is.EqualTo(1))
+                            Assert.That(inaccessibleCreatedGraceDirectory, Is.False)
+                            use inaccessibleDocument = JsonDocument.Parse(inaccessibleOutput)
+                            let inaccessibleStatus = inaccessibleDocument.RootElement.GetProperty("ReturnValue")
+
+                            Assert.That(
+                                inaccessibleStatus
+                                    .GetProperty("Enrollment")
+                                    .GetString(),
+                                Is.EqualTo("invalid")
+                            )
+
+                            Assert.That(inaccessibleStatus.GetProperty("Key").GetString(), Is.EqualTo("inaccessible"))
+                            assertReadyOnlyStatusFields false inaccessibleStatus
                         finally
                             File.SetUnixFileMode(
                                 readyDirectory,
@@ -507,7 +787,8 @@ module CacheCliTests =
                             Is.EqualTo("invalid")
                         )
 
-                        Assert.That(corruptStatus.GetProperty("Key").GetString(), Is.EqualTo("invalid")))))
+                        Assert.That(corruptStatus.GetProperty("Key").GetString(), Is.EqualTo("invalid"))
+                        assertReadyOnlyStatusFields false corruptStatus)))
 
     /// Verifies an invalid explicit PAT fails before credential success can stage local identity or contact enrollment.
     [<Test>]

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -1,0 +1,774 @@
+namespace Grace.CLI.Tests
+
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.CLI.CommandOutputContract
+open Grace.Shared
+open Grace.Types
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open NodaTime
+open NUnit.Framework
+open System
+open System.Collections.Concurrent
+open System.IO
+open System.Net
+open System.Net.Sockets
+open System.Text
+open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
+
+/// Covers serialized root-command status behavior that shares process console and current-directory state.
+[<TestFixture>]
+[<NonParallelizable>]
+module CacheCliTests =
+
+    /// Records only the target and bearer header needed to prove selected-server enrollment transport behavior.
+    type private RecordedRequest = { Target: string; Authorization: string option }
+
+    /// Runs one callback with the supplied environment values and restores every changed variable in a finally block.
+    let private withEnvironment (values: (string * string option) list) (action: unit -> 'T) =
+        let originals =
+            values
+            |> List.map (fun (name, _) -> name, Environment.GetEnvironmentVariable(name))
+
+        try
+            values
+            |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value |> Option.toObj))
+
+            action ()
+        finally
+            originals
+            |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value))
+
+    /// Creates a Linux-only protected root and restores Cache command process state after the callback returns.
+    let private withLinuxCacheRoot (action: string -> 'T) =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment command-path proof requires Linux protected-root semantics.")
+
+        let root = Path.Combine(Path.GetTempPath(), $"grace-cache-cli-root-{Guid.NewGuid():N}")
+
+        try
+            Directory.CreateDirectory(root) |> ignore
+
+            File.SetUnixFileMode(
+                root,
+                UnixFileMode.UserRead
+                ||| UnixFileMode.UserWrite
+                ||| UnixFileMode.UserExecute
+            )
+
+            CacheCommand.setStateRootForTests root
+            action root
+        finally
+            CacheCommand.resetStateRootForTests ()
+
+            if Directory.Exists(root) then Directory.Delete(root, true)
+
+    /// Hosts a loopback HTTP server that records each request and produces route-specific test responses.
+    let private withLoopbackServer (respond: RecordedRequest -> int * string) (action: string -> ConcurrentQueue<RecordedRequest> -> 'T) =
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        use cancellation = new CancellationTokenSource()
+        let requests = ConcurrentQueue<RecordedRequest>()
+        listener.Start()
+
+        /// Reads one compact HTTP request used by the focused local test server.
+        let readRequest (client: TcpClient) =
+            task {
+                use client = client
+                use stream = client.GetStream()
+                let buffer = Array.zeroCreate<byte> 16384
+                let! count = stream.ReadAsync(buffer, 0, buffer.Length)
+                let request = Encoding.UTF8.GetString(buffer, 0, count)
+                let lines = request.Split("\r\n", StringSplitOptions.None)
+
+                let target =
+                    lines[0]
+                        .Split(' ', StringSplitOptions.RemoveEmptyEntries)[1]
+
+                let authorization =
+                    lines
+                    |> Array.tryPick (fun line ->
+                        if line.StartsWith("Authorization:", StringComparison.OrdinalIgnoreCase) then
+                            Some(line.Substring("Authorization:".Length).Trim())
+                        else
+                            None)
+
+                let recorded = { Target = target; Authorization = authorization }
+                requests.Enqueue(recorded)
+                let statusCode, body = respond recorded
+                let bodyBytes = Encoding.UTF8.GetBytes(body)
+                let headers = $"HTTP/1.1 {statusCode} Test\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n"
+                let headerBytes = Encoding.ASCII.GetBytes(headers)
+                do! stream.WriteAsync(headerBytes, 0, headerBytes.Length)
+                do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length)
+            }
+
+        /// Serves test connections until the owning test finishes and cancels the loop.
+        let rec serve () =
+            task {
+                if not cancellation.IsCancellationRequested then
+                    try
+                        let! client =
+                            listener
+                                .AcceptTcpClientAsync(cancellation.Token)
+                                .AsTask()
+
+                        do! readRequest client
+                        return! serve ()
+                    with
+                    | :? OperationCanceledException -> return ()
+                    | :? ObjectDisposedException -> return ()
+            }
+
+        let serverTask = Task.Run(Func<Task>(fun () -> serve ()))
+        let port = (listener.LocalEndpoint :?> IPEndPoint).Port
+
+        try
+            action $"http://127.0.0.1:{port}" requests
+        finally
+            cancellation.Cancel()
+            listener.Stop()
+
+            if not (serverTask.Wait(TimeSpan.FromSeconds(5.0))) then
+                Assert.Fail("Timed out waiting for the Cache command test HTTP server to stop.")
+
+    /// Builds an accepted enrollment response with only server-owned facts required by the selected-server facade.
+    let private enrolledResponse () =
+        let now = SystemClock.Instance.GetCurrentInstant()
+
+        let registration: CacheRegistration =
+            {
+                Class = nameof CacheRegistration
+                CacheId = Guid.NewGuid()
+                DisplayName = "test cache"
+                BoundaryKind = CacheBoundaryKind.Owner
+                OwnerId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                OrganizationId = None
+                RepositoryScopes = Array.empty
+                PublicKey = CacheIdentityPublicKey.Create(String.replicate 43 "a", String.replicate 43 "a")
+                Endpoint = "https://cache.example.test"
+                AllowHttpEndpoint = false
+                Health = CacheHealthStatus.Unhealthy
+                SoftwareVersion = "Grace.Cache"
+                ProtocolVersion = "v1"
+                PrefetchSupported = false
+                EnrolledBy = "test"
+                EnrolledAt = now
+                LastRefreshedAt = now
+                RefreshAfter = now.Plus(Duration.FromHours(1))
+                ExpiresAt = now.Plus(Duration.FromHours(2))
+                RevokedAt = None
+            }
+
+        CacheRegistrationResult.Create(CacheRegistrationRefreshStatus.Enrolled, Some registration, "enrolled")
+        |> fun result -> GraceReturnValue.Create result "server-correlation"
+        |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
+
+    /// Returns explicit, valid owner-boundary enrollment arguments for actual root-command tests.
+    let private enrollmentArguments =
+        [|
+            "--output"
+            "Json"
+            "cache"
+            "enroll"
+            "--display-name"
+            "test cache"
+            "--endpoint"
+            "https://cache.example.test"
+            "--boundary"
+            "owner"
+            "--owner-id"
+            "11111111-1111-1111-1111-111111111111"
+            "--repository-organization-id"
+            "22222222-2222-2222-2222-222222222222"
+            "--repository-id"
+            "33333333-3333-3333-3333-333333333333"
+        |]
+
+    /// Supplies a clean credential environment so actual command tests cannot inherit another producer.
+    let private credentialEnvironment serverUri token authority clientId clientSecret =
+        [
+            Constants.EnvironmentVariables.GraceServerUri, Some serverUri
+            Constants.EnvironmentVariables.GraceToken, token
+            Constants.EnvironmentVariables.GraceTokenFile, None
+            Constants.EnvironmentVariables.GraceAuthOidcAuthority, authority
+            Constants.EnvironmentVariables.GraceAuthOidcAudience, authority |> Option.map (fun _ -> "test-audience")
+            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, clientId
+            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, clientSecret
+            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+        ]
+
+    /// Applies a bounded enrollment dependency override and restores the complete prior record in a finally block.
+    let private withEnrollmentDependencies (transform: CacheCommand.EnrollmentDependencies -> CacheCommand.EnrollmentDependencies) (action: unit -> 'T) =
+        let previous = CacheCommand.getEnrollmentDependenciesForTests ()
+
+        CacheCommand.setEnrollmentDependenciesForTests (transform previous)
+        |> ignore
+
+        try
+            action ()
+        finally
+            CacheCommand.setEnrollmentDependenciesForTests (previous)
+            |> ignore
+
+    /// Invokes a cache command from a fresh non-repository directory and restores console and directory process state.
+    let private invokeOutsideRepository arguments =
+        let temporaryDirectory = Path.Combine(Path.GetTempPath(), $"grace-cache-cli-tests-{Guid.NewGuid():N}")
+        let originalDirectory = Environment.CurrentDirectory
+        let originalOut = Console.Out
+        use output = new StringWriter()
+
+        try
+            Directory.CreateDirectory(temporaryDirectory)
+            |> ignore
+
+            Environment.CurrentDirectory <- temporaryDirectory
+            Console.SetOut(output)
+            let exitCode = GraceCommand.main arguments
+            exitCode, output.ToString(), Directory.Exists(Path.Combine(temporaryDirectory, ".grace"))
+        finally
+            Console.SetOut(originalOut)
+            Environment.CurrentDirectory <- originalDirectory
+
+            if Directory.Exists(temporaryDirectory) then
+                Directory.Delete(temporaryDirectory, true)
+
+    /// Verifies the root command dispatches pure cache status without repository discovery or invocation history.
+    [<Test>]
+    let ``cache status is repository independent and emits one JSON envelope`` () =
+        let exitCode, output, createdGraceDirectory =
+            invokeOutsideRepository [| "--output"
+                                       "Json"
+                                       "cache"
+                                       "status" |]
+
+        Assert.That(exitCode, Is.EqualTo(1))
+        Assert.That(createdGraceDirectory, Is.False)
+        Assert.That(output, Does.Not.Contain(".grace"))
+        Assert.That(output, Does.Not.Contain("/var/lib"))
+        use document = JsonDocument.Parse(output)
+        let status = document.RootElement.GetProperty("ReturnValue")
+        Assert.That(status.GetProperty("Enrollment").GetString(), Is.Not.EqualTo("enrolled"))
+        Assert.That(status.GetProperty("Key").GetString(), Is.Not.Null)
+
+    /// Verifies cache leaves participate in the shared command inventory used by schema and examples introspection.
+    [<Test>]
+    let ``cache commands are registered in the output contract`` () =
+        let commandIds =
+            CommandOutputContract.entries
+            |> List.map (fun entry -> entry.Identity.CommandId)
+
+        Assert.That(commandIds, Does.Contain("cache.enroll"))
+        Assert.That(commandIds, Does.Contain("cache.status"))
+
+    /// Verifies PAT enrollment uses one root-command POST with the exact resolved bearer and no repository state.
+    [<Test>]
+    let ``Linux PAT enrollment reuses one bearer for one selected-server request`` () =
+        let token = PersonalAccessToken.formatToken "cache-cli" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
+                        let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.True)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .GetProperty("Enrollment")
+                                .GetString(),
+                            Is.EqualTo("enrolled")
+                        )
+
+                        let recorded = requests.ToArray()
+                        Assert.That(recorded, Has.Length.EqualTo(1))
+                        Assert.That(recorded[0].Target, Is.EqualTo("/cache/enroll"))
+                        Assert.That(recorded[0].Authorization, Is.EqualTo(Some $"Bearer {token}")))))
+
+    /// Verifies root status observes a ready identity, then reports weak and corrupt state without leaking private facts.
+    [<Test>]
+    let ``Linux cache status is redacted for ready weak and corrupt identities`` () =
+        let token = PersonalAccessToken.formatToken "cache-status" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri _ ->
+                    withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
+                        let enrollmentExitCode, _, _ = invokeOutsideRepository enrollmentArguments
+                        Assert.That(enrollmentExitCode, Is.EqualTo(0))
+
+                        let readyExitCode, readyOutput, readyCreatedGraceDirectory =
+                            invokeOutsideRepository [| "--output"
+                                                       "Json"
+                                                       "cache"
+                                                       "status" |]
+
+                        Assert.That(readyExitCode, Is.EqualTo(0))
+                        Assert.That(readyCreatedGraceDirectory, Is.False)
+                        use readyDocument = JsonDocument.Parse(readyOutput)
+
+                        let readyFields =
+                            readyDocument
+                                .RootElement
+                                .GetProperty("ReturnValue")
+                                .EnumerateObject()
+                            |> Seq.map (fun property -> property.Name)
+                            |> Set.ofSeq
+
+                        Assert.That(
+                            Set.isSubset
+                                readyFields
+                                (Set.ofList [ "Class"
+                                              "Enrollment"
+                                              "CacheId"
+                                              "Endpoint"
+                                              "BoundaryKind"
+                                              "RepositoryCount"
+                                              "Key" ]),
+                            Is.True
+                        )
+
+                        let readyDirectory = Path.Combine(root, "ready")
+
+                        try
+                            File.SetUnixFileMode(
+                                readyDirectory,
+                                UnixFileMode.UserRead
+                                ||| UnixFileMode.UserWrite
+                                ||| UnixFileMode.UserExecute
+                                ||| UnixFileMode.GroupRead
+                            )
+
+                            let weakExitCode, weakOutput, weakCreatedGraceDirectory =
+                                invokeOutsideRepository [| "--output"
+                                                           "Json"
+                                                           "cache"
+                                                           "status" |]
+
+                            Assert.That(weakExitCode, Is.EqualTo(1))
+                            Assert.That(weakCreatedGraceDirectory, Is.False)
+                            Assert.That(weakOutput, Does.Not.Contain(root))
+                            use weakDocument = JsonDocument.Parse(weakOutput)
+                            let weakStatus = weakDocument.RootElement.GetProperty("ReturnValue")
+                            Assert.That(weakStatus.GetProperty("Enrollment").GetString(), Is.EqualTo("invalid"))
+                            Assert.That(weakStatus.GetProperty("Key").GetString(), Is.EqualTo("invalid"))
+                        finally
+                            File.SetUnixFileMode(
+                                readyDirectory,
+                                UnixFileMode.UserRead
+                                ||| UnixFileMode.UserWrite
+                                ||| UnixFileMode.UserExecute
+                            )
+
+                        File.WriteAllText(Path.Combine(readyDirectory, "registration.json"), "{}")
+
+                        let corruptExitCode, corruptOutput, corruptCreatedGraceDirectory =
+                            invokeOutsideRepository [| "--output"
+                                                       "Json"
+                                                       "cache"
+                                                       "status" |]
+
+                        Assert.That(corruptExitCode, Is.EqualTo(1))
+                        Assert.That(corruptCreatedGraceDirectory, Is.False)
+                        Assert.That(corruptOutput, Does.Not.Contain(root))
+                        Assert.That(corruptOutput, Does.Not.Contain("PublicKey"))
+                        use corruptDocument = JsonDocument.Parse(corruptOutput)
+                        let corruptStatus = corruptDocument.RootElement.GetProperty("ReturnValue")
+
+                        Assert.That(
+                            corruptStatus
+                                .GetProperty("Enrollment")
+                                .GetString(),
+                            Is.EqualTo("invalid")
+                        )
+
+                        Assert.That(corruptStatus.GetProperty("Key").GetString(), Is.EqualTo("invalid")))))
+
+    /// Verifies an invalid explicit PAT fails before credential success can stage local identity or contact enrollment.
+    [<Test>]
+    let ``Linux invalid PAT performs no enrollment request or local mutation`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun _ -> 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some "not-a-grace-pat") None None None) (fun () ->
+                        let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        Assert.That(requests.IsEmpty, Is.True)
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))
+
+    /// Verifies definitive server rejection removes only the current attempt and does not expose the PAT in JSON output.
+    [<Test>]
+    let ``Linux PAT rejection leaves no ready state or attempt`` () =
+        let token = PersonalAccessToken.formatToken "cache-cli" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    if request.Target = "/cache/enroll" then
+                        403, "{\"Error\":\"rejected\"}"
+                    else
+                        404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
+                        let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        Assert.That(output, Does.Not.Contain(token))
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.filter (fun request -> request.Target = "/cache/enroll"),
+                            Has.Length.EqualTo(1)
+                        )
+
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))
+
+    /// Verifies M2M acquires one token before one enrollment request and forwards that bearer unchanged.
+    [<Test>]
+    let ``Linux M2M enrollment acquires one token then sends one enrollment request`` () =
+        let bearer = "m2m-test-bearer"
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    match request.Target with
+                    | "/oauth/token" -> 200, "{\"access_token\":\"m2m-test-bearer\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+                    | "/cache/enroll" -> 200, enrolledResponse ()
+                    | _ -> 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None (Some serverUri) (Some "client") (Some "secret")) (fun () ->
+                        let exitCode, _, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.True)
+                        let recorded = requests.ToArray()
+
+                        Assert.That(
+                            recorded
+                            |> Array.filter (fun request -> request.Target = "/oauth/token"),
+                            Has.Length.EqualTo(1)
+                        )
+
+                        Assert.That(
+                            recorded
+                            |> Array.filter (fun request -> request.Target = "/cache/enroll"),
+                            Has.Length.EqualTo(1)
+                        )
+
+                        let enrollmentRequest =
+                            recorded
+                            |> Array.find (fun request -> request.Target = "/cache/enroll")
+
+                        Assert.That(enrollmentRequest.Authorization, Is.EqualTo(Some $"Bearer {bearer}")))))
+
+    /// Verifies a failed M2M acquisition performs neither enrollment nor protected-root mutation.
+    [<Test>]
+    let ``Linux M2M failure performs no enrollment request or local mutation`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    if request.Target = "/oauth/token" then
+                        (500, "{\"error\":\"temporarily_unavailable\"}")
+                    else
+                        (404, "{}"))
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None (Some serverUri) (Some "client") (Some "secret")) (fun () ->
+                        let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.filter (fun request -> request.Target = "/oauth/token"),
+                            Has.Length.EqualTo(1)
+                        )
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.exists (fun request -> request.Target = "/cache/enroll"),
+                            Is.False
+                        )
+
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))
+
+    /// Verifies missing interactive credentials may use the existing OIDC configuration lookup but cannot stage or enroll.
+    [<Test>]
+    let ``Linux missing interactive credential performs no enrollment or local mutation`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request ->
+                    if request.Target = "/authenticate/oidc/config" then
+                        (200,
+                         "{\"ReturnValue\":{\"Authority\":\"https://tenant.example.test/\",\"Audience\":\"test-audience\",\"CliClientId\":\"test-client\"},\"EventTime\":\"2026-01-01T00:00:00Z\",\"CorrelationId\":\"test\",\"Properties\":{}}")
+                    else
+                        (404, "{}"))
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.exists (fun request -> request.Target = "/cache/enroll"),
+                            Is.False
+                        )
+
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))
+
+    /// Proves actual root dispatch consumes one deterministic result from the normal credential-resolution boundary for stored-login composition.
+    [<Test>]
+    let ``Linux root enrollment consumes one stored interactive credential result`` () =
+        let bearer = "stored-interactive-bearer"
+        let mutable credentialCalls = 0
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies ->
+                                { dependencies with
+                                    ResolveBearer =
+                                        fun () ->
+                                            credentialCalls <- credentialCalls + 1
+                                            Task.FromResult(Ok(Some bearer))
+                                })
+                            (fun () ->
+                                let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                                Assert.That(exitCode, Is.EqualTo(0))
+                                Assert.That(credentialCalls, Is.EqualTo(1))
+                                Assert.That(createdGraceDirectory, Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.True)
+                                let recorded = requests.ToArray()
+                                Assert.That(recorded, Has.Length.EqualTo(1))
+                                Assert.That(recorded[0].Authorization, Is.EqualTo(Some $"Bearer {bearer}"))
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("ReturnValue")
+                                        .GetProperty("Enrollment")
+                                        .GetString(),
+                                    Is.EqualTo("enrolled")
+                                )))))
+
+    /// Proves an expired stored-login result leaves no local attempt or enrollment request when consumed through root dispatch.
+    [<Test>]
+    let ``Linux expired interactive result performs no enrollment or local mutation`` () =
+        let mutable credentialCalls = 0
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun _ -> 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies ->
+                                { dependencies with
+                                    ResolveBearer =
+                                        fun () ->
+                                            credentialCalls <- credentialCalls + 1
+                                            Task.FromResult(Error "Stored interactive credential is expired.")
+                                })
+                            (fun () ->
+                                let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                                Assert.That(exitCode, Is.Not.EqualTo(0))
+                                Assert.That(credentialCalls, Is.EqualTo(1))
+                                Assert.That(createdGraceDirectory, Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                                Assert.That(requests.IsEmpty, Is.True)
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("Error")
+                                        .GetString(),
+                                    Does.Contain("expired")
+                                )))))
+
+    /// Proves cancellation after staging removes the attempt without performing an enrollment request or publishing ready state.
+    [<Test>]
+    let ``Linux cancellation after attempt creation cleans only the current attempt`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun _ -> 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies ->
+                                { dependencies with
+                                    ResolveBearer = fun () -> Task.FromResult(Ok(Some "cancellation-bearer"))
+                                    AfterAttemptCreated = fun () -> raise (OperationCanceledException("test cancellation"))
+                                })
+                            (fun () ->
+                                let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                                Assert.That(exitCode, Is.Not.EqualTo(0))
+                                Assert.That(createdGraceDirectory, Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                                Assert.That(requests.IsEmpty, Is.True)
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("Error")
+                                        .GetString(),
+                                    Does.Contain("cancelled")
+                                )))))
+
+    /// Proves cancellation before protected staging emits a single redacted result and leaves the root unchanged.
+    [<Test>]
+    let ``Linux cancellation before attempt creation performs no enrollment or local mutation`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun _ -> 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies -> { dependencies with ResolveBearer = (fun () -> raise (OperationCanceledException("test cancellation"))) })
+                            (fun () ->
+                                let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                                Assert.That(exitCode, Is.Not.EqualTo(0))
+                                Assert.That(createdGraceDirectory, Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                                Assert.That(requests.IsEmpty, Is.True)
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("Error")
+                                        .GetString(),
+                                    Does.Contain("cancelled")
+                                )))))
+
+    /// Proves a forced protected commit failure preserves the enrollment request count and cleans the current attempt.
+    [<Test>]
+    let ``Linux forced local commit failure cleans attempt after one enrollment request`` () =
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, enrolledResponse () else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri None None None None) (fun () ->
+                        withEnrollmentDependencies
+                            (fun dependencies ->
+                                { dependencies with
+                                    ResolveBearer = (fun () -> Task.FromResult(Ok(Some "commit-failure-bearer")))
+                                    CommitReady = (fun _ -> false)
+                                })
+                            (fun () ->
+                                let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                                Assert.That(exitCode, Is.Not.EqualTo(0))
+                                Assert.That(createdGraceDirectory, Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                                Assert.That(
+                                    requests.ToArray()
+                                    |> Array.filter (fun request -> request.Target = "/cache/enroll"),
+                                    Has.Length.EqualTo(1)
+                                )
+
+                                use document = JsonDocument.Parse(output)
+
+                                Assert.That(
+                                    document
+                                        .RootElement
+                                        .GetProperty("Error")
+                                        .GetString(),
+                                    Does.Contain("could not be committed")
+                                )))))
+
+    /// Proves a malformed nominal-success response is an unknown outcome that cleans the current attempt without retrying.
+    [<Test>]
+    let ``Linux malformed enrollment response leaves no ready state or attempt`` () =
+        let token = PersonalAccessToken.formatToken "cache-malformed" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withLinuxCacheRoot (fun root ->
+            withLoopbackServer
+                (fun request -> if request.Target = "/cache/enroll" then 200, "{}" else 404, "{}")
+                (fun serverUri requests ->
+                    withEnvironment (credentialEnvironment serverUri (Some token) None None None) (fun () ->
+                        let exitCode, output, createdGraceDirectory = invokeOutsideRepository enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0))
+                        Assert.That(createdGraceDirectory, Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                        Assert.That(
+                            requests.ToArray()
+                            |> Array.filter (fun request -> request.Target = "/cache/enroll"),
+                            Has.Length.EqualTo(1)
+                        )
+
+                        use document = JsonDocument.Parse(output)
+
+                        Assert.That(
+                            document
+                                .RootElement
+                                .GetProperty("Error")
+                                .GetString(),
+                            Is.Not.Empty
+                        ))))

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -238,16 +238,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 206
+        |> should equal 208
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 197
+        |> should equal 199
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 185
+        |> should equal 187
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -289,7 +289,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 185
+        jsonReady |> should equal 187
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -466,7 +466,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 185
+        commonEntries.Length |> should equal 187
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -484,7 +484,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 185
+        commonEntries.Length |> should equal 187
 
         let parserInvalidEntries =
             commonEntries

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -5,6 +5,7 @@
 		<Prefer32Bit>false</Prefer32Bit>
 		<LangVersion>preview</LangVersion>
 		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 		<SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -20,6 +21,8 @@
     <Compile Include="AuthTokenBundle.Tests.fs" />
     <Compile Include="Branch.CLI.Parsing.Tests.fs" />
     <Compile Include="Branch.CLI.Tests.fs" />
+    <Compile Include="Cache.CLI.Parsing.Tests.fs" />
+    <Compile Include="Cache.CLI.Tests.fs" />
     <Compile Include="Connect.CLI.Parsing.Tests.fs" />
     <Compile Include="Connect.CLI.Tests.fs" />
     <Compile Include="BuildInfo.Tests.fs" />

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -75,6 +75,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Grace.CLI\Grace.CLI.fsproj" />
 		<ProjectReference Include="..\Grace.CLI.LocalStateDb.Worker\Grace.CLI.LocalStateDb.Worker.fsproj" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\Grace.Cache.ClaimHolder\Grace.Cache.ClaimHolder.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
 		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -59,6 +59,7 @@
 		<PackageReference Include="FsCheck" Version="3.3.3" />
 		<PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
 		<PackageReference Include="FsUnit" Version="7.1.1" />
+		<PackageReference Include="JsonSchema.Net" Version="9.4.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="NUnit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -76,6 +76,7 @@
 		<ProjectReference Include="..\Grace.CLI\Grace.CLI.fsproj" />
 		<ProjectReference Include="..\Grace.CLI.LocalStateDb.Worker\Grace.CLI.LocalStateDb.Worker.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
+		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 	</ItemGroup>
 

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -235,8 +235,8 @@ module CacheCommand =
     /// Renders a redacted cache enrollment failure without exposing local state or transport details.
     let private renderEnrollmentFailure parseResult message = renderOutput parseResult (Error(GraceError.Create message (getCorrelationId parseResult)))
 
-    /// Removes the current attempt after a post-staging failure without masking the primary command outcome.
-    let private completeAttempt (root: string) (completion: unit -> Task<int * bool>) =
+    /// Removes only this invocation's claimed attempt after a post-staging failure without masking the primary command outcome.
+    let private completeAttempt claim (root: string) publicKey (completion: unit -> Task<int * bool>) =
         task {
             let mutable committed = false
 
@@ -245,7 +245,9 @@ module CacheCommand =
                 committed <- isCommitted
                 return exitCode
             finally
-                if not committed then CacheIdentity.discardAttempt root
+                if not committed then
+                    CacheIdentity.discardClaimedAttempt claim root (Some publicKey)
+                    |> ignore
         }
 
     /// Enrolls exactly once after validation and one credential acquisition, then publishes ready only after local commit succeeds.
@@ -275,100 +277,124 @@ module CacheCommand =
                         return renderEnrollmentFailure parseResult "The protected Grace Cache state root is inaccessible."
                     | Ok CacheIdentityInspection.Ready -> return renderEnrollmentFailure parseResult "The protected Grace Cache state root is already enrolled."
                     | Ok (CacheIdentityInspection.Missing
-                    | CacheIdentityInspection.AttemptPresent as inspection) ->
+                    | CacheIdentityInspection.AttemptPresent) ->
                         let! bearer = resolveBearer parseResult cancellationToken
 
                         match bearer with
                         | Error error -> return renderOutput parseResult (Error error)
                         | Ok bearer ->
-                            let staleRecovery =
-                                match inspection with
-                                | CacheIdentityInspection.AttemptPresent -> CacheIdentity.discardStaleAttempt stateRoot
-                                | CacheIdentityInspection.Missing -> Ok()
-                                | _ -> Error CacheIdentityError.StateUnavailable
+                            match CacheIdentity.tryAcquireEnrollmentClaim stateRoot with
+                            | Error _ -> return renderEnrollmentFailure parseResult "Cache enrollment could not acquire exclusive local state."
+                            | Ok claim ->
+                                try
+                                    let staleRecovery =
+                                        match CacheIdentity.inspectEnrollmentRoot stateRoot with
+                                        | Ok CacheIdentityInspection.AttemptPresent -> CacheIdentity.discardStaleAttempt claim stateRoot
+                                        | Ok CacheIdentityInspection.Missing -> Ok()
+                                        | _ -> Error CacheIdentityError.StateUnavailable
 
-                            match staleRecovery with
-                            | Error _ -> return renderEnrollmentFailure parseResult "A stale cache enrollment attempt could not be safely cleared."
-                            | Ok () ->
-                                cancellationToken.ThrowIfCancellationRequested()
+                                    match staleRecovery with
+                                    | Error _ -> return renderEnrollmentFailure parseResult "A stale cache enrollment attempt could not be safely cleared."
+                                    | Ok () ->
+                                        cancellationToken.ThrowIfCancellationRequested()
 
-                                match CacheIdentity.createAttempt stateRoot with
-                                | Error _ ->
-                                    return
-                                        renderOutput
-                                            parseResult
-                                            (Error(
-                                                GraceError.Create
-                                                    "The protected Grace Cache state root could not create an enrollment attempt."
-                                                    (getCorrelationId parseResult)
-                                            ))
-                                | Ok publicKey ->
-                                    return!
-                                        completeAttempt stateRoot (fun () ->
-                                            task {
-                                                enrollmentDependencies.AfterAttemptCreated()
-                                                cancellationToken.ThrowIfCancellationRequested()
-
-                                                match requestFromArguments parseResult publicKey with
-                                                | Error error -> return renderOutput parseResult (Error error), false
-                                                | Ok request ->
-                                                    let! response =
-                                                        CacheRegistration.Enroll(request, serverUri, bearer, getCorrelationId parseResult, cancellationToken)
-
-                                                    match response with
-                                                    | Error error -> return renderOutput parseResult (Error error), false
-                                                    | Ok accepted ->
+                                        match CacheIdentity.createClaimedAttempt claim stateRoot with
+                                        | Error _ ->
+                                            return
+                                                renderOutput
+                                                    parseResult
+                                                    (Error(
+                                                        GraceError.Create
+                                                            "The protected Grace Cache state root could not create an enrollment attempt."
+                                                            (getCorrelationId parseResult)
+                                                    ))
+                                        | Ok publicKey ->
+                                            return!
+                                                completeAttempt claim stateRoot publicKey (fun () ->
+                                                    task {
+                                                        enrollmentDependencies.AfterAttemptCreated()
                                                         cancellationToken.ThrowIfCancellationRequested()
 
-                                                        match accepted.ReturnValue.Status, accepted.ReturnValue.Registration with
-                                                        | CacheRegistrationRefreshStatus.Enrolled, Some registration ->
-                                                            let configuration: Grace.Cache.CacheAcceptedRegistration =
-                                                                {
-                                                                    CacheId = registration.CacheId
-                                                                    DisplayName = request.DisplayName
-                                                                    BoundaryKind = request.BoundaryKind.ToString()
-                                                                    OwnerId = request.OwnerId
-                                                                    OrganizationId = request.OrganizationId
-                                                                    RepositoryScopes =
-                                                                        request.RepositoryScopes
-                                                                        |> Seq.map (fun (scope: Grace.Types.CacheRegistration.CacheRepositoryScope) ->
-                                                                            { OrganizationId = scope.OrganizationId; RepositoryId = scope.RepositoryId }: Grace.Cache.CacheAcceptedRepositoryScope)
-                                                                        |> Seq.toArray
-                                                                    Endpoint = request.Endpoint
-                                                                    ProtocolVersion = request.ProtocolVersion
-                                                                    PublicKey = publicKey
-                                                                }
-
-                                                            match
-                                                                enrollmentDependencies.CommitReady (fun () ->
-                                                                    CacheIdentity.commitReady stateRoot configuration
-                                                                    |> Result.isOk)
-                                                                with
-                                                            | false ->
+                                                        match requestFromArguments parseResult publicKey with
+                                                        | Error error -> return renderOutput parseResult (Error error), false
+                                                        | Ok request ->
+                                                            match CacheIdentity.validateClaimedAttempt claim stateRoot publicKey with
+                                                            | Error _ ->
                                                                 return
-                                                                    renderOutput
+                                                                    renderEnrollmentFailure
                                                                         parseResult
-                                                                        (Error(
-                                                                            GraceError.Create
-                                                                                "Cache enrollment was accepted but protected ready state could not be committed."
-                                                                                (getCorrelationId parseResult)
-                                                                        )),
+                                                                        "Cache enrollment local state changed before it could be sent.",
                                                                     false
-                                                            | true ->
-                                                                let status = CacheIdentity.status stateRoot
-                                                                let exitCode = renderStatus parseResult status
-                                                                return exitCode, status.Enrollment = "enrolled"
-                                                        | _ ->
-                                                            return
-                                                                renderOutput
-                                                                    parseResult
-                                                                    (Error(
-                                                                        GraceError.Create
-                                                                            "Cache enrollment did not return an accepted registration."
-                                                                            (getCorrelationId parseResult)
-                                                                    )),
-                                                                false
-                                            })
+                                                            | Ok () ->
+                                                                let! response =
+                                                                    CacheRegistration.Enroll(
+                                                                        request,
+                                                                        serverUri,
+                                                                        bearer,
+                                                                        getCorrelationId parseResult,
+                                                                        cancellationToken
+                                                                    )
+
+                                                                match response with
+                                                                | Error error -> return renderOutput parseResult (Error error), false
+                                                                | Ok accepted ->
+                                                                    cancellationToken.ThrowIfCancellationRequested()
+
+                                                                    match accepted.ReturnValue.Status, accepted.ReturnValue.Registration with
+                                                                    | CacheRegistrationRefreshStatus.Enrolled, Some registration ->
+                                                                        let configuration: Grace.Cache.CacheAcceptedRegistration =
+                                                                            {
+                                                                                CacheId = registration.CacheId
+                                                                                DisplayName = request.DisplayName
+                                                                                BoundaryKind = request.BoundaryKind.ToString()
+                                                                                OwnerId = request.OwnerId
+                                                                                OrganizationId = request.OrganizationId
+                                                                                RepositoryScopes =
+                                                                                    request.RepositoryScopes
+                                                                                    |> Seq.map
+                                                                                        (fun (scope: Grace.Types.CacheRegistration.CacheRepositoryScope) ->
+                                                                                            {
+                                                                                                OrganizationId = scope.OrganizationId
+                                                                                                RepositoryId = scope.RepositoryId
+                                                                                            }: Grace.Cache.CacheAcceptedRepositoryScope)
+                                                                                    |> Seq.toArray
+                                                                                Endpoint = request.Endpoint
+                                                                                ProtocolVersion = request.ProtocolVersion
+                                                                                PublicKey = publicKey
+                                                                            }
+
+                                                                        match
+                                                                            enrollmentDependencies.CommitReady (fun () ->
+                                                                                CacheIdentity.commitClaimedReady claim stateRoot configuration
+                                                                                |> Result.isOk)
+                                                                            with
+                                                                        | false ->
+                                                                            return
+                                                                                renderOutput
+                                                                                    parseResult
+                                                                                    (Error(
+                                                                                        GraceError.Create
+                                                                                            "Cache enrollment was accepted but protected ready state could not be committed."
+                                                                                            (getCorrelationId parseResult)
+                                                                                    )),
+                                                                                false
+                                                                        | true ->
+                                                                            let status = CacheIdentity.status stateRoot
+                                                                            let exitCode = renderStatus parseResult status
+                                                                            return exitCode, status.Enrollment = "enrolled"
+                                                                    | _ ->
+                                                                        return
+                                                                            renderOutput
+                                                                                parseResult
+                                                                                (Error(
+                                                                                    GraceError.Create
+                                                                                        "Cache enrollment did not return an accepted registration."
+                                                                                        (getCorrelationId parseResult)
+                                                                                )),
+                                                                            false
+                                                    })
+                                finally
+                                    CacheIdentity.releaseEnrollmentClaim claim
         }
 
     /// Runs the pure local cache status handler through System.CommandLine.

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -12,6 +12,7 @@ open System.Collections.Generic
 open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
+open System.Text.Json.Nodes
 open System.Threading
 open System.Threading.Tasks
 
@@ -198,7 +199,24 @@ module CacheCommand =
     /// Renders only the approved redacted local identity facts for a cache command result.
     let private renderStatus (parseResult: ParseResult) (status: Grace.Cache.CacheIdentityStatus) =
         if parseResult |> json then
-            GraceReturnValue.Create status (getCorrelationId parseResult)
+            let jsonStatus = JsonObject()
+            jsonStatus["Class"] <- JsonValue.Create(status.Class)
+            jsonStatus["Enrollment"] <- JsonValue.Create(status.Enrollment)
+            jsonStatus["Key"] <- JsonValue.Create(status.Key)
+
+            status.CacheId
+            |> Option.iter (fun cacheId -> jsonStatus["CacheId"] <- JsonValue.Create(cacheId))
+
+            status.Endpoint
+            |> Option.iter (fun endpoint -> jsonStatus["Endpoint"] <- JsonValue.Create(endpoint))
+
+            status.BoundaryKind
+            |> Option.iter (fun boundaryKind -> jsonStatus["BoundaryKind"] <- JsonValue.Create(boundaryKind))
+
+            status.RepositoryCount
+            |> Option.iter (fun repositoryCount -> jsonStatus["RepositoryCount"] <- JsonValue.Create(repositoryCount))
+
+            GraceReturnValue.Create jsonStatus (getCorrelationId parseResult)
             |> Ok
             |> renderOutput parseResult
         elif parseResult |> silent then

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -163,7 +163,36 @@ module CacheCommand =
             match token with
             | Ok (Some bearer) when not (String.IsNullOrWhiteSpace bearer) -> return Ok bearer
             | Ok _ -> return Error(GraceError.Create "Authentication required. Run 'grace authenticate login' and try again." (getCorrelationId parseResult))
-            | Error message -> return Error(GraceError.Create message (getCorrelationId parseResult))
+            | Error message ->
+                let classification =
+                    let normalized = message.ToLowerInvariant()
+
+                    if
+                        normalized.Contains("expired")
+                        || normalized.Contains("refresh")
+                    then
+                        "Stored interactive credentials are expired or unusable. Run 'grace authenticate login' and try again."
+                    elif
+                        normalized.Contains("secure")
+                        || normalized.Contains("store")
+                    then
+                        "Interactive credential storage is unavailable. Use GRACE_TOKEN, configure M2M, or run 'grace authenticate login'."
+                    elif
+                        normalized.Contains("oidc")
+                        || normalized.Contains("authentication is not configured")
+                    then
+                        "Interactive authentication configuration is unavailable. Set GRACE_SERVER_URI or use GRACE_TOKEN or M2M."
+                    elif normalized.Contains("grace_token") then
+                        "GRACE_TOKEN does not contain a valid Grace PAT."
+                    elif
+                        normalized.Contains("m2m")
+                        || normalized.Contains("client_credentials")
+                    then
+                        "Machine-to-machine credential acquisition failed. Verify the configured M2M credential."
+                    else
+                        "Authentication could not provide a usable credential. Run 'grace authenticate login' or configure GRACE_TOKEN or M2M."
+
+                return Error(GraceError.Create classification (getCorrelationId parseResult))
         }
 
     /// Renders only the approved redacted local identity facts for a cache command result.
@@ -203,6 +232,9 @@ module CacheCommand =
             return if status.Enrollment = "enrolled" then 0 else 1
         }
 
+    /// Renders a redacted cache enrollment failure without exposing local state or transport details.
+    let private renderEnrollmentFailure parseResult message = renderOutput parseResult (Error(GraceError.Create message (getCorrelationId parseResult)))
+
     /// Removes the current attempt after a post-staging failure without masking the primary command outcome.
     let private completeAttempt (root: string) (completion: unit -> Task<int * bool>) =
         task {
@@ -227,99 +259,116 @@ module CacheCommand =
                 match configuredServerUri parseResult with
                 | Error error -> return renderOutput parseResult (Error error)
                 | Ok serverUri ->
-                    match CacheIdentity.validateEnrollmentRoot stateRoot with
-                    | Error _ ->
+                    match CacheIdentity.inspectEnrollmentRoot stateRoot with
+                    | Error CacheIdentityError.UnsupportedPlatform ->
                         return
                             renderOutput
                                 parseResult
                                 (Error(
-                                    GraceError.Create "The protected Grace Cache state root is unavailable or already enrolled." (getCorrelationId parseResult)
+                                    GraceError.Create
+                                        "Cache enrollment is supported only on Linux with a protected Grace Cache state root."
+                                        (getCorrelationId parseResult)
                                 ))
-                    | Ok () ->
+                    | Error CacheIdentityError.StateUnavailable
+                    | Ok CacheIdentityInspection.Invalid -> return renderEnrollmentFailure parseResult "The protected Grace Cache state root is invalid."
+                    | Ok CacheIdentityInspection.Inaccessible ->
+                        return renderEnrollmentFailure parseResult "The protected Grace Cache state root is inaccessible."
+                    | Ok CacheIdentityInspection.Ready -> return renderEnrollmentFailure parseResult "The protected Grace Cache state root is already enrolled."
+                    | Ok (CacheIdentityInspection.Missing
+                    | CacheIdentityInspection.AttemptPresent as inspection) ->
                         let! bearer = resolveBearer parseResult cancellationToken
 
                         match bearer with
                         | Error error -> return renderOutput parseResult (Error error)
                         | Ok bearer ->
-                            cancellationToken.ThrowIfCancellationRequested()
+                            let staleRecovery =
+                                match inspection with
+                                | CacheIdentityInspection.AttemptPresent -> CacheIdentity.discardStaleAttempt stateRoot
+                                | CacheIdentityInspection.Missing -> Ok()
+                                | _ -> Error CacheIdentityError.StateUnavailable
 
-                            match CacheIdentity.createAttempt stateRoot with
-                            | Error _ ->
-                                return
-                                    renderOutput
-                                        parseResult
-                                        (Error(
-                                            GraceError.Create
-                                                "The protected Grace Cache state root could not create an enrollment attempt."
-                                                (getCorrelationId parseResult)
-                                        ))
-                            | Ok publicKey ->
-                                return!
-                                    completeAttempt stateRoot (fun () ->
-                                        task {
-                                            enrollmentDependencies.AfterAttemptCreated()
-                                            cancellationToken.ThrowIfCancellationRequested()
+                            match staleRecovery with
+                            | Error _ -> return renderEnrollmentFailure parseResult "A stale cache enrollment attempt could not be safely cleared."
+                            | Ok () ->
+                                cancellationToken.ThrowIfCancellationRequested()
 
-                                            match requestFromArguments parseResult publicKey with
-                                            | Error error -> return renderOutput parseResult (Error error), false
-                                            | Ok request ->
-                                                let! response =
-                                                    CacheRegistration.Enroll(request, serverUri, bearer, getCorrelationId parseResult, cancellationToken)
+                                match CacheIdentity.createAttempt stateRoot with
+                                | Error _ ->
+                                    return
+                                        renderOutput
+                                            parseResult
+                                            (Error(
+                                                GraceError.Create
+                                                    "The protected Grace Cache state root could not create an enrollment attempt."
+                                                    (getCorrelationId parseResult)
+                                            ))
+                                | Ok publicKey ->
+                                    return!
+                                        completeAttempt stateRoot (fun () ->
+                                            task {
+                                                enrollmentDependencies.AfterAttemptCreated()
+                                                cancellationToken.ThrowIfCancellationRequested()
 
-                                                match response with
+                                                match requestFromArguments parseResult publicKey with
                                                 | Error error -> return renderOutput parseResult (Error error), false
-                                                | Ok accepted ->
-                                                    cancellationToken.ThrowIfCancellationRequested()
+                                                | Ok request ->
+                                                    let! response =
+                                                        CacheRegistration.Enroll(request, serverUri, bearer, getCorrelationId parseResult, cancellationToken)
 
-                                                    match accepted.ReturnValue.Status, accepted.ReturnValue.Registration with
-                                                    | CacheRegistrationRefreshStatus.Enrolled, Some registration ->
-                                                        let configuration: Grace.Cache.CacheAcceptedRegistration =
-                                                            {
-                                                                CacheId = registration.CacheId
-                                                                DisplayName = request.DisplayName
-                                                                BoundaryKind = request.BoundaryKind.ToString()
-                                                                OwnerId = request.OwnerId
-                                                                OrganizationId = request.OrganizationId
-                                                                RepositoryScopes =
-                                                                    request.RepositoryScopes
-                                                                    |> Seq.map (fun (scope: Grace.Types.CacheRegistration.CacheRepositoryScope) ->
-                                                                        { OrganizationId = scope.OrganizationId; RepositoryId = scope.RepositoryId }: Grace.Cache.CacheAcceptedRepositoryScope)
-                                                                    |> Seq.toArray
-                                                                Endpoint = request.Endpoint
-                                                                ProtocolVersion = request.ProtocolVersion
-                                                                PublicKey = publicKey
-                                                            }
+                                                    match response with
+                                                    | Error error -> return renderOutput parseResult (Error error), false
+                                                    | Ok accepted ->
+                                                        cancellationToken.ThrowIfCancellationRequested()
 
-                                                        match
-                                                            enrollmentDependencies.CommitReady (fun () ->
-                                                                CacheIdentity.commitReady stateRoot configuration
-                                                                |> Result.isOk)
-                                                            with
-                                                        | false ->
+                                                        match accepted.ReturnValue.Status, accepted.ReturnValue.Registration with
+                                                        | CacheRegistrationRefreshStatus.Enrolled, Some registration ->
+                                                            let configuration: Grace.Cache.CacheAcceptedRegistration =
+                                                                {
+                                                                    CacheId = registration.CacheId
+                                                                    DisplayName = request.DisplayName
+                                                                    BoundaryKind = request.BoundaryKind.ToString()
+                                                                    OwnerId = request.OwnerId
+                                                                    OrganizationId = request.OrganizationId
+                                                                    RepositoryScopes =
+                                                                        request.RepositoryScopes
+                                                                        |> Seq.map (fun (scope: Grace.Types.CacheRegistration.CacheRepositoryScope) ->
+                                                                            { OrganizationId = scope.OrganizationId; RepositoryId = scope.RepositoryId }: Grace.Cache.CacheAcceptedRepositoryScope)
+                                                                        |> Seq.toArray
+                                                                    Endpoint = request.Endpoint
+                                                                    ProtocolVersion = request.ProtocolVersion
+                                                                    PublicKey = publicKey
+                                                                }
+
+                                                            match
+                                                                enrollmentDependencies.CommitReady (fun () ->
+                                                                    CacheIdentity.commitReady stateRoot configuration
+                                                                    |> Result.isOk)
+                                                                with
+                                                            | false ->
+                                                                return
+                                                                    renderOutput
+                                                                        parseResult
+                                                                        (Error(
+                                                                            GraceError.Create
+                                                                                "Cache enrollment was accepted but protected ready state could not be committed."
+                                                                                (getCorrelationId parseResult)
+                                                                        )),
+                                                                    false
+                                                            | true ->
+                                                                let status = CacheIdentity.status stateRoot
+                                                                let exitCode = renderStatus parseResult status
+                                                                return exitCode, status.Enrollment = "enrolled"
+                                                        | _ ->
                                                             return
                                                                 renderOutput
                                                                     parseResult
                                                                     (Error(
                                                                         GraceError.Create
-                                                                            "Cache enrollment was accepted but protected ready state could not be committed."
+                                                                            "Cache enrollment did not return an accepted registration."
                                                                             (getCorrelationId parseResult)
                                                                     )),
                                                                 false
-                                                        | true ->
-                                                            let status = CacheIdentity.status stateRoot
-                                                            let exitCode = renderStatus parseResult status
-                                                            return exitCode, status.Enrollment = "enrolled"
-                                                    | _ ->
-                                                        return
-                                                            renderOutput
-                                                                parseResult
-                                                                (Error(
-                                                                    GraceError.Create
-                                                                        "Cache enrollment did not return an accepted registration."
-                                                                        (getCorrelationId parseResult)
-                                                                )),
-                                                            false
-                                        })
+                                            })
         }
 
     /// Runs the pure local cache status handler through System.CommandLine.
@@ -327,9 +376,6 @@ module CacheCommand =
         inherit AsynchronousCommandLineAction()
 
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> = statusHandler parseResult cancellationToken
-
-    /// Renders a redacted cache enrollment failure without exposing local state or transport details.
-    let private renderEnrollmentFailure parseResult message = renderOutput parseResult (Error(GraceError.Create message (getCorrelationId parseResult)))
 
     /// Runs the static cache enrollment handler through System.CommandLine.
     type Enroll() =

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -1,0 +1,369 @@
+namespace Grace.CLI.Command
+
+open Grace.Cache
+open Grace.CLI.Common
+open Grace.SDK
+open Grace.Shared
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open Spectre.Console
+open System
+open System.Collections.Generic
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.CommandLine.Parsing
+open System.Threading
+open System.Threading.Tasks
+
+/// Groups repository-independent static Cache enrollment and local status commands.
+module CacheCommand =
+
+    /// Holds the protected root with a test-only override for isolated command-path proof.
+    let mutable private stateRoot = CacheIdentity.StateRoot
+
+    /// Defines the internal operational dependencies used by cache enrollment before they are bound to the command action.
+    type internal EnrollmentDependencies =
+        {
+            ResolveBearer: unit -> Task<Result<string option, string>>
+            AfterAttemptCreated: unit -> unit
+            CommitReady: (unit -> bool) -> bool
+        }
+
+    /// Binds enrollment to the existing normal credential provider and protected local identity implementation.
+    let private productionDependencies =
+        {
+            ResolveBearer = (fun () -> Grace.CLI.Command.Auth.tryGetAccessToken ())
+            AfterAttemptCreated = (fun () -> ())
+            CommitReady = (fun commit -> commit ())
+        }
+
+    /// Holds the internal enrollment dependency record so serialized tests can prove root-command outcomes deterministically.
+    let mutable private enrollmentDependencies = productionDependencies
+
+    /// Redirects protected state for serialized command-path tests.
+    let internal setStateRootForTests root = stateRoot <- root
+
+    /// Restores the fixed Product V1 protected state root after a command-path test.
+    let internal resetStateRootForTests () = stateRoot <- CacheIdentity.StateRoot
+
+    /// Replaces internal enrollment dependencies for a serialized test and returns the prior record for exact restoration.
+    let internal setEnrollmentDependenciesForTests dependencies =
+        let previous = enrollmentDependencies
+        enrollmentDependencies <- dependencies
+        previous
+
+    /// Reads the internal enrollment dependency record for serialized tests that override one behavior and preserve the others.
+    let internal getEnrollmentDependenciesForTests () = enrollmentDependencies
+
+    /// Restores normal enrollment dependencies after a serialized test.
+    let internal resetEnrollmentDependenciesForTests () = enrollmentDependencies <- productionDependencies
+
+    /// Defines explicit administrator-supplied enrollment options.
+    module private Options =
+        let displayName = new Option<string>("--display-name", Description = "Cache display name.", Arity = ArgumentArity.ExactlyOne)
+        let endpoint = new Option<string>("--endpoint", Description = "Cache HTTPS endpoint.", Arity = ArgumentArity.ExactlyOne)
+
+        let boundary = new Option<string>("--boundary", Description = "Enrollment boundary: owner or organization.", Arity = ArgumentArity.ExactlyOne)
+
+        let ownerId = new Option<Guid>("--owner-id", Description = "Owner ID.", Arity = ArgumentArity.ExactlyOne)
+
+        let organizationId =
+            new Option<Guid>("--organization-id", Description = "Organization ID for an organization boundary.", Arity = ArgumentArity.ZeroOrOne)
+
+        let repositoryIds = new Option<Guid array>("--repository-id", Description = "One or more repository IDs.", Arity = ArgumentArity.OneOrMore)
+
+        let repositoryOrganizationId =
+            new Option<Guid>("--repository-organization-id", Description = "Organization ID for every repository assignment.", Arity = ArgumentArity.ExactlyOne)
+
+        let allowHttp = new Option<bool>("--allow-http", Description = "Allow the exact HTTP endpoint supplied by --endpoint.", Arity = ArgumentArity.Zero)
+        let softwareVersion = new Option<string>("--software-version", DefaultValueFactory = (fun _ -> "Grace.Cache"), Description = "Cache software version.")
+        let protocolVersion = new Option<string>("--protocol-version", DefaultValueFactory = (fun _ -> "v1"), Description = "Cache protocol version.")
+
+    /// Builds a validated cache request from explicit arguments and one generated public key.
+    let private requestFromArguments (parseResult: ParseResult) (publicKey: Grace.Cache.CacheIdentityPublicKey) =
+        let correlationId = getCorrelationId parseResult
+        let boundary = parseResult.GetValue(Options.boundary)
+        let ownerId = parseResult.GetValue(Options.ownerId)
+        let organizationId = parseResult.GetValue(Options.organizationId)
+        let repositoryOrganizationId = parseResult.GetValue(Options.repositoryOrganizationId)
+
+        let repositoryIds =
+            parseResult.GetValue(Options.repositoryIds)
+            |> Option.ofObj
+            |> Option.defaultValue [||]
+
+        let boundaryResult =
+            match Option.ofObj boundary
+                  |> Option.map (fun value -> value.Trim().ToLowerInvariant())
+                with
+            | Some "owner" when organizationId = Guid.Empty -> Ok(CacheBoundaryKind.Owner, None)
+            | Some "organization" when
+                organizationId <> Guid.Empty
+                && organizationId = repositoryOrganizationId
+                ->
+                Ok(CacheBoundaryKind.Organization, Some organizationId)
+            | _ -> Error(GraceError.Create "Cache boundary and organization inputs are invalid." correlationId)
+
+        match boundaryResult with
+        | Error error -> Error error
+        | Ok (kind, organization) ->
+            let request =
+                {
+                    Class = nameof CacheEnrollmentRequest
+                    DisplayName =
+                        parseResult.GetValue(Options.displayName)
+                        |> Option.ofObj
+                        |> Option.defaultValue String.Empty
+                    BoundaryKind = kind
+                    OwnerId = ownerId
+                    OrganizationId = organization
+                    RepositoryScopes =
+                        List<CacheRepositoryScope>(
+                            repositoryIds
+                            |> Seq.map (fun repositoryId -> CacheRepositoryScope.Create(repositoryOrganizationId, repositoryId))
+                        )
+                    PublicKey = Grace.Types.CacheRegistration.CacheIdentityPublicKey.Create(publicKey.PublicKeyX, publicKey.PublicKeyY)
+                    Endpoint =
+                        parseResult.GetValue(Options.endpoint)
+                        |> Option.ofObj
+                        |> Option.defaultValue String.Empty
+                    AllowHttpEndpoint = parseResult.GetValue(Options.allowHttp)
+                    SoftwareVersion = parseResult.GetValue(Options.softwareVersion)
+                    ProtocolVersion = parseResult.GetValue(Options.protocolVersion)
+                    PrefetchSupported = false
+                }
+
+            match Lifecycle.validateEnrollmentRequest request with
+            | Ok () -> Ok request
+            | Error errors -> Error(GraceError.Create (String.concat " " errors) correlationId)
+
+    /// Validates the configured standalone Grace Server URI without repository discovery.
+    let private configuredServerUri parseResult =
+        let value = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+
+        match Uri.TryCreate(value, UriKind.Absolute) with
+        | true, uri when
+            uri.Scheme = Uri.UriSchemeHttp
+            || uri.Scheme = Uri.UriSchemeHttps
+            ->
+            Ok uri
+        | _ ->
+            Error(
+                GraceError.Create
+                    $"Set {Constants.EnvironmentVariables.GraceServerUri} to an absolute HTTP or HTTPS Grace Server URI before cache enrollment."
+                    (getCorrelationId parseResult)
+            )
+
+    /// Resolves one normal Grace credential before cache-root mutation and returns its exact bearer value.
+    let private resolveBearer (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            cancellationToken.ThrowIfCancellationRequested()
+            let! token = enrollmentDependencies.ResolveBearer()
+
+            match token with
+            | Ok (Some bearer) when not (String.IsNullOrWhiteSpace bearer) -> return Ok bearer
+            | Ok _ -> return Error(GraceError.Create "Authentication required. Run 'grace authenticate login' and try again." (getCorrelationId parseResult))
+            | Error message -> return Error(GraceError.Create message (getCorrelationId parseResult))
+        }
+
+    /// Renders only the approved redacted local identity facts for a cache command result.
+    let private renderStatus (parseResult: ParseResult) (status: Grace.Cache.CacheIdentityStatus) =
+        if parseResult |> json then
+            GraceReturnValue.Create status (getCorrelationId parseResult)
+            |> Ok
+            |> renderOutput parseResult
+        elif parseResult |> silent then
+            0
+        else
+            let value = (string >> Markup.Escape)
+            AnsiConsole.MarkupLine($"Class: {value status.Class}")
+            AnsiConsole.MarkupLine($"Enrollment: {value status.Enrollment}")
+            AnsiConsole.MarkupLine($"Key: {value status.Key}")
+
+            status.CacheId
+            |> Option.iter (fun cacheId -> AnsiConsole.MarkupLine($"CacheId: {cacheId:D}"))
+
+            status.Endpoint
+            |> Option.iter (fun endpoint -> AnsiConsole.MarkupLine($"Endpoint: {value endpoint}"))
+
+            status.BoundaryKind
+            |> Option.iter (fun boundary -> AnsiConsole.MarkupLine($"BoundaryKind: {value boundary}"))
+
+            status.RepositoryCount
+            |> Option.iter (fun count -> AnsiConsole.MarkupLine($"RepositoryCount: {count}"))
+
+            0
+
+    /// Reads status without networking, cleanup, repair, or repository-local state.
+    let private statusHandler (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            cancellationToken.ThrowIfCancellationRequested()
+            let status = CacheIdentity.status stateRoot
+            renderStatus parseResult status |> ignore
+            return if status.Enrollment = "enrolled" then 0 else 1
+        }
+
+    /// Removes the current attempt after a post-staging failure without masking the primary command outcome.
+    let private completeAttempt (root: string) (completion: unit -> Task<int * bool>) =
+        task {
+            let mutable committed = false
+
+            try
+                let! exitCode, isCommitted = completion ()
+                committed <- isCommitted
+                return exitCode
+            finally
+                if not committed then CacheIdentity.discardAttempt root
+        }
+
+    /// Enrolls exactly once after validation and one credential acquisition, then publishes ready only after local commit succeeds.
+    let private enrollHandler (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            let placeholder: Grace.Cache.CacheIdentityPublicKey = { PublicKeyX = String.replicate 43 "a"; PublicKeyY = String.replicate 43 "a" }
+
+            match requestFromArguments parseResult placeholder with
+            | Error error -> return renderOutput parseResult (Error error)
+            | Ok _ ->
+                match configuredServerUri parseResult with
+                | Error error -> return renderOutput parseResult (Error error)
+                | Ok serverUri ->
+                    match CacheIdentity.validateEnrollmentRoot stateRoot with
+                    | Error _ ->
+                        return
+                            renderOutput
+                                parseResult
+                                (Error(
+                                    GraceError.Create "The protected Grace Cache state root is unavailable or already enrolled." (getCorrelationId parseResult)
+                                ))
+                    | Ok () ->
+                        let! bearer = resolveBearer parseResult cancellationToken
+
+                        match bearer with
+                        | Error error -> return renderOutput parseResult (Error error)
+                        | Ok bearer ->
+                            cancellationToken.ThrowIfCancellationRequested()
+
+                            match CacheIdentity.createAttempt stateRoot with
+                            | Error _ ->
+                                return
+                                    renderOutput
+                                        parseResult
+                                        (Error(
+                                            GraceError.Create
+                                                "The protected Grace Cache state root could not create an enrollment attempt."
+                                                (getCorrelationId parseResult)
+                                        ))
+                            | Ok publicKey ->
+                                return!
+                                    completeAttempt stateRoot (fun () ->
+                                        task {
+                                            enrollmentDependencies.AfterAttemptCreated()
+                                            cancellationToken.ThrowIfCancellationRequested()
+
+                                            match requestFromArguments parseResult publicKey with
+                                            | Error error -> return renderOutput parseResult (Error error), false
+                                            | Ok request ->
+                                                let! response =
+                                                    CacheRegistration.Enroll(request, serverUri, bearer, getCorrelationId parseResult, cancellationToken)
+
+                                                match response with
+                                                | Error error -> return renderOutput parseResult (Error error), false
+                                                | Ok accepted ->
+                                                    cancellationToken.ThrowIfCancellationRequested()
+
+                                                    match accepted.ReturnValue.Status, accepted.ReturnValue.Registration with
+                                                    | CacheRegistrationRefreshStatus.Enrolled, Some registration ->
+                                                        let configuration: Grace.Cache.CacheAcceptedRegistration =
+                                                            {
+                                                                CacheId = registration.CacheId
+                                                                DisplayName = request.DisplayName
+                                                                BoundaryKind = request.BoundaryKind.ToString()
+                                                                OwnerId = request.OwnerId
+                                                                OrganizationId = request.OrganizationId
+                                                                RepositoryScopes =
+                                                                    request.RepositoryScopes
+                                                                    |> Seq.map (fun (scope: Grace.Types.CacheRegistration.CacheRepositoryScope) ->
+                                                                        { OrganizationId = scope.OrganizationId; RepositoryId = scope.RepositoryId }: Grace.Cache.CacheAcceptedRepositoryScope)
+                                                                    |> Seq.toArray
+                                                                Endpoint = request.Endpoint
+                                                                ProtocolVersion = request.ProtocolVersion
+                                                                PublicKey = publicKey
+                                                            }
+
+                                                        match
+                                                            enrollmentDependencies.CommitReady (fun () ->
+                                                                CacheIdentity.commitReady stateRoot configuration
+                                                                |> Result.isOk)
+                                                            with
+                                                        | false ->
+                                                            return
+                                                                renderOutput
+                                                                    parseResult
+                                                                    (Error(
+                                                                        GraceError.Create
+                                                                            "Cache enrollment was accepted but protected ready state could not be committed."
+                                                                            (getCorrelationId parseResult)
+                                                                    )),
+                                                                false
+                                                        | true ->
+                                                            let status = CacheIdentity.status stateRoot
+                                                            let exitCode = renderStatus parseResult status
+                                                            return exitCode, status.Enrollment = "enrolled"
+                                                    | _ ->
+                                                        return
+                                                            renderOutput
+                                                                parseResult
+                                                                (Error(
+                                                                    GraceError.Create
+                                                                        "Cache enrollment did not return an accepted registration."
+                                                                        (getCorrelationId parseResult)
+                                                                )),
+                                                            false
+                                        })
+        }
+
+    /// Runs the pure local cache status handler through System.CommandLine.
+    type Status() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> = statusHandler parseResult cancellationToken
+
+    /// Renders a redacted cache enrollment failure without exposing local state or transport details.
+    let private renderEnrollmentFailure parseResult message = renderOutput parseResult (Error(GraceError.Create message (getCorrelationId parseResult)))
+
+    /// Runs the static cache enrollment handler through System.CommandLine.
+    type Enroll() =
+        inherit AsynchronousCommandLineAction()
+
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            task {
+                try
+                    return! enrollHandler parseResult cancellationToken
+                with
+                | :? OperationCanceledException -> return renderEnrollmentFailure parseResult "Cache enrollment was cancelled."
+                | _ -> return renderEnrollmentFailure parseResult "Cache enrollment failed before ready state could be published."
+            }
+
+    /// Builds the repository-independent `grace cache` command group.
+    let Build =
+        let cache = Command("cache", "Enroll and inspect a static Grace Cache identity.")
+
+        let enroll =
+            Command("enroll", "Enroll a static Linux Grace Cache identity.")
+            |> addOption Options.displayName
+            |> addOption Options.endpoint
+            |> addOption Options.boundary
+            |> addOption Options.ownerId
+            |> addOption Options.organizationId
+            |> addOption Options.repositoryIds
+            |> addOption Options.repositoryOrganizationId
+            |> addOption Options.allowHttp
+            |> addOption Options.softwareVersion
+            |> addOption Options.protocolVersion
+
+        enroll.Action <- Enroll()
+        cache.Subcommands.Add(enroll)
+        let status = Command("status", "Report redacted local Grace Cache enrollment status.")
+        status.Action <- Status()
+        cache.Subcommands.Add(status)
+        cache

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -301,6 +301,8 @@ module CacheCommand =
                         match bearer with
                         | Error error -> return renderOutput parseResult (Error error)
                         | Ok bearer ->
+                            cancellationToken.ThrowIfCancellationRequested()
+
                             match CacheIdentity.tryAcquireEnrollmentClaim stateRoot with
                             | Error _ -> return renderEnrollmentFailure parseResult "Cache enrollment could not acquire exclusive local state."
                             | Ok claim ->

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -192,6 +192,13 @@ module CommandOutputContract =
         schema["description"] <- description
         box schema
 
+    /// Builds the nullable integer schema used in generated command-output metadata.
+    let private nullableIntegerSchema description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- [| "integer"; "null" |]
+        schema["description"] <- description
+        box schema
+
     /// Constructs an array schema and attaches the item schema used by repeated command-output fields.
     let private arraySchema itemSchema description =
         let schema = Dictionary<string, obj>(StringComparer.Ordinal)
@@ -546,6 +553,42 @@ module CommandOutputContract =
                 Summary = {| Total = 1; Ok = 1; Warning = 0; Failed = 0; Skipped = 0 |}
             |}
 
+    /// Defines the redacted local identity shape shared by successful Cache enrollment and status output.
+    let private cacheStatusSchema =
+        schemaObject
+            "CacheStatusDto"
+            [
+                "Class", scalarSchema "string"
+                "Enrollment", scalarSchema "string"
+                "CacheId", nullableStringSchema "Cache identifier when protected ready state is valid."
+                "Endpoint", nullableStringSchema "Registered cache endpoint when protected ready state is valid."
+                "BoundaryKind", nullableStringSchema "Registered boundary kind when protected ready state is valid."
+                "RepositoryCount", nullableIntegerSchema "Repository assignment count when protected ready state is valid."
+                "Key", scalarSchema "string"
+            ]
+            [|
+                "Class"
+                "Enrollment"
+                "CacheId"
+                "Endpoint"
+                "BoundaryKind"
+                "RepositoryCount"
+                "Key"
+            |]
+
+    /// Provides the representative enrolled local identity output used by inert Cache command examples.
+    let private cacheStatusExample =
+        box
+            {|
+                Class = "Grace.Cache.Status"
+                Enrollment = "enrolled"
+                CacheId = "11111111-1111-1111-1111-111111111111"
+                Endpoint = "https://cache.example.test"
+                BoundaryKind = "Organization"
+                RepositoryCount = 1
+                Key = "available"
+            |}
+
     /// Builds command-output contract metadata for supported return value contract so automation can rely on stable JSON shapes.
     let private supportedReturnValueContract name provenance schema example notes =
         { Name = name; Provenance = provenance; Status = SchemaReady; Schema = schema; Example = example; Notes = notes }
@@ -604,6 +647,17 @@ module CommandOutputContract =
     /// Builds command-output contract metadata for return value contract for so automation can rely on stable JSON shapes.
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
+        | ("cache.enroll"
+          | "cache.status"),
+          ExistingGraceResultEnvelope _ ->
+            supportedReturnValueContract
+                "CacheStatusDto"
+                "Grace.CLI.Command.CacheCommand"
+                cacheStatusSchema
+                cacheStatusExample
+                [
+                    "The command never exposes private key material, filesystem paths, or enrollment attempt details."
+                ]
         | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
             supportedReturnValueContract
                 "MaintenanceIgnoreEntriesDto"
@@ -959,6 +1013,8 @@ module CommandOutputContract =
 
     let entries =
         [
+            row [ "cache" ] "enroll" true true common_renderOutput_envelope mutating_state_transition server_via_sdk RequiresCliDto
+            row [ "cache" ] "status" true false common_renderOutput_envelope read_list_search local_client RequiresCliDto
             row [ "authorize" ] "can" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -166,6 +166,15 @@ module CommandOutputContract =
         schema["properties"] <- Dictionary<string, obj>(properties |> Seq.map KeyValuePair)
         box schema
 
+    /// Constructs a draft 2020-12 object schema that rejects properties outside its published contract.
+    let private closedSchemaObject title properties required =
+        let schema =
+            schemaObject title properties required
+            |> unbox<Dictionary<string, obj>>
+
+        schema["additionalProperties"] <- false
+        box schema
+
     /// Constructs a JSON schema for scalar command-output fields such as strings, booleans, or numbers.
     let private scalarSchema (typeName: string) =
         let schema = Dictionary<string, obj>(StringComparer.Ordinal)
@@ -207,13 +216,11 @@ module CommandOutputContract =
         schema["description"] <- description
         box schema
 
-    /// Constructs a string schema that excludes one value for conditional command-output variants.
-    let private stringExceptSchema excludedValue description =
-        let excluded = Dictionary<string, obj>(StringComparer.Ordinal)
-        excluded["const"] <- excludedValue
+    /// Constructs a string schema restricted to the values currently emitted by one command-output field.
+    let private enumStringSchema values description =
         let schema = Dictionary<string, obj>(StringComparer.Ordinal)
         schema["type"] <- "string"
-        schema["not"] <- box excluded
+        schema["enum"] <- values
         schema["description"] <- description
         box schema
 
@@ -581,16 +588,16 @@ module CommandOutputContract =
 
     /// Defines the ready-only redacted local identity fields shared by Cache enrollment and status output.
     let private cacheStatusReadySchema =
-        schemaObject
+        closedSchemaObject
             "CacheStatusReadyDto"
             [
-                "Class", scalarSchema "string"
+                "Class", constantStringSchema "Grace.Cache.Status" "Redacted local Cache status projection."
                 "Enrollment", constantStringSchema "enrolled" "Protected ready state is valid."
                 "CacheId", scalarSchema "string"
                 "Endpoint", scalarSchema "string"
-                "BoundaryKind", scalarSchema "string"
+                "BoundaryKind", enumStringSchema [| "Owner"; "Organization" |] "Accepted Cache enrollment boundary."
                 "RepositoryCount", scalarSchema "integer"
-                "Key", scalarSchema "string"
+                "Key", constantStringSchema "available" "The ready identity key is available."
             ]
             [|
                 "Class"
@@ -602,14 +609,25 @@ module CommandOutputContract =
                 "Key"
             |]
 
-    /// Defines a non-ready Cache status shape that omits every ready-only identity fact.
-    let private cacheStatusNonReadySchema =
-        schemaObject
-            "CacheStatusNonReadyDto"
+    /// Defines the not-enrolled Cache status combinations that omit every ready-only identity fact.
+    let private cacheStatusNotEnrolledSchema =
+        closedSchemaObject
+            "CacheStatusNotEnrolledDto"
             [
-                "Class", scalarSchema "string"
-                "Enrollment", stringExceptSchema "enrolled" "Any status without a valid protected ready identity."
-                "Key", scalarSchema "string"
+                "Class", constantStringSchema "Grace.Cache.Status" "Redacted local Cache status projection."
+                "Enrollment", constantStringSchema "notEnrolled" "No valid protected ready identity exists."
+                "Key", enumStringSchema [| "missing"; "available" |] "The missing root or staged attempt key state."
+            ]
+            [| "Class"; "Enrollment"; "Key" |]
+
+    /// Defines the invalid Cache status combinations that omit every ready-only identity fact.
+    let private cacheStatusInvalidSchema =
+        closedSchemaObject
+            "CacheStatusInvalidDto"
+            [
+                "Class", constantStringSchema "Grace.Cache.Status" "Redacted local Cache status projection."
+                "Enrollment", constantStringSchema "invalid" "The protected root cannot supply a valid ready identity."
+                "Key", enumStringSchema [| "invalid"; "inaccessible" |] "The invalid or inaccessible key state."
             ]
             [| "Class"; "Enrollment"; "Key" |]
 
@@ -619,7 +637,8 @@ module CommandOutputContract =
             "CacheStatusDto"
             [|
                 cacheStatusReadySchema
-                cacheStatusNonReadySchema
+                cacheStatusNotEnrolledSchema
+                cacheStatusInvalidSchema
             |]
 
     /// Provides the representative enrolled local identity output used by inert Cache command examples.
@@ -634,6 +653,9 @@ module CommandOutputContract =
                 RepositoryCount = 1
                 Key = "available"
             |}
+
+    /// Provides the representative non-ready local identity output used by inert Cache status examples.
+    let private cacheStatusNotEnrolledExample = box {| Class = "Grace.Cache.Status"; Enrollment = "notEnrolled"; Key = "missing" |}
 
     /// Builds command-output contract metadata for supported return value contract so automation can rely on stable JSON shapes.
     let private supportedReturnValueContract name provenance schema example notes =
@@ -891,6 +913,21 @@ module CommandOutputContract =
                     |}
         }
 
+    /// Builds the representative non-ready Cache status success envelope alongside its enrolled success example.
+    let private cacheStatusNotEnrolledSuccessExample (entry: CommandContractEntry) =
+        {
+            Name = "not-enrolled-envelope-shape"
+            Description = "Representative non-ready GraceReturnValue<CacheStatusDto> envelope shape from registry metadata."
+            Document =
+                box
+                    {|
+                        ReturnValue = cacheStatusNotEnrolledExample
+                        EventTime = "2026-06-05T00:00:00Z"
+                        CorrelationId = "correlation-id"
+                        Properties = cliProperties entry.Identity.CommandId entry.ReturnValueContract.Provenance
+                    |}
+        }
+
     /// Builds command-output contract metadata for incomplete metadata example so automation can rely on stable JSON shapes.
     let private incompleteMetadataExample (entry: CommandContractEntry) =
         {
@@ -950,6 +987,8 @@ module CommandOutputContract =
                     | SchemaReady ->
                         [
                             successExample entry
+                            if entry.Identity.CommandId = "cache.status" then
+                                cacheStatusNotEnrolledSuccessExample entry
                             errorExample entry
                         ]
                     | MetadataIncomplete

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -199,6 +199,32 @@ module CommandOutputContract =
         schema["description"] <- description
         box schema
 
+    /// Constructs a string schema restricted to one value for conditional command-output variants.
+    let private constantStringSchema value description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "string"
+        schema["const"] <- value
+        schema["description"] <- description
+        box schema
+
+    /// Constructs a string schema that excludes one value for conditional command-output variants.
+    let private stringExceptSchema excludedValue description =
+        let excluded = Dictionary<string, obj>(StringComparer.Ordinal)
+        excluded["const"] <- excludedValue
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "string"
+        schema["not"] <- box excluded
+        schema["description"] <- description
+        box schema
+
+    /// Combines mutually exclusive command-output object variants under one named schema.
+    let private oneOfSchema title (variants: obj array) =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["$schema"] <- "https://json-schema.org/draft/2020-12/schema"
+        schema["title"] <- title
+        schema["oneOf"] <- variants
+        box schema
+
     /// Constructs an array schema and attaches the item schema used by repeated command-output fields.
     let private arraySchema itemSchema description =
         let schema = Dictionary<string, obj>(StringComparer.Ordinal)
@@ -553,17 +579,17 @@ module CommandOutputContract =
                 Summary = {| Total = 1; Ok = 1; Warning = 0; Failed = 0; Skipped = 0 |}
             |}
 
-    /// Defines the redacted local identity shape shared by successful Cache enrollment and status output.
-    let private cacheStatusSchema =
+    /// Defines the ready-only redacted local identity fields shared by Cache enrollment and status output.
+    let private cacheStatusReadySchema =
         schemaObject
-            "CacheStatusDto"
+            "CacheStatusReadyDto"
             [
                 "Class", scalarSchema "string"
-                "Enrollment", scalarSchema "string"
-                "CacheId", nullableStringSchema "Cache identifier when protected ready state is valid."
-                "Endpoint", nullableStringSchema "Registered cache endpoint when protected ready state is valid."
-                "BoundaryKind", nullableStringSchema "Registered boundary kind when protected ready state is valid."
-                "RepositoryCount", nullableIntegerSchema "Repository assignment count when protected ready state is valid."
+                "Enrollment", constantStringSchema "enrolled" "Protected ready state is valid."
+                "CacheId", scalarSchema "string"
+                "Endpoint", scalarSchema "string"
+                "BoundaryKind", scalarSchema "string"
+                "RepositoryCount", scalarSchema "integer"
                 "Key", scalarSchema "string"
             ]
             [|
@@ -574,6 +600,26 @@ module CommandOutputContract =
                 "BoundaryKind"
                 "RepositoryCount"
                 "Key"
+            |]
+
+    /// Defines a non-ready Cache status shape that omits every ready-only identity fact.
+    let private cacheStatusNonReadySchema =
+        schemaObject
+            "CacheStatusNonReadyDto"
+            [
+                "Class", scalarSchema "string"
+                "Enrollment", stringExceptSchema "enrolled" "Any status without a valid protected ready identity."
+                "Key", scalarSchema "string"
+            ]
+            [| "Class"; "Enrollment"; "Key" |]
+
+    /// Defines the conditional redacted local identity shape shared by successful Cache enrollment and status output.
+    let private cacheStatusSchema =
+        oneOfSchema
+            "CacheStatusDto"
+            [|
+                cacheStatusReadySchema
+                cacheStatusNonReadySchema
             |]
 
     /// Provides the representative enrolled local identity output used by inert Cache command examples.
@@ -657,6 +703,7 @@ module CommandOutputContract =
                 cacheStatusExample
                 [
                     "The command never exposes private key material, filesystem paths, or enrollment attempt details."
+                    "CacheId, Endpoint, BoundaryKind, and RepositoryCount are present only when Enrollment is enrolled; all non-ready output omits them."
                 ]
         | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
             supportedReturnValueContract

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -42,6 +42,7 @@
 		<Compile Include="Command\Watch.CLI.fs" />
 		<Compile Include="Command\Maintenance.CLI.fs" />
 		<Compile Include="Command\Doctor.CLI.fs" />
+		<Compile Include="Command\Cache.CLI.fs" />
                 
                 <Compile Include="Command\WorkItem.CLI.fs" />
                 <Compile Include="Command\Review.CLI.fs" />
@@ -90,6 +91,7 @@
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 		<ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
+		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
 	</ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.301" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -507,7 +507,16 @@ module GraceCommand =
 
     let private rootHelpSections =
         [
-            { Heading = "Getting started"; CommandNames = [ "authenticate"; "connect"; "config" ] }
+            {
+                Heading = "Getting started"
+                CommandNames =
+                    [
+                        "authenticate"
+                        "connect"
+                        "config"
+                        "cache"
+                    ]
+            }
             {
                 Heading = "Day-to-day development"
                 CommandNames =
@@ -881,6 +890,7 @@ module GraceCommand =
         rootCommand.Subcommands.Add(Auth.Build)
         rootCommand.Subcommands.Add(Maintenance.Build)
         rootCommand.Subcommands.Add(Doctor.Build)
+        rootCommand.Subcommands.Add(CacheCommand.Build)
         rootCommand.Subcommands.Add(WorkItemCommand.Build)
         rootCommand.Subcommands.Add(ReviewCommand.Build)
         rootCommand.Subcommands.Add(CandidateCommand.Build)
@@ -1004,6 +1014,14 @@ module GraceCommand =
         else
             Seq.append [ parseResult.CommandResult.Command ] (parseResult.CommandResult.Command.Parents.OfType<Command>())
             |> Seq.exists (fun command -> command.Name.Equals("doctor", StringComparison.OrdinalIgnoreCase))
+
+    /// Checks whether the parsed command belongs to the repository-independent Cache command group.
+    let isGraceCache (parseResult: ParseResult) =
+        if isNull parseResult then
+            false
+        else
+            Seq.append [ parseResult.CommandResult.Command ] (parseResult.CommandResult.Command.Parents.OfType<Command>())
+            |> Seq.exists (fun command -> command.Name.Equals("cache", StringComparison.OrdinalIgnoreCase))
 
     /// Checks if the command is a foreground `grace watch` command.
     let isGraceWatchForeground (parseResult: ParseResult) =
@@ -1202,7 +1220,10 @@ module GraceCommand =
                                 raise (IntrospectionExit returnValue)
                             | None -> ()
 
-                        if not (parseResult |> isGraceDoctor) then
+                        if
+                            not (parseResult |> isGraceDoctor)
+                            && not (parseResult |> isGraceCache)
+                        then
                             LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
@@ -1373,6 +1394,9 @@ module GraceCommand =
 
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
+                    else if parseResult |> isGraceCache then
+                        let! invokedReturnValue = parseResult.InvokeAsync()
+                        returnValue <- invokedReturnValue
                     else if parseResult |> isGraceDoctor then
                         let invokedReturnValue = parseResult.Invoke()
                         returnValue <- invokedReturnValue
@@ -1526,6 +1550,7 @@ module GraceCommand =
                 if
                     not isIntrospection
                     && not (parseResult |> isGraceDoctor)
+                    && not (parseResult |> isGraceCache)
                 then
                     HistoryStorage.tryRecordInvocation
                         {

--- a/src/Grace.Cache.ClaimHolder/Grace.Cache.ClaimHolder.fsproj
+++ b/src/Grace.Cache.ClaimHolder/Grace.Cache.ClaimHolder.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="10.1.301" />
+  </ItemGroup>
+</Project>

--- a/src/Grace.Cache.ClaimHolder/Program.fs
+++ b/src/Grace.Cache.ClaimHolder/Program.fs
@@ -1,0 +1,29 @@
+namespace Grace.Cache.ClaimHolder
+
+open System
+open System.IO
+open System.Threading
+open Grace.Cache
+
+/// Hosts a test-only process that directly owns one production Cache enrollment claim until it is terminated.
+module Program =
+    /// Runs the direct claim-holder process with a protected root and held-signal file path.
+    [<EntryPoint>]
+    let main arguments =
+        match arguments with
+        | [| root; signalPath |] ->
+            match CacheIdentity.tryAcquireEnrollmentClaim root with
+            | Error error ->
+                Console.Error.WriteLine($"Could not acquire Cache enrollment claim: {error}")
+                2
+            | Ok claim ->
+                try
+                    File.WriteAllText(signalPath, "held")
+                    use lifetime = new ManualResetEventSlim(false)
+                    lifetime.Wait()
+                    0
+                finally
+                    CacheIdentity.releaseEnrollmentClaim claim
+        | _ ->
+            Console.Error.WriteLine("Usage: Grace.Cache.ClaimHolder <state-root> <held-signal-path>")
+            64

--- a/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
@@ -456,6 +456,27 @@ type CacheIdentityTests() =
 
             withRestoredMode registration UnixFileMode.UserWrite (fun () -> requireInspection CacheIdentityInspection.Inaccessible (CacheIdentity.inspect root)))
 
+    /// Proves staging faults remove only the newly created residue and do not prevent a later normal enrollment attempt.
+    [<Test>]
+    member _.``createAttempt cleans partial directory and private key residues``() =
+        withLinuxRoot (fun root ->
+            for fault in
+                [
+                    CacheIdentityCreateFault.AfterAttemptDirectory
+                    CacheIdentityCreateFault.AfterPrivateKeyFlush
+                ] do
+                CacheIdentity.createAttemptWithFault root fault
+                |> requireStateUnavailable
+
+                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                requireInspection CacheIdentityInspection.Missing (CacheIdentity.inspect root)
+
+            CacheIdentity.createAttempt root
+            |> requireOk
+            |> ignore
+
+            requireInspection CacheIdentityInspection.AttemptPresent (CacheIdentity.inspect root))
+
     /// Verifies discard has no cancellation/error channel and removes only the fixed attempt marker.
     [<Test>]
     member _.``discardAttempt removes staging without changing ready state``() =

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -57,6 +57,18 @@ type internal CacheIdentityInspection =
     | Invalid
     | Inaccessible
 
+/// Represents the only redacted local enrollment facts that CLI status may publish.
+type internal CacheIdentityStatus =
+    {
+        Class: string
+        Enrollment: string
+        CacheId: Guid option
+        Endpoint: string option
+        BoundaryKind: string option
+        RepositoryCount: int option
+        Key: string
+    }
+
 /// Represents the only failures exposed by the protected local identity boundary.
 [<RequireQualifiedAccess>]
 type internal CacheIdentityError =
@@ -65,6 +77,10 @@ type internal CacheIdentityError =
 
 /// Owns Linux-only protected static-key staging, ready publication, and opaque local inspection.
 module internal CacheIdentity =
+
+    /// Identifies the systemd-managed state root for the supported Linux cache installation.
+    [<Literal>]
+    let StateRoot = "/var/lib/grace-cache"
 
     [<Literal>]
     let private AttemptDirectoryName = "attempt"
@@ -738,6 +754,64 @@ module internal CacheIdentity =
                     | Ok true, Ok true -> Ok CacheIdentityInspection.Invalid
                     | Ok true, Ok false -> Ok(inspectAttempt attempt)
                     | Ok false, Ok true -> Ok(inspectReady ready)
+
+    /// Rejects roots that are not an empty, protected location before a command resolves credentials or stages a key.
+    let validateEnrollmentRoot root =
+        match validateRoot root with
+        | Error error -> Error error
+        | Ok () ->
+            match inspect root with
+            | Ok CacheIdentityInspection.Missing -> Ok()
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Reads the approved ready-state fields after protected inspection has established that the local identity is valid.
+    let private tryReadReadyStatus root =
+        try
+            let registrationPath = child (child root ReadyDirectoryName) RegistrationFileName
+
+            File.ReadAllBytes(registrationPath)
+            |> tryParseReadyRegistration
+            |> Option.bind (fun registration ->
+                tryReadyRegistrationFingerprint registration
+                |> Option.map (fun _ -> registration))
+            |> Option.map (fun registration ->
+                {
+                    Class = "Grace.Cache.Status"
+                    Enrollment = "enrolled"
+                    CacheId = Some registration.CacheId
+                    Endpoint = Some registration.Endpoint
+                    BoundaryKind = Some registration.BoundaryKind
+                    RepositoryCount = Some registration.RepositoryScopes.Length
+                    Key = "available"
+                })
+        with
+        | _ -> None
+
+    /// Observes protected local identity state without network, repair, cleanup, or private-material disclosure.
+    let status root =
+        let notEnrolled key =
+            {
+                Class = "Grace.Cache.Status"
+                Enrollment = "notEnrolled"
+                CacheId = None
+                Endpoint = None
+                BoundaryKind = None
+                RepositoryCount = None
+                Key = key
+            }
+
+        let invalid key =
+            { Class = "Grace.Cache.Status"; Enrollment = "invalid"; CacheId = None; Endpoint = None; BoundaryKind = None; RepositoryCount = None; Key = key }
+
+        match inspect root with
+        | Ok CacheIdentityInspection.Missing -> notEnrolled "missing"
+        | Ok CacheIdentityInspection.AttemptPresent -> notEnrolled "available"
+        | Ok CacheIdentityInspection.Ready ->
+            tryReadReadyStatus root
+            |> Option.defaultValue (invalid "invalid")
+        | Ok CacheIdentityInspection.Invalid -> invalid "invalid"
+        | Ok CacheIdentityInspection.Inaccessible -> invalid "inaccessible"
+        | Error _ -> invalid "inaccessible"
 
     /// Best-effort cleanup for a failed caller operation; it intentionally has no cancellation token or failure result.
     let discardAttempt root =

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -755,14 +755,34 @@ module internal CacheIdentity =
                     | Ok true, Ok false -> Ok(inspectAttempt attempt)
                     | Ok false, Ok true -> Ok(inspectReady ready)
 
-    /// Rejects roots that are not an empty, protected location before a command resolves credentials or stages a key.
-    let validateEnrollmentRoot root =
+    /// Inspects the protected root before enrollment so callers can distinguish ready, stale, missing, and unsafe state.
+    let inspectEnrollmentRoot root =
         match validateRoot root with
         | Error error -> Error error
-        | Ok () ->
-            match inspect root with
-            | Ok CacheIdentityInspection.Missing -> Ok()
+        | Ok () -> inspect root
+
+    /// Removes exactly one stale staged attempt and confirms that no changed state remains before a new enrollment starts.
+    let discardStaleAttempt root =
+        if not (OperatingSystem.IsLinux()) then
+            Error CacheIdentityError.UnsupportedPlatform
+        else
+            try
+                let attempt = child root AttemptDirectoryName
+
+                if Directory.Exists(attempt) then Directory.Delete(attempt, true)
+
+                match inspectEnrollmentRoot root with
+                | Ok CacheIdentityInspection.Missing -> Ok()
+                | _ -> Error CacheIdentityError.StateUnavailable
+            with
             | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Rejects roots that are not empty before legacy callers resolve credentials or stage a key.
+    let validateEnrollmentRoot root =
+        match inspectEnrollmentRoot root with
+        | Ok CacheIdentityInspection.Missing -> Ok()
+        | Ok _ -> Error CacheIdentityError.StateUnavailable
+        | Error error -> Error error
 
     /// Reads the approved ready-state fields after protected inspection has established that the local identity is valid.
     let private tryReadReadyStatus root =

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -75,6 +75,16 @@ type internal CacheIdentityError =
     | UnsupportedPlatform
     | StateUnavailable
 
+/// Holds one process-scoped exclusive enrollment lock and its opaque attempt ownership token.
+type internal CacheEnrollmentClaim = private CacheEnrollmentClaim of FileStream * string
+
+/// Selects a deterministic post-write failure used only to prove residue cleanup at the protected identity boundary.
+[<RequireQualifiedAccess>]
+type internal CacheIdentityCreateFault =
+    | None
+    | AfterAttemptDirectory
+    | AfterPrivateKeyFlush
+
 /// Owns Linux-only protected static-key staging, ready publication, and opaque local inspection.
 module internal CacheIdentity =
 
@@ -93,6 +103,12 @@ module internal CacheIdentity =
 
     [<Literal>]
     let private RegistrationFileName = "registration.json"
+
+    [<Literal>]
+    let private EnrollmentLockFileName = ".enrollment.lock"
+
+    [<Literal>]
+    let private AttemptOwnerFileName = ".enrollment-owner"
 
     let private directoryMode =
         UnixFileMode.UserRead
@@ -186,6 +202,39 @@ module internal CacheIdentity =
                 | Error _ -> Error CacheIdentityError.StateUnavailable
             | _ -> Error CacheIdentityError.StateUnavailable
 
+    /// Opens and exclusively locks one root-local coordination file; the Linux kernel releases the lock when its process exits.
+    let tryAcquireEnrollmentClaim root =
+        match validateRoot root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let lockPath = child root EnrollmentLockFileName
+                let stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite)
+
+                try
+                    File.SetUnixFileMode(lockPath, fileMode)
+
+                    match inspectMode lockPath fileMode with
+                    | Error _ ->
+                        stream.Dispose()
+                        Error CacheIdentityError.StateUnavailable
+                    | Ok () ->
+                        stream.Lock(0L, 1L)
+                        Ok(CacheEnrollmentClaim(stream, Guid.NewGuid().ToString("N")))
+                with
+                | _ ->
+                    stream.Dispose()
+                    Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Confirms that a caller still owns an open root-local enrollment lock before it mutates protected state.
+    let private validateClaim root (CacheEnrollmentClaim (stream, _)) =
+        if isNull stream || not stream.CanWrite then
+            Error CacheIdentityError.StateUnavailable
+        else
+            validateRoot root
+
     /// Writes one owner-only file and flushes its bytes before any directory publication can occur.
     let private writePrivateFile path bytes =
         try
@@ -198,6 +247,26 @@ module internal CacheIdentity =
             |> Result.mapError (fun _ -> CacheIdentityError.StateUnavailable)
         with
         | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Writes one private attempt marker whose random value binds staged residue to the invocation that created it.
+    let private writeAttemptOwner attempt (CacheEnrollmentClaim (_, token)) =
+        writePrivateFile (child attempt AttemptOwnerFileName) (Text.Encoding.ASCII.GetBytes token)
+
+    /// Verifies that a staged directory still belongs to one invocation before cleanup, validation, or publication.
+    let private hasAttemptOwner attempt (CacheEnrollmentClaim (_, token)) =
+        try
+            let ownerPath = child attempt AttemptOwnerFileName
+
+            match inspectMode ownerPath fileMode with
+            | Error _ -> false
+            | Ok () ->
+                let recorded =
+                    File.ReadAllBytes(ownerPath)
+                    |> Text.Encoding.ASCII.GetString
+
+                String.Equals(recorded, token, StringComparison.Ordinal)
+        with
+        | _ -> false
 
     /// Checks whether a value is canonical base64url for one required P-256 coordinate.
     let private tryCanonicalCoordinate value =
@@ -611,13 +680,93 @@ module internal CacheIdentity =
             | :? IOException -> CacheIdentityInspection.Inaccessible
             | _ -> CacheIdentityInspection.Invalid
 
-    /// Generates one protected P-256 key below a new fixed attempt directory and returns its canonical public half only.
-    let createAttempt root =
-        match validateRoot root with
+    /// Releases the kernel-managed root lock after one enrollment invocation reaches its terminal result.
+    let releaseEnrollmentClaim (CacheEnrollmentClaim (stream, _)) = stream.Dispose()
+
+    /// Reads a protected staged key only when it still yields canonical coordinates for ownership comparison.
+    let private tryReadAttemptPublicKey attempt : CacheIdentityPublicKey option =
+        try
+            let identityPath = child attempt IdentityFileName
+
+            match inspectMode attempt directoryMode, inspectMode identityPath fileMode with
+            | Ok (), Ok () ->
+                File.ReadAllBytes(identityPath)
+                |> tryImportP256
+                |> Option.map (fun (x, y) -> { PublicKeyX = base64Url x; PublicKeyY = base64Url y })
+            | _ -> None
+        with
+        | _ -> None
+
+    /// Compares only the canonical public half required to preserve staged-key ownership across command barriers.
+    let private samePublicKey (expected: CacheIdentityPublicKey) (actual: CacheIdentityPublicKey) =
+        String.Equals(expected.PublicKeyX, actual.PublicKeyX, StringComparison.Ordinal)
+        && String.Equals(expected.PublicKeyY, actual.PublicKeyY, StringComparison.Ordinal)
+
+    /// Removes only a still-owned staged attempt while the caller retains the root claim.
+    let discardClaimedAttempt claim root (expectedPublicKey: CacheIdentityPublicKey option) =
+        match validateClaim root claim with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let attempt = child root AttemptDirectoryName
+
+                let ownsAttempt =
+                    Directory.Exists(attempt)
+                    && hasAttemptOwner attempt claim
+                    && (expectedPublicKey
+                        |> Option.forall (fun expected ->
+                            tryReadAttemptPublicKey attempt
+                            |> Option.exists (samePublicKey expected)))
+
+                if ownsAttempt then Directory.Delete(attempt, true)
+
+                Ok()
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Revalidates one protected key immediately before publication, optionally requiring the current invocation's attempt marker.
+    let private validateAttemptForClaim claim root (expectedPublicKey: CacheIdentityPublicKey) requireAttemptOwner =
+        match validateClaim root claim with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let attempt = child root AttemptDirectoryName
+                let ready = child root ReadyDirectoryName
+
+                if Directory.Exists(ready)
+                   || not (Directory.Exists(attempt))
+                   || (requireAttemptOwner
+                       && not (hasAttemptOwner attempt claim)) then
+                    Error CacheIdentityError.StateUnavailable
+                else
+                    match tryReadAttemptPublicKey attempt with
+                    | Some actual when samePublicKey expectedPublicKey actual -> Ok()
+                    | _ -> Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Revalidates the claim-owned protected key immediately before external enrollment or local ready publication.
+    let validateClaimedAttempt claim root expectedPublicKey = validateAttemptForClaim claim root expectedPublicKey true
+
+    /// Creates a protected key under an already-held claim and removes only invocation-owned residue when staging fails.
+    let private createClaimedAttemptWithFault claim root fault =
+        match validateClaim root claim with
         | Error error -> Error error
         | Ok () ->
             let attempt = child root AttemptDirectoryName
             let ready = child root ReadyDirectoryName
+            let mutable createdDirectory = false
+
+            let cleanup () =
+                try
+                    if Directory.Exists(attempt) then
+                        if
+                            not (File.Exists(child attempt AttemptOwnerFileName))
+                            || hasAttemptOwner attempt claim
+                        then
+                            Directory.Delete(attempt, true)
+                with
+                | _ -> ()
 
             if
                 Directory.Exists(attempt)
@@ -625,33 +774,78 @@ module internal CacheIdentity =
             then
                 Error CacheIdentityError.StateUnavailable
             else
-                try
-                    Directory.CreateDirectory(attempt) |> ignore
-                    File.SetUnixFileMode(attempt, directoryMode)
+                let result =
+                    try
+                        Directory.CreateDirectory(attempt) |> ignore
+                        createdDirectory <- true
+                        File.SetUnixFileMode(attempt, directoryMode)
 
-                    match inspectMode attempt directoryMode with
-                    | Error _ -> Error CacheIdentityError.StateUnavailable
-                    | Ok () ->
-                        use key = ECDsa.Create(ECCurve.NamedCurves.nistP256)
-                        let parameters = key.ExportParameters(false)
+                        match inspectMode attempt directoryMode with
+                        | Error _ -> Error CacheIdentityError.StateUnavailable
+                        | Ok () ->
+                            if fault = CacheIdentityCreateFault.AfterAttemptDirectory then
+                                raise (IOException())
 
-                        match parameters.Q.X, parameters.Q.Y with
-                        | x, y when
-                            not (isNull x)
-                            && not (isNull y)
-                            && x.Length = 32
-                            && y.Length = 32
-                            ->
-                            match writePrivateFile (child attempt IdentityFileName) (key.ExportPkcs8PrivateKey()) with
-                            | Ok () -> Ok { PublicKeyX = base64Url x; PublicKeyY = base64Url y }
+                            match writeAttemptOwner attempt claim with
                             | Error error -> Error error
-                        | _ -> Error CacheIdentityError.StateUnavailable
-                with
-                | _ -> Error CacheIdentityError.StateUnavailable
+                            | Ok () ->
+                                use key = ECDsa.Create(ECCurve.NamedCurves.nistP256)
+                                let parameters = key.ExportParameters(false)
 
-    /// Publishes an accepted registration only after its key fingerprint matches the staged private key and all modes are protected.
-    let commitReady root configuration =
-        match validateRoot root, tryExpectedFingerprint configuration with
+                                match parameters.Q.X, parameters.Q.Y with
+                                | x, y when
+                                    not (isNull x)
+                                    && not (isNull y)
+                                    && x.Length = 32
+                                    && y.Length = 32
+                                    ->
+                                    let publicKey: CacheIdentityPublicKey = { PublicKeyX = base64Url x; PublicKeyY = base64Url y }
+
+                                    match writePrivateFile (child attempt IdentityFileName) (key.ExportPkcs8PrivateKey()) with
+                                    | Error error -> Error error
+                                    | Ok () ->
+                                        if fault = CacheIdentityCreateFault.AfterPrivateKeyFlush then
+                                            raise (IOException())
+                                        else
+                                            match validateClaimedAttempt claim root publicKey with
+                                            | Ok () -> Ok publicKey
+                                            | Error error -> Error error
+                                | _ -> Error CacheIdentityError.StateUnavailable
+                    with
+                    | _ -> Error CacheIdentityError.StateUnavailable
+
+                match result with
+                | Ok _ -> result
+                | Error _ ->
+                    if createdDirectory then cleanup ()
+                    result
+
+    /// Generates one protected P-256 key below a new fixed attempt directory and returns its canonical public half only.
+    let createAttempt root =
+        match tryAcquireEnrollmentClaim root with
+        | Error error -> Error error
+        | Ok claim ->
+            try
+                createClaimedAttemptWithFault claim root CacheIdentityCreateFault.None
+            finally
+                releaseEnrollmentClaim claim
+
+    /// Injects a bounded staging failure so Linux proof can verify cleanup after directory and key-file creation.
+    let createAttemptWithFault root fault =
+        match tryAcquireEnrollmentClaim root with
+        | Error error -> Error error
+        | Ok claim ->
+            try
+                createClaimedAttemptWithFault claim root fault
+            finally
+                releaseEnrollmentClaim claim
+
+    /// Generates one protected P-256 key while retaining the caller's enrollment claim through its external command flow.
+    let createClaimedAttempt claim root = createClaimedAttemptWithFault claim root CacheIdentityCreateFault.None
+
+    /// Publishes a claimed accepted registration only after the staged key remains protected, owned, and fingerprint-matched.
+    let private commitReadyWithClaim claim root (configuration: CacheAcceptedRegistration) requireAttemptOwner =
+        match validateAttemptForClaim claim root configuration.PublicKey requireAttemptOwner, tryExpectedFingerprint configuration with
         | Error error, _ -> Error error
         | _, None -> Error CacheIdentityError.StateUnavailable
         | _, Some _ when not (hasCompleteAcceptedRegistration configuration) -> Error CacheIdentityError.StateUnavailable
@@ -660,6 +854,7 @@ module internal CacheIdentity =
             let ready = child root ReadyDirectoryName
             let identityPath = child attempt IdentityFileName
             let registrationPath = child attempt RegistrationFileName
+            let ownerPath = child attempt AttemptOwnerFileName
 
             if
                 Directory.Exists(ready)
@@ -680,21 +875,51 @@ module internal CacheIdentity =
                                 match writePrivateFile registrationPath registrationBytes with
                                 | Error error -> Error error
                                 | Ok () ->
-                                    match inspectMode root directoryMode,
-                                          inspectMode attempt directoryMode,
-                                          inspectMode identityPath fileMode,
-                                          inspectMode registrationPath fileMode
-                                        with
-                                    | Ok (), Ok (), Ok (), Ok () ->
-                                        Directory.Move(attempt, ready)
+                                    let publishResult =
+                                        try
+                                            File.Delete(ownerPath)
 
-                                        inspectMode ready directoryMode
-                                        |> Result.mapError (fun _ -> CacheIdentityError.StateUnavailable)
-                                    | _ -> Error CacheIdentityError.StateUnavailable
+                                            match inspectMode root directoryMode,
+                                                  inspectMode attempt directoryMode,
+                                                  inspectMode identityPath fileMode,
+                                                  inspectMode registrationPath fileMode
+                                                with
+                                            | Ok (), Ok (), Ok (), Ok () ->
+                                                Directory.Move(attempt, ready)
+
+                                                inspectMode ready directoryMode
+                                                |> Result.mapError (fun _ -> CacheIdentityError.StateUnavailable)
+                                            | _ -> Error CacheIdentityError.StateUnavailable
+                                        with
+                                        | _ -> Error CacheIdentityError.StateUnavailable
+
+                                    match publishResult with
+                                    | Ok _ -> publishResult
+                                    | Error _ ->
+                                        if
+                                            requireAttemptOwner && Directory.Exists(attempt)
+                                            && not (File.Exists(ownerPath))
+                                        then
+                                            writeAttemptOwner attempt claim |> ignore
+
+                                        publishResult
                         | _ -> Error CacheIdentityError.StateUnavailable
                     | _ -> Error CacheIdentityError.StateUnavailable
                 with
                 | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Publishes an accepted registration only after its key fingerprint matches the staged private key and all modes are protected.
+    let commitReady root configuration =
+        match tryAcquireEnrollmentClaim root with
+        | Error error -> Error error
+        | Ok claim ->
+            try
+                commitReadyWithClaim claim root configuration false
+            finally
+                releaseEnrollmentClaim claim
+
+    /// Publishes one accepted registration while retaining the command invocation's marker-bound enrollment claim.
+    let commitClaimedReady claim root configuration = commitReadyWithClaim claim root configuration true
 
     /// Reads one ready configuration without emitting raw paths, filesystem errors, keys, or fingerprints.
     let private inspectReady ready =
@@ -762,10 +987,10 @@ module internal CacheIdentity =
         | Ok () -> inspect root
 
     /// Removes exactly one stale staged attempt and confirms that no changed state remains before a new enrollment starts.
-    let discardStaleAttempt root =
-        if not (OperatingSystem.IsLinux()) then
-            Error CacheIdentityError.UnsupportedPlatform
-        else
+    let discardStaleAttempt claim root =
+        match validateClaim root claim with
+        | Error error -> Error error
+        | Ok () ->
             try
                 let attempt = child root AttemptDirectoryName
 

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -26,6 +26,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Grace.CLI.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Grace.Cache.ClaimHolder</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -23,6 +23,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>grace</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Grace.CLI.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -20,6 +20,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Grace.Cache.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>grace</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.SDK/CacheRegistration.SDK.fs
+++ b/src/Grace.SDK/CacheRegistration.SDK.fs
@@ -1,0 +1,45 @@
+namespace Grace.SDK
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open System
+open System.Net.Http.Headers
+open System.Net.Http.Json
+open System.Threading
+
+/// Sends the single selected-server request used to enroll a static Grace Cache identity.
+type CacheRegistration() =
+    /// Posts one enrollment request with the caller-selected server and already-resolved bearer, without retries or configuration lookup.
+    static member Enroll(request: CacheEnrollmentRequest, serverUri: Uri, bearer: string, correlationId: string, cancellationToken: CancellationToken) =
+        task {
+            if obj.ReferenceEquals(request, null) then
+                return Error(GraceError.Create "Cache enrollment request is required." correlationId)
+            elif isNull serverUri || not serverUri.IsAbsoluteUri then
+                return Error(GraceError.Create "Cache enrollment requires an absolute Grace Server URI." correlationId)
+            elif String.IsNullOrWhiteSpace bearer then
+                return Error(GraceError.Create "Cache enrollment requires an authenticated bearer credential." correlationId)
+            else
+                try
+                    use client = ClientIdentity.getHttpClient correlationId
+                    client.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", bearer)
+                    use content = createJsonContent request
+                    let route = "cache/enroll"
+                    let target = Uri($"{serverUri.AbsoluteUri.TrimEnd('/')}/{route}")
+                    use! response = client.PostAsync(target, content, cancellationToken)
+
+                    if response.IsSuccessStatusCode then
+                        let! result =
+                            response.Content.ReadFromJsonAsync<GraceReturnValue<CacheRegistrationResult>>(Constants.JsonSerializerOptions, cancellationToken)
+
+                        if obj.ReferenceEquals(result, null) then
+                            return Error(GraceError.Create "Cache enrollment returned an empty response." correlationId)
+                        else
+                            return Ok result
+                    else
+                        return Error(GraceError.Create "Cache enrollment was rejected by the selected Grace Server." correlationId)
+                with
+                | :? OperationCanceledException as error -> return raise error
+                | _ -> return Error(GraceError.Create "Cache enrollment could not reach the selected Grace Server." correlationId)
+        }

--- a/src/Grace.SDK/CacheRegistration.SDK.fs
+++ b/src/Grace.SDK/CacheRegistration.SDK.fs
@@ -5,6 +5,7 @@ open Grace.Shared.Utilities
 open Grace.Types.CacheRegistration
 open Grace.Types.Common
 open System
+open System.Net.Http
 open System.Net.Http.Headers
 open System.Net.Http.Json
 open System.Threading
@@ -22,7 +23,15 @@ type CacheRegistration() =
                 return Error(GraceError.Create "Cache enrollment requires an authenticated bearer credential." correlationId)
             else
                 try
-                    use client = ClientIdentity.getHttpClient correlationId
+                    use handler = new SocketsHttpHandler(AllowAutoRedirect = false)
+
+                    use client =
+                        new HttpClient(handler)
+                        |> ClientIdentity.applyHeaders
+
+                    client.DefaultRequestHeaders.TryAddWithoutValidation(Constants.CorrelationIdHeaderKey, correlationId)
+                    |> ignore
+
                     client.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", bearer)
                     use content = createJsonContent request
                     let route = "cache/enroll"

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -20,6 +20,7 @@
         <Compile Include="ClientIdentity.SDK.fs" />
         <Compile Include="Auth.SDK.fs" />
         <Compile Include="Common.SDK.fs" />
+        <Compile Include="CacheRegistration.SDK.fs" />
         <Compile Include="PersonalAccessToken.SDK.fs" />
         <Compile Include="LocalPlanner.SDK.fs" />
         <Compile Include="Storage.SDK.fs" />

--- a/src/Grace.slnx
+++ b/src/Grace.slnx
@@ -13,6 +13,7 @@
   <Project Path="Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj" />
   <Project Path="Grace.CLI.Tests/Grace.CLI.Tests.fsproj" />
   <Project Path="Grace.CLI/Grace.CLI.fsproj" />
+  <Project Path="Grace.Cache.ClaimHolder/Grace.Cache.ClaimHolder.fsproj" />
   <Project Path="Grace.Cache.Tests/Grace.Cache.Tests.fsproj" />
   <Project Path="Grace.Cache/Grace.Cache.fsproj" />
   <Project Path="Grace.Load/Grace.Load.fsproj" />


### PR DESCRIPTION
## Linked Issue

Tracks #887. This PR targets the ME3 integration branch; #887 closes manually after verified integration.

## Purpose

Provide the Product V1 operator path for repository-independent static Grace Cache enrollment and local status on the
supported Linux service-account deployment.

## Summary

- Add **grace cache enroll** and **grace cache status** before repository configuration and invocation-history setup.
- Resolve one existing Grace credential before local mutation and reuse that exact bearer in one selected-server
  enrollment request.
- Consume R1A protected identity operations, publish ready only after server acceptance and local commit, and clean the
  current attempt best effort after every failure without retry or reconciliation.
- Emit truthful redacted human or single-document JSON status without network or local mutation.
- Add focused Linux root-command proof for PAT, M2M, interactive outcomes, failures, cleanup, repository independence,
  output contracts, help, schema, examples, and exit codes.

## Product V1 Boundaries

Included: interactive/M2M/PAT credential consumption, selected-server enrollment, protected ready commit, pure local
status, redaction, command metadata, and operator documentation.

Excluded: new credential types, automatic retry or reconciliation, pending enrollment state, rotation, runtime
liveness, listener behavior, artifact storage/serving, repository discovery, and Windows/macOS product support.

## Validation

Final worker 5 completed the session-4 closure at exact head
**79814dfe1ea95fbc0cb065f6ef2133147bb24a3a**:

- Targeted Fantomas passed.
- Windows Release solution build passed with 0 errors; the test-only claim holder is in the normal solution graph.
- Focused Windows CLI and command-output tests passed 25, with 22 expected Linux-only skips.
- Linux full solution build followed by Cache CLI tests passed 23, with 2 keyring tests skipped only in the plain
  container.
- Command metadata and inventory proof passed 22/22.
- MarkdownLint and working-tree/full-PR diff checks passed.

## Current-Head Gates

- Head: **79814dfe1ea95fbc0cb065f6ef2133147bb24a3a**
- Worker starts: 5
- GitHub Validate: run 31648703796 in progress.
- Fresh Product V1 review: final session 5 in progress against the same exact head.
## Supersession Rule

Epic #597 numerical counts are evidence, not general stop conditions. If this PR still has a valid addressable finding
after five implementation/fix workers, close it as superseded and restart from a corrected issue in a fresh worktree.
Do not assign a sixth worker to this PR.