### PR TITLE
WDU-05C1: add collision-safe exact-root topology planning

### DIFF
--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -52,6 +52,7 @@
     <Compile Include="WorkingDirectoryUpdate.Contracts.Tests.fs" />
     <Compile Include="WorkingDirectoryUpdate.PreparedContent.Tests.fs" />
     <Compile Include="WorkingDirectoryUpdate.Coordination.Tests.fs" />
+    <Compile Include="WorkingDirectoryUpdate.Topology.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs
@@ -1,0 +1,515 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.Shared
+open Grace.Shared.Client.Configuration
+open Grace.Shared.Constants
+open Grace.Types.Common
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+open System.Security.Cryptography
+open System.Text
+
+/// Exercises the pure pre-mutation topology boundary against real temporary working trees.
+module WorkingDirectoryUpdateTopologyTests =
+    /// Extracts a successful private construction or reports its rejected reason.
+    let private required =
+        function
+        | Ok value -> value
+        | Error error -> failwith error
+
+    /// Configures a disposable repository root so planner filesystem classification uses production configuration semantics.
+    let private configureForRoot (root: string) =
+        let configuration = GraceConfiguration()
+        configuration.OwnerId <- Guid.NewGuid()
+        configuration.OrganizationId <- Guid.NewGuid()
+        configuration.RepositoryId <- Guid.NewGuid()
+        configuration.RootDirectory <- root
+        configuration.StandardizedRootDirectory <- Grace.Shared.Utilities.normalizeFilePath root
+        configuration.GraceDirectory <- Path.Combine(root, GraceConfigDirectory)
+        configuration.ObjectDirectory <- Path.Combine(configuration.GraceDirectory, GraceObjectsDirectory)
+        configuration.GraceStatusFile <- Path.Combine(configuration.GraceDirectory, GraceLocalStateDbFileName)
+        configuration.GraceObjectCacheFile <- configuration.GraceStatusFile
+        configuration.ConfigurationDirectory <- configuration.GraceDirectory
+
+        Directory.CreateDirectory(configuration.ConfigurationDirectory)
+        |> ignore
+
+        saveConfigFile (Path.Combine(configuration.ConfigurationDirectory, GraceConfigFileName)) configuration
+        resetConfiguration ()
+        Current()
+
+    /// Runs one topology scenario with isolated configuration and a temporary filesystem root.
+    let private withTempRepo action =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-wdu-topology-{Guid.NewGuid():N}")
+        let originalDirectory = Environment.CurrentDirectory
+        let originalParseResult = Services.parseResult
+
+        try
+            Directory.CreateDirectory(root) |> ignore
+            Environment.CurrentDirectory <- root
+            Services.parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
+            let configuration = configureForRoot root
+            action root configuration
+        finally
+            Services.clearShouldIgnoreCache ()
+            Services.parseResult <- originalParseResult
+            Environment.CurrentDirectory <- originalDirectory
+            resetConfiguration ()
+
+            if Directory.Exists(root) then Directory.Delete(root, true)
+
+    /// Creates an exact target file entry whose declared hashes match the supplied prepared bytes.
+    let private targetFile (path: string) (bytes: byte array) =
+        let sha256Hash =
+            SHA256.HashData(bytes)
+            |> Convert.ToHexString
+            |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+        let blake3Hash = Blake3Hash(ContentAddress.computeBlake3Hex bytes)
+        WorkingDirectoryUpdateContracts.PreparedManifestEntry.File(RelativePath path, sha256Hash, blake3Hash)
+
+    /// Builds an immutable manifest or stops the test at the exact manifest validation failure.
+    let private manifest entries =
+        WorkingDirectoryUpdateContracts.PreparedManifest.create entries
+        |> required
+
+    /// Builds one tracked local file with deterministic current-status hashes for topology classification.
+    let private trackedFile (path: string) (bytes: byte array) =
+        let sha256Hash =
+            SHA256.HashData(bytes)
+            |> Convert.ToHexString
+            |> fun value -> Sha256Hash(value.ToLowerInvariant())
+
+        LocalFileVersion.CreateWithHashes
+            (RelativePath path)
+            sha256Hash
+            (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+            false
+            (int64 bytes.Length)
+            (Grace.Shared.Utilities.getCurrentInstant ())
+            true
+            DateTime.UtcNow
+
+    /// Builds one complete current status snapshot whose index explicitly names each tracked directory and file.
+    let private status (trackedDirectories: string list) (trackedFiles: LocalFileVersion list) =
+        let index = GraceIndex()
+
+        trackedDirectories
+        |> List.iteri (fun indexValue path ->
+            let directory =
+                LocalDirectoryVersion.CreateWithHashes
+                    (Guid.NewGuid())
+                    OwnerId.Empty
+                    OrganizationId.Empty
+                    RepositoryId.Empty
+                    (RelativePath path)
+                    (Sha256Hash $"directory-{indexValue}")
+                    (Blake3Hash $"directory-{indexValue}")
+                    (List<DirectoryVersionId>())
+                    (List<LocalFileVersion>())
+                    0L
+                    DateTime.UtcNow
+
+            index[directory.DirectoryVersionId] <- directory)
+
+        if trackedFiles |> List.isEmpty |> not then
+            let root =
+                LocalDirectoryVersion.CreateWithHashes
+                    (Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+                    OwnerId.Empty
+                    OrganizationId.Empty
+                    RepositoryId.Empty
+                    (RelativePath Constants.RootDirectoryPath)
+                    (Sha256Hash "root")
+                    (Blake3Hash "root")
+                    (List<DirectoryVersionId>())
+                    (List<LocalFileVersion>(trackedFiles))
+                    0L
+                    DateTime.UtcNow
+
+            index[root.DirectoryVersionId] <- root
+
+        { GraceStatus.Default with Index = index }
+
+    /// Executes planning synchronously so each real-filesystem test has one stable assertion point.
+    let private plan currentStatus preparedManifest =
+        WorkingDirectoryUpdate.Topology.plan currentStatus preparedManifest
+        |> fun task -> task.GetAwaiter().GetResult()
+
+    /// Captures every path kind and file byte sequence before a rejection proof.
+    let private snapshotTree root =
+        DirectoryInfo(root)
+            .GetFileSystemInfos("*", SearchOption.AllDirectories)
+        |> Array.map (fun entry ->
+            let path = Grace.Shared.Utilities.normalizeFilePath (Path.GetRelativePath(root, entry.FullName))
+
+            let value =
+                if entry :? DirectoryInfo then
+                    "directory"
+                else
+                    Convert.ToHexString(File.ReadAllBytes(entry.FullName))
+
+            path, value)
+        |> Array.sort
+
+    /// Asserts a planning rejection leaves every working-tree path, kind, and byte sequence unchanged.
+    let private shouldRejectWithoutTreeChange root before result =
+        match result with
+        | WorkingDirectoryUpdate.Topology.Rejected _ -> snapshotTree root |> should equal before
+        | WorkingDirectoryUpdate.Topology.Planned _ -> Assert.Fail("Expected a pre-mutation topology rejection.")
+
+    /// Proves ignored user bytes at a target file can never be planned for replacement.
+    [<Test>]
+    let ``topology rejects ignored target file without changing distinct user bytes`` () =
+        withTempRepo (fun root configuration ->
+            let targetPath = Path.Combine(root, "protected.txt")
+            let userBytes = Encoding.UTF8.GetBytes("ignored user bytes must survive")
+            File.WriteAllBytes(targetPath, userBytes)
+            configuration.GraceFileIgnoreEntries <- [| "protected.txt" |]
+            Services.clearShouldIgnoreCache ()
+
+            let preparedManifest = manifest [ targetFile "protected.txt" (Encoding.UTF8.GetBytes("selected bytes")) ]
+            let before = snapshotTree root
+            let result = plan GraceStatus.Default preparedManifest
+
+            match result with
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                WorkingDirectoryUpdate.Topology.Rejection.path rejection
+                |> should equal (RelativePath "protected.txt")
+            | WorkingDirectoryUpdate.Topology.Planned _ -> Assert.Fail("Ignored target bytes must reject before any mutation can be planned.")
+
+            File.ReadAllBytes(targetPath)
+            |> should equal userBytes
+
+            snapshotTree root |> should equal before)
+
+    /// Proves absent targets and verified tracked matches make a complete materialization plan without destructive actions.
+    [<Test>]
+    let ``topology retains matching tracked files and plans absent files and directories`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            let matchingBytes = Encoding.UTF8.GetBytes("matching")
+            File.WriteAllBytes(Path.Combine(root, "matching.txt"), matchingBytes)
+
+            let currentStatus =
+                status [] [
+                    trackedFile "matching.txt" matchingBytes
+                ]
+
+            let preparedManifest =
+                manifest [ targetFile "matching.txt" matchingBytes
+                           WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "src")
+                           targetFile "src/new.txt" (Encoding.UTF8.GetBytes("new")) ]
+
+            match plan currentStatus preparedManifest with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> should
+                    equal
+                    [
+                        WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "src")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "src/new.txt")
+                    ]
+            | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected a safe absent/matching plan."))
+
+    /// Proves tracked target files with a different verified version are copied without inventing a removal action.
+    [<Test>]
+    let ``topology copies a tracked target file when its verified bytes differ`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            let localBytes = Encoding.UTF8.GetBytes("old tracked bytes")
+            let selectedBytes = Encoding.UTF8.GetBytes("selected replacement bytes")
+            File.WriteAllBytes(Path.Combine(root, "replace.txt"), localBytes)
+
+            let currentStatus =
+                status [] [
+                    trackedFile "replace.txt" localBytes
+                ]
+
+            match plan currentStatus (manifest [ targetFile "replace.txt" selectedBytes ]) with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> should
+                    equal
+                    [
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "replace.txt")
+                    ]
+            | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected tracked file replacement plan."))
+
+    /// Proves tracked replacement and directory-to-file transitions name all tracked removals before copying target bytes.
+    [<Test>]
+    let ``topology orders tracked directory to file replacement deepest first`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "replace", "nested"))
+            |> ignore
+
+            File.WriteAllText(Path.Combine(root, "replace", "nested", "old.txt"), "old")
+
+            let currentStatus =
+                status [ "replace"; "replace/nested" ] [
+                    trackedFile "replace/nested/old.txt" (Encoding.UTF8.GetBytes("old"))
+                ]
+
+            let preparedManifest = manifest [ targetFile "replace" (Encoding.UTF8.GetBytes("new file")) ]
+
+            match plan currentStatus preparedManifest with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> should
+                    equal
+                    [
+                        WorkingDirectoryUpdate.Topology.RemoveTrackedFile(RelativePath "replace/nested/old.txt")
+                        WorkingDirectoryUpdate.Topology.RemoveTrackedDirectory(RelativePath "replace/nested")
+                        WorkingDirectoryUpdate.Topology.RemoveTrackedDirectory(RelativePath "replace")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "replace")
+                    ]
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                Assert.Fail(
+                    $"Expected tracked directory replacement plan; rejected {WorkingDirectoryUpdate.Topology.Rejection.path rejection} as {WorkingDirectoryUpdate.Topology.Rejection.classification rejection}."
+                ))
+
+    /// Proves directory targets replace tracked files before shallow directory creation.
+    [<Test>]
+    let ``topology removes tracked file before creating target directory`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            File.WriteAllText(Path.Combine(root, "src"), "old file")
+
+            let currentStatus =
+                status [] [
+                    trackedFile "src" (Encoding.UTF8.GetBytes("old file"))
+                ]
+
+            let preparedManifest = manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "src") ]
+
+            match plan currentStatus preparedManifest with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> should
+                    equal
+                    [
+                        WorkingDirectoryUpdate.Topology.RemoveTrackedFile(RelativePath "src")
+                        WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "src")
+                    ]
+            | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected tracked file replacement plan."))
+
+    /// Proves an already tracked target directory remains in place and produces no deferred work.
+    [<Test>]
+    let ``topology retains an existing tracked target directory`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "retained"))
+            |> ignore
+
+            let currentStatus = status [ "retained" ] []
+
+            match plan currentStatus (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "retained") ]) with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> List.isEmpty
+                |> should equal true
+            | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected tracked target directory retention."))
+
+    /// Proves an ignored descendant blocks a tracked directory-to-file replacement before any action is returned.
+    [<Test>]
+    let ``topology rejects a tracked directory target file with an ignored descendant`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- [| "replace/user.txt" |]
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "replace", "nested"))
+            |> ignore
+
+            File.WriteAllText(Path.Combine(root, "replace", "nested", "tracked.txt"), "tracked")
+            File.WriteAllText(Path.Combine(root, "replace", "user.txt"), "ignored user bytes")
+
+            let currentStatus =
+                status [ "replace"; "replace/nested" ] [
+                    trackedFile "replace/nested/tracked.txt" (Encoding.UTF8.GetBytes("tracked"))
+                ]
+
+            let before = snapshotTree root
+
+            plan currentStatus (manifest [ targetFile "replace" (Encoding.UTF8.GetBytes("selected file")) ])
+            |> shouldRejectWithoutTreeChange root before)
+
+    /// Proves untracked target files and nested ignored descendants reject without changing local user content.
+    [<Test>]
+    let ``topology rejects untracked blockers and ignored directory descendants without mutation`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- [| "ignored.txt" |]
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            let untrackedPath = Path.Combine(root, "untracked.txt")
+            File.WriteAllText(untrackedPath, "untracked")
+            let untrackedBefore = snapshotTree root
+            let untracked = plan GraceStatus.Default (manifest [ targetFile "untracked.txt" (Encoding.UTF8.GetBytes("selected")) ])
+            shouldRejectWithoutTreeChange root untrackedBefore untracked
+
+            File.Delete(untrackedPath)
+
+            Directory.CreateDirectory(Path.Combine(root, "replace"))
+            |> ignore
+
+            File.WriteAllText(Path.Combine(root, "replace", "ignored.txt"), "preserve")
+            let ignoredBefore = snapshotTree root
+            let currentStatus = status [ "replace" ] []
+            let ignored = plan currentStatus (manifest [ targetFile "replace" (Encoding.UTF8.GetBytes("selected")) ])
+            shouldRejectWithoutTreeChange root ignoredBefore ignored)
+
+    /// Proves target directories reject both ignored and untracked file blockers without deleting user bytes.
+    [<Test>]
+    let ``topology rejects ignored and untracked files where target directories are required`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- [| "ignored-directory-target" |]
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            let ignoredPath = Path.Combine(root, "ignored-directory-target")
+            File.WriteAllText(ignoredPath, "ignored user bytes")
+            let ignoredBefore = snapshotTree root
+
+            plan GraceStatus.Default (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "ignored-directory-target") ])
+            |> shouldRejectWithoutTreeChange root ignoredBefore
+
+            File.Delete(ignoredPath)
+            let untrackedPath = Path.Combine(root, "untracked-directory-target")
+            File.WriteAllText(untrackedPath, "untracked user bytes")
+            let untrackedBefore = snapshotTree root
+
+            plan GraceStatus.Default (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "untracked-directory-target") ])
+            |> shouldRejectWithoutTreeChange root untrackedBefore)
+
+    /// Proves an untracked target-file blocker produces a stable rejected path and preserves its exact user bytes.
+    [<Test>]
+    let ``topology rejects an untracked target file without changing its bytes`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            let targetPath = Path.Combine(root, "untracked.txt")
+            let userBytes = Encoding.UTF8.GetBytes("untracked user bytes must survive")
+            File.WriteAllBytes(targetPath, userBytes)
+            let before = snapshotTree root
+            let result = plan GraceStatus.Default (manifest [ targetFile "untracked.txt" (Encoding.UTF8.GetBytes("selected")) ])
+
+            match result with
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                WorkingDirectoryUpdate.Topology.Rejection.path rejection
+                |> should equal (RelativePath "untracked.txt")
+
+                WorkingDirectoryUpdate.Topology.Rejection.classification rejection
+                |> should equal WorkingDirectoryUpdate.Topology.Untracked
+            | WorkingDirectoryUpdate.Topology.Planned _ -> Assert.Fail("Expected untracked target-file rejection.")
+
+            File.ReadAllBytes(targetPath)
+            |> should equal userBytes
+
+            snapshotTree root |> should equal before)
+
+    /// Proves implicit directory ancestors are planned shallowest first before later verified file copies.
+    [<Test>]
+    let ``topology plans implicit target directories shallowest first`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+            let preparedManifest = manifest [ targetFile "one/two/three.txt" (Encoding.UTF8.GetBytes("selected")) ]
+
+            match plan GraceStatus.Default preparedManifest with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> should
+                    equal
+                    [
+                        WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "one")
+                        WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "one/two")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "one/two/three.txt")
+                    ]
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                Assert.Fail(
+                    $"Expected implicit target directory plan; rejected {WorkingDirectoryUpdate.Topology.Rejection.path rejection} as {WorkingDirectoryUpdate.Topology.Rejection.classification rejection}."
+                ))
+
+    /// Proves obsolete tracked empty directories are listed deepest first and user descendants prohibit removal.
+    [<Test>]
+    let ``topology removes obsolete tracked empty directories and rejects unsafe descendants`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "obsolete", "nested"))
+            |> ignore
+
+            let currentStatus = status [ "obsolete"; "obsolete/nested" ] []
+
+            match plan currentStatus (manifest []) with
+            | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
+                WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
+                |> should
+                    equal
+                    [
+                        WorkingDirectoryUpdate.Topology.RemoveTrackedDirectory(RelativePath "obsolete/nested")
+                        WorkingDirectoryUpdate.Topology.RemoveTrackedDirectory(RelativePath "obsolete")
+                    ]
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                Assert.Fail(
+                    $"Expected obsolete empty tracked directory removal; rejected {WorkingDirectoryUpdate.Topology.Rejection.path rejection} as {WorkingDirectoryUpdate.Topology.Rejection.classification rejection}."
+                )
+
+            File.WriteAllText(Path.Combine(root, "obsolete", "nested", "user.txt"), "user")
+            let before = snapshotTree root
+
+            plan currentStatus (manifest [])
+            |> shouldRejectWithoutTreeChange root before)
+
+    /// Proves an ignored descendant blocks obsolete tracked-directory removal and preserves the whole subtree.
+    [<Test>]
+    let ``topology rejects obsolete tracked directory removal with an ignored descendant`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- [| "obsolete/user.txt" |]
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "obsolete", "nested"))
+            |> ignore
+
+            File.WriteAllText(Path.Combine(root, "obsolete", "nested", "tracked.txt"), "tracked")
+            File.WriteAllText(Path.Combine(root, "obsolete", "user.txt"), "ignored user bytes")
+
+            let currentStatus =
+                status [ "obsolete"; "obsolete/nested" ] [
+                    trackedFile "obsolete/nested/tracked.txt" (Encoding.UTF8.GetBytes("tracked"))
+                ]
+
+            let before = snapshotTree root
+            let result = plan currentStatus (manifest [])
+            shouldRejectWithoutTreeChange root before result)
+
+    /// Proves manifest collision and escape validation reject before the planner can receive ambiguous Windows shapes.
+    [<Test>]
+    let ``prepared manifest rejects case collisions file directory conflicts and normalized escapes`` () =
+        let bytes = Encoding.UTF8.GetBytes("content")
+
+        manifest [ targetFile "safe.txt" bytes ] |> ignore
+
+        WorkingDirectoryUpdateContracts.PreparedManifest.create [ targetFile "Case.txt" bytes
+                                                                  targetFile "case.txt" bytes ]
+        |> Result.isError
+        |> should equal true
+
+        WorkingDirectoryUpdateContracts.PreparedManifest.create [ targetFile "node" bytes
+                                                                  WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "node/child") ]
+        |> Result.isError
+        |> should equal true
+
+        WorkingDirectoryUpdateContracts.PreparedManifest.create [ targetFile "../escape.txt" bytes ]
+        |> Result.isError
+        |> should equal true

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs
@@ -95,49 +95,137 @@ module WorkingDirectoryUpdateTopologyTests =
             true
             DateTime.UtcNow
 
