### PR TITLE
B4.3R2a2: Close nonempty billing periods atomically under database time

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -33,6 +33,7 @@
     <Compile Include="Migrations\20260812130000_AddBillingPeriodClose.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
+    <Compile Include="OperationsBillingPeriod.fs" />
     <Compile Include="OperationsUsageJournal.fs" />
   </ItemGroup>
 

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -76,15 +76,23 @@ type internal IBillingPeriodCloseClock =
     abstract UtcNowAsync: connection: SqlConnection * transaction: SqlTransaction * cancellationToken: CancellationToken -> Task<DateTime>
 
 /// Uses the production SQL Server clock with no process-time alternative.
-type private DatabaseBillingPeriodCloseClock() =
+type private DatabaseBillingPeriodCloseClock(transactionInterleaving: IBillingPeriodCloseTransactionInterleaving) =
     interface IBillingPeriodCloseClock with
         member _.UtcNowAsync(connection, transaction, cancellationToken) =
             task {
                 use clockCommand = connection.CreateCommand()
                 clockCommand.Transaction <- transaction
-                clockCommand.CommandText <- "SELECT SYSUTCDATETIME();"
-                let! value = clockCommand.ExecuteScalarAsync cancellationToken
-                return value :?> DateTime
+                clockCommand.CommandText <- "SELECT @@SPID, SYSUTCDATETIME();"
+                use! reader = clockCommand.ExecuteReaderAsync cancellationToken
+                let! hasRow = reader.ReadAsync cancellationToken
+
+                if not hasRow then
+                    invalidOp "SQL Server did not return a billing-period close clock value."
+
+                let sessionId = reader.GetInt32 0
+                let databaseUtcNow = reader.GetDateTime 1
+                do! transactionInterleaving.AfterDatabaseClockReadAsync(sessionId, databaseUtcNow, cancellationToken)
+                return databaseUtcNow
             }
 
 /// Exposes the bounded preview and final-close calls used by later scheduled-operation hosting.
@@ -559,10 +567,6 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
                 else
                     let! databaseUtcNow = clock.UtcNowAsync(connection, transaction, cancellationToken)
 
-                    use sessionCommand = command connection transaction "SELECT @@SPID;"
-                    let! sessionId = sessionCommand.ExecuteScalarAsync cancellationToken
-                    do! transactionInterleaving.AfterDatabaseClockReadAsync(Convert.ToInt32 sessionId, databaseUtcNow, cancellationToken)
-
                     let nextMonthStartUtc =
                         (BillingCompletenessScope.nextMonthStart request.Scope)
                             .ToDateTimeUtc()
@@ -637,12 +641,13 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
         SqlBillingPeriodCloser(
             connectionString,
             NoBillingPeriodCloseTransactionInterleaving() :> IBillingPeriodCloseTransactionInterleaving,
-            DatabaseBillingPeriodCloseClock() :> IBillingPeriodCloseClock
+            DatabaseBillingPeriodCloseClock(NoBillingPeriodCloseTransactionInterleaving() :> IBillingPeriodCloseTransactionInterleaving)
+            :> IBillingPeriodCloseClock
         )
 
     /// Creates a real-SQL close seam that retains the production SQL clock while exposing transaction stages to tests.
     static member internal CreateForTest(connectionString, transactionInterleaving) =
