### PR TITLE
Add pure local Grace Cache status

### DIFF
--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -129,8 +129,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `206`
-- JSON-ready routed commands: `185`
+- Total leaf commands: `207`
+- JSON-ready routed commands: `186`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`
@@ -173,6 +173,11 @@ starting the watcher.
 
 `doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
 supports `--schema`, `--examples`, and `--select`.
+
+`cache status` is also JSON-ready. It is repository-independent and reads only protected local Cache identity state.
+Its closed `oneOf` schema emits `Class`, `Enrollment`, and `Key` for every state; only an enrolled ready state includes
+`CacheId`, `Endpoint`, `BoundaryKind`, and `RepositoryCount`. The command performs no credential lookup, server request,
+repair, cleanup, or local mutation.
 
 ## Agent Recipes
 

--- a/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
@@ -1,0 +1,27 @@
+namespace Grace.CLI.Tests
+
+open FsUnit
+open Grace.CLI
+open NUnit.Framework
+
+/// Groups pure parser coverage for the repository-independent Cache status command.
+[<Parallelizable(ParallelScope.All)>]
+module CacheCliParsingTests =
+
+    /// Verifies the Cache status leaf accepts global output and introspection options without repository configuration.
+    [<Test>]
+    let ``cache status parser accepts output schema and examples`` () =
+        for args in
+            [
+                [| "cache"; "status" |]
+                [|
+                    "--output"
+                    "Json"
+                    "cache"
+                    "status"
+                |]
+                [| "cache"; "status"; "--schema" |]
+                [| "cache"; "status"; "--examples" |]
+            ] do
+            let parseResult = GraceCommand.rootCommand.Parse(args)
+            parseResult.Errors.Count |> should equal 0

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -1,0 +1,221 @@
+namespace Grace.CLI.Tests
+
+open Grace.Cache
+open Grace.CLI
+open Grace.CLI.Command
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.IO
+open System.Text.Json
+
+/// Covers serialized root-command behavior for pure local Cache status.
+[<TestFixture>]
+[<NonParallelizable>]
+module CacheCliTests =
+
+    /// Sets AnsiConsole output for root-command tests that capture stdout.
+    let private setAnsiConsoleOutput writer =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    /// Runs the root command while capturing complete stdout.
+    let private run args =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+            GraceCommand.main args, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    /// Creates an isolated protected state root and restores the cache command override.
+    let private withRoot action =
+        let root = Path.Combine(Path.GetTempPath(), $"grace-cache-status-{Guid.NewGuid():N}")
+        Directory.CreateDirectory(root) |> ignore
+
+        File.SetUnixFileMode(
+            root,
+            UnixFileMode.UserRead
+            ||| UnixFileMode.UserWrite
+            ||| UnixFileMode.UserExecute
+        )
+
+        try
+            CacheCommand.setStateRootForTests root
+            action root
+        finally
+            CacheCommand.resetStateRootForTests ()
+            if Directory.Exists(root) then Directory.Delete(root, true)
+
+    /// Requires a protected identity setup step to succeed.
+    let private requireOk =
+        function
+        | Ok value -> value
+        | Error error ->
+            Assert.Fail($"Unexpected identity setup error: {error}")
+            Unchecked.defaultof<_>
+
+    /// Constructs a ready registration tied to one staged key.
+    let private registration endpoint publicKey : CacheAcceptedRegistration =
+        {
+            CacheId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+            DisplayName = "Test cache"
+            BoundaryKind = "Organization"
+            OwnerId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+            OrganizationId = Some(Guid.Parse("33333333-3333-3333-3333-333333333333"))
+            RepositoryScopes =
+                [|
+                    { OrganizationId = Guid.Parse("33333333-3333-3333-3333-333333333333"); RepositoryId = Guid.Parse("44444444-4444-4444-4444-444444444444") }
+                |]
+            Endpoint = endpoint
+            ProtocolVersion = "v1"
+            PublicKey = publicKey
+        }
+
+    /// Captures protected-state metadata without reading private content.
+    let private snapshot root =
+        Array.append [| root |] (Directory.GetFileSystemEntries(root, "*", SearchOption.AllDirectories))
+        |> Array.sort
+        |> Array.map (fun path -> path, File.GetUnixFileMode(path), File.GetLastWriteTimeUtc(path), (if File.Exists(path) then FileInfo(path).Length else -1L))
+
+    /// Verifies one JSON status contains only redacted fields for its state.
+    let private assertStatus (enrollment: string) (key: string) (exitCode: int) (output: string) =
+        Assert.That(exitCode, Is.EqualTo(if enrollment = "enrolled" then 0 else 1))
+        use document = JsonDocument.Parse(output)
+        let status = document.RootElement.GetProperty("ReturnValue")
+        Assert.That(status.GetProperty("Class").GetString(), Is.EqualTo("Grace.Cache.Status"))
+        Assert.That(status.GetProperty("Enrollment").GetString(), Is.EqualTo(enrollment))
+        Assert.That(status.GetProperty("Key").GetString(), Is.EqualTo(key))
+
+        if enrollment <> "enrolled" then
+            [
+                "CacheId"
+                "Endpoint"
+                "BoundaryKind"
+                "RepositoryCount"
+            ]
+            |> List.iter (fun name ->
+                let mutable ignored = Unchecked.defaultof<JsonElement>
+                Assert.That(status.TryGetProperty(name, &ignored), Is.False))
+
+    /// Proves root dispatch has no Linux identity implementation until running in the real service-user environment.
+    [<Test>]
+    let ``cache status maps unsupported hosts to inaccessible without repository state`` () =
+        if OperatingSystem.IsLinux() then
+            Assert.Ignore("This direct branch proof is for unsupported hosts.")
+
+        let status = CacheIdentity.status CacheIdentity.StateRoot
+        Assert.That(status.Enrollment, Is.EqualTo("invalid"))
+        Assert.That(status.Key, Is.EqualTo("inaccessible"))
+
+    /// Proves every parser-accepted output mode uses root dispatch and leaves protected state unchanged.
+    [<Test>]
+    let ``Linux cache status honors shared output modes selectors and read-only states`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache status Product V1 supports Linux only.")
+
+        withRoot (fun root ->
+            let missingBefore = snapshot root
+            let normalExit, normal = run [| "cache"; "status" |]
+            Assert.That(normalExit, Is.EqualTo(1))
+            Assert.That(normal, Does.Contain("Enrollment: notEnrolled"))
+            Assert.That(snapshot root = missingBefore, Is.True)
+
+            let minimalExit, minimal =
+                run [| "--output"
+                       "Minimal"
+                       "cache"
+                       "status" |]
+
+            Assert.That(minimalExit, Is.EqualTo(1))
+            Assert.That(minimal, Is.Empty)
+
+            let silentExit, silent =
+                run [| "--output"
+                       "Silent"
+                       "cache"
+                       "status" |]
+
+            Assert.That(silentExit, Is.EqualTo(1))
+            Assert.That(silent, Is.Empty)
+
+            let verboseExit, verbose =
+                run [| "--output"
+                       "Verbose"
+                       "cache"
+                       "status" |]
+
+            Assert.That(verboseExit, Is.EqualTo(1))
+            Assert.That(verbose, Does.Contain("Enrollment: notEnrolled"))
+            Assert.That(verbose, Does.Contain("EventTime:"))
+
+            let missingExit, missing =
+                run [| "--output"
+                       "Json"
+                       "cache"
+                       "status" |]
+
+            assertStatus "notEnrolled" "missing" missingExit missing
+            Assert.That(snapshot root = missingBefore, Is.True)
+
+            let selectedExit, selected =
+                run [| "--output"
+                       "Minimal"
+                       "--select"
+                       "Enrollment"
+                       "cache"
+                       "status" |]
+
+            Assert.That(selectedExit, Is.EqualTo(1))
+            Assert.That(selected.Trim(), Is.EqualTo("\"notEnrolled\""))
+
+            let missingSelectExit, missingSelect =
+                run [| "--select"
+                       "CacheId"
+                       "cache"
+                       "status" |]
+
+            Assert.That(missingSelectExit, Is.Not.EqualTo(0))
+            Assert.That(missingSelect, Does.Contain("GraceError"))
+
+            let publicKey = CacheIdentity.createAttempt root |> requireOk
+
+            CacheIdentity.commitReady root (registration "https://cache.example.test" publicKey)
+            |> requireOk
+
+            let readyBefore = snapshot root
+
+            let readyExit, ready =
+                run [| "--output"
+                       "Json"
+                       "cache"
+                       "status" |]
+
+            assertStatus "enrolled" "available" readyExit ready
+            Assert.That(ready, Does.Contain("CacheId"))
+            Assert.That(snapshot root = readyBefore, Is.True)
+
+            let readySelectExit, readySelect =
+                run [| "--output"
+                       "Silent"
+                       "--select"
+                       "CacheId"
+                       "cache"
+                       "status" |]
+
+            Assert.That(readySelectExit, Is.EqualTo(0))
+            Assert.That(readySelect, Does.Contain("11111111-1111-1111-1111-111111111111"))
+
+            let malformedExit, malformed =
+                run [| "--select"
+                       "CacheId[0]"
+                       "cache"
+                       "status" |]
+
+            Assert.That(malformedExit, Is.Not.EqualTo(0))
+            Assert.That(malformed, Does.Contain("GraceError")))

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -7,6 +7,8 @@ open NUnit.Framework
 open Spectre.Console
 open System
 open System.IO
+open System.Net
+open System.Net.Sockets
 open System.Text.Json
 
 /// Covers serialized root-command behavior for pure local Cache status.
@@ -21,7 +23,7 @@ module CacheCliTests =
         AnsiConsole.Console <- AnsiConsole.Create(settings)
 
     /// Runs the root command while capturing complete stdout.
-    let private run args =
+    let private run (args: string array) =
         use writer = new StringWriter()
         let originalOut = Console.Out
 
@@ -33,24 +35,26 @@ module CacheCliTests =
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
 
-    /// Creates an isolated protected state root and restores the cache command override.
-    let private withRoot action =
-        let root = Path.Combine(Path.GetTempPath(), $"grace-cache-status-{Guid.NewGuid():N}")
-        Directory.CreateDirectory(root) |> ignore
+    /// Runs an action with one temporary environment variable value.
+    let private withEnv (name: string) (value: string option) (action: unit -> 'T) =
+        let original = Environment.GetEnvironmentVariable(name)
 
-        File.SetUnixFileMode(
-            root,
-            UnixFileMode.UserRead
-            ||| UnixFileMode.UserWrite
-            ||| UnixFileMode.UserExecute
-        )
+        match value with
+        | Some value -> Environment.SetEnvironmentVariable(name, value)
+        | None -> Environment.SetEnvironmentVariable(name, null)
 
         try
-            CacheCommand.setStateRootForTests root
-            action root
+            action ()
         finally
-            CacheCommand.resetStateRootForTests ()
-            if Directory.Exists(root) then Directory.Delete(root, true)
+            Environment.SetEnvironmentVariable(name, original)
+
+    /// Captures a file's existence and immutable-on-read metadata without reading its contents.
+    let private snapshotFile (path: string) =
+        if File.Exists(path) then
+            let info = FileInfo(path)
+            Some(info.Length, info.LastWriteTimeUtc, File.GetUnixFileMode(path))
+        else
+            None
 
     /// Requires a protected identity setup step to succeed.
     let private requireOk =
@@ -77,22 +81,200 @@ module CacheCliTests =
             PublicKey = publicKey
         }
 
-    /// Captures protected-state metadata without reading private content.
-    let private snapshot root =
-        Array.append [| root |] (Directory.GetFileSystemEntries(root, "*", SearchOption.AllDirectories))
+    /// Captures all accessible protected-state paths and metadata without reading protected file contents.
+    let private snapshot (root: string) =
+        let paths =
+            try
+                Array.append [| root |] (Directory.GetFileSystemEntries(root, "*", SearchOption.AllDirectories))
+            with
+            | :? UnauthorizedAccessException -> [| root |]
+
+        paths
         |> Array.sort
-        |> Array.map (fun path -> path, File.GetUnixFileMode(path), File.GetLastWriteTimeUtc(path), (if File.Exists(path) then FileInfo(path).Length else -1L))
+        |> Array.map (fun path ->
+            let mode =
+                try
+                    Some(File.GetUnixFileMode(path))
+                with
+                | _ -> None
+
+            let lastWriteTimeUtc =
+                try
+                    Some(File.GetLastWriteTimeUtc(path))
+                with
+                | _ -> None
+
+            let length =
+                if File.Exists(path) then
+                    try
+                        Some(FileInfo(path).Length)
+                    with
+                    | _ -> None
+                else
+                    None
+
+            path, mode, lastWriteTimeUtc, length)
+
+    /// Collects protected values that status output must never reveal.
+    let private protectedValues (root: string) =
+        let privateFileContents =
+            try
+                Directory.GetFiles(root, "*", SearchOption.AllDirectories)
+                |> Array.choose (fun path ->
+                    if Path
+                        .GetFileName(path)
+                           .Equals("identity.pk8", StringComparison.Ordinal) then
+                        try
+                            Some(File.ReadAllText(path))
+                        with
+                        | _ -> None
+                    else
+                        None)
+            with
+            | _ -> [||]
+
+        Array.append
+            [|
+                root
+                "identity.pk8"
+                "registration.json"
+                "invalid-private-key-material"
+                "test-token-should-not-appear"
+                "UnauthorizedAccessException"
+                "DirectoryNotFoundException"
+            |]
+            privateFileContents
+
+    /// Fails without echoing protected values when command output exposes a sensitive path, secret, or raw filesystem detail.
+    let private assertRedacted (output: string) (protectedValues: string array) =
+        for value in protectedValues do
+            if not (String.IsNullOrWhiteSpace(value)) then
+                Assert.That(output.Contains(value, StringComparison.Ordinal), Is.False, "Cache status output exposed protected state.")
+
+    /// Invokes the root command and proves the Cache status early path has no protected-state, repository, local-state, SDK, history, or loopback side effects.
+    let private invoke (root: string) (repositoryRoot: string) (args: string array) =
+        let rootBefore = snapshot root
+        let historyPath = HistoryStorage.getHistoryFilePath ()
+        let historyLockPath = HistoryStorage.getHistoryLockPath ()
+        let historyBefore = snapshotFile historyPath, snapshotFile historyLockPath
+        let tracePath = Path.Combine(repositoryRoot, "local-state-open-trace.log")
+        let graceDirectory = Path.Combine(repositoryRoot, ".grace")
+
+        Assert.That(Directory.Exists(graceDirectory), Is.False)
+        Assert.That(File.Exists(tracePath), Is.False)
+
+        let sdkIdentityBefore = Grace.SDK.ClientIdentity.tryGetConfiguredClientType ()
+
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        listener.Start()
+        let endpoint = listener.LocalEndpoint :?> IPEndPoint
+
+        let exitCode, output =
+            withEnv "GRACE_SERVER_URI" (Some $"http://127.0.0.1:{endpoint.Port}") (fun () ->
+                withEnv "GRACE_TOKEN" (Some "test-token-should-not-appear") (fun () ->
+                    withEnv "GRACE_LOCALSTATE_DB_TRACE_PATH" (Some tracePath) (fun () ->
+                        withEnv "GRACE_LOCALSTATE_DB_TRACE_OPEN" (Some "1") (fun () -> run args))))
+
+        Assert.That(listener.Pending(), Is.False, "Cache status made a loopback request.")
+        Assert.That(snapshot root = rootBefore, Is.True, "Cache status changed protected state.")
+        Assert.That(Directory.Exists(graceDirectory), Is.False, "Cache status created repository local state.")
+        Assert.That(File.Exists(tracePath), Is.False, "Cache status opened the LocalState DB.")
+        Assert.That(snapshotFile historyPath = fst historyBefore, Is.True, "Cache status changed invocation history.")
+        Assert.That(snapshotFile historyLockPath = snd historyBefore, Is.True, "Cache status changed the history lock.")
+        Assert.That((Grace.SDK.ClientIdentity.tryGetConfiguredClientType () = sdkIdentityBefore), Is.True, "Cache status configured SDK identity.")
+        assertRedacted output (protectedValues root)
+        exitCode, output
+
+    /// Creates an isolated protected state root, repository, home, and Cache root override for one serialized test.
+    let private withRoot (action: string -> string -> unit) =
+        let testRoot = Path.Combine(Path.GetTempPath(), $"grace-cache-status-{Guid.NewGuid():N}")
+        let root = Path.Combine(testRoot, "protected-cache-root")
+        let repositoryRoot = Path.Combine(testRoot, "repository")
+        let home = Path.Combine(testRoot, "home")
+        Directory.CreateDirectory(root) |> ignore
+
+        Directory.CreateDirectory(repositoryRoot)
+        |> ignore
+
+        Directory.CreateDirectory(home) |> ignore
+
+        File.SetUnixFileMode(
+            root,
+            UnixFileMode.UserRead
+            ||| UnixFileMode.UserWrite
+            ||| UnixFileMode.UserExecute
+        )
+
+        let originalDirectory = Environment.CurrentDirectory
+
+        try
+            CacheCommand.setStateRootForTests root
+            Environment.CurrentDirectory <- repositoryRoot
+
+            withEnv "USERPROFILE" (Some home) (fun () -> withEnv "HOME" (Some home) (fun () -> action root repositoryRoot))
+        finally
+            Environment.CurrentDirectory <- originalDirectory
+            CacheCommand.resetStateRootForTests ()
+
+            if Directory.Exists(root) then
+                File.SetUnixFileMode(
+                    root,
+                    UnixFileMode.UserRead
+                    ||| UnixFileMode.UserWrite
+                    ||| UnixFileMode.UserExecute
+                )
+
+            if Directory.Exists(testRoot) then Directory.Delete(testRoot, true)
+
+    /// Creates the valid staged-attempt inspection state.
+    let private createAttempt (root: string) = CacheIdentity.createAttempt root |> requireOk
+
+    /// Creates the valid ready inspection state.
+    let private createReady (root: string) =
+        let publicKey = createAttempt root
+
+        CacheIdentity.commitReady root (registration "https://cache.example.test" publicKey)
+        |> requireOk
+
+    /// Creates a syntactically invalid staged key while preserving the required protected file modes.
+    let private createInvalid (root: string) =
+        let attempt = Path.Combine(root, "attempt")
+        let identity = Path.Combine(attempt, "identity.pk8")
+        Directory.CreateDirectory(attempt) |> ignore
+
+        File.SetUnixFileMode(
+            attempt,
+            UnixFileMode.UserRead
+            ||| UnixFileMode.UserWrite
+            ||| UnixFileMode.UserExecute
+        )
+
+        File.WriteAllText(identity, "invalid-private-key-material")
+        File.SetUnixFileMode(identity, UnixFileMode.UserRead ||| UnixFileMode.UserWrite)
+
+    /// Removes read and search access from the protected root to create the inaccessible inspection state.
+    let private createInaccessible (root: string) = File.SetUnixFileMode(root, UnixFileMode.UserWrite)
 
     /// Verifies one JSON status contains only redacted fields for its state.
-    let private assertStatus (enrollment: string) (key: string) (exitCode: int) (output: string) =
-        Assert.That(exitCode, Is.EqualTo(if enrollment = "enrolled" then 0 else 1))
+    let private assertStatus (enrollment: string) (key: string) (expectedExit: int) (output: string) =
         use document = JsonDocument.Parse(output)
         let status = document.RootElement.GetProperty("ReturnValue")
+        Assert.That(expectedExit, Is.EqualTo(if enrollment = "enrolled" then 0 else 1))
         Assert.That(status.GetProperty("Class").GetString(), Is.EqualTo("Grace.Cache.Status"))
         Assert.That(status.GetProperty("Enrollment").GetString(), Is.EqualTo(enrollment))
         Assert.That(status.GetProperty("Key").GetString(), Is.EqualTo(key))
 
-        if enrollment <> "enrolled" then
+        if enrollment = "enrolled" then
+            [
+                "CacheId"
+                "Endpoint"
+                "BoundaryKind"
+                "RepositoryCount"
+            ]
+            |> List.iter (fun name ->
+                let mutable ignored = Unchecked.defaultof<JsonElement>
+                Assert.That(status.TryGetProperty(name, &ignored), Is.True))
+        else
             [
                 "CacheId"
                 "Endpoint"
@@ -102,6 +284,71 @@ module CacheCliTests =
             |> List.iter (fun name ->
                 let mutable ignored = Unchecked.defaultof<JsonElement>
                 Assert.That(status.TryGetProperty(name, &ignored), Is.False))
+
+    /// Compares approved human status facts with the same facts in a JSON status envelope.
+    let private assertHumanJsonParity (humanOutput: string) (jsonOutput: string) =
+        use document = JsonDocument.Parse(jsonOutput)
+        let status = document.RootElement.GetProperty("ReturnValue")
+
+        for property in status.EnumerateObject() do
+            let value =
+                if property.Value.ValueKind = JsonValueKind.String then
+                    property.Value.GetString()
+                else
+                    property.Value.ToString()
+
+            Assert.That(humanOutput, Does.Contain($"{property.Name}: {value}"))
+
+    /// Parses the complete shared JSON error envelope and verifies redacted exception details.
+    let private assertRedactedError (exitCode: int) (output: string) =
+        Assert.That(exitCode, Is.Not.EqualTo(0))
+        use document = JsonDocument.Parse(output)
+        let root = document.RootElement
+
+        let names =
+            root.EnumerateObject()
+            |> Seq.map (fun property -> property.Name)
+            |> Set.ofSeq
+
+        Assert.That(
+            (names = Set.ofList [ "Exception"
+                                  "Error"
+                                  "EventTime"
+                                  "CorrelationId"
+                                  "Properties" ]),
+            Is.True
+        )
+
+        Assert.That(root.GetProperty("Error").GetString(), Is.Not.Empty)
+        Assert.That(root.GetProperty("CorrelationId").GetString(), Is.Not.Empty)
+
+        let exceptionDetails = root.GetProperty("Exception")
+
+        Assert.That(
+            exceptionDetails
+                .GetProperty("Message")
+                .GetString(),
+            Is.Empty
+        )
+
+        Assert.That(
+            exceptionDetails
+                .GetProperty("StackTrace")
+                .GetString(),
+            Is.Empty
+        )
+
+        Assert.That(
+            exceptionDetails
+                .GetProperty(
+                    "InnerException"
+                )
+                .ValueKind,
+            Is.EqualTo(JsonValueKind.Null)
+        )
+
+        let mutable returnValue = Unchecked.defaultof<JsonElement>
+        Assert.That(root.TryGetProperty("ReturnValue", &returnValue), Is.False)
 
     /// Proves root dispatch has no Linux identity implementation until running in the real service-user environment.
     [<Test>]
@@ -113,109 +360,245 @@ module CacheCliTests =
         Assert.That(status.Enrollment, Is.EqualTo("invalid"))
         Assert.That(status.Key, Is.EqualTo("inaccessible"))
 
-    /// Proves every parser-accepted output mode uses root dispatch and leaves protected state unchanged.
+    /// Proves actual Linux root dispatch covers every finite protected identity inspection state.
     [<Test>]
-    let ``Linux cache status honors shared output modes selectors and read-only states`` () =
+    let ``Linux cache status projects every protected identity state through root dispatch`` () =
         if not (OperatingSystem.IsLinux()) then
             Assert.Ignore("Cache status Product V1 supports Linux only.")
 
-        withRoot (fun root ->
-            let missingBefore = snapshot root
-            let normalExit, normal = run [| "cache"; "status" |]
-            Assert.That(normalExit, Is.EqualTo(1))
-            Assert.That(normal, Does.Contain("Enrollment: notEnrolled"))
-            Assert.That(snapshot root = missingBefore, Is.True)
+        let cases =
+            [
+                "Missing", (fun _ -> ()), "notEnrolled", "missing", 1
+                "AttemptPresent", createAttempt >> ignore, "notEnrolled", "available", 1
+                "Ready", createReady >> ignore, "enrolled", "available", 0
+                "Invalid", createInvalid, "invalid", "invalid", 1
+                "Inaccessible", createInaccessible, "invalid", "inaccessible", 1
+            ]
+
+        for name, setup, enrollment, key, expectedExit in cases do
+            withRoot (fun root repositoryRoot ->
+                setup root
+
+                let exitCode, output =
+                    invoke
+                        root
+                        repositoryRoot
+                        [|
+                            "--output"
+                            "Json"
+                            "cache"
+                            "status"
+                        |]
+
+                Assert.That(exitCode, Is.EqualTo(expectedExit), name)
+                assertStatus enrollment key expectedExit output)
+
+    /// Proves every no-selector output mode preserves its shared renderer behavior for ready and representative non-ready status.
+    [<Test>]
+    let ``Linux cache status honors every shared no-selector output mode and human JSON parity`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache status Product V1 supports Linux only.")
+
+        let assertModes (root: string) (repositoryRoot: string) (expectedExit: int) =
+            let normalExit, normal = invoke root repositoryRoot [| "cache"; "status" |]
+            Assert.That(normalExit, Is.EqualTo(expectedExit))
 
             let minimalExit, minimal =
