### PR TITLE
[Superseded] B4.3R2: Close billing periods with immutable initial charges

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -29,8 +29,8 @@
     <Compile Include="Migrations\20260709110000_AddPricingPlanRateAssignment.fs" />
     <Compile Include="Migrations\20260711090000_AddChargePreviewLines.fs" />
     <Compile Include="Migrations\20260812090000_AddBillingCompletenessCoordination.fs" />
-    <Compile Include="Migrations\20260812130000_AddBillingPeriodClose.fs" />
     <Compile Include="Migrations\20260812110000_AddUsageFactJournal.fs" />
+    <Compile Include="Migrations\20260812130000_AddBillingPeriodClose.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
     <Compile Include="OperationsBillingPeriod.fs" />

--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="OperationsUsagePartitioningSql.fs" />
     <Compile Include="OperationsEntities.fs" />
     <Compile Include="OperationsChargePreview.fs" />
+    <Compile Include="OperationsBillingPeriodModel.fs" />
     <Compile Include="OperationsDbContext.fs" />
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
     <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
@@ -28,9 +29,11 @@
     <Compile Include="Migrations\20260709110000_AddPricingPlanRateAssignment.fs" />
     <Compile Include="Migrations\20260711090000_AddChargePreviewLines.fs" />
     <Compile Include="Migrations\20260812090000_AddBillingCompletenessCoordination.fs" />
+    <Compile Include="Migrations\20260812130000_AddBillingPeriodClose.fs" />
     <Compile Include="Migrations\20260812110000_AddUsageFactJournal.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