-    /// Builds one complete current status snapshot whose index explicitly names each tracked directory and file.
-    let private status (trackedDirectories: string list) (trackedFiles: LocalFileVersion list) =
-        let index = GraceIndex()
+    /// Returns the direct tracked parent path for one normalized local status path.
+    let private parentDirectoryPath path =
+        if path = Constants.RootDirectoryPath then
+            None
+        else
+            let separator = path.LastIndexOf('/')
 
-        trackedDirectories
-        |> List.iteri (fun indexValue path ->
+            if separator < 0 then
+                Some Constants.RootDirectoryPath
+            else
+                Some(path.Substring(0, separator))
+
+    /// Returns every directory needed to root one normalized tracked path.
+    let private directoryAncestors path =
+        let rec collect currentPath ancestors =
+            match parentDirectoryPath currentPath with
+            | Some parent -> collect parent (parent :: ancestors)
+            | None -> ancestors
+
+        collect path []
+
+    /// Builds a rooted, hash-complete production-valid status graph and checks it through the real complete-status validator.
+    let private status (trackedDirectories: string list) (trackedFiles: LocalFileVersion list) =
+        let paths =
+            seq {
+                yield Constants.RootDirectoryPath
+
+                for directory in trackedDirectories do
+                    yield directory
+                    yield! directoryAncestors directory
+
+                for file in trackedFiles do
+                    yield! directoryAncestors (string file.RelativePath)
+            }
+            |> Seq.distinct
+            |> Seq.sortByDescending (fun path ->
+                if path = Constants.RootDirectoryPath then
+                    0
+                else
+                    path
+                        .Split(
+                            '/',
+                            StringSplitOptions.RemoveEmptyEntries
+                        )
+                        .Length)
+            |> Seq.toArray
+
+        let directoryIds = Dictionary<string, DirectoryVersionId>(StringComparer.Ordinal)
+
+        for path in paths do
+            directoryIds[path] <- Guid.NewGuid()
+
+        let filesByDirectory =
+            trackedFiles
+            |> Seq.groupBy (fun file ->
+                parentDirectoryPath (string file.RelativePath)
+                |> Option.get)
+            |> Seq.map (fun (path, files) -> path, files |> Seq.toArray)
+            |> dict
+
+        let directories = Dictionary<string, LocalDirectoryVersion>(StringComparer.Ordinal)
+        let lastWrite = DateTime(2025, 2, 3, 4, 5, 6, DateTimeKind.Utc)
+        let current = Current()
+
+        for path in paths do
+            let directChildren =
+                paths
+                |> Array.filter (fun candidate -> parentDirectoryPath candidate = Some path)
+                |> Array.map (fun childPath -> directories[childPath])
+
+            let directFiles =
+                match filesByDirectory.TryGetValue(path) with
+                | true, files -> files
+                | false, _ -> Array.empty
+
+            let entries =
+                seq {
+                    yield!
+                        directChildren
+                        |> Seq.map (fun child ->
+                            Services.DirectoryVersionPreimageEntry.Directory child.RelativePath child.Size child.Blake3Hash child.Sha256Hash)
+
+                    yield!
+                        directFiles
+                        |> Seq.map (fun file -> Services.DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash)
+                }
+                |> Seq.toArray
+
             let directory =
                 LocalDirectoryVersion.CreateWithHashes
-                    (Guid.NewGuid())
-                    OwnerId.Empty
-                    OrganizationId.Empty
-                    RepositoryId.Empty
+                    directoryIds[path]
+                    current.OwnerId
+                    current.OrganizationId
+                    current.RepositoryId
                     (RelativePath path)
-                    (Sha256Hash $"directory-{indexValue}")
-                    (Blake3Hash $"directory-{indexValue}")
-                    (List<DirectoryVersionId>())
-                    (List<LocalFileVersion>())
-                    0L
-                    DateTime.UtcNow
+                    (Services.computeSha256ForDirectoryEntries (RelativePath path) entries)
+                    (Services.computeBlake3ForDirectory (RelativePath path) entries)
+                    (List<DirectoryVersionId>(
+                        directChildren
+                        |> Array.map (fun child -> child.DirectoryVersionId)
+                    ))
+                    (List<LocalFileVersion>(directFiles))
+                    (entries |> Array.sumBy (fun entry -> entry.Size))
+                    lastWrite
 
-            index[directory.DirectoryVersionId] <- directory)
+            directories[path] <- directory
 