-                run [| "--output"
-                       "Minimal"
-                       "cache"
-                       "status" |]
+                invoke
+                    root
+                    repositoryRoot
+                    [|
+                        "--output"
+                        "Minimal"
+                        "cache"
+                        "status"
+                    |]
 
-            Assert.That(minimalExit, Is.EqualTo(1))
+            Assert.That(minimalExit, Is.EqualTo(expectedExit))
             Assert.That(minimal, Is.Empty)
 
             let silentExit, silent =
-                run [| "--output"
-                       "Silent"
-                       "cache"
-                       "status" |]
+                invoke
+                    root
+                    repositoryRoot
+                    [|
+                        "--output"
+                        "Silent"
+                        "cache"
+                        "status"
+                    |]
 
-            Assert.That(silentExit, Is.EqualTo(1))
+            Assert.That(silentExit, Is.EqualTo(expectedExit))
             Assert.That(silent, Is.Empty)
 
             let verboseExit, verbose =
-                run [| "--output"
-                       "Verbose"
-                       "cache"
-                       "status" |]
+                invoke
+                    root
+                    repositoryRoot
+                    [|
+                        "--output"
+                        "Verbose"
+                        "cache"
+                        "status"
+                    |]
 
-            Assert.That(verboseExit, Is.EqualTo(1))
-            Assert.That(verbose, Does.Contain("Enrollment: notEnrolled"))
+            Assert.That(verboseExit, Is.EqualTo(expectedExit))
             Assert.That(verbose, Does.Contain("EventTime:"))
 