+    <Compile Include="OperationsBillingPeriod.fs" />
     <Compile Include="OperationsUsageJournal.fs" />
   </ItemGroup>
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
@@ -1,0 +1,464 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
+
+/// Holds the literal billing-close model fragment shared only by frozen migration representations.
+[<RequireQualifiedAccess>]
+module BillingPeriodFrozenModel =
+
+    /// Applies the immutable literal model fragment without reading runtime SQL or model helpers.
+    let apply (modelBuilder: Microsoft.EntityFrameworkCore.ModelBuilder) =
+        let period = modelBuilder.Entity<BillingPeriodEntity>()
+
+        period.ToTable(
+            "BillingPeriod",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_MonthRange",
+                    "[MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriod_State", "[State] IN (0, 1, 2)")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_Diagnostic",
+                    "([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        period
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriod")
+        |> ignore
+
+        period
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            period
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "MonthStartUtc"
+                "NextMonthStartUtc"
+                "CreatedAtUtc"
+                "UpdatedAtUtc"
+            ] do
+            period
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        period.Property<int>("State").IsRequired()
+        |> ignore
+
+        period
+            .Property<string>("RetryDiagnostic")
+            .HasMaxLength(400)
+        |> ignore
+
+        period
+            .Property<Nullable<DateTime>>("RetryDiagnosticAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        period
+            .Property<DateTime>("CreatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+        |> ignore
+
+        period
+            .Property<DateTime>("UpdatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "NextMonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_BillingPeriod_ExactScope")
+            .IsUnique()
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "State"
+                    "MonthStartUtc"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillingPeriod_NonterminalDiscovery")
+        |> ignore
+
+        let charge = modelBuilder.Entity<ChargeEntity>()
+
+        charge.ToTable(
+            "Charge",
+            "ops",
+            fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        charge
+            .HasKey([| "ChargeId" |])
+            .HasName("PK_ops_Charge")
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargeId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        charge
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<int64>("ChargeMicros")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .HasIndex(
+                [|
+                    "BillingPeriodId"
+                    "ChargePreviewLineId"
+                |]
+            )
+            .HasDatabaseName("UX_ops_Charge_InitialPosting")
+            .IsUnique()
+        |> ignore
+
+        charge
+            .HasIndex([| "ChargePreviewLineId" |])
+            .HasDatabaseName("IX_ops_Charge_ChargePreviewLine")
+        |> ignore
+
+        charge
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_Charge_BillingPeriod")
+            .OnDelete(Microsoft.EntityFrameworkCore.DeleteBehavior.Restrict)
+        |> ignore
+
+        charge
+            .HasOne<ChargePreviewLineEntity>()
+            .WithMany()
+            .HasForeignKey("ChargePreviewLineId")
+            .HasConstraintName("FK_ops_Charge_ChargePreviewLine")
+            .OnDelete(Microsoft.EntityFrameworkCore.DeleteBehavior.Restrict)
+        |> ignore
+
+        let evidence = modelBuilder.Entity<BillingPeriodCloseEvidenceEntity>()
+
+        evidence.ToTable(
+            "BillingPeriodCloseEvidence",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodCloseEvidenceEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodCloseEvidence_Digests",
+                    "LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodCloseEvidence_Provenance", "LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0")
+                |> ignore
+        )
+        |> ignore
+
+        evidence
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriodCloseEvidence")
+        |> ignore
+
+        evidence
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        evidence
+            .Property<string>("AcceptedFactDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("PricingPreviewDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<DateTime>("ClosedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("ScheduledOperationProvenance")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodCloseEvidence_BillingPeriod")
+            .OnDelete(Microsoft.EntityFrameworkCore.DeleteBehavior.Restrict)
+        |> ignore
+
+        let lateWork = modelBuilder.Entity<BillingPeriodLateWorkEntity>()
+
+        lateWork.ToTable("BillingPeriodLateWork", "ops")
+        |> ignore
+
+        lateWork
+            .HasKey([| "BillingPeriodId"; "UsageFactId" |])
+            .HasName("PK_ops_BillingPeriodLateWork")
+        |> ignore
+
+        lateWork
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .HasIndex([| "UsageFactId" |])
+            .HasDatabaseName("IX_ops_BillingPeriodLateWork_UsageFact")
+        |> ignore
+
+        lateWork
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_BillingPeriod")
+            .OnDelete(Microsoft.EntityFrameworkCore.DeleteBehavior.Restrict)
+        |> ignore
+
+        lateWork
+            .HasOne<RawUsageFactEntity>()
+            .WithMany()
+            .HasForeignKey("UsageFactId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_RawUsageFact")
+            .OnDelete(Microsoft.EntityFrameworkCore.DeleteBehavior.Restrict)
+        |> ignore
+
+/// Adds exact-scope billing periods, immutable initial postings, close evidence, and the minimal late-work handoff.
+[<DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260812130000_AddBillingPeriodClose")>]
+type AddBillingPeriodClose() =
+    inherit Migration()
+
+    /// Creates the durable close contract without calculating pricing or charges in SQL.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+CREATE TABLE ops.BillingPeriod
+(
+    BillingPeriodId uniqueidentifier NOT NULL,
+    OwnerId uniqueidentifier NOT NULL,
+    OrganizationId uniqueidentifier NOT NULL,
+    RepositoryId uniqueidentifier NOT NULL,
+    MonthStartUtc datetime2(7) NOT NULL,
+    NextMonthStartUtc datetime2(7) NOT NULL,
+    State int NOT NULL,
+    RetryDiagnostic nvarchar(400) NULL,
+    RetryDiagnosticAtUtc datetime2(7) NULL,
+    CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriod_CreatedAtUtc DEFAULT (SYSUTCDATETIME()),
+    UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriod_UpdatedAtUtc DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT PK_ops_BillingPeriod PRIMARY KEY (BillingPeriodId),
+    CONSTRAINT CK_ops_BillingPeriod_MonthRange CHECK
+    (
+        [MonthStartUtc] < [NextMonthStartUtc]
+        AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7)
+        AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])
+    ),
+    CONSTRAINT CK_ops_BillingPeriod_State CHECK ([State] IN (0, 1, 2)),
+    CONSTRAINT CK_ops_BillingPeriod_Diagnostic CHECK
+    (
+        ([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL)
+        OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX UX_ops_BillingPeriod_ExactScope
+    ON ops.BillingPeriod(OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc);
+CREATE INDEX IX_ops_BillingPeriod_NonterminalDiscovery
+    ON ops.BillingPeriod(State, MonthStartUtc, OwnerId, OrganizationId, RepositoryId);
+
+CREATE TABLE ops.Charge
+(
+    ChargeId uniqueidentifier NOT NULL,
+    BillingPeriodId uniqueidentifier NOT NULL,
+    ChargePreviewLineId uniqueidentifier NOT NULL,
+    CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL,
+    ChargeMicros bigint NOT NULL,
+    CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_Charge_CreatedAtUtc DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT PK_ops_Charge PRIMARY KEY (ChargeId),
+    CONSTRAINT FK_ops_Charge_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId),
+    CONSTRAINT FK_ops_Charge_ChargePreviewLine FOREIGN KEY (ChargePreviewLineId) REFERENCES ops.ChargePreviewLine(ChargePreviewLineId),
+    CONSTRAINT CK_ops_Charge_Amount CHECK ([ChargeMicros] >= 0),
+    CONSTRAINT CK_ops_Charge_Currency CHECK (LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%')
+);
+CREATE UNIQUE INDEX UX_ops_Charge_InitialPosting ON ops.Charge(BillingPeriodId, ChargePreviewLineId);
+CREATE INDEX IX_ops_Charge_ChargePreviewLine ON ops.Charge(ChargePreviewLineId);
+
+CREATE TABLE ops.BillingPeriodCloseEvidence
+(
+    BillingPeriodId uniqueidentifier NOT NULL,
+    AcceptedFactDigestSha256Hex char(64) NOT NULL,
+    PricingPreviewDigestSha256Hex char(64) NOT NULL,
+    ClosedAtUtc datetime2(7) NOT NULL,
+    ScheduledOperationProvenance nvarchar(200) NOT NULL,
+    CONSTRAINT PK_ops_BillingPeriodCloseEvidence PRIMARY KEY (BillingPeriodId),
+    CONSTRAINT FK_ops_BillingPeriodCloseEvidence_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId),
+    CONSTRAINT CK_ops_BillingPeriodCloseEvidence_Digests CHECK
+    (
+        LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'
+        AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'
+    ),
+    CONSTRAINT CK_ops_BillingPeriodCloseEvidence_Provenance CHECK (LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0)
+);
+
+CREATE TABLE ops.BillingPeriodLateWork
+(
+    BillingPeriodId uniqueidentifier NOT NULL,
+    UsageFactId uniqueidentifier NOT NULL,
+    CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriodLateWork_CreatedAtUtc DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT PK_ops_BillingPeriodLateWork PRIMARY KEY (BillingPeriodId, UsageFactId),
+    CONSTRAINT FK_ops_BillingPeriodLateWork_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId),
+    CONSTRAINT FK_ops_BillingPeriodLateWork_RawUsageFact FOREIGN KEY (UsageFactId) REFERENCES ops.RawUsageFact(UsageFactId)
+);
+CREATE INDEX IX_ops_BillingPeriodLateWork_UsageFact ON ops.BillingPeriodLateWork(UsageFactId);
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+CREATE TRIGGER ops.TR_ops_Charge_Immutable ON ops.Charge AFTER UPDATE, DELETE AS
+BEGIN
+    THROW 57231, 'Initial charge postings are append-only.', 1;
+END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+CREATE TRIGGER ops.TR_ops_BillingPeriodCloseEvidence_Immutable ON ops.BillingPeriodCloseEvidence AFTER UPDATE, DELETE AS
+BEGIN
+    THROW 57232, 'Billing-period close evidence is immutable.', 1;
+END;
+"""
+        )
+        |> ignore
+
+    /// Removes only the close structures introduced by this migration.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+DROP TRIGGER IF EXISTS ops.TR_ops_BillingPeriodCloseEvidence_Immutable;
+DROP TRIGGER IF EXISTS ops.TR_ops_Charge_Immutable;
+DROP TABLE ops.BillingPeriodLateWork;
+DROP TABLE ops.BillingPeriodCloseEvidence;
+DROP TABLE ops.Charge;
+DROP TABLE ops.BillingPeriod;
+"""
+        )
+        |> ignore
+
+    /// Captures the literal owned billing-close model used to validate this migration independently of runtime helpers.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        BillingPeriodFrozenModel.apply modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
@@ -459,6 +459,923 @@ DROP TABLE ops.BillingPeriod;
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
+        // Deliberately keep this snapshot frozen with literals so future runtime model edits
+        // cannot change the latest reviewed migration point before a new migration updates it.
         modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("ArchiveState").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveBlobName")
+            .HasMaxLength(512)
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveChecksumSha256Hex")
+            .HasMaxLength(64)
+            .IsFixedLength()
+            .IsUnicode(false)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<int64>>("ArchiveByteLength")
+            .HasColumnType("bigint")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchivedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("RehydrationExpiresAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<string>("LastArchiveFailureReason")
+            .HasMaxLength(400)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("LastArchiveFailureAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<int>("ArchiveFailureCount")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveRetiredAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "ArchiveState"
+                    "ObservedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ArchiveStateObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex([| "RehydrationExpiresAtUtc" |])
+            .HasDatabaseName("IX_ops_RawUsageFact_RehydrationExpiresAtUtc")
+            .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
+        |> ignore
+
+        let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()
+
+        rejection.ToTable(
+            "UsageFactRejection",
+            "ops",
+            fun (table: TableBuilder<UsageFactRejectionEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_SuppliedGuids",
+                    "[RejectionId] <> '00000000-0000-0000-0000-000000000000' AND ([UsageFactId] IS NULL OR [UsageFactId] <> '00000000-0000-0000-0000-000000000000') AND ([OwnerId] IS NULL OR [OwnerId] <> '00000000-0000-0000-0000-000000000000') AND ([OrganizationId] IS NULL OR [OrganizationId] <> '00000000-0000-0000-0000-000000000000') AND ([RepositoryId] IS NULL OR [RepositoryId] <> '00000000-0000-0000-0000-000000000000')"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_CompleteScopeRequiresFact",
+                    "NOT ([OwnerId] IS NOT NULL AND [OrganizationId] IS NOT NULL AND [RepositoryId] IS NOT NULL AND [MonthStartUtc] IS NOT NULL) OR ([UsageFactId] IS NOT NULL AND [UsageFactId] <> '00000000-0000-0000-0000-000000000000')"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_MonthStartUtc",
+                    "[MonthStartUtc] IS NULL OR [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7)"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_Resolution",
+                    "([IsActive] = 1 AND [ResolvedAtUtc] IS NULL) OR ([IsActive] = 0 AND [ResolvedAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_UsageFactRejection_Reason", "LEN(LTRIM(RTRIM([Reason]))) > 0")
+                |> ignore
+        )
+        |> ignore
+
+        rejection
+            .HasKey([| "RejectionId" |])
+            .HasName("PK_ops_UsageFactRejection")
+        |> ignore
+
+        rejection
+            .Property<Guid>("RejectionId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "UsageFactId"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            rejection
+                .Property<Nullable<Guid>>(name)
+                .HasColumnType("uniqueidentifier")
+            |> ignore
+
+        rejection
+            .Property<Nullable<DateTime>>("MonthStartUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rejection
+            .Property<string>("Reason")
+            .HasMaxLength(400)
+            .IsRequired()
+        |> ignore
+
+        rejection.Property<bool>("IsActive").IsRequired()
+        |> ignore
+
+        rejection
+            .Property<Nullable<DateTime>>("ResolvedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rejection
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rejection
+            .HasIndex(
+                [|
+                    "UsageFactId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_UsageFactRejection_ActiveScopedFact")
+            .IsUnique()
+            .HasFilter(
+                "[IsActive] = 1 AND [UsageFactId] IS NOT NULL AND [OwnerId] IS NOT NULL AND [OrganizationId] IS NOT NULL AND [RepositoryId] IS NOT NULL AND [MonthStartUtc] IS NOT NULL"
+            )
+        |> ignore
+
+        rejection
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "IsActive"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactRejection_ActiveScope")
+        |> ignore
+
+        let journal = modelBuilder.Entity<UsageFactJournalEntity>()
+
+        journal.ToTable(
+            "UsageFactJournal",
+            "ops",
+            fun (table: TableBuilder<UsageFactJournalEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_Identity",
+                    "[UsageFactId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([CorrelationId]))) > 0 AND LEN(LTRIM(RTRIM([StoragePoolId]))) > 0 AND DATALENGTH([RawPayload]) > 0"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_State",
+                    "([State] = 0 AND [TerminalAtUtc] IS NULL) OR ([State] IN (1, 2) AND [TerminalAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        journal
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_UsageFactJournal")
+        |> ignore
+
+        journal
+            .Property<Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        journal
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+            .IsRequired()
+        |> ignore
+
+        journal
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            journal
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        journal
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        journal
+            .Property<DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int>("State").IsRequired()
+        |> ignore
+
+        journal
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        journal
+            .Property<Nullable<DateTime>>("TerminalAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        journal
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "ObservedAtUtc"
+                    "State"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactJournal_ScopeState")
+        |> ignore
+
+        journal
+            .HasIndex(
+                [|
+                    "State"
+                    "CreatedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactJournal_PendingDispatch")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable("UsageAggregateMinute", "ops")
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore
+
+        let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
+
+        pricingPlan.ToTable("PricingPlan", "ops")
+        |> ignore
+
+        pricingPlan
+            .HasKey([| "PricingPlanId" |])
+            .HasName("PK_ops_PricingPlan")
+        |> ignore
+
+        pricingPlan
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("PlanCode")
+            .HasMaxLength(128)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .HasIndex([| "PlanCode"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_PricingPlan_CodeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
+
+        mapping.ToTable("BillableUsageKindMapping", "ops")
+        |> ignore
+
+        mapping
+            .HasKey([| "BillableUsageKindMappingId" |])
+            .HasName("PK_ops_BillableUsageKindMapping")
+        |> ignore
+
+        mapping
+            .Property<System.Guid>("BillableUsageKindMappingId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        mapping.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        mapping
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .HasIndex([| "FactKind"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        mapping
+            .HasIndex(
+                [|
+                    "FactKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillableUsageKindMapping_FactKindEffective")
+        |> ignore
+
+        let pricingRate = modelBuilder.Entity<PricingRateEntity>()
+
+        pricingRate.ToTable("PricingRate", "ops")
+        |> ignore
+
+        pricingRate
+            .HasKey([| "PricingRateId" |])
+            .HasName("PK_ops_PricingRate")
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingRateId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitQuantity")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitPriceMicros")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingRate_PlanUsageKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingRate_PlanUsageKindEffective")
+        |> ignore
+
+        pricingRate
+            .HasOne(fun rate -> rate.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingRate_PricingPlan")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
+
+        assignment.ToTable("PricingAssignment", "ops")
+        |> ignore
+
+        assignment
+            .HasKey([| "PricingAssignmentId" |])
+            .HasName("PK_ops_PricingAssignment")
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingAssignmentId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex([| "PricingPlanId" |])
+            .HasDatabaseName("IX_PricingAssignment_PricingPlanId")
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingAssignment_ScopeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingAssignment_ScopeEffective")
+        |> ignore
+
+        assignment
+            .HasOne(fun assignment -> assignment.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingAssignment_PricingPlan")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let line = modelBuilder.Entity<ChargePreviewLineEntity>()
+
+        line.ToTable(
+            "ChargePreviewLine",
+            "ops",
+            fun (table: TableBuilder<ChargePreviewLineEntity>) ->
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_PeriodRange", "[PeriodFromUtc] < [PeriodToUtc]")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_EffectiveRange",
+                    "[PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc]"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_UnitQuantity", "[UnitQuantity] > 0")
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_Amounts", "[UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0 AND [ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        line
+            .HasKey([| "ChargePreviewLineId" |])
+            .HasName("PK_ops_ChargePreviewLine")
+        |> ignore
+
+        line
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillableUsageKindMappingId"
+                "PricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            line
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            line
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        line.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        line
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            line.Property<int64>(name).IsRequired() |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_ChargePreviewLine_Scope")
+        |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                    "FactKind"
+                    "BillableUsageKindMappingId"
+                    "BillableUsageKind"
+                    "PricingAssignmentId"
+                    "PricingPlanId"
+                    "PricingRateId"
+                    "CurrencyCode"
+                    "UnitName"
+                    "UnitQuantity"
+                    "UnitPriceMicros"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
+            .IsUnique()
+        |> ignore
 
         BillingPeriodFrozenModel.apply modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -934,3 +934,5 @@ type OperationsDbContextModelSnapshot() =
             .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
             .IsUnique()
         |> ignore
+
+        BillingPeriodFrozenModel.apply modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -1,0 +1,597 @@
+namespace Grace.Operations.Data
+
+open Microsoft.Data.SqlClient
+open NodaTime
+open System
+open System.Data
+open System.Globalization
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+/// Names the nonterminal and terminal billing-period states owned by the initial-close contract.
+[<RequireQualifiedAccess>]
+type BillingPeriodState =
+    | Open = 0
+    | Provisional = 1
+    | Closed = 2
+
+/// Carries a close request whose provenance identifies the bounded scheduled operation that initiated it.
+type BillingPeriodCloseRequest = { Scope: BillingCompletenessScope; ScheduledOperationProvenance: string }
+
+/// Reports whether a period is below threshold, visibly blocked, provisionally rebuilt, or closed.
+type BillingPeriodCloseResult =
+    | NotEligible
+    | Blocked of diagnostic: string
+    | Provisional of billingPeriodId: Guid * previewLineCount: int
+    | Closed of billingPeriodId: Guid * chargeCount: int
+
+/// Exposes the bounded preview and final-close operations used by the scheduled shell.
+type IBillingPeriodCloser =
+    /// Rebuilds an eligible preview under the exact shared scope lock.
+    abstract PreviewAsync: request: BillingPeriodCloseRequest * cancellationToken: CancellationToken -> Task<BillingPeriodCloseResult>
+
+    /// Rebuilds and posts an eligible final close under the exact shared scope lock.
+    abstract CloseAsync: request: BillingPeriodCloseRequest * cancellationToken: CancellationToken -> Task<BillingPeriodCloseResult>
+
+/// Exposes test-only failure points within the one transaction that owns a billing-period close.
+type internal IBillingPeriodCloseTransactionInterleaving =
+    /// Runs after the current preview rows have been replaced but before any immutable posting is appended.
+    abstract AfterPreviewReplacementAsync: cancellationToken: CancellationToken -> Task
+
+    /// Runs after the initial charge set has been appended but before close evidence is written.
+    abstract AfterLedgerInsertionAsync: cancellationToken: CancellationToken -> Task
+
+    /// Runs after close evidence has been staged but before the period becomes Closed.
+    abstract AfterCloseEvidenceStagedAsync: cancellationToken: CancellationToken -> Task
+
+/// Provides production close execution with no injected work between transactional stages.
+type private NoBillingPeriodCloseTransactionInterleaving() =
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
+        member _.AfterLedgerInsertionAsync _ = Task.CompletedTask
+        member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+
+/// Rebuilds previews and immutable initial postings under the same SQL lock used by accepted fact processing.
+type SqlBillingPeriodCloser private (connectionString: string, transactionInterleaving: IBillingPeriodCloseTransactionInterleaving) =
+
+    /// Derives the deterministic period identity from every exact scope boundary without insertion-order dependence.
+    let billingPeriodId (scope: BillingCompletenessScope) =
+        let canonical =
+            String.Join(
+                "|",
+                [|
+                    "Grace.Operations.BillingPeriod.v1"
+                    scope.OwnerId.ToString("D")
+                    scope.OrganizationId.ToString("D")
+                    scope.RepositoryId.ToString("D")
+                    scope
+                        .MonthStart
+                        .ToDateTimeUtc()
+                        .Ticks.ToString(CultureInfo.InvariantCulture)
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+                        .Ticks.ToString(CultureInfo.InvariantCulture)
+                |]
+            )
+
+        let hash = SHA256.HashData(Encoding.UTF8.GetBytes canonical)
+        Guid(hash[0..15])
+
+    /// Derives an immutable posting identity from the period and already deterministic preview-line identity.
+    let chargeId periodId previewLineId =
+        let canonical = $"Grace.Operations.InitialCharge.v1|{periodId:D}|{previewLineId:D}"
+        let hash = SHA256.HashData(Encoding.UTF8.GetBytes canonical)
+        Guid(hash[0..15])
+
+    /// Converts a persisted UTC value into the exact NodaTime instant expected by Operations scope validation.
+    let toInstant (value: DateTime) =
+        let utc =
+            if value.Kind = DateTimeKind.Utc then
+                value
+            else
+                DateTime.SpecifyKind(value, DateTimeKind.Utc)
+
+        Instant.FromDateTimeUtc utc
+
+    /// Adds the exact scope and half-open month parameters to a SQL command.
+    let addScope (command: SqlCommand) (scope: BillingCompletenessScope) =
+        command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+        command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+        command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+        command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+        command.Parameters.Add("@NextMonthStartUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+            .ToDateTimeUtc()
+
+    /// Creates a command bound to the close transaction so every mutation shares its lock lifetime.
+    let command (connection: SqlConnection) (transaction: SqlTransaction) text =
+        let value = connection.CreateCommand()
+        value.Transaction <- transaction
+        value.CommandText <- text
+        value
+
+    /// Acquires the coordination primitive used by journal acceptance before examining committed completeness.
+    let acquireScopeLockAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use lockCommand = command connection transaction OperationsUsageSql.AcquireBillingCompletenessScopeLock
+            lockCommand.Parameters.Add("@BillingCompletenessLockResource", SqlDbType.NVarChar, 255).Value <- BillingCompletenessScope.databaseLockIdentity scope
+            lockCommand.Parameters.Add("@BillingCompletenessLockTimeoutMilliseconds", SqlDbType.Int).Value <- 60000
+            let! _ = lockCommand.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Reads database UTC inside the mutation transaction so callers cannot decide persisted eligibility.
+    let databaseUtcNowAsync (connection: SqlConnection) (transaction: SqlTransaction) (cancellationToken: CancellationToken) =
+        task {
+            use nowCommand = command connection transaction "SELECT SYSUTCDATETIME();"
+            let! value = nowCommand.ExecuteScalarAsync cancellationToken
+            return value :?> DateTime
+        }
+
+    /// Inserts the deterministic period if discovery has not already materialized it, then locks its row for this close.
+    let ensurePeriodAsync (connection: SqlConnection) (transaction: SqlTransaction) (scope: BillingCompletenessScope) (cancellationToken: CancellationToken) =
+        task {
+            let periodId = billingPeriodId scope
+
+            use insert =
+                command
+                    connection
+                    transaction
+                    """
+INSERT INTO ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State)
+SELECT @BillingPeriodId,@OwnerId,@OrganizationId,@RepositoryId,@MonthStartUtc,@NextMonthStartUtc,0
+WHERE NOT EXISTS
+(
+    SELECT 1 FROM ops.BillingPeriod WITH (UPDLOCK,HOLDLOCK)
+    WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId
+      AND MonthStartUtc=@MonthStartUtc AND NextMonthStartUtc=@NextMonthStartUtc
+);
+"""
+
+            addScope insert scope
+            insert.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            let! _ = insert.ExecuteNonQueryAsync cancellationToken
+
+            use select =
+                command
+                    connection
+                    transaction
+                    """
+SELECT BillingPeriodId, State FROM ops.BillingPeriod WITH (UPDLOCK,HOLDLOCK)
+WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId
+  AND MonthStartUtc=@MonthStartUtc AND NextMonthStartUtc=@NextMonthStartUtc;
+"""
+
+            addScope select scope
+            use! reader = select.ExecuteReaderAsync cancellationToken
+            let! exists = reader.ReadAsync cancellationToken
+
+            if not exists then
+                invalidOp "The exact billing period could not be materialized under its scope lock."
+
+            return (reader.GetGuid 0, enum<BillingPeriodState> (reader.GetInt32 1))
+        }
+
+    /// Returns a bounded completeness reason directly from committed rows while the shared lock prevents a race.
+    let completenessDiagnosticAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use check =
+                command
+                    connection
+                    transaction
+                    """
+IF EXISTS
+(
+    SELECT 1 FROM ops.UsageFactJournal
+    WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId
+      AND ObservedAtUtc >= @MonthStartUtc AND ObservedAtUtc < @NextMonthStartUtc AND State IN (0,2)
+)
+    SELECT CAST('Unresolved UsageFact journal rows block billing close.' AS nvarchar(400));
+ELSE IF EXISTS
+(
+    SELECT 1 FROM ops.UsageFactRejection
+    WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId
+      AND MonthStartUtc=@MonthStartUtc AND IsActive=1
+)
+    SELECT CAST('Active scoped usage rejection blocks billing close.' AS nvarchar(400));
+ELSE
+    SELECT CAST(NULL AS nvarchar(400));
+"""
+
+            addScope check scope
+            let! result = check.ExecuteScalarAsync cancellationToken
+            return if Convert.IsDBNull result then None else Some(result :?> string)
+        }
+
+    /// Writes or clears the bounded retry diagnostic without changing a nonterminal period to a failure state.
+    let setDiagnosticAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (periodId: Guid)
+        (diagnostic: string option)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use update =
+                command
+                    connection
+                    transaction
+                    """
+UPDATE ops.BillingPeriod
+SET RetryDiagnostic=@Diagnostic,
+    RetryDiagnosticAtUtc=CASE WHEN @Diagnostic IS NULL THEN NULL ELSE SYSUTCDATETIME() END,
+    UpdatedAtUtc=SYSUTCDATETIME()
+WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);
+"""
+
+            update.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            let parameter = update.Parameters.Add("@Diagnostic", SqlDbType.NVarChar, 400)
+
+            parameter.Value <-
+                match diagnostic with
+                | Some value -> box value
+                | None -> DBNull.Value
+
+            let! _ = update.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Reads all source facts with their independently effective pricing prerequisites using the shared preview query.
+    let readPricedFactsAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read = command connection transaction OperationsChargePreviewSql.SelectSourceAndPricing
+            read.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            read.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            read.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            read.Parameters.Add("@PeriodFromUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            read.Parameters.Add("@PeriodToUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+            use! reader = read.ExecuteReaderAsync cancellationToken
+            let rows = ResizeArray<ChargePreviewPricedFact>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+                reading <- hasRow
+
+                if hasRow then
+                    let usageFactId = reader.GetGuid 0
+
+                    match
+                        ChargePreviewCalculation.missingPrerequisite
+                            (not (reader.IsDBNull 4))
+                            (not (reader.IsDBNull 6))
+                            (not (reader.IsDBNull 7))
+                            (not (reader.IsDBNull 9))
+                        with
+                    | Some prerequisite ->
+                        let previewScope: ChargePreviewScope =
+                            {
+                                OwnerId = scope.OwnerId
+                                OrganizationId = scope.OrganizationId
+                                RepositoryId = scope.RepositoryId
+                                PeriodFromUtc = scope.MonthStart.ToDateTimeUtc()
+                                PeriodToUtc =
+                                    (BillingCompletenessScope.nextMonthStart scope)
+                                        .ToDateTimeUtc()
+                            }
+
+                        raise (ChargePreviewRebuildException(previewScope, usageFactId, prerequisite))
+                    | None ->
+                        let pricedFact: ChargePreviewPricedFact =
+                            {
+                                UsageFactId = usageFactId
+                                FactKind = reader.GetInt32 1
+                                Quantity = reader.GetInt64 2
+                                ObservedAtUtc = reader.GetDateTime 3
+                                PricingAssignmentId = reader.GetGuid 4
+                                PricingPlanId = reader.GetGuid 6
+                                BillableUsageKindMappingId = reader.GetGuid 7
+                                BillableUsageKind = reader.GetInt32 8
+                                PricingRateId = reader.GetGuid 9
+                                CurrencyCode = reader.GetString 10
+                                UnitName = reader.GetString 11
+                                UnitQuantity = reader.GetInt64 12
+                                UnitPriceMicros = reader.GetInt64 13
+                                EffectiveFromUtc = reader.GetDateTime 14
+                                EffectiveToUtc = reader.GetDateTime 15
+                            }
+
+                        rows.Add pricedFact
+
+            return rows |> Seq.toList
+        }
+
+    /// Replaces only the current period preview after successful calculation has produced every replacement line.
+    let replacePreviewAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (lines: ChargePreviewLineEntity array)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use delete = command connection transaction OperationsChargePreviewSql.DeleteScope
+            delete.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            delete.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            delete.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            delete.Parameters.Add("@PeriodFromUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            delete.Parameters.Add("@PeriodToUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+            let! _ = delete.ExecuteNonQueryAsync cancellationToken
+            let mutable index = 0
+
+            while index < lines.Length do
+                let line = lines[index]
+
+                use insert =
+                    command
+                        connection
+                        transaction
+                        "INSERT INTO ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@Id,@OwnerId,@OrganizationId,@RepositoryId,@PeriodFromUtc,@PeriodToUtc,@FactKind,@MappingId,@BillableKind,@AssignmentId,@PlanId,@RateId,@Currency,@UnitName,@UnitQuantity,@UnitPrice,@EffectiveFrom,@EffectiveTo,@TotalQuantity,@Charge);"
+
+                let add name dbType value = insert.Parameters.Add(name, dbType).Value <- value
+                add "@Id" SqlDbType.UniqueIdentifier line.ChargePreviewLineId
+                add "@OwnerId" SqlDbType.UniqueIdentifier line.OwnerId
+                add "@OrganizationId" SqlDbType.UniqueIdentifier line.OrganizationId
+                add "@RepositoryId" SqlDbType.UniqueIdentifier line.RepositoryId
+                add "@PeriodFromUtc" SqlDbType.DateTime2 line.PeriodFromUtc
+                add "@PeriodToUtc" SqlDbType.DateTime2 line.PeriodToUtc
+                add "@FactKind" SqlDbType.Int line.FactKind
+                add "@MappingId" SqlDbType.UniqueIdentifier line.BillableUsageKindMappingId
+                add "@BillableKind" SqlDbType.Int line.BillableUsageKind
+                add "@AssignmentId" SqlDbType.UniqueIdentifier line.PricingAssignmentId
+                add "@PlanId" SqlDbType.UniqueIdentifier line.PricingPlanId
+                add "@RateId" SqlDbType.UniqueIdentifier line.PricingRateId
+                insert.Parameters.Add("@Currency", SqlDbType.VarChar, 3).Value <- line.CurrencyCode
+                insert.Parameters.Add("@UnitName", SqlDbType.NVarChar, OperationsPricingSql.UnitNameMaxLength).Value <- line.UnitName
+                add "@UnitQuantity" SqlDbType.BigInt line.UnitQuantity
+                add "@UnitPrice" SqlDbType.BigInt line.UnitPriceMicros
+                add "@EffectiveFrom" SqlDbType.DateTime2 line.EffectiveFromUtc
+                add "@EffectiveTo" SqlDbType.DateTime2 line.EffectiveToUtc
+                add "@TotalQuantity" SqlDbType.BigInt line.TotalQuantity
+                add "@Charge" SqlDbType.BigInt line.ChargeMicros
+                let! _ = insert.ExecuteNonQueryAsync cancellationToken
+                index <- index + 1
+
+            return ()
+        }
+
+    /// Hashes canonical fact or preview-line values so close evidence remains reproducible after future pricing edits.
+    let digest values =
+        values
+        |> String.concat "\n"
+        |> Encoding.UTF8.GetBytes
+        |> SHA256.HashData
+        |> Convert.ToHexString
+
+    /// Reads canonical accepted-fact identities from the immutable raw source for close evidence.
+    let acceptedFactDigestAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT UsageFactId,FactKind,Quantity,ObservedAtUtc FROM ops.RawUsageFact WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND ObservedAtUtc>=@MonthStartUtc AND ObservedAtUtc<@NextMonthStartUtc ORDER BY ObservedAtUtc,UsageFactId;"
+
+            addScope read scope
+            use! reader = read.ExecuteReaderAsync cancellationToken
+            let values = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+                reading <- hasRow
+
+                if hasRow then
+                    values.Add($"{reader.GetGuid(0):D}|{reader.GetInt32(1)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}")
+
+            return values |> Seq.toList |> digest
+        }
+
+    /// Posts each calculated line once, then records close evidence and the terminal state in the same transaction.
+    let postCloseAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (periodId: Guid)
+        (request: BillingPeriodCloseRequest)
+        (closedAt: DateTime)
+        (lines: ChargePreviewLineEntity array)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            let mutable index = 0
+
+            while index < lines.Length do
+                let line = lines[index]
+
+                use insert =
+                    command
+                        connection
+                        transaction
+                        "INSERT INTO ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (@ChargeId,@BillingPeriodId,@ChargePreviewLineId,@CurrencyCode,@ChargeMicros);"
+
+                insert.Parameters.Add("@ChargeId", SqlDbType.UniqueIdentifier).Value <- chargeId periodId line.ChargePreviewLineId
+                insert.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+                insert.Parameters.Add("@ChargePreviewLineId", SqlDbType.UniqueIdentifier).Value <- line.ChargePreviewLineId
+                insert.Parameters.Add("@CurrencyCode", SqlDbType.VarChar, 3).Value <- line.CurrencyCode
+                insert.Parameters.Add("@ChargeMicros", SqlDbType.BigInt).Value <- line.ChargeMicros
+                let! _ = insert.ExecuteNonQueryAsync cancellationToken
+                index <- index + 1
+
+            do! transactionInterleaving.AfterLedgerInsertionAsync cancellationToken
+
+            let! factDigest = acceptedFactDigestAsync connection transaction request.Scope cancellationToken
+
+            let previewDigest =
+                lines
+                |> Seq.map (fun line -> $"{line.ChargePreviewLineId:D}|{line.CurrencyCode}|{line.ChargeMicros}|{line.TotalQuantity}")
+                |> Seq.toList
+                |> digest
+
+            use evidence =
+                command
+                    connection
+                    transaction
+                    "INSERT INTO ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (@BillingPeriodId,@FactDigest,@PreviewDigest,@ClosedAtUtc,@Provenance);"
+
+            evidence.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            evidence.Parameters.Add("@FactDigest", SqlDbType.Char, 64).Value <- factDigest
+            evidence.Parameters.Add("@PreviewDigest", SqlDbType.Char, 64).Value <- previewDigest
+            evidence.Parameters.Add("@ClosedAtUtc", SqlDbType.DateTime2).Value <- closedAt
+            evidence.Parameters.Add("@Provenance", SqlDbType.NVarChar, 200).Value <- request.ScheduledOperationProvenance
+            let! _ = evidence.ExecuteNonQueryAsync cancellationToken
+            do! transactionInterleaving.AfterCloseEvidenceStagedAsync cancellationToken
+
+            use close =
+                command
+                    connection
+                    transaction
+                    "UPDATE ops.BillingPeriod SET State=2,RetryDiagnostic=NULL,RetryDiagnosticAtUtc=NULL,UpdatedAtUtc=SYSUTCDATETIME() WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);"
+
+            close.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            let! affected = close.ExecuteNonQueryAsync cancellationToken
+
+            if affected <> 1 then
+                invalidOp "Billing-period state changed before terminal close could commit."
+
+            return ()
+        }
+
+    /// Rolls back a failed close without masking its originating exception.
+    let rollbackAsync (transaction: SqlTransaction) =
+        task {
+            try
+                do! transaction.RollbackAsync CancellationToken.None
+            with
+            | _ -> ()
+        }
+
+    /// Runs either preview or close in one scope-locked transaction and converts expected retry conditions into durable diagnostics.
+    let executeAsync (close: bool) (request: BillingPeriodCloseRequest) (cancellationToken: CancellationToken) =
+        task {
+            if String.IsNullOrWhiteSpace request.ScheduledOperationProvenance
+               || request.ScheduledOperationProvenance.Length > 200 then
+                invalidArg (nameof request) "Scheduled operation provenance is required and must be 200 characters or fewer."
+
+            match BillingCompletenessScope.validate request.Scope with
+            | Error errors -> invalidArg (nameof request) (String.Join("; ", errors))
+            | Ok _ -> ()
+
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            use! rawTransaction = connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken)
+            use transaction = rawTransaction :?> SqlTransaction
+
+            try
+                do! acquireScopeLockAsync connection transaction request.Scope cancellationToken
+                let! (periodId, state) = ensurePeriodAsync connection transaction request.Scope cancellationToken
+
+                if state = BillingPeriodState.Closed then
+                    use count = command connection transaction "SELECT COUNT(*) FROM ops.Charge WHERE BillingPeriodId=@BillingPeriodId;"
+                    count.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+                    let! chargeCount = count.ExecuteScalarAsync cancellationToken
+                    do! transaction.CommitAsync cancellationToken
+                    return Closed(periodId, Convert.ToInt32 chargeCount)
+                else
+                    let! now = databaseUtcNowAsync connection transaction cancellationToken
+
+                    let threshold =
+                        (BillingCompletenessScope.nextMonthStart request.Scope)
+                            .ToDateTimeUtc()
+                            .AddHours(if close then 72.0 else 24.0)
+
+                    if now < threshold then
+                        do! transaction.CommitAsync cancellationToken
+                        return NotEligible
+                    else
+                        let! blocked = completenessDiagnosticAsync connection transaction request.Scope cancellationToken
+
+                        match blocked with
+                        | Some diagnostic ->
+                            do! setDiagnosticAsync connection transaction periodId (Some diagnostic) cancellationToken
+                            do! transaction.CommitAsync cancellationToken
+                            return Blocked diagnostic
+                        | None ->
+                            let! pricedFacts = readPricedFactsAsync connection transaction request.Scope cancellationToken
+
+                            let previewScope: ChargePreviewScope =
+                                {
+                                    OwnerId = request.Scope.OwnerId
+                                    OrganizationId = request.Scope.OrganizationId
+                                    RepositoryId = request.Scope.RepositoryId
+                                    PeriodFromUtc = request.Scope.MonthStart.ToDateTimeUtc()
+                                    PeriodToUtc =
+                                        (BillingCompletenessScope.nextMonthStart request.Scope)
+                                            .ToDateTimeUtc()
+                                }
+
+                            let lines = ChargePreviewCalculation.buildLines previewScope pricedFacts
+                            do! replacePreviewAsync connection transaction request.Scope lines cancellationToken
+                            do! transactionInterleaving.AfterPreviewReplacementAsync cancellationToken
+
+                            if close then
+                                do! postCloseAsync connection transaction periodId request now lines cancellationToken
+                                do! transaction.CommitAsync cancellationToken
+                                return Closed(periodId, lines.Length)
+                            else
+                                use provisional =
+                                    command
+                                        connection
+                                        transaction
+                                        "UPDATE ops.BillingPeriod SET State=1,RetryDiagnostic=NULL,RetryDiagnosticAtUtc=NULL,UpdatedAtUtc=SYSUTCDATETIME() WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);"
+
+                                provisional.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+                                let! _ = provisional.ExecuteNonQueryAsync cancellationToken
+                                do! transaction.CommitAsync cancellationToken
+                                return Provisional(periodId, lines.Length)
+            with
+            | :? ChargePreviewRebuildException as ex ->
+                do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return Blocked ex.Message
+            | :? OverflowException as ex ->
+                do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return Blocked ex.Message
+            | ex ->
+                do! rollbackAsync transaction
+                return raise ex
+        }
+
+    interface IBillingPeriodCloser with
+        member _.PreviewAsync(request, cancellationToken) = executeAsync false request cancellationToken
+        member _.CloseAsync(request, cancellationToken) = executeAsync true request cancellationToken
+
+    /// Creates the production closer without test-only failure injection.
+    new(connectionString: string) =
+        SqlBillingPeriodCloser(connectionString, NoBillingPeriodCloseTransactionInterleaving() :> IBillingPeriodCloseTransactionInterleaving)
+
+    /// Creates a real-SQL closer that pauses or fails only at a named transaction-local proof seam.
+    static member internal CreateForTest(connectionString, transactionInterleaving) = SqlBillingPeriodCloser(connectionString, transactionInterleaving)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -57,8 +57,31 @@ type private NoBillingPeriodCloseTransactionInterleaving() =
         member _.AfterLedgerInsertionAsync _ = Task.CompletedTask
         member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
 
+/// Supplies the transaction-local database clock used to prove eligibility boundaries without caller-supplied close time.
+type internal IBillingPeriodCloseClock =
+    /// Reads the UTC instant that decides preview and close eligibility inside the locked SQL transaction.
+    abstract UtcNowAsync: connection: SqlConnection * transaction: SqlTransaction * cancellationToken: CancellationToken -> Task<DateTime>
+
+/// Reads SQL Server's UTC clock for all production close decisions.
+type private DatabaseBillingPeriodCloseClock() =
+    interface IBillingPeriodCloseClock with
+        member _.UtcNowAsync(connection, transaction, cancellationToken) =
+            task {
+                use nowCommand = connection.CreateCommand()
+                nowCommand.Transaction <- transaction
+                nowCommand.CommandText <- "SELECT SYSUTCDATETIME();"
+                let! value = nowCommand.ExecuteScalarAsync cancellationToken
+                return value :?> DateTime
+            }
+
 /// Rebuilds previews and immutable initial postings under the same SQL lock used by accepted fact processing.
-type SqlBillingPeriodCloser private (connectionString: string, transactionInterleaving: IBillingPeriodCloseTransactionInterleaving) =
+type SqlBillingPeriodCloser
+    private
+    (
+        connectionString: string,
+        transactionInterleaving: IBillingPeriodCloseTransactionInterleaving,
+        clock: IBillingPeriodCloseClock
+    ) =
 
     /// Derives the deterministic period identity from every exact scope boundary without insertion-order dependence.
     let billingPeriodId (scope: BillingCompletenessScope) =
@@ -129,14 +152,6 @@ type SqlBillingPeriodCloser private (connectionString: string, transactionInterl
             lockCommand.Parameters.Add("@BillingCompletenessLockTimeoutMilliseconds", SqlDbType.Int).Value <- 60000
             let! _ = lockCommand.ExecuteNonQueryAsync cancellationToken
             return ()
-        }
-
-    /// Reads database UTC inside the mutation transaction so callers cannot decide persisted eligibility.
-    let databaseUtcNowAsync (connection: SqlConnection) (transaction: SqlTransaction) (cancellationToken: CancellationToken) =
-        task {
-            use nowCommand = command connection transaction "SELECT SYSUTCDATETIME();"
-            let! value = nowCommand.ExecuteScalarAsync cancellationToken
-            return value :?> DateTime
         }
 
     /// Inserts the deterministic period if discovery has not already materialized it, then locks its row for this close.
@@ -666,7 +681,7 @@ SELECT CAST
                     do! transaction.CommitAsync cancellationToken
                     return Closed(periodId, Convert.ToInt32 chargeCount)
                 else
-                    let! now = databaseUtcNowAsync connection transaction cancellationToken
+                    let! now = clock.UtcNowAsync(connection, transaction, cancellationToken)
 
                     let threshold =
                         (BillingCompletenessScope.nextMonthStart request.Scope)
@@ -751,7 +766,16 @@ SELECT CAST
 
     /// Creates the production closer without test-only failure injection.
     new(connectionString: string) =
-        SqlBillingPeriodCloser(connectionString, NoBillingPeriodCloseTransactionInterleaving() :> IBillingPeriodCloseTransactionInterleaving)
+        SqlBillingPeriodCloser(
+            connectionString,
+            NoBillingPeriodCloseTransactionInterleaving() :> IBillingPeriodCloseTransactionInterleaving,
+            DatabaseBillingPeriodCloseClock() :> IBillingPeriodCloseClock
+        )
 
     /// Creates a real-SQL closer that pauses or fails only at a named transaction-local proof seam.
-    static member internal CreateForTest(connectionString, transactionInterleaving) = SqlBillingPeriodCloser(connectionString, transactionInterleaving)
+    static member internal CreateForTest(connectionString, transactionInterleaving) =
+        SqlBillingPeriodCloser(connectionString, transactionInterleaving, DatabaseBillingPeriodCloseClock() :> IBillingPeriodCloseClock)
+
+    /// Creates a real-SQL closer with an internal transaction-local clock seam for exact threshold proof.
+    static member internal CreateForTest(connectionString, transactionInterleaving, clock) =
+        SqlBillingPeriodCloser(connectionString, transactionInterleaving, clock)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -338,51 +338,128 @@ WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);
                     connection
                     transaction
                     """
-IF NOT EXISTS
+;WITH assignmentPlanApplicability AS
 (
-    SELECT 1
+    SELECT rangeStart.EffectiveFromUtc, rangeEnd.EffectiveToUtc
     FROM ops.PricingAssignment AS assignment
     INNER JOIN ops.PricingPlan AS pricingPlan ON pricingPlan.PricingPlanId=assignment.PricingPlanId
+    CROSS APPLY
+    (
+        SELECT CASE WHEN assignment.EffectiveFromUtc > pricingPlan.EffectiveFromUtc
+                    THEN assignment.EffectiveFromUtc ELSE pricingPlan.EffectiveFromUtc END AS EffectiveFromUtc
+    ) AS rangeStart
+    CROSS APPLY
+    (
+        SELECT CASE WHEN ISNULL(assignment.EffectiveToUtc,@NextMonthStartUtc) < ISNULL(pricingPlan.EffectiveToUtc,@NextMonthStartUtc)
+                    THEN ISNULL(assignment.EffectiveToUtc,@NextMonthStartUtc) ELSE ISNULL(pricingPlan.EffectiveToUtc,@NextMonthStartUtc) END AS EffectiveToUtc
+    ) AS rangeEnd
     WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-      AND assignment.EffectiveFromUtc<=@MonthStartUtc
-      AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc>=@NextMonthStartUtc)
-      AND pricingPlan.EffectiveFromUtc<=@MonthStartUtc
-      AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc>=@NextMonthStartUtc)
-)
-    SELECT CAST('Complete pricing assignment and plan coverage is required for zero-fact billing close.' AS nvarchar(400));
-ELSE IF NOT EXISTS
+      AND rangeStart.EffectiveFromUtc < @NextMonthStartUtc AND rangeEnd.EffectiveToUtc > @MonthStartUtc
+),
+assignmentPlanBoundary AS
 (
-    SELECT 1
-    FROM ops.BillableUsageKindMapping AS mapping
-    WHERE mapping.EffectiveFromUtc<=@MonthStartUtc
-      AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc>=@NextMonthStartUtc)
-)
-    SELECT CAST('Complete billable usage-kind mapping coverage is required for zero-fact billing close.' AS nvarchar(400));
-ELSE IF EXISTS
+    SELECT @MonthStartUtc AS BoundaryUtc
+    UNION
+    SELECT CASE WHEN EffectiveToUtc < @NextMonthStartUtc THEN EffectiveToUtc ELSE @NextMonthStartUtc END
+    FROM assignmentPlanApplicability
+),
+mappingApplicability AS
 (
-    SELECT 1
+    SELECT mapping.FactKind, mapping.BillableUsageKind, mapping.EffectiveFromUtc,
+           ISNULL(mapping.EffectiveToUtc,@NextMonthStartUtc) AS EffectiveToUtc
     FROM ops.BillableUsageKindMapping AS mapping
-    WHERE mapping.EffectiveFromUtc<=@MonthStartUtc
-      AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc>=@NextMonthStartUtc)
-      AND NOT EXISTS
-      (
-          SELECT 1
-          FROM ops.PricingAssignment AS assignment
-          INNER JOIN ops.PricingPlan AS pricingPlan ON pricingPlan.PricingPlanId=assignment.PricingPlanId
-          INNER JOIN ops.PricingRate AS rate ON rate.PricingPlanId=pricingPlan.PricingPlanId
-          WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-            AND assignment.EffectiveFromUtc<=@MonthStartUtc
-            AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc>=@NextMonthStartUtc)
-            AND pricingPlan.EffectiveFromUtc<=@MonthStartUtc
-            AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc>=@NextMonthStartUtc)
-            AND rate.BillableUsageKind=mapping.BillableUsageKind
-            AND rate.EffectiveFromUtc<=@MonthStartUtc
-            AND (rate.EffectiveToUtc IS NULL OR rate.EffectiveToUtc>=@NextMonthStartUtc)
-      )
+    WHERE mapping.EffectiveFromUtc < @NextMonthStartUtc
+      AND ISNULL(mapping.EffectiveToUtc,@NextMonthStartUtc) > @MonthStartUtc
+),
+mappingBoundary AS
+(
+    SELECT FactKind, @MonthStartUtc AS BoundaryUtc
+    FROM mappingApplicability
+    GROUP BY FactKind
+    UNION
+    SELECT FactKind, CASE WHEN EffectiveToUtc < @NextMonthStartUtc THEN EffectiveToUtc ELSE @NextMonthStartUtc END
+    FROM mappingApplicability
+),
+completeGrainApplicability AS
+(
+    SELECT mapping.FactKind, rangeStart.EffectiveFromUtc, rangeEnd.EffectiveToUtc
+    FROM ops.PricingAssignment AS assignment
+    INNER JOIN ops.PricingPlan AS pricingPlan ON pricingPlan.PricingPlanId=assignment.PricingPlanId
+    INNER JOIN mappingApplicability AS mapping ON 1=1
+    INNER JOIN ops.PricingRate AS rate ON rate.PricingPlanId=pricingPlan.PricingPlanId
+                                           AND rate.BillableUsageKind=mapping.BillableUsageKind
+    CROSS APPLY
+    (
+        SELECT MAX(boundary.EffectiveFromUtc) AS EffectiveFromUtc
+        FROM (VALUES (assignment.EffectiveFromUtc), (pricingPlan.EffectiveFromUtc), (mapping.EffectiveFromUtc), (rate.EffectiveFromUtc)) AS boundary(EffectiveFromUtc)
+    ) AS rangeStart
+    CROSS APPLY
+    (
+        SELECT MIN(boundary.EffectiveToUtc) AS EffectiveToUtc
+        FROM (VALUES (ISNULL(assignment.EffectiveToUtc,@NextMonthStartUtc)), (ISNULL(pricingPlan.EffectiveToUtc,@NextMonthStartUtc)), (mapping.EffectiveToUtc), (ISNULL(rate.EffectiveToUtc,@NextMonthStartUtc))) AS boundary(EffectiveToUtc)
+    ) AS rangeEnd
+    WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+      AND rangeStart.EffectiveFromUtc < @NextMonthStartUtc AND rangeEnd.EffectiveToUtc > @MonthStartUtc
+),
+completeGrainBoundary AS
+(
+    SELECT FactKind, @MonthStartUtc AS BoundaryUtc
+    FROM mappingApplicability
+    GROUP BY FactKind
+    UNION
+    SELECT FactKind, CASE WHEN EffectiveToUtc < @NextMonthStartUtc THEN EffectiveToUtc ELSE @NextMonthStartUtc END
+    FROM mappingApplicability
+    UNION
+    SELECT FactKind, CASE WHEN EffectiveToUtc < @NextMonthStartUtc THEN EffectiveToUtc ELSE @NextMonthStartUtc END
+    FROM completeGrainApplicability
 )
-    SELECT CAST('Complete pricing-rate coverage is required for zero-fact billing close.' AS nvarchar(400));
-ELSE
-    SELECT CAST(NULL AS nvarchar(400));
+SELECT CAST
+(
+    CASE
+        WHEN EXISTS
+        (
+            SELECT 1
+            FROM assignmentPlanBoundary AS boundary
+            WHERE boundary.BoundaryUtc < @NextMonthStartUtc
+              AND NOT EXISTS
+              (
+                  SELECT 1
+                  FROM assignmentPlanApplicability AS applicability
+                  WHERE applicability.EffectiveFromUtc <= boundary.BoundaryUtc
+                    AND boundary.BoundaryUtc < applicability.EffectiveToUtc
+              )
+        ) THEN 'Complete pricing assignment and plan coverage is required for zero-fact billing close.'
+        WHEN EXISTS
+        (
+            SELECT 1
+            FROM mappingBoundary AS boundary
+            WHERE boundary.BoundaryUtc < @NextMonthStartUtc
+              AND NOT EXISTS
+              (
+                  SELECT 1
+                  FROM mappingApplicability AS applicability
+                  WHERE applicability.FactKind=boundary.FactKind
+                    AND applicability.EffectiveFromUtc <= boundary.BoundaryUtc
+                    AND boundary.BoundaryUtc < applicability.EffectiveToUtc
+              )
+        ) THEN 'Complete billable usage-kind mapping coverage is required for zero-fact billing close.'
+        WHEN EXISTS
+        (
+            SELECT 1
+            FROM completeGrainBoundary AS boundary
+            WHERE boundary.BoundaryUtc < @NextMonthStartUtc
+              AND NOT EXISTS
+              (
+                  SELECT 1
+                  FROM completeGrainApplicability AS applicability
+                  WHERE applicability.FactKind=boundary.FactKind
+                    AND applicability.EffectiveFromUtc <= boundary.BoundaryUtc
+                    AND boundary.BoundaryUtc < applicability.EffectiveToUtc
+              )
+        ) THEN 'Complete pricing-rate coverage is required for zero-fact billing close.'
+        ELSE NULL
+    END AS nvarchar(400)
+);
 """
 
             addScope check scope

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -27,6 +27,10 @@ type BillingPeriodCloseResult =
     | Provisional of billingPeriodId: Guid * previewLineCount: int
     | Closed of billingPeriodId: Guid * chargeCount: int
 
+/// Signals a retryable zero-fact pricing-coverage failure after the scope lock has been acquired.
+type private ZeroFactPricingCoverageException(diagnostic: string) =
+    inherit Exception(diagnostic)
+
 /// Exposes the bounded preview and final-close operations used by the scheduled shell.
 type IBillingPeriodCloser =
     /// Rebuilds an eligible preview under the exact shared scope lock.
@@ -321,6 +325,71 @@ WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);
             return rows |> Seq.toList
         }
 
+    /// Verifies that a zero-fact period still has one complete current pricing grain before it can be closed.
+    let zeroFactPricingCoverageDiagnosticAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use check =
+                command
+                    connection
+                    transaction
+                    """
+IF NOT EXISTS
+(
+    SELECT 1
+    FROM ops.PricingAssignment AS assignment
+    INNER JOIN ops.PricingPlan AS pricingPlan ON pricingPlan.PricingPlanId=assignment.PricingPlanId
+    WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+      AND assignment.EffectiveFromUtc<=@MonthStartUtc
+      AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc>=@NextMonthStartUtc)
+      AND pricingPlan.EffectiveFromUtc<=@MonthStartUtc
+      AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc>=@NextMonthStartUtc)
+)
+    SELECT CAST('Complete pricing assignment and plan coverage is required for zero-fact billing close.' AS nvarchar(400));
+ELSE IF NOT EXISTS
+(
+    SELECT 1
+    FROM ops.BillableUsageKindMapping AS mapping
+    WHERE mapping.EffectiveFromUtc<=@MonthStartUtc
+      AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc>=@NextMonthStartUtc)
+)
+    SELECT CAST('Complete billable usage-kind mapping coverage is required for zero-fact billing close.' AS nvarchar(400));
+ELSE IF EXISTS
+(
+    SELECT 1
+    FROM ops.BillableUsageKindMapping AS mapping
+    WHERE mapping.EffectiveFromUtc<=@MonthStartUtc
+      AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc>=@NextMonthStartUtc)
+      AND NOT EXISTS
+      (
+          SELECT 1
+          FROM ops.PricingAssignment AS assignment
+          INNER JOIN ops.PricingPlan AS pricingPlan ON pricingPlan.PricingPlanId=assignment.PricingPlanId
+          INNER JOIN ops.PricingRate AS rate ON rate.PricingPlanId=pricingPlan.PricingPlanId
+          WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+            AND assignment.EffectiveFromUtc<=@MonthStartUtc
+            AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc>=@NextMonthStartUtc)
+            AND pricingPlan.EffectiveFromUtc<=@MonthStartUtc
+            AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc>=@NextMonthStartUtc)
+            AND rate.BillableUsageKind=mapping.BillableUsageKind
+            AND rate.EffectiveFromUtc<=@MonthStartUtc
+            AND (rate.EffectiveToUtc IS NULL OR rate.EffectiveToUtc>=@NextMonthStartUtc)
+      )
+)
+    SELECT CAST('Complete pricing-rate coverage is required for zero-fact billing close.' AS nvarchar(400));
+ELSE
+    SELECT CAST(NULL AS nvarchar(400));
+"""
+
+            addScope check scope
+            let! result = check.ExecuteScalarAsync cancellationToken
+            return if Convert.IsDBNull result then None else Some(result :?> string)
+        }
+
     /// Replaces only the current period preview after successful calculation has produced every replacement line.
     let replacePreviewAsync
         (connection: SqlConnection)
@@ -541,6 +610,16 @@ WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);
                         | None ->
                             let! pricedFacts = readPricedFactsAsync connection transaction request.Scope cancellationToken
 
+                            let! zeroFactPricingDiagnostic =
+                                if List.isEmpty pricedFacts then
+                                    zeroFactPricingCoverageDiagnosticAsync connection transaction request.Scope cancellationToken
+                                else
+                                    Task.FromResult None
+
+                            match zeroFactPricingDiagnostic with
+                            | Some diagnostic -> raise (ZeroFactPricingCoverageException(diagnostic))
+                            | None -> ()
+
                             let previewScope: ChargePreviewScope =
                                 {
                                     OwnerId = request.Scope.OwnerId
@@ -577,6 +656,10 @@ WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);
                 do! transaction.CommitAsync cancellationToken
                 return Blocked ex.Message
             | :? OverflowException as ex ->
+                do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return Blocked ex.Message
+            | :? ZeroFactPricingCoverageException as ex ->
                 do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
                 do! transaction.CommitAsync cancellationToken
                 return Blocked ex.Message

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodModel.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodModel.fs
@@ -1,0 +1,327 @@
+namespace Grace.Operations.Data
+
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
+
+/// Configures billing-period, immutable-charge, close-evidence, and late-work persistence constraints.
+[<RequireQualifiedAccess>]
+module OperationsBillingPeriodModel =
+
+    /// Adds the exact-scope period lifecycle and append-only close records to the Operations model.
+    let configure (modelBuilder: ModelBuilder) =
+        let period = modelBuilder.Entity<BillingPeriodEntity>()
+
+        period.ToTable(
+            "BillingPeriod",
+            OperationsUsageSql.SchemaName,
+            fun (table: TableBuilder<BillingPeriodEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_MonthRange",
+                    "[MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriod_State", "[State] IN (0, 1, 2)")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_Diagnostic",
+                    "([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        period
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriod")
+        |> ignore
+
+        period
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            period
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "MonthStartUtc"
+                "NextMonthStartUtc"
+                "CreatedAtUtc"
+                "UpdatedAtUtc"
+            ] do
+            period
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        period.Property<int>("State").IsRequired()
+        |> ignore
+
+        period
+            .Property<string>("RetryDiagnostic")
+            .HasMaxLength(400)
+        |> ignore
+
+        period
+            .Property<Nullable<DateTime>>("RetryDiagnosticAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        period
+            .Property<DateTime>("CreatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+        |> ignore
+
+        period
+            .Property<DateTime>("UpdatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "NextMonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_BillingPeriod_ExactScope")
+            .IsUnique()
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "State"
+                    "MonthStartUtc"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillingPeriod_NonterminalDiscovery")
+        |> ignore
+
+        let charge = modelBuilder.Entity<ChargeEntity>()
+
+        charge.ToTable(
+            "Charge",
+            OperationsUsageSql.SchemaName,
+            fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        charge
+            .HasKey([| "ChargeId" |])
+            .HasName("PK_ops_Charge")
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargeId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        charge
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<int64>("ChargeMicros")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .HasIndex(
+                [|
+                    "BillingPeriodId"
+                    "ChargePreviewLineId"
+                |]
+            )
+            .HasDatabaseName("UX_ops_Charge_InitialPosting")
+            .IsUnique()
+        |> ignore
+
+        charge
+            .HasIndex([| "ChargePreviewLineId" |])
+            .HasDatabaseName("IX_ops_Charge_ChargePreviewLine")
+        |> ignore
+
+        charge
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_Charge_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        charge
+            .HasOne<ChargePreviewLineEntity>()
+            .WithMany()
+            .HasForeignKey("ChargePreviewLineId")
+            .HasConstraintName("FK_ops_Charge_ChargePreviewLine")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let evidence = modelBuilder.Entity<BillingPeriodCloseEvidenceEntity>()
+
+        evidence.ToTable(
+            "BillingPeriodCloseEvidence",
+            OperationsUsageSql.SchemaName,
+            fun (table: TableBuilder<BillingPeriodCloseEvidenceEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodCloseEvidence_Digests",
+                    "LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodCloseEvidence_Provenance", "LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0")
+                |> ignore
+        )
+        |> ignore
+
+        evidence
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriodCloseEvidence")
+        |> ignore
+
+        evidence
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        evidence
+            .Property<string>("AcceptedFactDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("PricingPreviewDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<DateTime>("ClosedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("ScheduledOperationProvenance")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodCloseEvidence_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let lateWork = modelBuilder.Entity<BillingPeriodLateWorkEntity>()
+
+        lateWork.ToTable("BillingPeriodLateWork", OperationsUsageSql.SchemaName)
+        |> ignore
+
+        lateWork
+            .HasKey([| "BillingPeriodId"; "UsageFactId" |])
+            .HasName("PK_ops_BillingPeriodLateWork")
+        |> ignore
+
+        lateWork
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .HasIndex([| "UsageFactId" |])
+            .HasDatabaseName("IX_ops_BillingPeriodLateWork_UsageFact")
+        |> ignore
+
+        lateWork
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        lateWork
+            .HasOne<RawUsageFactEntity>()
+            .WithMany()
+            .HasForeignKey("UsageFactId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_RawUsageFact")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
@@ -43,7 +43,7 @@ module OperationsChargePreviewSql =
         """
 SELECT fact.UsageFactId, fact.FactKind, fact.Quantity, fact.ObservedAtUtc,
        assignment.PricingAssignmentId, assignment.PricingPlanId AS AssignedPricingPlanId,
-       plan.PricingPlanId, mapping.BillableUsageKindMappingId, mapping.BillableUsageKind,
+       pricingPlan.PricingPlanId, mapping.BillableUsageKindMappingId, mapping.BillableUsageKind,
        rate.PricingRateId, rate.CurrencyCode, rate.UnitName, rate.UnitQuantity, rate.UnitPriceMicros,
        applicability.EffectiveFromUtc, applicability.EffectiveToUtc
 FROM ops.RawUsageFact AS fact
@@ -64,7 +64,7 @@ OUTER APPLY (
       AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
       AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
     ORDER BY candidate.EffectiveFromUtc DESC, candidate.PricingPlanId
-) AS plan
+) AS pricingPlan
 OUTER APPLY (
     SELECT TOP (1) candidate.BillableUsageKindMappingId, candidate.BillableUsageKind,
            candidate.EffectiveFromUtc, candidate.EffectiveToUtc
@@ -77,7 +77,7 @@ OUTER APPLY (
     SELECT TOP (1) candidate.PricingRateId, candidate.CurrencyCode, candidate.UnitName,
            candidate.UnitQuantity, candidate.UnitPriceMicros, candidate.EffectiveFromUtc, candidate.EffectiveToUtc
     FROM ops.PricingRate AS candidate
-    WHERE candidate.PricingPlanId = plan.PricingPlanId
+    WHERE candidate.PricingPlanId = pricingPlan.PricingPlanId
       AND candidate.BillableUsageKind = mapping.BillableUsageKind
       AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
       AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
@@ -88,7 +88,7 @@ OUTER APPLY (
            MIN(boundary.EffectiveToUtc) AS EffectiveToUtc
     FROM (VALUES
         (assignment.EffectiveFromUtc, ISNULL(assignment.EffectiveToUtc, @PeriodToUtc)),
-        (plan.EffectiveFromUtc, ISNULL(plan.EffectiveToUtc, @PeriodToUtc)),
+        (pricingPlan.EffectiveFromUtc, ISNULL(pricingPlan.EffectiveToUtc, @PeriodToUtc)),
         (mapping.EffectiveFromUtc, ISNULL(mapping.EffectiveToUtc, @PeriodToUtc)),
         (rate.EffectiveFromUtc, ISNULL(rate.EffectiveToUtc, @PeriodToUtc)),
         (@PeriodFromUtc, @PeriodToUtc)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -702,6 +702,9 @@ type IOperationsUsageTransaction =
     /// Adds the accepted raw fact quantity to the derived minute aggregate.
     abstract AddToUsageAggregateMinuteAsync: aggregate: UsageAggregateMinute * cancellationToken: CancellationToken -> Task
 
+    /// Records minimal automatic late work only when this newly accepted fact belongs to a period already closed under the held scope lock.
+    abstract RecordClosedPeriodLateWorkAsync: rawFact: RawUsageFact * scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task
+
     /// Records the canonical scoped rejection unless accepted durable usage has already won.
     abstract RecordScopedUsageFactRejectionAsync: rejection: UsageFactRejection * cancellationToken: CancellationToken -> Task<UsageFactRejection option>
 
@@ -810,6 +813,31 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
         addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
 
+    /// Inserts the unique minimal post-close work handoff without calculating, claiming, or completing a correction.
+    let recordClosedPeriodLateWorkAsync (rawFact: RawUsageFact) (scope: BillingCompletenessScope) cancellationToken =
+        task {
+            use command =
+                createCommand
+                    """
+INSERT INTO ops.BillingPeriodLateWork (BillingPeriodId, UsageFactId)
+SELECT period.BillingPeriodId, @UsageFactId
+FROM ops.BillingPeriod AS period WITH (UPDLOCK,HOLDLOCK)
+WHERE period.OwnerId=@OwnerId AND period.OrganizationId=@OrganizationId AND period.RepositoryId=@RepositoryId
+  AND period.MonthStartUtc=@MonthStartUtc AND period.NextMonthStartUtc=@NextMonthStartUtc
+  AND period.State=2
+  AND NOT EXISTS
+  (
+      SELECT 1 FROM ops.BillingPeriodLateWork AS existing
+      WHERE existing.BillingPeriodId=period.BillingPeriodId AND existing.UsageFactId=@UsageFactId
+  );
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+            addBillingCompletenessScopeParameters command scope
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
     /// Acquires the shared transaction-owned SQL lock after rejecting malformed scope input.
     let acquireBillingCompletenessScopeAsync (scope: BillingCompletenessScope) cancellationToken =
         task {
@@ -889,6 +917,8 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
                 let! _ = command.ExecuteNonQueryAsync cancellationToken
                 return ()
             }
+
+        member _.RecordClosedPeriodLateWorkAsync(rawFact, scope, cancellationToken) = recordClosedPeriodLateWorkAsync rawFact scope cancellationToken
 
         member _.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken) =
             task {
@@ -1816,6 +1846,7 @@ type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
 
                         if accepted then
                             do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
+                            do! transaction.RecordClosedPeriodLateWorkAsync(plan.RawFact, scope, operationCancellationToken)
 
                             return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
                         else
@@ -1844,6 +1875,7 @@ type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
 
                             if accepted then
                                 do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
+                                do! transaction.RecordClosedPeriodLateWorkAsync(plan.RawFact, scope, operationCancellationToken)
 
                                 return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
                             else

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -794,6 +794,7 @@ module OperationsModel =
         |> ignore
 
         OperationsChargePreviewModel.configure modelBuilder
+        OperationsBillingPeriodModel.configure modelBuilder
 
 /// Owns the EF Core model for Grace Operations SQL Server schema evolution.
 type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
@@ -834,6 +835,22 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     /// Provides EF access to provisional charge-preview lines.
     [<DefaultValue>]
     val mutable private chargePreviewLines: DbSet<ChargePreviewLineEntity>
+
+    /// Provides EF access to exact-scope billing periods.
+    [<DefaultValue>]
+    val mutable private billingPeriods: DbSet<BillingPeriodEntity>
+
+    /// Provides EF access to append-only initial charge postings.
+    [<DefaultValue>]
+    val mutable private charges: DbSet<ChargeEntity>
+
+    /// Provides EF access to immutable close evidence.
+    [<DefaultValue>]
+    val mutable private billingPeriodCloseEvidence: DbSet<BillingPeriodCloseEvidenceEntity>
+
+    /// Provides EF access to minimal durable late-work handoff rows.
+    [<DefaultValue>]
+    val mutable private billingPeriodLateWork: DbSet<BillingPeriodLateWorkEntity>
 
     /// Provides the EF set for immutable usage fact rows.
     member this.RawUsageFacts
@@ -879,6 +896,26 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     member this.ChargePreviewLines
         with get () = this.chargePreviewLines
         and set value = this.chargePreviewLines <- value
+
+    /// Provides the EF set for exact-scope billing periods.
+    member this.BillingPeriods
+        with get () = this.billingPeriods
+        and set value = this.billingPeriods <- value
+
+    /// Provides the EF set for immutable initial charge postings.
+    member this.Charges
+        with get () = this.charges
+        and set value = this.charges <- value
+
+    /// Provides the EF set for immutable close evidence.
+    member this.BillingPeriodCloseEvidence
+        with get () = this.billingPeriodCloseEvidence
+        and set value = this.billingPeriodCloseEvidence <- value
+
+    /// Provides the EF set for pending automatic late-work handoffs.
+    member this.BillingPeriodLateWork
+        with get () = this.billingPeriodLateWork
+        and set value = this.billingPeriodLateWork <- value
 
     /// Configures the Operations SQL Server schema shape that migrations must preserve.
     override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -347,3 +347,62 @@ type ChargePreviewLineEntity() =
 
     /// Stores the once-rounded provisional charge in whole currency micros.
     member val ChargeMicros = 0L with get, set
+
+/// Represents the durable lifecycle and exact UTC-month identity of one repository billing period.
+[<AllowNullLiteral>]
+type BillingPeriodEntity() =
+
+    /// Stores the deterministic identity derived from the complete billing scope and half-open month.
+    member val BillingPeriodId = Guid.Empty with get, set
+
+    /// Stores the exact owner, organization, and repository scope that cannot share a period with another repository.
+    member val OwnerId = Guid.Empty with get, set
+    member val OrganizationId = Guid.Empty with get, set
+    member val RepositoryId = Guid.Empty with get, set
+
+    /// Stores the inclusive and exclusive UTC month boundaries for all period work.
+    member val MonthStartUtc = DateTime.MinValue with get, set
+    member val NextMonthStartUtc = DateTime.MinValue with get, set
+
+    /// Stores Open, Provisional, or Closed without introducing a terminal failure state.
+    member val State = 0 with get, set
+
+    /// Stores a bounded retry diagnostic only while the period remains nonterminal.
+    member val RetryDiagnostic: string = null with get, set
+    member val RetryDiagnosticAtUtc = Nullable<DateTime>() with get, set
+
+    /// Stores database-created and database-updated ordering evidence.
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+    member val UpdatedAtUtc = DateTime.MinValue with get, set
+
+/// Represents an append-only initial charge copied from one exact preview line at period close.
+[<AllowNullLiteral>]
+type ChargeEntity() =
+
+    /// Stores the deterministic immutable posting identity.
+    member val ChargeId = Guid.Empty with get, set
+    member val BillingPeriodId = Guid.Empty with get, set
+    member val ChargePreviewLineId = Guid.Empty with get, set
+    member val CurrencyCode = String.Empty with get, set
+    member val ChargeMicros = 0L with get, set
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+/// Preserves the exact facts, calculated preview, database time, and scheduled operation that closed a period.
+[<AllowNullLiteral>]
+type BillingPeriodCloseEvidenceEntity() =
+
+    /// Uses the period identity as the one immutable close-evidence identity.
+    member val BillingPeriodId = Guid.Empty with get, set
+    member val AcceptedFactDigestSha256Hex = String.Empty with get, set
+    member val PricingPreviewDigestSha256Hex = String.Empty with get, set
+    member val ClosedAtUtc = DateTime.MinValue with get, set
+    member val ScheduledOperationProvenance = String.Empty with get, set
+
+/// Records one accepted fact that arrived after a closed period without calculating or claiming a correction.
+[<AllowNullLiteral>]
+type BillingPeriodLateWorkEntity() =
+
+    /// Pairs exact period and accepted fact identities so duplicate delivery cannot enqueue more work.
+    member val BillingPeriodId = Guid.Empty with get, set
+    member val UsageFactId = Guid.Empty with get, set
+    member val CreatedAtUtc = DateTime.MinValue with get, set

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -249,6 +249,43 @@ VALUES
             return ()
         }
 
+    /// Adds the one minimal late-work handoff only when this newly accepted fact commits after its exact period closed.
+    let addClosedPeriodLateWorkAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (rawFact: RawUsageFact)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use command =
+                createCommand
+                    connection
+                    transaction
+                    """
+INSERT INTO ops.BillingPeriodLateWork (BillingPeriodId, UsageFactId)
+SELECT period.BillingPeriodId, @UsageFactId
+FROM ops.BillingPeriod AS period WITH (UPDLOCK,HOLDLOCK)
+WHERE period.OwnerId=@OwnerId AND period.OrganizationId=@OrganizationId AND period.RepositoryId=@RepositoryId
+  AND period.MonthStartUtc=@MonthStartUtc AND period.NextMonthStartUtc=@NextMonthStartUtc
+  AND period.State=2
+  AND NOT EXISTS
+  (
+      SELECT 1 FROM ops.BillingPeriodLateWork AS existing
+      WHERE existing.BillingPeriodId=period.BillingPeriodId AND existing.UsageFactId=@UsageFactId
+  );
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
+            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier scope.OrganizationId
+            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier scope.RepositoryId
+            addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
+            addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
     /// Marks one still-unresolved matching journal row Accepted only after raw and aggregate persistence succeeded.
     let markAcceptedAsync (connection: SqlConnection) (transaction: SqlTransaction) (usageFactId: UsageFactId) (cancellationToken: CancellationToken) =
         task {
@@ -513,6 +550,7 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
 
                                     if inserted then
                                         do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
+                                        do! addClosedPeriodLateWorkAsync connection transaction plan.RawFact scope operationCancellationToken
 
                                     do! transactionInterleaving.AfterRawAndAggregateStagedAsync(operationCancellationToken)
                                     do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
@@ -546,6 +584,7 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
 
                                     if inserted then
                                         do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
+                                        do! addClosedPeriodLateWorkAsync connection transaction plan.RawFact scope operationCancellationToken
 
                                     do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
                                     do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken

--- a/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="OperationsSkeleton.Tests.fs" />
     <Compile Include="OperationsUsageStorage.Tests.fs" />
     <Compile Include="OperationsBillingCompleteness.Tests.fs" />
+    <Compile Include="OperationsBillingPeriodClose.Tests.fs" />
     <Compile Include="OperationsPricing.Tests.fs" />
     <Compile Include="OperationsChargePreview.Tests.fs" />
     <Compile Include="OperationsUsageArchive.Tests.fs" />

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -47,6 +47,8 @@ type private ObservedOperationsUsageTransaction
                 do! afterUsageAggregateAsync aggregate cancellationToken
             }
 
+        member _.RecordClosedPeriodLateWorkAsync(rawFact, scope, cancellationToken) = inner.RecordClosedPeriodLateWorkAsync(rawFact, scope, cancellationToken)
+
         member _.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken) = inner.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken)
 
         member _.RecordUnscopedUsageFactRejectionAsync(rejection, cancellationToken) = inner.RecordUnscopedUsageFactRejectionAsync(rejection, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -1,0 +1,371 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.Data.SqlClient
+open NUnit.Framework
+open NodaTime
+open System
+open System.Threading
+open System.Threading.Tasks
+
+/// Pauses or fails one real billing-close transaction only after a named durable stage.
+type private BillingCloseInterleaving(stage: string, pause: bool) =
+    let reached = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+    /// Fails or pauses the requested stage without writing a test-only database substitute.
+    let observe expected (cancellationToken: CancellationToken) =
+        task {
+            if stage = expected then
+                reached.TrySetResult() |> ignore
+
+                if pause then
+                    do! release.Task.WaitAsync(cancellationToken)
+                else
+                    return raise (InvalidOperationException($"Injected billing-close failure after {expected}."))
+        }
+        :> Task
+
+    /// Completes when the selected production close stage has run under the held SQL scope lock.
+    member _.Reached = reached.Task
+
+    /// Allows a paused production close transaction to proceed.
+    member _.Release() = release.TrySetResult() |> ignore
+
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.AfterPreviewReplacementAsync cancellationToken = observe "preview" cancellationToken
+        member _.AfterLedgerInsertionAsync cancellationToken = observe "ledger" cancellationToken
+        member _.AfterCloseEvidenceStagedAsync cancellationToken = observe "evidence" cancellationToken
+
+/// Proves billing-period close against isolated real SQL Server databases and production acceptance/close seams.
+[<TestFixture>]
+[<NonParallelizable>]
+type OperationsBillingPeriodCloseTests() =
+
+    /// Names the explicit isolated SQL Server connection used by Operations real-database proofs.
+    [<Literal>]
+    let sqlConnectionStringEnvironmentVariable = "GRACE_OPERATIONS_SQL_TEST_CONNECTION_STRING"
+
+    /// Returns an old UTC billing month whose preview and close thresholds are already eligible on the database clock.
+    let monthStart = Instant.FromUtc(2026, 6, 1, 0, 0)
+
+    /// Creates one test database name that cannot share durable state with another proof.
+    let databaseName () = $"GraceOperationsBillingClose_{Guid.NewGuid():N}"
+
+    /// Gets the required SQL connection or marks the fixture skipped instead of silently passing without SQL.
+    let requireSqlConnectionString () =
+        let connectionString = Environment.GetEnvironmentVariable sqlConnectionStringEnvironmentVariable
+
+        if String.IsNullOrWhiteSpace connectionString then
+            Assert.Ignore($"{sqlConnectionStringEnvironmentVariable} is required for real SQL billing-period close tests.")
+
+        connectionString
+
+    /// Creates and migrates an isolated database through the production Operations schema initializer.
+    let createDatabaseAsync () =
+        task {
+            let builder = SqlConnectionStringBuilder(requireSqlConnectionString ())
+            builder.InitialCatalog <- databaseName ()
+            let schema = OperationsUsageSchema(builder.ConnectionString, OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing)
+            do! schema.EnsureCreatedAsync CancellationToken.None
+            return builder.ConnectionString
+        }
+
+    /// Deletes a fixture database even when its assertion fails.
+    let dropDatabaseAsync connectionString =
+        task {
+            let builder = SqlConnectionStringBuilder(connectionString)
+            let database = builder.InitialCatalog
+            builder.InitialCatalog <- "master"
+            use connection = new SqlConnection(builder.ConnectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- $"ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{database}];"
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
+    /// Runs one SQL proof with deterministic database cleanup on every outcome.
+    let withDatabaseAsync operation =
+        task {
+            let! connectionString = createDatabaseAsync ()
+
+            try
+                let! result = operation connectionString
+                do! dropDatabaseAsync connectionString
+                return result
+            with
+            | ex ->
+                do! dropDatabaseAsync connectionString
+                return raise ex
+        }
+
+    /// Derives one valid exact owner/repository/month scope from the supplied identities.
+    let scopeFor ownerId organizationId repositoryId =
+        match BillingCompletenessScope.tryCreate ownerId organizationId repositoryId monthStart with
+        | Ok scope -> scope
+        | Error errors -> invalidOp (String.Join("; ", errors))
+
+    /// Builds supported repository-storage usage that flows through the production immutable journal.
+    let usageFact usageFactId ownerId organizationId repositoryId observedAt quantity =
+        UsageFact.RepositoryStorageBytesMinute(
+            usageFactId,
+            CorrelationId $"billing-close-{usageFactId:D}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            StoragePoolId "billing-close-pool",
+            quantity,
+            observedAt
+        )
+
+    /// Accepts one fact through production journal processing so raw, aggregate, and journal state share one transaction.
+    let acceptAsync connectionString fact =
+        task {
+            let journal = SqlOperationsUsageJournalStore(connectionString)
+            let! _ = journal.AppendAsync(fact, CancellationToken.None)
+            let! result = journal.ProcessAsync(fact, Array.empty, CancellationToken.None)
+            Assert.That(result, Is.EqualTo(UsageFactJournalProcessResult.AcceptedFromJournal))
+        }
+
+    /// Adds complete current pricing through parameterized SQL so real schema triggers remain part of the fixture.
+    let addPricingAsync connectionString scope =
+        task {
+            let planId = Guid.NewGuid()
+            let mappingId = Guid.NewGuid()
+            let rateId = Guid.NewGuid()
+            let assignmentId = Guid.NewGuid()
+            let effectiveFrom = scope.MonthStart.ToDateTimeUtc()
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc)
+VALUES (@PlanId,@PlanCode,@DisplayName,@EffectiveFrom);
+INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc)
+VALUES (@MappingId,1,101,@MappingName,@EffectiveFrom);
+INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc)
+VALUES (@RateId,@PlanId,101,'USD','byte-minute',1,2,@EffectiveFrom);
+INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc)
+VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveFrom);
+"""
+
+            command.Parameters.Add("@PlanId", System.Data.SqlDbType.UniqueIdentifier).Value <- planId
+            command.Parameters.Add("@PlanCode", System.Data.SqlDbType.NVarChar, 80).Value <- $"close-{planId:N}"
+            command.Parameters.Add("@DisplayName", System.Data.SqlDbType.NVarChar, 200).Value <- "Billing close test plan"
+            command.Parameters.Add("@MappingId", System.Data.SqlDbType.UniqueIdentifier).Value <- mappingId
+            command.Parameters.Add("@MappingName", System.Data.SqlDbType.NVarChar, 200).Value <- "Storage byte minute"
+            command.Parameters.Add("@RateId", System.Data.SqlDbType.UniqueIdentifier).Value <- rateId
+            command.Parameters.Add("@AssignmentId", System.Data.SqlDbType.UniqueIdentifier).Value <- assignmentId
+            command.Parameters.Add("@OwnerId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            command.Parameters.Add("@OrganizationId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            command.Parameters.Add("@EffectiveFrom", System.Data.SqlDbType.DateTime2).Value <- effectiveFrom
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
+    /// Executes a trusted scalar count command against the isolated SQL database.
+    let countAsync connectionString sql =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- sql
+            let! value = command.ExecuteScalarAsync CancellationToken.None
+            return Convert.ToInt32 value
+        }
+
+    /// Builds the fixed scheduled-operation request used by all close proofs.
+    let request scope = { Scope = scope; ScheduledOperationProvenance = "operations-tests/billing-period-close/v1" }
+
+    /// Extracts the immutable posting count from a successful close result and rejects every nonterminal outcome.
+    let closedChargeCount result =
+        match result with
+        | BillingPeriodCloseResult.Closed (_, count) -> count
+        | _ ->
+            Assert.Fail($"Expected a Closed billing-period result but received {result}.")
+            Unchecked.defaultof<int>
+
+    /// Proves accepted usage before close appears in exactly one immutable posting and does not create late work.
+    [<Test>]
+    member _.AcceptanceBeforeCloseIsIncludedWithoutLateWork() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 2) 7L
+                do! acceptAsync connectionString fact
+                do! addPricingAsync connectionString scope
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! closed = closer.CloseAsync(request scope, CancellationToken.None)
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! lateWorkCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodLateWork;"
+                let! evidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(closedChargeCount closed, Is.EqualTo(1))
+                        Assert.That(chargeCount, Is.EqualTo(1))
+                        Assert.That(lateWorkCount, Is.Zero)
+                        Assert.That(evidenceCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves a close holding the real scope lock wins before accepted usage and that the later acceptance becomes one handoff row.
+    [<Test>]
+    member _.CloseBeforeAcceptanceCreatesExactlyOneLateWorkRow() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! addPricingAsync connectionString scope
+                let interleaving = BillingCloseInterleaving("preview", true)
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                let closing = closer.CloseAsync(request scope, CancellationToken.None)
+                do! interleaving.Reached.WaitAsync(TimeSpan.FromSeconds 10.0)
+                let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 3) 9L
+                let accepting = acceptAsync connectionString fact
+                interleaving.Release()
+                let! _ = closing
+                do! accepting
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! lateWorkCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodLateWork;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(chargeCount, Is.Zero)
+                        Assert.That(lateWorkCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves a pricing-covered empty period closes and its first later accepted fact becomes late work rather than changing the initial posting.
+    [<Test>]
+    member _.ZeroEntryCloseThenFirstAcceptanceCreatesLateWork() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! addPricingAsync connectionString scope
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! _ = closer.CloseAsync(request scope, CancellationToken.None)
+                let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 4) 5L
+                do! acceptAsync connectionString fact
+                let! periodCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State = 2;"
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! lateWorkCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodLateWork;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(periodCount, Is.EqualTo(1))
+                        Assert.That(chargeCount, Is.Zero)
+                        Assert.That(lateWorkCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves missing pricing retains a nonterminal period with no posting and a bounded retry diagnostic.
+    [<Test>]
+    member _.MissingPricingBlocksWithoutPosting() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 5) 3L
+                do! acceptAsync connectionString fact
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! result = closer.CloseAsync(request scope, CancellationToken.None)
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! blockedCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0, 1) AND RetryDiagnostic IS NOT NULL;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Blocked _ -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(chargeCount, Is.Zero)
+                        Assert.That(blockedCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves every named mutation-stage failure rolls preview, charges, evidence, and terminal state back together.
+    [<TestCase("preview")>]
+    [<TestCase("ledger")>]
+    [<TestCase("evidence")>]
+    member _.InjectedCloseFailureRollsBackEveryStage(stage: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 6) 11L
+                do! acceptAsync connectionString fact
+                do! addPricingAsync connectionString scope
+                let interleaving = BillingCloseInterleaving(stage, false)
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                Assert.ThrowsAsync<InvalidOperationException>(Func<Task>(fun () -> closer.CloseAsync(request scope, CancellationToken.None) :> Task))
+                |> ignore
+
+                let! previewCount = countAsync connectionString "SELECT COUNT(*) FROM ops.ChargePreviewLine;"
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! closedCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State = 2;"
+                let! lateWorkCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodLateWork;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(previewCount, Is.Zero)
+                        Assert.That(chargeCount, Is.Zero)
+                        Assert.That(evidenceCount, Is.Zero)
+                        Assert.That(closedCount, Is.Zero)
+                        Assert.That(lateWorkCount, Is.Zero))
+                )
+            })
+
+    /// Proves competing close retries converge on one immutable posting and no duplicate evidence.
+    [<Test>]
+    member _.CompetingCloseAndRestartConvergeOnOnePosting() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 7) 13L
+                do! acceptAsync connectionString fact
+                do! addPricingAsync connectionString scope
+
+                let first =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request scope, CancellationToken.None)
+
+                let second =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request scope, CancellationToken.None)
+
+                let! _ = Task.WhenAll(first, second)
+
+                let! restart =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request scope, CancellationToken.None)
+
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(closedChargeCount restart, Is.EqualTo(1))
+                        Assert.That(chargeCount, Is.EqualTo(1))
+                        Assert.That(evidenceCount, Is.EqualTo(1)))
+                )
+            })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.Operations.Tests
 
 open Grace.Operations.Data
+open Grace.Operations.Worker
 open Grace.Types.Common
 open Grace.Types.Usage
 open Microsoft.Data.SqlClient
@@ -191,6 +192,75 @@ VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveF
             Assert.Fail($"Expected a Closed billing-period result but received {result}.")
             Unchecked.defaultof<int>
 
+    /// Proves terminal pricing scopes cannot exhaust a bounded discovery batch and every month in one assignment is emitted.
+    [<Test>]
+    member _.DiscoverySkipsClosedPricingScopesAndExpandsEveryCompletedAssignmentMonth() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    """
+DECLARE @PlanId uniqueidentifier = NEWID();
+INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc)
+VALUES (@PlanId, 'discovery-plan', 'Discovery plan', '2026-01-01T00:00:00');
+
+DECLARE @index int = 0;
+WHILE @index < 101
+BEGIN
+    DECLARE @OwnerId uniqueidentifier = CONVERT(uniqueidentifier, HASHBYTES('MD5', CONCAT('owner-', @index)));
+    DECLARE @OrganizationId uniqueidentifier = CONVERT(uniqueidentifier, HASHBYTES('MD5', CONCAT('organization-', @index)));
+    DECLARE @RepositoryId uniqueidentifier = CONVERT(uniqueidentifier, HASHBYTES('MD5', CONCAT('repository-', @index)));
+    DECLARE @MonthStartUtc datetime2(7) = '2026-01-01T00:00:00';
+    INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc,EffectiveToUtc)
+    VALUES (NEWID(), @OwnerId, @OrganizationId, @RepositoryId, @PlanId, @MonthStartUtc, '2026-02-01T00:00:00');
+    INSERT INTO ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State)
+    VALUES (NEWID(), @OwnerId, @OrganizationId, @RepositoryId, @MonthStartUtc, '2026-02-01T00:00:00', 2);
+    SET @index = @index + 1;
+END;
+
+INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc,EffectiveToUtc)
+VALUES (NEWID(), @TargetOwnerId, @TargetOrganizationId, @TargetRepositoryId, @PlanId, '2026-01-01T00:00:00', '2026-07-01T00:00:00');
+"""
+
+                command.Parameters.Add("@TargetOwnerId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+                command.Parameters.Add("@TargetOrganizationId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+                command.Parameters.Add("@TargetRepositoryId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                let! firstPass = OperationsBillingPeriodCloseDiscovery.discoverAsync connectionString CancellationToken.None
+                let! repeatedPass = OperationsBillingPeriodCloseDiscovery.discoverAsync connectionString CancellationToken.None
+
+                let months (scopes: BillingCompletenessScope array) : Instant array =
+                    scopes
+                    |> Array.filter (fun candidate ->
+                        candidate.OwnerId = scope.OwnerId
+                        && candidate.OrganizationId = scope.OrganizationId
+                        && candidate.RepositoryId = scope.RepositoryId)
+                    |> Array.map (fun candidate -> candidate.MonthStart)
+                    |> Array.sort
+
+                let expected =
+                    [|
+                        Instant.FromUtc(2026, 1, 1, 0, 0)
+                        Instant.FromUtc(2026, 2, 1, 0, 0)
+                        Instant.FromUtc(2026, 3, 1, 0, 0)
+                        Instant.FromUtc(2026, 4, 1, 0, 0)
+                        Instant.FromUtc(2026, 5, 1, 0, 0)
+                        Instant.FromUtc(2026, 6, 1, 0, 0)
+                    |]
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(firstPass.Length, Is.EqualTo(6))
+                        Assert.That(months firstPass, Is.EqualTo(expected :> obj))
+                        Assert.That(months repeatedPass, Is.EqualTo(expected :> obj)))
+                )
+            })
+
     /// Proves accepted usage before close appears in exactly one immutable posting and does not create late work.
     [<Test>]
     member _.AcceptanceBeforeCloseIsIncludedWithoutLateWork() =
@@ -246,27 +316,47 @@ VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveF
                 )
             })
 
-    /// Proves a pricing-covered empty period closes and its first later accepted fact becomes late work rather than changing the initial posting.
+    /// Proves an empty period remains nonterminal until complete pricing coverage exists, then closes and hands later usage to late work.
     [<Test>]
-    member _.ZeroEntryCloseThenFirstAcceptanceCreatesLateWork() =
+    member _.ZeroEntryPricingCoverageBlocksThenRetryClosesAndFirstAcceptanceCreatesLateWork() =
         withDatabaseAsync (fun connectionString ->
             task {
                 let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
                 let scope = scopeFor ownerId organizationId repositoryId
-                do! addPricingAsync connectionString scope
                 let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
-                let! _ = closer.CloseAsync(request scope, CancellationToken.None)
+                let! blocked = closer.CloseAsync(request scope, CancellationToken.None)
+                let! blockedChargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! blockedEvidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                let! blockedDiagnosticCount =
+                    countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0, 1) AND RetryDiagnostic IS NOT NULL;"
+
+                do! addPricingAsync connectionString scope
+                let! closed = closer.CloseAsync(request scope, CancellationToken.None)
                 let fact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 4) 5L
                 do! acceptAsync connectionString fact
                 let! periodCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State = 2;"
                 let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
                 let! lateWorkCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodLateWork;"
+                let! clearedDiagnosticCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE RetryDiagnostic IS NOT NULL;"
 
                 Assert.Multiple(
                     Action (fun () ->
+                        Assert.That(
+                            (match blocked with
+                             | BillingPeriodCloseResult.Blocked _ -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(blockedChargeCount, Is.Zero)
+                        Assert.That(blockedEvidenceCount, Is.Zero)
+                        Assert.That(blockedDiagnosticCount, Is.EqualTo(1))
+                        Assert.That(closedChargeCount closed, Is.Zero)
                         Assert.That(periodCount, Is.EqualTo(1))
                         Assert.That(chargeCount, Is.Zero)
-                        Assert.That(lateWorkCount, Is.EqualTo(1)))
+                        Assert.That(lateWorkCount, Is.EqualTo(1))
+                        Assert.That(clearedDiagnosticCount, Is.Zero))
                 )
             })
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -40,6 +40,15 @@ type private BillingCloseInterleaving(stage: string, pause: bool) =
         member _.AfterLedgerInsertionAsync cancellationToken = observe "ledger" cancellationToken
         member _.AfterCloseEvidenceStagedAsync cancellationToken = observe "evidence" cancellationToken
 
