### PR TITLE
Implement WDU local transaction through pending completion

### DIFF
--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -53,6 +53,7 @@
     <Compile Include="WorkingDirectoryUpdate.PreparedContent.Tests.fs" />
     <Compile Include="WorkingDirectoryUpdate.Coordination.Tests.fs" />
     <Compile Include="WorkingDirectoryUpdate.Topology.Tests.fs" />
+    <Compile Include="WorkingDirectoryUpdate.LocalTransaction.Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
@@ -340,12 +340,10 @@ module WorkingDirectoryUpdateContractsTests =
         WorkingDirectoryUpdate.Operation.value operation
         |> should equal "sha256:66d663c833c8a6984092cbd243d78dd7c01518aae7fa3456f234e7c7339f94f2"
 
-    /// Verifies Branch and Connect requests and receipts cannot substitute any root identity fact.
+    /// Verifies Branch and Connect receipts cannot substitute any root identity fact after the generic request seam is removed.
     [<Test>]
     let ``Branch and Connect bind requests and receipts to their complete selected target`` () =
         let selectedTarget = selectedTarget ()
-        let preparedContent = preparedContent ()
-
         let branchOperation =
             WorkingDirectoryUpdate.Operation.branchSwitch
                 (Guid.Parse("2c461ab1-72a0-42c3-9c2e-ea9c0c3b83de"))
@@ -369,25 +367,15 @@ module WorkingDirectoryUpdateContractsTests =
             ]
 
         let assertCompleteBinding operation =
-            WorkingDirectoryUpdate.Request.create selectedTarget operation preparedContent "target-binding"
-            |> Result.isOk
-            |> should equal true
-
             WorkingDirectoryUpdate.Receipt.create selectedTarget operation true
             |> Result.isOk
             |> should equal true
 
             mismatchedTargets
             |> List.iter (fun mismatchedTarget ->
-                WorkingDirectoryUpdate.Request.create mismatchedTarget operation preparedContent "target-binding"
-                |> Result.isError
-                |> should equal true
-
                 WorkingDirectoryUpdate.Receipt.create mismatchedTarget operation true
                 |> Result.isError
                 |> should equal true)
 
         assertCompleteBinding branchOperation
         assertCompleteBinding connectOperation
-
-        WorkingDirectoryUpdate.PreparedContent.dispose preparedContent

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Contracts.Tests.fs
@@ -344,6 +344,7 @@ module WorkingDirectoryUpdateContractsTests =
     [<Test>]
     let ``Branch and Connect bind requests and receipts to their complete selected target`` () =
         let selectedTarget = selectedTarget ()
+
         let branchOperation =
             WorkingDirectoryUpdate.Operation.branchSwitch
                 (Guid.Parse("2c461ab1-72a0-42c3-9c2e-ea9c0c3b83de"))

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
@@ -77,6 +77,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             Services.parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
             action root
         finally
+            WorkingDirectoryUpdate.LocalTransactionTesting.reset ()
             Services.clearShouldIgnoreCache ()
             Services.parseResult <- originalParseResult
             Environment.CurrentDirectory <- originalDirectory
@@ -113,11 +114,19 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             else
                 Some(path.Substring(0, separator))
 
-    /// Builds a complete rooted graph whose directory hashes cover the exact supplied files.
-    let private completeStatus (files: LocalFileVersion array) =
+    /// Builds a complete rooted graph whose directory hashes cover exact supplied files and explicitly selected empty directories.
+    let private completeStatusWithDirectories (explicitDirectories: string array) (files: LocalFileVersion array) =
         let paths =
             seq {
                 yield Constants.RootDirectoryPath
+
+                for directory in explicitDirectories do
+                    let mutable current = Some directory
+
+                    while Option.isSome current do
+                        let path = Option.get current
+                        yield path
+                        current <- parentPath path
 
                 for (file: LocalFileVersion) in files do
                     let mutable current = parentPath (string file.RelativePath)
@@ -201,6 +210,9 @@ module WorkingDirectoryUpdateLocalTransactionTests =
 
         status
 
+    /// Builds a complete rooted graph whose directories are implied solely by its supplied files.
+    let private completeStatus (files: LocalFileVersion array) = completeStatusWithDirectories Array.empty files
+
     /// Prepares one immutable manifest/byte pair matching the complete target graph's sole file.
     let private preparedContent (file: LocalFileVersion) (bytes: byte array) =
         let manifest =
@@ -215,10 +227,58 @@ module WorkingDirectoryUpdateLocalTransactionTests =
         |> fun task -> task.GetAwaiter().GetResult()
         |> required
 
-    /// Builds the single-file resolved target tuple required by the production five-input transaction.
-    let private targetGraph repositoryId branchId (file: LocalFileVersion) =
-        let status = completeStatus [| file |]
+    /// Prepares immutable bytes and explicit empty-directory topology for one direct production transaction.
+    let private preparedContentWithDirectories (directories: string array) (file: LocalFileVersion) (bytes: byte array) =
+        let entries =
+            seq {
+                yield!
+                    directories
+                    |> Seq.map (fun directory -> WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath directory))
 
+                yield WorkingDirectoryUpdateContracts.PreparedManifestEntry.File(file.RelativePath, file.Sha256Hash, file.Blake3Hash)
+            }
+
+        let manifest =
+            WorkingDirectoryUpdateContracts.PreparedManifest.create entries
+            |> required
+
+        WorkingDirectoryUpdateContracts.PreparedContent.create manifest (new Reader([ string file.RelativePath, bytes ])) CancellationToken.None
+        |> fun task -> task.GetAwaiter().GetResult()
+        |> required
+
+    /// Saves a direct configuration change without resetting the process cache that the transaction must not trust.
+    let private saveConfigurationChange (current: GraceConfiguration) change =
+        change current
+        saveConfigFile (Path.Combine(current.ConfigurationDirectory, GraceConfigFileName)) current
+
+    /// Verifies that the local transaction has not recorded any pending or terminal completion for a rejected or incomplete attempt.
+    let private assertNoCompletion (current: GraceConfiguration) target branchId selection =
+        let operation =
+            WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection branchId selection target
+            |> required
+
+        LocalStateDb.readWorkingDirectoryUpdateCompletion current.GraceStatusFile target operation
+        |> fun task -> task.GetAwaiter().GetResult()
+        |> should equal None
+
+        LocalStateDb.readPendingWorkingDirectoryUpdateFinalization current.GraceStatusFile
+        |> fun task -> task.GetAwaiter().GetResult()
+        |> should equal None
+
+    /// Reacquires the exact WDU scope to prove every direct transaction outcome has released its local lease.
+    let private assertLeaseReacquirable repositoryId root =
+        let scope =
+            WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+            |> required
+
+        use acquired =
+            WorkingDirectoryUpdateCoordination.Lease.acquire scope CancellationToken.None
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        acquired |> should not' (be Null)
+
+    /// Builds the resolved target tuple required by the production five-input transaction for one complete status graph.
+    let private targetGraphForStatus repositoryId branchId status =
         let target =
             WorkingDirectoryUpdateContracts.Target.create
                 repositoryId
@@ -232,6 +292,11 @@ module WorkingDirectoryUpdateLocalTransactionTests =
         status,
         WorkingDirectoryUpdate.ResolvedTargetGraph.create target status
         |> required
+
+    /// Builds the single-file resolved target tuple required by the production five-input transaction.
+    let private targetGraph repositoryId branchId (file: LocalFileVersion) =
+        let status = completeStatus [| file |]
+        targetGraphForStatus repositoryId branchId status
 
     /// Creates one phase from the exact current SQLite snapshot and an optional distinct cancellation token.
     let private acceptedPhase (current: GraceConfiguration) (cancellationToken: CancellationToken) =
@@ -394,3 +459,299 @@ module WorkingDirectoryUpdateLocalTransactionTests =
 
             Directory.Exists(current.ObjectDirectory)
             |> should equal false)
+
+    /// Proves a configuration change while the WDU lease is held rejects at the mandatory post-lease disk reread.
+    [<Test>]
+    let ``five-input transaction rejects configuration changed while waiting for the lease`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "selected.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+            let phase = acceptedPhase current CancellationToken.None
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            use sealedConfiguration = new ManualResetEventSlim(false)
+
+            use heldLease =
+                WorkingDirectoryUpdateCoordination.Lease.acquire scope CancellationToken.None
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterSealedConfiguration (fun () -> sealedConfiguration.Set())
+
+            let running =
+                Task.Run (fun () ->
+                    WorkingDirectoryUpdate.LocalTransaction.run
+                        phase
+                        selection
+                        graph
+                        prepared
+                        (WorkingDirectoryUpdate.DiagnosticCorrelation.create "configuration-while-waiting"
+                         |> required)
+                    |> fun task -> task.GetAwaiter().GetResult())
+
+            sealedConfiguration.Wait(TimeSpan.FromSeconds(5.0))
+            |> should equal true
+
+            saveConfigurationChange current (fun configuration -> configuration.BranchId <- Guid.NewGuid())
+            WorkingDirectoryUpdateCoordination.Lease.dispose heldLease
+            let outcome = running.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | _ -> Assert.Fail($"Expected fresh configuration rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "selected.txt"))
+            |> should equal false
+
+            assertNoCompletion current target branchId selection
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves final pre-mutation validation rereads disk configuration after object publication instead of trusting a cached object.
+    [<Test>]
+    let ``five-input transaction rejects configuration changed after object publication`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "selected.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+            let phase = acceptedPhase current CancellationToken.None
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterObjectPublication (fun () ->
+                saveConfigurationChange current (fun configuration -> configuration.BranchId <- Guid.NewGuid()))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    phase
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "configuration-after-objects"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | _ -> Assert.Fail($"Expected final fresh configuration rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "selected.txt"))
+            |> should equal false
+
+            assertNoCompletion current target branchId selection
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves independent final-root verification requires nested empty directories and leaves no completion after their loss.
+    [<Test>]
+    let ``five-input transaction detects a removed expected empty directory before SQLite completion`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "nested/target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            let targetStatus =
+                completeStatusWithDirectories [| "nested"; "nested/empty" |] [|
+                    selected
+                |]
+
+            let target, _, graph = targetGraphForStatus repositoryId branchId targetStatus
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+            let prepared = preparedContentWithDirectories [| "nested/empty" |] selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterPlannedActions (fun () -> Directory.Delete(Path.Combine(root, "nested", "empty"), false))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "missing-empty-directory"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _ -> ()
+            | _ -> Assert.Fail($"Expected incomplete topology verification, got {outcome}.")
+
+            Directory.Exists(Path.Combine(root, "nested", "empty"))
+            |> should equal false
+
+            File.Exists(Path.Combine(root, "nested", "target.txt"))
+            |> should equal true
+
+            assertNoCompletion current target branchId selection
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves an injected failure immediately before the first mutable filesystem call remains a clean pre-mutation rejection.
+    [<Test>]
+    let ``five-input transaction rejects an injected failure immediately before first mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "nested/target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+            WorkingDirectoryUpdate.LocalTransactionTesting.installBeforeFirstMutation (fun () -> raise (IOException("before first mutation")))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    (preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes")))
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "before-first-mutation"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | _ -> Assert.Fail($"Expected pre-mutation rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "nested", "target.txt"))
+            |> should equal false
+
+            assertNoCompletion current target branchId selection
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves a failure after a filesystem action begins preserves marker evidence and reports incomplete without completion.
+    [<Test>]
+    let ``five-input transaction reports incomplete for injected failure after first mutation begins`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "nested/target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFirstMutationBegan (fun () -> raise (IOException("after first mutation began")))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    (preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes")))
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "after-first-mutation"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _ -> ()
+            | _ -> Assert.Fail($"Expected post-mutation incomplete outcome, got {outcome}.")
+
+            File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
+            |> should equal true
+
+            assertNoCompletion current target branchId selection
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves cancellation during final planning remains pre-mutation, while cancellation after the first action begins remains incomplete.
+    [<Test>]
+    let ``five-input transaction honors cancellation only before first working-tree mutation`` () =
+        let runCase cancelDuringFinalPlanning cancelBeforeFirstMutation cancelAfterMutationBegins expectedIncomplete =
+            withTempRepository (fun root ->
+                let repositoryId = Guid.NewGuid()
+                let branchId = Guid.NewGuid()
+                let current = configure root repositoryId branchId
+                let baseline = completeStatus Array.empty<LocalFileVersion>
+
+                LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+                |> fun task -> task.GetAwaiter().GetResult()
+                |> ignore
+
+                let selected = localFile "nested/target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+                let target, _, graph = targetGraph repositoryId branchId selected
+                let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+                let scope =
+                    WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                    |> required
+
+                use cancellation = new CancellationTokenSource()
+
+                if cancelDuringFinalPlanning then
+                    WorkingDirectoryUpdate.LocalTransactionTesting.installBeforeFinalPlanning (fun () -> cancellation.Cancel())
+
+                if cancelBeforeFirstMutation then
+                    WorkingDirectoryUpdate.LocalTransactionTesting.installBeforeFirstMutation (fun () -> cancellation.Cancel())
+
+                if cancelAfterMutationBegins then
+                    WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFirstMutationBegan (fun () ->
+                        cancellation.Cancel()
+                        raise (OperationCanceledException(cancellation.Token)))
+
+                let outcome =
+                    WorkingDirectoryUpdate.LocalTransaction.run
+                        (acceptedPhase current cancellation.Token)
+                        selection
+                        graph
+                        (preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes")))
+                        (WorkingDirectoryUpdate.DiagnosticCorrelation.create "cancellation-boundary"
+                         |> required)
+                    |> fun task -> task.GetAwaiter().GetResult()
+
+                if expectedIncomplete then
+                    match outcome with
+                    | WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _ -> ()
+                    | _ -> Assert.Fail($"Expected post-mutation incomplete cancellation outcome, got {outcome}.")
+                else
+                    match outcome with
+                    | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+                    | _ -> Assert.Fail($"Expected pre-mutation rejected cancellation outcome, got {outcome}.")
+
+                if expectedIncomplete then
+                    File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
+                    |> should equal true
+
+                assertNoCompletion current target branchId selection
+                assertLeaseReacquirable repositoryId root)
+
+        runCase true false false false
+        runCase false true false false
+        runCase false false true true

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
@@ -277,6 +277,15 @@ module WorkingDirectoryUpdateLocalTransactionTests =
 
         acquired |> should not' (be Null)
 
+    /// Proves the five-input owner clears one prepared-content buffer exactly once after every terminal local result.
+    let private assertPreparedDisposed prepared path =
+        WorkingDirectoryUpdateContracts.PreparedContent.disposalCount prepared
+        |> should equal 1
+
+        WorkingDirectoryUpdateContracts.PreparedContent.openRead prepared path
+        |> Result.isError
+        |> should equal true
+
     /// Builds the resolved target tuple required by the production five-input transaction for one complete status graph.
     let private targetGraphForStatus repositoryId branchId status =
         let target =
@@ -347,8 +356,16 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.Updated _ -> ()
-            | _ -> Assert.Fail($"Expected verified pending completion, got {outcome}.")
+            | Ok completion ->
+                WorkingDirectoryUpdate.LocalCompletion.target completion
+                |> should equal target
+
+                WorkingDirectoryUpdate.LocalCompletion.operation completion
+                |> should
+                    equal
+                    (WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection currentBranchId selection target
+                     |> required)
+            | Error result -> Assert.Fail($"Expected verified pending completion, got {result}.")
 
             File.ReadAllText(Path.Combine(root, "nested", "target.txt"))
             |> should equal "selected target bytes"
@@ -360,7 +377,9 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 persistedTarget |> should equal target
                 previousBranchId |> should equal currentBranchId
                 persistedSelection |> should equal selection
-            | _ -> Assert.Fail("Expected one typed pending Branch finalization after verified local completion."))
+            | _ -> Assert.Fail("Expected one typed pending Branch finalization after verified local completion.")
+
+            assertPreparedDisposed prepared (RelativePath "nested/target.txt"))
 
     /// Proves a stale accepted revision rejects before object or working-tree mutation and disposes immutable prepared bytes.
     [<Test>]
@@ -396,7 +415,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
             | _ -> Assert.Fail($"Expected stale phase rejection, got {outcome}.")
 
             File.Exists(Path.Combine(root, "selected.txt"))
@@ -416,8 +435,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             |> fun task -> task.GetAwaiter().GetResult()
             |> should equal None
 
-            WorkingDirectoryUpdateContracts.PreparedContent.openRead prepared (RelativePath "selected.txt")
-            |> ignore)
+            assertPreparedDisposed prepared (RelativePath "selected.txt"))
 
     /// Proves graph/manifest topology disagreement rejects before #898 planning, objects, or working bytes change.
     [<Test>]
@@ -448,7 +466,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
             | _ -> Assert.Fail($"Expected graph/manifest mismatch rejection, got {outcome}.")
 
             File.Exists(Path.Combine(root, "selected.txt"))
@@ -510,13 +528,14 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             let outcome = running.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
             | _ -> Assert.Fail($"Expected fresh configuration rejection, got {outcome}.")
 
             File.Exists(Path.Combine(root, "selected.txt"))
             |> should equal false
 
             assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "selected.txt")
             assertLeaseReacquirable repositoryId root)
 
     /// Proves final pre-mutation validation rereads disk configuration after object publication instead of trusting a cached object.
@@ -552,13 +571,14 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
             | _ -> Assert.Fail($"Expected final fresh configuration rejection, got {outcome}.")
 
             File.Exists(Path.Combine(root, "selected.txt"))
             |> should equal false
 
             assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "selected.txt")
             assertLeaseReacquirable repositoryId root)
 
     /// Proves independent final-root verification requires nested empty directories and leaves no completion after their loss.
@@ -598,7 +618,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _) -> ()
             | _ -> Assert.Fail($"Expected incomplete topology verification, got {outcome}.")
 
             Directory.Exists(Path.Combine(root, "nested", "empty"))
@@ -608,6 +628,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             |> should equal true
 
             assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "nested/target.txt")
             assertLeaseReacquirable repositoryId root)
 
     /// Proves an injected failure immediately before the first mutable filesystem call remains a clean pre-mutation rejection.
@@ -628,24 +649,27 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
             WorkingDirectoryUpdate.LocalTransactionTesting.installBeforeFirstMutation (fun () -> raise (IOException("before first mutation")))
 
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
             let outcome =
                 WorkingDirectoryUpdate.LocalTransaction.run
                     (acceptedPhase current CancellationToken.None)
                     selection
                     graph
-                    (preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes")))
+                    prepared
                     (WorkingDirectoryUpdate.DiagnosticCorrelation.create "before-first-mutation"
                      |> required)
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
             | _ -> Assert.Fail($"Expected pre-mutation rejection, got {outcome}.")
 
             File.Exists(Path.Combine(root, "nested", "target.txt"))
             |> should equal false
 
             assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "nested/target.txt")
             assertLeaseReacquirable repositoryId root)
 
     /// Proves a failure after a filesystem action begins preserves marker evidence and reports incomplete without completion.
@@ -671,24 +695,27 @@ module WorkingDirectoryUpdateLocalTransactionTests =
 
             WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFirstMutationBegan (fun () -> raise (IOException("after first mutation began")))
 
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
             let outcome =
                 WorkingDirectoryUpdate.LocalTransaction.run
                     (acceptedPhase current CancellationToken.None)
                     selection
                     graph