-            let missingExit, missing =
-                run [| "--output"
-                       "Json"
-                       "cache"
-                       "status" |]
+            let jsonExit, json =
+                invoke
+                    root
+                    repositoryRoot
+                    [|
+                        "--output"
+                        "Json"
+                        "cache"
+                        "status"
+                    |]
 
-            assertStatus "notEnrolled" "missing" missingExit missing
-            Assert.That(snapshot root = missingBefore, Is.True)
+            Assert.That(jsonExit, Is.EqualTo(expectedExit))
+            assertHumanJsonParity normal json
+            normal, json
 
-            let selectedExit, selected =
-                run [| "--output"
-                       "Minimal"
-                       "--select"
-                       "Enrollment"
-                       "cache"
-                       "status" |]
+        withRoot (fun root repositoryRoot ->
+            let missingHuman, missingJson = assertModes root repositoryRoot 1
+            assertStatus "notEnrolled" "missing" 1 missingJson
+            Assert.That(missingHuman, Does.Contain("Enrollment: notEnrolled"))
 
-            Assert.That(selectedExit, Is.EqualTo(1))
-            Assert.That(selected.Trim(), Is.EqualTo("\"notEnrolled\""))
+            createReady root |> ignore
+            let readyHuman, readyJson = assertModes root repositoryRoot 0
+            assertStatus "enrolled" "available" 0 readyJson
+            Assert.That(readyHuman, Does.Contain("CacheId: 11111111-1111-1111-1111-111111111111")))
 