-        if trackedFiles |> List.isEmpty |> not then
-            let root =
-                LocalDirectoryVersion.CreateWithHashes
-                    (Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff"))
-                    OwnerId.Empty
-                    OrganizationId.Empty
-                    RepositoryId.Empty
-                    (RelativePath Constants.RootDirectoryPath)
-                    (Sha256Hash "root")
-                    (Blake3Hash "root")
-                    (List<DirectoryVersionId>())
-                    (List<LocalFileVersion>(trackedFiles))
-                    0L
-                    DateTime.UtcNow
+        let root = directories[Constants.RootDirectoryPath]
+        let index = GraceIndex()
 
-            index[root.DirectoryVersionId] <- root
+        for directory in directories.Values do
+            index[directory.DirectoryVersionId] <- directory
 
-        { GraceStatus.Default with Index = index }
+        let completeStatus =
+            { GraceStatus.Default with
+                Index = index
+                RootDirectoryId = root.DirectoryVersionId
+                RootDirectorySha256Hash = root.Sha256Hash
+                RootDirectoryBlake3Hash = root.Blake3Hash
+            }
+
+        match LocalStateDb.validateCompleteStatusTree completeStatus with
+        | Ok () -> completeStatus
+        | Error error -> invalidOp $"Topology test fixture must be a complete rooted Grace status graph: {error}"
 
     /// Executes planning synchronously so each real-filesystem test has one stable assertion point.
     let private plan currentStatus preparedManifest =
+        match LocalStateDb.validateCompleteStatusTree currentStatus with
+        | Ok () -> ()
+        | Error error -> invalidOp $"Topology planner tests require a production-valid complete status graph: {error}"
+
         WorkingDirectoryUpdate.Topology.plan currentStatus preparedManifest
         |> fun task -> task.GetAwaiter().GetResult()
 
@@ -175,7 +263,7 @@ module WorkingDirectoryUpdateTopologyTests =
 
             let preparedManifest = manifest [ targetFile "protected.txt" (Encoding.UTF8.GetBytes("selected bytes")) ]
             let before = snapshotTree root
-            let result = plan GraceStatus.Default preparedManifest
+            let result = plan (status [] []) preparedManifest
 
             match result with
             | WorkingDirectoryUpdate.Topology.Rejected rejection ->
@@ -323,6 +411,91 @@ module WorkingDirectoryUpdateTopologyTests =
                 |> should equal true
             | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected tracked target directory retention."))
 
+    /// Proves a late eligible descendant makes a retained target directory reject before another planned action can be returned.
+    [<Test>]
+    let ``topology rejects a late untracked descendant beneath a retained target directory without changing the full tree`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "retained"))
+            |> ignore
+
+            let acceptedStatus = status [ "retained" ] []
+            let lateUserPath = Path.Combine(root, "retained", "late-user.txt")
+            File.WriteAllText(lateUserPath, "created after accepted status")
+            let before = snapshotTree root
+
+            let result =
+                plan
+                    acceptedStatus
+                    (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "retained")
+                                targetFile "other/new.txt" (Encoding.UTF8.GetBytes("would otherwise materialize")) ])
+
+            match result with
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                WorkingDirectoryUpdate.Topology.Rejection.path rejection
+                |> should equal (RelativePath "retained/late-user.txt")
+
+                WorkingDirectoryUpdate.Topology.Rejection.classification rejection
+                |> should equal WorkingDirectoryUpdate.Topology.Untracked
+            | WorkingDirectoryUpdate.Topology.Planned _ ->
+                Assert.Fail("A retained target directory with a late untracked descendant must reject before any later mutation can be planned.")
+
+            snapshotTree root |> should equal before)
+
+    /// Proves a tracked file that became a directory cannot be silently omitted from the tracked removal plan.
+    [<Test>]
+    let ``topology rejects tracked file actual directory drift without changing the tree`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            Directory.CreateDirectory(Path.Combine(root, "former-file"))
+            |> ignore
+
+            let currentStatus =
+                status [] [
+                    trackedFile "former-file" (Encoding.UTF8.GetBytes("tracked file"))
+                ]
+
+            let before = snapshotTree root
+            let result = plan currentStatus (manifest [])
+
+            match result with
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                WorkingDirectoryUpdate.Topology.Rejection.path rejection
+                |> should equal (RelativePath "former-file")
+
+                WorkingDirectoryUpdate.Topology.Rejection.classification rejection
+                |> should equal WorkingDirectoryUpdate.Topology.Untracked
+            | WorkingDirectoryUpdate.Topology.Planned _ -> Assert.Fail("A tracked file whose actual kind is directory must not be omitted from the plan.")
+
+            snapshotTree root |> should equal before)
+
+    /// Proves a tracked directory that became a file cannot be silently omitted from the tracked removal plan.
+    [<Test>]
+    let ``topology rejects tracked directory actual file drift without changing the tree`` () =
+        withTempRepo (fun root configuration ->
+            configuration.GraceFileIgnoreEntries <- Array.empty
+            configuration.GraceDirectoryIgnoreEntries <- Array.empty
+
+            File.WriteAllText(Path.Combine(root, "former-directory"), "actual file")
+            let currentStatus = status [ "former-directory" ] []
+            let before = snapshotTree root
+            let result = plan currentStatus (manifest [])
+
+            match result with
+            | WorkingDirectoryUpdate.Topology.Rejected rejection ->
+                WorkingDirectoryUpdate.Topology.Rejection.path rejection
+                |> should equal (RelativePath "former-directory")
+
+                WorkingDirectoryUpdate.Topology.Rejection.classification rejection
+                |> should equal WorkingDirectoryUpdate.Topology.Untracked
+            | WorkingDirectoryUpdate.Topology.Planned _ -> Assert.Fail("A tracked directory whose actual kind is file must not be omitted from the plan.")
+
+            snapshotTree root |> should equal before)
+
     /// Proves an ignored descendant blocks a tracked directory-to-file replacement before any action is returned.
     [<Test>]
     let ``topology rejects a tracked directory target file with an ignored descendant`` () =