+/// Returns a fixed transaction-local UTC instant while still requiring the production closer to acquire its SQL lock.
+type private FixedBillingCloseClock(now: DateTime) =
+    interface IBillingPeriodCloseClock with
+        member _.UtcNowAsync(_connection, _transaction, cancellationToken) =
+            task {
+                cancellationToken.ThrowIfCancellationRequested()
+                return now
+            }
+
 /// Proves billing-period close against isolated real SQL Server databases and production acceptance/close seams.
 [<TestFixture>]
 [<NonParallelizable>]
@@ -222,6 +231,17 @@ VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveF
             return Convert.ToInt32 value
         }
 
+    /// Reads an independently queried integer total from the isolated SQL database.
+    let int64Async connectionString sql =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- sql
+            let! value = command.ExecuteScalarAsync CancellationToken.None
+            return Convert.ToInt64 value
+        }
+
     /// Builds the fixed scheduled-operation request used by all close proofs.
     let request scope = { Scope = scope; ScheduledOperationProvenance = "operations-tests/billing-period-close/v1" }
 
@@ -363,6 +383,191 @@ END;
                         Assert.That(closedChargeCount targetClose, Is.Zero)
                         Assert.That(blockedCount, Is.EqualTo(100))
                         Assert.That(closedCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves only the database-owned instant at the exact +24h and +72h thresholds makes each operation eligible.
+    [<Test>]
+    member _.DatabaseClockTreatsPreviewAndCloseThresholdEqualityAsEligible() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! addPricingAsync connectionString scope
+
+                let nextMonthStartUtc =
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+
+                let inert = BillingCloseInterleaving("none", false) :> IBillingPeriodCloseTransactionInterleaving
+
+                let previewTooEarly =
+                    SqlBillingPeriodCloser.CreateForTest(
+                        connectionString,
+                        inert,
+                        FixedBillingCloseClock(nextMonthStartUtc.AddHours(24.0).AddTicks(-1L)) :> IBillingPeriodCloseClock
+                    )
+                    :> IBillingPeriodCloser
+
+                let previewAtBoundary =
+                    SqlBillingPeriodCloser.CreateForTest(
+                        connectionString,
+                        inert,
+                        FixedBillingCloseClock(nextMonthStartUtc.AddHours 24.0) :> IBillingPeriodCloseClock
+                    )
+                    :> IBillingPeriodCloser
+
+                let closeTooEarly =
+                    SqlBillingPeriodCloser.CreateForTest(
+                        connectionString,
+                        inert,
+                        FixedBillingCloseClock(nextMonthStartUtc.AddHours(72.0).AddTicks(-1L)) :> IBillingPeriodCloseClock
+                    )
+                    :> IBillingPeriodCloser
+
+                let closeAtBoundary =
+                    SqlBillingPeriodCloser.CreateForTest(
+                        connectionString,
+                        inert,
+                        FixedBillingCloseClock(nextMonthStartUtc.AddHours 72.0) :> IBillingPeriodCloseClock
+                    )
+                    :> IBillingPeriodCloser
+
+                let! previewBefore = previewTooEarly.PreviewAsync(request scope, CancellationToken.None)
+                let! previewAt = previewAtBoundary.PreviewAsync(request scope, CancellationToken.None)
+                let! closeBefore = closeTooEarly.CloseAsync(request scope, CancellationToken.None)
+                let! closeAt = closeAtBoundary.CloseAsync(request scope, CancellationToken.None)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(previewBefore, Is.EqualTo(BillingPeriodCloseResult.NotEligible))
+
+                        Assert.That(
+                            (match previewAt with
+                             | BillingPeriodCloseResult.Provisional _ -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(closeBefore, Is.EqualTo(BillingPeriodCloseResult.NotEligible))
+                        Assert.That(closedChargeCount closeAt, Is.Zero))
+                )
+            })
+
+    /// Proves the half-open billing month includes its first instant and excludes the next month's first instant.
+    [<Test>]
+    member _.CloseIncludesMonthStartFactAndExcludesNextMonthStartFact() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let nextMonthStart = BillingCompletenessScope.nextMonthStart scope
+                do! acceptAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId scope.MonthStart 7L)
+                do! acceptAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId nextMonthStart 11L)
+                do! addPricingAsync connectionString scope
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! closed = closer.CloseAsync(request scope, CancellationToken.None)
+
+                let! postedQuantity =
+                    int64Async
+                        connectionString
+                        "SELECT COALESCE(SUM(TotalQuantity),0) FROM ops.ChargePreviewLine WHERE PeriodFromUtc='2026-06-01T00:00:00' AND PeriodToUtc='2026-07-01T00:00:00';"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(closedChargeCount closed, Is.EqualTo(1))
+                        Assert.That(postedQuantity, Is.EqualTo(7L)))
+                )
+            })
+
+    /// Proves physical constraints and immutable triggers reject mutation while preserving the original close records.
+    [<Test>]
+    member _.PhysicalChargeAndEvidenceMutationsAreRejectedWithoutChangingDurableState() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! acceptAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 2) 7L)
+                do! addPricingAsync connectionString scope
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! _ = closer.CloseAsync(request scope, CancellationToken.None)
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+
+                let rejectMutation sql =
+                    use command = connection.CreateCommand()
+                    command.CommandText <- sql
+
+                    Assert.ThrowsAsync<SqlException>(Func<Task>(fun () -> command.ExecuteNonQueryAsync(CancellationToken.None) :> Task))
+                    |> ignore
+
+                rejectMutation "UPDATE ops.Charge SET ChargeMicros=99;"
+                rejectMutation "DELETE FROM ops.Charge;"
+                rejectMutation "UPDATE ops.BillingPeriodCloseEvidence SET ScheduledOperationProvenance='tampered';"
+                rejectMutation "DELETE FROM ops.BillingPeriodCloseEvidence;"
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(charges, Is.EqualTo(1))
+                        Assert.That(evidence, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves owner concurrency and repository identity remain isolated at the exact close scope.
+    [<Test>]
+    member _.ConcurrentOwnersAndSiblingRepositoriesCloseAsSeparateScopes() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let organizationId = Guid.NewGuid()
+                let ownerA, ownerB = Guid.NewGuid(), Guid.NewGuid()
+                let repositoryA, repositoryB = Guid.NewGuid(), Guid.NewGuid()
+                let ownerAScope = scopeFor ownerA organizationId repositoryA
+                let ownerBScope = scopeFor ownerB organizationId repositoryA
+                let siblingRepositoryScope = scopeFor ownerA organizationId repositoryB
+                do! addPricingAsync connectionString ownerAScope
+                use setup = new SqlConnection(connectionString)
+                do! setup.OpenAsync CancellationToken.None
+                use copyAssignments = setup.CreateCommand()
+
+                copyAssignments.CommandText <-
+                    """
+INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc)
+SELECT NEWID(), @OwnerB, @OrganizationId, @RepositoryA, PricingPlanId, EffectiveFromUtc
+FROM ops.PricingAssignment WHERE OwnerId=@OwnerA AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryA;
+INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc)
+SELECT NEWID(), @OwnerA, @OrganizationId, @RepositoryB, PricingPlanId, EffectiveFromUtc
+FROM ops.PricingAssignment WHERE OwnerId=@OwnerA AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryA;
+"""
+
+                copyAssignments.Parameters.Add("@OwnerA", System.Data.SqlDbType.UniqueIdentifier).Value <- ownerA
+                copyAssignments.Parameters.Add("@OwnerB", System.Data.SqlDbType.UniqueIdentifier).Value <- ownerB
+                copyAssignments.Parameters.Add("@OrganizationId", System.Data.SqlDbType.UniqueIdentifier).Value <- organizationId
+                copyAssignments.Parameters.Add("@RepositoryA", System.Data.SqlDbType.UniqueIdentifier).Value <- repositoryA
+                copyAssignments.Parameters.Add("@RepositoryB", System.Data.SqlDbType.UniqueIdentifier).Value <- repositoryB
+                let! _ = copyAssignments.ExecuteNonQueryAsync CancellationToken.None
+
+                let close scope =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request scope, CancellationToken.None)
+
+                let! results = Task.WhenAll(close ownerAScope, close ownerBScope, close siblingRepositoryScope)
+                let! periodCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
+                let! evidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            results
+                            |> Array.forall (function
+                                | BillingPeriodCloseResult.Closed _ -> true
+                                | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(periodCount, Is.EqualTo(3))
+                        Assert.That(evidenceCount, Is.EqualTo(3)))
                 )
             })
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -170,6 +170,47 @@ VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveF
             return ()
         }
 
