### PR TITLE
B4.3R2a1: Persist billing-close records with exact physical-schema proof

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="OperationsUsagePartitioningSql.fs" />
     <Compile Include="OperationsEntities.fs" />
     <Compile Include="OperationsChargePreview.fs" />
+    <Compile Include="OperationsBillingPeriodModel.fs" />
     <Compile Include="OperationsDbContext.fs" />
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
     <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
@@ -29,6 +30,7 @@
     <Compile Include="Migrations\20260711090000_AddChargePreviewLines.fs" />
     <Compile Include="Migrations\20260812090000_AddBillingCompletenessCoordination.fs" />
     <Compile Include="Migrations\20260812110000_AddUsageFactJournal.fs" />
+    <Compile Include="Migrations\20260812130000_AddBillingPeriodClose.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
     <Compile Include="OperationsUsageJournal.fs" />

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -9,11 +9,26 @@ schema is intentionally narrow:
 - `ops.ChargePreviewLine` stores deterministic provisional owner charge lines rebuilt from compact immutable usage
   facts and complete effective pricing. A rebuild atomically replaces one owner/repository/half-open-period scope;
   these rows are neither invoices nor immutable ledger entries.
+- `ops.BillingPeriod` stores one deterministic owner, organization, repository, and half-open UTC month. Its storage
+  state permits `Open`, `Provisional`, and the future close transition's `Closed` value, but this migration does not
+  perform that transition.
+- `ops.Charge` stores one immutable initial posting for a billing period and preview line. The physical trigger rejects
+  update and delete; the migration contains no pricing calculation.
+- `ops.BillingPeriodCloseEvidence` stores immutable accepted-fact and pricing-preview digests, close time, and
+  nonempty scheduled-operation provenance. The physical trigger rejects update and delete.
 - The EF migrations history table lives in `ops.__EFMigrationsHistory` so operations schema state stays with the
   operations schema.
 
 The ingestion hot path still uses reviewed raw SQL for the durable insert and aggregate update. That path preserves the
 `UsageFactId` idempotency lock and the aggregate `MERGE ... WITH (HOLDLOCK)` behavior that the worker depends on.
+
+## Billing-close schema
+
+Migration `20260812130000_AddBillingPeriodClose` is deliberately self-contained: it emits literal SQL for only the
+three billing-close tables, their named checks, indexes, foreign keys, defaults, and immutable triggers. The runtime EF
+model, migration target, and snapshot each declare the close fragment independently so later runtime edits cannot make
+the migration or snapshot appear to agree by sharing a helper. Close execution, late-work storage, and public behavior
+remain outside this migration.
 
 ## Usage-Fact Journal
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
@@ -11,25 +11,933 @@ open System
 [<RequireQualifiedAccess>]
 module BillingPeriodCloseFrozenTarget =
 