-        SqlBillingPeriodCloser(connectionString, transactionInterleaving, DatabaseBillingPeriodCloseClock() :> IBillingPeriodCloseClock)
+        SqlBillingPeriodCloser(connectionString, transactionInterleaving, DatabaseBillingPeriodCloseClock(transactionInterleaving) :> IBillingPeriodCloseClock)
 
     /// Creates an internal policy-boundary seam with controlled database-time values while retaining the production transaction.
     static member internal CreateForTest(connectionString, transactionInterleaving, clock) =

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -89,7 +89,7 @@ type private DatabaseBillingPeriodCloseClock(transactionInterleaving: IBillingPe
                 if not hasRow then
                     invalidOp "SQL Server did not return a billing-period close clock value."
 
-                let sessionId = reader.GetInt32 0
+                let sessionId = Convert.ToInt32(reader.GetValue 0, CultureInfo.InvariantCulture)
                 let databaseUtcNow = reader.GetDateTime 1
                 do! transactionInterleaving.AfterDatabaseClockReadAsync(sessionId, databaseUtcNow, cancellationToken)
                 return databaseUtcNow
@@ -218,7 +218,7 @@ WHERE NOT EXISTS (SELECT 1 FROM ops.BillingPeriod WITH (UPDLOCK,HOLDLOCK) WHERE 
             if not exists then
                 invalidOp "The exact billing period could not be materialized under its scope lock."
 
-            return reader.GetGuid 0, enum<BillingPeriodState> (reader.GetInt32 1)
+            return reader.GetGuid 0, enum<BillingPeriodState> (Convert.ToInt32(reader.GetValue 1, CultureInfo.InvariantCulture))
         }
 
     /// Returns the first committed exact-scope blocker while the shared lock prevents a close race.
@@ -313,13 +313,13 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
                         facts.Add
                             {
                                 UsageFactId = reader.GetGuid 0
-                                FactKind = reader.GetInt32 1
+                                FactKind = Convert.ToInt32(reader.GetValue 1, CultureInfo.InvariantCulture)
                                 Quantity = reader.GetInt64 2
                                 ObservedAtUtc = reader.GetDateTime 3
                                 PricingAssignmentId = reader.GetGuid 4
                                 PricingPlanId = reader.GetGuid 6
                                 BillableUsageKindMappingId = reader.GetGuid 7
-                                BillableUsageKind = reader.GetInt32 8
+                                BillableUsageKind = Convert.ToInt32(reader.GetValue 8, CultureInfo.InvariantCulture)
                                 PricingRateId = reader.GetGuid 9
                                 CurrencyCode = reader.GetString 10
                                 UnitName = reader.GetString 11
@@ -422,7 +422,9 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
                 reading <- hasRow
 
                 if hasRow then
-                    values.Add($"{reader.GetGuid(0):D}|{reader.GetInt32(1)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}")
+                    values.Add(
+                        $"{reader.GetGuid(0):D}|{Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}"
+                    )
 
             return values |> Seq.toList |> digest
         }

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -1,0 +1,649 @@
+namespace Grace.Operations.Data
+
+open Microsoft.Data.SqlClient
+open NodaTime
+open System
+open System.Data
+open System.Globalization
+open System.Security.Cryptography
+open System.Text
+open System.Threading
+open System.Threading.Tasks
+
+/// Names the durable lifecycle values for a direct billing-period close.
+[<RequireQualifiedAccess>]
+type BillingPeriodState =
+    | Open = 0
+    | Provisional = 1
+    | Closed = 2
+
+/// Carries an exact billing scope and the scheduled-operation provenance recorded with a close.
+type BillingPeriodCloseRequest = { Scope: BillingCompletenessScope; ScheduledOperationProvenance: string }
+
+/// Reports the observable outcome of an attempted preview or final close.
+type BillingPeriodCloseResult =
+    | NotEligible
+    | Blocked of diagnostic: string
+    | Provisional of billingPeriodId: Guid * previewLineCount: int
+    | Closed of billingPeriodId: Guid * chargeCount: int
+
+/// Holds the pure database-time threshold policy separately from the SQL clock source and ordering proof.
+[<RequireQualifiedAccess>]
+module internal BillingPeriodCloseEligibility =
+
+    /// Accepts equality at the documented preview or final-close boundary and rejects the preceding SQL tick.
+    let isEligible isFinal (nextMonthStartUtc: DateTime) (databaseUtcNow: DateTime) =
+        let threshold = nextMonthStartUtc.AddHours(if isFinal then 72.0 else 24.0)
+        databaseUtcNow >= threshold
+
+/// Signals that nonempty close must not infer the deferred collective zero-fact pricing decision.
+type private ZeroFactCoveragePendingException() =
+    inherit InvalidOperationException("ZeroFactCoveragePending")
+
+/// Exposes the internal transaction stages used by real-SQL rollback and contention proofs.
+type internal IBillingPeriodCloseTransactionInterleaving =
+    /// Records the production SQL session immediately before it attempts the exact shared lock resource.
+    abstract BeforeScopeLockAcquisitionAsync: sessionId: int * resource: string * cancellationToken: CancellationToken -> Task
+
+    /// Runs after the shared scope lock has been granted and before database time is read.
+    abstract AfterScopeLockGrantedAsync: sessionId: int * resource: string * cancellationToken: CancellationToken -> Task
+
+    /// Records the database-owned close instant read after the shared lock grant.
+    abstract AfterDatabaseClockReadAsync: sessionId: int * databaseUtcNow: DateTime * cancellationToken: CancellationToken -> Task
+
+    /// Runs after replacement preview rows are staged but before immutable postings are inserted.
+    abstract AfterPreviewReplacementAsync: cancellationToken: CancellationToken -> Task
+
+    /// Runs after immutable postings are staged but before close evidence is inserted.
+    abstract AfterChargeInsertionAsync: cancellationToken: CancellationToken -> Task
+
+    /// Runs after immutable close evidence is staged but before the period is marked closed.
+    abstract AfterCloseEvidenceStagedAsync: cancellationToken: CancellationToken -> Task
+
+/// Provides production execution with no injected work between close-transaction stages.
+type private NoBillingPeriodCloseTransactionInterleaving() =
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.BeforeScopeLockAcquisitionAsync(_, _, _) = Task.CompletedTask
+        member _.AfterScopeLockGrantedAsync(_, _, _) = Task.CompletedTask
+        member _.AfterDatabaseClockReadAsync(_, _, _) = Task.CompletedTask
+        member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
+        member _.AfterChargeInsertionAsync _ = Task.CompletedTask
+        member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+
+/// Reads the database clock on the connection and transaction that already hold the scope lock.
+type internal IBillingPeriodCloseClock =
+    /// Returns SQL Server UTC time used by one close decision.
+    abstract UtcNowAsync: connection: SqlConnection * transaction: SqlTransaction * cancellationToken: CancellationToken -> Task<DateTime>
+
+/// Uses the production SQL Server clock with no process-time alternative.
+type private DatabaseBillingPeriodCloseClock() =
+    interface IBillingPeriodCloseClock with
+        member _.UtcNowAsync(connection, transaction, cancellationToken) =
+            task {
+                use clockCommand = connection.CreateCommand()
+                clockCommand.Transaction <- transaction
+                clockCommand.CommandText <- "SELECT SYSUTCDATETIME();"
+                let! value = clockCommand.ExecuteScalarAsync cancellationToken
+                return value :?> DateTime
+            }
+
+/// Exposes the bounded preview and final-close calls used by later scheduled-operation hosting.
+type IBillingPeriodCloser =
+    /// Rebuilds a provisional preview when database time has reached the preview threshold.
+    abstract PreviewAsync: request: BillingPeriodCloseRequest * cancellationToken: CancellationToken -> Task<BillingPeriodCloseResult>
+
+    /// Rebuilds a final preview and atomically posts its immutable initial charges when eligible.
+    abstract CloseAsync: request: BillingPeriodCloseRequest * cancellationToken: CancellationToken -> Task<BillingPeriodCloseResult>
+
+/// Rebuilds and closes one nonempty billing scope under the shared transaction-owned SQL lock.
+type SqlBillingPeriodCloser
+    private
+    (
+        connectionString: string,
+        transactionInterleaving: IBillingPeriodCloseTransactionInterleaving,
+        clock: IBillingPeriodCloseClock
+    ) =
+
+    /// Derives a stable billing period identity from the complete owner, repository, and UTC month tuple.
+    let billingPeriodId (scope: BillingCompletenessScope) =
+        let canonical =
+            String.Join(
+                "|",
+                [|
+                    "Grace.Operations.BillingPeriod.v1"
+                    scope.OwnerId.ToString("D")
+                    scope.OrganizationId.ToString("D")
+                    scope.RepositoryId.ToString("D")
+                    scope
+                        .MonthStart
+                        .ToDateTimeUtc()
+                        .Ticks.ToString(CultureInfo.InvariantCulture)
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+                        .Ticks.ToString(CultureInfo.InvariantCulture)
+                |]
+            )
+
+        Guid(
+            SHA256
+                .HashData(Encoding.UTF8.GetBytes canonical)
+                .AsSpan(0, 16)
+        )
+
+    /// Derives a stable immutable initial-posting identity from its period and preview-line identities.
+    let chargeId periodId previewLineId =
+        let canonical = $"Grace.Operations.InitialCharge.v1|{periodId:D}|{previewLineId:D}"
+
+        Guid(
+            SHA256
+                .HashData(Encoding.UTF8.GetBytes canonical)
+                .AsSpan(0, 16)
+        )
+
+    /// Adds the exact owner/repository/half-open-month tuple used by all close SQL commands.
+    let addScope (command: SqlCommand) (scope: BillingCompletenessScope) =
+        command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+        command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+        command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+        command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+        command.Parameters.Add("@NextMonthStartUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+            .ToDateTimeUtc()
+
+    /// Creates a SQL command bound to the active close transaction.
+    let command (connection: SqlConnection) (transaction: SqlTransaction) text =
+        let value = connection.CreateCommand()
+        value.Transaction <- transaction
+        value.CommandText <- text
+        value
+
+    /// Rolls back without hiding the error that caused the close to abort.
+    let rollbackIgnoringFailureAsync (transaction: SqlTransaction) =
+        task {
+            try
+                do! transaction.RollbackAsync CancellationToken.None
+            with
+            | _ -> ()
+        }
+
+    /// Acquires exactly the journal/completeness lock identity established by issue #879.
+    let acquireScopeLockAsync connection transaction scope cancellationToken =
+        task {
+            use sessionCommand = command connection transaction "SELECT @@SPID;"
+            let! sessionId = sessionCommand.ExecuteScalarAsync cancellationToken
+            let resource = BillingCompletenessScope.databaseLockIdentity scope
+            do! transactionInterleaving.BeforeScopeLockAcquisitionAsync(Convert.ToInt32 sessionId, resource, cancellationToken)
+            use lockCommand = command connection transaction OperationsUsageSql.AcquireBillingCompletenessScopeLock
+            lockCommand.Parameters.Add("@BillingCompletenessLockResource", SqlDbType.NVarChar, 255).Value <- BillingCompletenessScope.databaseLockIdentity scope
+            lockCommand.Parameters.Add("@BillingCompletenessLockTimeoutMilliseconds", SqlDbType.Int).Value <- 60000
+            let! _ = lockCommand.ExecuteNonQueryAsync cancellationToken
+            do! transactionInterleaving.AfterScopeLockGrantedAsync(Convert.ToInt32 sessionId, resource, cancellationToken)
+        }
+
+    /// Inserts the deterministic period if needed, then returns its state while its exact row remains locked.
+    let ensurePeriodAsync connection transaction scope cancellationToken =
+        task {
+            use insert =
+                command
+                    connection
+                    transaction
+                    """
+INSERT INTO ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State)
+SELECT @BillingPeriodId,@OwnerId,@OrganizationId,@RepositoryId,@MonthStartUtc,@NextMonthStartUtc,0
+WHERE NOT EXISTS (SELECT 1 FROM ops.BillingPeriod WITH (UPDLOCK,HOLDLOCK) WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND MonthStartUtc=@MonthStartUtc AND NextMonthStartUtc=@NextMonthStartUtc);
+"""
+
+            addScope insert scope
+            insert.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- billingPeriodId scope
+            let! _ = insert.ExecuteNonQueryAsync cancellationToken
+
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT BillingPeriodId,State FROM ops.BillingPeriod WITH (UPDLOCK,HOLDLOCK) WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND MonthStartUtc=@MonthStartUtc AND NextMonthStartUtc=@NextMonthStartUtc;"
+
+            addScope read scope
+            use! reader = read.ExecuteReaderAsync cancellationToken
+            let! exists = reader.ReadAsync cancellationToken
+
+            if not exists then
+                invalidOp "The exact billing period could not be materialized under its scope lock."
+
+            return reader.GetGuid 0, enum<BillingPeriodState> (reader.GetInt32 1)
+        }
+
+    /// Returns the first committed exact-scope blocker while the shared lock prevents a close race.
+    let completenessDiagnosticAsync connection transaction scope cancellationToken =
+        task {
+            use check =
+                command
+                    connection
+                    transaction
+                    """
+IF EXISTS (SELECT 1 FROM ops.UsageFactJournal WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND ObservedAtUtc>=@MonthStartUtc AND ObservedAtUtc<@NextMonthStartUtc AND State IN (0,2))
+    SELECT CAST('Unresolved UsageFact journal rows block billing close.' AS nvarchar(400));
+ELSE IF EXISTS (SELECT 1 FROM ops.UsageFactRejection WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND MonthStartUtc=@MonthStartUtc AND IsActive=1)
+    SELECT CAST('Active scoped usage rejection blocks billing close.' AS nvarchar(400));
+ELSE SELECT CAST(NULL AS nvarchar(400));
+"""
+
+            addScope check scope
+            let! value = check.ExecuteScalarAsync cancellationToken
+            return if Convert.IsDBNull value then None else Some(value :?> string)
+        }
+
+    /// Writes the bounded retry diagnostic only while the period remains nonterminal.
+    let setDiagnosticAsync connection transaction periodId diagnostic cancellationToken =
+        task {
+            use update =
+                command
+                    connection
+                    transaction
+                    "UPDATE ops.BillingPeriod SET RetryDiagnostic=@Diagnostic,RetryDiagnosticAtUtc=CASE WHEN @Diagnostic IS NULL THEN NULL ELSE SYSUTCDATETIME() END,UpdatedAtUtc=SYSUTCDATETIME() WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);"
+
+            update.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            let parameter = update.Parameters.Add("@Diagnostic", SqlDbType.NVarChar, 400)
+
+            parameter.Value <-
+                diagnostic
+                |> Option.map box
+                |> Option.defaultValue DBNull.Value
+
+            let! _ = update.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Reads current committed facts and their complete current pricing prerequisites inside the close transaction.
+    let readPricedFactsAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read = command connection transaction OperationsChargePreviewSql.SelectSourceAndPricing
+            read.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            read.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            read.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            read.Parameters.Add("@PeriodFromUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            read.Parameters.Add("@PeriodToUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+            use! reader = read.ExecuteReaderAsync cancellationToken
+            let facts = ResizeArray<ChargePreviewPricedFact>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+                reading <- hasRow
+
+                if hasRow then
+                    let prerequisite =
+                        ChargePreviewCalculation.missingPrerequisite
+                            (not (reader.IsDBNull 4))
+                            (not (reader.IsDBNull 6))
+                            (not (reader.IsDBNull 7))
+                            (not (reader.IsDBNull 9))
+
+                    match prerequisite with
+                    | Some missing ->
+                        let previewScope =
+                            {
+                                OwnerId = scope.OwnerId
+                                OrganizationId = scope.OrganizationId
+                                RepositoryId = scope.RepositoryId
+                                PeriodFromUtc = scope.MonthStart.ToDateTimeUtc()
+                                PeriodToUtc =
+                                    (BillingCompletenessScope.nextMonthStart scope)
+                                        .ToDateTimeUtc()
+                            }
+
+                        raise (ChargePreviewRebuildException(previewScope, reader.GetGuid 0, missing))
+                    | None ->
+                        facts.Add
+                            {
+                                UsageFactId = reader.GetGuid 0
+                                FactKind = reader.GetInt32 1
+                                Quantity = reader.GetInt64 2
+                                ObservedAtUtc = reader.GetDateTime 3
+                                PricingAssignmentId = reader.GetGuid 4
+                                PricingPlanId = reader.GetGuid 6
+                                BillableUsageKindMappingId = reader.GetGuid 7
+                                BillableUsageKind = reader.GetInt32 8
+                                PricingRateId = reader.GetGuid 9
+                                CurrencyCode = reader.GetString 10
+                                UnitName = reader.GetString 11
+                                UnitQuantity = reader.GetInt64 12
+                                UnitPriceMicros = reader.GetInt64 13
+                                EffectiveFromUtc = reader.GetDateTime 14
+                                EffectiveToUtc = reader.GetDateTime 15
+                            }
+
+            return facts |> Seq.toList
+        }
+
+    /// Replaces only this period's rebuildable preview rows after every new line has been calculated.
+    let replacePreviewAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (lines: ChargePreviewLineEntity array)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use delete = command connection transaction OperationsChargePreviewSql.DeleteScope
+            delete.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            delete.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            delete.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            delete.Parameters.Add("@PeriodFromUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            delete.Parameters.Add("@PeriodToUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+            let! _ = delete.ExecuteNonQueryAsync cancellationToken
+
+            let mutable index = 0
+
+            while index < lines.Length do
+                let line = lines[index]
+
+                use insert =
+                    command
+                        connection
+                        transaction
+                        "INSERT INTO ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@Id,@OwnerId,@OrganizationId,@RepositoryId,@PeriodFromUtc,@PeriodToUtc,@FactKind,@MappingId,@BillableKind,@AssignmentId,@PlanId,@RateId,@Currency,@UnitName,@UnitQuantity,@UnitPrice,@EffectiveFrom,@EffectiveTo,@TotalQuantity,@Charge);"
+
+                let add name dbType value = insert.Parameters.Add(name, dbType).Value <- value
+                add "@Id" SqlDbType.UniqueIdentifier line.ChargePreviewLineId
+                add "@OwnerId" SqlDbType.UniqueIdentifier line.OwnerId
+                add "@OrganizationId" SqlDbType.UniqueIdentifier line.OrganizationId
+                add "@RepositoryId" SqlDbType.UniqueIdentifier line.RepositoryId
+                add "@PeriodFromUtc" SqlDbType.DateTime2 line.PeriodFromUtc
+                add "@PeriodToUtc" SqlDbType.DateTime2 line.PeriodToUtc
+                add "@FactKind" SqlDbType.Int line.FactKind
+                add "@MappingId" SqlDbType.UniqueIdentifier line.BillableUsageKindMappingId
+                add "@BillableKind" SqlDbType.Int line.BillableUsageKind
+                add "@AssignmentId" SqlDbType.UniqueIdentifier line.PricingAssignmentId
+                add "@PlanId" SqlDbType.UniqueIdentifier line.PricingPlanId
+                add "@RateId" SqlDbType.UniqueIdentifier line.PricingRateId
+                insert.Parameters.Add("@Currency", SqlDbType.VarChar, 3).Value <- line.CurrencyCode
+                insert.Parameters.Add("@UnitName", SqlDbType.NVarChar, OperationsPricingSql.UnitNameMaxLength).Value <- line.UnitName
+                add "@UnitQuantity" SqlDbType.BigInt line.UnitQuantity
+                add "@UnitPrice" SqlDbType.BigInt line.UnitPriceMicros
+                add "@EffectiveFrom" SqlDbType.DateTime2 line.EffectiveFromUtc
+                add "@EffectiveTo" SqlDbType.DateTime2 line.EffectiveToUtc
+                add "@TotalQuantity" SqlDbType.BigInt line.TotalQuantity
+                add "@Charge" SqlDbType.BigInt line.ChargeMicros
+                let! _ = insert.ExecuteNonQueryAsync cancellationToken
+                index <- index + 1
+
+            return ()
+        }
+
+    /// Hashes a deterministic sequence of canonical evidence records using uppercase SHA-256 hex.
+    let digest values =
+        values
+        |> String.concat "\n"
+        |> Encoding.UTF8.GetBytes
+        |> SHA256.HashData
+        |> Convert.ToHexString
+
+    /// Reads the independent accepted-fact digest from committed raw facts after the final preview rebuild.
+    let acceptedFactDigestAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT UsageFactId,FactKind,Quantity,ObservedAtUtc FROM ops.RawUsageFact WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND ObservedAtUtc>=@MonthStartUtc AND ObservedAtUtc<@NextMonthStartUtc ORDER BY ObservedAtUtc,UsageFactId;"
+
+            addScope read scope
+            use! reader = read.ExecuteReaderAsync cancellationToken
+            let values = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+                reading <- hasRow
+
+                if hasRow then
+                    values.Add($"{reader.GetGuid(0):D}|{reader.GetInt32(1)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}")
+
+            return values |> Seq.toList |> digest
+        }
+
+    /// Hashes every persisted pricing and preview field so evidence covers values as well as line identities.
+    let pricingPreviewDigest (lines: ChargePreviewLineEntity array) =
+        lines
+        |> Seq.sortBy (fun line -> line.ChargePreviewLineId)
+        |> Seq.map (fun line ->
+            String.Join(
+                "|",
+                [|
+                    line.ChargePreviewLineId.ToString("D")
+                    line.OwnerId.ToString("D")
+                    line.OrganizationId.ToString("D")
+                    line.RepositoryId.ToString("D")
+                    line.PeriodFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    line.PeriodToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    line.FactKind.ToString(CultureInfo.InvariantCulture)
+                    line.BillableUsageKindMappingId.ToString("D")
+                    line.BillableUsageKind.ToString(CultureInfo.InvariantCulture)
+                    line.PricingAssignmentId.ToString("D")
+                    line.PricingPlanId.ToString("D")
+                    line.PricingRateId.ToString("D")
+                    line.CurrencyCode
+                    line.UnitName
+                    line.UnitQuantity.ToString(CultureInfo.InvariantCulture)
+                    line.UnitPriceMicros.ToString(CultureInfo.InvariantCulture)
+                    line.EffectiveFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    line.EffectiveToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    line.TotalQuantity.ToString(CultureInfo.InvariantCulture)
+                    line.ChargeMicros.ToString(CultureInfo.InvariantCulture)
+                |]
+            ))
+        |> Seq.toList
+        |> digest
+
+    /// Inserts full immutable posting provenance, evidence, and the terminal period state in the active transaction.
+    let postCloseAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (periodId: Guid)
+        (request: BillingPeriodCloseRequest)
+        (closedAt: DateTime)
+        (lines: ChargePreviewLineEntity array)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            let mutable index = 0
+
+            while index < lines.Length do
+                let line = lines[index]
+
+                use insert =
+                    command
+                        connection
+                        transaction
+                        "INSERT INTO ops.Charge (ChargeId,OwnerId,OrganizationId,RepositoryId,BillingPeriodId,ChargePreviewLineId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@ChargeId,@OwnerId,@OrganizationId,@RepositoryId,@BillingPeriodId,@PreviewLineId,@PeriodFrom,@PeriodTo,@FactKind,@MappingId,@BillableKind,@AssignmentId,@PlanId,@RateId,@Currency,@UnitName,@UnitQuantity,@UnitPrice,@EffectiveFrom,@EffectiveTo,@TotalQuantity,@Charge);"
+
+                let add name dbType value = insert.Parameters.Add(name, dbType).Value <- value
+                add "@ChargeId" SqlDbType.UniqueIdentifier (chargeId periodId line.ChargePreviewLineId)
+                add "@OwnerId" SqlDbType.UniqueIdentifier line.OwnerId
+                add "@OrganizationId" SqlDbType.UniqueIdentifier line.OrganizationId
+                add "@RepositoryId" SqlDbType.UniqueIdentifier line.RepositoryId
+                add "@BillingPeriodId" SqlDbType.UniqueIdentifier periodId
+                add "@PreviewLineId" SqlDbType.UniqueIdentifier line.ChargePreviewLineId
+                add "@PeriodFrom" SqlDbType.DateTime2 line.PeriodFromUtc
+                add "@PeriodTo" SqlDbType.DateTime2 line.PeriodToUtc
+                add "@FactKind" SqlDbType.Int line.FactKind
+                add "@MappingId" SqlDbType.UniqueIdentifier line.BillableUsageKindMappingId
+                add "@BillableKind" SqlDbType.Int line.BillableUsageKind
+                add "@AssignmentId" SqlDbType.UniqueIdentifier line.PricingAssignmentId
+                add "@PlanId" SqlDbType.UniqueIdentifier line.PricingPlanId
+                add "@RateId" SqlDbType.UniqueIdentifier line.PricingRateId
+                insert.Parameters.Add("@Currency", SqlDbType.VarChar, 3).Value <- line.CurrencyCode
+                insert.Parameters.Add("@UnitName", SqlDbType.NVarChar, OperationsPricingSql.UnitNameMaxLength).Value <- line.UnitName
+                add "@UnitQuantity" SqlDbType.BigInt line.UnitQuantity
+                add "@UnitPrice" SqlDbType.BigInt line.UnitPriceMicros
+                add "@EffectiveFrom" SqlDbType.DateTime2 line.EffectiveFromUtc
+                add "@EffectiveTo" SqlDbType.DateTime2 line.EffectiveToUtc
+                add "@TotalQuantity" SqlDbType.BigInt line.TotalQuantity
+                add "@Charge" SqlDbType.BigInt line.ChargeMicros
+                let! _ = insert.ExecuteNonQueryAsync cancellationToken
+                index <- index + 1
+
+            do! transactionInterleaving.AfterChargeInsertionAsync cancellationToken
+            let! factDigest = acceptedFactDigestAsync connection transaction request.Scope cancellationToken
+
+            use evidence =
+                command
+                    connection
+                    transaction
+                    "INSERT INTO ops.BillingPeriodCloseEvidence (BillingPeriodId,AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance) VALUES (@BillingPeriodId,@FactDigest,@PreviewDigest,@ClosedAtUtc,@Provenance);"
+
+            evidence.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            evidence.Parameters.Add("@FactDigest", SqlDbType.Char, 64).Value <- factDigest
+            evidence.Parameters.Add("@PreviewDigest", SqlDbType.Char, 64).Value <- pricingPreviewDigest lines
+            evidence.Parameters.Add("@ClosedAtUtc", SqlDbType.DateTime2).Value <- closedAt
+            evidence.Parameters.Add("@Provenance", SqlDbType.NVarChar, 200).Value <- request.ScheduledOperationProvenance
+            let! _ = evidence.ExecuteNonQueryAsync cancellationToken
+            do! transactionInterleaving.AfterCloseEvidenceStagedAsync cancellationToken
+
+            use close =
+                command
+                    connection
+                    transaction
+                    "UPDATE ops.BillingPeriod SET State=2,RetryDiagnostic=NULL,RetryDiagnosticAtUtc=NULL,UpdatedAtUtc=SYSUTCDATETIME() WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);"
+
+            close.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+            let! affected = close.ExecuteNonQueryAsync cancellationToken
+
+            if affected <> 1 then
+                invalidOp "Billing-period state changed before terminal close could commit."
+        }
+
+    /// Runs preview or final close as one lock-held SQL transaction, preserving nonterminal retry truth for expected failures.
+    let executeAsync isFinal request cancellationToken =
+        task {
+            if String.IsNullOrWhiteSpace request.ScheduledOperationProvenance
+               || request.ScheduledOperationProvenance.Length > 200 then
+                invalidArg (nameof request) "Scheduled operation provenance is required and must be 200 characters or fewer."
+
+            match BillingCompletenessScope.validate request.Scope with
+            | Error errors -> invalidArg (nameof request) (String.Join("; ", errors))
+            | Ok _ -> ()
+
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            use! rawTransaction = connection.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken)
+            use transaction = rawTransaction :?> SqlTransaction
+
+            try
+                do! acquireScopeLockAsync connection transaction request.Scope cancellationToken
+                let! periodId, state = ensurePeriodAsync connection transaction request.Scope cancellationToken
+
+                if state = BillingPeriodState.Closed then
+                    use count = command connection transaction "SELECT COUNT(*) FROM ops.Charge WHERE BillingPeriodId=@BillingPeriodId;"
+                    count.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+                    let! chargeCount = count.ExecuteScalarAsync cancellationToken
+                    do! transaction.CommitAsync cancellationToken
+                    return Closed(periodId, Convert.ToInt32 chargeCount)
+                else
+                    let! databaseUtcNow = clock.UtcNowAsync(connection, transaction, cancellationToken)
+
+                    use sessionCommand = command connection transaction "SELECT @@SPID;"
+                    let! sessionId = sessionCommand.ExecuteScalarAsync cancellationToken
+                    do! transactionInterleaving.AfterDatabaseClockReadAsync(Convert.ToInt32 sessionId, databaseUtcNow, cancellationToken)
+
+                    let nextMonthStartUtc =
+                        (BillingCompletenessScope.nextMonthStart request.Scope)
+                            .ToDateTimeUtc()
+
+                    if not (BillingPeriodCloseEligibility.isEligible isFinal nextMonthStartUtc databaseUtcNow) then
+                        do! transaction.CommitAsync cancellationToken
+                        return NotEligible
+                    else
+                        let! blocker = completenessDiagnosticAsync connection transaction request.Scope cancellationToken
+
+                        match blocker with
+                        | Some diagnostic ->
+                            do! setDiagnosticAsync connection transaction periodId (Some diagnostic) cancellationToken
+                            do! transaction.CommitAsync cancellationToken
+                            return Blocked diagnostic
+                        | None ->
+                            let! facts = readPricedFactsAsync connection transaction request.Scope cancellationToken
+                            if List.isEmpty facts then raise (ZeroFactCoveragePendingException())
+
+                            let previewScope: ChargePreviewScope =
+                                {
+                                    OwnerId = request.Scope.OwnerId
+                                    OrganizationId = request.Scope.OrganizationId
+                                    RepositoryId = request.Scope.RepositoryId
+                                    PeriodFromUtc = request.Scope.MonthStart.ToDateTimeUtc()
+                                    PeriodToUtc = nextMonthStartUtc
+                                }
+
+                            let lines = ChargePreviewCalculation.buildLines previewScope facts
+                            do! replacePreviewAsync connection transaction request.Scope lines cancellationToken
+                            do! transactionInterleaving.AfterPreviewReplacementAsync cancellationToken
+
+                            if isFinal then
+                                do! postCloseAsync connection transaction periodId request databaseUtcNow lines cancellationToken
+                                do! transaction.CommitAsync cancellationToken
+                                return Closed(periodId, lines.Length)
+                            else
+                                use provisional =
+                                    command
+                                        connection
+                                        transaction
+                                        "UPDATE ops.BillingPeriod SET State=1,RetryDiagnostic=NULL,RetryDiagnosticAtUtc=NULL,UpdatedAtUtc=SYSUTCDATETIME() WHERE BillingPeriodId=@BillingPeriodId AND State IN (0,1);"
+
+                                provisional.Parameters.Add("@BillingPeriodId", SqlDbType.UniqueIdentifier).Value <- periodId
+                                let! _ = provisional.ExecuteNonQueryAsync cancellationToken
+                                do! transaction.CommitAsync cancellationToken
+                                return Provisional(periodId, lines.Length)
+            with
+            | :? ChargePreviewRebuildException as ex ->
+                do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return Blocked ex.Message
+            | :? OverflowException as ex ->
+                do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return Blocked ex.Message
+            | :? ZeroFactCoveragePendingException as ex ->
+                do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
+                do! transaction.CommitAsync cancellationToken
+                return Blocked ex.Message
+            | ex ->
+                do! rollbackIgnoringFailureAsync transaction
+                return raise ex
+        }
+
+    interface IBillingPeriodCloser with
+        member _.PreviewAsync(request, cancellationToken) = executeAsync false request cancellationToken
+        member _.CloseAsync(request, cancellationToken) = executeAsync true request cancellationToken
+
+    /// Creates the production closer using only SQL Server time and no test interleaving.
+    new(connectionString: string) =
+        SqlBillingPeriodCloser(
+            connectionString,
+            NoBillingPeriodCloseTransactionInterleaving() :> IBillingPeriodCloseTransactionInterleaving,
+            DatabaseBillingPeriodCloseClock() :> IBillingPeriodCloseClock
+        )
+
+    /// Creates a real-SQL close seam that retains the production SQL clock while exposing transaction stages to tests.
+    static member internal CreateForTest(connectionString, transactionInterleaving) =
+        SqlBillingPeriodCloser(connectionString, transactionInterleaving, DatabaseBillingPeriodCloseClock() :> IBillingPeriodCloseClock)
+
+    /// Creates an internal policy-boundary seam with controlled database-time values while retaining the production transaction.
+    static member internal CreateForTest(connectionString, transactionInterleaving, clock) =
+        SqlBillingPeriodCloser(connectionString, transactionInterleaving, clock)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsChargePreview.fs
@@ -43,7 +43,7 @@ module OperationsChargePreviewSql =
         """
 SELECT fact.UsageFactId, fact.FactKind, fact.Quantity, fact.ObservedAtUtc,
        assignment.PricingAssignmentId, assignment.PricingPlanId AS AssignedPricingPlanId,
-       plan.PricingPlanId, mapping.BillableUsageKindMappingId, mapping.BillableUsageKind,
+       pricingPlan.PricingPlanId, mapping.BillableUsageKindMappingId, mapping.BillableUsageKind,
        rate.PricingRateId, rate.CurrencyCode, rate.UnitName, rate.UnitQuantity, rate.UnitPriceMicros,
        applicability.EffectiveFromUtc, applicability.EffectiveToUtc
 FROM ops.RawUsageFact AS fact
@@ -64,7 +64,7 @@ OUTER APPLY (
       AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
       AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
     ORDER BY candidate.EffectiveFromUtc DESC, candidate.PricingPlanId
-) AS plan
+) AS pricingPlan
 OUTER APPLY (
     SELECT TOP (1) candidate.BillableUsageKindMappingId, candidate.BillableUsageKind,
            candidate.EffectiveFromUtc, candidate.EffectiveToUtc
@@ -77,7 +77,7 @@ OUTER APPLY (
     SELECT TOP (1) candidate.PricingRateId, candidate.CurrencyCode, candidate.UnitName,
            candidate.UnitQuantity, candidate.UnitPriceMicros, candidate.EffectiveFromUtc, candidate.EffectiveToUtc
     FROM ops.PricingRate AS candidate
-    WHERE candidate.PricingPlanId = plan.PricingPlanId
+    WHERE candidate.PricingPlanId = pricingPlan.PricingPlanId
       AND candidate.BillableUsageKind = mapping.BillableUsageKind
       AND candidate.EffectiveFromUtc <= fact.ObservedAtUtc
       AND (candidate.EffectiveToUtc IS NULL OR fact.ObservedAtUtc < candidate.EffectiveToUtc)
@@ -88,7 +88,7 @@ OUTER APPLY (
            MIN(boundary.EffectiveToUtc) AS EffectiveToUtc
     FROM (VALUES
         (assignment.EffectiveFromUtc, ISNULL(assignment.EffectiveToUtc, @PeriodToUtc)),
-        (plan.EffectiveFromUtc, ISNULL(plan.EffectiveToUtc, @PeriodToUtc)),
+        (pricingPlan.EffectiveFromUtc, ISNULL(pricingPlan.EffectiveToUtc, @PeriodToUtc)),
         (mapping.EffectiveFromUtc, ISNULL(mapping.EffectiveToUtc, @PeriodToUtc)),
         (rate.EffectiveFromUtc, ISNULL(rate.EffectiveToUtc, @PeriodToUtc)),
         (@PeriodFromUtc, @PeriodToUtc)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -6,6 +6,7 @@ open Microsoft.Data.SqlClient
 open NodaTime
 open System
 open System.Data
+open System.Globalization
 open System.Threading
 open System.Threading.Tasks
 
@@ -179,14 +180,14 @@ WHERE UsageFactId = @UsageFactId;
                             UsageFactId = reader.GetGuid 0
                             RawPayload = reader.GetFieldValue<byte array> 1
                             CorrelationId = reader.GetString 2
-                            FactKind = enum<UsageFactKind> (reader.GetInt32 3)
+                            FactKind = enum<UsageFactKind> (Convert.ToInt32(reader.GetValue 3, CultureInfo.InvariantCulture))
                             OwnerId = reader.GetGuid 4
                             OrganizationId = reader.GetGuid 5
                             RepositoryId = reader.GetGuid 6
                             StoragePoolId = reader.GetString 7
                             Quantity = reader.GetInt64 8
                             ObservedAt = reader.GetDateTime 9 |> toInstant
-                            State = enum<UsageFactJournalState> (reader.GetInt32 10)
+                            State = enum<UsageFactJournalState> (Convert.ToInt32(reader.GetValue 10, CultureInfo.InvariantCulture))
                         }
         }
 
@@ -435,14 +436,14 @@ ORDER BY CreatedAtUtc ASC, UsageFactId ASC;
                             UsageFactId = reader.GetGuid 0
                             RawPayload = reader.GetFieldValue<byte array> 1
                             CorrelationId = reader.GetString 2
-                            FactKind = enum<UsageFactKind> (reader.GetInt32 3)
+                            FactKind = enum<UsageFactKind> (Convert.ToInt32(reader.GetValue 3, CultureInfo.InvariantCulture))
                             OwnerId = reader.GetGuid 4
                             OrganizationId = reader.GetGuid 5
                             RepositoryId = reader.GetGuid 6
                             StoragePoolId = reader.GetString 7
                             Quantity = reader.GetInt64 8
                             ObservedAt = reader.GetDateTime 9 |> toInstant
-                            State = enum<UsageFactJournalState> (reader.GetInt32 10)
+                            State = enum<UsageFactJournalState> (Convert.ToInt32(reader.GetValue 10, CultureInfo.InvariantCulture))
                         }
                     )
                 else
@@ -478,14 +479,14 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
                             UsageFactId = reader.GetGuid 0
                             RawPayload = reader.GetFieldValue<byte array> 1
                             CorrelationId = reader.GetString 2
-                            FactKind = enum<UsageFactKind> (reader.GetInt32 3)
+                            FactKind = enum<UsageFactKind> (Convert.ToInt32(reader.GetValue 3, CultureInfo.InvariantCulture))
                             OwnerId = reader.GetGuid 4
                             OrganizationId = reader.GetGuid 5
                             RepositoryId = reader.GetGuid 6
                             StoragePoolId = reader.GetString 7
                             Quantity = reader.GetInt64 8
                             ObservedAt = reader.GetDateTime 9 |> toInstant
-                            State = enum<UsageFactJournalState> (reader.GetInt32 10)
+                            State = enum<UsageFactJournalState> (Convert.ToInt32(reader.GetValue 10, CultureInfo.InvariantCulture))
                         }
         }
 

--- a/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="OperationsBillingCompleteness.Tests.fs" />
     <Compile Include="OperationsPricing.Tests.fs" />
     <Compile Include="OperationsChargePreview.Tests.fs" />
+    <Compile Include="OperationsBillingPeriodCloseBehavior.Tests.fs" />
     <Compile Include="OperationsBillingPeriodClose.Tests.fs" />
     <Compile Include="OperationsUsageArchive.Tests.fs" />
     <Compile Include="OperationsWorkerIngestion.Tests.fs" />

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -8,6 +8,7 @@ open NUnit.Framework
 open NodaTime
 open System
 open System.Data
+open System.Globalization
 open System.Security.Cryptography
 open System.Text
 open System.Threading
@@ -114,7 +115,7 @@ type private StageCancellationInterleaving(stage: string, cancellation: Cancella
         member _.AfterCloseEvidenceStagedAsync _ = cancelAt "evidence"
 
 /// Proves the exact database-time policy boundary independently of the production SQL clock source.
-[<TestFixture>]
+[<TestFixture; NonParallelizable>]
 type OperationsBillingPeriodCloseBehaviorTests() =
 
     /// Names the isolated SQL connection needed by the retained real-SQL production-clock proof.
@@ -227,13 +228,14 @@ type OperationsBillingPeriodCloseBehaviorTests() =
     /// Adds one complete pricing grain through the live Operations SQL schema.
     let addPricingAsync connectionString (scope: BillingCompletenessScope) =
         task {
-            let planId, mappingId, rateId, assignmentId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+            let planId, rateId, assignmentId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+            let mappingId = Guid.Parse "47a4d91d-43e7-450b-8800-917000000001"
             use connection = new SqlConnection(connectionString)
             do! connection.OpenAsync CancellationToken.None
             use command = connection.CreateCommand()
 
             command.CommandText <-
-                "INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@PlanId,@PlanCode,@DisplayName,@EffectiveFrom); INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@MappingId,1,101,@MappingName,@EffectiveFrom); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@RateId,@PlanId,101,'USD','byte-minute',1,2,@EffectiveFrom); INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveFrom);"
+                "INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@PlanId,@PlanCode,@DisplayName,@EffectiveFrom); IF NOT EXISTS (SELECT 1 FROM ops.BillableUsageKindMapping WHERE FactKind=1 AND EffectiveFromUtc=@EffectiveFrom) INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@MappingId,1,101,@MappingName,@EffectiveFrom); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@RateId,@PlanId,101,'USD','byte-minute',1,2,@EffectiveFrom); INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveFrom);"
 
             command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- planId
             command.Parameters.Add("@PlanCode", SqlDbType.NVarChar, 80).Value <- $"close-{planId:N}"
@@ -258,7 +260,7 @@ type OperationsBillingPeriodCloseBehaviorTests() =
             use command = connection.CreateCommand()
 
             command.CommandText <-
-                "SELECT CONCAT(request_status,'|',request_mode,'|',request_session_id,'|',resource_description) FROM sys.dm_tran_locks WHERE resource_type='APPLICATION' AND resource_database_id=DB_ID() AND request_session_id IN (@FirstSessionId,@SecondSessionId) ORDER BY request_session_id,request_status;"
+                "SELECT CONCAT(request_status,'|',request_mode,'|',request_session_id,'|',RTRIM(resource_description)) FROM sys.dm_tran_locks WHERE resource_type='APPLICATION' AND resource_database_id=DB_ID() AND request_session_id IN (@FirstSessionId,@SecondSessionId) ORDER BY request_session_id,request_status;"
 
             command.Parameters.Add("@FirstSessionId", SqlDbType.Int).Value <- firstSessionId
             command.Parameters.Add("@SecondSessionId", SqlDbType.Int).Value <- secondSessionId
@@ -272,6 +274,29 @@ type OperationsBillingPeriodCloseBehaviorTests() =
                 if hasRow then rows.Add(reader.GetString 0)
 
             return rows |> Seq.toList
+        }
+
+    /// Derives SQL Server's exact DMV description for one supplied application-lock resource before contention begins.
+    let applicationLockDmvDescriptionAsync connectionString resource =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use transaction = connection.BeginTransaction()
+            use acquireCommand = connection.CreateCommand()
+            acquireCommand.Transaction <- transaction
+            acquireCommand.CommandText <- OperationsUsageSql.AcquireBillingCompletenessScopeLock
+            acquireCommand.Parameters.Add("@BillingCompletenessLockResource", SqlDbType.NVarChar, 255).Value <- resource
+            acquireCommand.Parameters.Add("@BillingCompletenessLockTimeoutMilliseconds", SqlDbType.Int).Value <- 0
+            let! _ = acquireCommand.ExecuteNonQueryAsync CancellationToken.None
+            use descriptionCommand = connection.CreateCommand()
+            descriptionCommand.Transaction <- transaction
+
+            descriptionCommand.CommandText <-
+                "SELECT TOP(1) RTRIM(resource_description) FROM sys.dm_tran_locks WHERE resource_type='APPLICATION' AND resource_database_id=DB_ID() AND request_session_id=@@SPID AND request_status='GRANT';"
+
+            let! description = descriptionCommand.ExecuteScalarAsync CancellationToken.None
+            do! transaction.RollbackAsync CancellationToken.None
+            return Convert.ToString(description, CultureInfo.InvariantCulture)
         }
 
     /// Counts the exact durable rows that must converge after competing close calls.
@@ -315,12 +340,23 @@ ORDER BY 1;
         }
 
     /// Recomputes the fact-evidence digest from independent persisted raw facts.
-    let acceptedFactDigestAsync connectionString =
+    let acceptedFactDigestAsync connectionString (scope: BillingCompletenessScope) =
         task {
             use connection = new SqlConnection(connectionString)
             do! connection.OpenAsync CancellationToken.None
             use command = connection.CreateCommand()
-            command.CommandText <- "SELECT UsageFactId,FactKind,Quantity,ObservedAtUtc FROM ops.RawUsageFact ORDER BY ObservedAtUtc,UsageFactId;"
+
+            command.CommandText <-
+                "SELECT UsageFactId,FactKind,Quantity,ObservedAtUtc FROM ops.RawUsageFact WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND ObservedAtUtc>=@MonthStartUtc AND ObservedAtUtc<@NextMonthStartUtc ORDER BY ObservedAtUtc,UsageFactId;"
+
+            command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            command.Parameters.Add("@NextMonthStartUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
             use! reader = command.ExecuteReaderAsync CancellationToken.None
             let values = ResizeArray<string>()
             let mutable reading = true
@@ -330,10 +366,82 @@ ORDER BY 1;
                 reading <- hasRow
 
                 if hasRow then
-                    values.Add($"{reader.GetGuid(0):D}|{reader.GetInt32(1)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}")
+                    values.Add(
+                        $"{reader.GetGuid(0):D}|{Convert.ToInt32(reader.GetValue(1), CultureInfo.InvariantCulture)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}"
+                    )
 
             return
                 values
+                |> String.concat "\n"
+                |> Encoding.UTF8.GetBytes
+                |> SHA256.HashData
+                |> Convert.ToHexString
+        }
+
+    /// Rebuilds the full pricing-preview evidence digest from persisted rows without calling the closer's digest helper.
+    let pricingPreviewDigestAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros FROM ops.ChargePreviewLine;"
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let lines = ResizeArray<Guid * string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then
+                    let lineId = reader.GetGuid 0
+
+                    let canonical =
+                        String.Join(
+                            "|",
+                            [|
+                                lineId.ToString "D"
+                                (reader.GetGuid 1).ToString "D"
+                                (reader.GetGuid 2).ToString "D"
+                                (reader.GetGuid 3).ToString "D"
+                                (reader.GetDateTime 4)
+                                    .Ticks.ToString CultureInfo.InvariantCulture
+                                (reader.GetDateTime 5)
+                                    .Ticks.ToString CultureInfo.InvariantCulture
+                                (Convert.ToInt32(reader.GetValue 6, CultureInfo.InvariantCulture))
+                                    .ToString CultureInfo.InvariantCulture
+                                (reader.GetGuid 7).ToString "D"
+                                (Convert.ToInt32(reader.GetValue 8, CultureInfo.InvariantCulture))
+                                    .ToString CultureInfo.InvariantCulture
+                                (reader.GetGuid 9).ToString "D"
+                                (reader.GetGuid 10).ToString "D"
+                                (reader.GetGuid 11).ToString "D"
+                                reader.GetString 12
+                                reader.GetString 13
+                                (reader.GetInt64 14)
+                                    .ToString CultureInfo.InvariantCulture
+                                (reader.GetInt64 15)
+                                    .ToString CultureInfo.InvariantCulture
+                                (reader.GetDateTime 16)
+                                    .Ticks.ToString CultureInfo.InvariantCulture
+                                (reader.GetDateTime 17)
+                                    .Ticks.ToString CultureInfo.InvariantCulture
+                                (reader.GetInt64 18)
+                                    .ToString CultureInfo.InvariantCulture
+                                (reader.GetInt64 19)
+                                    .ToString CultureInfo.InvariantCulture
+                            |]
+                        )
+
+                    lines.Add(lineId, canonical)
+
+            return
+                lines
+                |> Seq.sortBy fst
+                |> Seq.map snd
                 |> String.concat "\n"
                 |> Encoding.UTF8.GetBytes
                 |> SHA256.HashData
@@ -417,6 +525,8 @@ ORDER BY 1;
                 let firstInterleaving = ContentionInterleaving(true)
                 let secondInterleaving = ContentionInterleaving(false)
                 let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/two-session-contention/v1" }
+                let expectedResource = BillingCompletenessScope.databaseLockIdentity scope
+                let! expectedDmvResource = applicationLockDmvDescriptionAsync connectionString expectedResource
 
                 let firstCloser =
                     SqlBillingPeriodCloser.CreateForTest(connectionString, firstInterleaving :> IBillingPeriodCloseTransactionInterleaving)
@@ -438,19 +548,20 @@ ORDER BY 1;
                             Assert.That(first.IsCompleted, Is.False)
                             Assert.That(second.IsCompleted, Is.False)
                             Assert.That(firstSessionId, Is.Not.EqualTo(secondSessionId))
-                            Assert.That(firstResource, Is.EqualTo(BillingCompletenessScope.databaseLockIdentity scope))
-                            Assert.That(secondResource, Is.EqualTo(firstResource))
+                            Assert.That(firstResource, Is.EqualTo(expectedResource))
+                            Assert.That(secondResource, Is.EqualTo(expectedResource))
+                            Assert.That(expectedDmvResource, Is.Not.Empty)
 
                             Assert.That(
                                 locks
-                                |> List.exists (fun row -> row.StartsWith($"GRANT|X|{firstSessionId}|", StringComparison.Ordinal)),
+                                |> List.exists (fun row -> row = $"GRANT|X|{firstSessionId}|{expectedDmvResource}"),
                                 Is.True,
                                 $"Expected first session grant; rows: {locks}"
                             )
 
                             Assert.That(
                                 locks
-                                |> List.exists (fun row -> row.StartsWith($"WAIT|X|{secondSessionId}|", StringComparison.Ordinal)),
+                                |> List.exists (fun row -> row = $"WAIT|X|{secondSessionId}|{expectedDmvResource}"),
                                 Is.True,
                                 $"Expected second session wait; rows: {locks}"
                             ))
@@ -509,7 +620,8 @@ ORDER BY 1;
                         return value :?> DateTime
                     }
 
-                let! expectedFactDigest = acceptedFactDigestAsync connectionString
+                let! expectedFactDigest = acceptedFactDigestAsync connectionString scope
+                let! expectedPreviewDigest = pricingPreviewDigestAsync connectionString
                 use connection = new SqlConnection(connectionString)
                 do! connection.OpenAsync CancellationToken.None
                 use command = connection.CreateCommand()
@@ -534,7 +646,7 @@ ORDER BY 1;
                         Assert.That(reader.GetInt64 1, Is.EqualTo(14L))
                         Assert.That(reader.GetInt64 2, Is.EqualTo(14L))
                         Assert.That(reader.GetString 3, Is.EqualTo(expectedFactDigest))
-                        Assert.That(reader.GetString 4, Is.Not.EqualTo(expectedFactDigest))
+                        Assert.That(reader.GetString 4, Is.EqualTo(expectedPreviewDigest))
                         Assert.That(reader.GetDateTime 5, Is.GreaterThanOrEqualTo(beforeClose))
                         Assert.That(reader.GetDateTime 5, Is.LessThanOrEqualTo(afterClose))
                         Assert.That(reader.GetString 6, Is.EqualTo("operations-tests/close-evidence/v1")))
@@ -718,7 +830,7 @@ ORDER BY 1;
                 let closer =
                     SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
 
-                Assert.ThrowsAsync<OperationCanceledException>(Func<Task>(fun () -> closer.CloseAsync(request, cancellation.Token) :> Task))
+                Assert.CatchAsync<OperationCanceledException>(Func<Task>(fun () -> closer.CloseAsync(request, cancellation.Token) :> Task))
                 |> ignore
 
                 let! after = closeProjectionAsync connectionString

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -1,0 +1,372 @@
+namespace Grace.Operations.Tests
+
+open Grace.Operations.Data
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.Data.SqlClient
+open NUnit.Framework
+open NodaTime
+open System
+open System.Data
+open System.Threading
+open System.Threading.Tasks
+
+/// Records the production session, exact lock resource, and database-clock order without replacing the clock.
+type private ClockOrderingInterleaving() =
+    let events = ResizeArray<string>()
+    let mutable sessionId = 0
+    let mutable resource = String.Empty
+    let mutable databaseUtcNow = DateTime.MinValue
+
+    /// Gets the ordered production events captured from one SQL close transaction.
+    member _.Events = events |> Seq.toList
+
+    /// Gets the SQL session used by lock acquisition and database-clock reads.
+    member _.SessionId = sessionId
+
+    /// Gets the exact shared application-lock resource supplied by the closer.
+    member _.Resource = resource
+
+    /// Gets the SQL Server UTC instant that drove the close decision.
+    member _.DatabaseUtcNow = databaseUtcNow
+
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.BeforeScopeLockAcquisitionAsync(observedSessionId, observedResource, _) =
+            sessionId <- observedSessionId
+            resource <- observedResource
+            events.Add("before-lock")
+            Task.CompletedTask
+
+        member _.AfterScopeLockGrantedAsync(observedSessionId, observedResource, _) =
+            Assert.That(observedSessionId, Is.EqualTo(sessionId))
+            Assert.That(observedResource, Is.EqualTo(resource))
+            events.Add("lock-granted")
+            Task.CompletedTask
+
+        member _.AfterDatabaseClockReadAsync(observedSessionId, observedDatabaseUtcNow, _) =
+            Assert.That(observedSessionId, Is.EqualTo(sessionId))
+            databaseUtcNow <- observedDatabaseUtcNow
+            events.Add("database-clock-read")
+            Task.CompletedTask
+
+        member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
+        member _.AfterChargeInsertionAsync _ = Task.CompletedTask
+        member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+
+/// Holds one production close after its exact SQL lock grant so a second production call can be observed waiting.
+type private ContentionInterleaving(holdAfterGrant: bool) =
+    let beforeAcquisition = TaskCompletionSource<int * string>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let granted = TaskCompletionSource<int * string>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+    /// Completes when the production closer has entered exact-resource acquisition on its own SQL session.
+    member _.BeforeAcquisition = beforeAcquisition.Task
+
+    /// Completes when the production closer has been granted the exact shared SQL lock.
+    member _.Granted = granted.Task
+
+    /// Allows the lock holder to continue its transaction after the contention observation is complete.
+    member _.Release() = release.TrySetResult() |> ignore
+
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.BeforeScopeLockAcquisitionAsync(sessionId, resource, _) =
+            beforeAcquisition.TrySetResult(sessionId, resource)
+            |> ignore
+
+            Task.CompletedTask
+
+        member _.AfterScopeLockGrantedAsync(sessionId, resource, cancellationToken) =
+            task {
+                granted.TrySetResult(sessionId, resource)
+                |> ignore
+
+                if holdAfterGrant then do! release.Task.WaitAsync(cancellationToken)
+            }
+            :> Task
+
+        member _.AfterDatabaseClockReadAsync(_, _, _) = Task.CompletedTask
+        member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
+        member _.AfterChargeInsertionAsync _ = Task.CompletedTask
+        member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+
+/// Proves the exact database-time policy boundary independently of the production SQL clock source.
+[<TestFixture>]
+type OperationsBillingPeriodCloseBehaviorTests() =
+
+    /// Names the isolated SQL connection needed by the retained real-SQL production-clock proof.
+    [<Literal>]
+    let sqlConnectionStringEnvironmentVariable = "GRACE_OPERATIONS_SQL_TEST_CONNECTION_STRING"
+
+    /// Uses a fixed past month so the production SQL clock is independently eligible for final close.
+    let monthStart = Instant.FromUtc(2026, 6, 1, 0, 0)
+
+    /// Returns a distinct disposable database name for one real-SQL proof.
+    let databaseName () = $"GraceOperationsBillingCloseBehavior_{Guid.NewGuid():N}"
+
+    /// Opens the explicit real-SQL test resource or marks the named integration proof unavailable.
+    let requireSqlConnectionString () =
+        let connectionString = Environment.GetEnvironmentVariable sqlConnectionStringEnvironmentVariable
+
+        if String.IsNullOrWhiteSpace connectionString then
+            Assert.Ignore($"{sqlConnectionStringEnvironmentVariable} is required for real SQL billing-period close tests.")
+
+        connectionString
+
+    /// Creates an isolated Operations schema through the production bootstrap seam.
+    let createDatabaseAsync () =
+        task {
+            let builder = SqlConnectionStringBuilder(requireSqlConnectionString ())
+            builder.InitialCatalog <- databaseName ()
+            let schema = OperationsUsageSchema(builder.ConnectionString, OperationsUsageSchemaBootstrapMode.CreateDatabaseIfMissing)
+            do! schema.EnsureCreatedAsync CancellationToken.None
+            return builder.ConnectionString
+        }
+
+    /// Removes only the disposable database owned by this test.
+    let dropDatabaseAsync connectionString =
+        task {
+            let builder = SqlConnectionStringBuilder(connectionString)
+            let database = builder.InitialCatalog
+            builder.InitialCatalog <- "master"
+            use connection = new SqlConnection(builder.ConnectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- $"ALTER DATABASE [{database}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{database}];"
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
+    /// Runs an isolated real-SQL proof and always removes the database it created.
+    let withDatabaseAsync operation =
+        task {
+            let! connectionString = createDatabaseAsync ()
+
+            try
+                let! result = operation connectionString
+                do! dropDatabaseAsync connectionString
+                return result
+            with
+            | ex ->
+                do! dropDatabaseAsync connectionString
+                return raise ex
+        }
+
+    /// Creates a valid exact owner/repository/month scope for the production closer.
+    let scopeFor ownerId organizationId repositoryId =
+        match BillingCompletenessScope.tryCreate ownerId organizationId repositoryId monthStart with
+        | Ok scope -> scope
+        | Error errors -> invalidOp (String.Join("; ", errors))
+
+    /// Accepts one supported usage fact through the journal before a close reads committed facts.
+    let acceptAsync connectionString ownerId organizationId repositoryId =
+        task {
+            let fact =
+                UsageFact.RepositoryStorageBytesMinute(
+                    Guid.NewGuid(),
+                    CorrelationId "billing-close-clock-ordering",
+                    ownerId,
+                    organizationId,
+                    repositoryId,
+                    StoragePoolId "billing-close-pool",
+                    7L,
+                    monthStart + Duration.FromDays 1
+                )
+
+            let journal = SqlOperationsUsageJournalStore(connectionString)
+            let! _ = journal.AppendAsync(fact, CancellationToken.None)
+            let! result = journal.ProcessAsync(fact, Array.empty, CancellationToken.None)
+            Assert.That(result, Is.EqualTo(UsageFactJournalProcessResult.AcceptedFromJournal))
+        }
+
+    /// Adds one complete pricing grain through the live Operations SQL schema.
+    let addPricingAsync connectionString (scope: BillingCompletenessScope) =
+        task {
+            let planId, mappingId, rateId, assignmentId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@PlanId,@PlanCode,@DisplayName,@EffectiveFrom); INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@MappingId,1,101,@MappingName,@EffectiveFrom); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@RateId,@PlanId,101,'USD','byte-minute',1,2,@EffectiveFrom); INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@EffectiveFrom);"
+
+            command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- planId
+            command.Parameters.Add("@PlanCode", SqlDbType.NVarChar, 80).Value <- $"close-{planId:N}"
+            command.Parameters.Add("@DisplayName", SqlDbType.NVarChar, 200).Value <- "Billing close clock ordering"
+            command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- mappingId
+            command.Parameters.Add("@MappingName", SqlDbType.NVarChar, 200).Value <- "Storage byte minute"
+            command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- rateId
+            command.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- assignmentId
+            command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            command.Parameters.Add("@EffectiveFrom", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+            let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+            return ()
+        }
+
+    /// Reads application-lock rows only for the two captured production sessions from this contention test.
+    let applicationLocksAsync connectionString firstSessionId secondSessionId =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT CONCAT(request_status,'|',request_mode,'|',request_session_id,'|',resource_description) FROM sys.dm_tran_locks WHERE resource_type='APPLICATION' AND resource_database_id=DB_ID() AND request_session_id IN (@FirstSessionId,@SecondSessionId) ORDER BY request_session_id,request_status;"
+
+            command.Parameters.Add("@FirstSessionId", SqlDbType.Int).Value <- firstSessionId
+            command.Parameters.Add("@SecondSessionId", SqlDbType.Int).Value <- secondSessionId
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let rows = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+                if hasRow then rows.Add(reader.GetString 0)
+
+            return rows |> Seq.toList
+        }
+
+    /// Counts the exact durable rows that must converge after competing close calls.
+    let countAsync connectionString sql =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- sql
+            let! value = command.ExecuteScalarAsync CancellationToken.None
+            return Convert.ToInt32 value
+        }
+
+    /// Confirms one SQL tick before the preview threshold is rejected while equality is eligible.
+    [<Test>]
+    member _.PreviewThresholdRejectsOneSqlTickBeforeAndAcceptsEquality() =
+        let nextMonthStart = DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+        let threshold = nextMonthStart.AddHours 24.0
+        let oneSqlTickBefore = threshold.AddTicks -1L
+
+        Assert.That(BillingPeriodCloseEligibility.isEligible false nextMonthStart oneSqlTickBefore, Is.False)
+        Assert.That(BillingPeriodCloseEligibility.isEligible false nextMonthStart threshold, Is.True)
+
+    /// Confirms one SQL tick before the final-close threshold is rejected while equality is eligible.
+    [<Test>]
+    member _.FinalCloseThresholdRejectsOneSqlTickBeforeAndAcceptsEquality() =
+        let nextMonthStart = DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+        let threshold = nextMonthStart.AddHours 72.0
+        let oneSqlTickBefore = threshold.AddTicks -1L
+
+        Assert.That(BillingPeriodCloseEligibility.isEligible true nextMonthStart oneSqlTickBefore, Is.False)
+        Assert.That(BillingPeriodCloseEligibility.isEligible true nextMonthStart threshold, Is.True)
+
+    /// Proves the production clock reads SQL time after exact-lock grant on one session and persists that value as close evidence.
+    [<Test>]
+    member _.ProductionSqlClockRunsAfterExactScopeLockAndPersistsItsValue() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! acceptAsync connectionString ownerId organizationId repositoryId
+                do! addPricingAsync connectionString scope
+                let interleaving = ClockOrderingInterleaving()
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/database-clock-ordering/v1" }
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                let! result = closer.CloseAsync(request, CancellationToken.None)
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+                command.CommandText <- "SELECT ClosedAtUtc FROM ops.BillingPeriodCloseEvidence;"
+                let! persistedClosedAt = command.ExecuteScalarAsync CancellationToken.None
+
+                match result with
+                | BillingPeriodCloseResult.Closed (_, chargeCount) -> Assert.That(chargeCount, Is.EqualTo(1))
+                | unexpected -> Assert.Fail($"Expected a closed billing period but received {unexpected}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            interleaving.Events,
+                            Is.EqualTo<string list>(
+                                [
+                                    "before-lock"
+                                    "lock-granted"
+                                    "database-clock-read"
+                                ]
+                            )
+                        )
+
+                        Assert.That(interleaving.SessionId, Is.GreaterThan(0))
+                        Assert.That(interleaving.Resource, Is.EqualTo(BillingCompletenessScope.databaseLockIdentity scope))
+                        Assert.That(persistedClosedAt :?> DateTime, Is.EqualTo(interleaving.DatabaseUtcNow)))
+                )
+            })
+
+    /// Proves two production close calls expose their own sessions, share the exact resource, show grant-plus-wait, and converge.
+    [<Test>]
+    member _.TwoProductionClosersWaitOnTheExactSharedResourceAndConverge() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! acceptAsync connectionString ownerId organizationId repositoryId
+                do! addPricingAsync connectionString scope
+                let firstInterleaving = ContentionInterleaving(true)
+                let secondInterleaving = ContentionInterleaving(false)
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/two-session-contention/v1" }
+
+                let firstCloser =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, firstInterleaving :> IBillingPeriodCloseTransactionInterleaving)
+                    :> IBillingPeriodCloser
+
+                let secondCloser =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, secondInterleaving :> IBillingPeriodCloseTransactionInterleaving)
+                    :> IBillingPeriodCloser
+
+                let first = firstCloser.CloseAsync(request, CancellationToken.None)
+                let! firstSessionId, firstResource = firstInterleaving.Granted.WaitAsync(TimeSpan.FromSeconds 30.0)
+                let second = secondCloser.CloseAsync(request, CancellationToken.None)
+                let! secondSessionId, secondResource = secondInterleaving.BeforeAcquisition.WaitAsync(TimeSpan.FromSeconds 30.0)
+                let! locks = applicationLocksAsync connectionString firstSessionId secondSessionId
+
+                try
+                    Assert.Multiple(
+                        Action (fun () ->
+                            Assert.That(first.IsCompleted, Is.False)
+                            Assert.That(second.IsCompleted, Is.False)
+                            Assert.That(firstSessionId, Is.Not.EqualTo(secondSessionId))
+                            Assert.That(firstResource, Is.EqualTo(BillingCompletenessScope.databaseLockIdentity scope))
+                            Assert.That(secondResource, Is.EqualTo(firstResource))
+
+                            Assert.That(
+                                locks
+                                |> List.exists (fun row -> row.StartsWith($"GRANT|X|{firstSessionId}|", StringComparison.Ordinal)),
+                                Is.True,
+                                $"Expected first session grant; rows: {locks}"
+                            )
+
+                            Assert.That(
+                                locks
+                                |> List.exists (fun row -> row.StartsWith($"WAIT|X|{secondSessionId}|", StringComparison.Ordinal)),
+                                Is.True,
+                                $"Expected second session wait; rows: {locks}"
+                            ))
+                    )
+                finally
+                    firstInterleaving.Release()
+
+                let! results = Task.WhenAll(first, second)
+                let! periods = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(results.Length, Is.EqualTo(2))
+                        Assert.That(periods, Is.EqualTo(1))
+                        Assert.That(charges, Is.EqualTo(1))
+                        Assert.That(evidence, Is.EqualTo(1)))
+                )
+            })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -8,6 +8,8 @@ open NUnit.Framework
 open NodaTime
 open System
 open System.Data
+open System.Security.Cryptography
+open System.Text
 open System.Threading
 open System.Threading.Tasks
 
@@ -88,6 +90,28 @@ type private ContentionInterleaving(holdAfterGrant: bool) =
         member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
         member _.AfterChargeInsertionAsync _ = Task.CompletedTask
         member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+
+/// Supplies one controlled database instant for policy-boundary tests without changing the production clock proof.
+type private FixedBillingPeriodCloseClock(databaseUtcNow: DateTime) =
+    interface IBillingPeriodCloseClock with
+        member _.UtcNowAsync(_, _, _) = Task.FromResult databaseUtcNow
+
+/// Cancels a production transaction immediately after one named close stage has staged its durable writes.
+type private StageCancellationInterleaving(stage: string, cancellation: CancellationTokenSource) =
+    let cancelAt requestedStage =
+        if stage = requestedStage then
+            cancellation.Cancel()
+            Task.FromCanceled cancellation.Token
+        else
+            Task.CompletedTask
+
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.BeforeScopeLockAcquisitionAsync(_, _, _) = Task.CompletedTask
+        member _.AfterScopeLockGrantedAsync(_, _, _) = Task.CompletedTask
+        member _.AfterDatabaseClockReadAsync(_, _, _) = Task.CompletedTask
+        member _.AfterPreviewReplacementAsync _ = cancelAt "preview"
+        member _.AfterChargeInsertionAsync _ = cancelAt "charge"
+        member _.AfterCloseEvidenceStagedAsync _ = cancelAt "evidence"
 
 /// Proves the exact database-time policy boundary independently of the production SQL clock source.
 [<TestFixture>]
@@ -178,6 +202,28 @@ type OperationsBillingPeriodCloseBehaviorTests() =
             Assert.That(result, Is.EqualTo(UsageFactJournalProcessResult.AcceptedFromJournal))
         }
 
+    /// Builds one supported fact with explicit identity, month position, and quantity for close-boundary proof.
+    let usageFact factId ownerId organizationId repositoryId observedAt quantity =
+        UsageFact.RepositoryStorageBytesMinute(
+            factId,
+            CorrelationId $"billing-close-{factId:D}",
+            ownerId,
+            organizationId,
+            repositoryId,
+            StoragePoolId "billing-close-pool",
+            quantity,
+            observedAt
+        )
+
+    /// Persists one chosen supported fact through the production journal and acceptance transaction.
+    let acceptFactAsync connectionString fact =
+        task {
+            let journal = SqlOperationsUsageJournalStore(connectionString)
+            let! _ = journal.AppendAsync(fact, CancellationToken.None)
+            let! result = journal.ProcessAsync(fact, Array.empty, CancellationToken.None)
+            Assert.That(result, Is.EqualTo(UsageFactJournalProcessResult.AcceptedFromJournal))
+        }
+
     /// Adds one complete pricing grain through the live Operations SQL schema.
     let addPricingAsync connectionString (scope: BillingCompletenessScope) =
         task {
@@ -237,6 +283,61 @@ type OperationsBillingPeriodCloseBehaviorTests() =
             command.CommandText <- sql
             let! value = command.ExecuteScalarAsync CancellationToken.None
             return Convert.ToInt32 value
+        }
+
+    /// Reads a byte-for-byte JSON projection of the durable direct-close records for rollback proof.
+    let closeProjectionAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+SELECT CONCAT('BillingPeriod|',(SELECT * FROM ops.BillingPeriod ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('ChargePreviewLine|',(SELECT * FROM ops.ChargePreviewLine ORDER BY ChargePreviewLineId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('Charge|',(SELECT * FROM ops.Charge ORDER BY ChargeId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodCloseEvidence|',(SELECT * FROM ops.BillingPeriodCloseEvidence ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+ORDER BY 1;
+"""
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let rows = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then rows.Add(reader.GetString 0)
+
+            return rows |> Seq.toList
+        }
+
+    /// Recomputes the fact-evidence digest from independent persisted raw facts.
+    let acceptedFactDigestAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+            command.CommandText <- "SELECT UsageFactId,FactKind,Quantity,ObservedAtUtc FROM ops.RawUsageFact ORDER BY ObservedAtUtc,UsageFactId;"
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let values = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then
+                    values.Add($"{reader.GetGuid(0):D}|{reader.GetInt32(1)}|{reader.GetInt64(2)}|{reader.GetDateTime(3).Ticks}")
+
+            return
+                values
+                |> String.concat "\n"
+                |> Encoding.UTF8.GetBytes
+                |> SHA256.HashData
+                |> Convert.ToHexString
         }
 
     /// Confirms one SQL tick before the preview threshold is rejected while equality is eligible.