@@ -355,7 +528,7 @@ module WorkingDirectoryUpdateTopologyTests =
             let untrackedPath = Path.Combine(root, "untracked.txt")
             File.WriteAllText(untrackedPath, "untracked")
             let untrackedBefore = snapshotTree root
-            let untracked = plan GraceStatus.Default (manifest [ targetFile "untracked.txt" (Encoding.UTF8.GetBytes("selected")) ])
+            let untracked = plan (status [] []) (manifest [ targetFile "untracked.txt" (Encoding.UTF8.GetBytes("selected")) ])
             shouldRejectWithoutTreeChange root untrackedBefore untracked
 
             File.Delete(untrackedPath)
@@ -379,7 +552,7 @@ module WorkingDirectoryUpdateTopologyTests =
             File.WriteAllText(ignoredPath, "ignored user bytes")
             let ignoredBefore = snapshotTree root
 
-            plan GraceStatus.Default (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "ignored-directory-target") ])
+            plan (status [] []) (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "ignored-directory-target") ])
             |> shouldRejectWithoutTreeChange root ignoredBefore
 
             File.Delete(ignoredPath)
@@ -387,7 +560,7 @@ module WorkingDirectoryUpdateTopologyTests =
             File.WriteAllText(untrackedPath, "untracked user bytes")
             let untrackedBefore = snapshotTree root
 
-            plan GraceStatus.Default (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "untracked-directory-target") ])
+            plan (status [] []) (manifest [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath "untracked-directory-target") ])
             |> shouldRejectWithoutTreeChange root untrackedBefore)
 
     /// Proves an untracked target-file blocker produces a stable rejected path and preserves its exact user bytes.
@@ -400,7 +573,7 @@ module WorkingDirectoryUpdateTopologyTests =
             let userBytes = Encoding.UTF8.GetBytes("untracked user bytes must survive")
             File.WriteAllBytes(targetPath, userBytes)
             let before = snapshotTree root
-            let result = plan GraceStatus.Default (manifest [ targetFile "untracked.txt" (Encoding.UTF8.GetBytes("selected")) ])
+            let result = plan (status [] []) (manifest [ targetFile "untracked.txt" (Encoding.UTF8.GetBytes("selected")) ])
 
             match result with
             | WorkingDirectoryUpdate.Topology.Rejected rejection ->
@@ -424,7 +597,7 @@ module WorkingDirectoryUpdateTopologyTests =
             configuration.GraceDirectoryIgnoreEntries <- Array.empty
             let preparedManifest = manifest [ targetFile "one/two/three.txt" (Encoding.UTF8.GetBytes("selected")) ]
 
-            match plan GraceStatus.Default preparedManifest with
+            match plan (status [] []) preparedManifest with
             | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
                 WorkingDirectoryUpdate.Topology.Plan.actions topologyPlan
                 |> should

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -1,5 +1,480 @@
 namespace Grace.CLI.Command
 
+open System
+open System.Collections.Generic
+open System.IO
+open System.Threading.Tasks
+open Grace.CLI
+open Grace.Shared
+open Grace.Shared.Client.Configuration
+open Grace.Types.Common
+
 /// Owns the verified local working-directory update transaction after its private contracts and storage seams exist.
 module internal WorkingDirectoryUpdate =