+    /// Adds one complete effective pricing grain for a chosen half-open interval through the real Operations schema.
+    let addPricingWindowAsync connectionString (scope: BillingCompletenessScope) factKind (effectiveFrom: DateTime) (effectiveTo: DateTime) =
+        task {
+            let planId = Guid.NewGuid()
+            let mappingId = Guid.NewGuid()
+            let rateId = Guid.NewGuid()
+            let assignmentId = Guid.NewGuid()
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc,EffectiveToUtc)
+VALUES (@PlanId,@PlanCode,@DisplayName,@EffectiveFrom,@EffectiveTo);
+INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc,EffectiveToUtc)
+VALUES (@MappingId,@FactKind,@BillableUsageKind,@MappingName,@EffectiveFrom,@EffectiveTo);
+INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc)
+VALUES (@RateId,@PlanId,@BillableUsageKind,'USD','byte-minute',1,2,@EffectiveFrom,@EffectiveTo);
+INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc,EffectiveToUtc)
+VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveFrom,@EffectiveTo);
+"""
+
+            command.Parameters.Add("@PlanId", System.Data.SqlDbType.UniqueIdentifier).Value <- planId
+            command.Parameters.Add("@PlanCode", System.Data.SqlDbType.NVarChar, 80).Value <- $"close-window-{planId:N}"
+            command.Parameters.Add("@DisplayName", System.Data.SqlDbType.NVarChar, 200).Value <- "Billing close test window"
+            command.Parameters.Add("@MappingId", System.Data.SqlDbType.UniqueIdentifier).Value <- mappingId
+            command.Parameters.Add("@MappingName", System.Data.SqlDbType.NVarChar, 200).Value <- "Storage byte minute"
+            command.Parameters.Add("@FactKind", System.Data.SqlDbType.Int).Value <- factKind
+            command.Parameters.Add("@BillableUsageKind", System.Data.SqlDbType.Int).Value <- 100 + factKind
+            command.Parameters.Add("@RateId", System.Data.SqlDbType.UniqueIdentifier).Value <- rateId
+            command.Parameters.Add("@AssignmentId", System.Data.SqlDbType.UniqueIdentifier).Value <- assignmentId
+            command.Parameters.Add("@OwnerId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            command.Parameters.Add("@OrganizationId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", System.Data.SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            command.Parameters.Add("@EffectiveFrom", System.Data.SqlDbType.DateTime2).Value <- effectiveFrom
+            command.Parameters.Add("@EffectiveTo", System.Data.SqlDbType.DateTime2).Value <- effectiveTo
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
     /// Executes a trusted scalar count command against the isolated SQL database.
     let countAsync connectionString sql =
         task {
@@ -258,6 +299,70 @@ VALUES (NEWID(), @TargetOwnerId, @TargetOrganizationId, @TargetRepositoryId, @Pl
                         Assert.That(firstPass.Length, Is.EqualTo(6))
                         Assert.That(months firstPass, Is.EqualTo(expected :> obj))
                         Assert.That(months repeatedPass, Is.EqualTo(expected :> obj)))
+                )
+            })
+
+    /// Proves a later closable scope is reached after the first page remains occupied by retryable nonterminal periods.
+    [<Test>]
+    member _.DiscoveryCursorReachesLaterClosableScopeWithoutDiscardingPersistentBlockers() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    """
+DECLARE @index int = 0;
+WHILE @index < 100
+BEGIN
+    INSERT INTO ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State,RetryDiagnostic,RetryDiagnosticAtUtc)
+    VALUES
+    (
+        NEWID(),
+        CONVERT(uniqueidentifier, HASHBYTES('MD5', CONCAT('blocked-owner-', @index))),
+        CONVERT(uniqueidentifier, HASHBYTES('MD5', CONCAT('blocked-organization-', @index))),
+        CONVERT(uniqueidentifier, HASHBYTES('MD5', CONCAT('blocked-repository-', @index))),
+        '2026-01-01T00:00:00',
+        '2026-02-01T00:00:00',
+        0,
+        'Missing pricing remains retryable.',
+        SYSUTCDATETIME()
+    );
+    SET @index = @index + 1;
+END;
+"""
+
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                do! addPricingAsync connectionString scope
+
+                let! firstPage = OperationsBillingPeriodCloseDiscovery.discoverAsync connectionString CancellationToken.None
+
+                let! secondPage =
+                    OperationsBillingPeriodCloseDiscovery.discoverAfterAsync connectionString (Some firstPage[firstPage.Length - 1]) CancellationToken.None
+
+                let targetDiscovered =
+                    secondPage
+                    |> Array.exists (fun candidate ->
+                        candidate.OwnerId = scope.OwnerId
+                        && candidate.OrganizationId = scope.OrganizationId
+                        && candidate.RepositoryId = scope.RepositoryId
+                        && candidate.MonthStart = scope.MonthStart)
+
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! targetClose = closer.CloseAsync(request scope, CancellationToken.None)
+                let! blockedCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0,1) AND RetryDiagnostic IS NOT NULL;"
+                let! closedCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State = 2;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(firstPage.Length, Is.EqualTo(100))
+                        Assert.That(targetDiscovered, Is.True)
+                        Assert.That(closedChargeCount targetClose, Is.Zero)
+                        Assert.That(blockedCount, Is.EqualTo(100))
+                        Assert.That(closedCount, Is.EqualTo(1)))
                 )
             })
 
@@ -357,6 +462,72 @@ VALUES (NEWID(), @TargetOwnerId, @TargetOrganizationId, @TargetRepositoryId, @Pl
                         Assert.That(chargeCount, Is.Zero)
                         Assert.That(lateWorkCount, Is.EqualTo(1))
                         Assert.That(clearedDiagnosticCount, Is.Zero))
+                )
+            })
+
+    /// Proves adjacent effective grains collectively cover a zero-fact month while a one-tick gap remains retryable.
+    [<Test>]
+    member _.ZeroFactCloseAcceptsAdjacentCoverageAndRejectsOneTickGapUntilRepaired() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let adjacentScope = scopeFor ownerId organizationId repositoryId
+                let gapScope = { adjacentScope with MonthStart = Instant.FromUtc(2026, 7, 1, 0, 0) }
+                let monthStartUtc = adjacentScope.MonthStart.ToDateTimeUtc()
+
+                let nextMonthStartUtc =
+                    (BillingCompletenessScope.nextMonthStart adjacentScope)
+                        .ToDateTimeUtc()
+
+                let gapMonthStartUtc = gapScope.MonthStart.ToDateTimeUtc()
+
+                let gapNextMonthStartUtc =
+                    (BillingCompletenessScope.nextMonthStart gapScope)
+                        .ToDateTimeUtc()
+
+                let boundary = monthStartUtc.AddDays 15.0
+                let gapBoundary = gapMonthStartUtc.AddDays 15.0
+                let afterGapBoundary = gapBoundary.AddTicks 1L
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+
+                do! addPricingWindowAsync connectionString adjacentScope 1 monthStartUtc boundary
+                do! addPricingWindowAsync connectionString adjacentScope 1 boundary nextMonthStartUtc
+                let! adjacentResult = closer.CloseAsync(request adjacentScope, CancellationToken.None)
+
+                do! addPricingWindowAsync connectionString gapScope 1 gapMonthStartUtc gapBoundary
+                do! addPricingWindowAsync connectionString gapScope 1 afterGapBoundary gapNextMonthStartUtc
+                let! gappedResult = closer.CloseAsync(request gapScope, CancellationToken.None)
+
+                let! gappedPostingCount =
+                    countAsync
+                        connectionString
+                        "SELECT COUNT(*) FROM ops.Charge WHERE BillingPeriodId IN (SELECT BillingPeriodId FROM ops.BillingPeriod WHERE RepositoryId <> '00000000-0000-0000-0000-000000000000');"
+
+                let! gappedEvidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! gappedDiagnosticCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE RetryDiagnostic IS NOT NULL;"
+
+                do! addPricingWindowAsync connectionString gapScope 1 gapBoundary afterGapBoundary
+                let! repairedResult = closer.CloseAsync(request gapScope, CancellationToken.None)
+                let! repairedDiagnosticCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE RetryDiagnostic IS NOT NULL;"
+                let! closedCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State = 2;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(closedChargeCount adjacentResult, Is.Zero)
+
+                        Assert.That(
+                            (match gappedResult with
+                             | BillingPeriodCloseResult.Blocked _ -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(gappedPostingCount, Is.Zero)
+                        Assert.That(gappedEvidenceCount, Is.EqualTo(1))
+                        Assert.That(gappedDiagnosticCount, Is.EqualTo(1))
+                        Assert.That(closedChargeCount repairedResult, Is.Zero)
+                        Assert.That(repairedDiagnosticCount, Is.Zero)
+                        Assert.That(closedCount, Is.EqualTo(2)))
                 )
             })
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -226,7 +226,7 @@ type OperationsChargePreviewTests() =
             Assert.That(sql, Does.Contain("fact.ObservedAtUtc >= @PeriodFromUtc"))
             Assert.That(sql, Does.Contain("fact.ObservedAtUtc < @PeriodToUtc"))
             Assert.That(sql, Does.Contain("assignment.EffectiveFromUtc"))
-            Assert.That(sql, Does.Contain("plan.EffectiveFromUtc"))
+            Assert.That(sql, Does.Contain("pricingPlan.EffectiveFromUtc"))
             Assert.That(sql, Does.Contain("mapping.EffectiveFromUtc"))
             Assert.That(sql, Does.Contain("rate.EffectiveFromUtc"))
             Assert.That(sql, Does.Contain("MAX(boundary.EffectiveFromUtc)"))
@@ -244,7 +244,7 @@ type OperationsChargePreviewTests() =
                 "..",
                 "Grace.Operations.Data",
                 "Migrations",
-                "20260812110000_AddUsageFactJournal.fs"
+                "20260812130000_AddBillingPeriodClose.fs"
             )
             |> Path.GetFullPath
 
@@ -274,7 +274,7 @@ type OperationsChargePreviewTests() =
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewModel;Integrated Security=true;"
         let runtime = context.GetService<IDesignTimeModel>().Model
         let snapshot = OperationsDbContextModelSnapshot().Model
-        let migration = AddUsageFactJournal().TargetModel
+        let migration = AddBillingPeriodClose().TargetModel
 
         let modelShape (model: Microsoft.EntityFrameworkCore.Metadata.IModel) =
             model.GetEntityTypes()
@@ -344,6 +344,10 @@ type OperationsChargePreviewTests() =
             Assert.That(snapshotModelSource, Does.Contain("let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()"))
             Assert.That(targetModelSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
             Assert.That(snapshotModelSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
+            Assert.That(migration.FindEntityType(typeof<BillingPeriodEntity>), Is.Not.Null)
+            Assert.That(migration.FindEntityType(typeof<ChargeEntity>), Is.Not.Null)
+            Assert.That(migration.FindEntityType(typeof<BillingPeriodCloseEvidenceEntity>), Is.Not.Null)
+            Assert.That(migration.FindEntityType(typeof<BillingPeriodLateWorkEntity>), Is.Not.Null)
             Assert.That(rejection, Is.Not.Null)
             Assert.That((migrationShape = snapshotShape), Is.True)
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -149,6 +149,10 @@ type private InMemoryOperationsUsageTransactionScope() =
                                 aggregates[aggregate.Key] <- current + aggregate.Quantity
                                 Task.CompletedTask
 
+                        member _.RecordClosedPeriodLateWorkAsync(_rawFact, _scope, lateWorkCancellationToken) =
+                            lateWorkCancellationToken.ThrowIfCancellationRequested()
+                            Task.CompletedTask
+
                         member _.RecordScopedUsageFactRejectionAsync(_rejection, rejectionCancellationToken) =
                             rejectionCancellationToken.ThrowIfCancellationRequested()
                             Task.FromResult(None)

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -489,7 +489,7 @@ type OperationsUsageStorageTests() =
     /// Verifies partitioning is limited to current Operations tables and keeps local SQL Server testability.
     [<Test>]
     member _.MonthlyPartitioningMigrationStaysInsideCurrentUsageTables() =
-        let script = migrationScript ()
+        let script = migrationScriptFromTo "20260707000000_AddRawUsageFactPayload" "20260707120000_AddOperationsMonthlyPartitioning"
 
         Assert.Multiple(
             Action (fun () ->

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -2360,13 +2360,30 @@ module internal OperationsBillingPeriodCloseDiscovery =
     /// Caps one discovery pass so a worker restart or long history cannot monopolize the hosted process.
     let batchSize = 100
 
-    /// Reads accepted-usage, pricing-coverage, and existing nonterminal scopes while excluding terminal exact periods.
-    let discoverAsync connectionString cancellationToken =
+    /// Reads one stable discovery page after an optional exact scope cursor while excluding terminal exact periods.
+    let discoverAfterAsync connectionString (afterScope: BillingCompletenessScope option) cancellationToken =
         task {
             use connection = new SqlConnection(connectionString)
             do! connection.OpenAsync cancellationToken
             use command = connection.CreateCommand()
             command.Parameters.Add("@BatchSize", SqlDbType.Int).Value <- batchSize
+
+            let afterMonthStart = command.Parameters.Add("@AfterMonthStartUtc", SqlDbType.DateTime2)
+            let afterOwner = command.Parameters.Add("@AfterOwnerId", SqlDbType.UniqueIdentifier)
+            let afterOrganization = command.Parameters.Add("@AfterOrganizationId", SqlDbType.UniqueIdentifier)
+            let afterRepository = command.Parameters.Add("@AfterRepositoryId", SqlDbType.UniqueIdentifier)
+
+            match afterScope with
+            | Some scope ->
+                afterMonthStart.Value <- scope.MonthStart.ToDateTimeUtc()
+                afterOwner.Value <- scope.OwnerId
+                afterOrganization.Value <- scope.OrganizationId
+                afterRepository.Value <- scope.RepositoryId
+            | None ->
+                afterMonthStart.Value <- DBNull.Value
+                afterOwner.Value <- DBNull.Value
+                afterOrganization.Value <- DBNull.Value
+                afterRepository.Value <- DBNull.Value
 
             command.CommandText <-
                 """