@@ -368,5 +469,316 @@ type OperationsBillingPeriodCloseBehaviorTests() =
                         Assert.That(periods, Is.EqualTo(1))
                         Assert.That(charges, Is.EqualTo(1))
                         Assert.That(evidence, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves the half-open month, exact arithmetic, independent fact digest, and database-time evidence bracket.
+    [<Test>]
+    member _.CloseUsesExactHalfOpenFactsAndCompleteIndependentEvidence() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let nextMonthStart = BillingCompletenessScope.nextMonthStart scope
+                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId scope.MonthStart 7L)
+                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId nextMonthStart 11L)
+                do! addPricingAsync connectionString scope
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/close-evidence/v1" }
+
+                let! beforeClose =
+                    task {
+                        use connection = new SqlConnection(connectionString)
+                        do! connection.OpenAsync CancellationToken.None
+                        use command = connection.CreateCommand()
+                        command.CommandText <- "SELECT SYSUTCDATETIME();"
+                        let! value = command.ExecuteScalarAsync CancellationToken.None
+                        return value :?> DateTime
+                    }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! afterClose =
+                    task {
+                        use connection = new SqlConnection(connectionString)
+                        do! connection.OpenAsync CancellationToken.None
+                        use command = connection.CreateCommand()
+                        command.CommandText <- "SELECT SYSUTCDATETIME();"
+                        let! value = command.ExecuteScalarAsync CancellationToken.None
+                        return value :?> DateTime
+                    }
+
+                let! expectedFactDigest = acceptedFactDigestAsync connectionString
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    "SELECT TotalQuantity,ChargeMicros,(SELECT ChargeMicros FROM ops.Charge),AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance FROM ops.ChargePreviewLine CROSS JOIN ops.BillingPeriodCloseEvidence;"
+
+                use! reader = command.ExecuteReaderAsync CancellationToken.None
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                Assert.That(hasRow, Is.True)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Closed (_, 1) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(reader.GetInt64 0, Is.EqualTo(7L))
+                        Assert.That(reader.GetInt64 1, Is.EqualTo(14L))
+                        Assert.That(reader.GetInt64 2, Is.EqualTo(14L))
+                        Assert.That(reader.GetString 3, Is.EqualTo(expectedFactDigest))
+                        Assert.That(reader.GetString 4, Is.Not.EqualTo(expectedFactDigest))
+                        Assert.That(reader.GetDateTime 5, Is.GreaterThanOrEqualTo(beforeClose))
+                        Assert.That(reader.GetDateTime 5, Is.LessThanOrEqualTo(afterClose))
+                        Assert.That(reader.GetString 6, Is.EqualTo("operations-tests/close-evidence/v1")))
+                )
+            })
+
+    /// Proves every unresolved completeness source independently prevents a final preview, posting, evidence, or Closed state.
+    [<TestCase("pending")>]
+    [<TestCase("rejected")>]
+    [<TestCase("active-rejection")>]
+    member _.EveryCompletenessBlockerLeavesNoFinalCloseProjection(blocker: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let factId = Guid.NewGuid()
+                let fact = usageFact factId ownerId organizationId repositoryId (monthStart + Duration.FromDays 2) 5L
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let! _ = journal.AppendAsync(fact, CancellationToken.None)
+
+                match blocker with
+                | "pending" -> ()
+                | "rejected" ->
+                    let! rejected = journal.RejectAsync(fact, Array.empty, "close blocker", CancellationToken.None)
+                    Assert.That(rejected, Is.EqualTo(UsageFactJournalRejectResult.RejectedFromJournal))
+                | "active-rejection" ->
+                    let! accepted = journal.ProcessAsync(fact, Array.empty, CancellationToken.None)
+                    Assert.That(accepted, Is.EqualTo(UsageFactJournalProcessResult.AcceptedFromJournal))
+                    use connection = new SqlConnection(connectionString)
+                    do! connection.OpenAsync CancellationToken.None
+                    use command = connection.CreateCommand()
+
+                    command.CommandText <-
+                        "INSERT INTO ops.UsageFactRejection (RejectionId,UsageFactId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,Reason,IsActive) VALUES (@Id,@FactId,@OwnerId,@OrganizationId,@RepositoryId,@MonthStartUtc,'test',1);"
+
+                    command.Parameters.Add("@Id", SqlDbType.UniqueIdentifier).Value <- Guid.NewGuid()
+                    command.Parameters.Add("@FactId", SqlDbType.UniqueIdentifier).Value <- factId
+                    command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- ownerId
+                    command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- organizationId
+                    command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- repositoryId
+                    command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+                    let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                    ()
+                | value -> invalidArg (nameof blocker) value
+
+                do! addPricingAsync connectionString scope
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/blockers/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! previews = countAsync connectionString "SELECT COUNT(*) FROM ops.ChargePreviewLine;"
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! closed = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Blocked _ -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(previews, Is.Zero)
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(evidence, Is.Zero)
+                        Assert.That(closed, Is.Zero))
+                )
+            })
+
+    /// Proves missing pricing and arithmetic overflow each retain retry truth until corrected pricing closes exactly once.
+    [<TestCase(false)>]
+    [<TestCase(true)>]
+    member _.RepairablePricingFailuresThenReplayConvergeOnOnePosting(overflows: bool) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let quantity = if overflows then Int64.MaxValue else 3L
+
+                do!
+                    acceptFactAsync
+                        connectionString
+                        (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 3) quantity)
+
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/pricing-retry/v1" }
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+
+                if overflows then
+                    do! addPricingAsync connectionString scope
+                    use setOverflow = new SqlConnection(connectionString)
+                    do! setOverflow.OpenAsync CancellationToken.None
+                    use command = setOverflow.CreateCommand()
+                    command.CommandText <- "UPDATE ops.PricingRate SET UnitPriceMicros=@Price;"
+                    command.Parameters.Add("@Price", SqlDbType.BigInt).Value <- Int64.MaxValue
+                    let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                    ()
+
+                let! blocked = closer.CloseAsync(request, CancellationToken.None)
+                let! diagnostic = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE RetryDiagnostic IS NOT NULL AND State IN (0,1);"
+
+                if overflows then
+                    use correctPrice = new SqlConnection(connectionString)
+                    do! correctPrice.OpenAsync CancellationToken.None
+                    use command = correctPrice.CreateCommand()
+                    command.CommandText <- "UPDATE ops.PricingRate SET UnitPriceMicros=1;"
+                    let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                    ()
+                else
+                    do! addPricingAsync connectionString scope
+
+                let! repaired = closer.CloseAsync(request, CancellationToken.None)
+                let! replay = closer.CloseAsync(request, CancellationToken.None)
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+
+                let! cleared =
+                    countAsync
+                        connectionString
+                        "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2 AND RetryDiagnostic IS NULL AND RetryDiagnosticAtUtc IS NULL;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match blocked with
+                             | BillingPeriodCloseResult.Blocked _ -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(diagnostic, Is.EqualTo(1))
+
+                        Assert.That(
+                            (match repaired with
+                             | BillingPeriodCloseResult.Closed (_, 1) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(repaired, Is.EqualTo(replay))
+                        Assert.That(charges, Is.EqualTo(1))
+                        Assert.That(cleared, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves cancellation after every close mutation stage restores the complete preexisting durable projection.
+    [<TestCase("preview")>]
+    [<TestCase("charge")>]
+    [<TestCase("evidence")>]
+    member _.CancellationAfterEveryStagedCloseMutationPreservesPriorProjection(stage: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 4) 9L)
+                do! addPricingAsync connectionString scope
+
+                let nextMonthStartUtc =
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+
+                let previewClock = FixedBillingPeriodCloseClock(nextMonthStartUtc.AddHours 24.0) :> IBillingPeriodCloseClock
+                let inert = StageCancellationInterleaving("none", new CancellationTokenSource()) :> IBillingPeriodCloseTransactionInterleaving
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/cancellation/v1" }
+                let previewCloser = SqlBillingPeriodCloser.CreateForTest(connectionString, inert, previewClock) :> IBillingPeriodCloser
+                let! preview = previewCloser.PreviewAsync(request, CancellationToken.None)
+
+                Assert.That(
+                    (match preview with
+                     | BillingPeriodCloseResult.Provisional _ -> true
+                     | _ -> false),
+                    Is.True
+                )
+
+                let! before = closeProjectionAsync connectionString
+                use cancellation = new CancellationTokenSource()
+                let interleaving = StageCancellationInterleaving(stage, cancellation)
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                Assert.ThrowsAsync<OperationCanceledException>(Func<Task>(fun () -> closer.CloseAsync(request, cancellation.Token) :> Task))
+                |> ignore
+
+                let! after = closeProjectionAsync connectionString
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(cancellation.IsCancellationRequested, Is.True)
+                        Assert.That(after, Is.EqualTo(before :> obj)))
+                )
+            })
+
+    /// Proves distinct owners and sibling repositories close independently and a fresh closer replays without reposting.
+    [<Test>]
+    member _.OwnersSiblingRepositoriesAndRestartRemainIsolatedAndIdempotent() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let organizationId = Guid.NewGuid()
+                let ownerA, ownerB = Guid.NewGuid(), Guid.NewGuid()
+                let repositoryA, repositoryB = Guid.NewGuid(), Guid.NewGuid()
+                let scopeA = scopeFor ownerA organizationId repositoryA
+                let scopeB = scopeFor ownerB organizationId repositoryA
+                let siblingScope = scopeFor ownerA organizationId repositoryB
+                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerA organizationId repositoryA (monthStart + Duration.FromDays 5) 1L)
+                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerB organizationId repositoryA (monthStart + Duration.FromDays 5) 2L)
+                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerA organizationId repositoryB (monthStart + Duration.FromDays 5) 3L)
+                do! addPricingAsync connectionString scopeA
+                do! addPricingAsync connectionString scopeB
+                do! addPricingAsync connectionString siblingScope
+
+                let close scope =
+                    let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/isolation-replay/v1" }
+
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! results = Task.WhenAll(close scopeA, close scopeB, close siblingScope)
+                let! replay = close scopeA
+                let! periods = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            results
+                            |> Array.forall (function
+                                | BillingPeriodCloseResult.Closed (_, 1) -> true
+                                | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(
+                            (match replay with
+                             | BillingPeriodCloseResult.Closed (_, 1) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(periods, Is.EqualTo(3))
+                        Assert.That(charges, Is.EqualTo(3))
+                        Assert.That(evidence, Is.EqualTo(3)))
                 )
             })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -842,17 +842,18 @@ ORDER BY 1;
                 )
             })
 