-    ()
+    /// Classifies one immutable topology result before a later transaction can mutate the working tree.
+    module Topology =
+        /// Identifies why a local path cannot safely participate in a tracked-only topology plan.
+        type RejectionClassification =
+            | Ignored
+            | Untracked
+            | AmbiguousTarget
+            | EscapesLocalRoot
+
+        /// Carries the stable repository-relative path and classification that prevented a pre-mutation plan.
+        type Rejection = private { Path: RelativePath; Classification: RejectionClassification }
+
+        /// Describes one tracked later transaction step without carrying a writer, callback, or mutable filesystem handle.
+        type Action =
+            | RemoveTrackedFile of RelativePath
+            | RemoveTrackedDirectory of RelativePath
+            | EnsureDirectory of RelativePath
+            | CopyVerifiedFile of RelativePath
+
+        /// Represents the complete immutable topology plan that a later transaction may apply without discovering blockers.
+        type Plan = private Plan of Action list
+
+        /// Represents either the complete immutable plan or one stable pre-mutation conflict.
+        type Result =
+            | Planned of Plan
+            | Rejected of Rejection
+
+        /// Returns the conflict path from a rejected topology decision.
+        module Rejection =
+            /// Gets the repository-relative path that prevents safe planning.
+            let path rejection = rejection.Path
+
+            /// Returns the safety classification that caused the topology decision to reject.
+            let classification rejection = rejection.Classification
+
+        /// Returns every deterministic action in a successful topology plan.
+        module Plan =
+            /// Gets the complete immutable action sequence in transaction order.
+            let actions (Plan actions) = actions
+
+        /// Represents the filesystem shape observed for one candidate repository path.
+        type private ActualKind =
+            | Missing
+            | File
+            | Directory
+
+        /// Returns the Windows-normalized comparison key for one already-normalized relative path.
+        let private pathKey (path: RelativePath) =
+            string path
+            |> fun value -> value.ToUpperInvariant()
+
+        /// Counts path components so tracked removals and target directory creation have explicit stable ordering.
+        let private depth (path: RelativePath) =
+            if string path = Constants.RootDirectoryPath then
+                0
+            else
+                (string path).Split(
+                    '/',
+                    StringSplitOptions.RemoveEmptyEntries
+                )
+                    .Length
+
+        /// Compares two paths using the exact case-insensitive behavior required for Windows target shapes.
+        let private comparePaths left right = StringComparer.OrdinalIgnoreCase.Compare((string left), (string right))
+
+        /// Orders tracked directories by Windows comparison path so rejection selection never depends on dictionary enumeration.
+        let private orderedTrackedDirectories (entries: seq<LocalDirectoryVersion>) =
+            entries
+            |> Seq.sortWith (fun left right -> comparePaths left.RelativePath right.RelativePath)
+
+        /// Orders tracked files by Windows comparison path so rejection selection never depends on dictionary enumeration.
+        let private orderedTrackedFiles (entries: seq<LocalFileVersion>) =
+            entries
+            |> Seq.sortWith (fun left right -> comparePaths left.RelativePath right.RelativePath)
+
+        /// Orders target directories by Windows comparison path so rejection selection never depends on dictionary enumeration.
+        let private orderedTargetDirectories (entries: seq<RelativePath>) = entries |> Seq.sortWith comparePaths
+
+        /// Orders target files by Windows comparison path so rejection selection never depends on dictionary enumeration.
+        let private orderedTargetFiles (entries: seq<Sha256Hash * Blake3Hash * RelativePath>) =
+            entries
+            |> Seq.sortWith (fun (_, _, left) (_, _, right) -> comparePaths left right)
+
+        /// Returns the parent directories implied by one target file or directory path.
+        let private parentDirectories (path: RelativePath) =
+            let segments =
+                (string path)
+                    .Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+            [
+                for index in 1 .. segments.Length - 1 do
+                    RelativePath(String.Join('/', segments[0 .. index - 1]))
+            ]
+
+        /// Converts a repository-relative path into one fully-qualified candidate beneath the configured local root.
+        let private fullPathUnderRoot localRoot (path: RelativePath) =
+            let relative = string path
+
+            let candidate =
+                if relative = Constants.RootDirectoryPath then
+                    localRoot
+                else
+                    Path.Combine(localRoot, relative.Replace('/', Path.DirectorySeparatorChar))
+                    |> Path.GetFullPath
+
+            if Services.isPathWithinDirectoryWithComparison StringComparison.OrdinalIgnoreCase localRoot candidate then
+                Ok candidate
+            else
+                Error { Path = path; Classification = EscapesLocalRoot }
+
+        /// Returns the actual filesystem kind without mutating the path.
+        let private actualKind fullPath =
+            if File.Exists(fullPath) then File
+            elif Directory.Exists(fullPath) then Directory
+            else Missing
+
+        /// Builds the immutable current configuration snapshot consumed by the repository scan/ignore classifier.
+        let private currentScanInput () : Services.WorkingTreeScanInput =
+            let current = Current()
+
+            {
+                RootDirectory = current.RootDirectory
+                GraceDirectory = current.GraceDirectory
+                GraceStatusFile = current.GraceStatusFile
+                DirectoryIgnoreEntries = current.GraceDirectoryIgnoreEntries
+                FileIgnoreEntries = current.GraceFileIgnoreEntries
+            }
+
+        /// Builds the supported repository classifier input from one immutable scan snapshot.
+        let private classifierInput (scanInput: Services.WorkingTreeScanInput) : Services.RepositoryPathClassifierInput =
+            {
+                RootDirectory = scanInput.RootDirectory
+                GraceDirectory = scanInput.GraceDirectory
+                GraceStatusFile = scanInput.GraceStatusFile
+                DirectoryIgnoreEntries = scanInput.DirectoryIgnoreEntries
+                FileIgnoreEntries = scanInput.FileIgnoreEntries
+                PathComparison = StringComparison.OrdinalIgnoreCase
+            }
+
+        /// Returns whether a tracked file already contains the exact selected target bytes.
+        let private hasVerifiedTargetBytes fullPath targetSha256 targetBlake3 =
+            Services.createLocalFileVersion (FileInfo(fullPath))
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> Option.exists (fun actual ->
+                actual.Sha256Hash = targetSha256
+                && actual.Blake3Hash = targetBlake3)
+
+        /// Builds the complete tracked file and directory maps from one status snapshot while rejecting Windows collisions.
+        let private trackedTopology (status: GraceStatus) =
+            let files = Dictionary<string, LocalFileVersion>(StringComparer.Ordinal)
+            let directories = Dictionary<string, LocalDirectoryVersion>(StringComparer.Ordinal)
+            let mutable rejection = None
+
+            for directoryVersion in orderedTrackedDirectories status.Index.Values do
+                let directoryKey = pathKey directoryVersion.RelativePath
+
+                if
+                    directories.ContainsKey(directoryKey)
+                    || files.ContainsKey(directoryKey)
+                then
+                    rejection <- Some { Path = directoryVersion.RelativePath; Classification = AmbiguousTarget }
+                else
+                    directories[directoryKey] <- directoryVersion
+
+                for fileVersion in orderedTrackedFiles directoryVersion.Files do
+                    let fileKey = pathKey fileVersion.RelativePath
+
+                    if
+                        files.ContainsKey(fileKey)
+                        || directories.ContainsKey(fileKey)
+                    then
+                        rejection <- Some { Path = fileVersion.RelativePath; Classification = AmbiguousTarget }
+                    else
+                        files[fileKey] <- fileVersion
+
+            rejection, files, directories
+
+        /// Derives complete target file and directory topology from the immutable prepared manifest, including file ancestors.
+        let private targetTopology manifest =
+            let files = Dictionary<string, Sha256Hash * Blake3Hash * RelativePath>(StringComparer.Ordinal)
+            let directories = Dictionary<string, RelativePath>(StringComparer.Ordinal)
+            directories[pathKey (RelativePath Constants.RootDirectoryPath)] <- RelativePath Constants.RootDirectoryPath
+            let mutable rejection = None
+
+            for entry in WorkingDirectoryUpdateContracts.PreparedManifest.entries manifest do
+                match entry with
+                | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory path ->
+                    let key = pathKey path
+
+                    if
+                        files.ContainsKey(key)
+                        || directories.ContainsKey(key)
+                    then
+                        rejection <- Some { Path = path; Classification = AmbiguousTarget }
+                    else
+                        directories[key] <- path
+
+                    for parent in parentDirectories path do
+                        let parentKey = pathKey parent
+
+                        if files.ContainsKey(parentKey) then
+                            rejection <- Some { Path = parent; Classification = AmbiguousTarget }
+                        else
+                            directories[parentKey] <- parent
+                | WorkingDirectoryUpdateContracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) ->
+                    let key = pathKey path
+
+                    if
+                        files.ContainsKey(key)
+                        || directories.ContainsKey(key)
+                    then
+                        rejection <- Some { Path = path; Classification = AmbiguousTarget }
+                    else
+                        files[key] <- (sha256Hash, blake3Hash, path)
+
+                    for parent in parentDirectories path do
+                        let parentKey = pathKey parent
+
+                        if files.ContainsKey(parentKey) then
+                            rejection <- Some { Path = parent; Classification = AmbiguousTarget }
+                        else
+                            directories[parentKey] <- parent
+
+            rejection, files, directories
+
+        /// Classifies an actual local entry through the supported ignore rules before it can be treated as tracked.
+        let private localClassification
+            (classifierInput: Services.RepositoryPathClassifierInput)
+            (files: Dictionary<string, LocalFileVersion>)
+            (directories: Dictionary<string, LocalDirectoryVersion>)
+            (fullPath: string)
+            (relativePath: RelativePath)
+            kind
+            =
+            let pathKind =
+                match kind with
+                | File -> Services.RepositoryPathKind.FilePath
+                | Directory -> Services.RepositoryPathKind.DirectoryPath
+                | Missing -> Services.RepositoryPathKind.UnknownPath
+
+            match Services.classifyRepositoryPath classifierInput pathKind fullPath with
+            | Services.RepositoryPathClassification.Eligible ->
+                let key = pathKey relativePath
+
+                match kind, files.TryGetValue(key), directories.TryGetValue(key) with
+                | File, (true, _), _ -> Ok "tracked-file"
+                | Directory, _, (true, _) -> Ok "tracked-directory"
+                | Missing, _, _ -> Ok "missing"
+                | _ -> Error { Path = relativePath; Classification = Untracked }
+            | _ -> Error { Path = relativePath; Classification = Ignored }
+
+        /// Finds the first ignored or untracked descendant that would make a tracked directory unsafe to remove.
+        let private firstUnsafeDescendant classifierInput files directories localRoot rootDirectory relativePath =
+            let rec visit fullPath currentRelative =
+                let children =
+                    DirectoryInfo(fullPath).GetFileSystemInfos()
+                    |> Array.sortWith (fun left right -> StringComparer.OrdinalIgnoreCase.Compare(left.FullName, right.FullName))
+
+                let mutable conflict = None
+                let mutable index = 0
+
+                while index < children.Length && Option.isNone conflict do
+                    let child = children[index]
+
+                    let childRelative =
+                        Path.GetRelativePath(localRoot, child.FullName)
+                        |> Grace.Shared.Utilities.normalizeFilePath
+                        |> RelativePath
+
+                    let childKind = if child :? DirectoryInfo then Directory else File
+
+                    match localClassification classifierInput files directories child.FullName childRelative childKind with
+                    | Error rejection -> conflict <- Some rejection
+                    | Ok "tracked-directory" -> conflict <- visit child.FullName childRelative
+                    | Ok _ -> ()
+
+                    index <- index + 1
+
+                conflict
+
+            visit rootDirectory relativePath
+
+        /// Produces one complete pre-mutation action list after classifying every target and removable tracked blocker.
+        let plan (currentStatus: GraceStatus) manifest =
+            task {
+                let scanInput = currentScanInput ()
+                let classifier = classifierInput scanInput
+                let trackedRejection, trackedFiles, trackedDirectories = trackedTopology currentStatus
+                let targetRejection, targetFiles, targetDirectories = targetTopology manifest
+
+                match trackedRejection, targetRejection with
+                | Some rejection, _
+                | _, Some rejection -> return Rejected rejection
+                | None, None ->
+                    let mutable rejection = None
+                    let removals = Dictionary<string, Action>(StringComparer.Ordinal)
+                    let creates = Dictionary<string, Action>(StringComparer.Ordinal)
+                    let copies = Dictionary<string, Action>(StringComparer.Ordinal)
+
+                    let addRemoval path action = removals[pathKey path] <- action
+                    let addCreate path = creates[pathKey path] <- EnsureDirectory path
+                    let addCopy path = copies[pathKey path] <- CopyVerifiedFile path
+
+                    for targetDirectory in orderedTargetDirectories targetDirectories.Values do
+                        if Option.isNone rejection
+                           && string targetDirectory
+                              <> Constants.RootDirectoryPath then
+                            match fullPathUnderRoot scanInput.RootDirectory targetDirectory with
+                            | Error value -> rejection <- Some value
+                            | Ok fullPath ->
+                                match actualKind fullPath with
+                                | Missing -> addCreate targetDirectory
+                                | File ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory File with
+                                    | Error value -> rejection <- Some value
+                                    | Ok "tracked-file" ->
+                                        addRemoval targetDirectory (RemoveTrackedFile targetDirectory)
+                                        addCreate targetDirectory
+                                    | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
+                                | Directory ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory Directory with
+                                    | Error value -> rejection <- Some value
+                                    | Ok "tracked-directory" -> ()
+                                    | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
+
+                    for targetFile in orderedTargetFiles targetFiles.Values do
+                        if Option.isNone rejection then
+                            let _, _, targetPath = targetFile
+
+                            match fullPathUnderRoot scanInput.RootDirectory targetPath with
+                            | Error value -> rejection <- Some value
+                            | Ok fullPath ->
+                                match actualKind fullPath with
+                                | Missing -> addCopy targetPath
+                                | File ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetPath File with
+                                    | Error value -> rejection <- Some value
+                                    | Ok "tracked-file" ->
+                                        let targetSha256, targetBlake3, _ = targetFile
+                                        let tracked = trackedFiles[pathKey targetPath]
+
+                                        if
+                                            tracked.Sha256Hash <> targetSha256
+                                            || tracked.Blake3Hash <> targetBlake3
+                                            || not (hasVerifiedTargetBytes fullPath targetSha256 targetBlake3)
+                                        then
+                                            addCopy targetPath
+                                    | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
+                                | Directory ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetPath Directory with
+                                    | Error value -> rejection <- Some value
+                                    | Ok "tracked-directory" ->
+                                        match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath targetPath with
+                                        | Some value -> rejection <- Some value
+                                        | None ->
+                                            for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
+                                                let directoryPath = directoryVersion.RelativePath
+
+                                                if string directoryPath
+                                                   <> Constants.RootDirectoryPath
+                                                   && (pathKey directoryPath = pathKey targetPath
+                                                       || (string directoryPath)
+                                                           .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase)) then
+                                                    addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
+
+                                            for fileVersion in orderedTrackedFiles trackedFiles.Values do
+                                                let filePath = fileVersion.RelativePath
+
+                                                if (string filePath)
+                                                    .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase) then
+                                                    addRemoval filePath (RemoveTrackedFile filePath)
+
+                                            addCopy targetPath
+                                    | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
+
+                    for fileVersion in orderedTrackedFiles trackedFiles.Values do
+                        if
+                            Option.isNone rejection
+                            && not (targetFiles.ContainsKey(pathKey fileVersion.RelativePath))
+                        then
+                            match fullPathUnderRoot scanInput.RootDirectory fileVersion.RelativePath with
+                            | Error value -> rejection <- Some value
+                            | Ok fullPath when actualKind fullPath = File ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath File with
+                                | Ok "tracked-file" -> addRemoval fileVersion.RelativePath (RemoveTrackedFile fileVersion.RelativePath)
+                                | Error value -> rejection <- Some value
+                                | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
+                            | Ok _ -> ()
+
+                    for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
+                        let directoryPath = directoryVersion.RelativePath
+
+                        if
+                            Option.isNone rejection
+                            && string directoryPath
+                               <> Constants.RootDirectoryPath
+                            && not (targetDirectories.ContainsKey(pathKey directoryPath))
+                        then
+                            match fullPathUnderRoot scanInput.RootDirectory directoryPath with
+                            | Error value -> rejection <- Some value
+                            | Ok fullPath when actualKind fullPath = Directory ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath Directory with
+                                | Error value -> rejection <- Some value
+                                | Ok "tracked-directory" ->
+                                    match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath directoryPath with
+                                    | Some value -> rejection <- Some value
+                                    | None -> addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
+                                | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
+                            | Ok _ -> ()
+
+                    match rejection with
+                    | Some value -> return Rejected value
+                    | None ->
+                        let orderedRemovals =
+                            removals.Values
+                            |> Seq.sortWith (fun left right ->
+                                let leftPath =
+                                    match left with
+                                    | RemoveTrackedFile path
+                                    | RemoveTrackedDirectory path -> path
+                                    | _ -> RelativePath Constants.RootDirectoryPath
+
+                                let rightPath =
+                                    match right with
+                                    | RemoveTrackedFile path
+                                    | RemoveTrackedDirectory path -> path
+                                    | _ -> RelativePath Constants.RootDirectoryPath
+
+                                let byDepth = compare (depth rightPath) (depth leftPath)
+                                if byDepth <> 0 then byDepth else comparePaths leftPath rightPath)
+                            |> Seq.toList
+
+                        let orderedCreates =
+                            creates.Values
+                            |> Seq.sortWith (fun left right ->
+                                let leftPath =
+                                    match left with
+                                    | EnsureDirectory path -> path
+                                    | _ -> RelativePath Constants.RootDirectoryPath
+
+                                let rightPath =
+                                    match right with
+                                    | EnsureDirectory path -> path
+                                    | _ -> RelativePath Constants.RootDirectoryPath
+
+                                let byDepth = compare (depth leftPath) (depth rightPath)
+                                if byDepth <> 0 then byDepth else comparePaths leftPath rightPath)
+                            |> Seq.toList
+
+                        let orderedCopies =
+                            copies.Values
+                            |> Seq.sortWith (fun left right ->
+                                let leftPath =
+                                    match left with
+                                    | CopyVerifiedFile path -> path
+                                    | _ -> RelativePath Constants.RootDirectoryPath
+
+                                let rightPath =
+                                    match right with
+                                    | CopyVerifiedFile path -> path
+                                    | _ -> RelativePath Constants.RootDirectoryPath
+
+                                comparePaths leftPath rightPath)
+                            |> Seq.toList
+
+                        return Planned(Plan(orderedRemovals @ orderedCreates @ orderedCopies))
+            }

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -333,7 +333,11 @@ module internal WorkingDirectoryUpdate =
                                 | Directory ->
                                     match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory Directory with
                                     | Error value -> rejection <- Some value