-            let missingSelectExit, missingSelect =
-                run [| "--select"
-                       "CacheId"
-                       "cache"
-                       "status" |]
+    /// Proves selectors take precedence over human output modes and renderer failure wins over a ready domain exit.
+    [<Test>]
+    let ``Linux cache status selectors take precedence and use the shared redacted error envelope`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache status Product V1 supports Linux only.")
 
-            Assert.That(missingSelectExit, Is.Not.EqualTo(0))
-            Assert.That(missingSelect, Does.Contain("GraceError"))
+        let outputModes =
+            [
+                "Normal"
+                "Minimal"
+                "Silent"
+                "Verbose"
+            ]
 
-            let publicKey = CacheIdentity.createAttempt root |> requireOk
+        let assertSelector (root: string) (repositoryRoot: string) (state: string) (expectedExit: int) (selector: string) (expected: string) =
+            for outputMode in outputModes do
+                let exitCode, output =
+                    invoke
+                        root
+                        repositoryRoot
+                        [|
+                            "--output"
+                            outputMode
+                            "--select"
+                            selector
+                            "cache"
+                            "status"
+                        |]
 
-            CacheIdentity.commitReady root (registration "https://cache.example.test" publicKey)
-            |> requireOk
+                Assert.That(exitCode, Is.EqualTo(expectedExit), $"{state} {outputMode} {selector}")
+                Assert.That(output.Trim(), Is.EqualTo($"\"{expected}\""), $"{state} {outputMode} {selector}")
 
-            let readyBefore = snapshot root
+        withRoot (fun root repositoryRoot ->
+            assertSelector root repositoryRoot "missing" 1 "Enrollment" "notEnrolled"
+            assertSelector root repositoryRoot "missing" 1 "Key" "missing"
 
-            let readyExit, ready =
-                run [| "--output"
-                       "Json"
-                       "cache"
-                       "status" |]
+            let missingCacheIdExit, missingCacheId =
+                invoke
+                    root
+                    repositoryRoot
+                    [|
+                        "--select"
+                        "CacheId"
+                        "cache"
+                        "status"
+                    |]
 
-            assertStatus "enrolled" "available" readyExit ready
-            Assert.That(ready, Does.Contain("CacheId"))
-            Assert.That(snapshot root = readyBefore, Is.True)
+            assertRedactedError missingCacheIdExit missingCacheId
+            Assert.That(missingCacheId, Does.Contain("was not found in ReturnValue"))
 
-            let readySelectExit, readySelect =
-                run [| "--output"
-                       "Silent"
-                       "--select"
-                       "CacheId"
-                       "cache"
-                       "status" |]
+            for selector, expectedError in
+                [
+                    "CacheId[0]", "supports only dot-separated"
+                    "Error", "cannot project 'Error'"
+                ] do
+                let exitCode, output =
+                    invoke
+                        root
+                        repositoryRoot
+                        [|
+                            "--select"
+                            selector
+                            "cache"
+                            "status"
+                        |]
 
-            Assert.That(readySelectExit, Is.EqualTo(0))
-            Assert.That(readySelect, Does.Contain("11111111-1111-1111-1111-111111111111"))
+                assertRedactedError exitCode output
 
-            let malformedExit, malformed =
-                run [| "--select"
-                       "CacheId[0]"
-                       "cache"
-                       "status" |]
+                use errorDocument = JsonDocument.Parse(output)
 
-            Assert.That(malformedExit, Is.Not.EqualTo(0))
-            Assert.That(malformed, Does.Contain("GraceError")))
+                Assert.That(
+                    errorDocument
+                        .RootElement
+                        .GetProperty("Error")
+                        .GetString(),
+                    Does.Contain(expectedError)
+                )
+
+            createReady root |> ignore
+            assertSelector root repositoryRoot "ready" 0 "Enrollment" "enrolled"
+            assertSelector root repositoryRoot "ready" 0 "Key" "available"
+            assertSelector root repositoryRoot "ready" 0 "CacheId" "11111111-1111-1111-1111-111111111111"
+
+            let missingReadyFieldExit, missingReadyField =
+                invoke
+                    root
+                    repositoryRoot
+                    [|
+                        "--select"
+                        "DoesNotExist"
+                        "cache"
+                        "status"
+                    |]
+
+            assertRedactedError missingReadyFieldExit missingReadyField
+            Assert.That(missingReadyField, Does.Contain("was not found in ReturnValue")))
+
+    /// Proves built Cache status schema and examples remain inert and retain their existing-behavior registry metadata.
+    [<Test>]
+    let ``Linux cache status built schema and examples are existing behavior without side effects`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache status Product V1 supports Linux only.")
+
+        withRoot (fun root repositoryRoot ->
+            let schemaExit, schemaOutput = invoke root repositoryRoot [| "cache"; "status"; "--schema" |]
+            Assert.That(schemaExit, Is.EqualTo(0))
+
+            use schemaDocument = JsonDocument.Parse(schemaOutput)
+            let schemaRegistry = schemaDocument.RootElement.GetProperty("Registry")
+            Assert.That(schemaRegistry.GetProperty("Schema").GetString(), Is.EqualTo("ExistingBehavior"))
+            Assert.That(schemaRegistry.GetProperty("Examples").GetString(), Is.EqualTo("ExistingBehavior"))
+
+            let examplesExit, examplesOutput = invoke root repositoryRoot [| "cache"; "status"; "--examples" |]
+            Assert.That(examplesExit, Is.EqualTo(0))
+
+            use examplesDocument = JsonDocument.Parse(examplesOutput)
+            let examplesRegistry = examplesDocument.RootElement.GetProperty("Registry")
+
+            Assert.That(
+                examplesRegistry
+                    .GetProperty("JsonMode")
+                    .GetString(),
+                Is.EqualTo("ExistingBehavior")
+            )
+
+            Assert.That(
+                examplesDocument
+                    .RootElement
+                    .GetProperty("Examples")
+                    .GetArrayLength(),
+                Is.GreaterThanOrEqualTo(3)
+            ))

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -238,16 +238,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 206
+        |> should equal 207
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 197
+        |> should equal 198
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 185
+        |> should equal 186
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -289,7 +289,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 185
+        jsonReady |> should equal 186
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -466,12 +466,13 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 185
+        commonEntries.Length |> should equal 186
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
             | ExistingGraceResultEnvelope (ReuseExistingApiOrSdkDto
-            | RequiresCliDto) -> ()
+            | RequiresCliDto
+            | NoServerDto) -> ()
             | other -> Assert.Fail($"Expected existing Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
 
             entry.Features.Select
@@ -484,7 +485,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 185
+        commonEntries.Length |> should equal 186
 
         let parserInvalidEntries =
             commonEntries
@@ -515,7 +516,8 @@ module CommandOutputContractRegistryTests =
 
             match entry.EnvelopeContract with
             | ExistingGraceResultEnvelope (ReuseExistingApiOrSdkDto
-            | RequiresCliDto) -> ()
+            | RequiresCliDto
+            | NoServerDto) -> ()
             | other -> Assert.Fail($"Expected central Grace result envelope metadata for {entry.Identity.CommandId}, got {other}.")
 
             let successValue = GraceReturnValue.Create $"success:{entry.Identity.CommandId}" $"corr-success-{entry.Identity.CommandId}"

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -5,6 +5,7 @@ open Grace.CLI
 open Grace.CLI.CommandOutputContract
 open Grace.Shared
 open Grace.Types.Common
