### PR TITLE
WDU-05C0: correct the superseded hash-transaction packet

### DIFF
--- a/docs/Working Directory Update.md
+++ b/docs/Working Directory Update.md
@@ -29,10 +29,10 @@ when lower-level details are incomplete.
 | DEC-002 | Successful Save or no-Save admission seals the sole accepted baseline. | `AcceptedBranchPhase` carries SQLite revision, full-status fingerprint, and action token through preparation. | #872 |
 | DEC-003 | Marker evidence retains typed dispositions. | Missing, exact, different operation, malformed, unsupported, unreadable, and exact-cleanup-failed never collapse to a Boolean. | #869 |
 | DEC-004 | Reference finalization is repeatable from persisted typed facts. | Previous Branch publishes once, selected Branch proves prior publication, and a third Branch retains pending. | #871 |
-| DEC-005 | Planning and verification cover complete tracked topology. | Empty directories, path-type transitions, ignored content, object verification, and complete-root proof are included. | #870 |
+| DEC-005 | Planning and verification cover complete tracked topology. | Empty directories, path-type transitions, ignored content, object verification, and complete-root proof are included. | #898 and #899 |
 | DEC-006 | The lifecycle table is the sole ordering authority. | Cancellation, cleanup, publication/proof, terminal recording, outcomes, and retry follow `WDU-LC-*` rows only. | #881 |
-| DEC-007 | The Branch module has one exact five-input seam. | Inputs are sealed phase, typed selection, exact target graph, immutable prepared content, and diagnostic correlation. | #870 |
-| DEC-008 | Proof is split by stable boundary. | Real filesystem/SQLite tests activate lifecycle failures; built commands prove selectors and public projections. | #870–#872 |
+| DEC-007 | The Branch module has one exact five-input seam. | Inputs are sealed phase, typed selection, exact target graph, immutable prepared content, and diagnostic correlation. | #899 and #901 |
+| DEC-008 | Proof is split by stable boundary. | Real filesystem/SQLite tests activate lifecycle failures; built commands prove selectors and public projections. | #898–#901 |
 | DEC-009 | #868 and PR #873 are superseded planning evidence. | Their review findings inform this table but their commits and competing prose are not implementation authority. | #881 |
 
 No product decision remains open. Projection of this table into consumer issue bodies is required before the
@@ -228,25 +228,68 @@ immediately before that write begins. These statements identify row families and
 
 | ID | Requirement | Primary owner | Required lifecycle rows or proof |
 | --- | --- | --- | --- |
-| REQ-001 | One deep Branch transaction module | #870 | All `initial` rows and one reachable `run` seam. |
+| REQ-001 | One deep Branch transaction module | #899 | All `initial` rows and one reachable five-input `run` seam. |
 | REQ-002 | Exact typed target and operation identity | #869 | Persisted facts select the row predicates. |
 | REQ-003 | Exact immutable prepared content | #837 | `WDU-LC-200`–`WDU-LC-210` fresh-plan and boundary proof. |
 | REQ-004 | Stable repository/local-root serialization | #839 | Every non-replay row runs under the same lease scope. |
 | REQ-005 | Typed, versioned marker evidence | #869 | `WDU-LC-200`–`WDU-LC-212`, `WDU-LC-010`–`WDU-LC-015`, and `WDU-LC-100`–`WDU-LC-116`. |