-                                    | Ok "tracked-directory" -> ()
+                                    | Ok "tracked-directory" ->
+                                        match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath targetDirectory
+                                            with
+                                        | Some value -> rejection <- Some value
+                                        | None -> ()
                                     | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
 
                     for targetFile in orderedTargetFiles targetFiles.Values do
@@ -393,12 +397,18 @@ module internal WorkingDirectoryUpdate =
                         then
                             match fullPathUnderRoot scanInput.RootDirectory fileVersion.RelativePath with
                             | Error value -> rejection <- Some value
-                            | Ok fullPath when actualKind fullPath = File ->
-                                match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath File with
-                                | Ok "tracked-file" -> addRemoval fileVersion.RelativePath (RemoveTrackedFile fileVersion.RelativePath)
-                                | Error value -> rejection <- Some value
-                                | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
-                            | Ok _ -> ()
+                            | Ok fullPath ->
+                                match actualKind fullPath with
+                                | Missing -> ()
+                                | File ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath File with
+                                    | Ok "tracked-file" -> addRemoval fileVersion.RelativePath (RemoveTrackedFile fileVersion.RelativePath)
+                                    | Error value -> rejection <- Some value
+                                    | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
+                                | Directory ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath Directory with
+                                    | Error value -> rejection <- Some value
+                                    | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
 
                     for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
                         let directoryPath = directoryVersion.RelativePath
@@ -411,15 +421,22 @@ module internal WorkingDirectoryUpdate =
                         then
                             match fullPathUnderRoot scanInput.RootDirectory directoryPath with
                             | Error value -> rejection <- Some value
-                            | Ok fullPath when actualKind fullPath = Directory ->
-                                match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath Directory with
-                                | Error value -> rejection <- Some value
-                                | Ok "tracked-directory" ->
-                                    match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath directoryPath with
-                                    | Some value -> rejection <- Some value
-                                    | None -> addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
-                                | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
-                            | Ok _ -> ()
+                            | Ok fullPath ->
+                                match actualKind fullPath with
+                                | Missing -> ()
+                                | Directory ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath Directory with
+                                    | Error value -> rejection <- Some value
+                                    | Ok "tracked-directory" ->
+                                        match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath directoryPath
+                                            with
+                                        | Some value -> rejection <- Some value
+                                        | None -> addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
+                                    | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
+                                | File ->
+                                    match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath File with
+                                    | Error value -> rejection <- Some value
+                                    | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
 
                     match rejection with
                     | Some value -> return Rejected value

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -293,205 +293,204 @@ module internal WorkingDirectoryUpdate =
 
             visit rootDirectory relativePath
 