-                    (preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes")))
+                    prepared
                     (WorkingDirectoryUpdate.DiagnosticCorrelation.create "after-first-mutation"
                      |> required)
                 |> fun task -> task.GetAwaiter().GetResult()
 
             match outcome with
-            | WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _ -> ()
+            | Error (WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _) -> ()
             | _ -> Assert.Fail($"Expected post-mutation incomplete outcome, got {outcome}.")
 
             File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
             |> should equal true
 
             assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "nested/target.txt")
             assertLeaseReacquirable repositoryId root)
 
     /// Proves cancellation during final planning remains pre-mutation, while cancellation after the first action begins remains incomplete.
@@ -726,23 +753,25 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                         cancellation.Cancel()
                         raise (OperationCanceledException(cancellation.Token)))
 
+                let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
                 let outcome =
                     WorkingDirectoryUpdate.LocalTransaction.run
                         (acceptedPhase current cancellation.Token)
                         selection
                         graph
-                        (preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes")))
+                        prepared
                         (WorkingDirectoryUpdate.DiagnosticCorrelation.create "cancellation-boundary"
                          |> required)
                     |> fun task -> task.GetAwaiter().GetResult()
 
                 if expectedIncomplete then
                     match outcome with
-                    | WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _ -> ()
+                    | Error (WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete _) -> ()
                     | _ -> Assert.Fail($"Expected post-mutation incomplete cancellation outcome, got {outcome}.")
                 else
                     match outcome with
-                    | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+                    | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
                     | _ -> Assert.Fail($"Expected pre-mutation rejected cancellation outcome, got {outcome}.")
 
                 if expectedIncomplete then
@@ -750,8 +779,98 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                     |> should equal true
 
                 assertNoCompletion current target branchId selection
+                assertPreparedDisposed prepared (RelativePath "nested/target.txt")
                 assertLeaseReacquirable repositoryId root)
 
         runCase true false false false
         runCase false true false false
         runCase false false true true