@@ -2401,6 +2418,30 @@ candidate AS
 SELECT TOP (@BatchSize) OwnerId, OrganizationId, RepositoryId, MonthStartUtc
 FROM candidate
 WHERE MonthStartUtc < DATETIME2FROMPARTS(YEAR(SYSUTCDATETIME()), MONTH(SYSUTCDATETIME()), 1, 0, 0, 0, 0, 7)
+  AND
+  (
+      @AfterMonthStartUtc IS NULL
+      OR MonthStartUtc > @AfterMonthStartUtc
+      OR
+      (
+          MonthStartUtc = @AfterMonthStartUtc
+          AND
+          (
+              CONVERT(binary(16), OwnerId) > CONVERT(binary(16), @AfterOwnerId)
+              OR
+              (
+                  OwnerId = @AfterOwnerId
+                  AND CONVERT(binary(16), OrganizationId) > CONVERT(binary(16), @AfterOrganizationId)
+              )
+              OR
+              (
+                  OwnerId = @AfterOwnerId
+                  AND OrganizationId = @AfterOrganizationId
+                  AND CONVERT(binary(16), RepositoryId) > CONVERT(binary(16), @AfterRepositoryId)
+              )
+          )
+      )
+  )
   AND NOT EXISTS
   (
       SELECT 1
@@ -2409,7 +2450,7 @@ WHERE MonthStartUtc < DATETIME2FROMPARTS(YEAR(SYSUTCDATETIME()), MONTH(SYSUTCDAT
         AND period.MonthStartUtc=candidate.MonthStartUtc AND period.NextMonthStartUtc=DATEADD(month, 1, candidate.MonthStartUtc)
         AND period.State=2
   )
-ORDER BY MonthStartUtc, OwnerId, OrganizationId, RepositoryId
+ORDER BY MonthStartUtc, CONVERT(binary(16), OwnerId), CONVERT(binary(16), OrganizationId), CONVERT(binary(16), RepositoryId)
 OPTION (MAXRECURSION 100);
 """
 
@@ -2434,6 +2475,9 @@ OPTION (MAXRECURSION 100);
             return scopes |> Seq.toArray
         }
 
+    /// Starts a bounded discovery pass at the first ordered scope.
+    let discoverAsync connectionString cancellationToken = discoverAfterAsync connectionString None cancellationToken
+
 /// Runs bounded, repeatable billing-period discovery without persisting a second claim or retry lifecycle.
 type OperationsBillingPeriodCloseWorkerService
     (
@@ -2447,11 +2491,14 @@ type OperationsBillingPeriodCloseWorkerService
     /// Uses a short fixed cadence because database eligibility and the scope-locked closer remain the source of truth.
     let cadence = TimeSpan.FromMinutes(5.0)
 
-    /// Revalidates every discovered candidate through the closer; stale scans cannot decide close eligibility.
+    /// Retains only the volatile cursor for a fully processed page; SQL rows remain the retry source after restart.
+    let mutable resumeAfter: BillingCompletenessScope option = None
+
+    /// Revalidates one stable candidate page through the closer, advancing only after every scope in that page completed.
     let runPassAsync cancellationToken =
         task {
             do! schema.EnsureCreatedAsync cancellationToken
-            let! scopes = OperationsBillingPeriodCloseDiscovery.discoverAsync settings.SqlConnectionString cancellationToken
+            let! scopes = OperationsBillingPeriodCloseDiscovery.discoverAfterAsync settings.SqlConnectionString resumeAfter cancellationToken
             let mutable index = 0
 
             while index < scopes.Length do
@@ -2472,6 +2519,12 @@ type OperationsBillingPeriodCloseWorkerService
                     ()
 
                 index <- index + 1
+
+            resumeAfter <-
+                if scopes.Length = OperationsBillingPeriodCloseDiscovery.batchSize then
+                    Some scopes[scopes.Length - 1]
+                else
+                    None
         }
 
     /// Repeats bounded discovery and leaves every failure retryable through the next scan without an additional claim table.

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -17,6 +17,7 @@ open Microsoft.Extensions.Logging
 open NodaTime
 open System
 open System.Collections.Generic
+open System.Data
 open System.Globalization
 open System.IO
 open System.IO.Compression
@@ -2352,6 +2353,116 @@ type internal IOperationsUsageJournalSignalSender =
 
     /// Sends the immutable Pending entry that was reread immediately before this call.
     abstract SendAsync: entry: UsageFactJournalEntry * cancellationToken: CancellationToken -> Task
+
+/// Runs bounded, repeatable billing-period discovery without persisting a second claim or retry lifecycle.
+type OperationsBillingPeriodCloseWorkerService
+    (
+        settings: OperationsWorkerSettings,
+        schema: IOperationsUsageSchemaInitializer,
+        closer: IBillingPeriodCloser,
+        logger: ILogger<OperationsBillingPeriodCloseWorkerService>
+    ) =
+    inherit BackgroundService()
+
+    /// Caps one discovery pass so a worker restart or long history cannot monopolize the hosted process.
+    let batchSize = 100
+
+    /// Uses a short fixed cadence because database eligibility and the scope-locked closer remain the source of truth.
+    let cadence = TimeSpan.FromMinutes(5.0)
+
+    /// Discovers accepted-usage, pricing-coverage, and existing nonterminal scopes in a single bounded SQL read.
+    let discoverAsync cancellationToken =
+        task {
+            use connection = new SqlConnection(settings.SqlConnectionString)
+            do! connection.OpenAsync cancellationToken
+            use command = connection.CreateCommand()
+            command.Parameters.Add("@BatchSize", SqlDbType.Int).Value <- batchSize
+
+            command.CommandText <-
+                """
+WITH candidate AS
+(
+    SELECT OwnerId, OrganizationId, RepositoryId,
+           DATETIME2FROMPARTS(YEAR(ObservedAtUtc), MONTH(ObservedAtUtc), 1, 0, 0, 0, 0, 7) AS MonthStartUtc
+    FROM ops.RawUsageFact
+    UNION
+    SELECT OwnerId, OrganizationId, RepositoryId, MonthStartUtc
+    FROM ops.BillingPeriod
+    WHERE State IN (0, 1)
+    UNION
+    SELECT assignment.OwnerId, assignment.OrganizationId, assignment.RepositoryId,
+           DATETIME2FROMPARTS(YEAR(assignment.EffectiveFromUtc), MONTH(assignment.EffectiveFromUtc), 1, 0, 0, 0, 0, 7)
+    FROM ops.PricingAssignment AS assignment
+    WHERE assignment.EffectiveFromUtc < SYSUTCDATETIME()
+      AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > DATEADD(month, DATEDIFF(month, 0, assignment.EffectiveFromUtc), 0))
+)
+SELECT TOP (@BatchSize) OwnerId, OrganizationId, RepositoryId, MonthStartUtc
+FROM candidate
+WHERE MonthStartUtc < DATETIME2FROMPARTS(YEAR(SYSUTCDATETIME()), MONTH(SYSUTCDATETIME()), 1, 0, 0, 0, 0, 7)
+ORDER BY MonthStartUtc, OwnerId, OrganizationId, RepositoryId;
+"""
+
+            use! reader = command.ExecuteReaderAsync cancellationToken
+            let scopes = ResizeArray<BillingCompletenessScope>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+                reading <- hasRow
+
+                if hasRow then
+                    scopes.Add(
+                        {
+                            OwnerId = reader.GetGuid 0
+                            OrganizationId = reader.GetGuid 1
+                            RepositoryId = reader.GetGuid 2
+                            MonthStart = reader.GetDateTime 3 |> Instant.FromDateTimeUtc
+                        }
+                    )
+
+            return scopes |> Seq.toArray
+        }
+
+    /// Revalidates every discovered candidate through the closer; stale scans cannot decide close eligibility.
+    let runPassAsync cancellationToken =
+        task {
+            do! schema.EnsureCreatedAsync cancellationToken
+            let! scopes = discoverAsync cancellationToken
+            let mutable index = 0
+
+            while index < scopes.Length do
+                let request = { Scope = scopes[index]; ScheduledOperationProvenance = "operations-worker/billing-period-close/v1" }
+                let! preview = closer.PreviewAsync(request, cancellationToken)
+
+                match preview with
+                | NotEligible -> ()
+                | Blocked diagnostic ->
+                    logger.LogWarning(
+                        "Billing period {Scope} remains nonterminal: {Diagnostic}",
+                        BillingCompletenessScope.databaseLockIdentity request.Scope,
+                        diagnostic
+                    )
+                | Provisional _
+                | Closed _ ->
+                    let! _ = closer.CloseAsync(request, cancellationToken)
+                    ()
+
+                index <- index + 1
+        }
+
+    /// Repeats bounded discovery and leaves every failure retryable through the next scan without an additional claim table.
+    override _.ExecuteAsync(cancellationToken: CancellationToken) =
+        task {
+            while not cancellationToken.IsCancellationRequested do
+                try
+                    do! runPassAsync cancellationToken
+                with
+                | :? OperationCanceledException when cancellationToken.IsCancellationRequested -> ()
+                | ex -> logger.LogWarning(ex, "Operations billing-period close pass failed; the next bounded scan will revalidate candidates.")
+
+                if not cancellationToken.IsCancellationRequested then
+                    do! Task.Delay(cadence, cancellationToken)
+        }
 
 /// Observes the narrow gap between one Pending scan and its per-row production reread for deterministic stale-scan proof.
 type internal IOperationsUsageJournalDispatchInterleaving =

--- a/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/OperationsWorker.fs
@@ -2354,52 +2354,63 @@ type internal IOperationsUsageJournalSignalSender =
     /// Sends the immutable Pending entry that was reread immediately before this call.
     abstract SendAsync: entry: UsageFactJournalEntry * cancellationToken: CancellationToken -> Task
 
-/// Runs bounded, repeatable billing-period discovery without persisting a second claim or retry lifecycle.
-type OperationsBillingPeriodCloseWorkerService
-    (
-        settings: OperationsWorkerSettings,
-        schema: IOperationsUsageSchemaInitializer,
-        closer: IBillingPeriodCloser,
-        logger: ILogger<OperationsBillingPeriodCloseWorkerService>
-    ) =
-    inherit BackgroundService()
+/// Discovers bounded nonterminal billing scopes without adding a second claim or retry lifecycle.
+module internal OperationsBillingPeriodCloseDiscovery =
 
     /// Caps one discovery pass so a worker restart or long history cannot monopolize the hosted process.
     let batchSize = 100
 
-    /// Uses a short fixed cadence because database eligibility and the scope-locked closer remain the source of truth.
-    let cadence = TimeSpan.FromMinutes(5.0)
-
-    /// Discovers accepted-usage, pricing-coverage, and existing nonterminal scopes in a single bounded SQL read.
-    let discoverAsync cancellationToken =
+    /// Reads accepted-usage, pricing-coverage, and existing nonterminal scopes while excluding terminal exact periods.
+    let discoverAsync connectionString cancellationToken =
         task {
-            use connection = new SqlConnection(settings.SqlConnectionString)
+            use connection = new SqlConnection(connectionString)
             do! connection.OpenAsync cancellationToken
             use command = connection.CreateCommand()
             command.Parameters.Add("@BatchSize", SqlDbType.Int).Value <- batchSize
 
             command.CommandText <-
                 """
-WITH candidate AS
+WITH pricingCandidate AS
 (
-    SELECT OwnerId, OrganizationId, RepositoryId,
+    SELECT assignment.OwnerId, assignment.OrganizationId, assignment.RepositoryId,
+           DATETIME2FROMPARTS(YEAR(assignment.EffectiveFromUtc), MONTH(assignment.EffectiveFromUtc), 1, 0, 0, 0, 0, 7) AS MonthStartUtc,
+           assignment.EffectiveToUtc
+    FROM ops.PricingAssignment AS assignment
+    WHERE assignment.EffectiveFromUtc < DATETIME2FROMPARTS(YEAR(SYSUTCDATETIME()), MONTH(SYSUTCDATETIME()), 1, 0, 0, 0, 0, 7)
+
+    UNION ALL
+
+    SELECT OwnerId, OrganizationId, RepositoryId, DATEADD(month, 1, MonthStartUtc), EffectiveToUtc
+    FROM pricingCandidate
+    WHERE DATEADD(month, 1, MonthStartUtc) < DATETIME2FROMPARTS(YEAR(SYSUTCDATETIME()), MONTH(SYSUTCDATETIME()), 1, 0, 0, 0, 0, 7)
+      AND (EffectiveToUtc IS NULL OR DATEADD(month, 1, MonthStartUtc) < EffectiveToUtc)
+),
+candidate AS
+(
+    SELECT fact.OwnerId, fact.OrganizationId, fact.RepositoryId,
            DATETIME2FROMPARTS(YEAR(ObservedAtUtc), MONTH(ObservedAtUtc), 1, 0, 0, 0, 0, 7) AS MonthStartUtc
-    FROM ops.RawUsageFact
+    FROM ops.RawUsageFact AS fact
     UNION
     SELECT OwnerId, OrganizationId, RepositoryId, MonthStartUtc
     FROM ops.BillingPeriod
     WHERE State IN (0, 1)
     UNION
-    SELECT assignment.OwnerId, assignment.OrganizationId, assignment.RepositoryId,
-           DATETIME2FROMPARTS(YEAR(assignment.EffectiveFromUtc), MONTH(assignment.EffectiveFromUtc), 1, 0, 0, 0, 0, 7)
-    FROM ops.PricingAssignment AS assignment
-    WHERE assignment.EffectiveFromUtc < SYSUTCDATETIME()
-      AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > DATEADD(month, DATEDIFF(month, 0, assignment.EffectiveFromUtc), 0))
+    SELECT OwnerId, OrganizationId, RepositoryId, MonthStartUtc
+    FROM pricingCandidate
 )
 SELECT TOP (@BatchSize) OwnerId, OrganizationId, RepositoryId, MonthStartUtc
 FROM candidate
 WHERE MonthStartUtc < DATETIME2FROMPARTS(YEAR(SYSUTCDATETIME()), MONTH(SYSUTCDATETIME()), 1, 0, 0, 0, 0, 7)