+        /// Classifies every target and removable tracked blocker without entering the asynchronous transaction workflow.
+        let private planSynchronously (currentStatus: GraceStatus) manifest =
+            let scanInput = currentScanInput ()
+            let classifier = classifierInput scanInput
+            let trackedRejection, trackedFiles, trackedDirectories = trackedTopology currentStatus
+            let targetRejection, targetFiles, targetDirectories = targetTopology manifest
+
+            match trackedRejection, targetRejection with
+            | Some rejection, _
+            | _, Some rejection -> Rejected rejection
+            | None, None ->
+                let mutable rejection = None
+                let removals = Dictionary<string, Action>(StringComparer.Ordinal)
+                let creates = Dictionary<string, Action>(StringComparer.Ordinal)
+                let copies = Dictionary<string, Action>(StringComparer.Ordinal)
+
+                let addRemoval path action = removals[pathKey path] <- action
+                let addCreate path = creates[pathKey path] <- EnsureDirectory path
+                let addCopy path = copies[pathKey path] <- CopyVerifiedFile path
+
+                for targetDirectory in orderedTargetDirectories targetDirectories.Values do
+                    if Option.isNone rejection
+                       && string targetDirectory
+                          <> Constants.RootDirectoryPath then
+                        match fullPathUnderRoot scanInput.RootDirectory targetDirectory with
+                        | Error value -> rejection <- Some value
+                        | Ok fullPath ->
+                            match actualKind fullPath with
+                            | Missing -> addCreate targetDirectory
+                            | File ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory File with
+                                | Error value -> rejection <- Some value
+                                | Ok "tracked-file" ->
+                                    addRemoval targetDirectory (RemoveTrackedFile targetDirectory)
+                                    addCreate targetDirectory
+                                | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
+                            | Directory ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory Directory with
+                                | Error value -> rejection <- Some value
+                                | Ok "tracked-directory" ->
+                                    match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath targetDirectory with
+                                    | Some value -> rejection <- Some value
+                                    | None -> ()
+                                | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
+
+                for targetFile in orderedTargetFiles targetFiles.Values do
+                    if Option.isNone rejection then
+                        let _, _, targetPath = targetFile
+
+                        match fullPathUnderRoot scanInput.RootDirectory targetPath with
+                        | Error value -> rejection <- Some value
+                        | Ok fullPath ->
+                            match actualKind fullPath with
+                            | Missing -> addCopy targetPath
+                            | File ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath targetPath File with
+                                | Error value -> rejection <- Some value
+                                | Ok "tracked-file" ->
+                                    let targetSha256, targetBlake3, _ = targetFile
+                                    let tracked = trackedFiles[pathKey targetPath]
+
+                                    if
+                                        tracked.Sha256Hash <> targetSha256
+                                        || tracked.Blake3Hash <> targetBlake3
+                                        || not (hasVerifiedTargetBytes fullPath targetSha256 targetBlake3)
+                                    then
+                                        addCopy targetPath
+                                | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
+                            | Directory ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath targetPath Directory with
+                                | Error value -> rejection <- Some value
+                                | Ok "tracked-directory" ->
+                                    match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath targetPath with
+                                    | Some value -> rejection <- Some value
+                                    | None ->
+                                        for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
+                                            let directoryPath = directoryVersion.RelativePath
+
+                                            if string directoryPath
+                                               <> Constants.RootDirectoryPath
+                                               && (pathKey directoryPath = pathKey targetPath
+                                                   || (string directoryPath)
+                                                       .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase)) then
+                                                addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
+
+                                        for fileVersion in orderedTrackedFiles trackedFiles.Values do
+                                            let filePath = fileVersion.RelativePath
+
+                                            if (string filePath)
+                                                .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase) then
+                                                addRemoval filePath (RemoveTrackedFile filePath)
+
+                                        addCopy targetPath
+                                | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
+
+                for fileVersion in orderedTrackedFiles trackedFiles.Values do
+                    if
+                        Option.isNone rejection
+                        && not (targetFiles.ContainsKey(pathKey fileVersion.RelativePath))
+                    then
+                        match fullPathUnderRoot scanInput.RootDirectory fileVersion.RelativePath with
+                        | Error value -> rejection <- Some value
+                        | Ok fullPath ->
+                            match actualKind fullPath with
+                            | Missing -> ()
+                            | File ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath File with
+                                | Ok "tracked-file" -> addRemoval fileVersion.RelativePath (RemoveTrackedFile fileVersion.RelativePath)
+                                | Error value -> rejection <- Some value
+                                | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
+                            | Directory ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath Directory with
+                                | Error value -> rejection <- Some value
+                                | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
+
+                for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
+                    let directoryPath = directoryVersion.RelativePath
+
+                    if
+                        Option.isNone rejection
+                        && string directoryPath
+                           <> Constants.RootDirectoryPath
+                        && not (targetDirectories.ContainsKey(pathKey directoryPath))
+                    then
+                        match fullPathUnderRoot scanInput.RootDirectory directoryPath with
+                        | Error value -> rejection <- Some value
+                        | Ok fullPath ->
+                            match actualKind fullPath with
+                            | Missing -> ()
+                            | Directory ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath Directory with
+                                | Error value -> rejection <- Some value
+                                | Ok "tracked-directory" ->
+                                    match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath directoryPath with
+                                    | Some value -> rejection <- Some value
+                                    | None -> addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
+                                | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
+                            | File ->
+                                match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath File with
+                                | Error value -> rejection <- Some value
+                                | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
+
+                match rejection with
+                | Some value -> Rejected value
+                | None ->
+                    let orderedRemovals =
+                        removals.Values
+                        |> Seq.sortWith (fun left right ->
+                            let leftPath =
+                                match left with
+                                | RemoveTrackedFile path
+                                | RemoveTrackedDirectory path -> path
+                                | _ -> RelativePath Constants.RootDirectoryPath
+
+                            let rightPath =
+                                match right with
+                                | RemoveTrackedFile path
+                                | RemoveTrackedDirectory path -> path
+                                | _ -> RelativePath Constants.RootDirectoryPath
+
+                            let byDepth = compare (depth rightPath) (depth leftPath)
+                            if byDepth <> 0 then byDepth else comparePaths leftPath rightPath)
+                        |> Seq.toList
+
+                    let orderedCreates =
+                        creates.Values
+                        |> Seq.sortWith (fun left right ->
+                            let leftPath =
+                                match left with
+                                | EnsureDirectory path -> path
+                                | _ -> RelativePath Constants.RootDirectoryPath
+
+                            let rightPath =
+                                match right with
+                                | EnsureDirectory path -> path
+                                | _ -> RelativePath Constants.RootDirectoryPath
+
+                            let byDepth = compare (depth leftPath) (depth rightPath)
+                            if byDepth <> 0 then byDepth else comparePaths leftPath rightPath)
+                        |> Seq.toList
+
+                    let orderedCopies =
+                        copies.Values
+                        |> Seq.sortWith (fun left right ->
+                            let leftPath =
+                                match left with
+                                | CopyVerifiedFile path -> path
+                                | _ -> RelativePath Constants.RootDirectoryPath
+
+                            let rightPath =
+                                match right with
+                                | CopyVerifiedFile path -> path
+                                | _ -> RelativePath Constants.RootDirectoryPath
+
+                            comparePaths leftPath rightPath)
+                        |> Seq.toList
+
+                    Planned(Plan(orderedRemovals @ orderedCreates @ orderedCopies))
+
         /// Produces one complete pre-mutation action list after classifying every target and removable tracked blocker.