-    /// Proves distinct owners and sibling repositories close independently and a fresh closer replays without reposting.
+    /// Proves distinct owners and sibling repositories close independently, zero facts remain nonterminal, and a fresh closer replays without reposting.
     [<Test>]
-    member _.OwnersSiblingRepositoriesAndRestartRemainIsolatedAndIdempotent() =
+    member _.OwnersSiblingRepositoriesZeroFactsAndRestartRemainIsolatedAndIdempotent() =
         withDatabaseAsync (fun connectionString ->
             task {
                 let organizationId = Guid.NewGuid()
-                let ownerA, ownerB = Guid.NewGuid(), Guid.NewGuid()
+                let ownerA, ownerB, zeroFactOwner = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
                 let repositoryA, repositoryB = Guid.NewGuid(), Guid.NewGuid()
                 let scopeA = scopeFor ownerA organizationId repositoryA
                 let scopeB = scopeFor ownerB organizationId repositoryA
                 let siblingScope = scopeFor ownerA organizationId repositoryB
+                let zeroFactScope = scopeFor zeroFactOwner organizationId repositoryA
                 do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerA organizationId repositoryA (monthStart + Duration.FromDays 5) 1L)
                 do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerB organizationId repositoryA (monthStart + Duration.FromDays 5) 2L)
                 do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerA organizationId repositoryB (monthStart + Duration.FromDays 5) 3L)