-ORDER BY MonthStartUtc, OwnerId, OrganizationId, RepositoryId;
+  AND NOT EXISTS
+  (
+      SELECT 1
+      FROM ops.BillingPeriod AS period
+      WHERE period.OwnerId=candidate.OwnerId AND period.OrganizationId=candidate.OrganizationId AND period.RepositoryId=candidate.RepositoryId
+        AND period.MonthStartUtc=candidate.MonthStartUtc AND period.NextMonthStartUtc=DATEADD(month, 1, candidate.MonthStartUtc)
+        AND period.State=2
+  )
+ORDER BY MonthStartUtc, OwnerId, OrganizationId, RepositoryId
+OPTION (MAXRECURSION 100);
 """
 
             use! reader = command.ExecuteReaderAsync cancellationToken
@@ -2416,18 +2427,31 @@ ORDER BY MonthStartUtc, OwnerId, OrganizationId, RepositoryId;
                             OwnerId = reader.GetGuid 0
                             OrganizationId = reader.GetGuid 1
                             RepositoryId = reader.GetGuid 2
-                            MonthStart = reader.GetDateTime 3 |> Instant.FromDateTimeUtc
+                            MonthStart = Instant.FromDateTimeUtc(DateTime.SpecifyKind(reader.GetDateTime 3, DateTimeKind.Utc))
                         }
                     )
 
             return scopes |> Seq.toArray
         }
 
+/// Runs bounded, repeatable billing-period discovery without persisting a second claim or retry lifecycle.
+type OperationsBillingPeriodCloseWorkerService
+    (
+        settings: OperationsWorkerSettings,
+        schema: IOperationsUsageSchemaInitializer,
+        closer: IBillingPeriodCloser,
+        logger: ILogger<OperationsBillingPeriodCloseWorkerService>
+    ) =
+    inherit BackgroundService()
+
+    /// Uses a short fixed cadence because database eligibility and the scope-locked closer remain the source of truth.
+    let cadence = TimeSpan.FromMinutes(5.0)
+
     /// Revalidates every discovered candidate through the closer; stale scans cannot decide close eligibility.
     let runPassAsync cancellationToken =
         task {
             do! schema.EnsureCreatedAsync cancellationToken
-            let! scopes = discoverAsync cancellationToken
+            let! scopes = OperationsBillingPeriodCloseDiscovery.discoverAsync settings.SqlConnectionString cancellationToken
             let mutable index = 0
 
             while index < scopes.Length do

--- a/src/Grace.Operations/Grace.Operations.Worker/Program.fs
+++ b/src/Grace.Operations/Grace.Operations.Worker/Program.fs
@@ -63,6 +63,9 @@ module Program =
         services.AddSingleton<IChargePreviewRebuilder>(fun _ -> SqlChargePreviewRebuilder(settings.SqlConnectionString) :> IChargePreviewRebuilder)
         |> ignore
 
+        services.AddSingleton<IBillingPeriodCloser>(fun _ -> SqlBillingPeriodCloser(settings.SqlConnectionString) :> IBillingPeriodCloser)
+        |> ignore
+
         services.AddSingleton<OperationsUsageIngestionProcessor>()
         |> ignore
 
@@ -78,6 +81,9 @@ module Program =
         |> ignore
 
         services.AddHostedService<OperationsUsageJournalDispatcherService>()
+        |> ignore
+
+        services.AddHostedService<OperationsBillingPeriodCloseWorkerService>()
         |> ignore
 
         services.AddHostedService<OperationsUsageTemporaryHotCleanupWorkerService>()


### PR DESCRIPTION
# Close billing periods with immutable initial charges

## Purpose

Give Grace owners a reproducible initial monthly charge while preserving every supported usage fact that races the
close transaction.

Related to #864. Parent replacement mini-epic: #576. Epic chain: #554 -> #560 -> #576.

## Current implementation checkpoint

- Adds exact-scope billing-period, immutable charge, close-evidence, and minimal pending late-work persistence.
- Adds a self-contained migration with runtime, frozen target-model, and snapshot propagation.
- Closes eligible periods under the same exact-scope SQL lock used by usage acceptance and completeness.
- Writes initial charges, close evidence, and `Closed` atomically.
- Adds the bounded scheduled close shell.
- Creates minimal late-work rows when accepted usage commits after a closed period.
- Repairs the production charge-preview SQL alias because `plan` is reserved by SQL Server.

## Current proof

- Operations Data and Operations Tests Release builds pass with zero warnings and errors.
- Isolated real-SQL cases pass for acceptance-first, close-first, zero-entry close, missing pricing, competing close and
  restart convergence, and three rollback injection points.
- `git diff --check` passes.

## Known completion work

This normal ready PR remains in progress so review and fixes stay attached to the published branch. The current head
does not yet directly prove every #864 requirement:

- exact `+24h` and `+72h` timing boundaries;
- first/next-month fact boundaries;
- concurrent owner and repository isolation;
- direct physical constraint and immutability rejection;
- complete worker discovery behavior;
- a retained numeric total for the shared billing-completeness regression.

Worker 3 will receive the completed exact-head review plus these known gaps as one consolidated completion set.

## Scope and deferred behavior

- Product V1, internal Operations surfaces only.
- #865 retains correction claiming, retry, calculation, posting, and completion.
- #866 retains manual adjustments.
- #715 retains any terminal failed-period settlement.
- No public HTTP, CLI, SDK, OpenAPI, generated-client, or server-route changes.
- No compatibility behavior for imagined production data.

## Review status

- **Superseded at exact head `137c35b02f57493d9976fa54e1eebee56ee047d8`.**
- Implementation/fix workers started: **4**. Worker 5 was not assigned.
- Decisive review 3 found both repeated cycle-2 invariant families still open after structural stabilization:
  - zero-fact coverage can pass vacuously when the required mapping/rate set is empty;
  - the discovery test bypasses the production worker cursor/pass lifecycle.
- Exact-head GitHub `Validate` run `31652106485` also failed one Operations-worker shutdown tracer; causality remained
  unproven, so it is recorded as a blocking CI gap rather than a confirmed code defect.
- Issue #864 is now a replacement mini-epic with Plan-ready children #908, #909, and #910.
- Preserve the selective salvage map in #864. Do not merge or cherry-pick this PR wholesale.

## Documentation impact

No public behavior or command documentation changes. The durable model is described by F# XML comments and the
self-contained migration.