+open Json.Schema
 open NUnit.Framework
 open System
 open System.CommandLine
@@ -970,6 +971,80 @@ module CommandOutputContractRegistryTests =
                 examplesDocument.Examples[0].Name
                 |> should equal "metadata-incomplete"
             | None -> Assert.Fail($"{identity.CommandId} should have a registry entry.")
+
+    /// Evaluates the built Cache status ReturnValue schema with JsonSchema.Net.
+    let private evaluateCacheStatusSchema (value: string) =
+        let identity = CommandOutputContract.commandIdentity [ "cache" ] "status"
+
+        match CommandOutputContract.tryFind identity with
+        | Some entry ->
+            entry.Features.JsonMode
+            |> should equal ExistingBehavior
+
+            entry.Features.Schema
+            |> should equal ExistingBehavior
+
+            entry.Features.Examples
+            |> should equal ExistingBehavior
+
+            entry.Features.Select
+            |> should equal ExistingBehavior
+
+            let document = CommandOutputContract.introspectionDocument Schema entry
+
+            match document.Schema with
+            | Some schema ->
+                use successSchema = JsonDocument.Parse(Grace.Shared.Utilities.serialize schema.SuccessSchema)
+
+                let returnValueSchema =
+                    successSchema
+                        .RootElement
+                        .GetProperty("properties")
+                        .GetProperty("ReturnValue")
+                        .GetRawText()
+                    |> JsonSchema.FromText
+
+                use valueDocument = JsonDocument.Parse(value)
+
+                returnValueSchema
+                    .Evaluate(
+                        valueDocument.RootElement,
+                        EvaluationOptions()
+                    )
+                    .IsValid
+            | None ->
+                Assert.Fail("Cache status should publish a schema-ready output contract.")
+                false
+        | None ->
+            Assert.Fail("Cache status should have a registry entry.")
+            false
+
+    /// Verifies that real JsonSchema.Net evaluation accepts every production Cache status variant and rejects invalid projections.
+    [<Test>]
+    let ``cache status schema accepts closed production variants and rejects invalid projections`` () =
+        [
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"enrolled\",\"CacheId\":\"11111111-1111-1111-1111-111111111111\",\"Endpoint\":\"https://cache.example.test\",\"BoundaryKind\":\"Organization\",\"RepositoryCount\":1,\"Key\":\"available\"}",
+            true
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\"}", true
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"invalid\",\"Key\":\"inaccessible\"}", true
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\",\"Extra\":true}", false
+            "{\"Class\":\"Other\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"unknown\",\"Key\":\"missing\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"unknown\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"enrolled\",\"CacheId\":\"11111111-1111-1111-1111-111111111111\",\"Endpoint\":\"https://cache.example.test\",\"BoundaryKind\":\"Unknown\",\"RepositoryCount\":1,\"Key\":\"available\"}",
+            false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"invalid\",\"Key\":\"available\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"inaccessible\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\",\"CacheId\":\"11111111-1111-1111-1111-111111111111\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\",\"Endpoint\":\"https://cache.example.test\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\",\"BoundaryKind\":\"Organization\"}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"notEnrolled\",\"Key\":\"missing\",\"RepositoryCount\":1}", false
+            "{\"Class\":\"Grace.Cache.Status\",\"Enrollment\":\"enrolled\",\"CacheId\":\"11111111-1111-1111-1111-111111111111\",\"Endpoint\":\"https://cache.example.test\",\"BoundaryKind\":\"Organization\",\"Key\":\"available\"}",
+            false
+        ]
+        |> List.iter (fun (value, expectedValid) ->
+            evaluateCacheStatusSchema value
+            |> should equal expectedValid)
 
     /// Verifies that examples for schema ready commands parse as grace envelopes.
     [<Test>]

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -20,6 +20,8 @@
     <Compile Include="AuthTokenBundle.Tests.fs" />
     <Compile Include="Branch.CLI.Parsing.Tests.fs" />
     <Compile Include="Branch.CLI.Tests.fs" />
+		<Compile Include="Cache.CLI.Parsing.Tests.fs" />
+		<Compile Include="Cache.CLI.Tests.fs" />
     <Compile Include="Connect.CLI.Parsing.Tests.fs" />
     <Compile Include="Connect.CLI.Tests.fs" />
     <Compile Include="BuildInfo.Tests.fs" />
@@ -56,6 +58,7 @@
 		<PackageReference Include="FsCheck" Version="3.3.3" />
 		<PackageReference Include="FsCheck.NUnit" Version="3.3.3" />
 		<PackageReference Include="FsUnit" Version="7.1.1" />
+		<PackageReference Include="JsonSchema.Net" Version="9.4.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="NUnit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
@@ -73,6 +76,7 @@
 		<ProjectReference Include="..\Grace.CLI\Grace.CLI.fsproj" />
 		<ProjectReference Include="..\Grace.CLI.LocalStateDb.Worker\Grace.CLI.LocalStateDb.Worker.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
+		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 	</ItemGroup>
 

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -2287,6 +2287,16 @@ module RootHelpGroupingTests =
 
             administration |> should contain "authorize"
 
+            let otherStart = output.IndexOf("Other:", StringComparison.Ordinal)
+
+            let localUtilities =
+                if otherStart >= 0 then
+                    sliceBetween output "Local utilities:" "Other:"
+                else
+                    output.Substring(output.IndexOf("Local utilities:", StringComparison.Ordinal))
+
+            localUtilities |> should contain "cache"
+
             administration
             |> should not' (contain $"{Environment.NewLine}    access "))
 

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -2297,6 +2297,10 @@ module RootHelpGroupingTests =
 
             localUtilities |> should contain "cache"
 