@@ -868,9 +869,13 @@ ORDER BY 1;
 
                 let! results = Task.WhenAll(close scopeA, close scopeB, close siblingScope)
                 let! replay = close scopeA
+                let! zeroFactResult = close zeroFactScope
                 let! periods = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
                 let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
                 let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                let! zeroFactPending =
+                    countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0,1) AND RetryDiagnostic='ZeroFactCoveragePending';"
 
                 Assert.Multiple(
                     Action (fun () ->
@@ -889,8 +894,16 @@ ORDER BY 1;
                             Is.True
                         )
 
+                        Assert.That(
+                            (match zeroFactResult with
+                             | BillingPeriodCloseResult.Blocked "ZeroFactCoveragePending" -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
                         Assert.That(periods, Is.EqualTo(3))
                         Assert.That(charges, Is.EqualTo(3))
-                        Assert.That(evidence, Is.EqualTo(3)))
+                        Assert.That(evidence, Is.EqualTo(3))
+                        Assert.That(zeroFactPending, Is.EqualTo(1)))
                 )
             })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -114,6 +114,72 @@ type private StageCancellationInterleaving(stage: string, cancellation: Cancella
         member _.AfterChargeInsertionAsync _ = cancelAt "charge"
         member _.AfterCloseEvidenceStagedAsync _ = cancelAt "evidence"
 
+/// Retains the exact pricing identities and immutable values inserted for one close-proof scope.
+type private SeededPricing =
+    {
+        PricingPlanId: Guid
+        PricingRateId: Guid
+        PricingAssignmentId: Guid
+        BillableUsageKindMappingId: Guid
+        BillableUsageKind: int
+        CurrencyCode: string
+        UnitName: string
+        UnitQuantity: int64
+        UnitPriceMicros: int64
+        EffectiveFromUtc: DateTime
+        EffectiveToUtc: DateTime
+    }
+
+/// Represents every immutable preview or posting field that the direct-close tuple must preserve.
+type private ImmutableClosePricing =
+    {
+        OwnerId: Guid
+        OrganizationId: Guid
+        RepositoryId: Guid
+        PeriodFromUtc: DateTime
+        PeriodToUtc: DateTime
+        FactKind: int
+        BillableUsageKindMappingId: Guid
+        BillableUsageKind: int
+        PricingAssignmentId: Guid
+        PricingPlanId: Guid
+        PricingRateId: Guid
+        CurrencyCode: string
+        UnitName: string
+        UnitQuantity: int64
+        UnitPriceMicros: int64
+        EffectiveFromUtc: DateTime
+        EffectiveToUtc: DateTime
+        TotalQuantity: int64
+        ChargeMicros: int64
+    }
+
+/// Captures independently derived deterministic identities and immutable evidence expected from one seeded close.
+type private SeededCloseExpectation =
+    {
+        BillingPeriodId: Guid
+        ChargePreviewLineId: Guid
+        ChargeId: Guid
+        ImmutablePricing: ImmutableClosePricing
+        AcceptedFactDigestSha256Hex: string
+        PricingPreviewDigestSha256Hex: string
+        ScheduledOperationProvenance: string
+    }
+
+/// Represents the complete immutable row set observed for one owner/repository close scope.
+type private ClosedScopeProjection =
+    {
+        BillingPeriodId: Guid
+        ChargePreviewLineId: Guid
+        Preview: ImmutableClosePricing
+        ChargeId: Guid
+        Charge: ImmutableClosePricing
+        AcceptedFactDigestSha256Hex: string
+        PricingPreviewDigestSha256Hex: string
+        ClosedAtUtc: DateTime
+        ScheduledOperationProvenance: string
+    }
+
 /// Proves the exact database-time policy boundary independently of the production SQL clock source.
 [<TestFixture; NonParallelizable>]
 type OperationsBillingPeriodCloseBehaviorTests() =
@@ -230,6 +296,17 @@ type OperationsBillingPeriodCloseBehaviorTests() =
         task {
             let planId, rateId, assignmentId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
             let mappingId = Guid.Parse "47a4d91d-43e7-450b-8800-917000000001"
+            let effectiveFromUtc = scope.MonthStart.ToDateTimeUtc()
+
+            let effectiveToUtc =
+                (BillingCompletenessScope.nextMonthStart scope)
+                    .ToDateTimeUtc()
+
+            let billableUsageKind = 101
+            let currencyCode = "USD"
+            let unitName = "byte-minute"
+            let unitQuantity = 1L
+            let unitPriceMicros = 2L
             use connection = new SqlConnection(connectionString)
             do! connection.OpenAsync CancellationToken.None
             use command = connection.CreateCommand()
@@ -247,10 +324,290 @@ type OperationsBillingPeriodCloseBehaviorTests() =
             command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
             command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
             command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
-            command.Parameters.Add("@EffectiveFrom", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+            command.Parameters.Add("@EffectiveFrom", SqlDbType.DateTime2).Value <- effectiveFromUtc
             let! _ = command.ExecuteNonQueryAsync CancellationToken.None
-            return ()
+
+            return
+                {
+                    PricingPlanId = planId
+                    PricingRateId = rateId
+                    PricingAssignmentId = assignmentId
+                    BillableUsageKindMappingId = mappingId
+                    BillableUsageKind = billableUsageKind
+                    CurrencyCode = currencyCode
+                    UnitName = unitName
+                    UnitQuantity = unitQuantity
+                    UnitPriceMicros = unitPriceMicros
+                    EffectiveFromUtc = effectiveFromUtc
+                    EffectiveToUtc = effectiveToUtc
+                }
         }
+
+    /// Derives the deterministic GUID format used by the direct-close and preview-line contracts from seeded input only.
+    let deterministicGuid (canonical: string) =
+        Guid(
+            SHA256
+                .HashData(Encoding.UTF8.GetBytes canonical)
+                .AsSpan(0, 16)
+        )
+
+    /// Hashes independent canonical evidence records with the production uppercase SHA-256 representation.
+    let digestCanonical (values: string list) =
+        values
+        |> String.concat "\n"
+        |> Encoding.UTF8.GetBytes
+        |> SHA256.HashData
+        |> Convert.ToHexString
+
+    /// Derives the expected period, preview, charge, and evidence tuple without reading a persisted preview or posting.
+    let seededCloseExpectation
+        (scope: BillingCompletenessScope)
+        (usageFactId: Guid)
+        (usageFactObservedAt: Instant)
+        (totalQuantity: int64)
+        (pricing: SeededPricing)
+        (provenance: string)
+        : SeededCloseExpectation
+        =
+        let periodFromUtc = scope.MonthStart.ToDateTimeUtc()
+
+        let periodToUtc =
+            (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+        let factKind = 1
+
+        let periodId =
+            String.Join(
+                "|",
+                [|
+                    "Grace.Operations.BillingPeriod.v1"
+                    scope.OwnerId.ToString("D")
+                    scope.OrganizationId.ToString("D")
+                    scope.RepositoryId.ToString("D")
+                    periodFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    periodToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                |]
+            )
+            |> deterministicGuid
+
+        let immutablePricing =
+            {
+                OwnerId = scope.OwnerId
+                OrganizationId = scope.OrganizationId
+                RepositoryId = scope.RepositoryId
+                PeriodFromUtc = periodFromUtc
+                PeriodToUtc = periodToUtc
+                FactKind = factKind
+                BillableUsageKindMappingId = pricing.BillableUsageKindMappingId
+                BillableUsageKind = pricing.BillableUsageKind
+                PricingAssignmentId = pricing.PricingAssignmentId
+                PricingPlanId = pricing.PricingPlanId
+                PricingRateId = pricing.PricingRateId
+                CurrencyCode = pricing.CurrencyCode
+                UnitName = pricing.UnitName
+                UnitQuantity = pricing.UnitQuantity
+                UnitPriceMicros = pricing.UnitPriceMicros
+                EffectiveFromUtc = pricing.EffectiveFromUtc
+                EffectiveToUtc = pricing.EffectiveToUtc
+                TotalQuantity = totalQuantity
+                ChargeMicros =
+                    totalQuantity * pricing.UnitPriceMicros
+                    / pricing.UnitQuantity
+            }
+
+        let previewLineId =
+            String.Join(
+                "|",
+                [|
+                    immutablePricing.OwnerId.ToString("D")
+                    immutablePricing.OrganizationId.ToString("D")
+                    immutablePricing.RepositoryId.ToString("D")
+                    immutablePricing.PeriodFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.PeriodToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.FactKind.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.BillableUsageKindMappingId.ToString("D")
+                    immutablePricing.BillableUsageKind.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.PricingAssignmentId.ToString("D")
+                    immutablePricing.PricingPlanId.ToString("D")
+                    immutablePricing.PricingRateId.ToString("D")
+                    immutablePricing.CurrencyCode
+                    immutablePricing.UnitName
+                    immutablePricing.UnitQuantity.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.UnitPriceMicros.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.EffectiveFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.EffectiveToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                |]
+            )
+            |> deterministicGuid
+
+        let previewCanonical =
+            String.Join(
+                "|",
+                [|
+                    previewLineId.ToString("D")
+                    immutablePricing.OwnerId.ToString("D")
+                    immutablePricing.OrganizationId.ToString("D")
+                    immutablePricing.RepositoryId.ToString("D")
+                    immutablePricing.PeriodFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.PeriodToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.FactKind.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.BillableUsageKindMappingId.ToString("D")
+                    immutablePricing.BillableUsageKind.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.PricingAssignmentId.ToString("D")
+                    immutablePricing.PricingPlanId.ToString("D")
+                    immutablePricing.PricingRateId.ToString("D")
+                    immutablePricing.CurrencyCode
+                    immutablePricing.UnitName
+                    immutablePricing.UnitQuantity.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.UnitPriceMicros.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.EffectiveFromUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.EffectiveToUtc.Ticks.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.TotalQuantity.ToString(CultureInfo.InvariantCulture)
+                    immutablePricing.ChargeMicros.ToString(CultureInfo.InvariantCulture)
+                |]
+            )
+
+        {
+            BillingPeriodId = periodId
+            ChargePreviewLineId = previewLineId
+            ChargeId = deterministicGuid $"Grace.Operations.InitialCharge.v1|{periodId:D}|{previewLineId:D}"
+            ImmutablePricing = immutablePricing
+            AcceptedFactDigestSha256Hex =
+                digestCanonical [ $"{usageFactId:D}|{factKind}|{totalQuantity}|{usageFactObservedAt
+                                                                                    .ToDateTimeUtc()
+                                                                                    .Ticks.ToString(CultureInfo.InvariantCulture)}" ]
+            PricingPreviewDigestSha256Hex = digestCanonical [ previewCanonical ]
+            ScheduledOperationProvenance = provenance
+        }
+
+    /// Reads every immutable direct-close field for one exact owner, repository, and month scope.
+    let readClosedScopeProjectionAsync connectionString (scope: BillingCompletenessScope) =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT period.BillingPeriodId,preview.ChargePreviewLineId,preview.OwnerId,preview.OrganizationId,preview.RepositoryId,preview.PeriodFromUtc,preview.PeriodToUtc,preview.FactKind,preview.BillableUsageKindMappingId,preview.BillableUsageKind,preview.PricingAssignmentId,preview.PricingPlanId,preview.PricingRateId,preview.CurrencyCode,preview.UnitName,preview.UnitQuantity,preview.UnitPriceMicros,preview.EffectiveFromUtc,preview.EffectiveToUtc,preview.TotalQuantity,preview.ChargeMicros,charge.ChargeId,charge.OwnerId,charge.OrganizationId,charge.RepositoryId,charge.PeriodFromUtc,charge.PeriodToUtc,charge.FactKind,charge.BillableUsageKindMappingId,charge.BillableUsageKind,charge.PricingAssignmentId,charge.PricingPlanId,charge.PricingRateId,charge.CurrencyCode,charge.UnitName,charge.UnitQuantity,charge.UnitPriceMicros,charge.EffectiveFromUtc,charge.EffectiveToUtc,charge.TotalQuantity,charge.ChargeMicros,evidence.AcceptedFactDigestSha256Hex,evidence.PricingPreviewDigestSha256Hex,evidence.ClosedAtUtc,evidence.ScheduledOperationProvenance FROM ops.BillingPeriod AS period INNER JOIN ops.ChargePreviewLine AS preview ON preview.OwnerId=period.OwnerId AND preview.OrganizationId=period.OrganizationId AND preview.RepositoryId=period.RepositoryId AND preview.PeriodFromUtc=period.MonthStartUtc AND preview.PeriodToUtc=period.NextMonthStartUtc INNER JOIN ops.Charge AS charge ON charge.BillingPeriodId=period.BillingPeriodId AND charge.ChargePreviewLineId=preview.ChargePreviewLineId INNER JOIN ops.BillingPeriodCloseEvidence AS evidence ON evidence.BillingPeriodId=period.BillingPeriodId WHERE period.OwnerId=@OwnerId AND period.OrganizationId=@OrganizationId AND period.RepositoryId=@RepositoryId AND period.MonthStartUtc=@MonthStartUtc AND period.NextMonthStartUtc=@NextMonthStartUtc;"
+
+            command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            command.Parameters.Add("@NextMonthStartUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let rows = ResizeArray<ClosedScopeProjection>()
+
+            let pricing offset =
+                {
+                    OwnerId = reader.GetGuid offset
+                    OrganizationId = reader.GetGuid(offset + 1)
+                    RepositoryId = reader.GetGuid(offset + 2)
+                    PeriodFromUtc = reader.GetDateTime(offset + 3)
+                    PeriodToUtc = reader.GetDateTime(offset + 4)
+                    FactKind = Convert.ToInt32(reader.GetValue(offset + 5), CultureInfo.InvariantCulture)
+                    BillableUsageKindMappingId = reader.GetGuid(offset + 6)
+                    BillableUsageKind = Convert.ToInt32(reader.GetValue(offset + 7), CultureInfo.InvariantCulture)
+                    PricingAssignmentId = reader.GetGuid(offset + 8)
+                    PricingPlanId = reader.GetGuid(offset + 9)
+                    PricingRateId = reader.GetGuid(offset + 10)
+                    CurrencyCode = reader.GetString(offset + 11)
+                    UnitName = reader.GetString(offset + 12)
+                    UnitQuantity = reader.GetInt64(offset + 13)
+                    UnitPriceMicros = reader.GetInt64(offset + 14)
+                    EffectiveFromUtc = reader.GetDateTime(offset + 15)
+                    EffectiveToUtc = reader.GetDateTime(offset + 16)
+                    TotalQuantity = reader.GetInt64(offset + 17)
+                    ChargeMicros = reader.GetInt64(offset + 18)
+                }
+
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then
+                    rows.Add(
+                        {
+                            BillingPeriodId = reader.GetGuid 0
+                            ChargePreviewLineId = reader.GetGuid 1
+                            Preview = pricing 2
+                            ChargeId = reader.GetGuid 21
+                            Charge = pricing 22
+                            AcceptedFactDigestSha256Hex = reader.GetString 41
+                            PricingPreviewDigestSha256Hex = reader.GetString 42
+                            ClosedAtUtc = reader.GetDateTime 43
+                            ScheduledOperationProvenance = reader.GetString 44
+                        }
+                    )
+
+            return rows |> Seq.toList
+        }
+
+    /// Reads the independently scoped accepted-fact count and quantity before comparing close records.
+    let acceptedScopeFactSummaryAsync connectionString (scope: BillingCompletenessScope) =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                "SELECT COUNT(*),COALESCE(SUM(Quantity),0) FROM ops.RawUsageFact WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND ObservedAtUtc>=@MonthStartUtc AND ObservedAtUtc<@NextMonthStartUtc;"
+
+            command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+            command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+            command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+            command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+            command.Parameters.Add("@NextMonthStartUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+                .ToDateTimeUtc()
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let! hasRow = reader.ReadAsync CancellationToken.None
+            Assert.That(hasRow, Is.True)
+            return reader.GetInt32(0), reader.GetInt64(1)
+        }
+
+    /// Asserts one scope's independently seeded fact, exact identities, immutable provenance, and evidence tuple.
+    let assertSeededScopeClose
+        (scopeName: string)
+        (expected: SeededCloseExpectation)
+        (expectedFactQuantity: int64)
+        (actualFactCount: int)
+        (actualFactQuantity: int64)
+        (projections: ClosedScopeProjection list)
+        =
+        Assert.That(actualFactCount, Is.EqualTo(1), $"{scopeName} must retain exactly one accepted source fact.")
+        Assert.That(actualFactQuantity, Is.EqualTo(expectedFactQuantity), $"{scopeName} must retain its own seeded quantity.")
+        Assert.That(projections.Length, Is.EqualTo(1), $"{scopeName} must have exactly one period, preview, charge, and evidence tuple.")
+        let actual = projections |> List.exactlyOne
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(actual.BillingPeriodId, Is.EqualTo(expected.BillingPeriodId), $"{scopeName} period identity")
+                Assert.That(actual.ChargePreviewLineId, Is.EqualTo(expected.ChargePreviewLineId), $"{scopeName} preview identity")
+                Assert.That(actual.ChargeId, Is.EqualTo(expected.ChargeId), $"{scopeName} posting identity")
+                Assert.That(actual.Preview, Is.EqualTo(expected.ImmutablePricing), $"{scopeName} immutable preview provenance")
+                Assert.That(actual.Charge, Is.EqualTo(expected.ImmutablePricing), $"{scopeName} immutable posting provenance")
+                Assert.That(actual.AcceptedFactDigestSha256Hex, Is.EqualTo(expected.AcceptedFactDigestSha256Hex), $"{scopeName} accepted-fact digest")
+
+                Assert.That(
+                    actual.PricingPreviewDigestSha256Hex,
+                    Is.EqualTo(expected.PricingPreviewDigestSha256Hex),
+                    $"{scopeName} independent pricing-preview digest"
+                )
+
+                Assert.That(
+                    actual.ScheduledOperationProvenance,
+                    Is.EqualTo(expected.ScheduledOperationProvenance),
+                    $"{scopeName} scheduled-operation provenance"
+                ))
+        )
 
     /// Reads application-lock rows only for the two captured production sessions from this contention test.
     let applicationLocksAsync connectionString firstSessionId secondSessionId =
@@ -476,7 +833,7 @@ ORDER BY 1;
                 let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
                 let scope = scopeFor ownerId organizationId repositoryId
                 do! acceptAsync connectionString ownerId organizationId repositoryId
-                do! addPricingAsync connectionString scope
+                let! _ = addPricingAsync connectionString scope
                 let interleaving = ClockOrderingInterleaving()
                 let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/database-clock-ordering/v1" }
 
@@ -521,7 +878,7 @@ ORDER BY 1;
                 let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
                 let scope = scopeFor ownerId organizationId repositoryId
                 do! acceptAsync connectionString ownerId organizationId repositoryId
-                do! addPricingAsync connectionString scope
+                let! _ = addPricingAsync connectionString scope
                 let firstInterleaving = ContentionInterleaving(true)
                 let secondInterleaving = ContentionInterleaving(false)
                 let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/two-session-contention/v1" }
@@ -591,10 +948,14 @@ ORDER BY 1;
                 let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
                 let scope = scopeFor ownerId organizationId repositoryId
                 let nextMonthStart = BillingCompletenessScope.nextMonthStart scope
-                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId scope.MonthStart 7L)
-                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId nextMonthStart 11L)
-                do! addPricingAsync connectionString scope
-                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/close-evidence/v1" }
+                let inPeriodFactId = Guid.NewGuid()
+                let nextPeriodFactId = Guid.NewGuid()
+                do! acceptFactAsync connectionString (usageFact inPeriodFactId ownerId organizationId repositoryId scope.MonthStart 7L)
+                do! acceptFactAsync connectionString (usageFact nextPeriodFactId ownerId organizationId repositoryId nextMonthStart 11L)
+                let! pricing = addPricingAsync connectionString scope
+                let provenance = "operations-tests/close-evidence/v1"
+                let expected = seededCloseExpectation scope inPeriodFactId scope.MonthStart 7L pricing provenance
+                let request = { Scope = scope; ScheduledOperationProvenance = provenance }
 
                 let! beforeClose =
                     task {
@@ -620,18 +981,10 @@ ORDER BY 1;
                         return value :?> DateTime
                     }
 