+
+    /// Proves a file that appears after final planning cannot be overwritten by a previously safe absent-target copy.
+    [<Test>]
+    let ``five-input transaction preserves late untracked target bytes at the action boundary`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFinalGlobalFactGate (fun () ->
+                File.WriteAllText(Path.Combine(root, "target.txt"), "late untracked bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "late-target"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
+            | _ -> Assert.Fail($"Expected action-time target rejection, got {outcome}.")
+
+            File.ReadAllText(Path.Combine(root, "target.txt"))
+            |> should equal "late untracked bytes"
+
+            assertNoCompletion current target branchId WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+            assertPreparedDisposed prepared (RelativePath "target.txt")
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves a source object replaced after publication rejects before the first filesystem mutation and cleans owned evidence.
+    [<Test>]
+    let ``five-input transaction rejects a replaced source object before mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterObjectPublication (fun () ->
+                let objectFile =
+                    Path.Combine(
+                        current.ObjectDirectory,
+                        string selected.RelativePath,
+                        Services.getLocalObjectCacheFileName selected.RelativePath selected.Sha256Hash selected.Blake3Hash
+                    )
+
+                File.WriteAllText(objectFile, "replaced object bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "replaced-object"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
+            | _ -> Assert.Fail($"Expected pre-mutation object rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "target.txt"))
+            |> should equal false
+
+            assertNoCompletion current target branchId WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+            assertPreparedDisposed prepared (RelativePath "target.txt")
+            assertLeaseReacquirable repositoryId root)

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
@@ -246,6 +246,54 @@ module WorkingDirectoryUpdateLocalTransactionTests =
         |> fun task -> task.GetAwaiter().GetResult()
         |> required
 
+    /// Prepares an exact multi-file immutable manifest for direct transaction compositions.
+    let private preparedContentForFiles (directories: string array) (files: (LocalFileVersion * byte array) array) =
+        let entries =
+            seq {
+                yield!
+                    directories
+                    |> Seq.map (fun directory -> WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory(RelativePath directory))
+
+                yield!
+                    files
+                    |> Seq.map (fun (file, _) -> WorkingDirectoryUpdateContracts.PreparedManifestEntry.File(file.RelativePath, file.Sha256Hash, file.Blake3Hash))
+            }
+
+        let manifest =
+            WorkingDirectoryUpdateContracts.PreparedManifest.create entries
+            |> required
+
+        let readerEntries =
+            files
+            |> Seq.map (fun (file, bytes) -> string file.RelativePath, bytes)
+            |> Seq.toList
+
+        WorkingDirectoryUpdateContracts.PreparedContent.create manifest (new Reader(readerEntries)) CancellationToken.None
+        |> fun task -> task.GetAwaiter().GetResult()
+        |> required
+
+    /// Rewrites only the persisted revision so a direct regression can isolate an accepted-fact guard.
+    let private rewriteLocalStatusRevision dbPath revision =
+        SqliteConnection.ClearAllPools()
+
+        use connection = new SqliteConnection($"Data Source={dbPath}")
+        connection.Open()
+        use command = connection.CreateCommand()
+        command.CommandText <- "UPDATE meta SET value = $value WHERE key = 'LocalStatusRevision';"
+
+        command.Parameters.AddWithValue("$value", string revision)
+        |> ignore
+
+        command.ExecuteNonQuery() |> should equal 1
+
+    /// Asserts that a direct transaction rejection identifies the single global guard that observed the changed fact.
+    let private assertRejectedFor expectedReason outcome =
+        match outcome with
+        | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected failure) ->
+            WorkingDirectoryUpdateContracts.Failure.reason failure
+            |> should contain expectedReason
+        | _ -> Assert.Fail($"Expected rejected outcome for '{expectedReason}', got {outcome}.")
+
     /// Saves a direct configuration change without resetting the process cache that the transaction must not trust.
     let private saveConfigurationChange (current: GraceConfiguration) change =
         change current
@@ -379,7 +427,10 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 persistedSelection |> should equal selection
             | _ -> Assert.Fail("Expected one typed pending Branch finalization after verified local completion.")
 
-            assertPreparedDisposed prepared (RelativePath "nested/target.txt"))
+            Current().BranchId |> should equal currentBranchId
+
+            assertPreparedDisposed prepared (RelativePath "nested/target.txt")
+            assertLeaseReacquirable repositoryId root)
 
     /// Proves a stale accepted revision rejects before object or working-tree mutation and disposes immutable prepared bytes.
     [<Test>]
@@ -827,6 +878,306 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             assertPreparedDisposed prepared (RelativePath "target.txt")
             assertLeaseReacquirable repositoryId root)
 
+    /// Proves a tracked file with its accepted old dual hashes is the only existing copy target that may be replaced.
+    [<Test>]
+    let ``five-input transaction replaces a verified tracked file and records pending completion`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let oldBytes = Encoding.UTF8.GetBytes("accepted old bytes")
+            let newBytes = Encoding.UTF8.GetBytes("selected replacement bytes")
+            let oldFile = localFile "target.txt" oldBytes
+            let newFile = localFile "target.txt" newBytes
+            let baseline = completeStatus [| oldFile |]
+            let target, targetStatus, graph = targetGraph repositoryId branchId newFile
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            File.WriteAllBytes(Path.Combine(root, "target.txt"), oldBytes)
+            let prepared = preparedContent newFile newBytes
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "tracked-replacement"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Ok completion ->
+                WorkingDirectoryUpdate.LocalCompletion.target completion
+                |> should equal target
+            | Error result -> Assert.Fail($"Expected tracked replacement completion, got {result}.")
+
+            File.ReadAllBytes(Path.Combine(root, "target.txt"))
+            |> should equal newBytes
+
+            LocalStateDb.readCompleteStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> required
+            |> WorkingDirectoryUpdate.LocalTransaction.statusFingerprint
+            |> should equal (WorkingDirectoryUpdate.LocalTransaction.statusFingerprint targetStatus)
+
+            LocalStateDb.readPendingWorkingDirectoryUpdateFinalization current.GraceStatusFile
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> Option.isSome
+            |> should equal true
+
+            assertPreparedDisposed prepared (RelativePath "target.txt")
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves a tracked replacement rechecks the accepted old identity at its action boundary before overwriting bytes.
+    [<Test>]
+    let ``five-input transaction rejects a late tracked replacement identity change before mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let oldBytes = Encoding.UTF8.GetBytes("accepted old bytes")
+            let newBytes = Encoding.UTF8.GetBytes("selected replacement bytes")
+            let oldFile = localFile "target.txt" oldBytes
+            let newFile = localFile "target.txt" newBytes
+            let baseline = completeStatus [| oldFile |]
+            let target, _, graph = targetGraph repositoryId branchId newFile
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            File.WriteAllBytes(Path.Combine(root, "target.txt"), oldBytes)
+            let prepared = preparedContent newFile newBytes
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFinalGlobalFactGate (fun () ->
+                File.WriteAllText(Path.Combine(root, "target.txt"), "late tracked bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "late-tracked-replacement"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            assertRejectedFor "Tracked file 'target.txt' changed" outcome
+
+            File.ReadAllText(Path.Combine(root, "target.txt"))
+            |> should equal "late tracked bytes"
+
+            assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "target.txt")
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves a retained tracked file is part of the whole final-plan applicability check before an unrelated copy begins.
+    [<Test>]
+    let ``five-input transaction rejects a late retained tracked file change before unrelated mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let retainedBytes = Encoding.UTF8.GetBytes("retained bytes")
+            let addedBytes = Encoding.UTF8.GetBytes("new bytes")
+            let retained = localFile "retained.txt" retainedBytes
+            let added = localFile "new.txt" addedBytes
+            let baseline = completeStatus [| retained |]
+            let targetStatus = completeStatus [| retained; added |]
+            let target, _, graph = targetGraphForStatus repositoryId branchId targetStatus
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            File.WriteAllBytes(Path.Combine(root, "retained.txt"), retainedBytes)
+
+            let prepared =
+                preparedContentForFiles
+                    Array.empty
+                    [|
+                        retained, retainedBytes
+                        added, addedBytes
+                    |]
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFinalGlobalFactGate (fun () ->
+                File.WriteAllText(Path.Combine(root, "retained.txt"), "late retained bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "late-retained-file"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            assertRejectedFor "complete Working Directory Update plan changed" outcome
+
+            File.ReadAllText(Path.Combine(root, "retained.txt"))
+            |> should equal "late retained bytes"
+
+            File.Exists(Path.Combine(root, "new.txt"))
+            |> should equal false
+
+            assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "retained.txt")
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves a retained tracked directory's newly eligible descendant invalidates the entire final plan before another action mutates.
+    [<Test>]
+    let ``five-input transaction rejects a late eligible descendant under a retained directory`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let addedBytes = Encoding.UTF8.GetBytes("new bytes")
+            let added = localFile "new.txt" addedBytes
+            let baseline = completeStatusWithDirectories [| "retained" |] Array.empty<LocalFileVersion>
+
+            let targetStatus =
+                completeStatusWithDirectories [| "retained" |] [|
+                    added
+                |]
+
+            let target, _, graph = targetGraphForStatus repositoryId branchId targetStatus
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            Directory.CreateDirectory(Path.Combine(root, "retained"))
+            |> ignore
+
+            let prepared =
+                preparedContentForFiles [| "retained" |] [|
+                    added, addedBytes
+                |]
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installAfterFinalGlobalFactGate (fun () ->
+                File.WriteAllText(Path.Combine(root, "retained", "late.txt"), "late eligible descendant"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "late-retained-directory"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            assertRejectedFor "topology rejected 'retained/late.txt'" outcome
+
+            File.ReadAllText(Path.Combine(root, "retained", "late.txt"))
+            |> should equal "late eligible descendant"
+
+            File.Exists(Path.Combine(root, "new.txt"))
+            |> should equal false
+
+            assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "new.txt")
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves an accepted tracked file can be removed before its path becomes a target directory.
+    [<Test>]
+    let ``five-input transaction applies a tracked file to directory composition`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let oldBytes = Encoding.UTF8.GetBytes("tracked file")
+            let newBytes = Encoding.UTF8.GetBytes("nested target")
+            let oldFile = localFile "switch" oldBytes
+            let newFile = localFile "switch/new.txt" newBytes
+            let baseline = completeStatus [| oldFile |]
+            let targetStatus = completeStatus [| newFile |]
+            let _, _, graph = targetGraphForStatus repositoryId branchId targetStatus
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            File.WriteAllBytes(Path.Combine(root, "switch"), oldBytes)
+            let prepared = preparedContent newFile newBytes
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "file-to-directory"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Ok _ -> ()
+            | Error result -> Assert.Fail($"Expected file-to-directory completion, got {result}.")
+
+            Directory.Exists(Path.Combine(root, "switch"))
+            |> should equal true
+
+            File.ReadAllBytes(Path.Combine(root, "switch", "new.txt"))
+            |> should equal newBytes
+
+            assertPreparedDisposed prepared (RelativePath "switch/new.txt")
+            assertLeaseReacquirable repositoryId root)
+
+    /// Proves tracked directory descendants are removed before the exact path becomes a target file.
+    [<Test>]
+    let ``five-input transaction applies a tracked directory to file composition`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let oldBytes = Encoding.UTF8.GetBytes("tracked nested file")
+            let newBytes = Encoding.UTF8.GetBytes("target file")
+            let oldFile = localFile "switch/old.txt" oldBytes
+            let newFile = localFile "switch" newBytes
+            let baseline = completeStatus [| oldFile |]
+            let target, _, graph = targetGraph repositoryId branchId newFile
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            Directory.CreateDirectory(Path.Combine(root, "switch"))
+            |> ignore
+
+            File.WriteAllBytes(Path.Combine(root, "switch", "old.txt"), oldBytes)
+            let prepared = preparedContent newFile newBytes
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "directory-to-file"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Ok _ -> ()
+            | Error result -> Assert.Fail($"Expected directory-to-file completion, got {result}.")
+
+            File.ReadAllBytes(Path.Combine(root, "switch"))
+            |> should equal newBytes
+
+            assertPreparedDisposed prepared (RelativePath "switch")
+            assertLeaseReacquirable repositoryId root)
+
     /// Proves a source object replaced after publication rejects before the first filesystem mutation and cleans owned evidence.
     [<Test>]
     let ``five-input transaction rejects a replaced source object before mutation`` () =
@@ -875,12 +1226,69 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             assertPreparedDisposed prepared (RelativePath "target.txt")
             assertLeaseReacquirable repositoryId root)
 
+    /// Proves corrupt immutable bytes already present at the object path reject before marker-backed working-tree mutation.
+    [<Test>]
+    let ``five-input transaction rejects an initially corrupt existing source object before mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let objectDirectory = Path.Combine(current.ObjectDirectory, string selected.RelativePath)
+
+            Directory.CreateDirectory(objectDirectory)
+            |> ignore
+
+            File.WriteAllText(
+                Path.Combine(objectDirectory, Services.getLocalObjectCacheFileName selected.RelativePath selected.Sha256Hash selected.Blake3Hash),
+                "initially corrupt object bytes"
+            )
+
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "initially-corrupt-object"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
+            | _ -> Assert.Fail($"Expected initially corrupt object rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "target.txt"))
+            |> should equal false
+
+            File.Exists(WorkingDirectoryUpdateCoordination.Scope.markerPath scope)
+            |> should equal false
+
+            assertNoCompletion current target branchId selection
+            assertPreparedDisposed prepared (RelativePath "target.txt")
+            assertLeaseReacquirable repositoryId root)
+
     /// Proves every post-plan global fact is reread before the first action can mutate the working tree.
-    [<TestCase("configuration")>]
-    [<TestCase("status")>]
+    [<TestCase("revision")>]
+    [<TestCase("fingerprint")>]
     [<TestCase("pending")>]
     [<TestCase("marker-attempt")>]
-    let ``five-input transaction rejects post-plan global fact changes`` changedFact =
+    let ``five-input transaction independently rejects each post-plan global fact change`` changedFact =
         withTempRepository (fun root ->
             let repositoryId = Guid.NewGuid()
             let branchId = Guid.NewGuid()
@@ -904,16 +1312,23 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                 |> required
 
             let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+            let accepted = acceptedPhase current CancellationToken.None
+
+            let acceptedRevision =
+                LocalStateDb.readLocalStatusRevisionReadOnly current.GraceStatusFile
+                |> fun task -> task.GetAwaiter().GetResult()
 
             WorkingDirectoryUpdate.LocalTransactionTesting.installBeforeFinalGlobalFactGate (fun () ->
                 match changedFact with
-                | "configuration" -> saveConfigurationChange current (fun configuration -> configuration.BranchId <- Guid.NewGuid())
-                | "status" ->
+                | "revision" -> rewriteLocalStatusRevision current.GraceStatusFile (acceptedRevision + 1L)
+                | "fingerprint" ->
                     let changed = completeStatus [| localFile "different.txt" (Encoding.UTF8.GetBytes("different status bytes")) |]
 
                     LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile changed
                     |> fun task -> task.GetAwaiter().GetResult()
                     |> ignore
+
+                    rewriteLocalStatusRevision current.GraceStatusFile acceptedRevision
                 | "pending" ->
                     LocalStateDb.commitWorkingDirectoryUpdateCompletion
                         current.GraceStatusFile
@@ -924,6 +1339,12 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                         operation
                     |> fun task -> task.GetAwaiter().GetResult()
                     |> ignore
+
+                    LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+                    |> fun task -> task.GetAwaiter().GetResult()
+                    |> ignore
+
+                    rewriteLocalStatusRevision current.GraceStatusFile acceptedRevision
                 | "marker-attempt" ->
                     let differentAttempt = WorkingDirectoryUpdateContracts.AttemptToken.create ()
 
@@ -935,7 +1356,7 @@ module WorkingDirectoryUpdateLocalTransactionTests =
 
             let outcome =
                 WorkingDirectoryUpdate.LocalTransaction.run
-                    (acceptedPhase current CancellationToken.None)
+                    accepted
                     selection
                     graph
                     prepared
@@ -943,9 +1364,15 @@ module WorkingDirectoryUpdateLocalTransactionTests =
                      |> required)
                 |> fun task -> task.GetAwaiter().GetResult()
 
-            match outcome with
-            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
-            | _ -> Assert.Fail($"Expected post-plan {changedFact} rejection, got {outcome}.")
+            match changedFact with
+            | "revision" -> assertRejectedFor "Accepted local-status revision changed after final planning." outcome
+            | "fingerprint" -> assertRejectedFor "Accepted complete local-status fingerprint changed after final planning." outcome
+            | "pending" -> assertRejectedFor "Pending Working Directory Update finalization changed after final planning." outcome
+            | "marker-attempt" ->
+                match outcome with
+                | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
+                | _ -> Assert.Fail($"Expected post-plan marker-attempt rejection, got {outcome}.")
+            | value -> Assert.Fail($"Unexpected global fact '{value}'.")
 
             File.Exists(Path.Combine(root, "target.txt"))
             |> should equal false

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
@@ -874,3 +874,84 @@ module WorkingDirectoryUpdateLocalTransactionTests =
             assertNoCompletion current target branchId WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
             assertPreparedDisposed prepared (RelativePath "target.txt")
             assertLeaseReacquirable repositoryId root)
+
+    /// Proves every post-plan global fact is reread before the first action can mutate the working tree.
+    [<TestCase("configuration")>]
+    [<TestCase("status")>]
+    [<TestCase("pending")>]
+    [<TestCase("marker-attempt")>]
+    let ``five-input transaction rejects post-plan global fact changes`` changedFact =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, targetStatus, graph = targetGraph repositoryId branchId selected
+            let selection = WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            let operation =
+                WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection branchId selection target
+                |> required
+
+            let scope =
+                WorkingDirectoryUpdateCoordination.Scope.create repositoryId root
+                |> required
+
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            WorkingDirectoryUpdate.LocalTransactionTesting.installBeforeFinalGlobalFactGate (fun () ->
+                match changedFact with
+                | "configuration" -> saveConfigurationChange current (fun configuration -> configuration.BranchId <- Guid.NewGuid())
+                | "status" ->
+                    let changed = completeStatus [| localFile "different.txt" (Encoding.UTF8.GetBytes("different status bytes")) |]
+
+                    LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile changed
+                    |> fun task -> task.GetAwaiter().GetResult()
+                    |> ignore
+                | "pending" ->
+                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                        current.GraceStatusFile
+                        targetStatus
+                        (targetStatus.Index.Values :> IEnumerable<LocalDirectoryVersion>)
+                        (LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization branchId)
+                        target
+                        operation
+                    |> fun task -> task.GetAwaiter().GetResult()
+                    |> ignore
+                | "marker-attempt" ->
+                    let differentAttempt = WorkingDirectoryUpdateContracts.AttemptToken.create ()
+
+                    WorkingDirectoryUpdateCoordination.Marker.create scope differentAttempt target operation
+                    |> required
+                    |> WorkingDirectoryUpdateCoordination.Marker.write scope
+                    |> fun task -> task.GetAwaiter().GetResult()
+                | value -> Assert.Fail($"Unexpected global fact '{value}'."))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    selection
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create $"post-plan-{changedFact}"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | Error (WorkingDirectoryUpdateContracts.Outcome.Rejected _) -> ()
+            | _ -> Assert.Fail($"Expected post-plan {changedFact} rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "target.txt"))
+            |> should equal false
+
+            if changedFact <> "pending" then
+                assertNoCompletion current target branchId selection
+
+            assertPreparedDisposed prepared (RelativePath "target.txt")
+            assertLeaseReacquirable repositoryId root)

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs
@@ -1,0 +1,396 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open Grace.CLI.Command
+open Grace.Shared
+open Grace.Shared.Client.Configuration
+open Grace.Shared.Constants
+open Grace.Types.Common
+open Microsoft.Data.Sqlite
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.IO
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+/// Exercises the production five-input local transaction against real temporary files and SQLite state.
+module WorkingDirectoryUpdateLocalTransactionTests =
+    /// Extracts a successful private contract construction or reports the exact failure.
+    let private required =
+        function
+        | Ok value -> value
+        | Error error -> failwith error
+
+    /// Provides immutable in-memory prepared bytes while recording disposal by the production preparation contract.
+    type private Reader(entries: (string * byte array) list) =
+        let values = Dictionary<string, byte array>(StringComparer.Ordinal)
+
+        do
+            entries
+            |> Seq.iter (fun (path, bytes) -> values[path] <- bytes)
+
+        interface WorkingDirectoryUpdateContracts.IPreparedContentReader with
+            member _.FilePaths = values.Keys :> seq<string>
+
+            member _.OpenReadAsync(path, _) =
+                match values.TryGetValue(string path) with
+                | true, bytes -> Task.FromResult(new MemoryStream(bytes, writable = false) :> Stream)
+                | false, _ -> Task.FromException<Stream>(FileNotFoundException(string path))
+
+            member _.Dispose() = ()
+
+    /// Configures one isolated repository root using the production local configuration location and paths.
+    let private configure root repositoryId branchId =
+        let configuration = GraceConfiguration()
+        configuration.OwnerId <- Guid.NewGuid()
+        configuration.OrganizationId <- Guid.NewGuid()
+        configuration.RepositoryId <- repositoryId
+        configuration.BranchId <- branchId
+        configuration.RootDirectory <- root
+        configuration.StandardizedRootDirectory <- Grace.Shared.Utilities.normalizeFilePath root
+        configuration.GraceDirectory <- Path.Combine(root, GraceConfigDirectory)
+        configuration.ObjectDirectory <- Path.Combine(configuration.GraceDirectory, GraceObjectsDirectory)
+        configuration.GraceStatusFile <- Path.Combine(configuration.GraceDirectory, GraceLocalStateDbFileName)
+        configuration.GraceObjectCacheFile <- configuration.GraceStatusFile
+        configuration.ConfigurationDirectory <- configuration.GraceDirectory
+
+        Directory.CreateDirectory(configuration.ConfigurationDirectory)
+        |> ignore
+
+        saveConfigFile (Path.Combine(configuration.ConfigurationDirectory, GraceConfigFileName)) configuration
+        resetConfiguration ()
+        Current()
+
+    /// Runs a real temporary filesystem and SQLite scenario without preserving process-static CLI configuration.
+    let private withTempRepository action =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-wdu-local-transaction-{Guid.NewGuid():N}")
+        let originalDirectory = Environment.CurrentDirectory
+        let originalParseResult = Services.parseResult
+
+        try
+            Directory.CreateDirectory(root) |> ignore
+            Environment.CurrentDirectory <- root
+            Services.parseResult <- GraceCommand.rootCommand.Parse(Array.empty<string>)
+            action root
+        finally
+            Services.clearShouldIgnoreCache ()
+            Services.parseResult <- originalParseResult
+            Environment.CurrentDirectory <- originalDirectory
+            resetConfiguration ()
+            SqliteConnection.ClearAllPools()
+
+            if Directory.Exists(root) then Directory.Delete(root, true)
+
+    /// Builds one dual-hashed file with deterministic status metadata.
+    let private localFile (path: string) (bytes: byte array) : LocalFileVersion =
+        LocalFileVersion.CreateWithHashes
+            (RelativePath path)
+            (Sha256Hash(
+                Convert
+                    .ToHexString(SHA256.HashData(bytes))
+                    .ToLowerInvariant()
+            ))
+            (Blake3Hash(ContentAddress.computeBlake3Hex bytes))
+            false
+            (int64 bytes.Length)
+            (Grace.Shared.Utilities.getCurrentInstant ())
+            true
+            (DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc))
+
+    /// Returns the direct parent path of a normalized repository path.
+    let private parentPath (path: string) =
+        if path = Constants.RootDirectoryPath then
+            None
+        else
+            let separator = path.LastIndexOf('/')
+
+            if separator < 0 then
+                Some Constants.RootDirectoryPath
+            else
+                Some(path.Substring(0, separator))
+
+    /// Builds a complete rooted graph whose directory hashes cover the exact supplied files.
+    let private completeStatus (files: LocalFileVersion array) =
+        let paths =
+            seq {
+                yield Constants.RootDirectoryPath
+
+                for (file: LocalFileVersion) in files do
+                    let mutable current = parentPath (string file.RelativePath)
+
+                    while Option.isSome current do
+                        let path = Option.get current
+                        yield path
+                        current <- parentPath path
+            }
+            |> Seq.distinct
+            |> Seq.sortByDescending (fun path -> if path = Constants.RootDirectoryPath then 0 else path.Split('/').Length)
+            |> Seq.toArray
+
+        let ids = Dictionary<string, DirectoryVersionId>(StringComparer.Ordinal)
+
+        paths
+        |> Seq.iter (fun path -> ids[path] <- Guid.NewGuid())
+
+        let directories = Dictionary<string, LocalDirectoryVersion>(StringComparer.Ordinal)
+        let current = Current()
+
+        paths
+        |> Seq.iter (fun path ->
+            let childDirectories =
+                paths
+                |> Seq.filter (fun candidate -> parentPath candidate = Some path)
+                |> Seq.map (fun child -> directories[child])
+                |> Seq.toArray
+
+            let directFiles =
+                files
+                |> Seq.filter (fun (file: LocalFileVersion) -> parentPath (string file.RelativePath) = Some path)
+                |> Seq.toArray
+
+            let entries =
+                seq {
+                    yield!
+                        childDirectories
+                        |> Seq.map (fun child ->
+                            Services.DirectoryVersionPreimageEntry.Directory child.RelativePath child.Size child.Blake3Hash child.Sha256Hash)
+
+                    yield!
+                        directFiles
+                        |> Seq.map (fun (file: LocalFileVersion) ->
+                            Services.DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash)
+                }
+                |> Seq.toArray
+
+            directories[path] <- LocalDirectoryVersion.CreateWithHashes
+                                     ids[path]
+                                     current.OwnerId
+                                     current.OrganizationId
+                                     current.RepositoryId
+                                     (RelativePath path)
+                                     (Services.computeSha256ForDirectoryEntries (RelativePath path) entries)
+                                     (Services.computeBlake3ForDirectory (RelativePath path) entries)
+                                     (List<DirectoryVersionId>(
+                                         childDirectories
+                                         |> Seq.map (fun child -> child.DirectoryVersionId)
+                                     ))
+                                     (List<LocalFileVersion>(directFiles: LocalFileVersion array))
+                                     (entries |> Seq.sumBy (fun entry -> entry.Size))
+                                     (DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc)))
+
+        let root = directories[Constants.RootDirectoryPath]
+        let index = GraceIndex()
+
+        directories.Values
+        |> Seq.iter (fun directory -> index[directory.DirectoryVersionId] <- directory)
+
+        let status =
+            { GraceStatus.Default with
+                Index = index
+                RootDirectoryId = root.DirectoryVersionId
+                RootDirectorySha256Hash = root.Sha256Hash
+                RootDirectoryBlake3Hash = root.Blake3Hash
+            }
+
+        LocalStateDb.validateCompleteStatusTree status
+        |> required
+
+        status
+
+    /// Prepares one immutable manifest/byte pair matching the complete target graph's sole file.
+    let private preparedContent (file: LocalFileVersion) (bytes: byte array) =
+        let manifest =
+            WorkingDirectoryUpdateContracts.PreparedManifest.create [ WorkingDirectoryUpdateContracts.PreparedManifestEntry.File(
+                                                                          file.RelativePath,
+                                                                          file.Sha256Hash,
+                                                                          file.Blake3Hash
+                                                                      ) ]
+            |> required
+
+        WorkingDirectoryUpdateContracts.PreparedContent.create manifest (new Reader([ string file.RelativePath, bytes ])) CancellationToken.None
+        |> fun task -> task.GetAwaiter().GetResult()
+        |> required
+
+    /// Builds the single-file resolved target tuple required by the production five-input transaction.
+    let private targetGraph repositoryId branchId (file: LocalFileVersion) =
+        let status = completeStatus [| file |]
+
+        let target =
+            WorkingDirectoryUpdateContracts.Target.create
+                repositoryId
+                branchId
+                status.RootDirectoryId
+                status.RootDirectorySha256Hash
+                status.RootDirectoryBlake3Hash
+            |> required
+
+        target,
+        status,
+        WorkingDirectoryUpdate.ResolvedTargetGraph.create target status
+        |> required
+
+    /// Creates one phase from the exact current SQLite snapshot and an optional distinct cancellation token.
+    let private acceptedPhase (current: GraceConfiguration) (cancellationToken: CancellationToken) =
+        let revision =
+            LocalStateDb.readLocalStatusRevisionReadOnly current.GraceStatusFile
+            |> fun task -> task.GetAwaiter().GetResult()
+
+        let status =
+            LocalStateDb.readCompleteStatusSnapshotReadOnly current.GraceStatusFile current.OwnerId current.OrganizationId current.RepositoryId
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> required
+
+        WorkingDirectoryUpdateContracts.AcceptedBranchPhase.create revision (WorkingDirectoryUpdate.LocalTransaction.statusFingerprint status) cancellationToken
+        |> required
+
+    /// Executes both typed Branch selections through the same production transaction and verifies pending SQLite facts.
+    [<TestCase(true)>]
+    [<TestCase(false)>]
+    let ``five-input transaction writes verified bytes and typed pending Branch completion`` referenceSelection =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let currentBranchId = Guid.NewGuid()
+            let targetBranchId = if referenceSelection then Guid.NewGuid() else currentBranchId
+            let current = configure root repositoryId currentBranchId
+            let currentStatus = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile currentStatus
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let targetFile = localFile "nested/target.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, resolvedGraph = targetGraph repositoryId targetBranchId targetFile
+            let prepared = preparedContent targetFile (Encoding.UTF8.GetBytes("selected target bytes"))
+            let phase = acceptedPhase current CancellationToken.None
+
+            let selection =
+                if referenceSelection then
+                    WorkingDirectoryUpdateContracts.BranchSelection.Reference(Guid.NewGuid())
+                else
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+
+            let correlation =
+                WorkingDirectoryUpdate.DiagnosticCorrelation.create "direct-runtime"
+                |> required
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run phase selection resolvedGraph prepared correlation
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.Updated _ -> ()
+            | _ -> Assert.Fail($"Expected verified pending completion, got {outcome}.")
+
+            File.ReadAllText(Path.Combine(root, "nested", "target.txt"))
+            |> should equal "selected target bytes"
+
+            match LocalStateDb.readPendingWorkingDirectoryUpdateFinalization current.GraceStatusFile
+                  |> fun task -> task.GetAwaiter().GetResult()
+                with
+            | Some (LocalStateDb.PendingWorkingDirectoryUpdateFinalization.PendingBranchFinalization (persistedTarget, _, previousBranchId, persistedSelection)) ->
+                persistedTarget |> should equal target
+                previousBranchId |> should equal currentBranchId
+                persistedSelection |> should equal selection
+            | _ -> Assert.Fail("Expected one typed pending Branch finalization after verified local completion."))
+
+    /// Proves a stale accepted revision rejects before object or working-tree mutation and disposes immutable prepared bytes.
+    [<Test>]
+    let ``five-input transaction rejects a stale accepted phase before mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let stalePhase = acceptedPhase current CancellationToken.None
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "selected.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let target, _, graph = targetGraph repositoryId branchId selected
+            let prepared = preparedContent selected (Encoding.UTF8.GetBytes("selected target bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    stalePhase
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "stale"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | _ -> Assert.Fail($"Expected stale phase rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "selected.txt"))
+            |> should equal false
+
+            Directory.Exists(current.ObjectDirectory)
+            |> should equal false
+
+            LocalStateDb.readWorkingDirectoryUpdateCompletion
+                current.GraceStatusFile
+                target
+                (WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection
+                    branchId
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+                    target
+                 |> required)
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> should equal None
+
+            WorkingDirectoryUpdateContracts.PreparedContent.openRead prepared (RelativePath "selected.txt")
+            |> ignore)
+
+    /// Proves graph/manifest topology disagreement rejects before #898 planning, objects, or working bytes change.
+    [<Test>]
+    let ``five-input transaction rejects graph manifest topology mismatch before mutation`` () =
+        withTempRepository (fun root ->
+            let repositoryId = Guid.NewGuid()
+            let branchId = Guid.NewGuid()
+            let current = configure root repositoryId branchId
+            let baseline = completeStatus Array.empty<LocalFileVersion>
+
+            LocalStateDb.replaceStatusSnapshotWithRevision current.GraceStatusFile baseline
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> ignore
+
+            let selected = localFile "selected.txt" (Encoding.UTF8.GetBytes("selected target bytes"))
+            let _, _, graph = targetGraph repositoryId branchId selected
+            let different = localFile "different.txt" (Encoding.UTF8.GetBytes("different target bytes"))
+            let prepared = preparedContent different (Encoding.UTF8.GetBytes("different target bytes"))
+
+            let outcome =
+                WorkingDirectoryUpdate.LocalTransaction.run
+                    (acceptedPhase current CancellationToken.None)
+                    WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion
+                    graph
+                    prepared
+                    (WorkingDirectoryUpdate.DiagnosticCorrelation.create "mismatch"
+                     |> required)
+                |> fun task -> task.GetAwaiter().GetResult()
+
+            match outcome with
+            | WorkingDirectoryUpdateContracts.Outcome.Rejected _ -> ()
+            | _ -> Assert.Fail($"Expected graph/manifest mismatch rejection, got {outcome}.")
+
+            File.Exists(Path.Combine(root, "selected.txt"))
+            |> should equal false
+
+            File.Exists(Path.Combine(root, "different.txt"))
+            |> should equal false
+
+            Directory.Exists(current.ObjectDirectory)
+            |> should equal false)

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.PreparedContent.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.PreparedContent.Tests.fs
@@ -359,32 +359,11 @@ module WorkingDirectoryUpdatePreparedContentTests =
             WorkingDirectoryUpdate.Operation.watchReplay repositoryId branchId "cursor-002"
             |> required
 
-        let firstRequest =
-            WorkingDirectoryUpdate.Request.create target first preparedContent "diagnostic-42"
-            |> required
-
-        let secondRequest =
-            WorkingDirectoryUpdate.Request.create target second preparedContent "diagnostic-42"
-            |> required
-
-        let differentCorrelationRequest =
-            WorkingDirectoryUpdate.Request.create target first preparedContent "diagnostic-99"
-            |> required
-
-        WorkingDirectoryUpdate.Request.operation firstRequest
-        |> WorkingDirectoryUpdate.Operation.value
-        |> should
-            equal
-            (WorkingDirectoryUpdate.Request.operation differentCorrelationRequest
-             |> WorkingDirectoryUpdate.Operation.value)
-
-        WorkingDirectoryUpdate.Request.operation firstRequest
-        |> WorkingDirectoryUpdate.Operation.value
+        WorkingDirectoryUpdate.Operation.value first
         |> should
             not'
             (equal (
-                WorkingDirectoryUpdate.Request.operation secondRequest
-                |> WorkingDirectoryUpdate.Operation.value
+                WorkingDirectoryUpdate.Operation.value second
             ))
 
         WorkingDirectoryUpdate.PreparedContent.dispose preparedContent

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.PreparedContent.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.PreparedContent.Tests.fs
@@ -360,10 +360,6 @@ module WorkingDirectoryUpdatePreparedContentTests =
             |> required
 
         WorkingDirectoryUpdate.Operation.value first
-        |> should
-            not'
-            (equal (
-                WorkingDirectoryUpdate.Operation.value second
-            ))
+        |> should not' (equal (WorkingDirectoryUpdate.Operation.value second))
 
         WorkingDirectoryUpdate.PreparedContent.dispose preparedContent

--- a/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs
+++ b/src/Grace.CLI.Tests/WorkingDirectoryUpdate.Topology.Tests.fs
@@ -302,7 +302,7 @@ module WorkingDirectoryUpdateTopologyTests =
                     equal
                     [
                         WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "src")
-                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "src/new.txt")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "src/new.txt", WorkingDirectoryUpdate.Topology.MustBeAbsent)
                     ]
             | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected a safe absent/matching plan."))
 
@@ -316,10 +316,8 @@ module WorkingDirectoryUpdateTopologyTests =
             let selectedBytes = Encoding.UTF8.GetBytes("selected replacement bytes")
             File.WriteAllBytes(Path.Combine(root, "replace.txt"), localBytes)
 
-            let currentStatus =
-                status [] [
-                    trackedFile "replace.txt" localBytes
-                ]
+            let existing = trackedFile "replace.txt" localBytes
+            let currentStatus = status [] [ existing ]
 
             match plan currentStatus (manifest [ targetFile "replace.txt" selectedBytes ]) with
             | WorkingDirectoryUpdate.Topology.Planned topologyPlan ->
@@ -327,7 +325,10 @@ module WorkingDirectoryUpdateTopologyTests =
                 |> should
                     equal
                     [
-                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "replace.txt")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(
+                            RelativePath "replace.txt",
+                            WorkingDirectoryUpdate.Topology.ReplaceVerifiedTrackedFile(existing.Sha256Hash, existing.Blake3Hash)
+                        )
                     ]
             | WorkingDirectoryUpdate.Topology.Rejected _ -> Assert.Fail("Expected tracked file replacement plan."))
 
@@ -359,7 +360,7 @@ module WorkingDirectoryUpdateTopologyTests =
                         WorkingDirectoryUpdate.Topology.RemoveTrackedFile(RelativePath "replace/nested/old.txt")
                         WorkingDirectoryUpdate.Topology.RemoveTrackedDirectory(RelativePath "replace/nested")
                         WorkingDirectoryUpdate.Topology.RemoveTrackedDirectory(RelativePath "replace")
-                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "replace")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "replace", WorkingDirectoryUpdate.Topology.MustBeAbsent)
                     ]
             | WorkingDirectoryUpdate.Topology.Rejected rejection ->
                 Assert.Fail(
@@ -605,7 +606,7 @@ module WorkingDirectoryUpdateTopologyTests =
                     [
                         WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "one")
                         WorkingDirectoryUpdate.Topology.EnsureDirectory(RelativePath "one/two")
-                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "one/two/three.txt")
+                        WorkingDirectoryUpdate.Topology.CopyVerifiedFile(RelativePath "one/two/three.txt", WorkingDirectoryUpdate.Topology.MustBeAbsent)
                     ]
             | WorkingDirectoryUpdate.Topology.Rejected rejection ->
                 Assert.Fail(

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -294,8 +294,7 @@ module internal WorkingDirectoryUpdate =
             visit rootDirectory relativePath
 
         /// Classifies every target and removable tracked blocker without entering the asynchronous transaction workflow.
-        let private planSynchronously (currentStatus: GraceStatus) manifest =
-            let scanInput = currentScanInput ()
+        let private planSynchronously (scanInput: Services.WorkingTreeScanInput) (currentStatus: GraceStatus) manifest =
             let classifier = classifierInput scanInput
             let trackedRejection, trackedFiles, trackedDirectories = trackedTopology currentStatus
             let targetRejection, targetFiles, targetDirectories = targetTopology manifest
@@ -493,13 +492,178 @@ module internal WorkingDirectoryUpdate =
                     Planned(Plan(orderedRemovals @ orderedCreates @ orderedCopies))
 
         /// Produces one complete pre-mutation action list after classifying every target and removable tracked blocker.
-        let plan (currentStatus: GraceStatus) manifest = task { return planSynchronously currentStatus manifest }
+        let plan (currentStatus: GraceStatus) manifest = task { return planSynchronously (currentScanInput ()) currentStatus manifest }
+
+        /// Plans from one already-reread configuration snapshot so a transaction never falls back to cached configuration.
+        let internal planWithScanInput (scanInput: Services.WorkingTreeScanInput) (currentStatus: GraceStatus) manifest =
+            task { return planSynchronously scanInput currentStatus manifest }
 
     /// Carries the one complete target status graph and its exact selected-root identity through the local transaction.
     type ResolvedTargetGraph = private ResolvedTargetGraph of WorkingDirectoryUpdateContracts.Target * GraceStatus
 
     /// Carries correlation used only to identify diagnostics from one invocation; it never changes the update identity.
     type DiagnosticCorrelation = private DiagnosticCorrelation of string
+
+    /// Holds the immutable configuration facts that must remain unchanged from admission through first working-tree mutation.
+    type private CanonicalConfiguration =
+        {
+            OwnerId: OwnerId
+            OrganizationId: OrganizationId
+            RepositoryId: RepositoryId
+            BranchId: BranchId
+            RootDirectory: string
+            StandardizedRootDirectory: string
+            GraceDirectory: string
+            ObjectDirectory: string
+            GraceStatusFile: string
+            GraceObjectCacheFile: string
+            DirectoryVersionCache: string
+            ConfigurationDirectory: string
+            ConfigurationFile: string
+            GraceFileIgnoreEntries: string list
+            GraceDirectoryIgnoreEntries: string list
+        }
+
+    /// Loads immutable local configuration facts directly from disk instead of reusing the process cache.
+    module private CanonicalConfiguration =
+        /// Converts a deserialized configuration into the exact local facts consumed by this transaction.
+        let private fromInspection (inspection: GraceConfigurationInspection) =
+            let configuration = inspection.Configuration
+
+            {
+                OwnerId = configuration.OwnerId
+                OrganizationId = configuration.OrganizationId
+                RepositoryId = configuration.RepositoryId
+                BranchId = configuration.BranchId
+                RootDirectory = configuration.RootDirectory
+                StandardizedRootDirectory = configuration.StandardizedRootDirectory
+                GraceDirectory = configuration.GraceDirectory
+                ObjectDirectory = configuration.ObjectDirectory
+                GraceStatusFile = configuration.GraceStatusFile
+                GraceObjectCacheFile = configuration.GraceObjectCacheFile
+                DirectoryVersionCache = configuration.DirectoryVersionCache
+                ConfigurationDirectory = configuration.ConfigurationDirectory
+                ConfigurationFile = inspection.Path
+                GraceFileIgnoreEntries =
+                    configuration.GraceFileIgnoreEntries
+                    |> Array.toList
+                GraceDirectoryIgnoreEntries =
+                    configuration.GraceDirectoryIgnoreEntries
+                    |> Array.toList
+            }
+
+        /// Rereads the configured repository file and its derived ignore facts for a transaction boundary.
+        let loadFresh () =
+            match tryInspectCurrentDirectoryConfiguration () with
+            | Ok inspection -> Ok(fromInspection inspection)
+            | Error (ConfigurationFileNotFound error) -> Error error
+            | Error (ConfigurationFileMalformed (_, error)) -> Error error
+
+        /// Compares every configuration fact that controls local identity, paths, status, objects, and topology classification.
+        let matches left right = left = right
+
+        /// Builds the planner input without accessing Configuration.Current().
+        let scanInput configuration : Services.WorkingTreeScanInput =
+            {
+                RootDirectory = configuration.RootDirectory
+                GraceDirectory = configuration.GraceDirectory
+                GraceStatusFile = configuration.GraceStatusFile
+                DirectoryIgnoreEntries =
+                    configuration.GraceDirectoryIgnoreEntries
+                    |> List.toArray
+                FileIgnoreEntries =
+                    configuration.GraceFileIgnoreEntries
+                    |> List.toArray
+            }
+
+    /// Exposes precise test-only timing points without adding callers, request bags, or production transaction options.
+    module internal LocalTransactionTesting =
+        let mutable private afterSealedConfiguration: (unit -> unit) option = None
+        let mutable private afterLeaseAcquired: (unit -> unit) option = None
+        let mutable private afterObjectPublication: (unit -> unit) option = None
+        let mutable private beforeFinalPlanning: (unit -> unit) option = None
+        let mutable private beforeFirstMutation: (unit -> unit) option = None
+        let mutable private afterFirstMutationBegan: (unit -> unit) option = None
+        let mutable private afterPlannedActions: (unit -> unit) option = None
+
+        /// Removes all deterministic timing actions after a direct-runtime test completes.
+        let reset () =
+            afterSealedConfiguration <- None
+            afterLeaseAcquired <- None
+            afterObjectPublication <- None
+            beforeFinalPlanning <- None
+            beforeFirstMutation <- None
+            afterFirstMutationBegan <- None
+            afterPlannedActions <- None
+
+        /// Installs one action after the immutable configuration baseline is sealed and before WDU lease acquisition.
+        let installAfterSealedConfiguration action = afterSealedConfiguration <- Some action
+
+        /// Installs one action after the WDU lease is acquired and before the mandatory fresh configuration reread.
+        let installAfterLeaseAcquired action = afterLeaseAcquired <- Some action
+
+        /// Installs one action immediately after immutable objects are published and before final configuration reread.
+        let installAfterObjectPublication action = afterObjectPublication <- Some action
+
+        /// Installs one action immediately before final planning begins.
+        let installBeforeFinalPlanning action = beforeFinalPlanning <- Some action
+
+        /// Installs one action between the final cancellation check and the first possible working-tree mutation.
+        let installBeforeFirstMutation action = beforeFirstMutation <- Some action
+
+        /// Installs one action after a filesystem mutation begins but before the action returns to the transaction loop.
+        let installAfterFirstMutationBegan action = afterFirstMutationBegan <- Some action
+
+        /// Installs one action after all planned working-tree actions and before independent final-root verification.
+        let installAfterPlannedActions action = afterPlannedActions <- Some action
+
+        /// Executes and clears one deterministic action so later actions in the same transaction remain production-shaped.
+        let private invoke hook =
+            match hook with
+            | Some action -> action ()
+            | None -> ()
+
+        /// Executes the post-sealed-configuration test action once.
+        let afterSealedConfigurationNow () =
+            let hook = afterSealedConfiguration
+            afterSealedConfiguration <- None
+            invoke hook
+
+        /// Executes the post-lease-acquisition test action once.
+        let afterLeaseAcquiredNow () =
+            let hook = afterLeaseAcquired
+            afterLeaseAcquired <- None
+            invoke hook
+
+        /// Executes the post-object-publication test action once.
+        let afterObjectPublicationNow () =
+            let hook = afterObjectPublication
+            afterObjectPublication <- None
+            invoke hook
+
+        /// Executes the pre-final-planning test action once.
+        let beforeFinalPlanningNow () =
+            let hook = beforeFinalPlanning
+            beforeFinalPlanning <- None
+            invoke hook
+
+        /// Executes the pre-first-mutation test action once.
+        let beforeFirstMutationNow () =
+            let hook = beforeFirstMutation
+            beforeFirstMutation <- None
+            invoke hook
+
+        /// Executes the in-first-mutation test action once.
+        let afterFirstMutationBeganNow () =
+            let hook = afterFirstMutationBegan
+            afterFirstMutationBegan <- None
+            invoke hook
+
+        /// Executes the post-action test action once.
+        let afterPlannedActionsNow () =
+            let hook = afterPlannedActions
+            afterPlannedActions <- None
+            invoke hook
 
     /// Holds the private local-completion result that a later finalization leaf may consume without reconstructing facts.
     type LocalCompletion = private LocalCompletion of WorkingDirectoryUpdateContracts.Target * WorkingDirectoryUpdateContracts.Operation
@@ -785,6 +949,7 @@ module internal WorkingDirectoryUpdate =
 
                 if File.Exists(fullPath) then
                     File.Delete(fullPath)
+                    LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
                 else
                     false
@@ -793,6 +958,7 @@ module internal WorkingDirectoryUpdate =
 
                 if Directory.Exists(fullPath) then
                     Directory.Delete(fullPath, false)
+                    LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
                 else
                     false
@@ -803,6 +969,7 @@ module internal WorkingDirectoryUpdate =
                     false
                 else
                     Directory.CreateDirectory(fullPath) |> ignore
+                    LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
             | Topology.CopyVerifiedFile path ->
                 let key = pathKey path
@@ -819,6 +986,7 @@ module internal WorkingDirectoryUpdate =
                     let directory = Path.GetDirectoryName(finalPath)
                     Directory.CreateDirectory(directory) |> ignore
                     File.Copy(objectFile, finalPath, true)
+                    LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
 
         /// Returns every target file declared by the complete selected graph.
@@ -860,20 +1028,32 @@ module internal WorkingDirectoryUpdate =
                 |> Array.filter (fun entry ->
                     not (Services.isPathWithinDirectoryWithComparison StringComparison.OrdinalIgnoreCase graceDirectory entry.FullName))
 
+            let actualDirectories = HashSet<string>(StringComparer.Ordinal)
+            let actualFiles = HashSet<string>(StringComparer.Ordinal)
+
+            actualDirectories.Add(pathKey (RelativePath Constants.RootDirectoryPath))
+            |> ignore
+
+            actualEntries
+            |> Seq.iter (fun entry ->
+                let relativePath =
+                    Path.GetRelativePath(root, entry.FullName)
+                    |> Grace.Shared.Utilities.normalizeFilePath
+                    |> RelativePath
+
+                if entry :? DirectoryInfo then
+                    actualDirectories.Add(pathKey relativePath)
+                    |> ignore
+                else
+                    actualFiles.Add(pathKey relativePath) |> ignore)
+
             let actualTopologyMatches =
-                actualEntries
-                |> Array.forall (fun entry ->
-                    let relativePath =
-                        Path.GetRelativePath(root, entry.FullName)
-                        |> Grace.Shared.Utilities.normalizeFilePath
-                        |> RelativePath
-
-                    let key = pathKey relativePath
-
-                    if entry :? DirectoryInfo then
-                        expectedDirectories.Contains(key)
-                    else
-                        expectedFiles.ContainsKey(key))
+                actualDirectories.Count = expectedDirectories.Count
+                && actualFiles.Count = expectedFiles.Count
+                && expectedDirectories
+                   |> Seq.forall actualDirectories.Contains
+                && expectedFiles.Keys
+                   |> Seq.forall actualFiles.Contains
 
             let actualDirectoryHashesMatch =
                 if not targetFilesMatch || not actualTopologyMatches then
@@ -974,182 +1154,252 @@ module internal WorkingDirectoryUpdate =
 
                 try
                     actionToken.ThrowIfCancellationRequested()
-                    let current = Current()
 
-                    if current.RepositoryId
-                       <> WorkingDirectoryUpdateContracts.Target.repositoryId target then
-                        return rejected $"[{correlationValue}] Local configuration repository changed before Working Directory Update admission."
-                    else
-                        match WorkingDirectoryUpdateCoordination.Scope.create current.RepositoryId current.RootDirectory with
-                        | Error error -> return rejected $"[{correlationValue}] {error}"
-                        | Ok scope ->
-                            let! acquiredLease = WorkingDirectoryUpdateCoordination.Lease.acquire scope actionToken
-                            use acquiredLease = acquiredLease
-                            let dbPath = current.GraceStatusFile
-                            let! revision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
+                    match CanonicalConfiguration.loadFresh () with
+                    | Error error -> return rejected $"[{correlationValue}] {error}"
+                    | Ok sealedConfiguration ->
+                        LocalTransactionTesting.afterSealedConfigurationNow ()
 
-                            let! currentStatusResult =
-                                LocalStateDb.readCompleteStatusSnapshotReadOnly dbPath current.OwnerId current.OrganizationId current.RepositoryId
+                        if sealedConfiguration.RepositoryId
+                           <> WorkingDirectoryUpdateContracts.Target.repositoryId target then
+                            return rejected $"[{correlationValue}] Local configuration repository changed before Working Directory Update admission."
+                        else
+                            match WorkingDirectoryUpdateCoordination.Scope.create sealedConfiguration.RepositoryId sealedConfiguration.RootDirectory with
+                            | Error error -> return rejected $"[{correlationValue}] {error}"
+                            | Ok scope ->
+                                let! acquiredLease = WorkingDirectoryUpdateCoordination.Lease.acquire scope actionToken
+                                use acquiredLease = acquiredLease
 
-                            let currentStatus =
-                                match currentStatusResult with
-                                | Ok status -> status
-                                | Error error -> invalidOp error
+                                LocalTransactionTesting.afterLeaseAcquiredNow ()
 
-                            let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
-
-                            if revision
-                               <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase then
-                                return rejected $"[{correlationValue}] Accepted local-status revision changed before Working Directory Update mutation."
-                            elif statusFingerprint currentStatus
-                                 <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase then
-                                return
-                                    rejected
-                                        $"[{correlationValue}] Accepted complete local-status fingerprint changed before Working Directory Update mutation."
-                            elif Option.isSome pending then
-                                return rejected $"[{correlationValue}] A pending Working Directory Update finalization blocks this local transaction."
-                            elif not (graphMatchesManifest targetStatus manifest) then
-                                return rejected $"[{correlationValue}] Resolved target graph does not match immutable prepared-content topology."
-                            else
-                                match branchOperation current.BranchId selection target with
+                                match CanonicalConfiguration.loadFresh () with
                                 | Error error -> return rejected $"[{correlationValue}] {error}"
-                                | Ok (operation, completionDetails) ->
-                                    let! markerInspection = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
+                                | Ok admissionConfiguration when not (CanonicalConfiguration.matches sealedConfiguration admissionConfiguration) ->
+                                    return rejected $"[{correlationValue}] Local configuration changed while waiting for the Working Directory Update lease."
+                                | Ok admissionConfiguration ->
+                                    let dbPath = admissionConfiguration.GraceStatusFile
+                                    let! revision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
 
-                                    match markerInspection with
-                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
-                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported
-                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.Unreadable ->
-                                        return rejected $"[{correlationValue}] Existing Working Directory Update marker is not exact owned admission evidence."
-                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.Missing
-                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch ->
-                                        let attempt = WorkingDirectoryUpdateContracts.AttemptToken.create ()
+                                    let! currentStatusResult =
+                                        LocalStateDb.readCompleteStatusSnapshotReadOnly
+                                            dbPath
+                                            admissionConfiguration.OwnerId
+                                            admissionConfiguration.OrganizationId
+                                            admissionConfiguration.RepositoryId
 
-                                        match WorkingDirectoryUpdateCoordination.Marker.create scope attempt target operation with
+                                    let currentStatus =
+                                        match currentStatusResult with
+                                        | Ok status -> status
+                                        | Error error -> invalidOp error
+
+                                    let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
+
+                                    if revision
+                                       <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase then
+                                        return rejected $"[{correlationValue}] Accepted local-status revision changed before Working Directory Update mutation."
+                                    elif statusFingerprint currentStatus
+                                         <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase then
+                                        return
+                                            rejected
+                                                $"[{correlationValue}] Accepted complete local-status fingerprint changed before Working Directory Update mutation."
+                                    elif Option.isSome pending then
+                                        return rejected $"[{correlationValue}] A pending Working Directory Update finalization blocks this local transaction."
+                                    elif not (graphMatchesManifest targetStatus manifest) then
+                                        return rejected $"[{correlationValue}] Resolved target graph does not match immutable prepared-content topology."
+                                    else
+                                        match branchOperation admissionConfiguration.BranchId selection target with
                                         | Error error -> return rejected $"[{correlationValue}] {error}"
-                                        | Ok marker ->
-                                            do! WorkingDirectoryUpdateCoordination.Marker.write scope marker
-                                            ownedMarker <- Some(scope, attempt)
-                                            let! objectResult = publishObjects preparedContent current.ObjectDirectory manifest
+                                        | Ok (operation, completionDetails) ->
+                                            let! markerInspection = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
 
-                                            match objectResult with
-                                            | Error error ->
-                                                let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
-
+                                            match markerInspection with
+                                            | WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
+                                            | WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported
+                                            | WorkingDirectoryUpdateCoordination.MarkerInspection.Unreadable ->
                                                 return
-                                                    match cleanup with
-                                                    | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
-                                                    | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker -> rejected $"[{correlationValue}] {error}"
-                                                    | _ -> rejected $"[{correlationValue}] {error}; exact marker cleanup failed."
-                                            | Ok () ->
-                                                let! initialPlan = Topology.plan currentStatus manifest
+                                                    rejected
+                                                        $"[{correlationValue}] Existing Working Directory Update marker is not exact owned admission evidence."
+                                            | WorkingDirectoryUpdateCoordination.MarkerInspection.Missing
+                                            | WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch ->
+                                                let attempt = WorkingDirectoryUpdateContracts.AttemptToken.create ()
 
-                                                match initialPlan with
-                                                | Topology.Rejected rejection ->
-                                                    invalidOp $"Initial Working Directory Update topology rejected '{Topology.Rejection.path rejection}'."
-                                                | Topology.Planned _ -> ()
+                                                match WorkingDirectoryUpdateCoordination.Marker.create scope attempt target operation with
+                                                | Error error -> return rejected $"[{correlationValue}] {error}"
+                                                | Ok marker ->
+                                                    do! WorkingDirectoryUpdateCoordination.Marker.write scope marker
+                                                    ownedMarker <- Some(scope, attempt)
+                                                    let! objectResult = publishObjects preparedContent admissionConfiguration.ObjectDirectory manifest
 
-                                                let finalCurrent = Current()
-                                                let! finalRevision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
-
-                                                let! finalStatusResult =
-                                                    LocalStateDb.readCompleteStatusSnapshotReadOnly
-                                                        dbPath
-                                                        current.OwnerId
-                                                        current.OrganizationId
-                                                        current.RepositoryId
-
-                                                let finalStatus =
-                                                    match finalStatusResult with
-                                                    | Ok status -> status
-                                                    | Error error -> invalidOp error
-
-                                                let! finalPending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
-                                                let! finalMarker = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
-
-                                                let! finalMarkerAttempt =
-                                                    WorkingDirectoryUpdateCoordination.Marker.inspectExactAttempt scope target operation attempt
-
-                                                if
-                                                    finalCurrent.RepositoryId <> current.RepositoryId
-                                                    || finalCurrent.RootDirectory
-                                                       <> current.RootDirectory
-                                                    || finalCurrent.GraceStatusFile
-                                                       <> current.GraceStatusFile
-                                                    || finalCurrent.ObjectDirectory
-                                                       <> current.ObjectDirectory
-                                                    || finalCurrent.GraceDirectory
-                                                       <> current.GraceDirectory
-                                                    || finalCurrent.BranchId <> current.BranchId
-                                                    || finalRevision
-                                                       <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase
-                                                    || statusFingerprint finalStatus
-                                                       <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase
-                                                    || Option.isSome finalPending
-                                                    || finalMarker
-                                                       <> WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
-                                                    || not finalMarkerAttempt
-                                                    || not (graphMatchesManifest targetStatus manifest)
-                                                then
-                                                    let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
-
-                                                    return
-                                                        match cleanup with
-                                                        | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
-                                                        | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
-                                                            rejected $"[{correlationValue}] Working Directory Update facts changed before the first mutation."
-                                                        | _ ->
-                                                            rejected
-                                                                $"[{correlationValue}] Working Directory Update facts changed before mutation and exact marker cleanup failed."
-                                                else
-                                                    actionToken.ThrowIfCancellationRequested()
-                                                    let! planResult = Topology.plan finalStatus manifest
-
-                                                    match planResult with
-                                                    | Topology.Rejected rejection ->
+                                                    match objectResult with
+                                                    | Error error ->
                                                         let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
-                                                        let path = Topology.Rejection.path rejection
 
                                                         return
                                                             match cleanup with
                                                             | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
                                                             | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
-                                                                rejected $"[{correlationValue}] Working Directory Update topology rejected '{path}'."
-                                                            | _ ->
-                                                                rejected
-                                                                    $"[{correlationValue}] Working Directory Update topology rejected '{path}' and exact marker cleanup failed."
-                                                    | Topology.Planned plan ->
-                                                        let actions = Topology.Plan.actions plan |> List.toArray
-                                                        let objectHashes = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.Ordinal)
+                                                                rejected $"[{correlationValue}] {error}"
+                                                            | _ -> rejected $"[{correlationValue}] {error}; exact marker cleanup failed."
+                                                    | Ok () ->
+                                                        let! initialPlan =
+                                                            Topology.planWithScanInput
+                                                                (CanonicalConfiguration.scanInput admissionConfiguration)
+                                                                currentStatus
+                                                                manifest
 
-                                                        WorkingDirectoryUpdateContracts.PreparedManifest.entries manifest
-                                                        |> Seq.iter (function
-                                                            | WorkingDirectoryUpdateContracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) ->
-                                                                objectHashes[pathKey path] <- (sha256Hash, blake3Hash)
-                                                            | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory _ -> ())
+                                                        match initialPlan with
+                                                        | Topology.Rejected rejection ->
+                                                            invalidOp
+                                                                $"Initial Working Directory Update topology rejected '{Topology.Rejection.path rejection}'."
+                                                        | Topology.Planned _ -> ()
 
-                                                        actions
-                                                        |> Array.iter (fun action ->
-                                                            if applyAction current.RootDirectory current.ObjectDirectory objectHashes action then
-                                                                mutationStarted <- true)
+                                                        LocalTransactionTesting.afterObjectPublicationNow ()
 
-                                                        if not (verifyCompleteTargetRoot current.RootDirectory current.GraceDirectory targetStatus) then
+                                                        match CanonicalConfiguration.loadFresh () with
+                                                        | Error error ->
+                                                            let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
                                                             return
-                                                                incomplete
-                                                                    $"[{correlationValue}] Complete target-root verification failed after working-tree mutation."
-                                                        else
-                                                            let! _ =
-                                                                LocalStateDb.commitWorkingDirectoryUpdateCompletion
-                                                                    dbPath
-                                                                    targetStatus
-                                                                    (targetStatus.Index.Values :> IEnumerable<LocalDirectoryVersion>)
-                                                                    completionDetails
-                                                                    target
-                                                                    operation
+                                                                match cleanup with
+                                                                | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                                | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                    rejected $"[{correlationValue}] {error}"
+                                                                | _ -> rejected $"[{correlationValue}] {error}; exact marker cleanup failed."
+                                                        | Ok finalConfiguration when not (CanonicalConfiguration.matches sealedConfiguration finalConfiguration) ->
+                                                            let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
 
-                                                            match WorkingDirectoryUpdateContracts.Receipt.create target operation mutationStarted with
-                                                            | Ok receipt -> return WorkingDirectoryUpdateContracts.Outcome.Updated receipt
-                                                            | Error error -> return incomplete $"[{correlationValue}] {error}"
+                                                            return
+                                                                match cleanup with
+                                                                | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                                | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                    rejected $"[{correlationValue}] Local configuration changed before the first mutation."
+                                                                | _ ->
+                                                                    rejected
+                                                                        $"[{correlationValue}] Local configuration changed before mutation and exact marker cleanup failed."
+                                                        | Ok finalConfiguration ->
+                                                            let! finalRevision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
+
+                                                            let! finalStatusResult =
+                                                                LocalStateDb.readCompleteStatusSnapshotReadOnly
+                                                                    dbPath
+                                                                    finalConfiguration.OwnerId
+                                                                    finalConfiguration.OrganizationId
+                                                                    finalConfiguration.RepositoryId
+
+                                                            let finalStatus =
+                                                                match finalStatusResult with
+                                                                | Ok status -> status
+                                                                | Error error -> invalidOp error
+
+                                                            let! finalPending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
+                                                            let! finalMarker = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
+
+                                                            let! finalMarkerAttempt =
+                                                                WorkingDirectoryUpdateCoordination.Marker.inspectExactAttempt scope target operation attempt
+
+                                                            if
+                                                                finalRevision
+                                                                <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase
+                                                                || statusFingerprint finalStatus
+                                                                   <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase
+                                                                || Option.isSome finalPending
+                                                                || finalMarker
+                                                                   <> WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
+                                                                || not finalMarkerAttempt
+                                                                || not (graphMatchesManifest targetStatus manifest)
+                                                            then
+                                                                let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
+                                                                return
+                                                                    match cleanup with
+                                                                    | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                                    | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                        rejected
+                                                                            $"[{correlationValue}] Working Directory Update facts changed before the first mutation."
+                                                                    | _ ->
+                                                                        rejected
+                                                                            $"[{correlationValue}] Working Directory Update facts changed before mutation and exact marker cleanup failed."
+                                                            else
+                                                                actionToken.ThrowIfCancellationRequested()
+                                                                LocalTransactionTesting.beforeFinalPlanningNow ()
+
+                                                                let! planResult =
+                                                                    Topology.planWithScanInput
+                                                                        (CanonicalConfiguration.scanInput finalConfiguration)
+                                                                        finalStatus
+                                                                        manifest
+
+                                                                actionToken.ThrowIfCancellationRequested()
+
+                                                                match planResult with
+                                                                | Topology.Rejected rejection ->
+                                                                    let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+                                                                    let path = Topology.Rejection.path rejection
+
+                                                                    return
+                                                                        match cleanup with
+                                                                        | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                                        | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                            rejected
+                                                                                $"[{correlationValue}] Working Directory Update topology rejected '{path}'."
+                                                                        | _ ->
+                                                                            rejected
+                                                                                $"[{correlationValue}] Working Directory Update topology rejected '{path}' and exact marker cleanup failed."
+                                                                | Topology.Planned plan ->
+                                                                    let actions = Topology.Plan.actions plan |> List.toArray
+                                                                    let objectHashes = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.Ordinal)
+
+                                                                    WorkingDirectoryUpdateContracts.PreparedManifest.entries manifest
+                                                                    |> Seq.iter (function
+                                                                        | WorkingDirectoryUpdateContracts.PreparedManifestEntry.File (path,
+                                                                                                                                      sha256Hash,
+                                                                                                                                      blake3Hash) ->
+                                                                            objectHashes[pathKey path] <- (sha256Hash, blake3Hash)
+                                                                        | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory _ -> ())
+
+                                                                    actions
+                                                                    |> Array.iter (fun action ->
+                                                                        if not mutationStarted then
+                                                                            actionToken.ThrowIfCancellationRequested()
+                                                                            LocalTransactionTesting.beforeFirstMutationNow ()
+                                                                            actionToken.ThrowIfCancellationRequested()
+                                                                            mutationStarted <- true
+
+                                                                        applyAction
+                                                                            finalConfiguration.RootDirectory
+                                                                            finalConfiguration.ObjectDirectory
+                                                                            objectHashes
+                                                                            action
+                                                                        |> ignore)
+
+                                                                    LocalTransactionTesting.afterPlannedActionsNow ()
+
+                                                                    if
+                                                                        not
+                                                                            (
+                                                                                verifyCompleteTargetRoot
+                                                                                    finalConfiguration.RootDirectory
+                                                                                    finalConfiguration.GraceDirectory
+                                                                                    targetStatus
+                                                                            )
+                                                                    then
+                                                                        return
+                                                                            incomplete
+                                                                                $"[{correlationValue}] Complete target-root verification failed after working-tree mutation."
+                                                                    else
+                                                                        let! _ =
+                                                                            LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                                                                                dbPath
+                                                                                targetStatus
+                                                                                (targetStatus.Index.Values :> IEnumerable<LocalDirectoryVersion>)
+                                                                                completionDetails
+                                                                                target
+                                                                                operation
+
+                                                                        match WorkingDirectoryUpdateContracts.Receipt.create target operation mutationStarted
+                                                                            with
+                                                                        | Ok receipt -> return WorkingDirectoryUpdateContracts.Outcome.Updated receipt
+                                                                        | Error error -> return incomplete $"[{correlationValue}] {error}"
                 with
                 | :? OperationCanceledException when mutationStarted ->
                     return incomplete $"[{correlationValue}] Cancellation arrived after the first working-tree mutation."

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -582,6 +582,8 @@ module internal WorkingDirectoryUpdate =
         let mutable private afterLeaseAcquired: (unit -> unit) option = None
         let mutable private afterObjectPublication: (unit -> unit) option = None
         let mutable private beforeFinalPlanning: (unit -> unit) option = None
+        let mutable private beforeFinalGlobalFactGate: (unit -> unit) option = None
+        let mutable private afterFinalGlobalFactGate: (unit -> unit) option = None
         let mutable private beforeFirstMutation: (unit -> unit) option = None
         let mutable private afterFirstMutationBegan: (unit -> unit) option = None
         let mutable private afterPlannedActions: (unit -> unit) option = None
@@ -592,6 +594,8 @@ module internal WorkingDirectoryUpdate =
             afterLeaseAcquired <- None
             afterObjectPublication <- None
             beforeFinalPlanning <- None
+            beforeFinalGlobalFactGate <- None
+            afterFinalGlobalFactGate <- None
             beforeFirstMutation <- None
             afterFirstMutationBegan <- None
             afterPlannedActions <- None
@@ -607,6 +611,12 @@ module internal WorkingDirectoryUpdate =
 
         /// Installs one action immediately before final planning begins.
         let installBeforeFinalPlanning action = beforeFinalPlanning <- Some action
+
+        /// Installs one action after final planning and immediately before the final global-fact reread.
+        let installBeforeFinalGlobalFactGate action = beforeFinalGlobalFactGate <- Some action
+
+        /// Installs one action after the final global-fact gate and before an action-time precondition is reread.
+        let installAfterFinalGlobalFactGate action = afterFinalGlobalFactGate <- Some action
 
         /// Installs one action between the final cancellation check and the first possible working-tree mutation.
         let installBeforeFirstMutation action = beforeFirstMutation <- Some action
@@ -645,6 +655,18 @@ module internal WorkingDirectoryUpdate =
         let beforeFinalPlanningNow () =
             let hook = beforeFinalPlanning
             beforeFinalPlanning <- None
+            invoke hook
+
+        /// Executes the pre-final-global-fact test action once.
+        let beforeFinalGlobalFactGateNow () =
+            let hook = beforeFinalGlobalFactGate
+            beforeFinalGlobalFactGate <- None
+            invoke hook
+
+        /// Executes the post-final-global-fact test action once.
+        let afterFinalGlobalFactGateNow () =
+            let hook = afterFinalGlobalFactGate
+            afterFinalGlobalFactGate <- None
             invoke hook
 
         /// Executes the pre-first-mutation test action once.
@@ -941,7 +963,93 @@ module internal WorkingDirectoryUpdate =
                 else
                     invalidOp $"Working Directory Update plan path escapes the local root: {path}"
 
-        /// Applies one preplanned action using only already-verified immutable objects.
+        /// Finds the exact tracked file identity for a planned removal from the last complete local status reread.
+        let private trackedFile (status: GraceStatus) path =
+            status.Index.Values
+            |> Seq.collect (fun directory -> directory.Files)
+            |> Seq.tryFind (fun file -> pathKey file.RelativePath = pathKey path)
+
+        /// Finds whether the last complete local status reread contains a tracked directory at the planned path.
+        let private hasTrackedDirectory (status: GraceStatus) path =
+            status.Index.Values
+            |> Seq.exists (fun directory -> pathKey directory.RelativePath = pathKey path)
+
+        /// Rereads the exact action-time filesystem fact that made one immutable plan action safe.
+        let private verifyActionPrecondition root (currentStatus: GraceStatus) action =
+            let fullPath path = workingPath root path
+
+            match action with
+            | Topology.RemoveTrackedFile path ->
+                match trackedFile currentStatus path with
+                | Some expected when
+                    File.Exists(fullPath path)
+                    && hasExpectedBytes (fullPath path) expected.Sha256Hash expected.Blake3Hash
+                    ->
+                    Ok()
+                | _ -> Error $"Tracked file '{path}' changed before its planned removal."
+            | Topology.RemoveTrackedDirectory path ->
+                let candidate = fullPath path
+
+                if
+                    Directory.Exists(candidate)
+                    && not (
+                        Directory
+                            .EnumerateFileSystemEntries(candidate)
+                            .GetEnumerator()
+                            .MoveNext()
+                    )
+                then
+                    Ok()
+                else
+                    Error $"Tracked directory '{path}' changed before its planned removal."
+            | Topology.EnsureDirectory path ->
+                let candidate = fullPath path
+
+                if hasTrackedDirectory currentStatus path then
+                    if Directory.Exists(candidate) then
+                        Ok()
+                    else
+                        Error $"Tracked directory '{path}' changed before it could be retained."
+                elif
+                    not
+                        (
+                            File.Exists(candidate)
+                            || Directory.Exists(candidate)
+                        )
+                then
+                    Ok()
+                else
+                    Error $"New directory '{path}' appeared or changed kind before it could be created."
+            | Topology.CopyVerifiedFile path ->
+                let candidate = fullPath path
+
+                if
+                    not
+                        (
+                            File.Exists(candidate)
+                            || Directory.Exists(candidate)
+                        )
+                then
+                    Ok()
+                else
+                    Error $"New file '{path}' appeared or changed kind before immutable bytes could be copied."
+
+        /// Rereads the source object before the mutation boundary so a corrupt or replaced object remains pre-mutation.
+        let private verifyActionObject objectDirectory (objectHashes: Dictionary<string, Sha256Hash * Blake3Hash>) =
+            function
+            | Topology.CopyVerifiedFile path ->
+                match objectHashes.TryGetValue(pathKey path) with
+                | true, (sha256Hash, blake3Hash) when hasExpectedBytes (objectPath objectDirectory path sha256Hash blake3Hash) sha256Hash blake3Hash -> Ok()
+                | _ -> Error $"Immutable object bytes are corrupt or were replaced for '{path}'."
+            | _ -> Ok()
+
+        /// Identifies whether a conditionally validated action will issue a filesystem call that can partially succeed.
+        let private actionCanMutate (currentStatus: GraceStatus) =
+            function
+            | Topology.EnsureDirectory path when hasTrackedDirectory currentStatus path -> false
+            | _ -> true
+
+        /// Applies one action only after its filesystem and immutable-object facts were reread at the mutation boundary.
         let private applyAction root objectDirectory (objectHashes: Dictionary<string, Sha256Hash * Blake3Hash>) =
             function
             | Topology.RemoveTrackedFile path ->
@@ -979,13 +1087,10 @@ module internal WorkingDirectoryUpdate =
                 | true, (sha256Hash, blake3Hash) ->
                     let objectFile = objectPath objectDirectory path sha256Hash blake3Hash
 
-                    if not (hasExpectedBytes objectFile sha256Hash blake3Hash) then
-                        invalidOp $"Immutable object bytes are corrupt or were replaced for '{path}'."
-
                     let finalPath = workingPath root path
                     let directory = Path.GetDirectoryName(finalPath)
                     Directory.CreateDirectory(directory) |> ignore
-                    File.Copy(objectFile, finalPath, true)
+                    File.Copy(objectFile, finalPath, false)
                     LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
 
@@ -1128,12 +1233,57 @@ module internal WorkingDirectoryUpdate =
             WorkingDirectoryUpdateContracts.Failure.create reason
             |> Result.map WorkingDirectoryUpdateContracts.Outcome.Rejected
             |> Result.defaultWith invalidOp
+            |> Error
 
         /// Produces a classified incomplete outcome after actual working-tree mutation begins.
         let private incomplete reason =
             WorkingDirectoryUpdateContracts.Failure.create reason
             |> Result.map WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete
             |> Result.defaultWith invalidOp
+            |> Error
+
+        /// Rereads every global admission fact after final planning and immediately before the first working-tree action.
+        let private verifyFinalGlobalFacts dbPath sealedConfiguration acceptedPhase targetStatus manifest scope target operation attempt =
+            task {
+                match CanonicalConfiguration.loadFresh () with
+                | Error error -> return Error error
+                | Ok currentConfiguration when not (CanonicalConfiguration.matches sealedConfiguration currentConfiguration) ->
+                    return Error "Local configuration changed after final planning."
+                | Ok currentConfiguration ->
+                    let! revision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
+
+                    let! statusResult =
+                        LocalStateDb.readCompleteStatusSnapshotReadOnly
+                            dbPath
+                            currentConfiguration.OwnerId
+                            currentConfiguration.OrganizationId
+                            currentConfiguration.RepositoryId
+
+                    let currentStatus =
+                        match statusResult with
+                        | Ok status -> status
+                        | Error error -> invalidOp error
+
+                    let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
+                    let! marker = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
+
+                    let! markerAttempt = WorkingDirectoryUpdateCoordination.Marker.inspectExactAttempt scope target operation attempt
+
+                    if
+                        revision
+                        <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase
+                        || statusFingerprint currentStatus
+                           <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase
+                        || Option.isSome pending
+                        || marker
+                           <> WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
+                        || not markerAttempt
+                        || not (graphMatchesManifest targetStatus manifest)
+                    then
+                        return Error "Working Directory Update facts changed after final planning."
+                    else
+                        return Ok currentConfiguration
+            }
 
         /// Applies the only Branch five-input local transaction through verified pending SQLite completion.
         let private runCore
@@ -1357,49 +1507,105 @@ module internal WorkingDirectoryUpdate =
                                                                             objectHashes[pathKey path] <- (sha256Hash, blake3Hash)
                                                                         | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory _ -> ())
 
-                                                                    actions
-                                                                    |> Array.iter (fun action ->
-                                                                        if not mutationStarted then
-                                                                            actionToken.ThrowIfCancellationRequested()
-                                                                            LocalTransactionTesting.beforeFirstMutationNow ()
-                                                                            actionToken.ThrowIfCancellationRequested()
-                                                                            mutationStarted <- true
+                                                                    LocalTransactionTesting.beforeFinalGlobalFactGateNow ()
 
-                                                                        applyAction
-                                                                            finalConfiguration.RootDirectory
-                                                                            finalConfiguration.ObjectDirectory
-                                                                            objectHashes
-                                                                            action
-                                                                        |> ignore)
+                                                                    let! globalFacts =
+                                                                        verifyFinalGlobalFacts
+                                                                            dbPath
+                                                                            sealedConfiguration
+                                                                            acceptedPhase
+                                                                            targetStatus
+                                                                            manifest
+                                                                            scope
+                                                                            target
+                                                                            operation
+                                                                            attempt
 
-                                                                    LocalTransactionTesting.afterPlannedActionsNow ()
+                                                                    match globalFacts with
+                                                                    | Error error ->
+                                                                        let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
 
-                                                                    if
-                                                                        not
-                                                                            (
-                                                                                verifyCompleteTargetRoot
-                                                                                    finalConfiguration.RootDirectory
-                                                                                    finalConfiguration.GraceDirectory
-                                                                                    targetStatus
-                                                                            )
-                                                                    then
                                                                         return
-                                                                            incomplete
-                                                                                $"[{correlationValue}] Complete target-root verification failed after working-tree mutation."
-                                                                    else
-                                                                        let! _ =
-                                                                            LocalStateDb.commitWorkingDirectoryUpdateCompletion
-                                                                                dbPath
-                                                                                targetStatus
-                                                                                (targetStatus.Index.Values :> IEnumerable<LocalDirectoryVersion>)
-                                                                                completionDetails
-                                                                                target
-                                                                                operation
+                                                                            match cleanup with
+                                                                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                                rejected $"[{correlationValue}] {error}"
+                                                                            | _ -> rejected $"[{correlationValue}] {error}; exact marker cleanup failed."
+                                                                    | Ok executionConfiguration ->
+                                                                        LocalTransactionTesting.afterFinalGlobalFactGateNow ()
 
-                                                                        match WorkingDirectoryUpdateContracts.Receipt.create target operation mutationStarted
-                                                                            with
-                                                                        | Ok receipt -> return WorkingDirectoryUpdateContracts.Outcome.Updated receipt
-                                                                        | Error error -> return incomplete $"[{correlationValue}] {error}"
+                                                                        let mutable actionFailure = None
+                                                                        let mutable index = 0
+
+                                                                        while index < actions.Length
+                                                                              && Option.isNone actionFailure do
+                                                                            let action = actions[index]
+
+                                                                            match verifyActionPrecondition
+                                                                                      executionConfiguration.RootDirectory
+                                                                                      finalStatus
+                                                                                      action,
+                                                                                  verifyActionObject executionConfiguration.ObjectDirectory objectHashes action
+                                                                                with
+                                                                            | Ok (), Ok () ->
+                                                                                let actionMutates = actionCanMutate finalStatus action
+
+                                                                                if not mutationStarted && actionMutates then
+                                                                                    actionToken.ThrowIfCancellationRequested()
+                                                                                    LocalTransactionTesting.beforeFirstMutationNow ()
+                                                                                    actionToken.ThrowIfCancellationRequested()
+
+                                                                                if actionMutates then mutationStarted <- true
+
+                                                                                applyAction
+                                                                                    executionConfiguration.RootDirectory
+                                                                                    executionConfiguration.ObjectDirectory
+                                                                                    objectHashes
+                                                                                    action
+                                                                                |> ignore
+                                                                            | Error error, _
+                                                                            | _, Error error -> actionFailure <- Some error
+
+                                                                            index <- index + 1
+
+                                                                        match actionFailure with
+                                                                        | Some error when mutationStarted -> return incomplete $"[{correlationValue}] {error}"
+                                                                        | Some error ->
+                                                                            let! cleanup =
+                                                                                WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
+                                                                            return
+                                                                                match cleanup with
+                                                                                | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                                                | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                                    rejected $"[{correlationValue}] {error}"
+                                                                                | _ -> rejected $"[{correlationValue}] {error}; exact marker cleanup failed."
+                                                                        | None ->
+                                                                            LocalTransactionTesting.afterPlannedActionsNow ()
+
+                                                                            if
+                                                                                not
+                                                                                    (
+                                                                                        verifyCompleteTargetRoot
+                                                                                            executionConfiguration.RootDirectory
+                                                                                            executionConfiguration.GraceDirectory
+                                                                                            targetStatus
+                                                                                    )
+                                                                            then
+                                                                                return
+                                                                                    incomplete
+                                                                                        $"[{correlationValue}] Complete target-root verification failed after working-tree mutation."
+                                                                            else
+                                                                                let! _ =
+                                                                                    LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                                                                                        dbPath
+                                                                                        targetStatus
+                                                                                        (targetStatus.Index.Values :> IEnumerable<LocalDirectoryVersion>)
+                                                                                        completionDetails
+                                                                                        target
+                                                                                        operation
+
+                                                                                return Ok(LocalCompletion(target, operation))
                 with
                 | :? OperationCanceledException when mutationStarted ->
                     return incomplete $"[{correlationValue}] Cancellation arrived after the first working-tree mutation."
@@ -1432,7 +1638,8 @@ module internal WorkingDirectoryUpdate =
         /// Disposes immutable prepared bytes exactly once after every five-input transaction path completes.
         let run acceptedPhase selection resolvedGraph preparedContent correlation =
             task {
-                let! outcome = runCore acceptedPhase selection resolvedGraph preparedContent correlation
-                WorkingDirectoryUpdateContracts.PreparedContent.dispose preparedContent
-                return outcome
+                try
+                    return! runCore acceptedPhase selection resolvedGraph preparedContent correlation
+                finally
+                    WorkingDirectoryUpdateContracts.PreparedContent.dispose preparedContent
             }

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -23,12 +23,17 @@ module internal WorkingDirectoryUpdate =
         /// Carries the stable repository-relative path and classification that prevented a pre-mutation plan.
         type Rejection = private { Path: RelativePath; Classification: RejectionClassification }
 
+        /// States whether an immutable object may create a new file or replace one exact accepted tracked file.
+        type CopyPrecondition =
+            | MustBeAbsent
+            | ReplaceVerifiedTrackedFile of Sha256Hash * Blake3Hash
+
         /// Describes one tracked later transaction step without carrying a writer, callback, or mutable filesystem handle.
         type Action =
             | RemoveTrackedFile of RelativePath
             | RemoveTrackedDirectory of RelativePath
             | EnsureDirectory of RelativePath
-            | CopyVerifiedFile of RelativePath
+            | CopyVerifiedFile of RelativePath * CopyPrecondition
 
         /// Represents the complete immutable topology plan that a later transaction may apply without discovering blockers.
         type Plan = private Plan of Action list
@@ -310,7 +315,7 @@ module internal WorkingDirectoryUpdate =
 
                 let addRemoval path action = removals[pathKey path] <- action
                 let addCreate path = creates[pathKey path] <- EnsureDirectory path
-                let addCopy path = copies[pathKey path] <- CopyVerifiedFile path
+                let addCopy path precondition = copies[pathKey path] <- CopyVerifiedFile(path, precondition)
 
                 for targetDirectory in orderedTargetDirectories targetDirectories.Values do
                     if Option.isNone rejection
@@ -345,7 +350,7 @@ module internal WorkingDirectoryUpdate =
                         | Error value -> rejection <- Some value
                         | Ok fullPath ->
                             match actualKind fullPath with
-                            | Missing -> addCopy targetPath
+                            | Missing -> addCopy targetPath MustBeAbsent
                             | File ->
                                 match localClassification classifier trackedFiles trackedDirectories fullPath targetPath File with
                                 | Error value -> rejection <- Some value
@@ -358,7 +363,7 @@ module internal WorkingDirectoryUpdate =
                                         || tracked.Blake3Hash <> targetBlake3
                                         || not (hasVerifiedTargetBytes fullPath targetSha256 targetBlake3)
                                     then
-                                        addCopy targetPath
+                                        addCopy targetPath (ReplaceVerifiedTrackedFile(tracked.Sha256Hash, tracked.Blake3Hash))
                                 | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
                             | Directory ->
                                 match localClassification classifier trackedFiles trackedDirectories fullPath targetPath Directory with
@@ -384,7 +389,7 @@ module internal WorkingDirectoryUpdate =
                                                 .StartsWith(string targetPath + "/", StringComparison.OrdinalIgnoreCase) then
                                                 addRemoval filePath (RemoveTrackedFile filePath)
 
-                                        addCopy targetPath
+                                        addCopy targetPath MustBeAbsent
                                 | Ok _ -> rejection <- Some { Path = targetPath; Classification = Untracked }
 
                 for fileVersion in orderedTrackedFiles trackedFiles.Values do
@@ -478,12 +483,12 @@ module internal WorkingDirectoryUpdate =
                         |> Seq.sortWith (fun left right ->
                             let leftPath =
                                 match left with
-                                | CopyVerifiedFile path -> path
+                                | CopyVerifiedFile (path, _) -> path
                                 | _ -> RelativePath Constants.RootDirectoryPath
 
                             let rightPath =
                                 match right with
-                                | CopyVerifiedFile path -> path
+                                | CopyVerifiedFile (path, _) -> path
                                 | _ -> RelativePath Constants.RootDirectoryPath
 
                             comparePaths leftPath rightPath)
@@ -497,6 +502,10 @@ module internal WorkingDirectoryUpdate =
         /// Plans from one already-reread configuration snapshot so a transaction never falls back to cached configuration.
         let internal planWithScanInput (scanInput: Services.WorkingTreeScanInput) (currentStatus: GraceStatus) manifest =
             task { return planSynchronously scanInput currentStatus manifest }
+
+        /// Re-evaluates the complete relevant filesystem without a task boundary before the first mutable action.
+        let internal planSynchronouslyWithScanInput (scanInput: Services.WorkingTreeScanInput) (currentStatus: GraceStatus) manifest =
+            planSynchronously scanInput currentStatus manifest
 
     /// Carries the one complete target status graph and its exact selected-root identity through the local transaction.
     type ResolvedTargetGraph = private ResolvedTargetGraph of WorkingDirectoryUpdateContracts.Target * GraceStatus
@@ -1020,7 +1029,7 @@ module internal WorkingDirectoryUpdate =
                     Ok()
                 else
                     Error $"New directory '{path}' appeared or changed kind before it could be created."
-            | Topology.CopyVerifiedFile path ->
+            | Topology.CopyVerifiedFile (path, Topology.MustBeAbsent) ->
                 let candidate = fullPath path
 
                 if
@@ -1033,11 +1042,21 @@ module internal WorkingDirectoryUpdate =
                     Ok()
                 else
                     Error $"New file '{path}' appeared or changed kind before immutable bytes could be copied."
+            | Topology.CopyVerifiedFile (path, Topology.ReplaceVerifiedTrackedFile (sha256Hash, blake3Hash)) ->
+                let candidate = fullPath path
+
+                if
+                    File.Exists(candidate)
+                    && hasExpectedBytes candidate sha256Hash blake3Hash
+                then
+                    Ok()
+                else
+                    Error $"Tracked file '{path}' changed before immutable bytes could replace it."
 
         /// Rereads the source object before the mutation boundary so a corrupt or replaced object remains pre-mutation.
         let private verifyActionObject objectDirectory (objectHashes: Dictionary<string, Sha256Hash * Blake3Hash>) =
             function
-            | Topology.CopyVerifiedFile path ->
+            | Topology.CopyVerifiedFile (path, _) ->
                 match objectHashes.TryGetValue(pathKey path) with
                 | true, (sha256Hash, blake3Hash) when hasExpectedBytes (objectPath objectDirectory path sha256Hash blake3Hash) sha256Hash blake3Hash -> Ok()
                 | _ -> Error $"Immutable object bytes are corrupt or were replaced for '{path}'."
@@ -1079,7 +1098,7 @@ module internal WorkingDirectoryUpdate =
                     Directory.CreateDirectory(fullPath) |> ignore
                     LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
-            | Topology.CopyVerifiedFile path ->
+            | Topology.CopyVerifiedFile (path, copyPrecondition) ->
                 let key = pathKey path
 
                 match objectHashes.TryGetValue(key) with
@@ -1090,7 +1109,13 @@ module internal WorkingDirectoryUpdate =
                     let finalPath = workingPath root path
                     let directory = Path.GetDirectoryName(finalPath)
                     Directory.CreateDirectory(directory) |> ignore
-                    File.Copy(objectFile, finalPath, false)
+
+                    let overwrite =
+                        match copyPrecondition with
+                        | Topology.MustBeAbsent -> false
+                        | Topology.ReplaceVerifiedTrackedFile _ -> true
+
+                    File.Copy(objectFile, finalPath, overwrite)
                     LocalTransactionTesting.afterFirstMutationBeganNow ()
                     true
 
@@ -1269,18 +1294,21 @@ module internal WorkingDirectoryUpdate =
 
                     let! markerAttempt = WorkingDirectoryUpdateCoordination.Marker.inspectExactAttempt scope target operation attempt
 
-                    if
-                        revision
-                        <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase
-                        || statusFingerprint currentStatus
-                           <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase
-                        || Option.isSome pending
-                        || marker
-                           <> WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
-                        || not markerAttempt
-                        || not (graphMatchesManifest targetStatus manifest)
-                    then
-                        return Error "Working Directory Update facts changed after final planning."
+                    if revision
+                       <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase then
+                        return Error "Accepted local-status revision changed after final planning."
+                    elif statusFingerprint currentStatus
+                         <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase then
+                        return Error "Accepted complete local-status fingerprint changed after final planning."
+                    elif Option.isSome pending then
+                        return Error "Pending Working Directory Update finalization changed after final planning."
+                    elif marker
+                         <> WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch then
+                        return Error "Working Directory Update marker changed after final planning."
+                    elif not markerAttempt then
+                        return Error "Working Directory Update marker attempt changed after final planning."
+                    elif not (graphMatchesManifest targetStatus manifest) then
+                        return Error "Resolved target graph changed after final planning."
                     else
                         return Ok currentConfiguration
             }
@@ -1534,7 +1562,25 @@ module internal WorkingDirectoryUpdate =
                                                                     | Ok executionConfiguration ->
                                                                         LocalTransactionTesting.afterFinalGlobalFactGateNow ()
 
-                                                                        let mutable actionFailure = None
+                                                                        let mutable actionFailure =
+                                                                            match
+                                                                                Topology.planSynchronouslyWithScanInput
+                                                                                    (CanonicalConfiguration.scanInput executionConfiguration)
+                                                                                    finalStatus
+                                                                                    manifest
+                                                                                with
+                                                                            | Topology.Planned revalidatedPlan when
+                                                                                (Topology.Plan.actions revalidatedPlan
+                                                                                 |> List.toArray) = actions
+                                                                                ->
+                                                                                None
+                                                                            | Topology.Planned _ ->
+                                                                                Some
+                                                                                    "The complete Working Directory Update plan changed before the first mutation."
+                                                                            | Topology.Rejected rejection ->
+                                                                                Some
+                                                                                    $"Working Directory Update topology rejected '{Topology.Rejection.path rejection}' before the first mutation."
+
                                                                         let mutable index = 0
 
                                                                         while index < actions.Length

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs
@@ -494,3 +494,695 @@ module internal WorkingDirectoryUpdate =
 
         /// Produces one complete pre-mutation action list after classifying every target and removable tracked blocker.
         let plan (currentStatus: GraceStatus) manifest = task { return planSynchronously currentStatus manifest }
+
+    /// Carries the one complete target status graph and its exact selected-root identity through the local transaction.
+    type ResolvedTargetGraph = private ResolvedTargetGraph of WorkingDirectoryUpdateContracts.Target * GraceStatus
+
+    /// Carries correlation used only to identify diagnostics from one invocation; it never changes the update identity.
+    type DiagnosticCorrelation = private DiagnosticCorrelation of string
+
+    /// Holds the private local-completion result that a later finalization leaf may consume without reconstructing facts.
+    type LocalCompletion = private LocalCompletion of WorkingDirectoryUpdateContracts.Target * WorkingDirectoryUpdateContracts.Operation
+
+    /// Builds the only accepted resolved graph when its complete rooted status and selected-root identity agree.
+    module ResolvedTargetGraph =
+        /// Creates the runtime target graph after proving its root matches the selected target exactly.
+        let create target (status: GraceStatus) =
+            match LocalStateDb.validateCompleteStatusTree status with
+            | Error error -> Error $"Resolved target graph must be complete: {error}"
+            | Ok () ->
+                match
+                    WorkingDirectoryUpdateContracts.Target.create
+                        (WorkingDirectoryUpdateContracts.Target.repositoryId target)
+                        (WorkingDirectoryUpdateContracts.Target.branchId target)
+                        status.RootDirectoryId
+                        status.RootDirectorySha256Hash
+                        status.RootDirectoryBlake3Hash
+                    with
+                | Ok graphTarget when graphTarget = target -> Ok(ResolvedTargetGraph(target, status))
+                | Ok _ -> Error "Resolved target graph root does not exactly match the selected target."
+                | Error error -> Error $"Resolved target graph has an invalid root: {error}"
+
+        /// Returns the exact selected-root identity retained by this immutable graph.
+        let internal target (ResolvedTargetGraph (target, _)) = target
+
+        /// Returns the complete rooted status graph retained by this immutable graph.
+        let internal status (ResolvedTargetGraph (_, status)) = status
+
+    /// Supplies construction for non-empty diagnostic correlation values without making them part of operation identity.
+    module DiagnosticCorrelation =
+        /// Creates correlation text that can distinguish simultaneous local attempts in diagnostics.
+        let create value =
+            if String.IsNullOrWhiteSpace(value) then
+                Error "Working Directory Update diagnostic correlation must not be empty."
+            else
+                Ok(DiagnosticCorrelation value)
+
+        /// Returns diagnostic-only correlation text to the local transaction implementation.
+        let internal value (DiagnosticCorrelation value) = value
+
+    /// Supplies the narrow immutable result consumed by later pending-finalization routing.
+    module LocalCompletion =
+        /// Returns the selected target preserved by verified SQLite local completion.
+        let internal target (LocalCompletion (target, _)) = target
+
+        /// Returns the exact operation whose pending local completion was committed.
+        let internal operation (LocalCompletion (_, operation)) = operation
+
+    /// Owns application of the private five-input Branch transaction through verified pending local completion.
+    module LocalTransaction =
+        /// Produces a deterministic complete-status fingerprint used to reject stale Branch admission after preparation.
+        let statusFingerprint (status: GraceStatus) =
+            let canonical =
+                status.Index.Values
+                |> Seq.sortBy (fun directory -> string directory.RelativePath)
+                |> Seq.collect (fun directory ->
+                    seq {
+                        yield $"D|{directory.RelativePath}|{directory.DirectoryVersionId:N}|{directory.Sha256Hash}|{directory.Blake3Hash}"
+
+                        yield!
+                            directory.Files
+                            |> Seq.sortBy (fun file -> string file.RelativePath)
+                            |> Seq.map (fun file -> $"F|{file.RelativePath}|{file.Sha256Hash}|{file.Blake3Hash}|{file.Size}")
+                    })
+                |> String.concat "\n"
+
+            System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(canonical))
+            |> Convert.ToHexString
+            |> fun value -> value.ToLowerInvariant()
+
+        /// Computes a stable Windows comparison key for graph and manifest topology proof.
+        let private pathKey (path: RelativePath) =
+            string path
+            |> fun value -> value.ToUpperInvariant()
+
+        /// Enumerates all parent directories implied by one target path, including the root directory.
+        let private parentDirectories (path: RelativePath) =
+            let segments =
+                (string path)
+                    .Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+            seq {
+                yield RelativePath Constants.RootDirectoryPath
+
+                for index in 1 .. segments.Length - 1 do
+                    yield RelativePath(String.Join('/', segments[0 .. index - 1]))
+            }
+
+        /// Compares the full normalized directory and dual-hash file topology before any planner can consume it.
+        let private graphMatchesManifest (graph: GraceStatus) manifest =
+            let graphDirectories = Dictionary<string, RelativePath>(StringComparer.Ordinal)
+            let graphFiles = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.Ordinal)
+            let manifestDirectories = Dictionary<string, RelativePath>(StringComparer.Ordinal)
+            let manifestFiles = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.Ordinal)
+            let mutable valid = true
+
+            graph.Index.Values
+            |> Seq.iter (fun directory ->
+                let directoryKey = pathKey directory.RelativePath
+
+                if
+                    graphDirectories.ContainsKey(directoryKey)
+                    || graphFiles.ContainsKey(directoryKey)
+                then
+                    valid <- false
+                else
+                    graphDirectories[directoryKey] <- directory.RelativePath
+
+                directory.Files
+                |> Seq.iter (fun file ->
+                    let fileKey = pathKey file.RelativePath
+
+                    if
+                        graphFiles.ContainsKey(fileKey)
+                        || graphDirectories.ContainsKey(fileKey)
+                    then
+                        valid <- false
+                    else
+                        graphFiles[fileKey] <- (file.Sha256Hash, file.Blake3Hash)))
+
+            WorkingDirectoryUpdateContracts.PreparedManifest.entries manifest
+            |> Seq.iter (function
+                | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory path ->
+                    let key = pathKey path
+
+                    if
+                        manifestDirectories.ContainsKey(key)
+                        || manifestFiles.ContainsKey(key)
+                    then
+                        valid <- false
+                    else
+                        manifestDirectories[key] <- path
+
+                    parentDirectories path
+                    |> Seq.iter (fun parent ->
+                        let parentKey = pathKey parent
+
+                        if manifestFiles.ContainsKey(parentKey) then
+                            valid <- false
+                        else
+                            manifestDirectories[parentKey] <- parent)
+                | WorkingDirectoryUpdateContracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) ->
+                    let key = pathKey path
+
+                    if
+                        manifestFiles.ContainsKey(key)
+                        || manifestDirectories.ContainsKey(key)
+                    then
+                        valid <- false
+                    else
+                        manifestFiles[key] <- (sha256Hash, blake3Hash)
+
+                    parentDirectories path
+                    |> Seq.iter (fun parent ->
+                        let parentKey = pathKey parent
+
+                        if manifestFiles.ContainsKey(parentKey) then
+                            valid <- false
+                        else
+                            manifestDirectories[parentKey] <- parent))
+
+            valid
+            && graphDirectories.Count = manifestDirectories.Count
+            && graphFiles.Count = manifestFiles.Count
+            && graphDirectories.Keys
+               |> Seq.forall manifestDirectories.ContainsKey
+            && graphFiles
+               |> Seq.forall (fun pair ->
+                   match manifestFiles.TryGetValue(pair.Key) with
+                   | true, hashes -> hashes = pair.Value
+                   | false, _ -> false)
+
+        /// Maps one prepared path and hashes to its immutable local object-cache path.
+        let private objectPath objectDirectory path sha256Hash blake3Hash =
+            Path.Combine(objectDirectory, string path, Services.getLocalObjectCacheFileName path sha256Hash blake3Hash)
+
+        /// Verifies one filesystem file against both selected content hashes without trusting its name or metadata.
+        let private hasExpectedBytes path sha256Hash blake3Hash =
+            Services.createLocalFileVersion (FileInfo(path))
+            |> fun task -> task.GetAwaiter().GetResult()
+            |> Option.exists (fun file ->
+                file.Sha256Hash = sha256Hash
+                && file.Blake3Hash = blake3Hash)
+
+        /// Publishes one verified prepared file exactly once and rejects a mismatching immutable object already at its final path.
+        let private publishObject preparedContent objectDirectory path sha256Hash blake3Hash =
+            task {
+                let finalPath = objectPath objectDirectory path sha256Hash blake3Hash
+
+                if File.Exists(finalPath) then
+                    if not (hasExpectedBytes finalPath sha256Hash blake3Hash) then
+                        return Error $"Immutable object bytes are corrupt or were replaced for '{path}'."
+                    else
+                        return Ok()
+                else
+                    match WorkingDirectoryUpdateContracts.PreparedContent.openRead preparedContent path with
+                    | Error error -> return Error error
+                    | Ok source ->
+                        use source = source
+                        let directory = Path.GetDirectoryName(finalPath)
+                        Directory.CreateDirectory(directory) |> ignore
+
+                        let temporaryPath =
+                            finalPath
+                            + "."
+                            + Guid.NewGuid().ToString("N")
+                            + ".tmp"
+
+                        use destination = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None)
+                        do! source.CopyToAsync(destination)
+                        destination.Flush(true)
+                        destination.Dispose()
+
+                        if not (hasExpectedBytes temporaryPath sha256Hash blake3Hash) then
+                            File.Delete(temporaryPath)
+                            return Error $"Prepared object bytes do not match their declared hashes for '{path}'."
+                        else
+                            try
+                                File.Move(temporaryPath, finalPath)
+                            with
+                            | :? IOException when File.Exists(finalPath) -> File.Delete(temporaryPath)
+
+                            if hasExpectedBytes finalPath sha256Hash blake3Hash then
+                                return Ok()
+                            else
+                                return Error $"Immutable object bytes are corrupt or were replaced for '{path}'."
+            }
+
+        /// Publishes and rechecks every prepared immutable object before working-directory mutation is considered.
+        let private publishObjects preparedContent objectDirectory manifest =
+            task {
+                let files =
+                    WorkingDirectoryUpdateContracts.PreparedManifest.entries manifest
+                    |> Seq.choose (function
+                        | WorkingDirectoryUpdateContracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) -> Some(path, sha256Hash, blake3Hash)
+                        | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory _ -> None)
+                    |> Seq.toArray
+
+                let mutable failure = None
+                let mutable index = 0
+
+                while index < files.Length && Option.isNone failure do
+                    let path, sha256Hash, blake3Hash = files[index]
+                    let! result = publishObject preparedContent objectDirectory path sha256Hash blake3Hash
+
+                    match result with
+                    | Ok () -> ()
+                    | Error error -> failure <- Some error
+
+                    index <- index + 1
+
+                return
+                    match failure with
+                    | Some error -> Error error
+                    | None -> Ok()
+            }
+
+        /// Converts a planned repository-relative path to a root-contained filesystem path.
+        let private workingPath root (path: RelativePath) =
+            if string path = Constants.RootDirectoryPath then
+                root
+            else
+                let fullPath =
+                    Path.GetFullPath(
+                        Path.Combine(
+                            root,
+                            (string path)
+                                .Replace('/', Path.DirectorySeparatorChar)
+                        )
+                    )
+
+                if Services.isPathWithinDirectoryWithComparison StringComparison.OrdinalIgnoreCase root fullPath then
+                    fullPath
+                else
+                    invalidOp $"Working Directory Update plan path escapes the local root: {path}"
+
+        /// Applies one preplanned action using only already-verified immutable objects.
+        let private applyAction root objectDirectory (objectHashes: Dictionary<string, Sha256Hash * Blake3Hash>) =
+            function
+            | Topology.RemoveTrackedFile path ->
+                let fullPath = workingPath root path
+
+                if File.Exists(fullPath) then
+                    File.Delete(fullPath)
+                    true
+                else
+                    false
+            | Topology.RemoveTrackedDirectory path ->
+                let fullPath = workingPath root path
+
+                if Directory.Exists(fullPath) then
+                    Directory.Delete(fullPath, false)
+                    true
+                else
+                    false
+            | Topology.EnsureDirectory path ->
+                let fullPath = workingPath root path
+
+                if Directory.Exists(fullPath) then
+                    false
+                else
+                    Directory.CreateDirectory(fullPath) |> ignore
+                    true
+            | Topology.CopyVerifiedFile path ->
+                let key = pathKey path
+
+                match objectHashes.TryGetValue(key) with
+                | false, _ -> invalidOp $"Planned file '{path}' has no immutable object declaration."
+                | true, (sha256Hash, blake3Hash) ->
+                    let objectFile = objectPath objectDirectory path sha256Hash blake3Hash
+
+                    if not (hasExpectedBytes objectFile sha256Hash blake3Hash) then
+                        invalidOp $"Immutable object bytes are corrupt or were replaced for '{path}'."
+
+                    let finalPath = workingPath root path
+                    let directory = Path.GetDirectoryName(finalPath)
+                    Directory.CreateDirectory(directory) |> ignore
+                    File.Copy(objectFile, finalPath, true)
+                    true
+
+        /// Returns every target file declared by the complete selected graph.
+        let private targetFiles (status: GraceStatus) =
+            status.Index.Values
+            |> Seq.collect (fun directory -> directory.Files)
+            |> Seq.map (fun file -> file.RelativePath, file.Sha256Hash, file.Blake3Hash)
+            |> Seq.toArray
+
+        /// Independently verifies every target path, file hash, directory kind, and absence of extra working-tree entries.
+        let private verifyCompleteTargetRoot root graceDirectory (status: GraceStatus) =
+            let expectedDirectories =
+                status.Index.Values
+                |> Seq.map (fun directory -> pathKey directory.RelativePath)
+                |> HashSet
+
+            let expectedFiles =
+                targetFiles status
+                |> Seq.map (fun (path, sha256Hash, blake3Hash) -> pathKey path, (sha256Hash, blake3Hash))
+                |> dict
+
+            let targetFilesMatch =
+                expectedFiles
+                |> Seq.forall (fun pair ->
+                    let relativePath =
+                        status.Index.Values
+                        |> Seq.collect (fun directory -> directory.Files)
+                        |> Seq.find (fun file -> pathKey file.RelativePath = pair.Key)
+                        |> fun file -> file.RelativePath
+
+                    let fullPath = workingPath root relativePath
+
+                    File.Exists(fullPath)
+                    && hasExpectedBytes fullPath (fst pair.Value) (snd pair.Value))
+
+            let actualEntries =
+                DirectoryInfo(root)
+                    .GetFileSystemInfos("*", SearchOption.AllDirectories)
+                |> Array.filter (fun entry ->
+                    not (Services.isPathWithinDirectoryWithComparison StringComparison.OrdinalIgnoreCase graceDirectory entry.FullName))
+
+            let actualTopologyMatches =
+                actualEntries
+                |> Array.forall (fun entry ->
+                    let relativePath =
+                        Path.GetRelativePath(root, entry.FullName)
+                        |> Grace.Shared.Utilities.normalizeFilePath
+                        |> RelativePath
+
+                    let key = pathKey relativePath
+
+                    if entry :? DirectoryInfo then
+                        expectedDirectories.Contains(key)
+                    else
+                        expectedFiles.ContainsKey(key))
+
+            let actualDirectoryHashesMatch =
+                if not targetFilesMatch || not actualTopologyMatches then
+                    false
+                else
+                    let computedDirectories = Dictionary<DirectoryVersionId, Sha256Hash * Blake3Hash>()
+
+                    let orderedDirectories =
+                        status.Index.Values
+                        |> Seq.sortByDescending (fun directory -> string directory.RelativePath)
+                        |> Seq.toArray
+
+                    let mutable matches = true
+
+                    orderedDirectories
+                    |> Seq.iter (fun directory ->
+                        let childDirectories =
+                            directory.Directories
+                            |> Seq.map (fun childId ->
+                                match computedDirectories.TryGetValue(childId) with
+                                | true, (sha256Hash, blake3Hash) ->
+                                    let child = status.Index[childId]
+
+                                    Services.DirectoryVersionPreimageEntry.Directory child.RelativePath child.Size blake3Hash sha256Hash
+                                | false, _ ->
+                                    matches <- false
+
+                                    Services.DirectoryVersionPreimageEntry.Directory
+                                        (RelativePath "invalid")
+                                        0L
+                                        (Blake3Hash String.Empty)
+                                        (Sha256Hash String.Empty))
+
+                        let files =
+                            directory.Files
+                            |> Seq.map (fun file -> Services.DirectoryVersionPreimageEntry.File file.RelativePath file.Size file.Blake3Hash file.Sha256Hash)
+
+                        let entries = Seq.append childDirectories files |> Seq.toArray
+                        let sha256Hash = Services.computeSha256ForDirectoryEntries directory.RelativePath entries
+                        let blake3Hash = Services.computeBlake3ForDirectory directory.RelativePath entries
+
+                        if directory.Sha256Hash <> sha256Hash
+                           || directory.Blake3Hash <> blake3Hash then
+                            matches <- false
+
+                        computedDirectories[directory.DirectoryVersionId] <- (sha256Hash, blake3Hash))
+
+                    matches
+                    && match computedDirectories.TryGetValue(status.RootDirectoryId) with
+                       | true, (sha256Hash, blake3Hash) ->
+                           sha256Hash = status.RootDirectorySha256Hash
+                           && blake3Hash = status.RootDirectoryBlake3Hash
+                       | false, _ -> false
+
+            targetFilesMatch
+            && actualTopologyMatches
+            && actualDirectoryHashesMatch
+
+        /// Forms the exact Branch operation and pending details from typed selection and current configuration only.
+        let private branchOperation currentBranchId selection target =
+            match selection with
+            | WorkingDirectoryUpdateContracts.BranchSelection.Reference referenceId ->
+                WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection currentBranchId selection target
+                |> Result.map (fun operation -> operation, LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchFinalization(currentBranchId, referenceId))
+            | WorkingDirectoryUpdateContracts.BranchSelection.DirectoryVersion ->
+                WorkingDirectoryUpdateContracts.Operation.branchSwitchWithSelection currentBranchId selection target
+                |> Result.map (fun operation ->
+                    operation, LocalStateDb.WorkingDirectoryUpdateCompletionDetails.BranchDirectoryVersionFinalization currentBranchId)
+
+        /// Produces a classified rejected outcome while retaining the exact runtime reason.
+        let private rejected reason =
+            WorkingDirectoryUpdateContracts.Failure.create reason
+            |> Result.map WorkingDirectoryUpdateContracts.Outcome.Rejected
+            |> Result.defaultWith invalidOp
+
+        /// Produces a classified incomplete outcome after actual working-tree mutation begins.
+        let private incomplete reason =
+            WorkingDirectoryUpdateContracts.Failure.create reason
+            |> Result.map WorkingDirectoryUpdateContracts.Outcome.UpdateIncomplete
+            |> Result.defaultWith invalidOp
+
+        /// Applies the only Branch five-input local transaction through verified pending SQLite completion.
+        let private runCore
+            (acceptedPhase: WorkingDirectoryUpdateContracts.AcceptedBranchPhase)
+            (selection: WorkingDirectoryUpdateContracts.BranchSelection)
+            (resolvedGraph: ResolvedTargetGraph)
+            (preparedContent: WorkingDirectoryUpdateContracts.PreparedContent)
+            (correlation: DiagnosticCorrelation)
+            =
+            task {
+                let target = ResolvedTargetGraph.target resolvedGraph
+                let targetStatus = ResolvedTargetGraph.status resolvedGraph
+                let manifest = WorkingDirectoryUpdateContracts.PreparedContent.manifest preparedContent
+                let actionToken = WorkingDirectoryUpdateContracts.AcceptedBranchPhase.actionToken acceptedPhase
+                let correlationValue = DiagnosticCorrelation.value correlation
+                let mutable mutationStarted = false
+                let mutable ownedMarker = None
+
+                try
+                    actionToken.ThrowIfCancellationRequested()
+                    let current = Current()
+
+                    if current.RepositoryId
+                       <> WorkingDirectoryUpdateContracts.Target.repositoryId target then
+                        return rejected $"[{correlationValue}] Local configuration repository changed before Working Directory Update admission."
+                    else
+                        match WorkingDirectoryUpdateCoordination.Scope.create current.RepositoryId current.RootDirectory with
+                        | Error error -> return rejected $"[{correlationValue}] {error}"
+                        | Ok scope ->
+                            let! acquiredLease = WorkingDirectoryUpdateCoordination.Lease.acquire scope actionToken
+                            use acquiredLease = acquiredLease
+                            let dbPath = current.GraceStatusFile
+                            let! revision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
+
+                            let! currentStatusResult =
+                                LocalStateDb.readCompleteStatusSnapshotReadOnly dbPath current.OwnerId current.OrganizationId current.RepositoryId
+
+                            let currentStatus =
+                                match currentStatusResult with
+                                | Ok status -> status
+                                | Error error -> invalidOp error
+
+                            let! pending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
+
+                            if revision
+                               <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase then
+                                return rejected $"[{correlationValue}] Accepted local-status revision changed before Working Directory Update mutation."
+                            elif statusFingerprint currentStatus
+                                 <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase then
+                                return
+                                    rejected
+                                        $"[{correlationValue}] Accepted complete local-status fingerprint changed before Working Directory Update mutation."
+                            elif Option.isSome pending then
+                                return rejected $"[{correlationValue}] A pending Working Directory Update finalization blocks this local transaction."
+                            elif not (graphMatchesManifest targetStatus manifest) then
+                                return rejected $"[{correlationValue}] Resolved target graph does not match immutable prepared-content topology."
+                            else
+                                match branchOperation current.BranchId selection target with
+                                | Error error -> return rejected $"[{correlationValue}] {error}"
+                                | Ok (operation, completionDetails) ->
+                                    let! markerInspection = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
+
+                                    match markerInspection with
+                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.DifferentOperation
+                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.MalformedOrUnsupported
+                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.Unreadable ->
+                                        return rejected $"[{correlationValue}] Existing Working Directory Update marker is not exact owned admission evidence."
+                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.Missing
+                                    | WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch ->
+                                        let attempt = WorkingDirectoryUpdateContracts.AttemptToken.create ()
+
+                                        match WorkingDirectoryUpdateCoordination.Marker.create scope attempt target operation with
+                                        | Error error -> return rejected $"[{correlationValue}] {error}"
+                                        | Ok marker ->
+                                            do! WorkingDirectoryUpdateCoordination.Marker.write scope marker
+                                            ownedMarker <- Some(scope, attempt)
+                                            let! objectResult = publishObjects preparedContent current.ObjectDirectory manifest
+
+                                            match objectResult with
+                                            | Error error ->
+                                                let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
+                                                return
+                                                    match cleanup with
+                                                    | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                    | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker -> rejected $"[{correlationValue}] {error}"
+                                                    | _ -> rejected $"[{correlationValue}] {error}; exact marker cleanup failed."
+                                            | Ok () ->
+                                                let! initialPlan = Topology.plan currentStatus manifest
+
+                                                match initialPlan with
+                                                | Topology.Rejected rejection ->
+                                                    invalidOp $"Initial Working Directory Update topology rejected '{Topology.Rejection.path rejection}'."
+                                                | Topology.Planned _ -> ()
+
+                                                let finalCurrent = Current()
+                                                let! finalRevision = LocalStateDb.readLocalStatusRevisionReadOnly dbPath
+
+                                                let! finalStatusResult =
+                                                    LocalStateDb.readCompleteStatusSnapshotReadOnly
+                                                        dbPath
+                                                        current.OwnerId
+                                                        current.OrganizationId
+                                                        current.RepositoryId
+
+                                                let finalStatus =
+                                                    match finalStatusResult with
+                                                    | Ok status -> status
+                                                    | Error error -> invalidOp error
+
+                                                let! finalPending = LocalStateDb.readPendingWorkingDirectoryUpdateFinalization dbPath
+                                                let! finalMarker = WorkingDirectoryUpdateCoordination.Marker.inspect scope target operation
+
+                                                let! finalMarkerAttempt =
+                                                    WorkingDirectoryUpdateCoordination.Marker.inspectExactAttempt scope target operation attempt
+
+                                                if
+                                                    finalCurrent.RepositoryId <> current.RepositoryId
+                                                    || finalCurrent.RootDirectory
+                                                       <> current.RootDirectory
+                                                    || finalCurrent.GraceStatusFile
+                                                       <> current.GraceStatusFile
+                                                    || finalCurrent.ObjectDirectory
+                                                       <> current.ObjectDirectory
+                                                    || finalCurrent.GraceDirectory
+                                                       <> current.GraceDirectory
+                                                    || finalCurrent.BranchId <> current.BranchId
+                                                    || finalRevision
+                                                       <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.localStatusRevision acceptedPhase
+                                                    || statusFingerprint finalStatus
+                                                       <> WorkingDirectoryUpdateContracts.AcceptedBranchPhase.statusFingerprint acceptedPhase
+                                                    || Option.isSome finalPending
+                                                    || finalMarker
+                                                       <> WorkingDirectoryUpdateCoordination.MarkerInspection.ExactMatch
+                                                    || not finalMarkerAttempt
+                                                    || not (graphMatchesManifest targetStatus manifest)
+                                                then
+                                                    let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
+                                                    return
+                                                        match cleanup with
+                                                        | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                        | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                            rejected $"[{correlationValue}] Working Directory Update facts changed before the first mutation."
+                                                        | _ ->
+                                                            rejected
+                                                                $"[{correlationValue}] Working Directory Update facts changed before mutation and exact marker cleanup failed."
+                                                else
+                                                    actionToken.ThrowIfCancellationRequested()
+                                                    let! planResult = Topology.plan finalStatus manifest
+
+                                                    match planResult with
+                                                    | Topology.Rejected rejection ->
+                                                        let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+                                                        let path = Topology.Rejection.path rejection
+
+                                                        return
+                                                            match cleanup with
+                                                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                                                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                                                rejected $"[{correlationValue}] Working Directory Update topology rejected '{path}'."
+                                                            | _ ->
+                                                                rejected
+                                                                    $"[{correlationValue}] Working Directory Update topology rejected '{path}' and exact marker cleanup failed."
+                                                    | Topology.Planned plan ->
+                                                        let actions = Topology.Plan.actions plan |> List.toArray
+                                                        let objectHashes = Dictionary<string, Sha256Hash * Blake3Hash>(StringComparer.Ordinal)
+
+                                                        WorkingDirectoryUpdateContracts.PreparedManifest.entries manifest
+                                                        |> Seq.iter (function
+                                                            | WorkingDirectoryUpdateContracts.PreparedManifestEntry.File (path, sha256Hash, blake3Hash) ->
+                                                                objectHashes[pathKey path] <- (sha256Hash, blake3Hash)
+                                                            | WorkingDirectoryUpdateContracts.PreparedManifestEntry.Directory _ -> ())
+
+                                                        actions
+                                                        |> Array.iter (fun action ->
+                                                            if applyAction current.RootDirectory current.ObjectDirectory objectHashes action then
+                                                                mutationStarted <- true)
+
+                                                        if not (verifyCompleteTargetRoot current.RootDirectory current.GraceDirectory targetStatus) then
+                                                            return
+                                                                incomplete
+                                                                    $"[{correlationValue}] Complete target-root verification failed after working-tree mutation."
+                                                        else
+                                                            let! _ =
+                                                                LocalStateDb.commitWorkingDirectoryUpdateCompletion
+                                                                    dbPath
+                                                                    targetStatus
+                                                                    (targetStatus.Index.Values :> IEnumerable<LocalDirectoryVersion>)
+                                                                    completionDetails
+                                                                    target
+                                                                    operation
+
+                                                            match WorkingDirectoryUpdateContracts.Receipt.create target operation mutationStarted with
+                                                            | Ok receipt -> return WorkingDirectoryUpdateContracts.Outcome.Updated receipt
+                                                            | Error error -> return incomplete $"[{correlationValue}] {error}"
+                with
+                | :? OperationCanceledException when mutationStarted ->
+                    return incomplete $"[{correlationValue}] Cancellation arrived after the first working-tree mutation."
+                | :? OperationCanceledException ->
+                    match ownedMarker with
+                    | Some (scope, attempt) ->
+                        let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
+                        return
+                            match cleanup with
+                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker ->
+                                rejected $"[{correlationValue}] Working Directory Update was cancelled before the first working-tree mutation."
+                            | _ -> rejected $"[{correlationValue}] Working Directory Update was cancelled before mutation and exact marker cleanup failed."
+                    | None -> return rejected $"[{correlationValue}] Working Directory Update was cancelled before the first working-tree mutation."
+                | ex when mutationStarted -> return incomplete $"[{correlationValue}] {ex.Message}"
+                | ex ->
+                    match ownedMarker with
+                    | Some (scope, attempt) ->
+                        let! cleanup = WorkingDirectoryUpdateCoordination.Marker.tryRemoveOwned scope attempt
+
+                        return
+                            match cleanup with
+                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.ExactMatchCleaned
+                            | WorkingDirectoryUpdateCoordination.MarkerCleanup.NoMarker -> rejected $"[{correlationValue}] {ex.Message}"
+                            | _ -> rejected $"[{correlationValue}] {ex.Message}; exact marker cleanup failed."
+                    | None -> return rejected $"[{correlationValue}] {ex.Message}"
+            }
+
+        /// Disposes immutable prepared bytes exactly once after every five-input transaction path completes.
+        let run acceptedPhase selection resolvedGraph preparedContent correlation =
+            task {
+                let! outcome = runCore acceptedPhase selection resolvedGraph preparedContent correlation
+                WorkingDirectoryUpdateContracts.PreparedContent.dispose preparedContent
+                return outcome
+            }

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs
@@ -383,6 +383,25 @@ module internal WorkingDirectoryUpdateCoordination =
                         | :? UnauthorizedAccessException -> return Unreadable
             }
 
+        /// Verifies that a reread marker still binds the exact fresh attempt token created under the held scope lease.
+        let inspectExactAttempt scope expectedTarget operation expectedAttempt =
+            task {
+                let! inspection = inspect scope expectedTarget operation
+
+                if inspection <> ExactMatch then
+                    return false
+                else
+                    try
+                        let content = File.ReadAllText(Scope.markerPath scope)
+
+                        match tryReadMarkerDocument scope content with
+                        | Ok marker -> return marker.AttemptToken = WorkingDirectoryUpdate.AttemptToken.value expectedAttempt
+                        | Error _ -> return false
+                    with
+                    | :? IOException
+                    | :? UnauthorizedAccessException -> return false
+            }
+
         /// Removes a marker with an injected deletion action so portable focused proofs can force the exact cleanup-failure boundary.
         let tryRemoveOwnedWithDelete scope attemptToken deleteMarker =
             task {

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -66,7 +66,7 @@ module internal WorkingDirectoryUpdateContracts =
         abstract member OpenReadAsync: RelativePath * CancellationToken -> Task<Stream>
 
     /// Represents immutable dual-hash-verified bytes for a future update engine.
-    type PreparedContent = private PreparedContent of PreparedManifest * Dictionary<string, byte array> * disposed: bool ref
+    type PreparedContent = private PreparedContent of PreparedManifest * Dictionary<string, byte array> * disposed: bool ref * disposalCount: int ref
 
     /// Seals the no-Save Branch admission facts that must survive immutable target preparation unchanged.
     type AcceptedBranchPhase = private AcceptedBranchPhase of localStatusRevision: int64 * statusFingerprint: string * actionToken: CancellationToken
@@ -532,13 +532,13 @@ module internal WorkingDirectoryUpdateContracts =
 
                             match byteError with
                             | Some error -> return Error error
-                            | None -> return Ok(PreparedContent(manifest, bytesByPath, ref false))
+                            | None -> return Ok(PreparedContent(manifest, bytesByPath, ref false, ref 0))
                     finally
                         reader.Dispose()
             }
 
         /// Opens a read-only stream over verified bytes for one declared file.
-        let openRead (PreparedContent (_, bytesByPath, disposed)) path =
+        let openRead (PreparedContent (_, bytesByPath, disposed, _)) path =
             match normalizeRelativePath path with
             | Error error -> Error error
             | Ok path when disposed.Value -> Error "Prepared-content has already been disposed."
@@ -548,16 +548,20 @@ module internal WorkingDirectoryUpdateContracts =
                 | false, _ -> Error $"Prepared-content has no declared file '{path}'."
 
         /// Returns the immutable manifest that is the sole topology input to the collision-safe planner.
-        let manifest (PreparedContent (manifest, _, _)) = manifest
+        let manifest (PreparedContent (manifest, _, _, _)) = manifest
+
+        /// Returns the exact number of effective byte-buffer disposals for direct lifecycle proofs.
+        let internal disposalCount (PreparedContent (_, _, _, disposalCount)) = disposalCount.Value
 
         /// Clears verified bytes when the owning update operation reaches a terminal path.
-        let dispose (PreparedContent (_, bytesByPath, disposed)) =
+        let dispose (PreparedContent (_, bytesByPath, disposed, disposalCount)) =
             if not disposed.Value then
                 bytesByPath.Values
                 |> Seq.iter (fun bytes -> Array.Clear(bytes, 0, bytes.Length))
 
                 bytesByPath.Clear()
                 disposed.Value <- true
+                disposalCount.Value <- disposalCount.Value + 1
 
     /// Supplies the sole construction and internal consumption path for accepted Branch admission facts.
     module AcceptedBranchPhase =

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -603,3 +603,6 @@ module internal WorkingDirectoryUpdateContracts =
                 Error "Working Directory Update failure reason must not be empty."
             else
                 Ok(Failure reason)
+
+        /// Exposes the classified private failure text to direct runtime regressions without widening the public transaction outcome.
+        let internal reason (Failure reason) = reason

--- a/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
+++ b/src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs
@@ -68,8 +68,8 @@ module internal WorkingDirectoryUpdateContracts =
     /// Represents immutable dual-hash-verified bytes for a future update engine.
     type PreparedContent = private PreparedContent of PreparedManifest * Dictionary<string, byte array> * disposed: bool ref
 
-    /// Holds validated update inputs without exposing a mutation plan, writer, or transaction callback.
-    type Request = private Request of Target * Operation * PreparedContent * CorrelationId
+    /// Seals the no-Save Branch admission facts that must survive immutable target preparation unchanged.
+    type AcceptedBranchPhase = private AcceptedBranchPhase of localStatusRevision: int64 * statusFingerprint: string * actionToken: CancellationToken
 
     /// Holds the target and operation facts proven by a completed update attempt.
     type Receipt = private Receipt of Target * Operation * bytesChanged: bool
@@ -236,6 +236,15 @@ module internal WorkingDirectoryUpdateContracts =
 
         /// Returns the canonical target encoding included in caller operation tuples.
         let canonical (Target (_, _, _, _, _, canonical)) = canonical
+
+        /// Returns the exact root directory-version identity that the resolved graph must prove.
+        let rootDirectoryVersionId (Target (_, _, rootDirectoryVersionId, _, _, _)) = rootDirectoryVersionId
+
+        /// Returns the exact root SHA-256 that the resolved graph must prove.
+        let rootSha256Hash (Target (_, _, _, sha256Hash, _, _)) = sha256Hash
+
+        /// Returns the exact root BLAKE3 that the resolved graph must prove.
+        let rootBlake3Hash (Target (_, _, _, _, blake3Hash, _)) = blake3Hash
 
     /// Supplies construction and access functions for local-root scopes.
     module LocalRootScope =
@@ -532,34 +541,43 @@ module internal WorkingDirectoryUpdateContracts =
         let openRead (PreparedContent (_, bytesByPath, disposed)) path =
             match normalizeRelativePath path with
             | Error error -> Error error
-            | Ok path when !disposed -> Error "Prepared-content has already been disposed."
+            | Ok path when disposed.Value -> Error "Prepared-content has already been disposed."
             | Ok path ->
                 match bytesByPath.TryGetValue(windowsPathKey path) with
                 | true, bytes -> Ok(new MemoryStream(bytes, writable = false) :> Stream)
                 | false, _ -> Error $"Prepared-content has no declared file '{path}'."
 
+        /// Returns the immutable manifest that is the sole topology input to the collision-safe planner.
+        let manifest (PreparedContent (manifest, _, _)) = manifest
+
         /// Clears verified bytes when the owning update operation reaches a terminal path.
         let dispose (PreparedContent (_, bytesByPath, disposed)) =
-            if not !disposed then
+            if not disposed.Value then
                 bytesByPath.Values
                 |> Seq.iter (fun bytes -> Array.Clear(bytes, 0, bytes.Length))
 
                 bytesByPath.Clear()
-                disposed := true
+                disposed.Value <- true
 
-    /// Supplies construction and access functions for private update requests.
-    module Request =
-        /// Creates a request only when its deterministic operation belongs to the selected target scope.
-        let create target operation preparedContent correlationId =
-            if isNull (box preparedContent) then
-                Error "Working Directory Update requires prepared content."
-            elif Operation.matchesTarget target operation then
-                Ok(Request(target, operation, preparedContent, correlationId))
+    /// Supplies the sole construction and internal consumption path for accepted Branch admission facts.
+    module AcceptedBranchPhase =
+        /// Seals one successful Branch admission before target resolution and immutable content preparation begin.
+        let create localStatusRevision statusFingerprint actionToken =
+            if localStatusRevision < 0L then
+                Error "Accepted Branch phase requires a non-negative local-status revision."
+            elif String.IsNullOrWhiteSpace(statusFingerprint) then
+                Error "Accepted Branch phase requires a complete status fingerprint."
             else
-                Error "Working Directory Update operation does not match the selected target."
+                Ok(AcceptedBranchPhase(localStatusRevision, statusFingerprint, actionToken))
 
-        /// Returns the logical operation independently of diagnostic correlation.
-        let operation (Request (_, operation, _, _)) = operation
+        /// Returns the accepted SQLite revision only to the canonical Working Directory Update runtime.
+        let internal localStatusRevision (AcceptedBranchPhase (revision, _, _)) = revision
+
+        /// Returns the complete-status fingerprint only to the canonical Working Directory Update runtime.
+        let internal statusFingerprint (AcceptedBranchPhase (_, fingerprint, _)) = fingerprint
+
+        /// Returns the original invocation token without permitting a caller to replace it after admission.
+        let internal actionToken (AcceptedBranchPhase (_, _, token)) = token
 
     /// Supplies construction and access functions for completed update receipts.
     module Receipt =


### PR DESCRIPTION
# Summary

Implement the Branch-only Working Directory Update transaction from the mandatory five-input seam through verified pending SQLite local completion.

The runtime accepts the sealed accepted phase, typed Branch selection, exact resolved target graph, immutable prepared content, and diagnostic correlation. It derives local facts, verifies graph/manifest identity, publishes and reverifies objects, reconstructs the collision-safe plan under the WDU lease, applies only that plan, proves the complete real root, and atomically records status, object metadata, and typed pending completion.

Tracks #899.

## Why this matters

Grace must not claim a local update until prepared objects, working bytes, the complete selected root, and SQLite state agree. This establishes the durable local boundary used by later terminalization and recovery without publishing Branch identity prematurely.

## Quality contract

- Product V1.
- One five-input Branch transaction; `Reference` and exact-root `DirectoryVersion` use the same seam.
- `PreparedManifest` is the planner's sole target-topology input.
- No terminal marker cleanup, Branch publication, terminal recording, retry, public rendering, Save, Doctor, Watch, or Connect behavior.
- Interruption after the first working-tree mutation and before pending SQLite completion remains truthful `UpdateIncomplete`; no rollback or journal.

## Changed paths

- `src/Grace.CLI/Command/WorkingDirectoryUpdate.CLI.fs`
- `src/Grace.CLI/Command/WorkingDirectoryUpdate.Coordination.CLI.fs`
- `src/Grace.CLI/Command/WorkingDirectoryUpdateContracts.CLI.fs`
- `src/Grace.CLI.Tests/WorkingDirectoryUpdate.LocalTransaction.Tests.fs`
- Narrow existing contract/prepared-content tests and the test project compile item.

## Delivered behavior

- Both typed Branch selections persist exact pending facts through the same operation and do not publish Branch identity.
- Exact graph/manifest normalized path, type, and dual-hash identity is checked before planner use.
- Object publication and dual-hash re-verification precede working-tree mutation.
- Fresh configuration, accepted phase, complete status, pending state, marker attempt, filesystem plan, and cancellation are checked before mutation.
- Immutable plan application copies only verified object bytes.
- Complete real topology and recursive dual root hashes are independently verified before atomic SQLite completion.
- Owned pre-mutation marker evidence is cleaned on rejection; post-mutation failures are classified as `UpdateIncomplete`.

## Validation

- Fantomas on touched F# files.
- Release `Grace.CLI.Tests` build: 0 warnings, 0 errors.
- Focused Working Directory Update suites: 56 passed.
- `LocalStateDb` suite: 133 passed, 1 platform-only skip.
- `git diff --check` passed.

## Review status

- Implementation/fix workers: 2 of 5.
- Review sessions: 0.
- Substantive review cycles: 0.
- First current-head review must independently assess standalone adversarial proof for injected post-mutation failure, object replacement/path swap, changed configuration between rereads, cleanup failure, cancellation boundaries, disposal, and lease release.
- #900 owns all post-pending terminalization and retry behavior.