-| REQ-006 | Fresh planning and local-content safety | #870 | `WDU-LC-200`–`WDU-LC-212` and `WDU-LC-001`–`WDU-LC-006`. |
-| REQ-007 | Verified object-first application | #870 | Initial-run proof before SQLite local completion. |
-| REQ-008 | Complete final-root verification | #870 | Required before every initial post-completion row. |
+| REQ-006 | Fresh planning and local-content safety | #898 | The finite collision matrix and immutable complete topology plan are proven before C2 consumes them. |
+| REQ-007 | Verified object-first application | #899 | Initial-run proof before SQLite local completion. |
+| REQ-008 | Complete final-root verification | #899 | Required before every initial post-completion row. |
 | REQ-009 | Canonical atomic local completion | #838 | Distinct boundary preceding `WDU-LC-010`–`WDU-LC-037`. |
 | REQ-010 | Bounded pending and terminal completion | #838 | Every terminal row names `durableResult`; routing rows name only valid successors. |
 | REQ-011 | Idempotent finalization and blocking | #871 | `WDU-LC-020`–`WDU-LC-037` and `WDU-LC-100`–`WDU-LC-143`. |
 | REQ-012 | Truthful outcomes, exits, and Doctor guidance | #871 | Every terminal row names outcome, exit class, and guidance. |
-| REQ-013 | Deterministic cancellation precedence | #870 | `WDU-LC-207`–`WDU-LC-210`, `WDU-LC-001`, `WDU-LC-003`, `WDU-LC-004`, `WDU-LC-101`, `WDU-LC-103`, `WDU-LC-110`, `WDU-LC-114`, `WDU-LC-120`, `WDU-LC-123`, `WDU-LC-140`, `WDU-LC-143`. |
+| REQ-013 | Deterministic cancellation precedence | #900 | DirectoryVersion retry selects its first applicable write from fresh durable evidence and then follows evidence, not cancellation. |
 | REQ-014 | Same-operation adoption replans freshly | #869 | `WDU-LC-200`–`WDU-LC-212`; no admission may reuse a prior plan. |
 | REQ-015 | Branch-only Doctor recovery without file mutation | #842 | All `finalizationRetry` rows require `workingFiles: unchanged`; Watch proof remains #843. |
 | REQ-016 | Caller-specific ordering | #871 | Branch order is exclusively the normative table; later callers consume it. |
 | REQ-017 | Current public and contributor documentation | #846 | Final audit validates row references and removes competing sequences. |
 
 Each row has one primary implementation owner even when companion issues prove a selector or recovery projection.
+
+### Serial supersession ownership
+
+Closed #870 and PR #895 are historical counterexamples only. They have no active requirement, lifecycle-row,
+dependency, checklist, assignment, or primary-delivery role. The active Branch packet is serial:
+
+| Former #870 delivery | Exact active owner | Primary scope |
+| --- | --- | --- |
+| Collision-safe topology classification and immutable plan | #898 | The finite pre-mutation matrix; it neither acquires a lease nor changes files. |
+| `WDU-LC-200`–`WDU-LC-212`, `WDU-LC-001`, `WDU-LC-002`, `WDU-LC-004`–`WDU-LC-006` | #899 | The real five-input transaction through verified pending SQLite completion. |
+| `WDU-LC-003`, `WDU-LC-010`–`WDU-LC-015`, `WDU-LC-026`, `WDU-LC-027`, `WDU-LC-036`, `WDU-LC-037`, `WDU-LC-100`–`WDU-LC-103`, `WDU-LC-115`, `WDU-LC-116`, and `WDU-LC-140`–`WDU-LC-143` | #900 | DirectoryVersion terminalization and exact filesystem-free retry. |
+| Hash-selected Branch orchestration and its public projection | #901 | Remote resolution and preparation outside local serialization, then the proven five-input call. |
+
+The primary requirement mapping is REQ-001, REQ-007, and REQ-008 to #899; REQ-006 to #898; and REQ-013 to #900.
+Issue #901 is the necessary production Branch consumer of those completed facts; its direct public wiring is not a
+second primary delivery claim for a transaction requirement.
+
+### Selected Product V1 boundaries
+
+The finite collision matrix is mandatory before mutation: a target file may replace only an absent or verified tracked
+file, or a tracked directory whose complete descendants are scheduled tracked removals; a target directory may replace
+only absence, a tracked directory, or a tracked file scheduled for removal. Ignored or untracked files, directories,
+or nested descendants reject and preserve the complete local subtree. Tracked empty-directory removal is deepest-first,
+creation is shallowest-first, and case-insensitive duplicate or ambiguous target shapes reject. Only tracked blockers
+named by the immutable plan may be removed.
+
+The lease inventory is also finite. No-Save admission, hash-prefix resolution, target graph retrieval, object download,
+and immutable preparation hold none of the Branch workflow, legacy materialization, or WDU leases. The sealed phase
+handoff holds none. Only the WDU transaction holds `working-directory-update.lease` during local reread, mutation,
+SQLite completion, and terminal outcome. Marker and sidecar files are evidence, never leases; no second lease is added.
+
+For DirectoryVersion retry, fresh pending SQLite and marker evidence select one first applicable write before any
+cancellation observation: an exact marker selects exact-marker cleanup; a missing marker selects terminal SQLite
+recording; foreign, malformed, unsupported, or unreadable marker evidence permits no write and retains pending; an
+exact terminal SQLite result selects no write and returns `Unchanged`. Cancellation is controlling only immediately
+before the selected cleanup or terminal-recording write. Once that write begins, cleanup and SQLite evidence determine
+the result and cancellation is non-controlling.
+
+SQLite completion is decisive durable truth. Terminal SQLite wins over stale marker or sidecar evidence; pending SQLite
+requires the exact retry path; markers and sidecars are readable evidence only and cannot create, downgrade, or replace
+SQLite completion. Production proof invokes the real five-input transaction and persisted retry entry with real
+filesystem and SQLite facts. Helper-only, source-string, sleep-based, and impossible-state fixtures do not establish
+this contract.
 
 ## 6. Proof, propagation, and readiness
 