+            if otherStart >= 0 then
+                output.Substring(otherStart)
+                |> should not' (contain "cache")
+
             administration
             |> should not' (contain $"{Environment.NewLine}    access "))
 

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -1,0 +1,103 @@
+namespace Grace.CLI.Command
+
+open Grace.Cache
+open Grace.CLI.Common
+open Grace.Shared
+open Grace.Types.Common
+open Spectre.Console
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.CommandLine.Parsing
+open System.Text.Json.Nodes
+open System.Threading
+open System.Threading.Tasks
+
+/// Groups the repository-independent, read-only Grace Cache status command.
+module CacheCommand =
+
+    /// Holds the protected state root with a test-only override for isolated root-command proof.
+    let mutable private stateRoot = CacheIdentity.StateRoot
+
+    /// Redirects the inspected protected state root for serialized CLI tests.
+    let internal setStateRootForTests root = stateRoot <- root
+
+    /// Restores the fixed Product V1 protected state root after a serialized CLI test.
+    let internal resetStateRootForTests () = stateRoot <- CacheIdentity.StateRoot
+
+    /// Builds the JSON value that excludes ready-only facts from non-ready status documents.
+    let private statusValue (status: CacheIdentityStatus) =
+        let value = JsonObject()
+        value["Class"] <- JsonValue.Create(status.Class)
+        value["Enrollment"] <- JsonValue.Create(status.Enrollment)
+        value["Key"] <- JsonValue.Create(status.Key)
+
+        status.CacheId
+        |> Option.iter (fun cacheId -> value["CacheId"] <- JsonValue.Create(cacheId))
+
+        status.Endpoint
+        |> Option.iter (fun endpoint -> value["Endpoint"] <- JsonValue.Create(endpoint))
+
+        status.BoundaryKind
+        |> Option.iter (fun boundaryKind -> value["BoundaryKind"] <- JsonValue.Create(boundaryKind))
+
+        status.RepositoryCount
+        |> Option.iter (fun repositoryCount -> value["RepositoryCount"] <- JsonValue.Create(repositoryCount))
+
+        value
+
+    /// Writes approved human status facts before the shared renderer supplies verbose metadata.
+    let private renderHumanStatus (status: CacheIdentityStatus) =
+        let escape = Markup.Escape
+        AnsiConsole.MarkupLine($"Class: {escape status.Class}")
+        AnsiConsole.MarkupLine($"Enrollment: {escape status.Enrollment}")
+        AnsiConsole.MarkupLine($"Key: {escape status.Key}")
+
+        status.CacheId
+        |> Option.iter (fun cacheId -> AnsiConsole.MarkupLine($"CacheId: {cacheId:D}"))
+
+        status.Endpoint
+        |> Option.iter (fun endpoint -> AnsiConsole.MarkupLine($"Endpoint: {escape endpoint}"))
+
+        status.BoundaryKind
+        |> Option.iter (fun boundaryKind -> AnsiConsole.MarkupLine($"BoundaryKind: {escape boundaryKind}"))
+
+        status.RepositoryCount
+        |> Option.iter (fun repositoryCount -> AnsiConsole.MarkupLine($"RepositoryCount: {repositoryCount}"))
+
+    /// Reads only protected local identity state and lets the shared renderer determine output and selector failures before the domain exit.
+    let private statusHandler (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            cancellationToken.ThrowIfCancellationRequested()
+            let status = CacheIdentity.status stateRoot
+
+            if
+                not (hasSelect parseResult)
+                && parseResult |> hasOutput
+            then
+                renderHumanStatus status
+
+            let renderExitCode =
+                GraceReturnValue.Create (statusValue status) (getCorrelationId parseResult)
+                |> Ok
+                |> renderOutput parseResult
+
+            return
+                if renderExitCode <> 0 then renderExitCode
+                elif status.Enrollment = "enrolled" then 0
+                else 1
+        }
+
+    /// Invokes the pure local Cache status command through System.CommandLine.
+    type Status() =
+        inherit AsynchronousCommandLineAction()
+
+        /// Executes the status projection without accessing repository or SDK state.
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> = statusHandler parseResult cancellationToken
+
+    /// Builds the repository-independent Cache command group.
+    let Build =
+        let cache = Command("cache", "Inspect a local Grace Cache identity.")
+        let status = Command("status", "Report redacted local Grace Cache enrollment status.")
+        status.Action <- Status()
+        cache.Subcommands.Add(status)
+        cache

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -166,6 +166,12 @@ module CommandOutputContract =
         schema["properties"] <- Dictionary<string, obj>(properties |> Seq.map KeyValuePair)
         box schema
 
+    /// Constructs a closed JSON object schema that rejects undeclared command-output properties.
+    let private closedSchemaObject title properties required =
+        let schema = schemaObject title properties required :?> Dictionary<string, obj>
+        schema["additionalProperties"] <- false
+        box schema
+
     /// Constructs a JSON schema for scalar command-output fields such as strings, booleans, or numbers.
     let private scalarSchema (typeName: string) =
         let schema = Dictionary<string, obj>(StringComparer.Ordinal)
@@ -244,6 +250,101 @@ module CommandOutputContract =
     let private unsupportedReturnValueExample reason = box {| Status = "metadata-incomplete"; Reason = reason |}
 
     let private stringReturnValueSchema = scalarSchema "string"
+
+    /// Constructs a string schema restricted to one value for conditional command-output variants.
+    let private constantStringSchema value description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "string"
+        schema["const"] <- value
+        schema["description"] <- description
+        box schema
+
+    /// Constructs a string schema restricted to the values emitted by one command-output field.
+    let private enumStringSchema values description =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["type"] <- "string"
+        schema["enum"] <- values
+        schema["description"] <- description
+        box schema
+
+    /// Combines mutually exclusive command-output object variants under one named schema.
+    let private oneOfSchema title (variants: obj array) =
+        let schema = Dictionary<string, obj>(StringComparer.Ordinal)
+        schema["$schema"] <- "https://json-schema.org/draft/2020-12/schema"
+        schema["title"] <- title
+        schema["oneOf"] <- variants
+        box schema
+
+    /// Defines the ready Cache status shape, including the facts that are safe only after protected identity validation.
+    let private cacheStatusReadySchema =
+        closedSchemaObject
+            "CacheStatusReadyDto"
+            [
+                "Class", constantStringSchema "Grace.Cache.Status" "Redacted local Cache status projection."
+                "Enrollment", constantStringSchema "enrolled" "Protected ready state is valid."
+                "CacheId", scalarSchema "string"
+                "Endpoint", scalarSchema "string"
+                "BoundaryKind", enumStringSchema [| "Owner"; "Organization" |] "Accepted Cache enrollment boundary."
+                "RepositoryCount", scalarSchema "integer"
+                "Key", constantStringSchema "available" "The ready identity key is available."
+            ]
+            [|
+                "Class"
+                "Enrollment"
+                "CacheId"
+                "Endpoint"
+                "BoundaryKind"
+                "RepositoryCount"
+                "Key"
+            |]
+
+    /// Defines the non-enrolled Cache status shape, which excludes every ready-only identity fact.
+    let private cacheStatusNotEnrolledSchema =
+        closedSchemaObject
+            "CacheStatusNotEnrolledDto"
+            [
+                "Class", constantStringSchema "Grace.Cache.Status" "Redacted local Cache status projection."
+                "Enrollment", constantStringSchema "notEnrolled" "No valid protected ready identity exists."
+                "Key", enumStringSchema [| "missing"; "available" |] "The missing root or staged attempt key state."
+            ]
+            [| "Class"; "Enrollment"; "Key" |]
+
+    /// Defines the invalid Cache status shape, which excludes every ready-only identity fact.
+    let private cacheStatusInvalidSchema =
+        closedSchemaObject
+            "CacheStatusInvalidDto"
+            [
+                "Class", constantStringSchema "Grace.Cache.Status" "Redacted local Cache status projection."
+                "Enrollment", constantStringSchema "invalid" "The protected root cannot supply a valid ready identity."
+                "Key", enumStringSchema [| "invalid"; "inaccessible" |] "The invalid or inaccessible key state."
+            ]
+            [| "Class"; "Enrollment"; "Key" |]
+
+    /// Defines every Cache status output variant that the production local inspection can emit.
+    let private cacheStatusSchema =
+        oneOfSchema
+            "CacheStatusDto"
+            [|
+                cacheStatusReadySchema
+                cacheStatusNotEnrolledSchema
+                cacheStatusInvalidSchema
+            |]
+
+    /// Provides the representative enrolled Cache status output used by inert command examples.
+    let private cacheStatusExample =
+        box
+            {|
+                Class = "Grace.Cache.Status"
+                Enrollment = "enrolled"
+                CacheId = "11111111-1111-1111-1111-111111111111"
+                Endpoint = "https://cache.example.test"
+                BoundaryKind = "Organization"
+                RepositoryCount = 2
+                Key = "available"
+            |}
+
+    /// Provides the representative missing Cache status output used by inert command examples.
+    let private cacheStatusNotEnrolledExample = box {| Class = "Grace.Cache.Status"; Enrollment = "notEnrolled"; Key = "missing" |}
 
     let private maintenanceStatsSchema =
         schemaObject