-        let plan (currentStatus: GraceStatus) manifest =
-            task {
-                let scanInput = currentScanInput ()
-                let classifier = classifierInput scanInput
-                let trackedRejection, trackedFiles, trackedDirectories = trackedTopology currentStatus
-                let targetRejection, targetFiles, targetDirectories = targetTopology manifest
-
-                match trackedRejection, targetRejection with
-                | Some rejection, _
-                | _, Some rejection -> return Rejected rejection
-                | None, None ->
-                    let mutable rejection = None
-                    let removals = Dictionary<string, Action>(StringComparer.Ordinal)
-                    let creates = Dictionary<string, Action>(StringComparer.Ordinal)
-                    let copies = Dictionary<string, Action>(StringComparer.Ordinal)
-
-                    let addRemoval path action = removals[pathKey path] <- action
-                    let addCreate path = creates[pathKey path] <- EnsureDirectory path
-                    let addCopy path = copies[pathKey path] <- CopyVerifiedFile path
-
-                    for targetDirectory in orderedTargetDirectories targetDirectories.Values do
-                        if Option.isNone rejection
-                           && string targetDirectory
-                              <> Constants.RootDirectoryPath then
-                            match fullPathUnderRoot scanInput.RootDirectory targetDirectory with
-                            | Error value -> rejection <- Some value
-                            | Ok fullPath ->
-                                match actualKind fullPath with
-                                | Missing -> addCreate targetDirectory
-                                | File ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory File with
-                                    | Error value -> rejection <- Some value
-                                    | Ok "tracked-file" ->
-                                        addRemoval targetDirectory (RemoveTrackedFile targetDirectory)
-                                        addCreate targetDirectory
-                                    | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
-                                | Directory ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetDirectory Directory with
-                                    | Error value -> rejection <- Some value
-                                    | Ok "tracked-directory" ->
-                                        match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath targetDirectory
-                                            with
-                                        | Some value -> rejection <- Some value
-                                        | None -> ()
-                                    | Ok _ -> rejection <- Some { Path = targetDirectory; Classification = Untracked }
-
-                    for targetFile in orderedTargetFiles targetFiles.Values do
-                        if Option.isNone rejection then
-                            let _, _, targetPath = targetFile
-
-                            match fullPathUnderRoot scanInput.RootDirectory targetPath with
-                            | Error value -> rejection <- Some value
-                            | Ok fullPath ->
-                                match actualKind fullPath with
-                                | Missing -> addCopy targetPath
-                                | File ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetPath File with
-                                    | Error value -> rejection <- Some value
-                                    | Ok "tracked-file" ->
-                                        let targetSha256, targetBlake3, _ = targetFile
-                                        let tracked = trackedFiles[pathKey targetPath]
-
-                                        if
-                                            tracked.Sha256Hash <> targetSha256
-                                            || tracked.Blake3Hash <> targetBlake3
-                                            || not (hasVerifiedTargetBytes fullPath targetSha256 targetBlake3)
-                                        then
-                                            addCopy targetPath
-                                    | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
-                                | Directory ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath targetPath Directory with
-                                    | Error value -> rejection <- Some value
-                                    | Ok "tracked-directory" ->
-                                        match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath targetPath with
-                                        | Some value -> rejection <- Some value
-                                        | None ->
-                                            for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
-                                                let directoryPath = directoryVersion.RelativePath
-
-                                                if string directoryPath
-                                                   <> Constants.RootDirectoryPath
-                                                   && (pathKey directoryPath = pathKey targetPath
-                                                       || (string directoryPath)
-                                                           .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase)) then
-                                                    addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
-
-                                            for fileVersion in orderedTrackedFiles trackedFiles.Values do
-                                                let filePath = fileVersion.RelativePath
-
-                                                if (string filePath)
-                                                    .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase) then
-                                                    addRemoval filePath (RemoveTrackedFile filePath)
-
-                                            addCopy targetPath
-                                    | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
-
-                    for fileVersion in orderedTrackedFiles trackedFiles.Values do
-                        if
-                            Option.isNone rejection
-                            && not (targetFiles.ContainsKey(pathKey fileVersion.RelativePath))
-                        then
-                            match fullPathUnderRoot scanInput.RootDirectory fileVersion.RelativePath with
-                            | Error value -> rejection <- Some value
-                            | Ok fullPath ->
-                                match actualKind fullPath with
-                                | Missing -> ()
-                                | File ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath File with
-                                    | Ok "tracked-file" -> addRemoval fileVersion.RelativePath (RemoveTrackedFile fileVersion.RelativePath)
-                                    | Error value -> rejection <- Some value
-                                    | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
-                                | Directory ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath fileVersion.RelativePath Directory with
-                                    | Error value -> rejection <- Some value
-                                    | Ok _ -> rejection <- Some { Path = fileVersion.RelativePath; Classification = Untracked }
-
-                    for directoryVersion in orderedTrackedDirectories trackedDirectories.Values do
-                        let directoryPath = directoryVersion.RelativePath
-
-                        if
-                            Option.isNone rejection
-                            && string directoryPath
-                               <> Constants.RootDirectoryPath
-                            && not (targetDirectories.ContainsKey(pathKey directoryPath))
-                        then
-                            match fullPathUnderRoot scanInput.RootDirectory directoryPath with
-                            | Error value -> rejection <- Some value
-                            | Ok fullPath ->
-                                match actualKind fullPath with
-                                | Missing -> ()
-                                | Directory ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath Directory with
-                                    | Error value -> rejection <- Some value
-                                    | Ok "tracked-directory" ->
-                                        match firstUnsafeDescendant classifier trackedFiles trackedDirectories scanInput.RootDirectory fullPath directoryPath
-                                            with
-                                        | Some value -> rejection <- Some value
-                                        | None -> addRemoval directoryPath (RemoveTrackedDirectory directoryPath)
-                                    | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
-                                | File ->
-                                    match localClassification classifier trackedFiles trackedDirectories fullPath directoryPath File with
-                                    | Error value -> rejection <- Some value
-                                    | Ok _ -> rejection <- Some { Path = directoryPath; Classification = Untracked }
-
-                    match rejection with
-                    | Some value -> return Rejected value
-                    | None ->
-                        let orderedRemovals =
-                            removals.Values
-                            |> Seq.sortWith (fun left right ->
-                                let leftPath =
-                                    match left with
-                                    | RemoveTrackedFile path
-                                    | RemoveTrackedDirectory path -> path
-                                    | _ -> RelativePath Constants.RootDirectoryPath
-
-                                let rightPath =
-                                    match right with
-                                    | RemoveTrackedFile path
-                                    | RemoveTrackedDirectory path -> path
-                                    | _ -> RelativePath Constants.RootDirectoryPath
-
-                                let byDepth = compare (depth rightPath) (depth leftPath)
-                                if byDepth <> 0 then byDepth else comparePaths leftPath rightPath)
-                            |> Seq.toList
-
-                        let orderedCreates =
-                            creates.Values
-                            |> Seq.sortWith (fun left right ->
-                                let leftPath =
-                                    match left with
-                                    | EnsureDirectory path -> path
-                                    | _ -> RelativePath Constants.RootDirectoryPath
-
-                                let rightPath =
-                                    match right with
-                                    | EnsureDirectory path -> path
-                                    | _ -> RelativePath Constants.RootDirectoryPath
-
-                                let byDepth = compare (depth leftPath) (depth rightPath)
-                                if byDepth <> 0 then byDepth else comparePaths leftPath rightPath)
-                            |> Seq.toList
-
-                        let orderedCopies =
-                            copies.Values
-                            |> Seq.sortWith (fun left right ->
-                                let leftPath =
-                                    match left with
-                                    | CopyVerifiedFile path -> path
-                                    | _ -> RelativePath Constants.RootDirectoryPath
-
-                                let rightPath =
-                                    match right with
-                                    | CopyVerifiedFile path -> path
-                                    | _ -> RelativePath Constants.RootDirectoryPath
-
-                                comparePaths leftPath rightPath)
-                            |> Seq.toList
-
-                        return Planned(Plan(orderedRemovals @ orderedCreates @ orderedCopies))
-            }
+        let plan (currentStatus: GraceStatus) manifest = task { return planSynchronously currentStatus manifest }


### PR DESCRIPTION
# Summary

Add the private collision-safe exact-root topology planner consumed by later Working Directory Update transaction work.

The planner accepts complete current Grace status plus immutable `PreparedManifest` topology, classifies actual local
filesystem entries through the supported scan/ignore behavior, and returns either a complete deterministic action list
or a typed pre-mutation rejection. It never mutates, opens a database, acquires a lease, writes marker evidence, or
accepts a callback/writer.

Tracks #898.

## Why this matters

A selected historical root can collide with ignored or untracked user content. Grace must reject those collisions
without changing local bytes and must identify every tracked removal or creation before the transaction starts.

## Quality contract

- Product V1.
- Primary invariant: only tracked blockers named in one immutable complete plan may later be removed.
- `PreparedManifest` is the planner's sole target-topology input.
- #899 separately proves resolved target graph and manifest correspondence before consuming this planner.
- No mutation, lease, marker, object, SQLite, Branch, public output, or later-caller behavior enters this PR.

## Changed paths

- `src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs`
- `src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs`
- `src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj`

## Behavior and proof

- Reject ignored and untracked target-file collisions without changing bytes.
- Plan tracked file replacement and file/directory transitions in complete deterministic order.
- Reject ignored/untracked descendants and preserve complete subtrees.
- Retain safe tracked directories and files.
- Remove obsolete tracked empty directories deepest-first.
- Create target directories shallowest-first.
- Reject Windows case collisions, ambiguous file/directory manifests, and normalized root escape.
- Return a stable conflicting path and classification on rejection.

## Validation

- RED: focused build failed on the initially absent `WorkingDirectoryUpdate.Topology` seam.
- Targeted Fantomas on both touched F# files.
- Release `Grace.CLI.Tests` build: 0 warnings, 0 errors.
- Focused real-filesystem topology suite: 14/14 passed.
- `git diff --check` and cached diff check passed.

## Review status

- Implementation/fix workers: 1 of 5.
- Review sessions: 0.
- Substantive review cycles: 0.
- First-pass review readiness: yes.
- Residual scope: #899 owns transaction integration and exact graph-to-manifest correspondence.