@@ -260,6 +303,9 @@ source-string assertions, sleeps, and impossible hand-built states are insuffici
 ```json
 {
   "schema": "grace.wdu.lifecycle-projection-plan/v1",
+  "nonLifecycleArtifacts": [
+    {"artifact":"issue-897","reason":"The supersession correction owns packet alignment and publication preparation, not a lifecycle-row delivery; the checker exports lifecycle consumers only."}
+  ],
   "assignments": [
     {"artifact":"adr-0011","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-023","WDU-LC-025","WDU-LC-026","WDU-LC-030","WDU-LC-033","WDU-LC-035","WDU-LC-036","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"],"proof":"Record the lasting Branch transaction lifecycle and reference canonical rows without copying their order."},
     {"artifact":"epic-835","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-030","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"],"proof":"Keep the epic dependency and requirement packet aligned with the sole canonical lifecycle."},
@@ -267,7 +313,10 @@ source-string assertions, sleeps, and impossible hand-built states are insuffici
     {"artifact":"issue-843","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-003","WDU-LC-100","WDU-LC-101","WDU-LC-103"],"proof":"Consume the completed Branch lifecycle while deferring the first real Watch producer and retry proof to this issue."},
     {"artifact":"issue-846","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-030","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"],"proof":"Audit the completed 17/9 packet, public outcomes, Doctor guidance, and removal of competing lifecycle paths."},
     {"artifact":"issue-869","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-203","WDU-LC-204","WDU-LC-205","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-211","WDU-LC-212","WDU-LC-010","WDU-LC-011","WDU-LC-012","WDU-LC-013","WDU-LC-014","WDU-LC-015","WDU-LC-100"],"proof":"Persist typed selection and marker facts that select canonical admission, refusal, cleanup, and retry rows."},
-    {"artifact":"issue-870","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-203","WDU-LC-204","WDU-LC-205","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-211","WDU-LC-212","WDU-LC-001","WDU-LC-005","WDU-LC-002","WDU-LC-004","WDU-LC-006","WDU-LC-010","WDU-LC-011","WDU-LC-012","WDU-LC-013","WDU-LC-014","WDU-LC-015","WDU-LC-026","WDU-LC-027","WDU-LC-036","WDU-LC-037","WDU-LC-100","WDU-LC-101","WDU-LC-102","WDU-LC-103","WDU-LC-115","WDU-LC-116","WDU-LC-140","WDU-LC-141","WDU-LC-142","WDU-LC-143","WDU-LC-003"],"proof":"Implement exact-root DirectoryVersion switching with fresh planning, mutation boundaries, retry, and current-Branch retention."},
+    {"artifact":"issue-898","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-209","WDU-LC-210","WDU-LC-211","WDU-LC-212"],"proof":"Prove the immutable collision-safe topology plan consumed by fresh admission and final pre-mutation reread."},
+    {"artifact":"issue-899","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-203","WDU-LC-204","WDU-LC-205","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-211","WDU-LC-212","WDU-LC-001","WDU-LC-005","WDU-LC-002","WDU-LC-004","WDU-LC-006"],"proof":"Invoke the production five-input transaction through verified pending SQLite completion without terminal finalization."},
+    {"artifact":"issue-900","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-003","WDU-LC-010","WDU-LC-011","WDU-LC-012","WDU-LC-013","WDU-LC-014","WDU-LC-015","WDU-LC-026","WDU-LC-027","WDU-LC-036","WDU-LC-037","WDU-LC-100","WDU-LC-101","WDU-LC-102","WDU-LC-103","WDU-LC-115","WDU-LC-116","WDU-LC-140","WDU-LC-141","WDU-LC-142","WDU-LC-143"],"proof":"Terminalize DirectoryVersion pending completion and retry from decisive SQLite and marker evidence with one conditional cancellation boundary."},
+    {"artifact":"issue-901","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-001","WDU-LC-002","WDU-LC-004","WDU-LC-006","WDU-LC-003","WDU-LC-140","WDU-LC-141","WDU-LC-142","WDU-LC-143"],"proof":"Route both production hash selectors through the proven transaction while remote work holds no local serialization lease."},
     {"artifact":"issue-871","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-020","WDU-LC-021","WDU-LC-022","WDU-LC-023","WDU-LC-024","WDU-LC-025","WDU-LC-030","WDU-LC-031","WDU-LC-032","WDU-LC-033","WDU-LC-034","WDU-LC-035","WDU-LC-100","WDU-LC-101","WDU-LC-102","WDU-LC-103","WDU-LC-104","WDU-LC-105","WDU-LC-106","WDU-LC-107","WDU-LC-108","WDU-LC-109","WDU-LC-110","WDU-LC-111","WDU-LC-112","WDU-LC-113","WDU-LC-114","WDU-LC-120","WDU-LC-121","WDU-LC-122","WDU-LC-123","WDU-LC-130","WDU-LC-003"],"proof":"Implement repeatable Reference previous, selected, and third-state finalization with truthful retry outcomes."},
     {"artifact":"issue-872","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7","rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-211","WDU-LC-212","WDU-LC-001","WDU-LC-005","WDU-LC-002","WDU-LC-004","WDU-LC-006","WDU-LC-003"],"proof":"Prove Save and no-Save admission preserve one sealed baseline and action token through the final pre-mutation reread."}
   ]
@@ -278,7 +327,10 @@ source-string assertions, sleeps, and impossible hand-built states are insuffici
 The following consumers carry generated projections rather than competing lifecycle sequences:
 
 - #869 persists selection and marker predicates.
-- #870 proves initial-run and cancellation rows.
+- #898 proves collision-safe planning without mutation.
+- #899 proves initial-run through pending SQLite completion.
+- #900 proves DirectoryVersion terminalization and retry cancellation precedence.
+- #901 proves production hash-selector consumption of the completed transaction.
 - #871 proves Reference and retry row families.
 - #872 proves Save/no-Save admission reaches the same initial rows.
 - #842 proves Branch-only retry rows without working-file mutation.
@@ -289,6 +341,10 @@ ADR 0011 and active issue bodies remain contextual consumers. The #890 checker v
 marker-delimited projections and required packet membership, ignoring surrounding Markdown or prose. The Plan-ready
 boundary is the closed structural proof from #889 plus the exact-projection proof from #890; normal review and later
 runtime proof establish lifecycle meaning.
+
+The exact projection packet contains lifecycle consumers only: ADR 0011, epic #835, #842, #843, #846, #869, and issues #898–#901, #871, and #872. Issue #897 is intentionally excluded because it corrects ownership and prepares publication
+without delivering or consuming a lifecycle row; its declared exclusion is part of the plan above. Closed #870 is not a
+packet artifact.
 
 The bounded Product V1 residual risk remains interruption after working-tree mutation but before SQLite local
 completion. `WDU-LC-002` requires truthful `UpdateIncomplete` and fresh revalidation; Grace does not guess, roll back,

--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -26,8 +26,10 @@ justify three local-integrity implementations.
 
 ## Decision
 
-- The internal module exposes one generic `run` operation and one `retryFinalization` operation. Caller-specific
-  constructors create private normalized requests.
+- The internal module exposes one exact five-input Branch `run` operation—sealed accepted phase, typed selection,
+  exact target graph, immutable prepared content, and diagnostic correlation—and one persisted-facts-only
+  `retryFinalization` operation. Callers cannot supply alternate paths, status graphs, readers, writers, finalizers,
+  or generic request bags.
 - Target identity contains repository, branch, root DirectoryVersion, SHA-256, and BLAKE3. Caller operation identity is
   separate and deterministic. Each execution attempt receives a separate random marker token.
 - Prepared-content adapters expose exact immutable manifests and readable uncompressed bytes. They never provide
@@ -53,6 +55,23 @@ justify three local-integrity implementations.
 - Connect keeps its zip download. It stages and validates the zip before lease acquisition, performs no network reads
   under the lease, verifies objects before populating the working directory, and limits `--force` to conflicting target
   paths.
+
+## Serial delivery and proof boundary
+
+The active exact-root packet is serial. #898 owns the finite collision-safe topology planner; #899 owns the real
+five-input transaction through verified pending SQLite completion; #900 owns DirectoryVersion terminalization and
+filesystem-free retry; and #901 owns hash-selected Branch wiring. Closed #870 and PR #895 are historical evidence,
+not active delivery, dependency, or projection artifacts.
+
+Remote hash resolution, target retrieval, download, and immutable preparation hold none of the Branch workflow,
+legacy materialization, or WDU leases. Only the WDU transaction holds its local lease for fresh reread, mutation,
+SQLite completion, and terminal outcome. Markers and sidecars are evidence, not leases.
+
+SQLite terminal completion is decisive durable truth. Marker and sidecar evidence cannot manufacture, downgrade, or
+replace it. For DirectoryVersion retry, fresh evidence selects exact-marker cleanup when an exact marker exists or
+terminal SQLite recording when it is missing; cancellation is observed immediately before that selected first write
+only. After it begins, durable evidence determines the result. Direct production-runtime proof uses the five-input
+operation and persisted retry entry with real filesystem and SQLite facts.
 
 The complete requirements, state model, propagation map, and proof contract are in
 [Working Directory Update](../Working%20Directory%20Update.md).

--- a/scripts/modules/WduLifecycleProjection.psm1
+++ b/scripts/modules/WduLifecycleProjection.psm1
@@ -16,9 +16,18 @@ $script:RequiredArtifactIds = @(
     'issue-843',
     'issue-846',
     'issue-869',
-    'issue-870',
+    'issue-898',
+    'issue-899',
+    'issue-900',
+    'issue-901',
     'issue-871',
     'issue-872'
+)
+$script:RequiredNonLifecycleArtifacts = @(
+    [pscustomobject]@{
+        Artifact = 'issue-897'
+        Reason = 'The supersession correction owns packet alignment and publication preparation, not a lifecycle-row delivery; the checker exports lifecycle consumers only.'
+    }
 )
 
 function Fail-Projection {
@@ -173,16 +182,36 @@ function Read-WduLifecycleProjectionPlan {
     $text = Normalize-LineEndings ([IO.File]::ReadAllText($resolved))
     $marked = Get-SingleMarkedBlock $text $script:PlanStartMarker $script:PlanEndMarker $resolved
     $plan = ConvertFrom-ExactJsonObject $marked.Content $resolved
-    Assert-ExactObjectProperties $plan @('schema', 'assignments') '$' $resolved
+    Assert-ExactObjectProperties $plan @('schema', 'nonLifecycleArtifacts', 'assignments') '$' $resolved
     Assert-NonBlankString $plan['schema'] '$.schema' $resolved
     if (-not [StringComparer]::Ordinal.Equals($plan['schema'], $script:PlanSchema)) {
         Fail-Projection $resolved "$.schema must equal '$script:PlanSchema'"
+    }
+    if ($plan['nonLifecycleArtifacts'] -is [string] -or $plan['nonLifecycleArtifacts'] -is [System.Collections.IDictionary] -or $plan['nonLifecycleArtifacts'] -isnot [System.Collections.IEnumerable]) {
+        Fail-Projection $resolved '$.nonLifecycleArtifacts must be a JSON array'
+    }
+    $rawNonLifecycleArtifacts = @($plan['nonLifecycleArtifacts'])
+    if ($rawNonLifecycleArtifacts.Count -ne $script:RequiredNonLifecycleArtifacts.Count) {
+        Fail-Projection $resolved '$.nonLifecycleArtifacts must contain the complete declared non-lifecycle packet'
+    }
+    for ($nonLifecycleIndex = 0; $nonLifecycleIndex -lt $rawNonLifecycleArtifacts.Count; $nonLifecycleIndex++) {
+        $rawNonLifecycle = $rawNonLifecycleArtifacts[$nonLifecycleIndex]
+        Assert-ExactObjectProperties $rawNonLifecycle @('artifact', 'reason') '$.nonLifecycleArtifacts[]' $resolved
+        Assert-NonBlankString $rawNonLifecycle['artifact'] '$.nonLifecycleArtifacts[].artifact' $resolved
+        Assert-NonBlankString $rawNonLifecycle['reason'] '$.nonLifecycleArtifacts[].reason' $resolved
+        $requiredNonLifecycle = $script:RequiredNonLifecycleArtifacts[$nonLifecycleIndex]
+        if (-not [StringComparer]::Ordinal.Equals($rawNonLifecycle['artifact'], $requiredNonLifecycle.Artifact)) {
+            Fail-Projection $resolved "$.nonLifecycleArtifacts must declare excluded artifact '$($requiredNonLifecycle.Artifact)' at ordinal $($nonLifecycleIndex + 1), not '$($rawNonLifecycle['artifact'])'"
+        }
+        if (-not [StringComparer]::Ordinal.Equals($rawNonLifecycle['reason'], $requiredNonLifecycle.Reason)) {
+            Fail-Projection $resolved "$.nonLifecycleArtifacts has a stale reason for excluded artifact '$($requiredNonLifecycle.Artifact)'"
+        }
     }
     if ($plan['assignments'] -is [string] -or $plan['assignments'] -is [System.Collections.IDictionary] -or $plan['assignments'] -isnot [System.Collections.IEnumerable]) {
         Fail-Projection $resolved '$.assignments must be a JSON array'
     }
     $rawAssignments = @($plan['assignments'])
-    if ($rawAssignments.Count -ne 9) { Fail-Projection $resolved '$.assignments must contain the complete nine-artifact packet' }
+    if ($rawAssignments.Count -ne $script:RequiredArtifactIds.Count) { Fail-Projection $resolved "$.assignments must contain the complete $($script:RequiredArtifactIds.Count)-artifact packet" }
     $knownRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
     foreach ($rowId in $Compiled.RowIds) { $null = $knownRows.Add($rowId) }
     $coveredRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)

--- a/scripts/tests/WduLifecycleProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleProjection.Tests.ps1
@@ -12,7 +12,7 @@ $modulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleProjection.
 $canonicalSource = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
 $getCommand = Join-Path $repositoryRoot 'scripts/get-wdu-lifecycle-projection.ps1'
 $checkCommand = Join-Path $repositoryRoot 'scripts/check-wdu-lifecycle-projections.ps1'
-$artifactIds = @('adr-0011', 'epic-835', 'issue-842', 'issue-843', 'issue-846', 'issue-869', 'issue-870', 'issue-871', 'issue-872')
+$artifactIds = @('adr-0011', 'epic-835', 'issue-842', 'issue-843', 'issue-846', 'issue-869', 'issue-898', 'issue-899', 'issue-900', 'issue-901', 'issue-871', 'issue-872')
 
 function Assert-True {
     param([bool] $Condition, [string] $Message)
@@ -106,15 +106,15 @@ try {
 
     Invoke-Case 'checks a complete packet with paths containing spaces and Unicode in arbitrary input order' {
         $packet = New-Packet 'paths with spaces é'
-        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths[8..0]))
-        Assert-True ($result.Count -eq 9) 'complete packet returns one scoped result per assignment'
+        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths[11..0]))
+        Assert-True ($result.Count -eq 12) 'complete packet returns one scoped result per assignment'
         Assert-True (($result | Select-Object -ExpandProperty Artifact) -join '|' -ceq ($artifactIds -join '|')) 'results are in canonical assignment order'
     }
 
     Invoke-Case 'normalizes LF and CRLF only while checking exact blocks' {
         $packet = New-Packet 'crlf packet' -CrLf
         $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
-        Assert-True ($result.Count -eq 9) 'CRLF packet succeeds under the documented normalization'
+        Assert-True ($result.Count -eq 12) 'CRLF packet succeeds under the documented normalization'
     }
 
     }
@@ -152,11 +152,23 @@ try {
 
     Invoke-Case 'rejects reordered required assignment artifacts' {
         $packet = New-Packet 'reordered-required-assignment-artifacts'
-        $reordered = Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-870"' '"artifact":"temporary-ordering-artifact"'
-        $reordered = Replace-Once $reordered '"artifact":"issue-871"' '"artifact":"issue-870"'
+        $reordered = Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-901"' '"artifact":"temporary-ordering-artifact"'
+        $reordered = Replace-Once $reordered '"artifact":"issue-871"' '"artifact":"issue-901"'
         $reordered = Replace-Once $reordered '"artifact":"temporary-ordering-artifact"' '"artifact":"issue-871"'
         Write-TestText $packet.Canonical $reordered
-        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-870'"
+        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-901'"
+    }
+
+    Invoke-Case 'rejects closed issue-870 as a replacement packet member' {
+        $packet = New-Packet 'closed-issue-870-member'
+        Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-901"' '"artifact":"issue-870"')
+        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-901'"
+    }
+
+    Invoke-Case 'requires the declared non-lifecycle exclusion for issue-897' {
+        $packet = New-Packet 'issue-897-non-lifecycle-exclusion'
+        Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) 'checker exports lifecycle consumers only.' 'changed reason.')
+        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "stale reason for excluded artifact 'issue-897'"
     }
     }
 
@@ -246,7 +258,7 @@ try {
             Write-TestText $path $block
         }
         $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
-        Assert-True ($result.Count -eq 9) 'empty surrounding content is ignored'
+        Assert-True ($result.Count -eq 12) 'empty surrounding content is ignored'
     }
 
     }
@@ -285,7 +297,7 @@ try {
         Assert-True ($LASTEXITCODE -eq 0) 'second generator invocation succeeds'
         Assert-True ([Convert]::ToHexString([IO.File]::ReadAllBytes($first)) -ceq [Convert]::ToHexString([IO.File]::ReadAllBytes($second))) 'stdout generation is byte-identical'
         $checked = @(& $checkCommand -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
-        Assert-True ($checked.Count -eq 9) 'thin checker returns the nine scoped results'
+        Assert-True ($checked.Count -eq 12) 'thin checker returns the twelve scoped results'
     }
     }
 }


### PR DESCRIPTION
# Summary

Correct the Working Directory Update planning and exact-projection packet after #870 and PR #895 were superseded.

This change replaces the oversized hash tracer with the serial #898 → #899 → #900 → #901 implementation sequence,
assigns every former #870 lifecycle/requirement item once, and gives future workers the collision, lease, retry, durable
truth, and direct-runtime proof boundaries that were missing from the original issue.

Tracks #897.

## Why this matters

Grace users need hash-selected switching to preserve ignored and untracked content, avoid remote work inside local
serialization, and recover truthfully from partial completion. Correcting the packet before more runtime work prevents
another broad implementation from rediscovering those boundaries in review.

## Quality contract

- Product V1.
- No user-visible behavior changes in this PR.
- No runtime, Branch, filesystem, SQLite, public command, durable-state, or migration changes.
- Closed #870 remains historical evidence only.

## Changed paths

- `docs/Working Directory Update.md`
- `docs/adr/0011-working-directory-update-transaction.md`
- `scripts/modules/WduLifecycleProjection.psm1`
- `scripts/tests/WduLifecycleProjection.Tests.ps1`

## Contract and projection changes

- Replaces active #870 delivery with #898–#901.
- Assigns REQ-001/REQ-007/REQ-008 to #899, REQ-006 to #898, and REQ-013 to #900.
- Adds the finite target-path collision matrix and three-lease inventory/order.
- Defines the conditional first retry write and cancellation cutoff for DirectoryVersion recovery.
- Keeps SQLite completion decisive over marker and sidecar evidence.
- Requires direct production-runtime proof before production Branch wiring.
- Defines a closed 12-member lifecycle-consumer packet; #897 is checked separately as the packet-correction record.

## Validation

- `WduLifecycleContract.Tests.ps1`: 46/46 passed.
- Required projection membership: 4/4 passed; remaining focused projection groups completed without failure.
- 12/12 rendered lifecycle consumers returned `ExactMatch`.
- Two independent `issue-901` renders were byte-identical.
- PowerShell parse passed.
- MarkdownLint passed on 15 repository/prepared Markdown files.
- Local links, introduced-term scan, and `git diff --check` passed.

## Prepared tracker packet

The worker prepared 13 publication artifacts outside the repository at
`C:\Users\scott\AppData\Local\Temp\grace-897-supersession-packet`. The orchestrator will publish them only after this
head passes fresh review and GitHub Validate, then export and verify the complete live packet before #898 becomes ready.

## Review status

- Implementation/fix workers: 2 of 5.
- Review sessions: 2; session 2 approved the unchanged repository head plus the corrected offline packet.
- Substantive review cycles: 0.
- Session 1 found one P2 offline-publication defect: two epic statements used the obsolete `#869–#872` shorthand.
- Fix worker 2 corrected the packet generator and rerendered only those two epic lines with the explicit
  `#869 → #897 → #898 → #899 → #900 → #901 → #871 → #872 → #842` chain. No repository byte or PR head changed.
- Corrected packet: `C:\Users\scott\AppData\Local\Temp\grace-897-supersession-packet-fix2`.
- Corrected bodies were published to #835, #842, #843, #846, #869, #871, #872, and #897–#901.
- Fresh live export: 12/12 full issue bodies match the prepared packet, 12/12 lifecycle consumers return `ExactMatch`,
  and MarkdownLint passes on all 12 live issue bodies.
- Residual coordination: merge and normal cleanup remain.