@@ -604,6 +705,16 @@ module CommandOutputContract =
     /// Builds command-output contract metadata for return value contract for so automation can rely on stable JSON shapes.
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
+        | "cache.status", ExistingGraceResultEnvelope NoServerDto ->
+            supportedReturnValueContract
+                "CacheStatusDto"
+                "Grace.CLI.Command.CacheCommand"
+                cacheStatusSchema
+                cacheStatusExample
+                [
+                    "The command reads local protected identity state without a repository, server request, credential lookup, or mutation."
+                    "CacheId, Endpoint, BoundaryKind, and RepositoryCount are present only when Enrollment is enrolled."
+                ]
         | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
             supportedReturnValueContract
                 "MaintenanceIgnoreEntriesDto"
@@ -790,6 +901,21 @@ module CommandOutputContract =
                     |}
         }
 
+    /// Builds the representative non-enrolled Cache status success envelope alongside the ready success example.
+    let private cacheStatusNotEnrolledSuccessExample (entry: CommandContractEntry) =
+        {
+            Name = "not-enrolled-envelope-shape"
+            Description = "Representative non-enrolled GraceReturnValue<CacheStatusDto> envelope shape from registry metadata."
+            Document =
+                box
+                    {|
+                        ReturnValue = cacheStatusNotEnrolledExample
+                        EventTime = "2026-06-05T00:00:00Z"
+                        CorrelationId = "correlation-id"
+                        Properties = cliProperties entry.Identity.CommandId entry.ReturnValueContract.Provenance
+                    |}
+        }
+
     /// Builds command-output contract metadata for incomplete metadata example so automation can rely on stable JSON shapes.
     let private incompleteMetadataExample (entry: CommandContractEntry) =
         {
@@ -849,6 +975,8 @@ module CommandOutputContract =
                     | SchemaReady ->
                         [
                             successExample entry
+                            if entry.Identity.CommandId = "cache.status" then
+                                cacheStatusNotEnrolledSuccessExample entry
                             errorExample entry
                         ]
                     | MetadataIncomplete
@@ -926,7 +1054,10 @@ module CommandOutputContract =
             Mutating = mutating
             EnvelopeContract = envelopeContract
             Features =
-                if identity.CommandId.Equals("doctor", StringComparison.Ordinal) then
+                if
+                    identity.CommandId.Equals("doctor", StringComparison.Ordinal)
+                    || identity.CommandId.Equals("cache.status", StringComparison.Ordinal)
+                then
                     { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
                 else
                     featuresFor behavior
@@ -1055,6 +1186,7 @@ module CommandOutputContract =
             row [ "branch" ] "switch" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "branch" ] "tag" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "update-parent-branch" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "cache" ] "status" true false common_renderOutput_envelope read_list_search local_client NoServerDto
             row [ "candidate" ] "attestations" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate" ] "cancel" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate"; "gate" ] "rerun" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -42,6 +42,7 @@
 		<Compile Include="Command\Watch.CLI.fs" />
 		<Compile Include="Command\Maintenance.CLI.fs" />
 		<Compile Include="Command\Doctor.CLI.fs" />
+		<Compile Include="Command\Cache.CLI.fs" />
                 
                 <Compile Include="Command\WorkItem.CLI.fs" />
                 <Compile Include="Command\Review.CLI.fs" />
@@ -90,6 +91,7 @@
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 		<ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
+		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
 	</ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.301" />

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -551,6 +551,7 @@ module GraceCommand =
                         "history"
                         "maintenance"
                         "alias"
+                        "cache"
                     ]
             }
         ]
@@ -881,6 +882,7 @@ module GraceCommand =
         rootCommand.Subcommands.Add(Auth.Build)
         rootCommand.Subcommands.Add(Maintenance.Build)
         rootCommand.Subcommands.Add(Doctor.Build)
+        rootCommand.Subcommands.Add(CacheCommand.Build)
         rootCommand.Subcommands.Add(WorkItemCommand.Build)
         rootCommand.Subcommands.Add(ReviewCommand.Build)
         rootCommand.Subcommands.Add(CandidateCommand.Build)
@@ -1016,6 +1018,19 @@ module GraceCommand =
             if parseResult.CommandResult.Parent.GetValue("config") then true else false
         else
             false
+
+    /// Checks whether the parsed command is the pure local Cache status leaf.
+    let isGraceCacheStatus (parseResult: ParseResult) =
+        if isNull parseResult then
+            false
+        else
+            let commands =
+                Seq.append [ parseResult.CommandResult.Command ] (parseResult.CommandResult.Command.Parents.OfType<Command>())
+                |> Seq.map (fun command -> command.Name)
+                |> Set.ofSeq
+
+            Set.contains "cache" commands
+            && Set.contains "status" commands
 
     /// Models feedback section values passed between the parser and program handlers.
     type FeedbackSection(action: HelpAction) =
@@ -1156,17 +1171,18 @@ module GraceCommand =
 
             try
                 try
-                    Auth.configureSdkAuth ()
-                    Services.configureSdkClientIdentity ()
-                    Services.resetInvocationCorrelationId ()
-                    Common.resetLifecycleWarningSuppression ()
-
                     //let commandLineConfiguration = ParserConfiguration rootCommand
 
                     let argvToParse = if args.Length = 0 then [| helpOptions[0] |] else argvNormalized
 
                     parseResult <- rootCommand.Parse(argvToParse)
                     parseSucceeded <- parseResult.Errors.Count = 0
+
+                    if not (parseResult |> isGraceCacheStatus) then
+                        Auth.configureSdkAuth ()
+                        Services.configureSdkClientIdentity ()
+                        Services.resetInvocationCorrelationId ()
+                        Common.resetLifecycleWarningSuppression ()
 
                     match introspectionRequestFromTokens argvToParse with
                     | Some (Ok kind) ->
@@ -1202,7 +1218,10 @@ module GraceCommand =
                                 raise (IntrospectionExit returnValue)
                             | None -> ()
 
-                        if not (parseResult |> isGraceDoctor) then
+                        if
+                            not (parseResult |> isGraceDoctor)
+                            && not (parseResult |> isGraceCacheStatus)
+                        then
                             LocalStateDb.setVerbose (parseResult |> verbose)
 
                     let helpAction =
@@ -1373,6 +1392,9 @@ module GraceCommand =
 
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
+                    else if parseResult |> isGraceCacheStatus then
+                        let! invokedReturnValue = parseResult.InvokeAsync()
+                        returnValue <- invokedReturnValue
                     else if parseResult |> isGraceDoctor then
                         let invokedReturnValue = parseResult.Invoke()
                         returnValue <- invokedReturnValue
@@ -1526,6 +1548,7 @@ module GraceCommand =
                 if
                     not isIntrospection
                     && not (parseResult |> isGraceDoctor)