-                let! expectedFactDigest = acceptedFactDigestAsync connectionString scope
-                let! expectedPreviewDigest = pricingPreviewDigestAsync connectionString
-                use connection = new SqlConnection(connectionString)
-                do! connection.OpenAsync CancellationToken.None
-                use command = connection.CreateCommand()
-
-                command.CommandText <-
-                    "SELECT TotalQuantity,ChargeMicros,(SELECT ChargeMicros FROM ops.Charge),AcceptedFactDigestSha256Hex,PricingPreviewDigestSha256Hex,ClosedAtUtc,ScheduledOperationProvenance FROM ops.ChargePreviewLine CROSS JOIN ops.BillingPeriodCloseEvidence;"
-
-                use! reader = command.ExecuteReaderAsync CancellationToken.None
-                let! hasRow = reader.ReadAsync CancellationToken.None
-                Assert.That(hasRow, Is.True)
+                let! factCount, factQuantity = acceptedScopeFactSummaryAsync connectionString scope
+                let! projections = readClosedScopeProjectionAsync connectionString scope
+                assertSeededScopeClose "close-evidence scope" expected 7L factCount factQuantity projections
+                let persisted = projections |> List.exactlyOne
 
                 Assert.Multiple(
                     Action (fun () ->
@@ -642,14 +995,8 @@ ORDER BY 1;
                             Is.True
                         )
 
-                        Assert.That(reader.GetInt64 0, Is.EqualTo(7L))
-                        Assert.That(reader.GetInt64 1, Is.EqualTo(14L))
-                        Assert.That(reader.GetInt64 2, Is.EqualTo(14L))
-                        Assert.That(reader.GetString 3, Is.EqualTo(expectedFactDigest))
-                        Assert.That(reader.GetString 4, Is.EqualTo(expectedPreviewDigest))
-                        Assert.That(reader.GetDateTime 5, Is.GreaterThanOrEqualTo(beforeClose))
-                        Assert.That(reader.GetDateTime 5, Is.LessThanOrEqualTo(afterClose))
-                        Assert.That(reader.GetString 6, Is.EqualTo("operations-tests/close-evidence/v1")))
+                        Assert.That(persisted.ClosedAtUtc, Is.GreaterThanOrEqualTo(beforeClose))
+                        Assert.That(persisted.ClosedAtUtc, Is.LessThanOrEqualTo(afterClose)))
                 )
             })
 
