### PR TITLE
Reconcile Grace Cache R1 completion records

### DIFF
--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -41,11 +41,27 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
 | [PR #723](https://github.com/ScottArbeit/Grace/pull/723) | Closed as superseded without merge at `647f4067252e5f2805e76a492d26096a854a75a9`. | Selectively inspect independent work; do not merge or replay it wholesale. |
 | [Issues #622](https://github.com/ScottArbeit/Grace/issues/622) and [#724](https://github.com/ScottArbeit/Grace/issues/724) | Closed and not planned. | Do not resume as cache work. |
 | [Issue #855](https://github.com/ScottArbeit/Grace/issues/855) | Complete R0 static-contract pruning. | Required predecessor completed. |
-| [Issue #856](https://github.com/ScottArbeit/Grace/issues/856) | Superseded by the narrower #886 and #887 R1 sequence. | Do not resume its mixed server, command, and status scope. |
-| [Issue #886](https://github.com/ScottArbeit/Grace/issues/886) and [PR #888](https://github.com/ScottArbeit/Grace/pull/888) | R1A static enrollment identity is implemented on the current PR head; focused proof and current-head Linux validation remain required before merge. | Owns only static enrollment state, protected local identity, and their focused proof. |
-| [Issue #887](https://github.com/ScottArbeit/Grace/issues/887) | Open R1B follow-on for repository-independent cache enrollment and status commands. | Starts after #886 integrates; owns no R1A implementation detail. |
+| [Issue #856](https://github.com/ScottArbeit/Grace/issues/856) | Superseded; the current R1 tracker record replaces its mixed scope. | Do not resume it. |
 | [Issue #857](https://github.com/ScottArbeit/Grace/issues/857) | Open R2: bounded registration liveness. | Starts after R1 and its liveness research gate. |
 | [Issue #835](https://github.com/ScottArbeit/Grace/issues/835) | Open. Later local materialization is blocked until it merges to `main` and Epic #597 is refreshed. | Required sequence for #628 to #630 and #634. |
+
+### Current R1 tracker record
+
+| Tracker | Current classification | Scope and sequence |
+| --- | --- | --- |
+| #886 | Implemented and proven; completed evidence. | R1A static enrollment identity is complete. |
+| PR #888 | Merged implementation and proof for #886. | Records the completed R1A implementation and focused proof. |
+| #887 | Superseded mixed enrollment/status issue. | It does not own current delivery work. |
+| PR #896 | Closed superseded mixed enrollment/status implementation. | Evidence only; do not reuse it wholesale. |
+| #904 | Superseded status issue. | It does not own current delivery work. |
+| PR #907 | Closed superseded status implementation. | Evidence only; do not reuse it wholesale. |
+| #913 / #914 | Current docs-only correction; planned pure local status follows. | #913 reconciles this record; #914 then owns status only. |
+| #905 | Planned one-shot enrollment after #913 and #914. | It owns enrollment only after the docs and status leaves complete. |
+
+### Enrollment ambiguity disposition
+
+An inactive accepted server enrollment is unselectable. Fresh manual enrollment is allowed. Server expiry performs
+eventual cleanup. Grace Cache adds no automatic enrollment retry or reconciliation.
 
 ## Implemented and proven server foundations
 
@@ -84,8 +100,8 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
   revocation, repository selection, malformed and duplicate inputs, durable state, and proof verification. #600 and
   PR #706 recorded the server-foundation validation.
 - **Status classification:** `implemented and proven` for the server foundation.
-- **Residual risk:** The static server foundation still requires the separate R1A identity and R2 liveness leaves before
-  a cache can safely participate in the later runtime path. Artifact-grant validation-key rollover remains separate.
+- **Residual risk:** The completed R1A identity foundation and planned R2 liveness leaf still precede later runtime
+  participation. Artifact-grant validation-key rollover remains separate.
 
 ### Direct materialization
 
@@ -108,17 +124,18 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
 
 ### R1A: static enrollment identity foundation (#886)
 
-- **Status classification:** `implementation leaf`.
-- **Required result:** Enrollment has no caller `Health`; the server creates an `Unhealthy` durable registration before
+- **Status classification:** `implemented and proven`.
+- **Completed result:** Enrollment has no caller `Health`; the server creates an `Unhealthy` durable registration before
   success, and existing selection excludes it. The internal Linux-only identity primitive stages one `0700` attempt
   directory with a flushed `0600` PKCS#8 P-256 key, then publishes `0700` ready only after a flushed `0600`
   registration configuration matches the derived base64url SHA-256 `X || Y` fingerprint.
-- **Proof:** Actor persistence failure cannot advance authoritative in-memory selection; raw JSON `Health` cannot make
-  a new registration healthy; inspection distinguishes missing, attempt, ready, invalid, and inaccessible without
-  mutation; Linux tests restore modified modes before cleanup.
-- **Deferred:** #887 owns HTTP, credentials, command output, accepted/rejected/unknown orchestration, and cleanup calls;
-  #857 owns signed refreshes that remain `Unhealthy`; #625 publishes `Healthy` only after serving readiness is proven.
-  R1A adds neither serving, rotation, reconciliation, non-Linux support, nor CacheStore behavior.
+- **Completed proof:** Actor persistence failure cannot advance in-memory selection; raw JSON `Health` cannot make a new
+  registration healthy; inspection distinguishes missing, attempt, ready, invalid, and inaccessible without mutation;
+  Linux tests restore modified modes before cleanup. PR #888 merged the implementation and proof.
+- **Current sequence:** #913 owns the canonical completion record, #914 owns pure local status only, #905 owns one-shot
+  enrollment only after #913 and #914, #857 owns signed refreshes that remain `Unhealthy`, and #625 publishes `Healthy`
+  only after serving readiness is proven. R1A added no serving, rotation, reconciliation, non-Linux support, or
+  CacheStore behavior.
 
 ### R2: registration liveness (#857)
 
@@ -177,18 +194,19 @@ The final Epic #597 release candidate requires all of the following:
 5. Current-head validation and a fresh review complete for every relevant pull request.
 6. The final `epic/597` to `main` pull request receives explicit maintainer approval at that reviewed, validated head.
 
-## R1A validation status
+## R1A completed proof
 
-The R1A source, contract, generated-artifact, and focused-proof changes are in PR #888. Its required evidence is
+PR #888 merged the R1A source, contract, generated-artifact, and focused-proof changes. Its completed evidence includes
 targeted F# formatting, affected Release builds and tests, OpenAPI/generated freshness, MarkdownLint, `git diff --check`,
-and a passing current-head GitHub `Validate` run that executes the Linux permission and inaccessible-state cases.
-Windows focused identity proof skips those Linux-only cases, so it cannot replace hosted Linux evidence.
+and a passing current-head GitHub `Validate` run with Linux permission and inaccessible-state cases. Windows focused
+identity proof skipped Linux-only cases and was supplemented by the hosted Linux evidence.
 
-The following documentation checks remain part of that focused proof:
+The following documentation checks remain part of the current canonical-record proof:
 
 ```powershell
 npx --yes markdownlint-cli2 "docs/Grace Cache.md" "docs/Grace Cache implementation audit.md"
 git diff --check
 ```
 
-This status does not claim R1B commands, R2 liveness, serving, rotation, reconciliation, non-Linux support, or CacheStore behavior.
+This completed proof does not claim #914 status, #905 enrollment, R2 liveness, serving, rotation, reconciliation,
+non-Linux support, or CacheStore behavior.

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -76,9 +76,7 @@ artifact retrieval.
 | [PR #723](https://github.com/ScottArbeit/Grace/pull/723) | Closed as superseded without merge at `647f4067252e5f2805e76a492d26096a854a75a9`. | Selective salvage source only; its behavioral commits are not reused wholesale. |
 | [Issue #622](https://github.com/ScottArbeit/Grace/issues/622) and [issue #724](https://github.com/ScottArbeit/Grace/issues/724) | Closed and not planned for Product V1. | Neither is a future implementation container. |
 | [Issue #855](https://github.com/ScottArbeit/Grace/issues/855) | R0 static-contract pruning is complete. | Static cache identity is the current source contract. |
-| [Issue #856](https://github.com/ScottArbeit/Grace/issues/856) | Superseded by the narrower R1A and R1B sequence. | Do not resume its mixed scope. |
-| [Issue #886](https://github.com/ScottArbeit/Grace/issues/886) and [PR #888](https://github.com/ScottArbeit/Grace/pull/888) | R1A static enrollment identity is the current implementation leaf. | It owns protected local identity and its focused proof. |
-| [Issue #887](https://github.com/ScottArbeit/Grace/issues/887) | R1B follows R1A with repository-independent enrollment and status commands. | It is not implemented by this leaf. |
+| [Issue #856](https://github.com/ScottArbeit/Grace/issues/856) | Superseded; the current R1 tracker record replaces its mixed scope. | Do not resume it. |
 | [Issue #857](https://github.com/ScottArbeit/Grace/issues/857) | R2 registration liveness remains planned. | It follows the R1 sequence. |
 | [Issue #835](https://github.com/ScottArbeit/Grace/issues/835) | Open. `WorkingDirectoryUpdate.run` is not available to this epic until #835 merges to `main` and Epic #597 is refreshed. | Hard sequencing gate for #628 to #630 and #634. |
 | `src/Grace.Types/MaterializationExecutionMode.Types.fs` (`MaterializationExecutionMode`) | Defines `Direct`, `CachePreferred`, and `CacheRequired`. | Existing public execution-mode contract. |
@@ -93,6 +91,24 @@ artifact retrieval.
 The specification profile is supplied from `C:\Source\Grace` for this recovery work. This specification applies that
 profile with the repository instructions, Product V1 quality contract, portable specification contract, current source
 evidence, and the durable owner decision.
+
+### Current R1 tracker record
+
+| Tracker | Current classification | Scope and sequence |
+| --- | --- | --- |
+| #886 | Implemented and proven; completed evidence. | R1A static enrollment identity is complete. |
+| PR #888 | Merged implementation and proof for #886. | Records the completed R1A implementation and focused proof. |
+| #887 | Superseded mixed enrollment/status issue. | It does not own current delivery work. |
+| PR #896 | Closed superseded mixed enrollment/status implementation. | Evidence only; do not reuse it wholesale. |
+| #904 | Superseded status issue. | It does not own current delivery work. |
+| PR #907 | Closed superseded status implementation. | Evidence only; do not reuse it wholesale. |
+| #913 / #914 | Current docs-only correction; planned pure local status follows. | #913 reconciles this record; #914 then owns status only. |
+| #905 | Planned one-shot enrollment after #913 and #914. | It owns enrollment only after the docs and status leaves complete. |
+
+### Enrollment ambiguity disposition
+
+An inactive accepted server enrollment is unselectable. Fresh manual enrollment is allowed. Server expiry performs
+eventual cleanup. Grace Cache adds no automatic enrollment retry or reconciliation.
 
 ## 4. Quality contract and accepted risk
 
@@ -109,8 +125,8 @@ The accepted deployment and risk boundary is deliberately narrow:
   directory.
 - One static cache service identity lasts until a current administrator revokes it and the host is manually
   re-enrolled.
-- A missed or ambiguous enrollment result does not start automatic reconciliation. It follows the R1 proof gate and,
-  only if that gate passes, allows fresh manual re-enrollment with the stated inactive-orphan risk.
+- A missed or ambiguous enrollment result does not start automatic retry or reconciliation. An inactive accepted server
+  enrollment is unselectable, fresh manual enrollment is allowed, and server expiry performs eventual cleanup.
 - Product V1 does not promise a platform-neutral keystore, high availability, disaster recovery, a defense against a
   hostile local root user, or automatic recovery from every local corruption event.
 
@@ -126,7 +142,7 @@ or unsupported-platform work merely because those capabilities could be useful l
 | DEC-GC-001 | Quality level | product | accepted | Product V1 governs every leaf and final release candidate. | Owner decision; each leaf declares the profile and proof. |
 | DEC-GC-002 | Cache service identity | domain | accepted | One static P-256 identity; no automatic or startup rotation. | R0 removes old rotation contract; R1 creates one static identity. |
 | DEC-GC-003 | Key custody promise | scope | accepted | OS-protected private storage and no Grace export surface; no hardware-backed claim. | R1 host and redaction proof. |
-| DEC-GC-004 | Enrollment ambiguity | proof | accepted with gate | No automatic reconciliation. R1 may accept an inactive orphan only after proving it cannot be selected or block manual re-enrollment. | R1 stops for owner direction if the proof fails. |
+| DEC-GC-004 | Enrollment ambiguity | product | accepted | An inactive accepted enrollment is unselectable; fresh manual enrollment is allowed; server expiry performs eventual cleanup; no automatic retry or reconciliation is added. | #886 completed the supporting implementation and proof; #905 consumes the disposition without changing it. |
 | DEC-GC-005 | Registration liveness | architecture | accepted | One scheduler, server-issued liveness times, bounded retry, and fail-closed expiration or definitive rejection. | R2 transition and fake-clock proof. |
 | DEC-GC-006 | Artifact-grant keys | domain | accepted | Keep existing artifact-grant validation-key rollover distinct from cache service identity. | R0 inventory must not remove grant-key behavior. |
 | DEC-GC-007 | Local mutation | architecture | accepted | Later materialization prepares exact content and calls `WorkingDirectoryUpdate.run`. | #835 merge and epic refresh gate before affected leaves. |
@@ -160,7 +176,7 @@ or unsupported-platform work merely because those capabilities could be useful l
 | Artifact-grant validation key | A public Grace Server signing key used to verify artifact grants. Its rollover is separate from cache service identity. |
 | Eligible cache | A cache selected by Grace Server because its registration is unrevoked, unexpired, healthy, and assigned to the resolved repository boundary. |
 | Ready configuration | Atomically committed local machine configuration that references one locally usable key and a server-accepted identity. |
-| Inactive orphan enrollment | A possible server enrollment left after an ambiguous request result before ready configuration commits. It is accepted only after R1 proves it is not selectable and cannot prevent fresh manual re-enrollment. |
+| Inactive accepted enrollment | A possible server enrollment left after an ambiguous request result before ready configuration commits. It is unselectable, does not prevent fresh manual enrollment, and expires under the server rule. |
 | Complete artifact | Locally staged and validated bytes plus committed metadata for every full-root artifact required by one plan. Local presence alone is neither user permission nor cache eligibility. |
 
 The identity tuple for one plan is the requester, repository, selector kind and selector value, resolved target-root
@@ -188,17 +204,17 @@ proof before every serve, and validate exact prepared content before making late
 5. On definitive rejection, it deletes the staged key and remains not enrolled.
 6. On an ambiguous response or a crash before ready configuration commits, the next command removes an unreferenced
    staged key and reports not enrolled. It does not retry or reconcile automatically.
-7. Before this path is implemented, R1 must prove the inactive-orphan condition in DEC-GC-004. Failure returns a small
-   owner decision packet; it does not add a generalized reconciliation protocol.
+7. An inactive accepted server enrollment remains unselectable, allows fresh manual enrollment, and expires under the
+   server rule. This path does not add automatic retry or reconciliation.
 8. Missing, corrupt, or mismatched configured key material fails closed. The recovery is server revocation, local reset,
    and manual re-enrollment.
 
-R1A owns only the static local identity boundary. It creates `<root>/attempt/identity.pk8` at `0600` beneath a `0700`
-root and attempt directory, and publishes a `0700` `<root>/ready` directory only after writing a matching `0600`
-`registration.json`. The fingerprint is the base64url SHA-256 of the derived P-256 `X || Y` bytes. Inspection is
-read-only and returns only missing, attempt-present, ready, invalid, or inaccessible; unsupported platforms fail before
-local mutation. R1A does not make an HTTP request, acquire credentials, start a listener, publish status output, retry,
-reconcile, rotate keys, or serve artifacts.
+Completed R1A work (#886 and PR #888) established the static local identity boundary. It creates
+`<root>/attempt/identity.pk8` at `0600` beneath a `0700` root and attempt directory, and publishes a `0700`
+`<root>/ready` directory only after writing a matching `0600` `registration.json`. The fingerprint is the base64url
+SHA-256 of the derived P-256 `X || Y` bytes. Inspection is read-only and returns only missing, attempt-present, ready,
+invalid, or inaccessible; unsupported platforms fail before local mutation. The completed work added no HTTP request,
+credential acquisition, listener, status output, retry, reconciliation, key rotation, or artifact serving.
 
 The administrator enrollment request has no caller `Health`. Grace Server durably creates every registration as
 `Unhealthy`, so existing eligibility selection rejects it until R2's authenticated refresh publishes a healthy state.
@@ -263,16 +279,16 @@ create another local working-tree mutation, SQLite-completion, Branch/Watch-fina
 - **Invariant:** V1 exposes no automatic or startup identity rotation contract.
 - **Forbidden shortcut:** reporting enrolled before both server acceptance and local ready-config commit.
 
-### GC-REQ-003 - Enrollment ambiguity gate
+### GC-REQ-003 - Resolved enrollment ambiguity disposition
 
-- **Trigger:** an R1 Tier-2 investigation before enrollment code starts.
-- **Preconditions:** inspect current server enrollment uniqueness, registration selection, revocation/list options, and
-  relevant tests on the leaf's current head.
-- **Result:** prove that an inactive orphan cannot be selected and cannot block fresh manual re-enrollment; record the
-  concrete paths, symbols, and proof.
-- **Failure:** stop R1 and return for owner direction with the smallest supported alternative.
-- **Invariant:** no implementation assumes orphan safety without this proof.
-- **Forbidden shortcut:** adding automatic reconciliation, background lookup, or a new durable recovery workflow.
+- **Trigger:** an accepted server enrollment remains after an ambiguous response or a crash before ready configuration
+  commits.
+- **Result:** the inactive enrollment is unselectable, fresh manual enrollment is allowed, and server expiry performs
+  eventual cleanup.
+- **Invariant:** Grace Cache does not add automatic enrollment retry, reconciliation, background lookup, or a durable
+  recovery workflow.
+- **Evidence:** #886 and PR #888 completed the static enrollment implementation and focused proof. #905 consumes this
+  disposition for one-shot enrollment.
 
 ### GC-REQ-004 - One bounded liveness scheduler
 
@@ -424,7 +440,7 @@ to establish the static Product V1 shape.
 | --- | --- | --- | --- |
 | Enrollment validation fails | No server effect; no ready configuration | Clear rejected input; no enrolled status | Validation-before-effect |
 | Enrollment definitively rejected | Staged key removed; no ready configuration | Not enrolled | Rejection and cleanup |
-| Enrollment response lost or crash before commit | Staged key cleaned next command; inactive-orphan handling only after R1 proof gate | Not enrolled; manual re-enrollment if gate passed | Ambiguous and crash path |
+| Enrollment response lost or crash before commit | Staged key cleaned next command; inactive accepted enrollment remains unselectable and expires under the server rule | Not enrolled; fresh manual enrollment is allowed | Ambiguous and crash path |
 | Ready-config atomic write fails | No ready configuration; staged material follows defined cleanup | Not enrolled or recovery-required, never enrolled | Atomic write failure |
 | Startup registration fails | Listener stops; no ready publication | Nonzero exit | Startup failure |
 | Temporary refresh fails | One bounded retry, never after expiry | Retrying before expiry | Fake-clock and retry cap |
@@ -455,7 +471,7 @@ to establish the static Product V1 shape.
 | Immutable plans and mode contract | Materialization types, server resolver, OpenAPI, SDK/CLI projections | Positive root resolution; rejected whole-file/manifest/block cache requests; mode serialization; CacheRequired no-fallback; generated freshness. |
 | Static identity pruning | Cache types, actor state, server routes, OpenAPI, SDKs, docs, test fixtures | Inventory finds no active service-identity rotation/candidate route, field, setting, state, or command; grant-key rollover remains proven. |
 | R1 enrollment | Cache CLI/host boundary, protected key store, local config | Success; validation-before-effect; rejection; lost response; crash cleanup; atomic write failure; key mismatch; redaction; unsupported-profile rejection. |
-| R1 ambiguity gate | Current server enrollment, selection, revoke/list declarations and tests | Concrete proof that inactive orphan is unselectable and fresh manual re-enrollment cannot be blocked; otherwise owner decision packet. |
+| Resolved enrollment ambiguity | Completed #886 server enrollment and protected-identity proof | Inactive accepted enrollment is unselectable; fresh manual enrollment is allowed; server expiry eventually cleans it up; no automatic retry or reconciliation. |
 | R2 liveness | Cache run host, registration route/actor, injectable clock/timer | Startup; exact endpoint; guard conflict; signed Unhealthy refresh; temporary retry; `Retry-After` cap; revocation; expiry; shutdown race; restart; server selection. #857 does not publish Healthy. |
 | Artifact store and serving | SQLite/filesystem metadata, read-through fetcher, artifact route | Authorized hit; miss-fill-serve-hit; hash/size mismatch; partial staging; grant/proof rejection; grant-key rollover; restart completeness. |
 | Working Directory Update | Cache execution path and #835 public local-update seam | Exact prepared content invokes `WorkingDirectoryUpdate.run`; no alternate local completion path. |
@@ -478,14 +494,14 @@ proof of a safe cache path.
 | --- | --- | --- | --- | --- | --- | --- |
 | GC-REQ-001 | Server-resolved immutable full-root plan | required | Materialization types/server/OpenAPI | Plan and resolver tests | Existing plan leaves | Cache must not become a resolver. |
 | GC-REQ-002 | One static cache service identity | required | R0/R1A contracts and host config | Enrollment, config, redaction tests | #855, #886 | Local custody is OS-protected, not hardware-backed. |
-| GC-REQ-003 | Inactive-orphan proof before R1A code | required gate | Current registration server/actor behavior | Tier-2 evidence packet | #886 | Failing proof returns to owner. |
+| GC-REQ-003 | Resolved enrollment ambiguity disposition | implemented and proven | Completed registration and protected-identity seams | #886 and PR #888 proof | #886, PR #888 | Inactive accepted enrollment is unselectable; manual enrollment remains available without automatic recovery. |
 | GC-REQ-004 | One bounded registration scheduler | required | R2 cache host and registration contract | Fake-clock transition tests | #857 | Exact response classes/time values require Tier-2 inventory. |
 | GC-REQ-005 | Current eligible-cache selection | required | Server selection and registration actor | Selection/revocation/expiry tests | Existing and R2 | Snapshot is limited to plan issuance. |
 | GC-REQ-006 | Authorized complete read-through | required | Store, artifact route, grant verifier | Miss-fill-serve-hit and negative integrity proof | #625 to #627 | Partial bytes must never become a hit. |
 | GC-REQ-007 | Three execution-mode behaviors | required | Plan resolver, SDK, CLI, cache executor | Positive/negative mode and generated-contract proof | #625 to #630 | CacheRequired false fallback is high risk. |
 | GC-REQ-008 | Working Directory Update sequence | required | Later local materialization | Cross-epic execution proof | #628 to #630 | Blocked until #835 merge and epic refresh. |
-| GC-REQ-009 | Truthful status and diagnostics | required | R1B/R2 commands and process state | Status, redaction, expiry tests | #887, #857 | Must not report stale readiness. |
-| GC-REQ-010 | Reset and redaction | required | Local config/key store and output | Failure and output scans | #887 | Manual recovery is intentional. |
+| GC-REQ-009 | Truthful status and diagnostics | required | #914 status and R2 process state | Status, redaction, expiry tests | #914, #857 | Must not report stale readiness. |
+| GC-REQ-010 | Reset and redaction | required | Local config/key store and enrollment output | Failure and output scans | #905 | Manual recovery is intentional. |
 | GC-REQ-011 | Static contract pruning | required | Shared types, routes, OpenAPI, SDK, docs | Inventory and freshness checks | #855 | Must retain artifact-grant key rollover. |
 | GC-DEF-001 | Automatic identity rotation | deferred | None | Absence scan | Future Hardened epic | Do not leave a partial surface. |
 | GC-DEF-002 | Prefetch and scheduled retention | deferred | None | Absence scan | Future work | Read-through remains the only correctness path. |
@@ -515,9 +531,11 @@ without rotation, prefetch, or scheduled retention.
 
 1. **R0 static-contract pruning (#855)**: Inventory every cache service-identity rotation/candidate surface, remove it or
    rebaseline it to static identity, regenerate contracts, and prove artifact-grant key rollover remains separate.
-2. **R1A static enrollment identity (#886)**: Starts after R0 and its Tier-2 orphan/re-enrollment proof gate pass.
-3. **R1B enrollment and status commands (#887)**: Follows R1A and owns no R1A protected-identity detail.
-4. **R2 registration liveness (#857)**: Starts after R1 and its Tier-2 server timestamp, response-class, selection, and clock
+2. **R1A static enrollment identity (#886 / PR #888)**: Implemented and proven; its merged evidence establishes the
+   completed static identity foundation.
+3. **R1 record, status, and enrollment (#913, #914, #905)**: #913 reconciles the canonical record; #914 then owns
+   pure local status only; #905 then owns one-shot enrollment only.
+4. **R2 registration liveness (#857)**: Starts after #905 and its Tier-2 server timestamp, response-class, selection, and clock
    table are complete. Its signed refreshes remain Unhealthy; it does not publish Healthy.
 5. **Runtime/artifact serving (#625)**: May proceed independently where write sets do not overlap with #835; it owns storage,
    grant verification, the miss-fill-serve-hit tracer, and Healthy publication only after serving readiness is proven.
@@ -534,8 +552,8 @@ high-conflict surfaces. Parallel work requires both independent user behavior an
 - **R0:** Tier-2 static inventory covers DTOs, actor state/events, routes, CLI settings/status, local configuration,
   OpenAPI/SDK, documentation, tests, serializers, AOT roots, and command catalogs. It distinguishes cache service
   identity from artifact-grant validation keys.
-- **R1:** Before code, prove the inactive-orphan condition in GC-REQ-003 from current server selection and enrollment
-  behavior. An orphan that can be selected or permanently block manual re-enrollment stops the leaf for owner direction.
+- **R1 completion sequence:** #913 records the completed #886 / PR #888 disposition, #914 implements status only, and
+  #905 implements enrollment only after #913 and #914. No leaf adds automatic retry or reconciliation.
 - **R2:** Before code, produce the exact current registration response, timestamp, revocation/access, selection,
   capability, and clock transition table. It names one bounded retry schedule and its expiry cap.
 - **All leaves:** Declare owned paths, forbidden paths, state/time model where needed, propagation dispositions, focused
@@ -562,10 +580,10 @@ The specification is Plan-ready for implementation planning because Product V1 s
 deferred capabilities, identity model, liveness shape, failure posture, propagation inventory, proof seams, tracer,
 sequencing, and owner interruption rules are explicit. The recovery topology may now compile into focused issue plans.
 
-This verdict does not make R0, R1, R2, or later semantic work ready to code. The portable specification contract says
-Plan-ready supports implementation planning, while `dev-process` requires each issue to complete Tier-2 research and
-the issue-level Implementation Readiness Gate. The R1 inactive-orphan proof and R2 exact liveness table are intentionally
-leaf-level gates with defined stop outcomes, not hidden assumptions in this document.
+This verdict does not make R2 or later semantic work ready to code. The portable specification contract says Plan-ready
+supports implementation planning, while `dev-process` requires each issue to complete Tier-2 research and the issue-level
+Implementation Readiness Gate. #913, #914, and #905 retain their declared docs, status, and enrollment boundaries; the
+R2 exact liveness table remains a leaf-level gate.
 
 ### Passed criteria
 
@@ -579,8 +597,7 @@ leaf-level gates with defined stop outcomes, not hidden assumptions in this docu
 
 - The requested project specification profile is absent at the required starting commit. Its absence is recorded for
   later repository restoration; this document does not infer missing profile rules.
-- R1 has no current proof that inactive orphan enrollment is unselectable and does not block manual re-enrollment. This
-  is a stop condition before R1 code, not an accepted behavior claim.
+- #914 status and #905 one-shot enrollment remain planned replacement leaves after #913's documentation correction.
 - R2 still needs exact current server liveness response classes, timestamps, and selection timing on its branch head.
 - Cache host, SQLite/filesystem implementation, artifact route execution, and the local Working Directory Update seam
   do not exist on this epic head. They are planned work, not present behavior.
@@ -591,7 +608,6 @@ leaf-level gates with defined stop outcomes, not hidden assumptions in this docu
 
 Return to the owner before expanding scope when:
 
-- R1's current-contract proof shows an inactive orphan can become selectable or block fresh manual re-enrollment.
 - R0 shows that pruning rotation changes the server source-of-truth model, needs a new durable object/state machine, or
   reveals a real deployed compatibility obligation.
 - R2 needs a second scheduler/state machine, durable recovery workflow, new server source of truth, or generalized

--- a/scripts/Test-GraceCacheR1Docs.ps1
+++ b/scripts/Test-GraceCacheR1Docs.ps1
@@ -1,0 +1,265 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+
+function Get-MarkdownHeading {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string[]] $Lines,
+
+        [Parameter(Mandatory)]
+        [string] $Title,
+
+        [Parameter(Mandatory)]
+        [string] $DocumentPath
+    )
+
+    for ($index = 0; $index -lt $Lines.Count; $index++) {
+        if ($Lines[$index] -match '^(?<markers>#{1,6}) (?<heading>.+?)\s*$' -and $Matches.heading -eq $Title) {
+            return [pscustomobject]@{
+                Index = $index
+                Level = $Matches.markers.Length
+            }
+        }
+    }
+
+    throw "$DocumentPath does not contain the '$Title' heading."
+}
+
+function ConvertFrom-MarkdownTableRow {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Line,
+
+        [Parameter(Mandatory)]
+        [string] $DocumentPath
+    )
+
+    if ($Line -notmatch '^\|.*\|\s*$') {
+        throw "$DocumentPath contains a malformed Markdown table row: $Line"
+    }
+
+    return @($Line.Trim().Trim('|').Split('|').ForEach({ $_.Trim() }))
+}
+
+function Get-MarkdownTableAfterHeading {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string[]] $Lines,
+
+        [Parameter(Mandatory)]
+        [string] $HeadingTitle,
+
+        [Parameter(Mandatory)]
+        [string] $DocumentPath
+    )
+
+    $heading = Get-MarkdownHeading -Lines $Lines -Title $HeadingTitle -DocumentPath $DocumentPath
+    $sectionEnd = $Lines.Count
+
+    for ($index = $heading.Index + 1; $index -lt $Lines.Count; $index++) {
+        if ($Lines[$index] -match '^(?<markers>#{1,6}) ') {
+            if ($Matches.markers.Length -le $heading.Level) {
+                $sectionEnd = $index
+                break
+            }
+        }
+    }
+
+    $tableStart = -1
+    for ($index = $heading.Index + 1; $index -lt $sectionEnd - 1; $index++) {
+        if ($Lines[$index] -match '^\|.*\|\s*$' -and $Lines[$index + 1] -match '^\|\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|\s*$') {
+            $tableStart = $index
+            break
+        }
+    }
+
+    if ($tableStart -lt 0) {
+        throw "$DocumentPath does not contain a Markdown table directly under '$HeadingTitle'."
+    }
+
+    $headers = ConvertFrom-MarkdownTableRow -Line $Lines[$tableStart] -DocumentPath $DocumentPath
+    $rows = @()
+
+    for ($index = $tableStart + 2; $index -lt $sectionEnd; $index++) {
+        if ($Lines[$index] -notmatch '^\|.*\|\s*$') {
+            break
+        }
+
+        $cells = ConvertFrom-MarkdownTableRow -Line $Lines[$index] -DocumentPath $DocumentPath
+        if ($cells.Count -ne $headers.Count) {
+            throw "$DocumentPath table under '$HeadingTitle' has $($cells.Count) cells where $($headers.Count) are required."
+        }
+
+        $row = [ordered]@{}
+        for ($cellIndex = 0; $cellIndex -lt $headers.Count; $cellIndex++) {
+            $row[$headers[$cellIndex]] = $cells[$cellIndex]
+        }
+
+        $rows += [pscustomobject]$row
+    }
+
+    return [pscustomobject]@{
+        Headers = $headers
+        Rows = $rows
+    }
+}
+
+function Get-MarkdownSectionText {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string[]] $Lines,
+
+        [Parameter(Mandatory)]
+        [string] $HeadingTitle,
+
+        [Parameter(Mandatory)]
+        [string] $DocumentPath
+    )
+
+    $heading = Get-MarkdownHeading -Lines $Lines -Title $HeadingTitle -DocumentPath $DocumentPath
+    $sectionLines = @()
+
+    for ($index = $heading.Index + 1; $index -lt $Lines.Count; $index++) {
+        if ($Lines[$index] -match '^(?<markers>#{1,6}) ' -and $Matches.markers.Length -le $heading.Level) {
+            break
+        }
+
+        $sectionLines += $Lines[$index]
+    }
+
+    return $sectionLines -join "`n"
+}
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Text,
+
+        [Parameter(Mandatory)]
+        [string] $Expected,
+
+        [Parameter(Mandatory)]
+        [string] $Description
+    )
+
+    $normalizedText = $Text -replace '\s+', ' '
+    $normalizedExpected = $Expected -replace '\s+', ' '
+
+    if (-not $normalizedText.Contains($normalizedExpected, [System.StringComparison]::Ordinal)) {
+        throw "$Description must contain '$Expected'."
+    }
+}
+
+function Assert-DoesNotMatch {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Text,
+
+        [Parameter(Mandatory)]
+        [string] $Pattern,
+
+        [Parameter(Mandatory)]
+        [string] $Description
+    )
+
+    if ($Text -match $Pattern) {
+        throw "$Description still matches obsolete text '$Pattern'."
+    }
+}
+
+$expectedRows = [ordered]@{
+    '#886' = 'Implemented and proven; completed evidence.'
+    'PR #888' = 'Merged implementation and proof for #886.'
+    '#887' = 'Superseded mixed enrollment/status issue.'
+    'PR #896' = 'Closed superseded mixed enrollment/status implementation.'
+    '#904' = 'Superseded status issue.'
+    'PR #907' = 'Closed superseded status implementation.'
+    '#913 / #914' = 'Current docs-only correction; planned pure local status follows.'
+    '#905' = 'Planned one-shot enrollment after #913 and #914.'
+}
+
+$requiredDisposition = @(
+    'An inactive accepted server enrollment is unselectable.',
+    'Fresh manual enrollment is allowed.',
+    'Server expiry performs eventual cleanup.',
+    'Grace Cache adds no automatic enrollment retry or reconciliation.'
+)
+
+$obsoletePatterns = @(
+    'R1 ambiguity gate',
+    'Inactive-orphan proof before R1A code',
+    'R1 may accept an inactive orphan only after',
+    'Before this path is implemented, R1 must prove',
+    'Before code, prove the inactive-orphan condition',
+    'R1''s current-contract proof',
+    'current implementation leaf',
+    'R1B follows R1A',
+    '\bR1B\b',
+    'R1A validation status',
+    'remain required before merge'
+)
+
+$documents = @(
+    (Join-Path $repositoryRoot 'docs/Grace Cache.md')
+    (Join-Path $repositoryRoot 'docs/Grace Cache implementation audit.md')
+)
+
+foreach ($documentPath in $documents) {
+    $lines = Get-Content -LiteralPath $documentPath
+    $trackerTable = Get-MarkdownTableAfterHeading -Lines $lines -HeadingTitle 'Current R1 tracker record' -DocumentPath $documentPath
+
+    if ($trackerTable.Headers.Count -ne 3 -or $trackerTable.Headers[0] -ne 'Tracker' -or $trackerTable.Headers[1] -ne 'Current classification' -or $trackerTable.Headers[2] -ne 'Scope and sequence') {
+        throw "$documentPath must use the Tracker, Current classification, Scope and sequence table contract."
+    }
+
+    if ($trackerTable.Rows.Count -ne $expectedRows.Count) {
+        throw "$documentPath must classify exactly $($expectedRows.Count) current R1 tracker rows."
+    }
+
+    $actualRows = @{}
+    foreach ($row in $trackerTable.Rows) {
+        if ($actualRows.ContainsKey($row.Tracker)) {
+            throw "$documentPath repeats tracker row '$($row.Tracker)'."
+        }
+
+        $actualRows[$row.Tracker] = $row
+    }
+
+    foreach ($expectedRow in $expectedRows.GetEnumerator()) {
+        if (-not $actualRows.ContainsKey($expectedRow.Key)) {
+            throw "$documentPath does not classify tracker row '$($expectedRow.Key)'."
+        }
+
+        if ($actualRows[$expectedRow.Key].'Current classification' -cne $expectedRow.Value) {
+            throw "$documentPath classifies '$($expectedRow.Key)' as '$($actualRows[$expectedRow.Key].'Current classification')', not '$($expectedRow.Value)'."
+        }
+    }
+
+    $statusScope = $actualRows['#913 / #914'].'Scope and sequence'
+    Assert-Contains -Text $statusScope -Expected '#914 then owns status only.' -Description "$documentPath #914 scope"
+    Assert-DoesNotMatch -Text $statusScope -Pattern 'enrollment' -Description "$documentPath #914 scope"
+
+    $enrollmentScope = $actualRows['#905'].'Scope and sequence'
+    Assert-Contains -Text $enrollmentScope -Expected 'enrollment only' -Description "$documentPath #905 scope"
+    Assert-DoesNotMatch -Text $enrollmentScope -Pattern 'status only' -Description "$documentPath #905 scope"
+
+    $disposition = Get-MarkdownSectionText -Lines $lines -HeadingTitle 'Enrollment ambiguity disposition' -DocumentPath $documentPath
+    foreach ($statement in $requiredDisposition) {
+        Assert-Contains -Text $disposition -Expected $statement -Description "$documentPath enrollment ambiguity disposition"
+    }
+
+    $documentText = $lines -join "`n"
+    foreach ($pattern in $obsoletePatterns) {
+        Assert-DoesNotMatch -Text $documentText -Pattern $pattern -Description $documentPath
+    }
+}
+
+Write-Output 'Grace Cache R1 documentation record is current.'


### PR DESCRIPTION
# Reconcile Grace Cache R1 completion records

## Purpose

Implements #913 for Product V1 by making the canonical Grace Cache specification and implementation audit state one
current R1 sequence. This keeps completed, superseded, current, and planned work distinguishable before the replacement
status and enrollment leaves begin.

## Changes

- publish the same eight-row R1 tracker record in both canonical documents;
- classify #886/PR #888 as completed evidence and #887/PR #896 plus #904/PR #907 as superseded evidence;
- assign pure local status to #914 and one-shot enrollment to #905 after #913/#914;
- remove obsolete future R1A feasibility gates while preserving the approved inactive-enrollment disposition;
- add a structural PowerShell proof that parses the named sections and Markdown tables.

## Validation

- RED: the structural proof failed against the stale documents because the current R1 tracker record was absent.
- `pwsh -NoProfile -File scripts/Test-GraceCacheR1Docs.ps1`
- `npx --yes markdownlint-cli2 "docs/Grace Cache.md" "docs/Grace Cache implementation audit.md"`
- `git diff --check`

No local Fast or Full run was used for this docs-only leaf. GitHub Validate and one fresh exact-head Product V1 review
are required for the current revision.

## Scope

No production, CLI, server, generated, persisted, runtime, enrollment, or cache-state behavior changes.

Relates to #913.