-    /// Applies the migration target independently of the mutable runtime model.
-    let apply (modelBuilder: ModelBuilder) =
-        // The new Charge foreign key references this pre-existing table, so its target metadata must retain the
-        // reviewed physical principal key instead of letting EF synthesize a shadow temporary key.
-        let previewLine = modelBuilder.Entity<ChargePreviewLineEntity>()
-
-        previewLine.ToTable("ChargePreviewLine", "ops")
+    /// Rebuilds the complete pre-close Operations model with migration-local literals.
+    let applyPriorModel (modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
-        previewLine
+        // Deliberately keep this snapshot frozen with literals so future runtime model edits
+        // cannot change the latest reviewed migration point before a new migration updates it.
+        modelBuilder.HasDefaultSchema("ops") |> ignore
+
+        let rawFact = modelBuilder.Entity<RawUsageFactEntity>()
+
+        rawFact.ToTable("RawUsageFact", "ops") |> ignore
+
+        rawFact
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_RawUsageFact")
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        rawFact
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+        |> ignore
+
+        rawFact
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        rawFact.Property<int>("ArchiveState").IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveBlobName")
+            .HasMaxLength(512)
+        |> ignore
+
+        rawFact
+            .Property<string>("ArchiveChecksumSha256Hex")
+            .HasMaxLength(64)
+            .IsFixedLength()
+            .IsUnicode(false)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<int64>>("ArchiveByteLength")
+            .HasColumnType("bigint")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveVerifiedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchivedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("RehydrationExpiresAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<string>("LastArchiveFailureReason")
+            .HasMaxLength(400)
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("LastArchiveFailureAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<int>("ArchiveFailureCount")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .Property<System.Nullable<System.DateTime>>("ArchiveRetiredAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rawFact
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "ObservedAtUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ScopeKindObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex(
+                [|
+                    "ArchiveState"
+                    "ObservedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_RawUsageFact_ArchiveStateObservedAt")
+        |> ignore
+
+        rawFact
+            .HasIndex([| "RehydrationExpiresAtUtc" |])
+            .HasDatabaseName("IX_ops_RawUsageFact_RehydrationExpiresAtUtc")
+            .HasFilter("[RehydrationExpiresAtUtc] IS NOT NULL")
+        |> ignore
+
+        let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()
+
+        rejection.ToTable(
+            "UsageFactRejection",
+            "ops",
+            fun (table: TableBuilder<UsageFactRejectionEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_SuppliedGuids",
+                    "[RejectionId] <> '00000000-0000-0000-0000-000000000000' AND ([UsageFactId] IS NULL OR [UsageFactId] <> '00000000-0000-0000-0000-000000000000') AND ([OwnerId] IS NULL OR [OwnerId] <> '00000000-0000-0000-0000-000000000000') AND ([OrganizationId] IS NULL OR [OrganizationId] <> '00000000-0000-0000-0000-000000000000') AND ([RepositoryId] IS NULL OR [RepositoryId] <> '00000000-0000-0000-0000-000000000000')"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_CompleteScopeRequiresFact",
+                    "NOT ([OwnerId] IS NOT NULL AND [OrganizationId] IS NOT NULL AND [RepositoryId] IS NOT NULL AND [MonthStartUtc] IS NOT NULL) OR ([UsageFactId] IS NOT NULL AND [UsageFactId] <> '00000000-0000-0000-0000-000000000000')"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_MonthStartUtc",
+                    "[MonthStartUtc] IS NULL OR [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7)"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactRejection_Resolution",
+                    "([IsActive] = 1 AND [ResolvedAtUtc] IS NULL) OR ([IsActive] = 0 AND [ResolvedAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_UsageFactRejection_Reason", "LEN(LTRIM(RTRIM([Reason]))) > 0")
+                |> ignore
+        )
+        |> ignore
+
+        rejection
+            .HasKey([| "RejectionId" |])
+            .HasName("PK_ops_UsageFactRejection")
+        |> ignore
+
+        rejection
+            .Property<Guid>("RejectionId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "UsageFactId"
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            rejection
+                .Property<Nullable<Guid>>(name)
+                .HasColumnType("uniqueidentifier")
+            |> ignore
+
+        rejection
+            .Property<Nullable<DateTime>>("MonthStartUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rejection
+            .Property<string>("Reason")
+            .HasMaxLength(400)
+            .IsRequired()
+        |> ignore
+
+        rejection.Property<bool>("IsActive").IsRequired()
+        |> ignore
+
+        rejection
+            .Property<Nullable<DateTime>>("ResolvedAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        rejection
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        rejection
+            .HasIndex(
+                [|
+                    "UsageFactId"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_UsageFactRejection_ActiveScopedFact")
+            .IsUnique()
+            .HasFilter(
+                "[IsActive] = 1 AND [UsageFactId] IS NOT NULL AND [OwnerId] IS NOT NULL AND [OrganizationId] IS NOT NULL AND [RepositoryId] IS NOT NULL AND [MonthStartUtc] IS NOT NULL"
+            )
+        |> ignore
+
+        rejection
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "IsActive"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactRejection_ActiveScope")
+        |> ignore
+
+        let journal = modelBuilder.Entity<UsageFactJournalEntity>()
+
+        journal.ToTable(
+            "UsageFactJournal",
+            "ops",
+            fun (table: TableBuilder<UsageFactJournalEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_Identity",
+                    "[UsageFactId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([CorrelationId]))) > 0 AND LEN(LTRIM(RTRIM([StoragePoolId]))) > 0 AND DATALENGTH([RawPayload]) > 0"
+                )
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_UsageFactJournal_State",
+                    "([State] = 0 AND [TerminalAtUtc] IS NULL) OR ([State] IN (1, 2) AND [TerminalAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        journal
+            .HasKey([| "UsageFactId" |])
+            .HasName("PK_ops_UsageFactJournal")
+        |> ignore
+
+        journal
+            .Property<Guid>("UsageFactId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        journal
+            .Property<byte array>("RawPayload")
+            .HasColumnType("varbinary(max)")
+            .IsRequired()
+        |> ignore
+
+        journal
+            .Property<string>("CorrelationId")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            journal
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        journal
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        journal
+            .Property<DateTime>("ObservedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        journal.Property<int>("State").IsRequired()
+        |> ignore
+
+        journal
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        journal
+            .Property<Nullable<DateTime>>("TerminalAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        journal
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "ObservedAtUtc"
+                    "State"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactJournal_ScopeState")
+        |> ignore
+
+        journal
+            .HasIndex(
+                [|
+                    "State"
+                    "CreatedAtUtc"
+                    "UsageFactId"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageFactJournal_PendingDispatch")
+        |> ignore
+
+        let aggregate = modelBuilder.Entity<UsageAggregateMinuteEntity>()
+
+        aggregate.ToTable("UsageAggregateMinute", "ops")
+        |> ignore
+
+        aggregate
+            .HasKey(
+                [|
+                    "FactKind"
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "StoragePoolId"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasName("PK_ops_UsageAggregateMinute")
+        |> ignore
+
+        aggregate.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<string>("StoragePoolId")
+            .HasMaxLength(256)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("BucketStartUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        aggregate.Property<int64>("Quantity").IsRequired()
+        |> ignore
+
+        aggregate
+            .Property<System.DateTime>("UpdatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        aggregate
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "FactKind"
+                    "BucketStartUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_UsageAggregateMinute_ScopeKindBucket")
+        |> ignore
+
+        let pricingPlan = modelBuilder.Entity<PricingPlanEntity>()
+
+        pricingPlan.ToTable("PricingPlan", "ops")
+        |> ignore
+
+        pricingPlan
+            .HasKey([| "PricingPlanId" |])
+            .HasName("PK_ops_PricingPlan")
+        |> ignore
+
+        pricingPlan
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("PlanCode")
+            .HasMaxLength(128)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingPlan
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingPlan
+            .HasIndex([| "PlanCode"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_PricingPlan_CodeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        let mapping = modelBuilder.Entity<BillableUsageKindMappingEntity>()
+
+        mapping.ToTable("BillableUsageKindMapping", "ops")
+        |> ignore
+
+        mapping
+            .HasKey([| "BillableUsageKindMappingId" |])
+            .HasName("PK_ops_BillableUsageKindMapping")
+        |> ignore
+
+        mapping
+            .Property<System.Guid>("BillableUsageKindMappingId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        mapping.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        mapping
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<string>("DisplayName")
+            .HasMaxLength(200)
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        mapping
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        mapping
+            .HasIndex([| "FactKind"; "EffectiveFromUtc" |])
+            .HasDatabaseName("UX_ops_BillableUsageKindMapping_FactKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        mapping
+            .HasIndex(
+                [|
+                    "FactKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_BillableUsageKindMapping_FactKindEffective")
+        |> ignore
+
+        let pricingRate = modelBuilder.Entity<PricingRateEntity>()
+
+        pricingRate.ToTable("PricingRate", "ops")
+        |> ignore
+
+        pricingRate
+            .HasKey([| "PricingRateId" |])
+            .HasName("PK_ops_PricingRate")
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingRateId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        pricingRate
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitQuantity")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<int64>("UnitPriceMicros")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        pricingRate
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingRate_PlanUsageKindEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        pricingRate
+            .HasIndex(
+                [|
+                    "PricingPlanId"
+                    "BillableUsageKind"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingRate_PlanUsageKindEffective")
+        |> ignore
+
+        pricingRate
+            .HasOne(fun rate -> rate.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingRate_PricingPlan")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let assignment = modelBuilder.Entity<PricingAssignmentEntity>()
+
+        assignment.ToTable("PricingAssignment", "ops")
+        |> ignore
+
+        assignment
+            .HasKey([| "PricingAssignmentId" |])
+            .HasName("PK_ops_PricingAssignment")
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingAssignmentId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OwnerId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("OrganizationId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("RepositoryId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Guid>("PricingPlanId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("EffectiveFromUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .Property<System.Nullable<System.DateTime>>("EffectiveToUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        assignment
+            .Property<System.DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()")
+            .IsRequired()
+        |> ignore
+
+        assignment
+            .HasIndex([| "PricingPlanId" |])
+            .HasDatabaseName("IX_PricingAssignment_PricingPlanId")
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_PricingAssignment_ScopeEffectiveFrom")
+            .IsUnique()
+        |> ignore
+
+        assignment
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_PricingAssignment_ScopeEffective")
+        |> ignore
+
+        assignment
+            .HasOne(fun assignment -> assignment.PricingPlan)
+            .WithMany()
+            .HasForeignKey("PricingPlanId")
+            .HasConstraintName("FK_ops_PricingAssignment_PricingPlan")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let line = modelBuilder.Entity<ChargePreviewLineEntity>()
+
+        line.ToTable(
+            "ChargePreviewLine",
+            "ops",
+            fun (table: TableBuilder<ChargePreviewLineEntity>) ->
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_PeriodRange", "[PeriodFromUtc] < [PeriodToUtc]")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_EffectiveRange",
+                    "[PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc]"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_UnitQuantity", "[UnitQuantity] > 0")
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_ChargePreviewLine_Amounts", "[UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0 AND [ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_ChargePreviewLine_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        line
             .HasKey([| "ChargePreviewLineId" |])
             .HasName("PK_ops_ChargePreviewLine")
         |> ignore
 
-        previewLine
+        line
             .Property<Guid>("ChargePreviewLineId")
             .HasColumnType("uniqueidentifier")
             .ValueGeneratedNever()
         |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillableUsageKindMappingId"
+                "PricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            line
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            line
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        line.Property<int>("FactKind").IsRequired()
+        |> ignore
+
+        line
+            .Property<int>("BillableUsageKind")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        line
+            .Property<string>("UnitName")
+            .HasMaxLength(64)
+            .IsRequired()
+        |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            line.Property<int64>(name).IsRequired() |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                |]
+            )
+            .HasDatabaseName("IX_ops_ChargePreviewLine_Scope")
+        |> ignore
+
+        line
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "PeriodFromUtc"
+                    "PeriodToUtc"
+                    "FactKind"
+                    "BillableUsageKindMappingId"
+                    "BillableUsageKind"
+                    "PricingAssignmentId"
+                    "PricingPlanId"
+                    "PricingRateId"
+                    "CurrencyCode"
+                    "UnitName"
+                    "UnitQuantity"
+                    "UnitPriceMicros"
+                    "EffectiveFromUtc"
+                    "EffectiveToUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
+            .IsUnique()
+        |> ignore
+
+
+    /// Applies the three billing-close tables after the complete frozen prior model.
+    let apply (modelBuilder: ModelBuilder) =
 
         let period = modelBuilder.Entity<BillingPeriodEntity>()
 
@@ -352,4 +1260,5 @@ DROP TABLE ops.BillingPeriod;
         modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
         |> ignore
 
+        BillingPeriodCloseFrozenTarget.applyPriorModel modelBuilder
         BillingPeriodCloseFrozenTarget.apply modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
@@ -1046,6 +1046,21 @@ module BillingPeriodCloseFrozenTarget =
             "Charge",
             "ops",
             fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Identity",
+                    "[ChargeId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND [BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [ChargePreviewLineId] <> '00000000-0000-0000-0000-000000000000'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_Charge_Quantity", "[UnitQuantity] > 0 AND [UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Provenance",
+                    "[PeriodFromUtc] < [PeriodToUtc] AND [PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc] AND [FactKind] >= 0 AND [BillableUsageKind] >= 0 AND [BillableUsageKindMappingId] <> '00000000-0000-0000-0000-000000000000' AND [PricingAssignmentId] <> '00000000-0000-0000-0000-000000000000' AND [PricingPlanId] <> '00000000-0000-0000-0000-000000000000' AND [PricingRateId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([UnitName]))) > 0"
+                )
+                |> ignore
+
                 table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
                 |> ignore
 
@@ -1071,15 +1086,46 @@ module BillingPeriodCloseFrozenTarget =
             .ValueGeneratedNever()
         |> ignore
 
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillingPeriodId"
+                "ChargePreviewLineId"
+                "BillableUsageKindMappingId"
+                "PricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            charge
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            charge
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
         charge
-            .Property<Guid>("BillingPeriodId")
-            .HasColumnType("uniqueidentifier")
+            .Property<int>("FactKind")
+            .HasColumnType("int")
             .IsRequired()
         |> ignore
 
         charge
-            .Property<Guid>("ChargePreviewLineId")
-            .HasColumnType("uniqueidentifier")
+            .Property<int>("BillableUsageKind")
+            .HasColumnType("int")
             .IsRequired()
         |> ignore
 
@@ -1093,10 +1139,25 @@ module BillingPeriodCloseFrozenTarget =
         |> ignore
 
         charge
-            .Property<int64>("ChargeMicros")
-            .HasColumnType("bigint")
+            .Property<string>("UnitName")
+            .HasColumnType("nvarchar(64)")
+            .HasMaxLength(64)
+            .IsUnicode(true)
             .IsRequired()
         |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            charge
+                .Property<int64>(name)
+                .HasColumnType("bigint")
+                .IsRequired()
+            |> ignore
 
         charge
             .Property<DateTime>("CreatedAtUtc")
@@ -1220,7 +1281,7 @@ type AddBillingPeriodClose() =
             """
 CREATE TABLE ops.BillingPeriod (BillingPeriodId uniqueidentifier NOT NULL, OwnerId uniqueidentifier NOT NULL, OrganizationId uniqueidentifier NOT NULL, RepositoryId uniqueidentifier NOT NULL, MonthStartUtc datetime2(7) NOT NULL, NextMonthStartUtc datetime2(7) NOT NULL, State int NOT NULL, RetryDiagnostic nvarchar(400) NULL, RetryDiagnosticAtUtc datetime2(7) NULL, CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriod_CreatedAtUtc DEFAULT (SYSUTCDATETIME()), UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriod_UpdatedAtUtc DEFAULT (SYSUTCDATETIME()), CONSTRAINT PK_ops_BillingPeriod PRIMARY KEY (BillingPeriodId), CONSTRAINT CK_ops_BillingPeriod_MonthRange CHECK ([MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])), CONSTRAINT CK_ops_BillingPeriod_State CHECK ([State] IN (0, 1, 2)), CONSTRAINT CK_ops_BillingPeriod_Diagnostic CHECK (([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)));
 CREATE UNIQUE INDEX UX_ops_BillingPeriod_ExactScope ON ops.BillingPeriod(OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc);
-CREATE TABLE ops.Charge (ChargeId uniqueidentifier NOT NULL, BillingPeriodId uniqueidentifier NOT NULL, ChargePreviewLineId uniqueidentifier NOT NULL, CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL, ChargeMicros bigint NOT NULL, CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_Charge_CreatedAtUtc DEFAULT (SYSUTCDATETIME()), CONSTRAINT PK_ops_Charge PRIMARY KEY (ChargeId), CONSTRAINT FK_ops_Charge_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId), CONSTRAINT FK_ops_Charge_ChargePreviewLine FOREIGN KEY (ChargePreviewLineId) REFERENCES ops.ChargePreviewLine(ChargePreviewLineId), CONSTRAINT CK_ops_Charge_Amount CHECK ([ChargeMicros] >= 0), CONSTRAINT CK_ops_Charge_Currency CHECK (LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'));
+CREATE TABLE ops.Charge (ChargeId uniqueidentifier NOT NULL, OwnerId uniqueidentifier NOT NULL, OrganizationId uniqueidentifier NOT NULL, RepositoryId uniqueidentifier NOT NULL, BillingPeriodId uniqueidentifier NOT NULL, ChargePreviewLineId uniqueidentifier NOT NULL, PeriodFromUtc datetime2(7) NOT NULL, PeriodToUtc datetime2(7) NOT NULL, FactKind int NOT NULL, BillableUsageKindMappingId uniqueidentifier NOT NULL, BillableUsageKind int NOT NULL, PricingAssignmentId uniqueidentifier NOT NULL, PricingPlanId uniqueidentifier NOT NULL, PricingRateId uniqueidentifier NOT NULL, CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL, UnitName nvarchar(64) NOT NULL, UnitQuantity bigint NOT NULL, UnitPriceMicros bigint NOT NULL, EffectiveFromUtc datetime2(7) NOT NULL, EffectiveToUtc datetime2(7) NOT NULL, TotalQuantity bigint NOT NULL, ChargeMicros bigint NOT NULL, CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_Charge_CreatedAtUtc DEFAULT (SYSUTCDATETIME()), CONSTRAINT PK_ops_Charge PRIMARY KEY (ChargeId), CONSTRAINT FK_ops_Charge_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId), CONSTRAINT FK_ops_Charge_ChargePreviewLine FOREIGN KEY (ChargePreviewLineId) REFERENCES ops.ChargePreviewLine(ChargePreviewLineId), CONSTRAINT CK_ops_Charge_Identity CHECK ([ChargeId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND [BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [ChargePreviewLineId] <> '00000000-0000-0000-0000-000000000000'), CONSTRAINT CK_ops_Charge_Quantity CHECK ([UnitQuantity] > 0 AND [UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0), CONSTRAINT CK_ops_Charge_Provenance CHECK ([PeriodFromUtc] < [PeriodToUtc] AND [PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc] AND [FactKind] >= 0 AND [BillableUsageKind] >= 0 AND [BillableUsageKindMappingId] <> '00000000-0000-0000-0000-000000000000' AND [PricingAssignmentId] <> '00000000-0000-0000-0000-000000000000' AND [PricingPlanId] <> '00000000-0000-0000-0000-000000000000' AND [PricingRateId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([UnitName]))) > 0), CONSTRAINT CK_ops_Charge_Amount CHECK ([ChargeMicros] >= 0), CONSTRAINT CK_ops_Charge_Currency CHECK (LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'));
 CREATE UNIQUE INDEX UX_ops_Charge_InitialPosting ON ops.Charge(BillingPeriodId, ChargePreviewLineId);
 CREATE INDEX IX_ops_Charge_ChargePreviewLine ON ops.Charge(ChargePreviewLineId);
  CREATE TABLE ops.BillingPeriodCloseEvidence (BillingPeriodId uniqueidentifier NOT NULL, AcceptedFactDigestSha256Hex char(64) NOT NULL, PricingPreviewDigestSha256Hex char(64) NOT NULL, ClosedAtUtc datetime2(7) NOT NULL, ScheduledOperationProvenance nvarchar(200) NOT NULL, CONSTRAINT PK_ops_BillingPeriodCloseEvidence PRIMARY KEY (BillingPeriodId), CONSTRAINT FK_ops_BillingPeriodCloseEvidence_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId), CONSTRAINT CK_ops_BillingPeriodCloseEvidence_Digests CHECK (LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'), CONSTRAINT CK_ops_BillingPeriodCloseEvidence_Provenance CHECK (LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0));

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812130000_AddBillingPeriodClose.fs
@@ -1,0 +1,355 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
+
+/// Owns the migration-local frozen declaration for the billing-close physical contract.
+[<RequireQualifiedAccess>]
+module BillingPeriodCloseFrozenTarget =
+
+    /// Applies the migration target independently of the mutable runtime model.
+    let apply (modelBuilder: ModelBuilder) =
+        // The new Charge foreign key references this pre-existing table, so its target metadata must retain the
+        // reviewed physical principal key instead of letting EF synthesize a shadow temporary key.
+        let previewLine = modelBuilder.Entity<ChargePreviewLineEntity>()
+
+        previewLine.ToTable("ChargePreviewLine", "ops")
+        |> ignore
+
+        previewLine
+            .HasKey([| "ChargePreviewLineId" |])
+            .HasName("PK_ops_ChargePreviewLine")
+        |> ignore
+
+        previewLine
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        let period = modelBuilder.Entity<BillingPeriodEntity>()
+
+        period.ToTable(
+            "BillingPeriod",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_MonthRange",
+                    "[MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriod_State", "[State] IN (0, 1, 2)")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_Diagnostic",
+                    "([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        period
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriod")
+        |> ignore
+
+        period
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            period
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "MonthStartUtc"
+                "NextMonthStartUtc"
+                "CreatedAtUtc"
+                "UpdatedAtUtc"
+            ] do
+            period
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        period
+            .Property<int>("State")
+            .HasColumnType("int")
+            .IsRequired()
+        |> ignore
+
+        period
+            .Property<string>("RetryDiagnostic")
+            .HasColumnType("nvarchar(400)")
+            .HasMaxLength(400)
+            .IsUnicode(true)
+        |> ignore
+
+        period
+            .Property<Nullable<DateTime>>("RetryDiagnosticAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        period
+            .Property<DateTime>("CreatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriod_CreatedAtUtc")
+        |> ignore
+
+        period
+            .Property<DateTime>("UpdatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriod_UpdatedAtUtc")
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "NextMonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_BillingPeriod_ExactScope")
+            .IsUnique()
+        |> ignore
+
+        let charge = modelBuilder.Entity<ChargeEntity>()
+
+        charge.ToTable(
+            "Charge",
+            "ops",
+            fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+
+                table.HasTrigger("TR_ops_Charge_Immutable")
+                |> ignore
+        )
+        |> ignore
+
+        charge
+            .HasKey([| "ChargeId" |])
+            .HasName("PK_ops_Charge")
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargeId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        charge
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<int64>("ChargeMicros")
+            .HasColumnType("bigint")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_Charge_CreatedAtUtc")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .HasIndex(
+                [|
+                    "BillingPeriodId"
+                    "ChargePreviewLineId"
+                |]
+            )
+            .HasDatabaseName("UX_ops_Charge_InitialPosting")
+            .IsUnique()
+        |> ignore
+
+        charge
+            .HasIndex([| "ChargePreviewLineId" |])
+            .HasDatabaseName("IX_ops_Charge_ChargePreviewLine")
+        |> ignore
+
+        charge
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_Charge_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        charge
+            .HasOne<ChargePreviewLineEntity>()
+            .WithMany()
+            .HasForeignKey("ChargePreviewLineId")
+            .HasConstraintName("FK_ops_Charge_ChargePreviewLine")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let evidence = modelBuilder.Entity<BillingPeriodCloseEvidenceEntity>()
+
+        evidence.ToTable(
+            "BillingPeriodCloseEvidence",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodCloseEvidenceEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodCloseEvidence_Digests",
+                    "LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodCloseEvidence_Provenance", "LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0")
+                |> ignore
+
+                table.HasTrigger("TR_ops_BillingPeriodCloseEvidence_Immutable")
+                |> ignore
+        )
+        |> ignore
+
+        evidence
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriodCloseEvidence")
+        |> ignore
+
+        evidence
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        evidence
+            .Property<string>("AcceptedFactDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsFixedLength()
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("PricingPreviewDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsFixedLength()
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<DateTime>("ClosedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("ScheduledOperationProvenance")
+            .HasColumnType("nvarchar(200)")
+            .HasMaxLength(200)
+            .IsUnicode(true)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodCloseEvidence_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+/// Adds the self-contained physical close schema without calculating charges in SQL.
+[<DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260812130000_AddBillingPeriodClose")>]
+type AddBillingPeriodClose() =
+    inherit Migration()
+
+    /// Creates only the period, posting, evidence, constraints, and immutable triggers owned by issue 916.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+CREATE TABLE ops.BillingPeriod (BillingPeriodId uniqueidentifier NOT NULL, OwnerId uniqueidentifier NOT NULL, OrganizationId uniqueidentifier NOT NULL, RepositoryId uniqueidentifier NOT NULL, MonthStartUtc datetime2(7) NOT NULL, NextMonthStartUtc datetime2(7) NOT NULL, State int NOT NULL, RetryDiagnostic nvarchar(400) NULL, RetryDiagnosticAtUtc datetime2(7) NULL, CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriod_CreatedAtUtc DEFAULT (SYSUTCDATETIME()), UpdatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriod_UpdatedAtUtc DEFAULT (SYSUTCDATETIME()), CONSTRAINT PK_ops_BillingPeriod PRIMARY KEY (BillingPeriodId), CONSTRAINT CK_ops_BillingPeriod_MonthRange CHECK ([MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])), CONSTRAINT CK_ops_BillingPeriod_State CHECK ([State] IN (0, 1, 2)), CONSTRAINT CK_ops_BillingPeriod_Diagnostic CHECK (([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)));
+CREATE UNIQUE INDEX UX_ops_BillingPeriod_ExactScope ON ops.BillingPeriod(OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc);
+CREATE TABLE ops.Charge (ChargeId uniqueidentifier NOT NULL, BillingPeriodId uniqueidentifier NOT NULL, ChargePreviewLineId uniqueidentifier NOT NULL, CurrencyCode varchar(3) COLLATE Latin1_General_100_BIN2 NOT NULL, ChargeMicros bigint NOT NULL, CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_Charge_CreatedAtUtc DEFAULT (SYSUTCDATETIME()), CONSTRAINT PK_ops_Charge PRIMARY KEY (ChargeId), CONSTRAINT FK_ops_Charge_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId), CONSTRAINT FK_ops_Charge_ChargePreviewLine FOREIGN KEY (ChargePreviewLineId) REFERENCES ops.ChargePreviewLine(ChargePreviewLineId), CONSTRAINT CK_ops_Charge_Amount CHECK ([ChargeMicros] >= 0), CONSTRAINT CK_ops_Charge_Currency CHECK (LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'));
+CREATE UNIQUE INDEX UX_ops_Charge_InitialPosting ON ops.Charge(BillingPeriodId, ChargePreviewLineId);
+CREATE INDEX IX_ops_Charge_ChargePreviewLine ON ops.Charge(ChargePreviewLineId);
+ CREATE TABLE ops.BillingPeriodCloseEvidence (BillingPeriodId uniqueidentifier NOT NULL, AcceptedFactDigestSha256Hex char(64) NOT NULL, PricingPreviewDigestSha256Hex char(64) NOT NULL, ClosedAtUtc datetime2(7) NOT NULL, ScheduledOperationProvenance nvarchar(200) NOT NULL, CONSTRAINT PK_ops_BillingPeriodCloseEvidence PRIMARY KEY (BillingPeriodId), CONSTRAINT FK_ops_BillingPeriodCloseEvidence_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId), CONSTRAINT CK_ops_BillingPeriodCloseEvidence_Digests CHECK (LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'), CONSTRAINT CK_ops_BillingPeriodCloseEvidence_Provenance CHECK (LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0));
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+CREATE TRIGGER ops.TR_ops_Charge_Immutable ON ops.Charge AFTER UPDATE, DELETE AS BEGIN THROW 57231, 'Initial charge postings are append-only.', 1; END;
+"""
+        )
+        |> ignore
+
+        migrationBuilder.Sql(
+            """
+CREATE TRIGGER ops.TR_ops_BillingPeriodCloseEvidence_Immutable ON ops.BillingPeriodCloseEvidence AFTER UPDATE, DELETE AS BEGIN THROW 57232, 'Billing-period close evidence is immutable.', 1; END;
+"""
+        )
+        |> ignore
+
+    /// Removes only the schema introduced by this literal migration.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+DROP TRIGGER IF EXISTS ops.TR_ops_BillingPeriodCloseEvidence_Immutable;
+DROP TRIGGER IF EXISTS ops.TR_ops_Charge_Immutable;
+DROP TABLE ops.BillingPeriodCloseEvidence;
+DROP TABLE ops.Charge;
+DROP TABLE ops.BillingPeriod;
+"""
+        )
+        |> ignore
+
+    /// Captures the literal migration target without reading the runtime model helpers.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        BillingPeriodCloseFrozenTarget.apply modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -934,3 +934,273 @@ type OperationsDbContextModelSnapshot() =
             .HasDatabaseName("UX_ops_ChargePreviewLine_CompleteGrain")
             .IsUnique()
         |> ignore
+
+        // Keep this close fragment independently declared from the migration target and runtime model.
+        let period = modelBuilder.Entity<BillingPeriodEntity>()
+
+        period.ToTable(
+            "BillingPeriod",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_MonthRange",
+                    "[MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriod_State", "[State] IN (0, 1, 2)")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_Diagnostic",
+                    "([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        period
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriod")
+        |> ignore
+
+        period
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            period
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "MonthStartUtc"
+                "NextMonthStartUtc"
+                "CreatedAtUtc"
+                "UpdatedAtUtc"
+            ] do
+            period
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        period
+            .Property<int>("State")
+            .HasColumnType("int")
+            .IsRequired()
+        |> ignore
+
+        period
+            .Property<string>("RetryDiagnostic")
+            .HasColumnType("nvarchar(400)")
+            .HasMaxLength(400)
+            .IsUnicode(true)
+        |> ignore
+
+        period
+            .Property<Nullable<DateTime>>("RetryDiagnosticAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        period
+            .Property<DateTime>("CreatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriod_CreatedAtUtc")
+        |> ignore
+
+        period
+            .Property<DateTime>("UpdatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriod_UpdatedAtUtc")
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "NextMonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_BillingPeriod_ExactScope")
+            .IsUnique()
+        |> ignore
+
+        let charge = modelBuilder.Entity<ChargeEntity>()
+
+        charge.ToTable(
+            "Charge",
+            "ops",
+            fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+
+                table.HasTrigger("TR_ops_Charge_Immutable")
+                |> ignore
+        )
+        |> ignore
+
+        charge
+            .HasKey([| "ChargeId" |])
+            .HasName("PK_ops_Charge")
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargeId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        charge
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<int64>("ChargeMicros")
+            .HasColumnType("bigint")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_Charge_CreatedAtUtc")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .HasIndex(
+                [|
+                    "BillingPeriodId"
+                    "ChargePreviewLineId"
+                |]
+            )
+            .HasDatabaseName("UX_ops_Charge_InitialPosting")
+            .IsUnique()
+        |> ignore
+
+        charge
+            .HasIndex([| "ChargePreviewLineId" |])
+            .HasDatabaseName("IX_ops_Charge_ChargePreviewLine")
+        |> ignore
+
+        charge
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_Charge_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        charge
+            .HasOne<ChargePreviewLineEntity>()
+            .WithMany()
+            .HasForeignKey("ChargePreviewLineId")
+            .HasConstraintName("FK_ops_Charge_ChargePreviewLine")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let evidence = modelBuilder.Entity<BillingPeriodCloseEvidenceEntity>()
+
+        evidence.ToTable(
+            "BillingPeriodCloseEvidence",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodCloseEvidenceEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodCloseEvidence_Digests",
+                    "LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodCloseEvidence_Provenance", "LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0")
+                |> ignore
+
+                table.HasTrigger("TR_ops_BillingPeriodCloseEvidence_Immutable")
+                |> ignore
+        )
+        |> ignore
+
+        evidence
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriodCloseEvidence")
+        |> ignore
+
+        evidence
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        evidence
+            .Property<string>("AcceptedFactDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsFixedLength()
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("PricingPreviewDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsFixedLength()
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<DateTime>("ClosedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("ScheduledOperationProvenance")
+            .HasColumnType("nvarchar(200)")
+            .HasMaxLength(200)
+            .IsUnicode(true)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodCloseEvidence_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -1043,6 +1043,21 @@ type OperationsDbContextModelSnapshot() =
             "Charge",
             "ops",
             fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Identity",
+                    "[ChargeId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND [BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [ChargePreviewLineId] <> '00000000-0000-0000-0000-000000000000'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_Charge_Quantity", "[UnitQuantity] > 0 AND [UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Provenance",
+                    "[PeriodFromUtc] < [PeriodToUtc] AND [PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc] AND [FactKind] >= 0 AND [BillableUsageKind] >= 0 AND [BillableUsageKindMappingId] <> '00000000-0000-0000-0000-000000000000' AND [PricingAssignmentId] <> '00000000-0000-0000-0000-000000000000' AND [PricingPlanId] <> '00000000-0000-0000-0000-000000000000' AND [PricingRateId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([UnitName]))) > 0"
+                )
+                |> ignore
+
                 table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
                 |> ignore
 
@@ -1068,15 +1083,46 @@ type OperationsDbContextModelSnapshot() =
             .ValueGeneratedNever()
         |> ignore
 
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillingPeriodId"
+                "ChargePreviewLineId"
+                "BillableUsageKindMappingId"
+                "PricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            charge
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            charge
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
         charge
-            .Property<Guid>("BillingPeriodId")
-            .HasColumnType("uniqueidentifier")
+            .Property<int>("FactKind")
+            .HasColumnType("int")
             .IsRequired()
         |> ignore
 
         charge
-            .Property<Guid>("ChargePreviewLineId")
-            .HasColumnType("uniqueidentifier")
+            .Property<int>("BillableUsageKind")
+            .HasColumnType("int")
             .IsRequired()
         |> ignore
 
@@ -1090,10 +1136,25 @@ type OperationsDbContextModelSnapshot() =
         |> ignore
 
         charge
-            .Property<int64>("ChargeMicros")
-            .HasColumnType("bigint")
+            .Property<string>("UnitName")
+            .HasColumnType("nvarchar(64)")
+            .HasMaxLength(64)
+            .IsUnicode(true)
             .IsRequired()
         |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            charge
+                .Property<int64>(name)
+                .HasColumnType("bigint")
+                .IsRequired()
+            |> ignore
 
         charge
             .Property<DateTime>("CreatedAtUtc")

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodModel.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodModel.fs
@@ -117,6 +117,21 @@ module OperationsBillingPeriodModel =
             "Charge",
             "ops",
             fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Identity",
+                    "[ChargeId] <> '00000000-0000-0000-0000-000000000000' AND [OwnerId] <> '00000000-0000-0000-0000-000000000000' AND [OrganizationId] <> '00000000-0000-0000-0000-000000000000' AND [RepositoryId] <> '00000000-0000-0000-0000-000000000000' AND [BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [ChargePreviewLineId] <> '00000000-0000-0000-0000-000000000000'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_Charge_Quantity", "[UnitQuantity] > 0 AND [UnitPriceMicros] >= 0 AND [TotalQuantity] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Provenance",
+                    "[PeriodFromUtc] < [PeriodToUtc] AND [PeriodFromUtc] <= [EffectiveFromUtc] AND [EffectiveFromUtc] < [EffectiveToUtc] AND [EffectiveToUtc] <= [PeriodToUtc] AND [FactKind] >= 0 AND [BillableUsageKind] >= 0 AND [BillableUsageKindMappingId] <> '00000000-0000-0000-0000-000000000000' AND [PricingAssignmentId] <> '00000000-0000-0000-0000-000000000000' AND [PricingPlanId] <> '00000000-0000-0000-0000-000000000000' AND [PricingRateId] <> '00000000-0000-0000-0000-000000000000' AND LEN(LTRIM(RTRIM([UnitName]))) > 0"
+                )
+                |> ignore
+
                 table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
                 |> ignore
 
@@ -142,15 +157,46 @@ module OperationsBillingPeriodModel =
             .ValueGeneratedNever()
         |> ignore
 
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+                "BillingPeriodId"
+                "ChargePreviewLineId"
+                "BillableUsageKindMappingId"
+                "PricingAssignmentId"
+                "PricingPlanId"
+                "PricingRateId"
+            ] do
+            charge
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "PeriodFromUtc"
+                "PeriodToUtc"
+                "EffectiveFromUtc"
+                "EffectiveToUtc"
+            ] do
+            charge
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
         charge
-            .Property<Guid>("BillingPeriodId")
-            .HasColumnType("uniqueidentifier")
+            .Property<int>("FactKind")
+            .HasColumnType("int")
             .IsRequired()
         |> ignore
 
         charge
-            .Property<Guid>("ChargePreviewLineId")
-            .HasColumnType("uniqueidentifier")
+            .Property<int>("BillableUsageKind")
+            .HasColumnType("int")
             .IsRequired()
         |> ignore
 
@@ -164,10 +210,25 @@ module OperationsBillingPeriodModel =
         |> ignore
 
         charge
-            .Property<int64>("ChargeMicros")
-            .HasColumnType("bigint")
+            .Property<string>("UnitName")
+            .HasColumnType("nvarchar(64)")
+            .HasMaxLength(64)
+            .IsUnicode(true)
             .IsRequired()
         |> ignore
+
+        for name in
+            [
+                "UnitQuantity"
+                "UnitPriceMicros"
+                "TotalQuantity"
+                "ChargeMicros"
+            ] do
+            charge
+                .Property<int64>(name)
+                .HasColumnType("bigint")
+                .IsRequired()
+            |> ignore
 
         charge
             .Property<DateTime>("CreatedAtUtc")

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodModel.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodModel.fs
@@ -1,0 +1,280 @@
+namespace Grace.Operations.Data
+
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
+
+/// Configures the runtime billing-close tables without performing a billing close.
+[<RequireQualifiedAccess>]
+module OperationsBillingPeriodModel =
+
+    /// Adds the exact period, initial posting, and immutable evidence physical contract.
+    let configure (modelBuilder: ModelBuilder) =
+        let period = modelBuilder.Entity<BillingPeriodEntity>()
+
+        period.ToTable(
+            "BillingPeriod",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_MonthRange",
+                    "[MonthStartUtc] < [NextMonthStartUtc] AND [MonthStartUtc] = DATETIME2FROMPARTS(YEAR([MonthStartUtc]), MONTH([MonthStartUtc]), 1, 0, 0, 0, 0, 7) AND [NextMonthStartUtc] = DATEADD(month, 1, [MonthStartUtc])"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriod_State", "[State] IN (0, 1, 2)")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriod_Diagnostic",
+                    "([RetryDiagnostic] IS NULL AND [RetryDiagnosticAtUtc] IS NULL) OR ([State] IN (0, 1) AND LEN(LTRIM(RTRIM([RetryDiagnostic]))) > 0 AND [RetryDiagnosticAtUtc] IS NOT NULL)"
+                )
+                |> ignore
+        )
+        |> ignore
+
+        period
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriod")
+        |> ignore
+
+        period
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        for name in
+            [
+                "OwnerId"
+                "OrganizationId"
+                "RepositoryId"
+            ] do
+            period
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .IsRequired()
+            |> ignore
+
+        for name in
+            [
+                "MonthStartUtc"
+                "NextMonthStartUtc"
+                "CreatedAtUtc"
+                "UpdatedAtUtc"
+            ] do
+            period
+                .Property<DateTime>(name)
+                .HasColumnType("datetime2(7)")
+                .IsRequired()
+            |> ignore
+
+        period
+            .Property<int>("State")
+            .HasColumnType("int")
+            .IsRequired()
+        |> ignore
+
+        period
+            .Property<string>("RetryDiagnostic")
+            .HasColumnType("nvarchar(400)")
+            .HasMaxLength(400)
+            .IsUnicode(true)
+        |> ignore
+
+        period
+            .Property<Nullable<DateTime>>("RetryDiagnosticAtUtc")
+            .HasColumnType("datetime2(7)")
+        |> ignore
+
+        period
+            .Property<DateTime>("CreatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriod_CreatedAtUtc")
+        |> ignore
+
+        period
+            .Property<DateTime>("UpdatedAtUtc")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriod_UpdatedAtUtc")
+        |> ignore
+
+        period
+            .HasIndex(
+                [|
+                    "OwnerId"
+                    "OrganizationId"
+                    "RepositoryId"
+                    "MonthStartUtc"
+                    "NextMonthStartUtc"
+                |]
+            )
+            .HasDatabaseName("UX_ops_BillingPeriod_ExactScope")
+            .IsUnique()
+        |> ignore
+
+        let charge = modelBuilder.Entity<ChargeEntity>()
+
+        charge.ToTable(
+            "Charge",
+            "ops",
+            fun (table: TableBuilder<ChargeEntity>) ->
+                table.HasCheckConstraint("CK_ops_Charge_Amount", "[ChargeMicros] >= 0")
+                |> ignore
+
+                table.HasCheckConstraint(
+                    "CK_ops_Charge_Currency",
+                    "LEN([CurrencyCode]) = 3 AND [CurrencyCode] = UPPER([CurrencyCode]) AND [CurrencyCode] NOT LIKE '%[^A-Z]%'"
+                )
+                |> ignore
+
+                table.HasTrigger("TR_ops_Charge_Immutable")
+                |> ignore
+        )
+        |> ignore
+
+        charge
+            .HasKey([| "ChargeId" |])
+            .HasName("PK_ops_Charge")
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargeId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        charge
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<Guid>("ChargePreviewLineId")
+            .HasColumnType("uniqueidentifier")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<string>("CurrencyCode")
+            .HasColumnType("varchar(3)")
+            .HasMaxLength(3)
+            .IsUnicode(false)
+            .UseCollation("Latin1_General_100_BIN2")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<int64>("ChargeMicros")
+            .HasColumnType("bigint")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_Charge_CreatedAtUtc")
+            .IsRequired()
+        |> ignore
+
+        charge
+            .HasIndex(
+                [|
+                    "BillingPeriodId"
+                    "ChargePreviewLineId"
+                |]
+            )
+            .HasDatabaseName("UX_ops_Charge_InitialPosting")
+            .IsUnique()
+        |> ignore
+
+        charge
+            .HasIndex([| "ChargePreviewLineId" |])
+            .HasDatabaseName("IX_ops_Charge_ChargePreviewLine")
+        |> ignore
+
+        charge
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_Charge_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        charge
+            .HasOne<ChargePreviewLineEntity>()
+            .WithMany()
+            .HasForeignKey("ChargePreviewLineId")
+            .HasConstraintName("FK_ops_Charge_ChargePreviewLine")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        let evidence = modelBuilder.Entity<BillingPeriodCloseEvidenceEntity>()
+
+        evidence.ToTable(
+            "BillingPeriodCloseEvidence",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodCloseEvidenceEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodCloseEvidence_Digests",
+                    "LEN([AcceptedFactDigestSha256Hex]) = 64 AND [AcceptedFactDigestSha256Hex] NOT LIKE '%[^0-9A-F]%' AND LEN([PricingPreviewDigestSha256Hex]) = 64 AND [PricingPreviewDigestSha256Hex] NOT LIKE '%[^0-9A-F]%'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodCloseEvidence_Provenance", "LEN(LTRIM(RTRIM([ScheduledOperationProvenance]))) > 0")
+                |> ignore
+
+                table.HasTrigger("TR_ops_BillingPeriodCloseEvidence_Immutable")
+                |> ignore
+        )
+        |> ignore
+
+        evidence
+            .HasKey([| "BillingPeriodId" |])
+            .HasName("PK_ops_BillingPeriodCloseEvidence")
+        |> ignore
+
+        evidence
+            .Property<Guid>("BillingPeriodId")
+            .HasColumnType("uniqueidentifier")
+            .ValueGeneratedNever()
+        |> ignore
+
+        evidence
+            .Property<string>("AcceptedFactDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsFixedLength()
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("PricingPreviewDigestSha256Hex")
+            .HasColumnType("char(64)")
+            .HasMaxLength(64)
+            .IsUnicode(false)
+            .IsFixedLength()
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<DateTime>("ClosedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .Property<string>("ScheduledOperationProvenance")
+            .HasColumnType("nvarchar(200)")
+            .HasMaxLength(200)
+            .IsUnicode(true)
+            .IsRequired()
+        |> ignore
+
+        evidence
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodCloseEvidence_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -794,6 +794,7 @@ module OperationsModel =
         |> ignore
 
         OperationsChargePreviewModel.configure modelBuilder
+        OperationsBillingPeriodModel.configure modelBuilder
 
 /// Owns the EF Core model for Grace Operations SQL Server schema evolution.
 type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -347,3 +347,43 @@ type ChargePreviewLineEntity() =
 
     /// Stores the once-rounded provisional charge in whole currency micros.
     member val ChargeMicros = 0L with get, set
+
+/// Represents one exact repository UTC-month that may later receive one immutable close result.
+[<AllowNullLiteral>]
+type BillingPeriodEntity() =
+
+    /// Stores the deterministic identity for the complete billing scope and month.
+    member val BillingPeriodId = Guid.Empty with get, set
+    member val OwnerId = Guid.Empty with get, set
+    member val OrganizationId = Guid.Empty with get, set
+    member val RepositoryId = Guid.Empty with get, set
+    member val MonthStartUtc = DateTime.MinValue with get, set
+    member val NextMonthStartUtc = DateTime.MinValue with get, set
+    member val State = 0 with get, set
+    member val RetryDiagnostic: string = null with get, set
+    member val RetryDiagnosticAtUtc = Nullable<DateTime>() with get, set
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+    member val UpdatedAtUtc = DateTime.MinValue with get, set
+
+/// Represents one append-only initial posting copied from an already calculated preview line.
+[<AllowNullLiteral>]
+type ChargeEntity() =
+
+    /// Stores the deterministic posting identity.
+    member val ChargeId = Guid.Empty with get, set
+    member val BillingPeriodId = Guid.Empty with get, set
+    member val ChargePreviewLineId = Guid.Empty with get, set
+    member val CurrencyCode = String.Empty with get, set
+    member val ChargeMicros = 0L with get, set
+    member val CreatedAtUtc = DateTime.MinValue with get, set
+
+/// Preserves the immutable accepted-fact and pricing evidence for one closed period.
+[<AllowNullLiteral>]
+type BillingPeriodCloseEvidenceEntity() =
+
+    /// Uses the billing period identity as the evidence identity.
+    member val BillingPeriodId = Guid.Empty with get, set
+    member val AcceptedFactDigestSha256Hex = String.Empty with get, set
+    member val PricingPreviewDigestSha256Hex = String.Empty with get, set
+    member val ClosedAtUtc = DateTime.MinValue with get, set
+    member val ScheduledOperationProvenance = String.Empty with get, set

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -371,9 +371,32 @@ type ChargeEntity() =
 
     /// Stores the deterministic posting identity.
     member val ChargeId = Guid.Empty with get, set
+
+    /// Stores the exact billing scope selected by the immutable preview line.
+    member val OwnerId = Guid.Empty with get, set
+    member val OrganizationId = Guid.Empty with get, set
+    member val RepositoryId = Guid.Empty with get, set
     member val BillingPeriodId = Guid.Empty with get, set
     member val ChargePreviewLineId = Guid.Empty with get, set
+
+    /// Stores the exact preview interval and usage-kind provenance copied at posting time.
+    member val PeriodFromUtc = DateTime.MinValue with get, set
+    member val PeriodToUtc = DateTime.MinValue with get, set
+    member val FactKind = 0 with get, set
+    member val BillableUsageKindMappingId = Guid.Empty with get, set
+    member val BillableUsageKind = 0 with get, set
+    member val PricingAssignmentId = Guid.Empty with get, set
+    member val PricingPlanId = Guid.Empty with get, set
+    member val PricingRateId = Guid.Empty with get, set
     member val CurrencyCode = String.Empty with get, set
+
+    /// Stores the immutable priced-unit and effective-rate provenance copied from the preview line.
+    member val UnitName = String.Empty with get, set
+    member val UnitQuantity = 0L with get, set
+    member val UnitPriceMicros = 0L with get, set
+    member val EffectiveFromUtc = DateTime.MinValue with get, set
+    member val EffectiveToUtc = DateTime.MinValue with get, set
+    member val TotalQuantity = 0L with get, set
     member val ChargeMicros = 0L with get, set
     member val CreatedAtUtc = DateTime.MinValue with get, set
 

--- a/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="OperationsBillingCompleteness.Tests.fs" />
     <Compile Include="OperationsPricing.Tests.fs" />
     <Compile Include="OperationsChargePreview.Tests.fs" />
+    <Compile Include="OperationsBillingPeriodClose.Tests.fs" />
     <Compile Include="OperationsUsageArchive.Tests.fs" />
     <Compile Include="OperationsWorkerIngestion.Tests.fs" />
     <Compile Include="Program.fs" />

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -1,0 +1,776 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Operations.Data.Migrations
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Metadata
+open Microsoft.Data.SqlClient
+open NUnit.Framework
+open System
+open System.Collections.Generic
+open System.Data
+open System.Threading
+open System.Threading.Tasks
+open System.Text.RegularExpressions
+
+/// Captures a normalized physical schema slice without sharing declarations between the compared representations.
+module private BillingCloseSchema =
+
+    /// Retains whether a store type was explicitly configured or derived from the CLR/provider mapping.
+    type StoreTypeProvenance =
+        | Explicit of string
+        | Inferred of string
+
+    /// Holds every normalized set that belongs to the billing-close physical contract.
+    type Representation =
+        {
+            Tables: Set<string>
+            Columns: Set<string>
+            Properties: Set<string>
+            StoreTypeProvenance: Set<string>
+            Keys: Set<string>
+            Indexes: Set<string>
+            ForeignKeys: Set<string>
+            Checks: Set<string>
+            Defaults: Set<string>
+            Triggers: Set<string>
+        }
+
+    /// Names only the tables introduced by the billing-close migration.
+    let private tables =
+        Set.ofList [ "BillingPeriod"
+                     "Charge"
+                     "BillingPeriodCloseEvidence" ]
+
+    /// Produces a stable SQL spelling without deriving aliases from configured provider types.
+    let normalizeSql (value: string) =
+        if String.IsNullOrWhiteSpace value then
+            String.Empty
+        else
+            Regex.Replace(value.Trim().ToLowerInvariant(), "\\s+", " ")
+
+    /// Produces a stable type spelling while preserving configured type names verbatim apart from case and whitespace.
+    let normalizeStoreType (value: string) = Regex.Replace(normalizeSql value, "\\s+", "")
+
+    /// Removes a single redundant outer SQL parenthesis layer when SQL Server adds it around a definition.
+    let rec normalizeDefinition (value: string) =
+        let normalized =
+            value
+            |> normalizeSql
+            |> fun definition -> Regex.Replace(definition, "\\bdatepart\\(year,([^)]*)\\)", "year($1)")
+            |> fun definition -> Regex.Replace(definition, "\\bdatepart\\(month,([^)]*)\\)", "month($1)")
+            |> fun definition -> Regex.Replace(definition, "\\bnot ([^ ]+) like", "$1 not like")
+            |> fun definition -> Regex.Replace(definition, "\\(\\[state\\] in \\(0, 1\\) and", "([state] = 1 or [state] = 0) and")
+            |> fun definition -> Regex.Replace(definition, "\\[state\\] in \\(0, 1, 2\\)", "[state] = 2 or [state] = 1 or [state] = 0")
+            |> fun definition -> Regex.Replace(definition, "\\((\\d+)\\)", "$1")
+            |> fun definition -> Regex.Replace(definition, "\\((\\[[^]]+\\] is null and \\[[^]]+\\] is null)\\) or", "$1 or")
+            |> fun definition -> Regex.Replace(definition, "\\s*>=\\s*", " >= ")
+            |> fun definition -> Regex.Replace(definition, "\\s*<=\\s*", " <= ")
+            |> fun definition -> Regex.Replace(definition, "(?<![<>=!])\\s*>\\s*(?![=])", " > ")
+            |> fun definition -> Regex.Replace(definition, "(?<![<>=!])\\s*<\\s*(?![=])", " < ")
+            |> fun definition -> Regex.Replace(definition, "(?<![<>=!])\\s*=\\s*(?![<>=])", " = ")
+            |> fun definition -> Regex.Replace(definition, ",\\s*", ",")
+            |> fun definition -> Regex.Replace(definition, "\\s+", " ").Trim()
+            |> fun definition ->
+                let opens = definition |> Seq.filter ((=) '(') |> Seq.length
+                let closes = definition |> Seq.filter ((=) ')') |> Seq.length
+
+                if closes > opens && definition.EndsWith(")") then
+                    definition.TrimEnd(')')
+                else
+                    definition
+
+        if
+            normalized.Length > 1
+            && normalized.StartsWith("(")
+            && normalized.EndsWith(")")
+        then
+            let mutable depth = 0
+            let mutable closesEarly = false
+
+            for index in 0 .. normalized.Length - 2 do
+                if normalized[index] = '(' then depth <- depth + 1
+                elif normalized[index] = ')' then depth <- depth - 1
+
+                if depth = 0 then closesEarly <- true
+
+            if closesEarly then
+                normalized
+            else
+                normalizeDefinition normalized[1 .. normalized.Length - 2]
+        else
+            normalized
+
+    /// Renders an optional string as a stable set member segment.
+    let private optional (value: string) = if String.IsNullOrWhiteSpace value then "-" else value
+
+    /// Renders an optional integer as a stable set member segment.
+    let private nullableInt (value: Nullable<int>) = if value.HasValue then string value.Value else "-"
+
+    /// Renders an optional boolean as a stable set member segment.
+    let private nullableBool (value: Nullable<bool>) = if value.HasValue then string value.Value else "-"
+
+    /// Normalizes delete semantics to the SQL catalog's NO_ACTION term.
+    let private normalizeDeleteBehavior behavior =
+        match string behavior with
+        | "Restrict"
+        | "NoAction" -> "no_action"
+        | value -> value.ToLowerInvariant()
+
+    /// Reads configured type provenance without confusing a provider-derived mapping for an explicit declaration.
+    let private storeTypeProvenance (property: IReadOnlyProperty) =
+        match property.FindAnnotation(RelationalAnnotationNames.ColumnType) with
+        | null -> Inferred(normalizeStoreType (property.GetColumnType()))
+        | annotation ->
+            match annotation.Value with
+            | :? string as value when not (String.IsNullOrWhiteSpace value) -> Explicit(normalizeStoreType value)
+            | _ -> Inferred(normalizeStoreType (property.GetColumnType()))
+
+    /// Extracts exact model metadata for the three tables owned by this migration.
+    let fromModel (model: IModel) =
+        let entities =
+            model.GetEntityTypes()
+            |> Seq.filter (fun entity -> tables.Contains(entity.GetTableName()))
+            |> Seq.toList
+
+        let tableNames =
+            entities
+            |> Seq.map (fun entity -> entity.GetTableName())
+            |> Set.ofSeq
+
+        let columns, properties, provenance =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+                let storeObject = StoreObjectIdentifier.Table(table, entity.GetSchema())
+
+                entity.GetProperties()
+                |> Seq.map (fun property ->
+                    let column = property.GetColumnName(&storeObject)
+                    let inferredStoreType = normalizeStoreType (property.GetColumnType())
+
+                    let columnEntry =
+                        String.Join(
+                            "|",
+                            [|
+                                table
+                                column
+                                inferredStoreType
+                                string property.IsNullable
+                                nullableInt (property.GetMaxLength())
+                                nullableInt (property.GetPrecision())
+                                nullableInt (property.GetScale())
+                                nullableBool (property.IsUnicode())
+                                nullableBool (property.IsFixedLength())
+                                optional (property.GetCollation())
+                            |]
+                        )
+
+                    let propertyEntry = $"{table}|{column}|{property.ClrType.FullName}"
+
+                    let provenanceEntry =
+                        match storeTypeProvenance property with
+                        | Explicit value -> $"{table}|{column}|explicit|{value}"
+                        | Inferred value -> $"{table}|{column}|inferred|{value}"
+
+                    columnEntry, propertyEntry, provenanceEntry))
+            |> Seq.toList
+            |> List.unzip3
+
+        let keys =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+
+                entity.GetKeys()
+                |> Seq.map (fun key ->
+                    let kind =
+                        if obj.ReferenceEquals(key, entity.FindPrimaryKey()) then
+                            "primary"
+                        else
+                            "alternate"
+
+                    let columns =
+                        key.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> String.concat ","
+
+                    $"{table}|{key.GetName()}|{kind}|{columns}"))
+            |> Set.ofSeq
+
+        let indexes =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+
+                entity.GetIndexes()
+                |> Seq.map (fun index ->
+                    let columns =
+                        index.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> String.concat ","
+
+                    $"{table}|{index.GetDatabaseName()}|{index.IsUnique}|{columns}|{optional (index.GetFilter())}"))
+            |> Set.ofSeq
+
+        let foreignKeys =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+
+                entity.GetForeignKeys()
+                |> Seq.map (fun foreignKey ->
+                    let dependentColumns =
+                        foreignKey.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> String.concat ","
+
+                    let principalColumns =
+                        foreignKey.PrincipalKey.Properties
+                        |> Seq.map (fun property -> property.Name)
+                        |> String.concat ","
+
+                    let principal = $"{foreignKey.PrincipalEntityType.GetSchema()}.{foreignKey.PrincipalEntityType.GetTableName()}"
+                    $"{table}|{foreignKey.GetConstraintName()}|{dependentColumns}|{principal}|{principalColumns}|{normalizeDeleteBehavior foreignKey.DeleteBehavior}"))
+            |> Set.ofSeq
+
+        let checks =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+
+                entity.GetCheckConstraints()
+                |> Seq.map (fun check -> $"{table}|{check.Name}|{normalizeDefinition check.Sql}"))
+            |> Set.ofSeq
+
+        let defaults =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+
+                entity.GetProperties()
+                |> Seq.choose (fun property ->
+                    let definition = property.GetDefaultValueSql()
+
+                    if String.IsNullOrWhiteSpace definition then
+                        None
+                    else
+                        let storeObject = StoreObjectIdentifier.Table(table, entity.GetSchema())
+                        Some $"{table}|{property.GetColumnName(&storeObject)}|{property.GetDefaultConstraintName()}|{normalizeDefinition definition}"))
+            |> Set.ofSeq
+
+        let triggers =
+            entities
+            |> Seq.collect (fun entity ->
+                let table = entity.GetTableName()
+
+                entity.GetDeclaredTriggers()
+                |> Seq.map (fun trigger -> $"{table}|{trigger.ModelName}"))
+            |> Set.ofSeq
+
+        {
+            Tables = tableNames
+            Columns = Set.ofList columns
+            Properties = Set.ofList properties
+            StoreTypeProvenance = Set.ofList provenance
+            Keys = keys
+            Indexes = indexes
+            ForeignKeys = foreignKeys
+            Checks = checks
+            Defaults = defaults
+            Triggers = triggers
+        }
+
+    /// Compares one exact set and reports both missing and unexpected members.
+    let private compareSet name expected actual =
+        let missing = Set.difference expected actual |> Set.toList
+        let unexpected = Set.difference actual expected |> Set.toList
+
+        let missingText = String.Join("; ", missing)
+        let unexpectedText = String.Join("; ", unexpected)
+
+        [
+            if not missing.IsEmpty then yield $"{name} missing: {missingText}"
+            if not unexpected.IsEmpty then yield $"{name} unexpected: {unexpectedText}"
+        ]
+
+    /// Compares all representation facets, including model-only CLR and explicit/inferred store metadata.
+    let compare expected actual includeModelMetadata =
+        [
+            yield! compareSet "tables" expected.Tables actual.Tables
+            yield! compareSet "columns" expected.Columns actual.Columns
+            yield! compareSet "keys" expected.Keys actual.Keys
+            yield! compareSet "indexes" expected.Indexes actual.Indexes
+            yield! compareSet "foreign keys" expected.ForeignKeys actual.ForeignKeys
+            yield! compareSet "checks" expected.Checks actual.Checks
+            yield! compareSet "defaults" expected.Defaults actual.Defaults
+            yield! compareSet "triggers" expected.Triggers actual.Triggers
+
+            if includeModelMetadata then
+                yield! compareSet "CLR properties" expected.Properties actual.Properties
+                yield! compareSet "store-type provenance" expected.StoreTypeProvenance actual.StoreTypeProvenance
+        ]
+
+    /// Reads one exact normalized set from the disposable SQL Server catalog.
+    let private catalogSetAsync connectionString sql =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- sql
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let values = ResizeArray<string>()
+            let mutable hasRow = true
+
+            while hasRow do
+                let! read = reader.ReadAsync CancellationToken.None
+                hasRow <- read
+
+                if read then values.Add(reader.GetString 0)
+
+            return values |> Set.ofSeq
+        }
+
+    /// Extracts all physical facets from SQL Server without consulting an EF representation.
+    let fromLiveSqlAsync connectionString =
+        task {
+            let! liveTables =
+                catalogSetAsync
+                    connectionString
+                    "SELECT t.name FROM sys.tables t JOIN sys.schemas s ON s.schema_id=t.schema_id WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');"
+
+            let! columns =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',c.name COLLATE DATABASE_DEFAULT,'|',
+    CASE ty.name COLLATE DATABASE_DEFAULT WHEN 'datetime2' THEN CONCAT('datetime2(',c.scale,')') WHEN 'nvarchar' THEN CONCAT('nvarchar(',c.max_length / 2,')') WHEN 'varchar' THEN CONCAT('varchar(',c.max_length,')') WHEN 'char' THEN CONCAT('char(',c.max_length,')') ELSE ty.name COLLATE DATABASE_DEFAULT END,
+    '|',CASE c.is_nullable WHEN 1 THEN 'True' ELSE 'False' END,
+    '|',CASE WHEN ty.name IN ('nvarchar','varchar','char') THEN CONVERT(varchar(10), CASE WHEN ty.name='nvarchar' THEN c.max_length / 2 ELSE c.max_length END) ELSE '-' END,
+    '|-|-|',CASE WHEN ty.name IN ('varchar','char') THEN 'False' WHEN ty.name='nvarchar' THEN 'True' ELSE '-' END,
+    '|',CASE WHEN ty.name='char' THEN 'True' ELSE '-' END,
+    '|',CASE WHEN c.collation_name COLLATE DATABASE_DEFAULT='Latin1_General_100_BIN2' THEN c.collation_name COLLATE DATABASE_DEFAULT ELSE '-' END)
+FROM sys.tables t
+JOIN sys.schemas s ON s.schema_id=t.schema_id
+JOIN sys.columns c ON c.object_id=t.object_id
+JOIN sys.types ty ON ty.user_type_id=c.user_type_id
+WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+"""
+
+            let! keys =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',kc.name COLLATE DATABASE_DEFAULT,'|',CASE kc.type COLLATE DATABASE_DEFAULT WHEN 'PK' THEN 'primary' ELSE 'alternate' END,'|',STRING_AGG(c.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY ic.key_ordinal))
+FROM sys.key_constraints kc
+JOIN sys.tables t ON t.object_id=kc.parent_object_id
+JOIN sys.schemas s ON s.schema_id=t.schema_id
+JOIN sys.index_columns ic ON ic.object_id=kc.parent_object_id AND ic.index_id=kc.unique_index_id
+JOIN sys.columns c ON c.object_id=ic.object_id AND c.column_id=ic.column_id
+WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence')
+GROUP BY t.name,kc.name,kc.type;
+"""
+
+            let! indexes =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',i.name COLLATE DATABASE_DEFAULT,'|',CASE i.is_unique WHEN 1 THEN 'True' ELSE 'False' END,'|',STRING_AGG(c.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY ic.key_ordinal),'|',COALESCE(i.filter_definition COLLATE DATABASE_DEFAULT,'-'))
+FROM sys.indexes i
+JOIN sys.tables t ON t.object_id=i.object_id
+JOIN sys.schemas s ON s.schema_id=t.schema_id
+JOIN sys.index_columns ic ON ic.object_id=i.object_id AND ic.index_id=i.index_id AND ic.key_ordinal > 0
+JOIN sys.columns c ON c.object_id=ic.object_id AND c.column_id=ic.column_id
+WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence') AND i.is_primary_key=0 AND i.is_unique_constraint=0
+GROUP BY t.name,i.name,i.is_unique,i.filter_definition;
+"""
+
+            let! foreignKeys =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(child.name COLLATE DATABASE_DEFAULT,'|',fk.name COLLATE DATABASE_DEFAULT,'|',STRING_AGG(childColumn.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY fkc.constraint_column_id),'|',principalSchema.name COLLATE DATABASE_DEFAULT,'.',parent.name COLLATE DATABASE_DEFAULT,'|',STRING_AGG(parentColumn.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY fkc.constraint_column_id),'|',LOWER(fk.delete_referential_action_desc) COLLATE DATABASE_DEFAULT)
+FROM sys.foreign_keys fk
+JOIN sys.tables child ON child.object_id=fk.parent_object_id
+JOIN sys.schemas childSchema ON childSchema.schema_id=child.schema_id
+JOIN sys.tables parent ON parent.object_id=fk.referenced_object_id
+JOIN sys.schemas principalSchema ON principalSchema.schema_id=parent.schema_id
+JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id=fk.object_id
+JOIN sys.columns childColumn ON childColumn.object_id=child.object_id AND childColumn.column_id=fkc.parent_column_id
+JOIN sys.columns parentColumn ON parentColumn.object_id=parent.object_id AND parentColumn.column_id=fkc.referenced_column_id
+WHERE childSchema.name='ops' AND child.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence')
+GROUP BY child.name,fk.name,principalSchema.name,parent.name,fk.delete_referential_action_desc;
+"""
+
+            let! checks =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',cc.name COLLATE DATABASE_DEFAULT,'|',cc.definition COLLATE DATABASE_DEFAULT)
+FROM sys.check_constraints cc
+JOIN sys.tables t ON t.object_id=cc.parent_object_id
+JOIN sys.schemas s ON s.schema_id=t.schema_id
+WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+"""
+
+            let! defaults =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',c.name COLLATE DATABASE_DEFAULT,'|',dc.name COLLATE DATABASE_DEFAULT,'|',dc.definition COLLATE DATABASE_DEFAULT)
+FROM sys.default_constraints dc
+JOIN sys.tables t ON t.object_id=dc.parent_object_id
+JOIN sys.schemas s ON s.schema_id=t.schema_id
+JOIN sys.columns c ON c.object_id=t.object_id AND c.column_id=dc.parent_column_id
+WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+"""
+
+            let! triggers =
+                catalogSetAsync
+                    connectionString
+                    """
+SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',tr.name COLLATE DATABASE_DEFAULT)
+FROM sys.triggers tr
+JOIN sys.tables t ON t.object_id=tr.parent_id
+JOIN sys.schemas s ON s.schema_id=t.schema_id
+WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+"""
+
+            return
+                {
+                    Tables = liveTables
+                    Columns = columns
+                    Properties = Set.empty
+                    StoreTypeProvenance = Set.empty
+                    Keys = keys
+                    Indexes = indexes
+                    ForeignKeys = foreignKeys
+                    Checks =
+                        checks
+                        |> Set.map (fun value -> let fields = value.Split('|', 3) in $"{fields[0]}|{fields[1]}|{normalizeDefinition fields[2]}")
+                    Defaults =
+                        defaults
+                        |> Set.map (fun value -> let fields = value.Split('|', 4) in $"{fields[0]}|{fields[1]}|{fields[2]}|{normalizeDefinition fields[3]}")
+                    Triggers = triggers
+                }
+        }
+
+    /// Replaces exactly one member in a set so false-pass probes cannot mutate production source files.
+    let replace original replacement members =
+        members
+        |> Set.remove original
+        |> Set.add replacement
+
+/// Establishes the billing-close physical contract tests without adding close behavior.
+[<TestFixture>]
+[<NonParallelizable>]
+type OperationsBillingPeriodCloseTests() =
+
+    /// Names the SQL Server connection used only for disposable physical-schema tests.
+    [<Literal>]
+    let sqlConnectionStringEnvironmentVariable = "GRACE_OPERATIONS_SQL_TEST_CONNECTION_STRING"
+
+    /// Creates a database name that cannot share rows with another test run.
+    let databaseName () = $"GraceOperationsBillingCloseSchema_{Guid.NewGuid():N}"
+
+    /// Requires the configured SQL Server because this issue's physical proof has no valid skipped path.
+    let requireSqlConnectionString () =
+        let value = Environment.GetEnvironmentVariable sqlConnectionStringEnvironmentVariable
+
+        if String.IsNullOrWhiteSpace value then
+            Assert.Fail($"{sqlConnectionStringEnvironmentVariable} is required; the physical-schema matrix has zero permitted skips.")
+
+        value
+
+    /// Creates one disposable database by running the production Operations migration initializer.
+    let createDatabaseAsync () =
+        task {
+            let builder = SqlConnectionStringBuilder(requireSqlConnectionString ())
+            builder.InitialCatalog <- databaseName ()
+            let schema = OperationsUsageSchema(builder.ConnectionString, OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing)
+            do! schema.EnsureCreatedAsync CancellationToken.None
+            return builder.ConnectionString
+        }
+
+    /// Removes a disposable database whether the contained proof passes or fails.
+    let dropDatabaseAsync connectionString =
+        task {
+            let builder = SqlConnectionStringBuilder(connectionString)
+            let database = builder.InitialCatalog
+            builder.InitialCatalog <- "master"
+            use connection = new SqlConnection(builder.ConnectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- $"ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{database}];"
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
+    /// Runs a physical proof with deterministic disposal of its isolated SQL database.
+    let withDatabaseAsync operation =
+        task {
+            let! connectionString = createDatabaseAsync ()
+
+            try
+                let! result = operation connectionString
+                do! dropDatabaseAsync connectionString
+                return result
+            with
+            | ex ->
+                do! dropDatabaseAsync connectionString
+                return raise ex
+        }
+
+    /// Fails with every missing and unexpected normalized schema member rather than a selected membership assertion.
+    let assertNoDrift (label: string) (drift: string list) =
+        let details = String.Join(Environment.NewLine, drift)
+        Assert.That(drift, Is.Empty, $"{label} drift: {details}")
+
+    /// Executes a physical statement and returns its scalar result when the SQL proof needs one.
+    let executeAsync connectionString sql =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- sql
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
+    /// Captures every durable value touched by this leaf before and after one rejected physical statement.
+    let durableSnapshotAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+SELECT CONCAT('BillingPeriod|',(SELECT * FROM ops.BillingPeriod ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('ChargePreviewLine|',(SELECT * FROM ops.ChargePreviewLine ORDER BY ChargePreviewLineId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('Charge|',(SELECT * FROM ops.Charge ORDER BY ChargeId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodCloseEvidence|',(SELECT * FROM ops.BillingPeriodCloseEvidence ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+ORDER BY 1;
+"""
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let values = ResizeArray<string>()
+            let mutable hasRow = true
+
+            while hasRow do
+                let! read = reader.ReadAsync CancellationToken.None
+                hasRow <- read
+                if read then values.Add(reader.GetString 0)
+
+            return values |> Seq.toList
+        }
+
+    /// Requires one invalid physical statement to fail and to preserve the complete durable projection.
+    let rejectAndPreserveAsync connectionString label sql =
+        task {
+            let! before = durableSnapshotAsync connectionString
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- sql
+
+            Assert.ThrowsAsync<SqlException>(Func<Task>(fun () -> command.ExecuteNonQueryAsync(CancellationToken.None) :> Task))
+            |> ignore
+
+            let! after = durableSnapshotAsync connectionString
+            Assert.That<string list>(after, Is.EqualTo<string list>(before), $"{label} changed durable state after SQL rejected it.")
+        }
+
+    /// Inserts one valid period, preview line, charge, and evidence without invoking any future close behavior.
+    let seedValidRowsAsync connectionString =
+        executeAsync
+            connectionString
+            """
+DECLARE @PeriodId uniqueidentifier=NEWID(), @LineId uniqueidentifier=NEWID();
+INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State,RetryDiagnostic,RetryDiagnosticAtUtc)
+VALUES (@PeriodId,NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',0,NULL,NULL);
+INSERT ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros)
+VALUES (@LineId,NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-06-01','2026-07-01',1,1);
+INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),@PeriodId,@LineId,'USD',1);
+INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance)
+VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-fixture');
+"""
+
+    /// Proves configured provider types retain their explicit provenance and cannot silently become CLR aliases.
+    [<Test>]
+    member _.RedProbeExplicitStoreTypeDriftIsNotIgnored() =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsBillingCloseModel;Integrated Security=true;"
+
+        let runtime =
+            context.GetService<IDesignTimeModel>().Model
+            |> BillingCloseSchema.fromModel
+
+        let original = "Charge|CurrencyCode|explicit|varchar(3)"
+
+        let mutated =
+            { runtime with StoreTypeProvenance = BillingCloseSchema.replace original "Charge|CurrencyCode|explicit|System.Int32" runtime.StoreTypeProvenance }
+
+        let drift = BillingCloseSchema.compare runtime mutated true
+        Assert.That(drift, Is.Not.Empty)
+
+    /// Proves complete-set comparison reports a missing live column instead of accepting selected membership.
+    [<Test>]
+    member _.RedProbeIncompleteLiveSetIsNotIgnored() =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsBillingCloseModel;Integrated Security=true;"
+
+        let runtime =
+            context.GetService<IDesignTimeModel>().Model
+            |> BillingCloseSchema.fromModel
+
+        let incomplete =
+            { runtime with
+                Columns =
+                    runtime.Columns
+                    |> Set.remove "Charge|ChargeMicros|bigint|False|-|-|-|-|-|-"
+            }
+
+        let drift = BillingCloseSchema.compare runtime incomplete false
+        Assert.That(drift, Is.Not.Empty)
+
+    /// Compares runtime, independently frozen migration target, independently declared snapshot, and migrated SQL catalog exactly.
+    [<Test>]
+    member _.RuntimeTargetSnapshotAndLiveSqlPhysicalSchemasAgreeExactly() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                use context =
+                    OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsBillingCloseModel;Integrated Security=true;"
+
+                let runtime =
+                    context.GetService<IDesignTimeModel>().Model
+                    |> BillingCloseSchema.fromModel
+
+                let target =
+                    AddBillingPeriodClose().TargetModel
+                    |> BillingCloseSchema.fromModel
+
+                let snapshot =
+                    OperationsDbContextModelSnapshot().Model
+                    |> BillingCloseSchema.fromModel
+
+                let! live = BillingCloseSchema.fromLiveSqlAsync connectionString
+                assertNoDrift "runtime-target" (BillingCloseSchema.compare runtime target true)
+                assertNoDrift "runtime-snapshot" (BillingCloseSchema.compare runtime snapshot true)
+                assertNoDrift "runtime-live" (BillingCloseSchema.compare runtime live false)
+            })
+
+    /// Verifies five independent altered fixture representations all produce exact-set drift reports.
+    [<Test>]
+    member _.FalsePassMutationsCannotCompareAsParity() =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsBillingCloseModel;Integrated Security=true;"
+
+        let runtime =
+            context.GetService<IDesignTimeModel>().Model
+            |> BillingCloseSchema.fromModel
+
+        let mutations =
+            [
+                { runtime with
+                    StoreTypeProvenance =
+                        BillingCloseSchema.replace
+                            "Charge|CurrencyCode|explicit|varchar(3)"
+                            "Charge|CurrencyCode|explicit|System.Int32"
+                            runtime.StoreTypeProvenance
+                }
+                { runtime with
+                    Checks =
+                        BillingCloseSchema.replace
+                            "Charge|CK_ops_Charge_Amount|[chargemicros] >= 0"
+                            "Charge|CK_ops_Charge_Amount|[chargemicros] > 0"
+                            runtime.Checks
+                }
+                { runtime with
+                    Indexes =
+                        BillingCloseSchema.replace
+                            "Charge|UX_ops_Charge_InitialPosting|True|BillingPeriodId,ChargePreviewLineId|-"
+                            "Charge|UX_ops_Charge_InitialPosting|True|ChargePreviewLineId,BillingPeriodId|-"
+                            runtime.Indexes
+                }
+                { runtime with
+                    ForeignKeys =
+                        BillingCloseSchema.replace
+                            "Charge|FK_ops_Charge_BillingPeriod|BillingPeriodId|ops.BillingPeriod|BillingPeriodId|no_action"
+                            "Charge|FK_ops_Charge_BillingPeriod|BillingPeriodId|ops.BillingPeriod|BillingPeriodId|cascade"
+                            runtime.ForeignKeys
+                }
+                { runtime with
+                    Triggers = BillingCloseSchema.replace "Charge|TR_ops_Charge_Immutable" "Charge|TR_ops_Charge_Immutable_Renamed" runtime.Triggers
+                }
+            ]
+
+        mutations
+        |> List.iter (fun mutated -> Assert.That(BillingCloseSchema.compare runtime mutated true, Is.Not.Empty))
+
+    /// Guards snapshot independence from the migration target helper for the close fragment.
+    [<Test>]
+    member _.SnapshotCloseFragmentDoesNotCallMigrationFrozenTargetHelper() =
+        let sourcePath =
+            IO.Path.Combine(
+                TestContext.CurrentContext.TestDirectory,
+                "..",
+                "..",
+                "..",
+                "..",
+                "Grace.Operations.Data",
+                "Migrations",
+                "OperationsDbContextModelSnapshot.fs"
+            )
+            |> IO.Path.GetFullPath
+
+        let source = IO.File.ReadAllText sourcePath
+        Assert.That(source, Does.Not.Contain("BillingPeriodCloseFrozenTarget.apply"))
+
+    /// Exercises every #916 check, identity, foreign-key, and immutable-trigger rejection against one migrated SQL database.
+    [<Test>]
+    member _.LivePhysicalRejectionMatrixRejectsFifteenNamedInvalidStatementsAndAllowsValidRows() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                do! seedValidRowsAsync connectionString
+
+                let cases =
+                    [
+                        "period state",
+                        "INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',3);"
+                        "period month",
+                        "INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'2026-06-02','2026-07-02',0);"
+                        "period diagnostic",
+                        "INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State,RetryDiagnostic,RetryDiagnosticAtUtc) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',2,'retry',SYSUTCDATETIME());"
+                        "charge amount",
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'USD',-1 FROM ops.Charge;"
+                        "charge currency",
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'usd',1 FROM ops.Charge;"
+                        "evidence digest",
+                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (NEWID(),'bad',REPLICATE('A',64),SYSUTCDATETIME(),'x');"
+                        "evidence provenance",
+                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (NEWID(),REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),' ');"
+                        "duplicate posting",
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'USD',1 FROM ops.Charge;"
+                        "charge period foreign key",
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),NEWID(),ChargePreviewLineId,'USD',1 FROM ops.Charge;"
+                        "charge preview foreign key",
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,NEWID(),'USD',1 FROM ops.Charge;"
+                        "evidence period foreign key",
+                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (NEWID(),REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'x');"
+                        "charge update", "UPDATE ops.Charge SET ChargeMicros=2;"
+                        "charge delete", "DELETE FROM ops.Charge;"
+                        "evidence update", "UPDATE ops.BillingPeriodCloseEvidence SET ScheduledOperationProvenance='tampered';"
+                        "evidence delete", "DELETE FROM ops.BillingPeriodCloseEvidence;"
+                    ]
+
+                Assert.That(cases.Length, Is.EqualTo(15), "The physical rejection matrix must retain every named #916 case.")
+
+                for label, sql in cases do
+                    do! rejectAndPreserveAsync connectionString label sql
+
+                do!
+                    executeAsync
+                        connectionString
+                        "INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'2026-07-01','2026-08-01',0);"
+
+                Assert.That(true, Is.True, "Valid physical insert succeeded after every rejected statement.")
+            })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -37,11 +37,18 @@ module private BillingCloseSchema =
             Triggers: Set<string>
         }
 
-    /// Names only the tables introduced by the billing-close migration.
+    /// Names only the tables introduced by the billing-close migration with their SQL schema.
     let private tables =
-        Set.ofList [ "BillingPeriod"
-                     "Charge"
-                     "BillingPeriodCloseEvidence" ]
+        Set.ofList [ "ops.BillingPeriod"
+                     "ops.Charge"
+                     "ops.BillingPeriodCloseEvidence" ]
+
+    /// Names tables that existed before the billing-close migration and are excluded from this leaf's live catalog slice.
+    let private priorTables =
+        "'__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine'"
+
+    /// Forms the schema-qualified physical identity used by every catalog comparison facet.
+    let private tableIdentity schema table = $"{schema}.{table}"
 
     /// Produces a stable SQL spelling without deriving aliases from configured provider types.
     let normalizeSql (value: string) =
@@ -131,19 +138,20 @@ module private BillingCloseSchema =
     let fromModel (model: IModel) =
         let entities =
             model.GetEntityTypes()
-            |> Seq.filter (fun entity -> tables.Contains(entity.GetTableName()))
+            |> Seq.filter (fun entity -> tables.Contains(tableIdentity (entity.GetSchema()) (entity.GetTableName())))
             |> Seq.toList
 
         let tableNames =
             entities
-            |> Seq.map (fun entity -> entity.GetTableName())
+            |> Seq.map (fun entity -> tableIdentity (entity.GetSchema()) (entity.GetTableName()))
             |> Set.ofSeq
 
         let columns, properties, provenance =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
-                let storeObject = StoreObjectIdentifier.Table(table, entity.GetSchema())
+                let tableName = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) tableName
+                let storeObject = StoreObjectIdentifier.Table(tableName, entity.GetSchema())
 
                 entity.GetProperties()
                 |> Seq.map (fun property ->
@@ -167,7 +175,7 @@ module private BillingCloseSchema =
                             |]
                         )
 
-                    let propertyEntry = $"{table}|{column}|{property.ClrType.FullName}"
+                    let propertyEntry = $"{table}|{property.Name}|{column}|{property.ClrType.FullName}"
 
                     let provenanceEntry =
                         match storeTypeProvenance property with
@@ -181,7 +189,7 @@ module private BillingCloseSchema =
         let keys =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) (entity.GetTableName())
 
                 entity.GetKeys()
                 |> Seq.map (fun key ->
@@ -202,7 +210,7 @@ module private BillingCloseSchema =
         let indexes =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) (entity.GetTableName())
 
                 entity.GetIndexes()
                 |> Seq.map (fun index ->
@@ -217,7 +225,7 @@ module private BillingCloseSchema =
         let foreignKeys =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) (entity.GetTableName())
 
                 entity.GetForeignKeys()
                 |> Seq.map (fun foreignKey ->
@@ -238,7 +246,7 @@ module private BillingCloseSchema =
         let checks =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) (entity.GetTableName())
 
                 entity.GetCheckConstraints()
                 |> Seq.map (fun check -> $"{table}|{check.Name}|{normalizeDefinition check.Sql}"))
@@ -247,7 +255,8 @@ module private BillingCloseSchema =
         let defaults =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
+                let tableName = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) tableName
 
                 entity.GetProperties()
                 |> Seq.choose (fun property ->
@@ -256,14 +265,14 @@ module private BillingCloseSchema =
                     if String.IsNullOrWhiteSpace definition then
                         None
                     else
-                        let storeObject = StoreObjectIdentifier.Table(table, entity.GetSchema())
+                        let storeObject = StoreObjectIdentifier.Table(tableName, entity.GetSchema())
                         Some $"{table}|{property.GetColumnName(&storeObject)}|{property.GetDefaultConstraintName()}|{normalizeDefinition definition}"))
             |> Set.ofSeq
 
         let triggers =
             entities
             |> Seq.collect (fun entity ->
-                let table = entity.GetTableName()
+                let table = tableIdentity (entity.GetSchema()) (entity.GetTableName())
 
                 entity.GetDeclaredTriggers()
                 |> Seq.map (fun trigger -> $"{table}|{trigger.ModelName}"))
@@ -338,13 +347,13 @@ module private BillingCloseSchema =
             let! liveTables =
                 catalogSetAsync
                     connectionString
-                    "SELECT t.name FROM sys.tables t JOIN sys.schemas s ON s.schema_id=t.schema_id WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');"
+                    $"SELECT CONCAT(s.name,'.',t.name) FROM sys.tables t JOIN sys.schemas s ON s.schema_id=t.schema_id WHERE s.name='ops' AND t.name NOT IN ({priorTables});"
 
             let! columns =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',c.name COLLATE DATABASE_DEFAULT,'|',
+SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAULT,'|',c.name COLLATE DATABASE_DEFAULT,'|',
     CASE ty.name COLLATE DATABASE_DEFAULT WHEN 'datetime2' THEN CONCAT('datetime2(',c.scale,')') WHEN 'nvarchar' THEN CONCAT('nvarchar(',c.max_length / 2,')') WHEN 'varchar' THEN CONCAT('varchar(',c.max_length,')') WHEN 'char' THEN CONCAT('char(',c.max_length,')') ELSE ty.name COLLATE DATABASE_DEFAULT END,
     '|',CASE c.is_nullable WHEN 1 THEN 'True' ELSE 'False' END,
     '|',CASE WHEN ty.name IN ('nvarchar','varchar','char') THEN CONVERT(varchar(10), CASE WHEN ty.name='nvarchar' THEN c.max_length / 2 ELSE c.max_length END) ELSE '-' END,
@@ -355,42 +364,42 @@ FROM sys.tables t
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.columns c ON c.object_id=t.object_id
 JOIN sys.types ty ON ty.user_type_id=c.user_type_id
-WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
 """
 
             let! keys =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',kc.name COLLATE DATABASE_DEFAULT,'|',CASE kc.type COLLATE DATABASE_DEFAULT WHEN 'PK' THEN 'primary' ELSE 'alternate' END,'|',STRING_AGG(c.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY ic.key_ordinal))
+SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAULT,'|',kc.name COLLATE DATABASE_DEFAULT,'|',CASE kc.type COLLATE DATABASE_DEFAULT WHEN 'PK' THEN 'primary' ELSE 'alternate' END,'|',STRING_AGG(c.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY ic.key_ordinal))
 FROM sys.key_constraints kc
 JOIN sys.tables t ON t.object_id=kc.parent_object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.index_columns ic ON ic.object_id=kc.parent_object_id AND ic.index_id=kc.unique_index_id
 JOIN sys.columns c ON c.object_id=ic.object_id AND c.column_id=ic.column_id
-WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence')
-GROUP BY t.name,kc.name,kc.type;
+WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine')
+GROUP BY s.name,t.name,kc.name,kc.type;
 """
 
             let! indexes =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',i.name COLLATE DATABASE_DEFAULT,'|',CASE i.is_unique WHEN 1 THEN 'True' ELSE 'False' END,'|',STRING_AGG(c.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY ic.key_ordinal),'|',COALESCE(i.filter_definition COLLATE DATABASE_DEFAULT,'-'))
+SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAULT,'|',i.name COLLATE DATABASE_DEFAULT,'|',CASE i.is_unique WHEN 1 THEN 'True' ELSE 'False' END,'|',STRING_AGG(c.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY ic.key_ordinal),'|',COALESCE(i.filter_definition COLLATE DATABASE_DEFAULT,'-'))
 FROM sys.indexes i
 JOIN sys.tables t ON t.object_id=i.object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.index_columns ic ON ic.object_id=i.object_id AND ic.index_id=i.index_id AND ic.key_ordinal > 0
 JOIN sys.columns c ON c.object_id=ic.object_id AND c.column_id=ic.column_id
-WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence') AND i.is_primary_key=0 AND i.is_unique_constraint=0
-GROUP BY t.name,i.name,i.is_unique,i.filter_definition;
+WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine') AND i.is_primary_key=0 AND i.is_unique_constraint=0
+GROUP BY s.name,t.name,i.name,i.is_unique,i.filter_definition;
 """
 
             let! foreignKeys =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(child.name COLLATE DATABASE_DEFAULT,'|',fk.name COLLATE DATABASE_DEFAULT,'|',STRING_AGG(childColumn.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY fkc.constraint_column_id),'|',principalSchema.name COLLATE DATABASE_DEFAULT,'.',parent.name COLLATE DATABASE_DEFAULT,'|',STRING_AGG(parentColumn.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY fkc.constraint_column_id),'|',LOWER(fk.delete_referential_action_desc) COLLATE DATABASE_DEFAULT)
+SELECT CONCAT(childSchema.name COLLATE DATABASE_DEFAULT,'.',child.name COLLATE DATABASE_DEFAULT,'|',fk.name COLLATE DATABASE_DEFAULT,'|',STRING_AGG(childColumn.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY fkc.constraint_column_id),'|',principalSchema.name COLLATE DATABASE_DEFAULT,'.',parent.name COLLATE DATABASE_DEFAULT,'|',STRING_AGG(parentColumn.name COLLATE DATABASE_DEFAULT,',') WITHIN GROUP (ORDER BY fkc.constraint_column_id),'|',LOWER(fk.delete_referential_action_desc) COLLATE DATABASE_DEFAULT)
 FROM sys.foreign_keys fk
 JOIN sys.tables child ON child.object_id=fk.parent_object_id
 JOIN sys.schemas childSchema ON childSchema.schema_id=child.schema_id
@@ -399,42 +408,42 @@ JOIN sys.schemas principalSchema ON principalSchema.schema_id=parent.schema_id
 JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id=fk.object_id
 JOIN sys.columns childColumn ON childColumn.object_id=child.object_id AND childColumn.column_id=fkc.parent_column_id
 JOIN sys.columns parentColumn ON parentColumn.object_id=parent.object_id AND parentColumn.column_id=fkc.referenced_column_id
-WHERE childSchema.name='ops' AND child.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence')
-GROUP BY child.name,fk.name,principalSchema.name,parent.name,fk.delete_referential_action_desc;
+WHERE childSchema.name='ops' AND child.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine')
+GROUP BY childSchema.name,child.name,fk.name,principalSchema.name,parent.name,fk.delete_referential_action_desc;
 """
 
             let! checks =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',cc.name COLLATE DATABASE_DEFAULT,'|',cc.definition COLLATE DATABASE_DEFAULT)
+SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAULT,'|',cc.name COLLATE DATABASE_DEFAULT,'|',cc.definition COLLATE DATABASE_DEFAULT)
 FROM sys.check_constraints cc
 JOIN sys.tables t ON t.object_id=cc.parent_object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
-WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
 """
 
             let! defaults =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',c.name COLLATE DATABASE_DEFAULT,'|',dc.name COLLATE DATABASE_DEFAULT,'|',dc.definition COLLATE DATABASE_DEFAULT)
+SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAULT,'|',c.name COLLATE DATABASE_DEFAULT,'|',dc.name COLLATE DATABASE_DEFAULT,'|',dc.definition COLLATE DATABASE_DEFAULT)
 FROM sys.default_constraints dc
 JOIN sys.tables t ON t.object_id=dc.parent_object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.columns c ON c.object_id=t.object_id AND c.column_id=dc.parent_column_id
-WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
 """
 
             let! triggers =
                 catalogSetAsync
                     connectionString
                     """
-SELECT CONCAT(t.name COLLATE DATABASE_DEFAULT,'|',tr.name COLLATE DATABASE_DEFAULT)
+SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAULT,'|',tr.name COLLATE DATABASE_DEFAULT)
 FROM sys.triggers tr
 JOIN sys.tables t ON t.object_id=tr.parent_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
-WHERE s.name='ops' AND t.name IN ('BillingPeriod','Charge','BillingPeriodCloseEvidence');
+WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
 """
 
             return
@@ -474,12 +483,14 @@ type OperationsBillingPeriodCloseTests() =
     /// Creates a database name that cannot share rows with another test run.
     let databaseName () = $"GraceOperationsBillingCloseSchema_{Guid.NewGuid():N}"
 
-    /// Requires the configured SQL Server because this issue's physical proof has no valid skipped path.
+    /// Explicitly skips only live SQL proofs when no disposable SQL Server was configured for this process.
     let requireSqlConnectionString () =
         let value = Environment.GetEnvironmentVariable sqlConnectionStringEnvironmentVariable
 
         if String.IsNullOrWhiteSpace value then
-            Assert.Fail($"{sqlConnectionStringEnvironmentVariable} is required; the physical-schema matrix has zero permitted skips.")
+            Assert.Ignore(
+                $"{sqlConnectionStringEnvironmentVariable} is unavailable; live SQL proof is skipped for this run and remains required in the isolated Docker gate."
+            )
 
         value
 
@@ -587,7 +598,7 @@ ORDER BY 1;
         executeAsync
             connectionString
             """
-DECLARE @PeriodId uniqueidentifier=NEWID(), @LineId uniqueidentifier=NEWID();
+DECLARE @PeriodId uniqueidentifier='11111111-1111-1111-1111-111111111111', @LineId uniqueidentifier='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State,RetryDiagnostic,RetryDiagnosticAtUtc)
 VALUES (@PeriodId,NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',0,NULL,NULL);
 INSERT ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros)
@@ -595,6 +606,13 @@ VALUES (@LineId,NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',1,NEWID(),1,NE
 INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),@PeriodId,@LineId,'USD',1);
 INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance)
 VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-fixture');
+DECLARE @AmountPeriodId uniqueidentifier='22222222-2222-2222-2222-222222222222', @AmountLineId uniqueidentifier='bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (@AmountPeriodId,NEWID(),NEWID(),NEWID(),'2026-07-01','2026-08-01',0);
+INSERT ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@AmountLineId,NEWID(),NEWID(),NEWID(),'2026-07-01','2026-08-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-07-01','2026-08-01',1,1);
+DECLARE @CurrencyPeriodId uniqueidentifier='33333333-3333-3333-3333-333333333333', @CurrencyLineId uniqueidentifier='cccccccc-cccc-cccc-cccc-cccccccccccc';
+INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (@CurrencyPeriodId,NEWID(),NEWID(),NEWID(),'2026-08-01','2026-09-01',0);
+INSERT ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@CurrencyLineId,NEWID(),NEWID(),NEWID(),'2026-08-01','2026-09-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-08-01','2026-09-01',1,1);
+INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES ('44444444-4444-4444-4444-444444444444',NEWID(),NEWID(),NEWID(),'2026-09-01','2026-10-01',0),('55555555-5555-5555-5555-555555555555',NEWID(),NEWID(),NEWID(),'2026-10-01','2026-11-01',0);
 """
 
     /// Proves configured provider types retain their explicit provenance and cannot silently become CLR aliases.
@@ -606,10 +624,12 @@ VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-f
             context.GetService<IDesignTimeModel>().Model
             |> BillingCloseSchema.fromModel
 
-        let original = "Charge|CurrencyCode|explicit|varchar(3)"
+        let original = "ops.Charge|CurrencyCode|explicit|varchar(3)"
 
         let mutated =
-            { runtime with StoreTypeProvenance = BillingCloseSchema.replace original "Charge|CurrencyCode|explicit|System.Int32" runtime.StoreTypeProvenance }
+            { runtime with
+                StoreTypeProvenance = BillingCloseSchema.replace original "ops.Charge|CurrencyCode|explicit|System.Int32" runtime.StoreTypeProvenance
+            }
 
         let drift = BillingCloseSchema.compare runtime mutated true
         Assert.That(drift, Is.Not.Empty)
@@ -627,7 +647,7 @@ VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-f
             { runtime with
                 Columns =
                     runtime.Columns
-                    |> Set.remove "Charge|ChargeMicros|bigint|False|-|-|-|-|-|-"
+                    |> Set.remove "ops.Charge|ChargeMicros|bigint|False|-|-|-|-|-|-"
             }
 
         let drift = BillingCloseSchema.compare runtime incomplete false
@@ -657,6 +677,15 @@ VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-f
                 assertNoDrift "runtime-target" (BillingCloseSchema.compare runtime target true)
                 assertNoDrift "runtime-snapshot" (BillingCloseSchema.compare runtime snapshot true)
                 assertNoDrift "runtime-live" (BillingCloseSchema.compare runtime live false)
+
+                do! executeAsync connectionString "CREATE TABLE ops.UnexpectedPhysicalObject (UnexpectedId uniqueidentifier NOT NULL);"
+                let! liveWithUnexpectedObject = BillingCloseSchema.fromLiveSqlAsync connectionString
+
+                Assert.That(
+                    BillingCloseSchema.compare runtime liveWithUnexpectedObject false,
+                    Is.Not.Empty,
+                    "The live catalog extractor must report an unexpected physical table instead of prefiltering it away."
+                )
             })
 
     /// Verifies five independent altered fixture representations all produce exact-set drift reports.
@@ -673,33 +702,46 @@ VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-f
                 { runtime with
                     StoreTypeProvenance =
                         BillingCloseSchema.replace
-                            "Charge|CurrencyCode|explicit|varchar(3)"
-                            "Charge|CurrencyCode|explicit|System.Int32"
+                            "ops.Charge|CurrencyCode|explicit|varchar(3)"
+                            "ops.Charge|CurrencyCode|explicit|System.Int32"
                             runtime.StoreTypeProvenance
                 }
                 { runtime with
                     Checks =
                         BillingCloseSchema.replace
-                            "Charge|CK_ops_Charge_Amount|[chargemicros] >= 0"
-                            "Charge|CK_ops_Charge_Amount|[chargemicros] > 0"
+                            "ops.Charge|CK_ops_Charge_Amount|[chargemicros] >= 0"
+                            "ops.Charge|CK_ops_Charge_Amount|[chargemicros] > 0"
                             runtime.Checks
                 }
                 { runtime with
                     Indexes =
                         BillingCloseSchema.replace
-                            "Charge|UX_ops_Charge_InitialPosting|True|BillingPeriodId,ChargePreviewLineId|-"
-                            "Charge|UX_ops_Charge_InitialPosting|True|ChargePreviewLineId,BillingPeriodId|-"
+                            "ops.Charge|UX_ops_Charge_InitialPosting|True|BillingPeriodId,ChargePreviewLineId|-"
+                            "ops.Charge|UX_ops_Charge_InitialPosting|True|ChargePreviewLineId,BillingPeriodId|-"
                             runtime.Indexes
                 }
                 { runtime with
                     ForeignKeys =
                         BillingCloseSchema.replace
-                            "Charge|FK_ops_Charge_BillingPeriod|BillingPeriodId|ops.BillingPeriod|BillingPeriodId|no_action"
-                            "Charge|FK_ops_Charge_BillingPeriod|BillingPeriodId|ops.BillingPeriod|BillingPeriodId|cascade"
+                            "ops.Charge|FK_ops_Charge_BillingPeriod|BillingPeriodId|ops.BillingPeriod|BillingPeriodId|no_action"
+                            "ops.Charge|FK_ops_Charge_BillingPeriod|BillingPeriodId|ops.BillingPeriod|BillingPeriodId|cascade"
                             runtime.ForeignKeys
                 }
                 { runtime with
-                    Triggers = BillingCloseSchema.replace "Charge|TR_ops_Charge_Immutable" "Charge|TR_ops_Charge_Immutable_Renamed" runtime.Triggers
+                    Triggers = BillingCloseSchema.replace "ops.Charge|TR_ops_Charge_Immutable" "ops.Charge|TR_ops_Charge_Immutable_Renamed" runtime.Triggers
+                }
+                { runtime with Tables = BillingCloseSchema.replace "ops.Charge" "dbo.Charge" runtime.Tables }
+                { runtime with
+                    Properties =
+                        BillingCloseSchema.replace
+                            "ops.Charge|CurrencyCode|CurrencyCode|System.String"
+                            "ops.Charge|Currency|CurrencyCode|System.String"
+                            runtime.Properties
+                }
+                { runtime with
+                    Tables =
+                        runtime.Tables
+                        |> Set.add "ops.UnexpectedPhysicalObject"
                 }
             ]
 
@@ -741,13 +783,13 @@ VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-f
                         "period diagnostic",
                         "INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State,RetryDiagnostic,RetryDiagnosticAtUtc) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',2,'retry',SYSUTCDATETIME());"
                         "charge amount",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'USD',-1 FROM ops.Charge;"
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),'22222222-2222-2222-2222-222222222222','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','USD',-1);"
                         "charge currency",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'usd',1 FROM ops.Charge;"
+                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),'33333333-3333-3333-3333-333333333333','cccccccc-cccc-cccc-cccc-cccccccccccc','usd',1);"
                         "evidence digest",
-                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (NEWID(),'bad',REPLICATE('A',64),SYSUTCDATETIME(),'x');"
+                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES ('44444444-4444-4444-4444-444444444444','bad',REPLICATE('A',64),SYSUTCDATETIME(),'x');"
                         "evidence provenance",
-                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (NEWID(),REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),' ');"
+                        "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES ('55555555-5555-5555-5555-555555555555',REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),' ');"
                         "duplicate posting",
                         "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'USD',1 FROM ops.Charge;"
                         "charge period foreign key",

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -43,9 +43,9 @@ module private BillingCloseSchema =
                      "ops.Charge"
                      "ops.BillingPeriodCloseEvidence" ]
 
-    /// Names tables that existed before the billing-close migration and are excluded from this leaf's live catalog slice.
+    /// Names the schema-qualified tables frozen before this migration and excluded from its live catalog remainder.
     let private priorTables =
-        "'__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine'"
+        "'ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine'"
 
     /// Forms the schema-qualified physical identity used by every catalog comparison facet.
     let private tableIdentity schema table = $"{schema}.{table}"
@@ -347,7 +347,7 @@ module private BillingCloseSchema =
             let! liveTables =
                 catalogSetAsync
                     connectionString
-                    $"SELECT CONCAT(s.name,'.',t.name) FROM sys.tables t JOIN sys.schemas s ON s.schema_id=t.schema_id WHERE s.name='ops' AND t.name NOT IN ({priorTables});"
+                    $"SELECT CONCAT(s.name,'.',t.name) FROM sys.tables t JOIN sys.schemas s ON s.schema_id=t.schema_id WHERE CONCAT(s.name,'.',t.name) NOT IN ({priorTables});"
 
             let! columns =
                 catalogSetAsync
@@ -364,7 +364,7 @@ FROM sys.tables t
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.columns c ON c.object_id=t.object_id
 JOIN sys.types ty ON ty.user_type_id=c.user_type_id
-WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
+WHERE CONCAT(s.name,'.',t.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine');
 """
 
             let! keys =
@@ -377,7 +377,7 @@ JOIN sys.tables t ON t.object_id=kc.parent_object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.index_columns ic ON ic.object_id=kc.parent_object_id AND ic.index_id=kc.unique_index_id
 JOIN sys.columns c ON c.object_id=ic.object_id AND c.column_id=ic.column_id
-WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine')
+WHERE CONCAT(s.name,'.',t.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine')
 GROUP BY s.name,t.name,kc.name,kc.type;
 """
 
@@ -391,7 +391,7 @@ JOIN sys.tables t ON t.object_id=i.object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.index_columns ic ON ic.object_id=i.object_id AND ic.index_id=i.index_id AND ic.key_ordinal > 0
 JOIN sys.columns c ON c.object_id=ic.object_id AND c.column_id=ic.column_id
-WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine') AND i.is_primary_key=0 AND i.is_unique_constraint=0
+WHERE CONCAT(s.name,'.',t.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine') AND i.is_primary_key=0 AND i.is_unique_constraint=0
 GROUP BY s.name,t.name,i.name,i.is_unique,i.filter_definition;
 """
 
@@ -408,7 +408,7 @@ JOIN sys.schemas principalSchema ON principalSchema.schema_id=parent.schema_id
 JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id=fk.object_id
 JOIN sys.columns childColumn ON childColumn.object_id=child.object_id AND childColumn.column_id=fkc.parent_column_id
 JOIN sys.columns parentColumn ON parentColumn.object_id=parent.object_id AND parentColumn.column_id=fkc.referenced_column_id
-WHERE childSchema.name='ops' AND child.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine')
+WHERE CONCAT(childSchema.name,'.',child.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine')
 GROUP BY childSchema.name,child.name,fk.name,principalSchema.name,parent.name,fk.delete_referential_action_desc;
 """
 
@@ -420,7 +420,7 @@ SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAUL
 FROM sys.check_constraints cc
 JOIN sys.tables t ON t.object_id=cc.parent_object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
-WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
+WHERE CONCAT(s.name,'.',t.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine');
 """
 
             let! defaults =
@@ -432,7 +432,7 @@ FROM sys.default_constraints dc
 JOIN sys.tables t ON t.object_id=dc.parent_object_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
 JOIN sys.columns c ON c.object_id=t.object_id AND c.column_id=dc.parent_column_id
-WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
+WHERE CONCAT(s.name,'.',t.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine');
 """
 
             let! triggers =
@@ -443,7 +443,7 @@ SELECT CONCAT(s.name COLLATE DATABASE_DEFAULT,'.',t.name COLLATE DATABASE_DEFAUL
 FROM sys.triggers tr
 JOIN sys.tables t ON t.object_id=tr.parent_id
 JOIN sys.schemas s ON s.schema_id=t.schema_id
-WHERE s.name='ops' AND t.name NOT IN ('__EFMigrationsHistory','RawUsageFact','UsageFactRejection','UsageFactJournal','UsageAggregateMinute','PricingPlan','BillableUsageKindMapping','PricingRate','PricingAssignment','ChargePreviewLine');
+WHERE CONCAT(s.name,'.',t.name) NOT IN ('ops.__EFMigrationsHistory','ops.RawUsageFact','ops.UsageFactRejection','ops.UsageFactJournal','ops.UsageAggregateMinute','ops.PricingPlan','ops.BillableUsageKindMapping','ops.PricingRate','ops.PricingAssignment','ops.ChargePreviewLine');
 """
 
             return
@@ -593,7 +593,7 @@ ORDER BY 1;
             Assert.That<string list>(after, Is.EqualTo<string list>(before), $"{label} changed durable state after SQL rejected it.")
         }
 
-    /// Inserts one valid period, preview line, charge, and evidence without invoking any future close behavior.
+    /// Inserts complete valid immutable-posting inputs without invoking any future close behavior.
     let seedValidRowsAsync connectionString =
         executeAsync
             connectionString
@@ -603,7 +603,7 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
 VALUES (@PeriodId,NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',0,NULL,NULL);
 INSERT ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros)
 VALUES (@LineId,NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-06-01','2026-07-01',1,1);
-INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),@PeriodId,@LineId,'USD',1);
+INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),@PeriodId,@LineId,'2026-06-01','2026-07-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-06-01','2026-07-01',1,1);
 INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance)
 VALUES (@PeriodId,REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'schema-fixture');
 DECLARE @AmountPeriodId uniqueidentifier='22222222-2222-2222-2222-222222222222', @AmountLineId uniqueidentifier='bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
@@ -679,13 +679,27 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
                 assertNoDrift "runtime-live" (BillingCloseSchema.compare runtime live false)
 
                 do! executeAsync connectionString "CREATE TABLE ops.UnexpectedPhysicalObject (UnexpectedId uniqueidentifier NOT NULL);"
+                do! executeAsync connectionString "CREATE TABLE dbo.UnexpectedPhysicalObject (UnexpectedId uniqueidentifier NOT NULL);"
                 let! liveWithUnexpectedObject = BillingCloseSchema.fromLiveSqlAsync connectionString
 
-                Assert.That(
-                    BillingCloseSchema.compare runtime liveWithUnexpectedObject false,
-                    Is.Not.Empty,
-                    "The live catalog extractor must report an unexpected physical table instead of prefiltering it away."
-                )
+                let unexpectedDrift =
+                    BillingCloseSchema.compare runtime liveWithUnexpectedObject false
+                    |> String.concat Environment.NewLine
+
+                Assert.That(unexpectedDrift, Does.Contain("ops.UnexpectedPhysicalObject"))
+                Assert.That(unexpectedDrift, Does.Contain("dbo.UnexpectedPhysicalObject"))
+                Assert.That(unexpectedDrift, Does.Contain("ops.UnexpectedPhysicalObject|UnexpectedId"))
+                Assert.That(unexpectedDrift, Does.Contain("dbo.UnexpectedPhysicalObject|UnexpectedId"))
+
+                do! executeAsync connectionString "ALTER SCHEMA dbo TRANSFER ops.Charge;"
+                let! liveWithMovedCharge = BillingCloseSchema.fromLiveSqlAsync connectionString
+
+                let movedDrift =
+                    BillingCloseSchema.compare runtime liveWithMovedCharge false
+                    |> String.concat Environment.NewLine
+
+                Assert.That(movedDrift, Does.Contain("tables missing: ops.Charge"))
+                Assert.That(movedDrift, Does.Contain("tables unexpected: dbo.Charge"))
             })
 
     /// Verifies five independent altered fixture representations all produce exact-set drift reports.
@@ -769,7 +783,7 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
 
     /// Exercises every #916 check, identity, foreign-key, and immutable-trigger rejection against one migrated SQL database.
     [<Test>]
-    member _.LivePhysicalRejectionMatrixRejectsFifteenNamedInvalidStatementsAndAllowsValidRows() =
+    member _.LivePhysicalRejectionMatrixRejectsEighteenNamedInvalidStatementsAndAllowsValidRows() =
         withDatabaseAsync (fun connectionString ->
             task {
                 do! seedValidRowsAsync connectionString
@@ -783,19 +797,25 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
                         "period diagnostic",
                         "INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State,RetryDiagnostic,RetryDiagnosticAtUtc) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'2026-06-01','2026-07-01',2,'retry',SYSUTCDATETIME());"
                         "charge amount",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),'22222222-2222-2222-2222-222222222222','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','USD',-1);"
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'22222222-2222-2222-2222-222222222222','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','2026-07-01','2026-08-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-07-01','2026-08-01',1,-1);"
                         "charge currency",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) VALUES (NEWID(),'33333333-3333-3333-3333-333333333333','cccccccc-cccc-cccc-cccc-cccccccccccc','usd',1);"
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'33333333-3333-3333-3333-333333333333','cccccccc-cccc-cccc-cccc-cccccccccccc','2026-08-01','2026-09-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'usd','unit',1,1,'2026-08-01','2026-09-01',1,1);"
+                        "charge identity",
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES ('00000000-0000-0000-0000-000000000000',NEWID(),NEWID(),NEWID(),'22222222-2222-2222-2222-222222222222','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','2026-07-01','2026-08-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-07-01','2026-08-01',1,1);"
+                        "charge quantity",
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'33333333-3333-3333-3333-333333333333','cccccccc-cccc-cccc-cccc-cccccccccccc','2026-08-01','2026-09-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',0,1,'2026-08-01','2026-09-01',1,1);"
+                        "charge provenance",
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (NEWID(),NEWID(),NEWID(),NEWID(),'33333333-3333-3333-3333-333333333333','cccccccc-cccc-cccc-cccc-cccccccccccc','2026-08-01','2026-09-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD',' ',1,1,'2026-08-01','2026-09-01',1,1);"
                         "evidence digest",
                         "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES ('44444444-4444-4444-4444-444444444444','bad',REPLICATE('A',64),SYSUTCDATETIME(),'x');"
                         "evidence provenance",
                         "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES ('55555555-5555-5555-5555-555555555555',REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),' ');"
                         "duplicate posting",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,ChargePreviewLineId,'USD',1 FROM ops.Charge;"
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) SELECT NEWID(),OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros FROM ops.Charge;"
                         "charge period foreign key",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),NEWID(),ChargePreviewLineId,'USD',1 FROM ops.Charge;"
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) SELECT NEWID(),OwnerId,OrganizationId,RepositoryId,NEWID(),ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros FROM ops.Charge;"
                         "charge preview foreign key",
-                        "INSERT ops.Charge (ChargeId,BillingPeriodId,ChargePreviewLineId,CurrencyCode,ChargeMicros) SELECT NEWID(),BillingPeriodId,NEWID(),'USD',1 FROM ops.Charge;"
+                        "INSERT ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) SELECT NEWID(),OwnerId,OrganizationId,RepositoryId,BillingPeriodId,NEWID(),PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros FROM ops.Charge;"
                         "evidence period foreign key",
                         "INSERT ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (NEWID(),REPLICATE('A',64),REPLICATE('B',64),SYSUTCDATETIME(),'x');"
                         "charge update", "UPDATE ops.Charge SET ChargeMicros=2;"
@@ -804,7 +824,7 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
                         "evidence delete", "DELETE FROM ops.BillingPeriodCloseEvidence;"
                     ]
 
-                Assert.That(cases.Length, Is.EqualTo(15), "The physical rejection matrix must retain every named #916 case.")
+                Assert.That(cases.Length, Is.EqualTo(18), "The physical rejection matrix must retain every named #916 case.")
 
                 for label, sql in cases do
                     do! rejectAndPreserveAsync connectionString label sql

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -244,7 +244,7 @@ type OperationsChargePreviewTests() =
                 "..",
                 "Grace.Operations.Data",
                 "Migrations",
-                "20260812110000_AddUsageFactJournal.fs"
+                "20260812130000_AddBillingPeriodClose.fs"
             )
             |> Path.GetFullPath
 
@@ -274,7 +274,7 @@ type OperationsChargePreviewTests() =
         use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsChargePreviewModel;Integrated Security=true;"
         let runtime = context.GetService<IDesignTimeModel>().Model
         let snapshot = OperationsDbContextModelSnapshot().Model
-        let migration = AddUsageFactJournal().TargetModel
+        let migration = AddBillingPeriodClose().TargetModel
 
         let modelShape (model: Microsoft.EntityFrameworkCore.Metadata.IModel) =
             model.GetEntityTypes()
@@ -288,9 +288,12 @@ type OperationsChargePreviewTests() =
                         |> Seq.toList)
                     |> Set.ofSeq
 
+                let storeObject = StoreObjectIdentifier.Table(entity.GetTableName(), entity.GetSchema())
+
                 let properties =
                     entity.GetProperties()
-                    |> Seq.map (fun property -> property.Name, property.ClrType.FullName, property.IsNullable)
+                    |> Seq.map (fun property ->
+                        property.Name, property.GetColumnName(&storeObject), property.ClrType.FullName, property.IsNullable, property.IsShadowProperty())
                     |> Set.ofSeq
 
                 let indexes =
@@ -328,23 +331,38 @@ type OperationsChargePreviewTests() =
         let preview = runtime.FindEntityType(typeof<ChargePreviewLineEntity>)
         let rejection = runtime.FindEntityType(typeof<UsageFactRejectionEntity>)
 
+        let noShadowMembers (model: IModel) =
+            model.GetEntityTypes()
+            |> Seq.collect (fun entity -> entity.GetProperties())
+            |> Seq.exists (fun property -> property.IsShadowProperty())
+
         ChargePreviewTestData.multiple (fun () ->
             Assert.That(targetModelSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
             Assert.That(migrationSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
             Assert.That(snapshotModelSource, Does.Not.Match(@"\bOperations[A-Za-z0-9_]*(?:Sql|Model|Configuration|Options|Schema)\."))
             Assert.That(targetModelSource, Does.Not.Match(@"(?im)^\s*[A-Za-z0-9_.]*(?:configure|configureModel)\s+modelBuilder\s*$"))
             Assert.That(snapshotModelSource, Does.Not.Match(@"(?im)^\s*[A-Za-z0-9_.]*(?:configure|configureModel)\s+modelBuilder\s*$"))
-            Assert.That(targetModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
+            Assert.That(migrationSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
             Assert.That(snapshotModelSource, Does.Contain("modelBuilder.HasDefaultSchema(\"ops\")"))
-            Assert.That(targetModelSource, Does.Contain("let rawFact = modelBuilder.Entity<RawUsageFactEntity>()"))
+            Assert.That(targetModelSource, Does.Contain("BillingPeriodCloseFrozenTarget.applyPriorModel modelBuilder"))
+            Assert.That(migrationSource, Does.Contain("let rawFact = modelBuilder.Entity<RawUsageFactEntity>()"))
             Assert.That(snapshotModelSource, Does.Contain("let rawFact = modelBuilder.Entity<RawUsageFactEntity>()"))
-            Assert.That(targetModelSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
+            Assert.That(migrationSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
             Assert.That(snapshotModelSource, Does.Contain("let line = modelBuilder.Entity<ChargePreviewLineEntity>()"))
-            Assert.That(targetModelSource, Does.Contain("let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()"))
+            Assert.That(migrationSource, Does.Contain("let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()"))
             Assert.That(snapshotModelSource, Does.Contain("let rejection = modelBuilder.Entity<UsageFactRejectionEntity>()"))
-            Assert.That(targetModelSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
+            Assert.That(migrationSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
             Assert.That(snapshotModelSource, Does.Contain("let journal = modelBuilder.Entity<UsageFactJournalEntity>()"))
+            Assert.That(migrationSource, Does.Contain("let period = modelBuilder.Entity<BillingPeriodEntity>()"))
+            Assert.That(migrationSource, Does.Contain("let charge = modelBuilder.Entity<ChargeEntity>()"))
+            Assert.That(migrationSource, Does.Contain("let evidence = modelBuilder.Entity<BillingPeriodCloseEvidenceEntity>()"))
             Assert.That(rejection, Is.Not.Null)
+            Assert.That(migration.GetEntityTypes() |> Seq.length, Is.EqualTo(12))
+            Assert.That(runtime.GetEntityTypes() |> Seq.length, Is.EqualTo(12))
+            Assert.That(snapshot.GetEntityTypes() |> Seq.length, Is.EqualTo(12))
+            Assert.That(noShadowMembers migration, Is.False, "Frozen migration target must not add convention shadow members.")
+            Assert.That(noShadowMembers runtime, Is.False, "Runtime model must not add convention shadow members.")
+            Assert.That(noShadowMembers snapshot, Is.False, "Snapshot must not add convention shadow members.")
             Assert.That((migrationShape = snapshotShape), Is.True)
 
             Assert.That(

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -485,7 +485,7 @@ type OperationsUsageStorageTests() =
     /// Verifies partitioning is limited to current Operations tables and keeps local SQL Server testability.
     [<Test>]
     member _.MonthlyPartitioningMigrationStaysInsideCurrentUsageTables() =
-        let script = migrationScript ()
+        let script = migrationScriptFromTo "20260707000000_AddRawUsageFactPayload" "20260707120000_AddOperationsMonthlyPartitioning"
 
         Assert.Multiple(
             Action (fun () ->


### PR DESCRIPTION
# Persist billing-close records with exact physical-schema proof

## Purpose

Give later billing-close behavior an independently proven durable schema for exact-scope periods, immutable initial
charges, and immutable close evidence.

Related to #916. Parent replacement packet: #908. Epic chain: #554 -> #560 -> #576 -> #864.

## Delivered

- Adds BillingPeriod, Charge, and BillingPeriodCloseEvidence entities and runtime EF configuration.
- Adds one self-contained literal migration with a complete frozen target.
- Adds an independently declared snapshot fragment that does not call the migration target helper.
- Adds immutable Charge and close-evidence triggers plus named checks, keys, indexes, foreign keys, and defaults.
- Adds exact runtime, frozen-target, snapshot, and live-SQL set comparison with explicit-versus-inferred store-type
  provenance.
- Adds false-pass mutation fixtures for explicit store type, check definition, index order, foreign-key delete behavior,
  and trigger name.
- Adds a 15-case migrated-SQL rejection matrix with full before/after durable projections and a valid-insert guard.

## Boundaries

- No close service, database-clock or lock behavior, pricing calculation, or final preview rebuild.
- No BillingPeriodLateWork or accepted-fact integration; #918 owns them.
- No collective zero-fact pricing, hosted discovery, corrections, adjustments, terminal settlement, Worker production
  edit, or public surface.
- No compatibility behavior and no wholesale PR #911 reuse.

## Exact-head local proof

- Head: `30a765cfd4c901b46be3625fcf0074ef9f6a1759`.
- Operations Tests Release build: zero warnings and errors.
- Full isolated Docker Operations suite: 205/205 passed, zero skipped.
- Live four-way parity and physical matrix: 2/2 passed, zero skipped.
- Pure comparer, mutation, and snapshot-independence suite: 4/4 passed, zero skipped.
- Targeted Fantomas, MarkdownLint for `MIGRATIONS.md`, and `git diff --check`: passed.
- Disposable SQL container removed; issue worktree clean and local head equals remote.

## Review status

- Implementation/fix workers exhausted: **5 of 5**.
- Mandatory post-worker-3 structural audit: architecture and scope remain valid.
- Reviews 1 and 2 and all earlier CI are stale; workers 4 and 5 closed their finite action sets.
- Worker 5 completed the Charge posting tuple/checks and full schema-qualified live-object closure at `30a765cf`.
- Fresh final exact-head review 3 and GitHub `Validate` run `31667499690` are active.
- Any valid addressable finding supersedes this PR; no worker 6 will start.

## Documentation impact

`MIGRATIONS.md` records the durable schema and literal migration. No public behavior or command documentation changes.