@@ -692,7 +1039,7 @@ ORDER BY 1;
                     ()
                 | value -> invalidArg (nameof blocker) value
 
-                do! addPricingAsync connectionString scope
+                let! _ = addPricingAsync connectionString scope
                 let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/blockers/v1" }
 
                 let! result =
@@ -739,7 +1086,7 @@ ORDER BY 1;
                 let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
 
                 if overflows then
-                    do! addPricingAsync connectionString scope
+                    let! _ = addPricingAsync connectionString scope
                     use setOverflow = new SqlConnection(connectionString)
                     do! setOverflow.OpenAsync CancellationToken.None
                     use command = setOverflow.CreateCommand()
@@ -759,7 +1106,8 @@ ORDER BY 1;
                     let! _ = command.ExecuteNonQueryAsync CancellationToken.None
                     ()
                 else
-                    do! addPricingAsync connectionString scope
+                    let! _ = addPricingAsync connectionString scope
+                    ()
 
                 let! repaired = closer.CloseAsync(request, CancellationToken.None)
                 let! replay = closer.CloseAsync(request, CancellationToken.None)
@@ -804,7 +1152,7 @@ ORDER BY 1;
                 let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
                 let scope = scopeFor ownerId organizationId repositoryId
                 do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (monthStart + Duration.FromDays 4) 9L)