+                    && not (parseResult |> isGraceCacheStatus)
                 then
                     HistoryStorage.tryRecordInvocation
                         {

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -63,8 +63,24 @@ type internal CacheIdentityError =
     | UnsupportedPlatform
     | StateUnavailable
 
+/// Represents the redacted local identity facts that the repository-independent CLI status command may publish.
+type internal CacheIdentityStatus =
+    {
+        Class: string
+        Enrollment: string
+        CacheId: Guid option
+        Endpoint: string option
+        BoundaryKind: string option
+        RepositoryCount: int option
+        Key: string
+    }
+
 /// Owns Linux-only protected static-key staging, ready publication, and opaque local inspection.
 module internal CacheIdentity =
+
+    /// Identifies the fixed Linux system-service root inspected by repository-independent Cache status.
+    [<Literal>]
+    let StateRoot = "/var/lib/grace-cache"
 
     [<Literal>]
     let private AttemptDirectoryName = "attempt"
@@ -680,6 +696,14 @@ module internal CacheIdentity =
                 with
                 | _ -> Error CacheIdentityError.StateUnavailable
 
+    /// Keeps the private parsed ready registration with its opaque inspection classification for one read-only inspection.
+    type private CacheIdentityInspectionDetail =
+        | Missing
+        | AttemptPresent
+        | Ready of CacheReadyRegistration
+        | Invalid
+        | Inaccessible
+
     /// Reads one ready configuration without emitting raw paths, filesystem errors, keys, or fingerprints.
     let private inspectReady ready =
         let identityPath = child ready IdentityFileName
@@ -688,10 +712,10 @@ module internal CacheIdentity =
         match inspectMode ready directoryMode, inspectMode identityPath fileMode, inspectMode registrationPath fileMode with
         | Error CacheIdentityInspection.Inaccessible, _, _
         | _, Error CacheIdentityInspection.Inaccessible, _
-        | _, _, Error CacheIdentityInspection.Inaccessible -> CacheIdentityInspection.Inaccessible
+        | _, _, Error CacheIdentityInspection.Inaccessible -> CacheIdentityInspectionDetail.Inaccessible
         | Error _, _, _
         | _, Error _, _
-        | _, _, Error _ -> CacheIdentityInspection.Invalid
+        | _, _, Error _ -> CacheIdentityInspectionDetail.Invalid
         | Ok (), Ok (), Ok () ->
             try
                 match tryParseReadyRegistration (File.ReadAllBytes(registrationPath)) with
@@ -703,41 +727,77 @@ module internal CacheIdentity =
                             fingerprint x y = expectedFingerprint
                             && String.Equals(registration.PublicKeyFingerprint, expectedFingerprint, StringComparison.Ordinal)
                             ->
-                            CacheIdentityInspection.Ready
-                        | _ -> CacheIdentityInspection.Invalid
-                    | None -> CacheIdentityInspection.Invalid
-                | None -> CacheIdentityInspection.Invalid
+                            CacheIdentityInspectionDetail.Ready registration
+                        | _ -> CacheIdentityInspectionDetail.Invalid
+                    | None -> CacheIdentityInspectionDetail.Invalid
+                | None -> CacheIdentityInspectionDetail.Invalid
             with
-            | :? UnauthorizedAccessException -> CacheIdentityInspection.Inaccessible
-            | :? IOException -> CacheIdentityInspection.Inaccessible
-            | _ -> CacheIdentityInspection.Invalid
+            | :? UnauthorizedAccessException -> CacheIdentityInspectionDetail.Inaccessible
+            | :? IOException -> CacheIdentityInspectionDetail.Inaccessible
+            | _ -> CacheIdentityInspectionDetail.Invalid
 
-    /// Inspects fixed local identity markers without mutating, repairing, deleting, or exposing protected state details.
-    let inspect root =
+    /// Reads fixed local identity markers once without mutation while retaining parsed ready facts inside this module.
+    let private inspectDetail root =
         if not (OperatingSystem.IsLinux()) then
             Error CacheIdentityError.UnsupportedPlatform
         else
             match probeDirectory root with
-            | Error CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspection.Inaccessible
-            | Error _ -> Ok CacheIdentityInspection.Invalid
-            | Ok false -> Ok CacheIdentityInspection.Missing
+            | Error CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspectionDetail.Inaccessible
+            | Error _ -> Ok CacheIdentityInspectionDetail.Invalid
+            | Ok false -> Ok CacheIdentityInspectionDetail.Missing
             | Ok true ->
                 match inspectMode root directoryMode with
-                | Error CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspection.Inaccessible
-                | Error _ -> Ok CacheIdentityInspection.Invalid
+                | Error CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspectionDetail.Inaccessible
+                | Error _ -> Ok CacheIdentityInspectionDetail.Invalid
                 | Ok () ->
                     let attempt = child root AttemptDirectoryName
                     let ready = child root ReadyDirectoryName
 
                     match probeDirectory attempt, probeDirectory ready with
                     | Error CacheIdentityInspection.Inaccessible, _
-                    | _, Error CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspection.Inaccessible
+                    | _, Error CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspectionDetail.Inaccessible
                     | Error _, _
-                    | _, Error _ -> Ok CacheIdentityInspection.Invalid
-                    | Ok false, Ok false -> Ok CacheIdentityInspection.Missing
-                    | Ok true, Ok true -> Ok CacheIdentityInspection.Invalid
-                    | Ok true, Ok false -> Ok(inspectAttempt attempt)
+                    | _, Error _ -> Ok CacheIdentityInspectionDetail.Invalid
+                    | Ok false, Ok false -> Ok CacheIdentityInspectionDetail.Missing
+                    | Ok true, Ok true -> Ok CacheIdentityInspectionDetail.Invalid
+                    | Ok true, Ok false ->
+                        match inspectAttempt attempt with
+                        | CacheIdentityInspection.AttemptPresent -> Ok CacheIdentityInspectionDetail.AttemptPresent
+                        | CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspectionDetail.Inaccessible
+                        | _ -> Ok CacheIdentityInspectionDetail.Invalid
                     | Ok false, Ok true -> Ok(inspectReady ready)
+
+    /// Inspects protected state without exposing parsed registration facts to Cache runtime callers.
+    let inspect root =
+        inspectDetail root
+        |> Result.map (function
+            | CacheIdentityInspectionDetail.Missing -> CacheIdentityInspection.Missing
+            | CacheIdentityInspectionDetail.AttemptPresent -> CacheIdentityInspection.AttemptPresent
+            | CacheIdentityInspectionDetail.Ready _ -> CacheIdentityInspection.Ready
+            | CacheIdentityInspectionDetail.Invalid -> CacheIdentityInspection.Invalid
+            | CacheIdentityInspectionDetail.Inaccessible -> CacheIdentityInspection.Inaccessible)
+
+    /// Projects one read-only identity inspection into the approved redacted Cache status facts.
+    let status root =
+        let nonReady enrollment key =
+            { Class = "Grace.Cache.Status"; Enrollment = enrollment; CacheId = None; Endpoint = None; BoundaryKind = None; RepositoryCount = None; Key = key }
+
+        match inspectDetail root with
+        | Ok CacheIdentityInspectionDetail.Missing -> nonReady "notEnrolled" "missing"
+        | Ok CacheIdentityInspectionDetail.AttemptPresent -> nonReady "notEnrolled" "available"
+        | Ok (CacheIdentityInspectionDetail.Ready registration) ->
+            {
+                Class = "Grace.Cache.Status"
+                Enrollment = "enrolled"
+                CacheId = Some registration.CacheId
+                Endpoint = Some registration.Endpoint
+                BoundaryKind = Some registration.BoundaryKind
+                RepositoryCount = Some registration.RepositoryScopes.Length
+                Key = "available"
+            }
+        | Ok CacheIdentityInspectionDetail.Invalid -> nonReady "invalid" "invalid"
+        | Ok CacheIdentityInspectionDetail.Inaccessible
+        | Error _ -> nonReady "invalid" "inaccessible"
 
     /// Best-effort cleanup for a failed caller operation; it intentionally has no cancellation token or failure result.
     let discardAttempt root =

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -20,6 +20,12 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Grace.Cache.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>grace</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Grace.CLI.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Add pure local Grace Cache status

## Purpose

Implements #914 for Product V1 by adding repository-independent, network-free `grace cache status` over the protected
static cache identity. The command reports only redacted facts and uses the existing CLI renderer and selector behavior.

## Current Revision

Worker 1 delivered the initial implementation and Windows focused proof. The current head is intentionally undergoing a
completion census before another worker: required Linux UID `10001` five-state proof, MarkdownLint, and the complete
schema rejection matrix are not yet recorded as complete.

## Implemented Surface

- internal redacted cache identity status projection;
- early cache-status dispatch before SDK, repository, LocalState DB, and history setup;
- shared Normal, Minimal, Silent, Verbose, JSON, and selector rendering;
- schema, examples, command inventory, and root-help grouping;
- focused parsing, root-dispatch, status, and output-contract tests.

## Current-Head Evidence

- RED root-help proof failed before the command existed and now passes.
- Cache and CLI Release builds passed.
- Windows CacheIdentity: 1 passed, 8 Linux-only skips.
- Windows CLI/output-contract/root-help: 27 passed, 1 Linux-only skip.
- Targeted Fantomas and `git diff --check` passed.

## Remaining Before Merge

- Linux UID `10001` root-dispatch matrix for all five filesystem states and required mode/selector cases;
- MarkdownLint for the changed machine-readable output document;
- complete schema adversarial acceptance/rejection proof;
- fresh exact-head Product V1 review and GitHub Validate for the final head.

Relates to #914.