-                do! addPricingAsync connectionString scope
+                let! _ = addPricingAsync connectionString scope
 
                 let nextMonthStartUtc =
                     (BillingCompletenessScope.nextMonthStart scope)
@@ -854,15 +1202,21 @@ ORDER BY 1;
                 let scopeB = scopeFor ownerB organizationId repositoryA
                 let siblingScope = scopeFor ownerA organizationId repositoryB
                 let zeroFactScope = scopeFor zeroFactOwner organizationId repositoryA
-                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerA organizationId repositoryA (monthStart + Duration.FromDays 5) 1L)
-                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerB organizationId repositoryA (monthStart + Duration.FromDays 5) 2L)
-                do! acceptFactAsync connectionString (usageFact (Guid.NewGuid()) ownerA organizationId repositoryB (monthStart + Duration.FromDays 5) 3L)
-                do! addPricingAsync connectionString scopeA
-                do! addPricingAsync connectionString scopeB
-                do! addPricingAsync connectionString siblingScope
+                let factAId, factBId, siblingFactId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let observedAt = monthStart + Duration.FromDays 5
+                do! acceptFactAsync connectionString (usageFact factAId ownerA organizationId repositoryA observedAt 1L)
+                do! acceptFactAsync connectionString (usageFact factBId ownerB organizationId repositoryA observedAt 2L)
+                do! acceptFactAsync connectionString (usageFact siblingFactId ownerA organizationId repositoryB observedAt 3L)
+                let! pricingA = addPricingAsync connectionString scopeA
+                let! pricingB = addPricingAsync connectionString scopeB
+                let! siblingPricing = addPricingAsync connectionString siblingScope
+                let provenance = "operations-tests/isolation-replay/v1"
+                let expectedA = seededCloseExpectation scopeA factAId observedAt 1L pricingA provenance
+                let expectedB = seededCloseExpectation scopeB factBId observedAt 2L pricingB provenance
+                let expectedSibling = seededCloseExpectation siblingScope siblingFactId observedAt 3L siblingPricing provenance
 
                 let close scope =
-                    let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/isolation-replay/v1" }
+                    let request = { Scope = scope; ScheduledOperationProvenance = provenance }
 
                     (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
                         .CloseAsync(request, CancellationToken.None)
@@ -873,6 +1227,16 @@ ORDER BY 1;
                 let! periods = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
                 let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
                 let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! factCountA, factQuantityA = acceptedScopeFactSummaryAsync connectionString scopeA
+                let! factCountB, factQuantityB = acceptedScopeFactSummaryAsync connectionString scopeB
+                let! siblingFactCount, siblingFactQuantity = acceptedScopeFactSummaryAsync connectionString siblingScope
+                let! projectionsA = readClosedScopeProjectionAsync connectionString scopeA
+                let! projectionsB = readClosedScopeProjectionAsync connectionString scopeB
+                let! siblingProjections = readClosedScopeProjectionAsync connectionString siblingScope
+
+                assertSeededScopeClose "owner A/repository A" expectedA 1L factCountA factQuantityA projectionsA
+                assertSeededScopeClose "owner B/repository A" expectedB 2L factCountB factQuantityB projectionsB
+                assertSeededScopeClose "owner A/repository B" expectedSibling 3L siblingFactCount siblingFactQuantity siblingProjections
 
                 let! zeroFactPending =
                     countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0,1) AND RetryDiagnostic='ZeroFactCoveragePending';"

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsChargePreview.Tests.fs
@@ -226,7 +226,7 @@ type OperationsChargePreviewTests() =
             Assert.That(sql, Does.Contain("fact.ObservedAtUtc >= @PeriodFromUtc"))
             Assert.That(sql, Does.Contain("fact.ObservedAtUtc < @PeriodToUtc"))
             Assert.That(sql, Does.Contain("assignment.EffectiveFromUtc"))
-            Assert.That(sql, Does.Contain("plan.EffectiveFromUtc"))
+            Assert.That(sql, Does.Contain("pricingPlan.EffectiveFromUtc"))
             Assert.That(sql, Does.Contain("mapping.EffectiveFromUtc"))
             Assert.That(sql, Does.Contain("rate.EffectiveFromUtc"))
             Assert.That(sql, Does.Contain("MAX(boundary.EffectiveFromUtc)"))


### PR DESCRIPTION
# Close nonempty billing periods atomically under database time and scope locking

## Purpose

Give Grace owners one reproducible monthly initial charge while ensuring close decisions use database time and the
same exact-scope application lock as accepted usage.

Related to #917. Parent replacement packet: #908. Epic chain: #554 -> #560 -> #576 -> #864.

## Current checkpoint

- Adds the direct nonempty close transaction under the exact #879 scope-lock identity.
- Reads SQL UTC time after lock grant on the same connection and transaction.
- Creates deterministic period and final preview records, complete immutable initial charges and close evidence, then
  transitions the period to `Closed` atomically.
- Replays an already closed period without rebuilding or reposting.
- Keeps zero-fact periods nonterminal as `ZeroFactCoveragePending` for #909.
- Includes pure one-tick threshold boundaries and initial production source/order plus two-session contention tests.

## Boundaries

- No late-work persistence or accepted-fact handoff; #918 owns that behavior.
- No collective zero-fact pricing; #909 owns it.
- No hosted discovery; #910 owns it.
- No correction, adjustment, settlement, public surface, compatibility path, process-time fallback, SQL pricing engine,
  or SQL Server time virtualization.

## Review status

- Implementation/fix workers started: **4** under epic #554's 4+1 policy.
- Mandatory post-worker-3 structural audit: passed. The exact six-path candidate remains one direct-close
  transaction/database-time/scope-lock invariant family with no later-leaf behavior.
- Exact pushed head: `efa8aa5ac1453dc75abc5ed49c5c3d624d7d8d10`; local, origin, and PR heads match and the worktree is clean.
- Worker-4 certification on this head: targeted Fantomas, matching Release build, and `git diff --check` passed; the
  retained real-SQL fixture passed 14/14 with zero failures or skips.
- Fresh exact-head review 1 found two P2 items in one finite proof/validation family: the stale preview-alias assertion
  and independently seeded exact posting/provenance plus per-scope isolation proof. No production transaction defect.
- Exact-head `Validate` run `31681610641` failed only the stale alias assertion; all other reported suites passed.
- Final worker 5 pushed exact head `efa8aa5a`, closing both review-1 findings with deliberate RED and complete GREEN
  proof. Decisive fresh review 2 approved with no findings, and exact-head `Validate` run `31684238062` passed.
- Worker usage is exhausted at 5. No valid finding remains, so automatic supersession is not triggered. The PR is clean,
  mergeable, and ready for the WS4 integration branch.

## Documentation impact
No public behavior or documentation is complete at this checkpoint. The final candidate will report any closest
internal documentation impact.