### PR TITLE
Render exact WDU lifecycle projections

### DIFF
--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -92,53 +92,155 @@ The complete requirements, state model, propagation map, and proof contract are 
 The projection below is an existing contextual consumer, not proof that the replacement packet has been published.
 Issue #929 rewrites and compares all fifteen exact projection blocks from the compiler result after PR #930 merges.
 
-<!-- grace:wdu-lifecycle-projection:start -->
+<!-- grace:wdu-lifecycle-projection:adr-0011:start -->
 ```json
 {
-  "schema": "grace.wdu.lifecycle-projection/v1",
+  "schema": "grace.wdu.lifecycle-projection/v2",
   "artifact": "adr-0011",
-  "canonical": "docs/Working Directory Update.md#normative-branch-lifecycle-table",
   "canonicalContentDigest": "ae3a77e28886485b49361d8836f040691e9f99228919cef87fac19b42e989d73",
-  "rowIds": [
-    "WDU-LC-200",
-    "WDU-LC-201",
-    "WDU-LC-202",
-    "WDU-LC-206",
-    "WDU-LC-207",
-    "WDU-LC-208",
-    "WDU-LC-209",
-    "WDU-LC-210",
-    "WDU-LC-212",
-    "WDU-LC-006",
-    "WDU-LC-007",
-    "WDU-LC-010",
-    "WDU-LC-015",
-    "WDU-LC-020",
-    "WDU-LC-023",
-    "WDU-LC-025",
-    "WDU-LC-026",
-    "WDU-LC-028",
-    "WDU-LC-030",
-    "WDU-LC-033",
-    "WDU-LC-035",
-    "WDU-LC-036",
-    "WDU-LC-038",
-    "WDU-LC-100",
-    "WDU-LC-101",
-    "WDU-LC-103",
-    "WDU-LC-110",
-    "WDU-LC-114",
-    "WDU-LC-120",
-    "WDU-LC-123",
-    "WDU-LC-130",
-    "WDU-LC-140",
-    "WDU-LC-143",
-    "WDU-LC-003"
+  "assignmentDigest": "20e329bd3aa4459a01f4ed3c6ec12cf365c86df3538b0323400639b90eeee877",
+  "counts": {
+    "rowCount": 70,
+    "applicabilityKeyCount": 260,
+    "requirementCount": 19,
+    "artifactCount": 15
+  },
+  "requirements": [
+    {
+      "id": "REQ-001",
+      "owner": "#923"
+    },
+    {
+      "id": "REQ-002",
+      "owner": "#869"
+    },
+    {
+      "id": "REQ-003",
+      "owner": "#837"
+    },
+    {
+      "id": "REQ-004",
+      "owner": "#839"
+    },
+    {
+      "id": "REQ-005",
+      "owner": "#869"
+    },
+    {
+      "id": "REQ-006",
+      "owner": "#898"
+    },
+    {
+      "id": "REQ-007",
+      "owner": "#922"
+    },
+    {
+      "id": "REQ-008",
+      "owner": "#922"
+    },
+    {
+      "id": "REQ-009",
+      "owner": "#838"
+    },
+    {
+      "id": "REQ-010",
+      "owner": "#838"
+    },
+    {
+      "id": "REQ-011",
+      "owner": "#871"
+    },
+    {
+      "id": "REQ-012",
+      "owner": "#871"
+    },
+    {
+      "id": "REQ-013",
+      "owner": "#900"
+    },
+    {
+      "id": "REQ-014",
+      "owner": "#921"
+    },
+    {
+      "id": "REQ-015",
+      "owner": "#842"
+    },
+    {
+      "id": "REQ-016",
+      "owner": "#871"
+    },
+    {
+      "id": "REQ-017",
+      "owner": "#846"
+    },
+    {
+      "id": "REQ-018",
+      "owner": "#928"
+    },
+    {
+      "id": "REQ-019",
+      "owner": "#923"
+    }
   ],
-  "proof": "Record the lasting Branch transaction lifecycle and reference canonical rows without copying their order."
+  "artifactIds": [
+    "adr-0011",
+    "epic-835",
+    "issue-842",
+    "issue-843",
+    "issue-846",
+    "issue-869",
+    "issue-898",
+    "issue-928",
+    "issue-921",
+    "issue-922",
+    "issue-923",
+    "issue-900",
+    "issue-901",
+    "issue-871",
+    "issue-872"
+  ],
+  "assignment": {
+    "rowIds": [
+      "WDU-LC-200",
+      "WDU-LC-201",
+      "WDU-LC-202",
+      "WDU-LC-206",
+      "WDU-LC-207",
+      "WDU-LC-208",
+      "WDU-LC-209",
+      "WDU-LC-210",
+      "WDU-LC-212",
+      "WDU-LC-006",
+      "WDU-LC-007",
+      "WDU-LC-010",
+      "WDU-LC-015",
+      "WDU-LC-020",
+      "WDU-LC-023",
+      "WDU-LC-025",
+      "WDU-LC-026",
+      "WDU-LC-028",
+      "WDU-LC-030",
+      "WDU-LC-033",
+      "WDU-LC-035",
+      "WDU-LC-036",
+      "WDU-LC-038",
+      "WDU-LC-100",
+      "WDU-LC-101",
+      "WDU-LC-103",
+      "WDU-LC-110",
+      "WDU-LC-114",
+      "WDU-LC-120",
+      "WDU-LC-123",
+      "WDU-LC-130",
+      "WDU-LC-140",
+      "WDU-LC-143",
+      "WDU-LC-003"
+    ]
+  }
 }
 ```
-<!-- grace:wdu-lifecycle-projection:end -->
+<!-- grace:wdu-lifecycle-projection:adr-0011:end -->
 
 ## Consequences
 

--- a/scripts/modules/WduLifecycleProjection.psm1
+++ b/scripts/modules/WduLifecycleProjection.psm1
@@ -3,32 +3,9 @@ $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot 'WduLifecycleContract.psm1') -Force
 
-$script:PlanStartMarker = '<!-- grace:wdu-lifecycle-projection-plan:start -->'
-$script:PlanEndMarker = '<!-- grace:wdu-lifecycle-projection-plan:end -->'
-$script:ProjectionStartMarker = '<!-- grace:wdu-lifecycle-projection:start -->'
-$script:ProjectionEndMarker = '<!-- grace:wdu-lifecycle-projection:end -->'
-$script:PlanSchema = 'grace.wdu.lifecycle-projection-plan/v1'
-$script:ProjectionSchema = 'grace.wdu.lifecycle-projection/v1'
-$script:RequiredArtifactIds = @(
-    'adr-0011',
-    'epic-835',
-    'issue-842',
-    'issue-843',
-    'issue-846',
-    'issue-869',
-    'issue-898',
-    'issue-899',
-    'issue-900',
-    'issue-901',
-    'issue-871',
-    'issue-872'
-)
-$script:RequiredNonLifecycleArtifacts = @(
-    [pscustomobject]@{
-        Artifact = 'issue-897'
-        Reason = 'The supersession correction owns packet alignment and publication preparation, not a lifecycle-row delivery; the checker exports lifecycle consumers only.'
-    }
-)
+$script:MarkerPrefix = '<!-- grace:wdu-lifecycle-projection:'
+$script:ProjectionSchema = 'grace.wdu.lifecycle-projection/v2'
+$script:Utf8 = [Text.UTF8Encoding]::new($false, $true)
 
 function Fail-Projection {
     param([string] $Subject, [string] $Reason)
@@ -40,244 +17,181 @@ function Normalize-LineEndings {
     return $Text.Replace("`r`n", "`n").Replace("`r", "`n")
 }
 
-function Get-OrdinalIndexes {
-    param([string] $Text, [string] $Value)
-    $indexes = [Collections.Generic.List[int]]::new()
+function Get-ProjectionMarker {
+    param([string] $Artifact, [ValidateSet('start', 'end')][string] $Kind)
+    return "<!-- grace:wdu-lifecycle-projection:$Artifact`:$Kind -->"
+}
+
+function Get-ProjectionLineEnding {
+    param([string] $Text)
+    if ($Text.Contains("`r`n", [StringComparison]::Ordinal)) { return "`r`n" }
+    if ($Text.Contains("`r", [StringComparison]::Ordinal)) { return "`r" }
+    return "`n"
+}
+
+function Get-CompiledArtifactMap {
+    param([object] $Compiled)
+    $map = [Collections.Generic.Dictionary[string, object]]::new([StringComparer]::Ordinal)
+    foreach ($artifact in $Compiled.Artifacts) {
+        if (-not $map.TryAdd($artifact.Id, $artifact)) {
+            Fail-Projection $Compiled.Digest "compiler returned duplicate artifact '$($artifact.Id)'"
+        }
+    }
+    return $map
+}
+
+function Get-ProjectionPairs {
+    param([string] $Text, [object] $Compiled, [string] $Subject)
+
+    $artifactMap = Get-CompiledArtifactMap $Compiled
+    $tokens = [Collections.Generic.List[object]]::new()
+    $matches = [regex]::Matches($Text, '<!-- grace:wdu-lifecycle-projection:(?<artifact>[a-z0-9-]+):(?<kind>start|end) -->')
+    $prefixCount = 0
     $offset = 0
-    while ($offset -le ($Text.Length - $Value.Length)) {
-        $index = $Text.IndexOf($Value, $offset, [StringComparison]::Ordinal)
+    while ($offset -lt $Text.Length) {
+        $index = $Text.IndexOf($script:MarkerPrefix, $offset, [StringComparison]::Ordinal)
         if ($index -lt 0) { break }
-        $indexes.Add($index)
-        $offset = $index + $Value.Length
+        $prefixCount++
+        $offset = $index + $script:MarkerPrefix.Length
     }
-    return @($indexes)
-}
-
-function Get-SingleMarkedBlock {
-    param([string] $Text, [string] $StartMarker, [string] $EndMarker, [string] $Subject)
-    $starts = @(Get-OrdinalIndexes $Text $StartMarker)
-    $ends = @(Get-OrdinalIndexes $Text $EndMarker)
-    if ($starts.Count -ne 1 -or $ends.Count -ne 1) {
-        Fail-Projection $Subject 'requires one exact projection marker pair'
-    }
-    $contentStart = $starts[0] + $StartMarker.Length
-    if ($ends[0] -le $contentStart) { Fail-Projection $Subject 'projection markers are reversed' }
-    return [pscustomobject]@{
-        Block = $Text.Substring($starts[0], ($ends[0] + $EndMarker.Length) - $starts[0])
-        Content = $Text.Substring($contentStart, $ends[0] - $contentStart)
-    }
-}
-
-function Get-FencedJson {
-    param([string] $Content, [string] $Subject)
-    $trimmed = $Content.Trim()
-    $prefix = '```json' + "`n"
-    $suffix = "`n" + '```'
-    if (-not $trimmed.StartsWith($prefix, [StringComparison]::Ordinal) -or -not $trimmed.EndsWith($suffix, [StringComparison]::Ordinal)) {
-        Fail-Projection $Subject 'marked payload must be one exact fenced JSON object'
-    }
-    return $trimmed.Substring($prefix.Length, $trimmed.Length - $prefix.Length - $suffix.Length)
-}
-
-function Assert-NoDuplicateJsonProperties {
-    param([string] $Json, [string] $Subject)
-    try { $document = [Text.Json.JsonDocument]::Parse($Json) }
-    catch { Fail-Projection $Subject "marked JSON is malformed: $($_.Exception.Message)" }
-    try {
-        $visit = $null
-        $visit = {
-            param([Text.Json.JsonElement] $Element, [string] $Location)
-            if ($Element.ValueKind -eq [Text.Json.JsonValueKind]::Object) {
-                $names = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
-                foreach ($property in $Element.EnumerateObject()) {
-                    if (-not $names.Add($property.Name)) {
-                        Fail-Projection $Subject "$Location has duplicate case-equivalent property '$($property.Name)'"
-                    }
-                    & $visit $property.Value "$Location.$($property.Name)"
-                }
-            }
-            elseif ($Element.ValueKind -eq [Text.Json.JsonValueKind]::Array) {
-                $index = 0
-                foreach ($item in $Element.EnumerateArray()) {
-                    & $visit $item "$Location[$index]"
-                    $index++
-                }
-            }
-        }
-        & $visit $document.RootElement '$'
-        if ($document.RootElement.ValueKind -ne [Text.Json.JsonValueKind]::Object) {
-            Fail-Projection $Subject 'marked JSON must be an object'
-        }
-    }
-    finally { $document.Dispose() }
-}
-
-function ConvertFrom-ExactJsonObject {
-    param([string] $Content, [string] $Subject)
-    $json = Get-FencedJson $Content $Subject
-    Assert-NoDuplicateJsonProperties $json $Subject
-    try { return $json | ConvertFrom-Json -AsHashtable -Depth 32 }
-    catch { Fail-Projection $Subject "marked JSON cannot be decoded: $($_.Exception.Message)" }
-}
-
-function Test-ExactKey {
-    param([System.Collections.IDictionary] $Value, [string] $Name)
-    foreach ($key in $Value.Keys) {
-        if ([StringComparer]::Ordinal.Equals([string] $key, $Name)) { return $true }
-    }
-    return $false
-}
-
-function Assert-ExactObjectProperties {
-    param([object] $Value, [string[]] $Names, [string] $Location, [string] $Subject)
-    if ($Value -isnot [System.Collections.IDictionary]) { Fail-Projection $Subject "$Location must be a JSON object" }
-    $expected = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    foreach ($name in $Names) { $null = $expected.Add($name) }
-    foreach ($key in $Value.Keys) {
-        if (-not $expected.Contains([string] $key)) { Fail-Projection $Subject "$Location has unknown property '$key'" }
-    }
-    foreach ($name in $Names) {
-        if (-not (Test-ExactKey $Value $name)) { Fail-Projection $Subject "$Location is missing property '$name'" }
-    }
-}
-
-function Assert-NonBlankString {
-    param([object] $Value, [string] $Location, [string] $Subject)
-    if ($Value -isnot [string] -or [string]::IsNullOrWhiteSpace($Value)) {
-        Fail-Projection $Subject "$Location must be a nonblank JSON string"
-    }
-}
-
-function Test-LowercaseSha256 {
-    param([string] $Value)
-    if ($Value.Length -ne 64) { return $false }
-    foreach ($character in $Value.ToCharArray()) {
-        if (($character -lt '0' -or $character -gt '9') -and ($character -lt 'a' -or $character -gt 'f')) { return $false }
-    }
-    return $true
-}
-
-function Get-StringArray {
-    param([object] $Value, [string] $Location, [string] $Subject)
-    if ($Value -is [string] -or $Value -is [System.Collections.IDictionary] -or $Value -isnot [System.Collections.IEnumerable]) {
-        Fail-Projection $Subject "$Location must be a nonempty JSON array of strings"
-    }
-    $values = @($Value)
-    if ($values.Count -eq 0) { Fail-Projection $Subject "$Location must be a nonempty JSON array of strings" }
-    foreach ($value in $values) { Assert-NonBlankString $value "$Location[]" $Subject }
-    return [string[]] $values
-}
-
-function Find-Assignment {
-    param([object[]] $Assignments, [string] $Artifact, [string] $Subject)
-    foreach ($assignment in $Assignments) {
-        if ([StringComparer]::Ordinal.Equals($assignment.Artifact, $Artifact)) { return $assignment }
-    }
-    Fail-Projection $Subject "has unexpected artifact '$Artifact'"
-}
-
-function Read-WduLifecycleProjectionPlan {
-    param([string] $CanonicalPath, [object] $Compiled)
-    $resolved = [IO.Path]::GetFullPath($CanonicalPath)
-    $text = Normalize-LineEndings ([IO.File]::ReadAllText($resolved))
-    $marked = Get-SingleMarkedBlock $text $script:PlanStartMarker $script:PlanEndMarker $resolved
-    $plan = ConvertFrom-ExactJsonObject $marked.Content $resolved
-    Assert-ExactObjectProperties $plan @('schema', 'nonLifecycleArtifacts', 'assignments') '$' $resolved
-    Assert-NonBlankString $plan['schema'] '$.schema' $resolved
-    if (-not [StringComparer]::Ordinal.Equals($plan['schema'], $script:PlanSchema)) {
-        Fail-Projection $resolved "$.schema must equal '$script:PlanSchema'"
-    }
-    if ($plan['nonLifecycleArtifacts'] -is [string] -or $plan['nonLifecycleArtifacts'] -is [System.Collections.IDictionary] -or $plan['nonLifecycleArtifacts'] -isnot [System.Collections.IEnumerable]) {
-        Fail-Projection $resolved '$.nonLifecycleArtifacts must be a JSON array'
-    }
-    $rawNonLifecycleArtifacts = @($plan['nonLifecycleArtifacts'])
-    if ($rawNonLifecycleArtifacts.Count -ne $script:RequiredNonLifecycleArtifacts.Count) {
-        Fail-Projection $resolved '$.nonLifecycleArtifacts must contain the complete declared non-lifecycle packet'
-    }
-    for ($nonLifecycleIndex = 0; $nonLifecycleIndex -lt $rawNonLifecycleArtifacts.Count; $nonLifecycleIndex++) {
-        $rawNonLifecycle = $rawNonLifecycleArtifacts[$nonLifecycleIndex]
-        Assert-ExactObjectProperties $rawNonLifecycle @('artifact', 'reason') '$.nonLifecycleArtifacts[]' $resolved
-        Assert-NonBlankString $rawNonLifecycle['artifact'] '$.nonLifecycleArtifacts[].artifact' $resolved
-        Assert-NonBlankString $rawNonLifecycle['reason'] '$.nonLifecycleArtifacts[].reason' $resolved
-        $requiredNonLifecycle = $script:RequiredNonLifecycleArtifacts[$nonLifecycleIndex]
-        if (-not [StringComparer]::Ordinal.Equals($rawNonLifecycle['artifact'], $requiredNonLifecycle.Artifact)) {
-            Fail-Projection $resolved "$.nonLifecycleArtifacts must declare excluded artifact '$($requiredNonLifecycle.Artifact)' at ordinal $($nonLifecycleIndex + 1), not '$($rawNonLifecycle['artifact'])'"
-        }
-        if (-not [StringComparer]::Ordinal.Equals($rawNonLifecycle['reason'], $requiredNonLifecycle.Reason)) {
-            Fail-Projection $resolved "$.nonLifecycleArtifacts has a stale reason for excluded artifact '$($requiredNonLifecycle.Artifact)'"
-        }
-    }
-    if ($plan['assignments'] -is [string] -or $plan['assignments'] -is [System.Collections.IDictionary] -or $plan['assignments'] -isnot [System.Collections.IEnumerable]) {
-        Fail-Projection $resolved '$.assignments must be a JSON array'
-    }
-    $rawAssignments = @($plan['assignments'])
-    if ($rawAssignments.Count -ne $script:RequiredArtifactIds.Count) { Fail-Projection $resolved "$.assignments must contain the complete $($script:RequiredArtifactIds.Count)-artifact packet" }
-    $knownRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    foreach ($rowId in $Compiled.RowIds) { $null = $knownRows.Add($rowId) }
-    $coveredRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    $artifacts = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    $assignments = [Collections.Generic.List[object]]::new()
-    $assignmentIndex = 0
-    foreach ($raw in $rawAssignments) {
-        Assert-ExactObjectProperties $raw @('artifact', 'canonical', 'canonicalContentDigest', 'rowIds', 'proof') '$.assignments[]' $resolved
-        foreach ($name in @('artifact', 'canonical', 'canonicalContentDigest', 'proof')) {
-            Assert-NonBlankString $raw[$name] "$.assignments[].$name" $resolved
-        }
-        if (-not $artifacts.Add($raw['artifact'])) { Fail-Projection $resolved "$.assignments contains duplicate artifact '$($raw['artifact'])'" }
-        $requiredArtifact = $script:RequiredArtifactIds[$assignmentIndex]
-        if (-not [StringComparer]::Ordinal.Equals($raw['artifact'], $requiredArtifact)) {
-            Fail-Projection $resolved "$.assignments must declare required artifact '$requiredArtifact' at ordinal $($assignmentIndex + 1), not '$($raw['artifact'])'"
-        }
-        if (-not (Test-LowercaseSha256 $raw['canonicalContentDigest'])) {
-            Fail-Projection $resolved '$.assignments[].canonicalContentDigest must be a lowercase SHA-256 digest'
-        }
-        if (-not [StringComparer]::Ordinal.Equals($raw['canonicalContentDigest'], $Compiled.Digest)) {
-            Fail-Projection $resolved "$.assignments[].canonicalContentDigest is stale for '$($raw['artifact'])'"
-        }
-        $rowIds = @(Get-StringArray $raw['rowIds'] '$.assignments[].rowIds' $resolved)
-        $assignedRows = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-        foreach ($rowId in $rowIds) {
-            if (-not $knownRows.Contains($rowId)) { Fail-Projection $resolved "$.assignments[] has unknown row ID '$rowId'" }
-            if (-not $assignedRows.Add($rowId)) { Fail-Projection $resolved "$.assignments[] has duplicate row ID '$rowId'" }
-            $null = $coveredRows.Add($rowId)
-        }
-        $assignments.Add([pscustomobject]@{
-                Artifact = [string] $raw['artifact']
-                Canonical = [string] $raw['canonical']
-                CanonicalContentDigest = [string] $raw['canonicalContentDigest']
-                RowIds = [string[]] $rowIds
-                Proof = [string] $raw['proof']
+    if ($prefixCount -ne $matches.Count) { Fail-Projection $Subject 'contains a malformed lifecycle projection marker' }
+    foreach ($match in $matches) {
+        $tokens.Add([pscustomobject]@{
+                Artifact = $match.Groups['artifact'].Value
+                Kind = $match.Groups['kind'].Value
+                Position = $match.Index
             })
-        $assignmentIndex++
     }
-    foreach ($rowId in $Compiled.RowIds) {
-        if (-not $coveredRows.Contains($rowId)) { Fail-Projection $resolved "$.assignments does not cover canonical row ID '$rowId'" }
+
+    if ($tokens.Count -eq 0) { Fail-Projection $Subject 'requires one artifact-specific projection marker pair' }
+    $starts = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $ends = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $pairs = [Collections.Generic.List[object]]::new()
+    $open = $null
+    foreach ($token in $tokens) {
+        if (-not $artifactMap.ContainsKey($token.Artifact)) {
+            Fail-Projection $Subject "contains unknown artifact marker '$($token.Artifact)'"
+        }
+        if ($token.Kind -eq 'start') {
+            if ($null -ne $open) { Fail-Projection $Subject 'contains nested lifecycle projection markers' }
+            if (-not $starts.Add($token.Artifact)) { Fail-Projection $Subject "contains duplicate start marker for '$($token.Artifact)'" }
+            $open = $token
+            continue
+        }
+        if ($null -eq $open) { Fail-Projection $Subject "contains reversed end marker for '$($token.Artifact)'" }
+        if (-not [StringComparer]::Ordinal.Equals($open.Artifact, $token.Artifact)) {
+            Fail-Projection $Subject "contains mismatched marker pair '$($open.Artifact)' and '$($token.Artifact)'"
+        }
+        if (-not $ends.Add($token.Artifact)) { Fail-Projection $Subject "contains duplicate end marker for '$($token.Artifact)'" }
+        $pairs.Add([pscustomobject]@{ Artifact = $token.Artifact })
+        $open = $null
     }
-    return @($assignments)
+    if ($null -ne $open) { Fail-Projection $Subject "is missing end marker for '$($open.Artifact)'" }
+    if ($pairs.Count -ne 1) { Fail-Projection $Subject 'requires exactly one artifact-specific projection marker pair' }
+
+    $artifact = $pairs[0].Artifact
+    $startMarker = Get-ProjectionMarker $artifact start
+    $endMarker = Get-ProjectionMarker $artifact end
+    $startIndex = $Text.IndexOf($startMarker, [StringComparison]::Ordinal)
+    $endIndex = $Text.IndexOf($endMarker, [StringComparison]::Ordinal)
+    if ($startIndex -lt 0 -or $endIndex -le $startIndex) { Fail-Projection $Subject "has malformed marker pair for '$artifact'" }
+    return [pscustomobject]@{
+        Artifact = $artifact
+        StartIndex = $startIndex
+        EndIndex = $endIndex
+        EndLength = $endMarker.Length
+        Block = $Text.Substring($startIndex, ($endIndex + $endMarker.Length) - $startIndex)
+    }
+}
+
+function Get-ProjectionPayload {
+    param([object] $Compiled, [object] $Artifact)
+    $requirements = @($Compiled.Requirements | ForEach-Object {
+            [ordered]@{ id = $_.Id; owner = $_.Owner }
+        })
+    $artifactIds = @($Compiled.Artifacts | ForEach-Object { $_.Id })
+    return [ordered]@{
+        schema = $script:ProjectionSchema
+        artifact = $Artifact.Id
+        canonicalContentDigest = $Compiled.Digest
+        assignmentDigest = $Compiled.AssignmentDigest
+        counts = [ordered]@{
+            rowCount = $Compiled.Counts.rowCount
+            applicabilityKeyCount = $Compiled.Counts.applicabilityKeyCount
+            requirementCount = $Compiled.Counts.requirementCount
+            artifactCount = $Compiled.Counts.artifactCount
+        }
+        requirements = $requirements
+        artifactIds = $artifactIds
+        assignment = [ordered]@{ rowIds = @($Artifact.RowIds) }
+    }
 }
 
 function New-ProjectionText {
-    param([object] $Assignment)
-    $projection = [ordered]@{
-        schema = $script:ProjectionSchema
-        artifact = $Assignment.Artifact
-        canonical = $Assignment.Canonical
-        canonicalContentDigest = $Assignment.CanonicalContentDigest
-        rowIds = @($Assignment.RowIds)
-        proof = $Assignment.Proof
-    }
-    $json = $projection | ConvertTo-Json -Depth 4
-    return $script:ProjectionStartMarker + "`n" + '```json' + "`n$json`n" + '```' + "`n" + $script:ProjectionEndMarker
+    param([object] $Compiled, [object] $Artifact)
+    $json = Normalize-LineEndings (Get-ProjectionPayload $Compiled $Artifact | ConvertTo-Json -Depth 8)
+    return (Get-ProjectionMarker $Artifact.Id start) + "`n" + '```json' + "`n" + $json + "`n" + '```' + "`n" + (Get-ProjectionMarker $Artifact.Id end)
 }
 
-function Get-ProjectionArtifact {
-    param([string] $Content, [string] $Subject)
-    $projection = ConvertFrom-ExactJsonObject $Content $Subject
-    if ($projection -isnot [System.Collections.IDictionary] -or -not (Test-ExactKey $projection 'artifact')) {
-        Fail-Projection $Subject "projection is missing property 'artifact'"
+function Get-Artifact {
+    param([object] $Compiled, [string] $Artifact, [string] $Subject)
+    $map = Get-CompiledArtifactMap $Compiled
+    if (-not $map.ContainsKey($Artifact)) { Fail-Projection $Subject "has unknown artifact '$Artifact'" }
+    return $map[$Artifact]
+}
+
+function Get-PacketInputs {
+    param([object] $Compiled, [string[]] $ArtifactPath, [switch] $RequireExact)
+
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $inputs = [Collections.Generic.List[object]]::new()
+    foreach ($path in $ArtifactPath) {
+        $resolved = [IO.Path]::GetFullPath($path)
+        if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) { Fail-Projection $resolved 'does not exist as an artifact file' }
+        $text = [IO.File]::ReadAllText($resolved)
+        $pair = Get-ProjectionPairs $text $Compiled $resolved
+        $expectedFileName = $pair.Artifact + '.md'
+        if (-not [StringComparer]::Ordinal.Equals([IO.Path]::GetFileName($resolved), $expectedFileName)) {
+            Fail-Projection $resolved "artifact path name must equal '$expectedFileName'"
+        }
+        if (-not $seen.Add($pair.Artifact)) { Fail-Projection $resolved "packet contains duplicate artifact '$($pair.Artifact)'" }
+        $artifact = Get-Artifact $Compiled $pair.Artifact $resolved
+        $expected = New-ProjectionText $Compiled $artifact
+        if ($RequireExact -and -not [StringComparer]::Ordinal.Equals((Normalize-LineEndings $pair.Block), $expected)) {
+            Fail-Projection $resolved "artifact '$($pair.Artifact)' does not equal its exact generated projection"
+        }
+        $inputs.Add([pscustomobject]@{ Path = $resolved; Text = $text; Pair = $pair; Artifact = $artifact; Expected = $expected })
     }
-    Assert-NonBlankString $projection['artifact'] '$.artifact' $Subject
-    return [string] $projection['artifact']
+    foreach ($artifact in $Compiled.Artifacts) {
+        if (-not $seen.Contains($artifact.Id)) { Fail-Projection $Compiled.Digest "packet is missing required artifact '$($artifact.Id)'" }
+    }
+    return $inputs.ToArray()
+}
+
+function Get-Utf8BomLength {
+    param([byte[]] $Bytes)
+    if ($Bytes.Length -ge 3 -and $Bytes[0] -eq 0xEF -and $Bytes[1] -eq 0xBB -and $Bytes[2] -eq 0xBF) { return 3 }
+    return 0
+}
+
+function Write-RenderedArtifact {
+    param([object] $ArtifactInput, [string] $Destination)
+    $bytes = [IO.File]::ReadAllBytes($ArtifactInput.Path)
+    $bomLength = Get-Utf8BomLength $bytes
+    $prefix = $ArtifactInput.Text.Substring(0, $ArtifactInput.Pair.StartIndex)
+    $suffixStart = $ArtifactInput.Pair.EndIndex + $ArtifactInput.Pair.EndLength
+    $suffix = $ArtifactInput.Text.Substring($suffixStart)
+    $lineEnding = Get-ProjectionLineEnding $ArtifactInput.Text
+    $replacement = $ArtifactInput.Expected.Replace("`n", $lineEnding)
+    $prefixBytes = $script:Utf8.GetBytes($prefix)
+    $replacementBytes = $script:Utf8.GetBytes($replacement)
+    $suffixBytes = $script:Utf8.GetBytes($suffix)
+    $result = [byte[]]::new($bomLength + $prefixBytes.Length + $replacementBytes.Length + $suffixBytes.Length)
+    if ($bomLength -gt 0) { [Array]::Copy($bytes, 0, $result, 0, $bomLength) }
+    [Array]::Copy($prefixBytes, 0, $result, $bomLength, $prefixBytes.Length)
+    [Array]::Copy($replacementBytes, 0, $result, $bomLength + $prefixBytes.Length, $replacementBytes.Length)
+    [Array]::Copy($suffixBytes, 0, $result, $bomLength + $prefixBytes.Length + $replacementBytes.Length, $suffixBytes.Length)
+    [IO.File]::WriteAllBytes($Destination, $result)
 }
 
 function New-WduLifecycleProjection {
@@ -286,9 +200,7 @@ function New-WduLifecycleProjection {
         [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Artifact
     )
     $compiled = Read-WduLifecycleContract -Path $CanonicalPath
-    $assignments = @(Read-WduLifecycleProjectionPlan -CanonicalPath $CanonicalPath -Compiled $compiled)
-    $assignment = Find-Assignment $assignments $Artifact $CanonicalPath
-    return New-ProjectionText $assignment
+    return New-ProjectionText $compiled (Get-Artifact $compiled $Artifact $CanonicalPath)
 }
 
 function Test-WduLifecycleProjection {
@@ -297,30 +209,45 @@ function Test-WduLifecycleProjection {
         [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]] $ArtifactPath
     )
     $compiled = Read-WduLifecycleContract -Path $CanonicalPath
-    $assignments = @(Read-WduLifecycleProjectionPlan -CanonicalPath $CanonicalPath -Compiled $compiled)
-    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    $pathsByArtifact = [Collections.Generic.Dictionary[string, string]]::new([StringComparer]::Ordinal)
-    foreach ($path in $ArtifactPath) {
-        $resolved = [IO.Path]::GetFullPath($path)
-        $text = Normalize-LineEndings ([IO.File]::ReadAllText($resolved))
-        $marked = Get-SingleMarkedBlock $text $script:ProjectionStartMarker $script:ProjectionEndMarker $resolved
-        $artifact = Get-ProjectionArtifact $marked.Content $resolved
-        if (-not $seen.Add($artifact)) { Fail-Projection $resolved "packet contains duplicate artifact '$artifact'" }
-        $assignment = Find-Assignment $assignments $artifact $resolved
-        $expected = Normalize-LineEndings (New-ProjectionText $assignment)
-        if (-not [StringComparer]::Ordinal.Equals($marked.Block, $expected)) {
-            Fail-Projection $resolved "artifact '$artifact' does not equal its exact generated projection"
+    $inputs = @(Get-PacketInputs $compiled $ArtifactPath -RequireExact)
+    foreach ($artifact in $compiled.Artifacts) {
+        $artifactInput = $null
+        foreach ($candidate in $inputs) {
+            if ([StringComparer]::Ordinal.Equals($candidate.Artifact.Id, $artifact.Id)) {
+                $artifactInput = $candidate
+                break
+            }
         }
-        $pathsByArtifact.Add($artifact, $resolved)
-    }
-    foreach ($assignment in $assignments) {
-        if (-not $seen.Contains($assignment.Artifact)) {
-            Fail-Projection $CanonicalPath "packet is missing required artifact '$($assignment.Artifact)'"
-        }
-    }
-    foreach ($assignment in $assignments) {
-        [pscustomobject]@{ Artifact = $assignment.Artifact; Path = $pathsByArtifact[$assignment.Artifact]; Result = 'ExactMatch' }
+        if ($null -eq $artifactInput) { Fail-Projection $Compiled.Digest "packet is missing required artifact '$($artifact.Id)'" }
+        [pscustomobject]@{ Artifact = $artifact.Id; Path = $artifactInput.Path; Result = 'ExactMatch' }
     }
 }
 
-Export-ModuleMember -Function New-WduLifecycleProjection, Test-WduLifecycleProjection
+function Export-WduLifecycleProjection {
+    param(
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $CanonicalPath,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string[]] $ArtifactPath,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $OutputDirectory
+    )
+    $compiled = Read-WduLifecycleContract -Path $CanonicalPath
+    $inputs = @(Get-PacketInputs $compiled $ArtifactPath)
+    $destination = [IO.Path]::GetFullPath($OutputDirectory)
+    if (Test-Path -LiteralPath $destination) { Fail-Projection $destination 'render destination already exists' }
+    $parent = [IO.Directory]::GetParent($destination)
+    if ($null -eq $parent -or -not $parent.Exists) { Fail-Projection $destination 'render destination parent does not exist' }
+    $staging = Join-Path $parent.FullName ('.' + [IO.Path]::GetFileName($destination) + '.staging-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [IO.Directory]::CreateDirectory($staging) | Out-Null
+        foreach ($artifactInput in $inputs) {
+            Write-RenderedArtifact $artifactInput (Join-Path $staging ($artifactInput.Artifact.Id + '.md'))
+        }
+        Move-Item -LiteralPath $staging -Destination $destination -ErrorAction Stop
+    }
+    catch {
+        if (Test-Path -LiteralPath $staging) { Remove-Item -LiteralPath $staging -Recurse -Force }
+        throw
+    }
+    return Get-ChildItem -LiteralPath $destination -File | Sort-Object Name | Select-Object -ExpandProperty FullName
+}
+
+Export-ModuleMember -Function New-WduLifecycleProjection, Test-WduLifecycleProjection, Export-WduLifecycleProjection

--- a/scripts/modules/WduLifecycleProjection.psm1
+++ b/scripts/modules/WduLifecycleProjection.psm1
@@ -6,6 +6,7 @@ Import-Module (Join-Path $PSScriptRoot 'WduLifecycleContract.psm1') -Force
 $script:MarkerPrefix = '<!-- grace:wdu-lifecycle-projection:'
 $script:ProjectionSchema = 'grace.wdu.lifecycle-projection/v2'
 $script:Utf8 = [Text.UTF8Encoding]::new($false, $true)
+$script:FailureAfterStagedWritesForTest = $null
 
 function Fail-Projection {
     param([string] $Subject, [string] $Reason)
@@ -174,6 +175,45 @@ function Get-Utf8BomLength {
     return 0
 }
 
+function Resolve-ExistingDirectoryIdentity {
+    param([string] $Path)
+    $directory = [IO.DirectoryInfo]::new([IO.Path]::GetFullPath($Path))
+    if (-not $directory.Exists) { Fail-Projection $directory.FullName 'requires an existing directory identity' }
+    $components = [Collections.Generic.Stack[string]]::new()
+    $cursor = $directory
+    while ($null -ne $cursor.Parent) {
+        $components.Push($cursor.Name)
+        $cursor = $cursor.Parent
+    }
+    $resolved = $cursor.FullName
+    while ($components.Count -gt 0) {
+        $candidate = [IO.DirectoryInfo]::new((Join-Path $resolved $components.Pop()))
+        $target = $candidate.ResolveLinkTarget($true)
+        $resolved = if ($null -eq $target) { $candidate.FullName } else { $target.FullName }
+    }
+    return [IO.Path]::GetFullPath($resolved)
+}
+
+function Test-PathIsWithinDirectory {
+    param([string] $Path, [string] $Directory)
+    $separator = [IO.Path]::DirectorySeparatorChar
+    $normalizedDirectory = $Directory.TrimEnd($separator, [IO.Path]::AltDirectorySeparatorChar)
+    return $Path.StartsWith($normalizedDirectory + $separator, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-RenderDestinationIsDisjoint {
+    param([object[]] $ArtifactInput, [string] $Destination)
+    $parent = [IO.Directory]::GetParent($Destination)
+    if ($null -eq $parent -or -not $parent.Exists) { Fail-Projection $Destination 'render destination parent does not exist' }
+    $physicalDestination = Join-Path (Resolve-ExistingDirectoryIdentity $parent.FullName) ([IO.Path]::GetFileName($Destination))
+    foreach ($input in $ArtifactInput) {
+        $inputDirectory = Resolve-ExistingDirectoryIdentity ([IO.Path]::GetDirectoryName($input.Path))
+        if (Test-PathIsWithinDirectory $physicalDestination $inputDirectory) {
+            Fail-Projection $Destination 'render destination must not be within an input artifact directory'
+        }
+    }
+}
+
 function Write-RenderedArtifact {
     param([object] $ArtifactInput, [string] $Destination)
     $bytes = [IO.File]::ReadAllBytes($ArtifactInput.Path)
@@ -233,13 +273,18 @@ function Export-WduLifecycleProjection {
     $inputs = @(Get-PacketInputs $compiled $ArtifactPath)
     $destination = [IO.Path]::GetFullPath($OutputDirectory)
     if (Test-Path -LiteralPath $destination) { Fail-Projection $destination 'render destination already exists' }
+    Assert-RenderDestinationIsDisjoint $inputs $destination
     $parent = [IO.Directory]::GetParent($destination)
-    if ($null -eq $parent -or -not $parent.Exists) { Fail-Projection $destination 'render destination parent does not exist' }
     $staging = Join-Path $parent.FullName ('.' + [IO.Path]::GetFileName($destination) + '.staging-' + [guid]::NewGuid().ToString('N'))
     try {
         [IO.Directory]::CreateDirectory($staging) | Out-Null
+        $stagedWrites = 0
         foreach ($artifactInput in $inputs) {
             Write-RenderedArtifact $artifactInput (Join-Path $staging ($artifactInput.Artifact.Id + '.md'))
+            $stagedWrites++
+            if ($null -ne $script:FailureAfterStagedWritesForTest -and $stagedWrites -ge $script:FailureAfterStagedWritesForTest) {
+                throw 'test-only deterministic failure after staged write'
+            }
         }
         Move-Item -LiteralPath $staging -Destination $destination -ErrorAction Stop
     }

--- a/scripts/test-wdu-lifecycle-packet.ps1
+++ b/scripts/test-wdu-lifecycle-packet.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+param(
+    [string] $CanonicalPath = (Join-Path $PSScriptRoot '../docs/Working Directory Update.md'),
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $PacketDirectory,
+    [ValidateNotNullOrEmpty()][string] $RenderDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'modules/WduLifecycleProjection.psm1') -Force
+
+$packet = [IO.Path]::GetFullPath($PacketDirectory)
+if (-not (Test-Path -LiteralPath $packet -PathType Container)) { throw "WDU lifecycle packet '$packet' does not exist" }
+$paths = @(Get-ChildItem -LiteralPath $packet -File -Filter '*.md' | Sort-Object Name | Select-Object -ExpandProperty FullName)
+if ($PSBoundParameters.ContainsKey('RenderDirectory')) {
+    Export-WduLifecycleProjection -CanonicalPath $CanonicalPath -ArtifactPath $paths -OutputDirectory $RenderDirectory
+}
+else {
+    Test-WduLifecycleProjection -CanonicalPath $CanonicalPath -ArtifactPath $paths
+}

--- a/scripts/tests/WduLifecyclePacket.Tests.ps1
+++ b/scripts/tests/WduLifecyclePacket.Tests.ps1
@@ -1,0 +1,99 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$canonicalPath = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
+$modulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleProjection.psm1'
+$contractModulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleContract.psm1'
+$packetCommand = Join-Path $repositoryRoot 'scripts/test-wdu-lifecycle-packet.ps1'
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw "Assertion failed: $Message" }
+}
+
+function Assert-Fails {
+    param([scriptblock] $Body, [string] $Contains)
+    try { & $Body | Out-Null }
+    catch {
+        Assert-True $_.Exception.Message.Contains($Contains, [StringComparison]::Ordinal) "failure should contain '$Contains': $($_.Exception.Message)"
+        return
+    }
+    throw "Expected failure containing '$Contains'"
+}
+
+function Invoke-Case {
+    param([string] $Name, [scriptblock] $Body)
+    try { & $Body; $script:Passed++; Write-Host "PASS $Name" }
+    catch { $script:Failed++; Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red }
+}
+
+function Write-TestText {
+    param([string] $Path, [string] $Text)
+    [IO.File]::WriteAllText($Path, $Text, [Text.UTF8Encoding]::new($false))
+}
+
+function Get-Hashes {
+    param([string[]] $Path)
+    return @($Path | ForEach-Object { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
+}
+
+function New-Packet {
+    param([string] $Name)
+    $directory = Join-Path $script:TestRoot $Name
+    [IO.Directory]::CreateDirectory($directory) | Out-Null
+    foreach ($artifact in $script:Compiled.Artifacts) {
+        Write-TestText (Join-Path $directory ($artifact.Id + '.md')) ($script:Projections[$artifact.Id] + "`n")
+    }
+    return $directory
+}
+
+Import-Module $modulePath -Force
+Import-Module $contractModulePath -Force
+$script:Compiled = Read-WduLifecycleContract -Path $canonicalPath
+$script:Projections = [Collections.Generic.Dictionary[string, string]]::new([StringComparer]::Ordinal)
+foreach ($artifact in $script:Compiled.Artifacts) {
+    $script:Projections.Add($artifact.Id, (New-WduLifecycleProjection -CanonicalPath $canonicalPath -Artifact $artifact.Id))
+}
+$script:Passed = 0
+$script:Failed = 0
+$script:TestRoot = Join-Path ([IO.Path]::GetTempPath()) ('wdu-lifecycle-packet-' + [guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($script:TestRoot) | Out-Null
+
+try {
+    Invoke-Case 'checks only a complete compiler-declared packet and stays read-only' {
+        $packet = New-Packet 'check'
+        $paths = @(Get-ChildItem -LiteralPath $packet -File | Select-Object -ExpandProperty FullName)
+        $before = Get-Hashes $paths
+        $result = @(& $packetCommand -CanonicalPath $canonicalPath -PacketDirectory $packet)
+        Assert-True ($result.Count -eq $script:Compiled.Artifacts.Count) 'check returns every compiled artifact'
+        Assert-True ((Get-Hashes $paths) -join '|' -ceq ($before -join '|')) 'check performs no writes'
+    }
+
+    Invoke-Case 'rejects renamed, extra, and case-changed packet artifacts' {
+        foreach ($name in @('issue-928-renamed.md', 'ISSUE-928.md', 'unknown.md')) {
+            $packet = New-Packet ([guid]::NewGuid().ToString('N'))
+            $source = Join-Path $packet 'issue-928.md'
+            Move-Item -LiteralPath $source -Destination (Join-Path $packet $name)
+            Assert-Fails { & $packetCommand -CanonicalPath $canonicalPath -PacketDirectory $packet } 'artifact path name must equal'
+        }
+    }
+
+    Invoke-Case 'renders only after complete preflight and validates the rendered packet' {
+        $packet = New-Packet 'render'
+        $output = Join-Path $script:TestRoot 'rendered'
+        $rendered = @(& $packetCommand -CanonicalPath $canonicalPath -PacketDirectory $packet -RenderDirectory $output)
+        Assert-True ($rendered.Count -eq $script:Compiled.Artifacts.Count) 'render writes every declared artifact'
+        @(& $packetCommand -CanonicalPath $canonicalPath -PacketDirectory $output) | Out-Null
+        Assert-Fails { & $packetCommand -CanonicalPath $canonicalPath -PacketDirectory $packet -RenderDirectory $output } 'render destination already exists'
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $script:TestRoot) { Remove-Item -LiteralPath $script:TestRoot -Recurse -Force }
+}
+
+Write-Host "Result: $script:Passed passed; $script:Failed failed"
+if ($script:Failed -ne 0) { exit 1 }

--- a/scripts/tests/WduLifecycleProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleProjection.Tests.ps1
@@ -1,18 +1,13 @@
 [CmdletBinding()]
-param(
-    [ValidateSet('All', 'PlanCore', 'PlanNegativeA', 'PlanNegativeB', 'PlanNegativeC', 'RequiredPacket', 'PlanMarkers', 'Marker', 'DriftA', 'DriftB', 'DriftC', 'PacketA', 'PacketAEmpty', 'PacketB', 'PacketBReadOnly', 'PacketBCommands')]
-    [string] $Group = 'All'
-)
+param()
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 $modulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleProjection.psm1'
-$canonicalSource = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
-$getCommand = Join-Path $repositoryRoot 'scripts/get-wdu-lifecycle-projection.ps1'
-$checkCommand = Join-Path $repositoryRoot 'scripts/check-wdu-lifecycle-projections.ps1'
-$artifactIds = @('adr-0011', 'epic-835', 'issue-842', 'issue-843', 'issue-846', 'issue-869', 'issue-898', 'issue-899', 'issue-900', 'issue-901', 'issue-871', 'issue-872')
+$contractModulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleContract.psm1'
+$canonicalPath = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
 
 function Assert-True {
     param([bool] $Condition, [string] $Message)
@@ -31,15 +26,8 @@ function Assert-Fails {
 
 function Invoke-Case {
     param([string] $Name, [scriptblock] $Body)
-    try {
-        & $Body
-        $script:Passed++
-        Write-Host "PASS $Name"
-    }
-    catch {
-        $script:Failed++
-        Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red
-    }
+    try { & $Body; $script:Passed++; Write-Host "PASS $Name" }
+    catch { $script:Failed++; Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red }
 }
 
 function Write-TestText {
@@ -47,9 +35,25 @@ function Write-TestText {
     [IO.File]::WriteAllText($Path, $Text, [Text.UTF8Encoding]::new($false))
 }
 
-function Get-TestText {
-    param([string] $Path)
-    return [IO.File]::ReadAllText($Path)
+function Get-TestPacket {
+    param([string] $Name, [switch] $CrLf)
+    $directory = Join-Path $script:TestRoot $Name
+    [IO.Directory]::CreateDirectory($directory) | Out-Null
+    $paths = [Collections.Generic.List[string]]::new()
+    foreach ($artifact in $script:Compiled.Artifacts) {
+        $path = Join-Path $directory ($artifact.Id + '.md')
+        $outside = "# $($artifact.Id)`n`nHistorical prose, dates, #920, and contradictory counts are not interpreted.`n`n"
+        $text = $outside + $script:Projections[$artifact.Id] + "`n`n$outside"
+        if ($CrLf) { $text = $text.Replace("`n", "`r`n") }
+        Write-TestText $path $text
+        $paths.Add($path)
+    }
+    return [pscustomobject]@{ Directory = $directory; Paths = @($paths) }
+}
+
+function Get-Hashes {
+    param([string[]] $Path)
+    return @($Path | ForEach-Object { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
 }
 
 function Replace-Once {
@@ -59,246 +63,97 @@ function Replace-Once {
     return $Text.Remove($index, $Old.Length).Insert($index, $New)
 }
 
-function New-Packet {
-    param([string] $Name, [switch] $CrLf)
-    $root = Join-Path $script:TestRoot $Name
-    [IO.Directory]::CreateDirectory($root) | Out-Null
-    $canonical = Join-Path $root 'canonical lifecycle.md'
-    [IO.File]::Copy($canonicalSource, $canonical, $true)
-    $paths = [Collections.Generic.List[string]]::new()
-    foreach ($artifact in $artifactIds) {
-        $path = Join-Path $root "$artifact body.md"
-        $outside = "# arbitrary $artifact é`n`n" + '<div data-lifecycle="not interpreted">outside</div>' + "`n`n" + '```json' + "`n" + '[false, 42, {"artifact":"outside"}]' + "`n" + '```' + "`n`n" + '```text' + "`ncontradictory prose is ignored`n" + '```' + "`n"
-        $text = "$outside`n$(New-WduLifecycleProjection -CanonicalPath $canonical -Artifact $artifact)`n`n$outside"
-        if ($CrLf) { $text = $text.Replace("`r`n", "`n").Replace("`r", "`n").Replace("`n", "`r`n") }
-        Write-TestText $path $text
-        $paths.Add($path)
-    }
-    return [pscustomobject]@{ Root = $root; Canonical = $canonical; Paths = @($paths) }
-}
-
-function Get-Hashes {
-    param([string[]] $Paths)
-    return @($Paths | ForEach-Object { (Get-FileHash -LiteralPath $_ -Algorithm SHA256).Hash })
-}
-
 Import-Module $modulePath -Force
+Import-Module $contractModulePath -Force
+$script:Compiled = Read-WduLifecycleContract -Path $canonicalPath
+$script:Projections = [Collections.Generic.Dictionary[string, string]]::new([StringComparer]::Ordinal)
+foreach ($artifact in $script:Compiled.Artifacts) {
+    $script:Projections.Add($artifact.Id, (New-WduLifecycleProjection -CanonicalPath $canonicalPath -Artifact $artifact.Id))
+}
 $script:Passed = 0
 $script:Failed = 0
 $script:TestRoot = Join-Path ([IO.Path]::GetTempPath()) ('wdu-lifecycle-projection-' + [guid]::NewGuid().ToString('N'))
 [IO.Directory]::CreateDirectory($script:TestRoot) | Out-Null
 
 try {
-    if ($Group -in @('All', 'PlanCore')) {
-    Invoke-Case 'exports exactly the two projection functions' {
-        $exports = @(Get-Command -Module WduLifecycleProjection | Select-Object -ExpandProperty Name | Sort-Object)
-        Assert-True (($exports -join '|') -ceq ('New-WduLifecycleProjection|Test-WduLifecycleProjection')) 'module exports only the two public functions'
+    Invoke-Case 'derives deterministic complete metadata from only the compiler result' {
+        $artifact = $script:Compiled.Artifacts[0]
+        $first = New-WduLifecycleProjection -CanonicalPath $canonicalPath -Artifact $artifact.Id
+        $second = New-WduLifecycleProjection -CanonicalPath $canonicalPath -Artifact $artifact.Id
+        Assert-True ($first -ceq $second) 'repeated generation is byte-identical'
+        Assert-True $first.Contains("projection:$($artifact.Id):start", [StringComparison]::Ordinal) 'marker is artifact-specific'
+        Assert-True $first.Contains(('"artifactCount": ' + $script:Compiled.Counts.artifactCount), [StringComparison]::Ordinal) 'artifact count comes from compiler'
+        foreach ($requirement in $script:Compiled.Requirements) {
+            Assert-True $first.Contains(('"id": "' + $requirement.Id + '"'), [StringComparison]::Ordinal) "projection includes $($requirement.Id)"
+            Assert-True $first.Contains(('"owner": "' + $requirement.Owner + '"'), [StringComparison]::Ordinal) "projection includes $($requirement.Owner)"
+        }
     }
 
-    Invoke-Case 'generates one deterministic ADR projection from the compiled canonical plan' {
-        $first = New-WduLifecycleProjection -CanonicalPath $canonicalSource -Artifact 'adr-0011'
-        $second = New-WduLifecycleProjection -CanonicalPath $canonicalSource -Artifact 'adr-0011'
-        Assert-True ($first -ceq $second) 'repeated in-process generation is byte-identical'
-        Assert-True $first.StartsWith('<!-- grace:wdu-lifecycle-projection:start -->', [StringComparison]::Ordinal) 'generated block starts with its exact marker'
-        Assert-True $first.EndsWith('<!-- grace:wdu-lifecycle-projection:end -->', [StringComparison]::Ordinal) 'generated block ends with its exact marker'
-        Assert-True $first.Contains('"artifact": "adr-0011"', [StringComparison]::Ordinal) 'generated block carries its artifact ID'
+    Invoke-Case 'checks all compiler artifacts in canonical order while ignoring prose outside blocks' {
+        $packet = Get-TestPacket 'complete' -CrLf
+        $result = @(Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath @($packet.Paths | Sort-Object -Descending))
+        Assert-True ($result.Count -eq $script:Compiled.Artifacts.Count) 'returns every compiler artifact'
+        Assert-True (($result.Artifact -join '|') -ceq (($script:Compiled.Artifacts.Id) -join '|')) 'returns compiler order'
     }
 
-    Invoke-Case 'checks a complete packet with paths containing spaces and Unicode in arbitrary input order' {
-        $packet = New-Packet 'paths with spaces é'
-        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths[11..0]))
-        Assert-True ($result.Count -eq 12) 'complete packet returns one scoped result per assignment'
-        Assert-True (($result | Select-Object -ExpandProperty Artifact) -join '|' -ceq ($artifactIds -join '|')) 'results are in canonical assignment order'
+    Invoke-Case 'rejects stale generated block content even when equivalent prose remains outside it' {
+        $packet = Get-TestPacket 'stale-block'
+        $path = $packet.Paths[0]
+        $text = [IO.File]::ReadAllText($path)
+        $old = '"canonicalContentDigest": "' + $script:Compiled.Digest + '"'
+        Write-TestText $path (Replace-Once $text $old '"canonicalContentDigest": "0000000000000000000000000000000000000000000000000000000000000000"')
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths } 'does not equal its exact generated projection'
     }
 
-    Invoke-Case 'normalizes LF and CRLF only while checking exact blocks' {
-        $packet = New-Packet 'crlf packet' -CrLf
-        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
-        Assert-True ($result.Count -eq 12) 'CRLF packet succeeds under the documented normalization'
-    }
-
-    }
-
-    if ($Group -in @('All', 'PlanNegativeA', 'PlanNegativeB', 'PlanNegativeC')) {
-    $planNegativeCases = @(
-            @{ Name = 'duplicate artifact assignment'; Old = '"artifact":"issue-843"'; New = '"artifact":"issue-842"'; Reason = 'duplicate artifact' },
-            @{ Name = 'duplicate assignment row ID'; Old = '"rowIds":["WDU-LC-003","WDU-LC-100","WDU-LC-101","WDU-LC-103"]'; New = '"rowIds":["WDU-LC-003","WDU-LC-100","WDU-LC-100","WDU-LC-103"]'; Reason = 'duplicate row ID' },
-            @{ Name = 'unknown assignment row ID'; Old = '"WDU-LC-027","WDU-LC-036","WDU-LC-037","WDU-LC-100"'; New = '"WDU-LC-027","WDU-LC-036","WDU-LC-999","WDU-LC-100"'; Reason = 'unknown row ID' },
-            @{ Name = 'blank assignment proof'; Old = '"proof":"Consume the completed Branch lifecycle while deferring the first real Watch producer and retry proof to this issue."'; New = '"proof":""'; Reason = 'must be a nonblank' },
-            @{ Name = 'malformed assignment digest'; Old = '901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7'; New = '901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7'; Reason = 'lowercase SHA-256' },
-            @{ Name = 'unknown assignment property'; Old = '"schema": "grace.wdu.lifecycle-projection-plan/v1",'; New = '"schema": "grace.wdu.lifecycle-projection-plan/v1", "extra": true,'; Reason = 'unknown property' },
-            @{ Name = 'incomplete assignment row coverage'; Old = ',"WDU-LC-037","WDU-LC-100"'; New = ',"WDU-LC-100"'; Reason = 'does not cover canonical row ID' }
+    Invoke-Case 'rejects malformed, duplicate, reversed, nested, and unknown markers' {
+        $mutations = @(
+            @{ Old = ':start -->'; New = ':started -->'; Error = 'malformed lifecycle projection marker' },
+            @{ Old = ':start -->'; New = ":start -->`n<!-- grace:wdu-lifecycle-projection:$($script:Compiled.Artifacts[0].Id):start -->"; Error = 'malformed lifecycle projection marker' },
+            @{ Old = ':start -->'; New = ':end -->'; Error = 'reversed end marker' },
+            @{ Old = ':start -->'; New = ':start -->`n<!-- grace:wdu-lifecycle-projection:unknown:start -->`n<!-- grace:wdu-lifecycle-projection:unknown:end -->'; Error = 'nested lifecycle projection markers' }
         )
-    $planNegativeSelected = if ($Group -eq 'PlanNegativeA') { @($planNegativeCases[0..2]) }
-    elseif ($Group -eq 'PlanNegativeB') { @($planNegativeCases[3..5]) }
-    elseif ($Group -eq 'PlanNegativeC') { @($planNegativeCases[6]) }
-    else { $planNegativeCases }
-    foreach ($case in $planNegativeSelected) {
-        Invoke-Case "rejects $($case.Name)" {
-            $packet = New-Packet ($case.Name.Replace(' ', '-'))
-            Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) $case.Old $case.New)
-            Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } $case.Reason
+        $errors = @()
+        foreach ($mutation in $mutations) {
+            $packet = Get-TestPacket ([guid]::NewGuid().ToString('N'))
+            $path = $packet.Paths[0]
+            Write-TestText $path (Replace-Once ([IO.File]::ReadAllText($path)) $mutation.Old $mutation.New)
+            try { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths | Out-Null }
+            catch { $errors += $_.Exception.Message; continue }
+            throw 'marker mutation unexpectedly passed'
         }
+        Assert-True ($errors.Count -eq $mutations.Count) 'all marker mutations fail'
     }
 
+    Invoke-Case 'rejects missing, duplicate, and extra packet artifacts without scanning prose' {
+        $packet = Get-TestPacket 'membership'
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths[0..($packet.Paths.Count - 2)] } 'packet is missing required artifact'
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath @($packet.Paths + $packet.Paths[0]) } 'packet contains duplicate artifact'
+        $extra = Join-Path $packet.Directory 'extra.md'
+        Write-TestText $extra (New-WduLifecycleProjection -CanonicalPath $canonicalPath -Artifact $script:Compiled.Artifacts[0].Id)
+        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath @($packet.Paths + $extra) } 'artifact path name must equal'
     }
 
-    if ($Group -in @('All', 'RequiredPacket')) {
-    Invoke-Case 'rejects a renamed required assignment artifact' {
-        $packet = New-Packet 'renamed-required-assignment-artifact'
-        Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-872"' '"artifact":"issue-999"')
-        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-872'"
+    Invoke-Case 'renders a complete packet twice without changing inputs and rejects unsafe destinations before writes' {
+        $packet = Get-TestPacket 'render-input'
+        $stalePath = $packet.Paths[0]
+        Write-TestText $stalePath (Replace-Once ([IO.File]::ReadAllText($stalePath)) '"assignmentDigest": "' + $script:Compiled.AssignmentDigest + '"' '"assignmentDigest": "0000000000000000000000000000000000000000000000000000000000000000"')
+        $before = Get-Hashes $packet.Paths
+        $first = Join-Path $script:TestRoot 'render-one'
+        $second = Join-Path $script:TestRoot 'render-two'
+        $firstPaths = @(Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $first)
+        $secondPaths = @(Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $second)
+        Assert-True (($firstPaths.Count -eq $script:Compiled.Artifacts.Count) -and ($secondPaths.Count -eq $script:Compiled.Artifacts.Count)) 'both complete renders contain compiler artifacts'
+        Assert-True ((Get-Hashes $packet.Paths) -join '|' -ceq ($before -join '|')) 'render leaves inputs byte-identical'
+        Assert-True ((Get-Hashes $firstPaths) -join '|' -ceq ((Get-Hashes $secondPaths) -join '|')) 'complete renders are deterministic'
+        Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $firstPaths | Out-Null
+        Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $first } 'render destination already exists'
     }
 
-    Invoke-Case 'rejects reordered required assignment artifacts' {
-        $packet = New-Packet 'reordered-required-assignment-artifacts'
-        $reordered = Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-901"' '"artifact":"temporary-ordering-artifact"'
-        $reordered = Replace-Once $reordered '"artifact":"issue-871"' '"artifact":"issue-901"'
-        $reordered = Replace-Once $reordered '"artifact":"temporary-ordering-artifact"' '"artifact":"issue-871"'
-        Write-TestText $packet.Canonical $reordered
-        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-901'"
-    }
-
-    Invoke-Case 'rejects closed issue-870 as a replacement packet member' {
-        $packet = New-Packet 'closed-issue-870-member'
-        Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) '"artifact":"issue-901"' '"artifact":"issue-870"')
-        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "required artifact 'issue-901'"
-    }
-
-    Invoke-Case 'requires the declared non-lifecycle exclusion for issue-897' {
-        $packet = New-Packet 'issue-897-non-lifecycle-exclusion'
-        Write-TestText $packet.Canonical (Replace-Once (Get-TestText $packet.Canonical) 'checker exports lifecycle consumers only.' 'changed reason.')
-        Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } "stale reason for excluded artifact 'issue-897'"
-    }
-    }
-
-    if ($Group -in @('All', 'PlanMarkers')) {
-    foreach ($case in @(
-            @{ Name = 'missing assignment plan marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection-plan:start -->', '') }; Reason = 'marker pair' },
-            @{ Name = 'duplicate assignment plan marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection-plan:start -->', "<!-- grace:wdu-lifecycle-projection-plan:start -->`n<!-- grace:wdu-lifecycle-projection-plan:start -->") }; Reason = 'marker pair' },
-            @{ Name = 'reversed assignment plan markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection-plan:start -->', '<!-- temporary marker -->').Replace('<!-- grace:wdu-lifecycle-projection-plan:end -->', '<!-- grace:wdu-lifecycle-projection-plan:start -->').Replace('<!-- temporary marker -->', '<!-- grace:wdu-lifecycle-projection-plan:end -->') }; Reason = 'markers are reversed' }
-        )) {
-        Invoke-Case "rejects $($case.Name)" {
-            $packet = New-Packet ($case.Name.Replace(' ', '-'))
-            Write-TestText $packet.Canonical (& $case.Mutate (Get-TestText $packet.Canonical))
-            Assert-Fails { New-WduLifecycleProjection -CanonicalPath $packet.Canonical -Artifact 'adr-0011' } $case.Reason
-        }
-    }
-    }
-
-    if ($Group -in @('All', 'Marker')) {
-    foreach ($case in @(
-            @{ Name = 'missing projection marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection:start -->', '') }; Reason = 'marker pair' },
-            @{ Name = 'duplicate projection marker'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection:start -->', "<!-- grace:wdu-lifecycle-projection:start -->`n<!-- grace:wdu-lifecycle-projection:start -->") }; Reason = 'marker pair' },
-            @{ Name = 'reversed projection markers'; Mutate = { param($text) $text.Replace('<!-- grace:wdu-lifecycle-projection:start -->', '<!-- temporary marker -->').Replace('<!-- grace:wdu-lifecycle-projection:end -->', '<!-- grace:wdu-lifecycle-projection:start -->').Replace('<!-- temporary marker -->', '<!-- grace:wdu-lifecycle-projection:end -->') }; Reason = 'markers are reversed' }
-        )) {
-        Invoke-Case "rejects $($case.Name)" {
-            $packet = New-Packet ($case.Name.Replace(' ', '-'))
-            Write-TestText $packet.Paths[0] (& $case.Mutate (Get-TestText $packet.Paths[0]))
-            Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths } $case.Reason
-        }
-    }
-    }
-
-    if ($Group -in @('All', 'DriftA', 'DriftB', 'DriftC')) {
-    $driftCases = @(
-            @{ Name = 'stale projection digest'; Old = '901fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7'; New = '001fe35f11362c73d7200151e84ee2827dfee965758cb8e42925167c26aee7f7'; Reason = 'does not equal' },
-            @{ Name = 'wrong projection artifact'; Old = '"artifact": "issue-842"'; New = '"artifact": "unexpected"'; Reason = 'unexpected artifact' },
-            @{ Name = 'wrong projection anchor'; Old = 'docs/Working Directory Update.md#normative-branch-lifecycle-table'; New = 'docs/Working Directory Update.md#wrong-anchor'; Reason = 'does not equal' },
-            @{ Name = 'changed projection proof'; Old = 'Prove Branch-only Doctor retry, refusal, cancellation boundaries, terminal replay, and no working-file mutation.'; New = 'changed proof'; Reason = 'does not equal' },
-            @{ Name = 'missing projection row'; Old = "    `"WDU-LC-100`",`r`n"; New = ''; Reason = 'does not equal' },
-            @{ Name = 'extra projection row'; Old = "    `"WDU-LC-100`",`r`n"; New = "    `"WDU-LC-extra`",`r`n    `"WDU-LC-100`",`r`n"; Reason = 'does not equal' },
-            @{ Name = 'reordered projection row'; Old = "`"WDU-LC-100`",`r`n    `"WDU-LC-101`""; New = "`"WDU-LC-101`",`r`n    `"WDU-LC-100`""; Reason = 'does not equal' },
-            @{ Name = 'extra projection property'; Old = '"schema": "grace.wdu.lifecycle-projection/v1",'; New = '"schema": "grace.wdu.lifecycle-projection/v1", "extra": true,'; Reason = 'does not equal' }
-        )
-    $driftSelected = if ($Group -eq 'DriftA') { @($driftCases[0..2]) }
-    elseif ($Group -eq 'DriftB') { @($driftCases[3..5]) }
-    elseif ($Group -eq 'DriftC') { @($driftCases[6..7]) }
-    else { $driftCases }
-    foreach ($case in $driftSelected) {
-        Invoke-Case "rejects $($case.Name)" {
-            $packet = New-Packet ($case.Name.Replace(' ', '-'))
-            $target = $packet.Paths[2]
-            Write-TestText $target (Replace-Once (Get-TestText $target) $case.Old $case.New)
-            Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths } $case.Reason
-        }
-    }
-
-    }
-
-    if ($Group -in @('All', 'PacketA')) {
-
-    Invoke-Case 'requires complete packet membership before success' {
-        $packet = New-Packet 'missing packet artifact'
-        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths[0..7] } 'packet is missing required artifact'
-    }
-
-    Invoke-Case 'rejects a duplicate packet artifact before success' {
-        $packet = New-Packet 'duplicate packet artifact'
-        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths + $packet.Paths[0]) } 'duplicate artifact'
-    }
-
-    Invoke-Case 'rejects an unexpected packet artifact before success' {
-        $packet = New-Packet 'unexpected packet artifact'
-        $unexpected = Join-Path $packet.Root 'unexpected.md'
-        Write-TestText $unexpected (Replace-Once (Get-TestText $packet.Paths[2]) '"artifact": "issue-842"' '"artifact": "unexpected"')
-        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath @($packet.Paths + $unexpected) } 'unexpected artifact'
-    }
-
-    }
-
-    if ($Group -in @('All', 'PacketAEmpty')) {
-    Invoke-Case 'accepts empty content outside the exact projection markers' {
-        $packet = New-Packet 'empty outside content'
-        foreach ($path in $packet.Paths) {
-            $text = Get-TestText $path
-            $start = $text.IndexOf('<!-- grace:wdu-lifecycle-projection:start -->', [StringComparison]::Ordinal)
-            $end = $text.IndexOf('<!-- grace:wdu-lifecycle-projection:end -->', [StringComparison]::Ordinal)
-            $block = $text.Substring($start, ($end + '<!-- grace:wdu-lifecycle-projection:end -->'.Length) - $start)
-            Write-TestText $path $block
-        }
-        $result = @(Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
-        Assert-True ($result.Count -eq 12) 'empty surrounding content is ignored'
-    }
-
-    }
-
-    if ($Group -in @('All', 'PacketB', 'PacketBReadOnly')) {
-
-    Invoke-Case 'leaves every input byte unchanged on success and failure' {
-        $packet = New-Packet 'read only packet'
-        $all = @($packet.Canonical) + $packet.Paths
-        $before = Get-Hashes $all
-        Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths | Out-Null
-        Assert-True ((Get-Hashes $all) -join '|' -ceq ($before -join '|')) 'successful check is read-only'
-        Write-TestText $packet.Paths[0] ((Get-TestText $packet.Paths[0]).Replace('<!-- grace:wdu-lifecycle-projection:end -->', ''))
-        $beforeFailure = Get-Hashes $all
-        Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths } 'marker pair'
-        Assert-True ((Get-Hashes $all) -join '|' -ceq ($beforeFailure -join '|')) 'failed check is read-only'
-    }
-
-    Invoke-Case 'has no output-path parameter on the module or thin commands' {
-        foreach ($command in @('New-WduLifecycleProjection', 'Test-WduLifecycleProjection', $getCommand, $checkCommand)) {
-            $parameters = if ($command -like '*.ps1') { (Get-Command $command).Parameters.Keys } else { (Get-Command $command).Parameters.Keys }
-            Assert-True (-not ($parameters | Where-Object { $_ -match 'output|render|stage|publish' })) "$command has no output or publication parameter"
-        }
-    }
-
-    }
-
-    if ($Group -in @('All', 'PacketB', 'PacketBCommands')) {
-    Invoke-Case 'thin commands generate byte-identical stdout and check a complete offline packet' {
-        $packet = New-Packet 'thin commands packet'
-        $first = Join-Path $packet.Root 'first stdout.bin'
-        $second = Join-Path $packet.Root 'second stdout.bin'
-        & pwsh -NoProfile -File $getCommand -CanonicalPath $packet.Canonical -Artifact 'adr-0011' > $first
-        Assert-True ($LASTEXITCODE -eq 0) 'first generator invocation succeeds'
-        & pwsh -NoProfile -File $getCommand -CanonicalPath $packet.Canonical -Artifact 'adr-0011' > $second
-        Assert-True ($LASTEXITCODE -eq 0) 'second generator invocation succeeds'
-        Assert-True ([Convert]::ToHexString([IO.File]::ReadAllBytes($first)) -ceq [Convert]::ToHexString([IO.File]::ReadAllBytes($second))) 'stdout generation is byte-identical'
-        $checked = @(& $checkCommand -CanonicalPath $packet.Canonical -ArtifactPath $packet.Paths)
-        Assert-True ($checked.Count -eq 12) 'thin checker returns the twelve scoped results'
-    }
+    Invoke-Case 'rejects a partial packet before creating an output directory' {
+        $packet = Get-TestPacket 'render-preflight'
+        $destination = Join-Path $script:TestRoot 'must-not-exist'
+        Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths[0..($packet.Paths.Count - 2)] -OutputDirectory $destination } 'packet is missing required artifact'
+        Assert-True (-not (Test-Path -LiteralPath $destination)) 'failed preflight creates no destination'
     }
 }
 finally {

--- a/scripts/tests/WduLifecycleProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleProjection.Tests.ps1
@@ -63,6 +63,20 @@ function Replace-Once {
     return $Text.Remove($index, $Old.Length).Insert($index, $New)
 }
 
+function Set-TestStagedWriteFailure {
+    param([int] $After)
+    & (Get-Module WduLifecycleProjection) {
+        param([int] $Value)
+        $script:FailureAfterStagedWritesForTest = $Value
+    } $After
+}
+
+function Clear-TestStagedWriteFailure {
+    & (Get-Module WduLifecycleProjection) {
+        $script:FailureAfterStagedWritesForTest = $null
+    }
+}
+
 Import-Module $modulePath -Force
 Import-Module $contractModulePath -Force
 $script:Compiled = Read-WduLifecycleContract -Path $canonicalPath
@@ -108,9 +122,9 @@ try {
     Invoke-Case 'rejects malformed, duplicate, reversed, nested, and unknown markers' {
         $mutations = @(
             @{ Old = ':start -->'; New = ':started -->'; Error = 'malformed lifecycle projection marker' },
-            @{ Old = ':start -->'; New = ":start -->`n<!-- grace:wdu-lifecycle-projection:$($script:Compiled.Artifacts[0].Id):start -->"; Error = 'malformed lifecycle projection marker' },
+            @{ Old = ':start -->'; New = ":start -->`n<!-- grace:wdu-lifecycle-projection:$($script:Compiled.Artifacts[0].Id):start -->"; Error = 'nested lifecycle projection markers' },
             @{ Old = ':start -->'; New = ':end -->'; Error = 'reversed end marker' },
-            @{ Old = ':start -->'; New = ':start -->`n<!-- grace:wdu-lifecycle-projection:unknown:start -->`n<!-- grace:wdu-lifecycle-projection:unknown:end -->'; Error = 'nested lifecycle projection markers' }
+            @{ Old = ':start -->'; New = ':start -->`n<!-- grace:wdu-lifecycle-projection:unknown:start -->`n<!-- grace:wdu-lifecycle-projection:unknown:end -->'; Error = "unknown artifact marker 'unknown'" }
         )
         $errors = @()
         foreach ($mutation in $mutations) {
@@ -118,7 +132,11 @@ try {
             $path = $packet.Paths[0]
             Write-TestText $path (Replace-Once ([IO.File]::ReadAllText($path)) $mutation.Old $mutation.New)
             try { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths | Out-Null }
-            catch { $errors += $_.Exception.Message; continue }
+            catch {
+                Assert-True $_.Exception.Message.Contains($mutation.Error, [StringComparison]::Ordinal) "marker mutation reports '$($mutation.Error)': $($_.Exception.Message)"
+                $errors += $_.Exception.Message
+                continue
+            }
             throw 'marker mutation unexpectedly passed'
         }
         Assert-True ($errors.Count -eq $mutations.Count) 'all marker mutations fail'
@@ -154,6 +172,39 @@ try {
         $destination = Join-Path $script:TestRoot 'must-not-exist'
         Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths[0..($packet.Paths.Count - 2)] -OutputDirectory $destination } 'packet is missing required artifact'
         Assert-True (-not (Test-Path -LiteralPath $destination)) 'failed preflight creates no destination'
+    }
+
+    Invoke-Case 'rejects lexical and junction aliases inside an input packet before writes' {
+        $packet = Get-TestPacket 'destination-aliases'
+        $before = Get-Hashes $packet.Paths
+        $lexicalDestination = Join-Path $packet.Directory '.\rendered'
+        Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $lexicalDestination } 'render destination must not be within an input artifact directory'
+        Assert-True (-not (Test-Path -LiteralPath $lexicalDestination)) 'lexical alias creates no destination'
+
+        $junction = Join-Path $script:TestRoot 'input-packet-junction'
+        New-Item -ItemType Junction -Path $junction -Target $packet.Directory | Out-Null
+        $junctionDestination = Join-Path $junction 'rendered'
+        Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $junctionDestination } 'render destination must not be within an input artifact directory'
+        Assert-True (-not (Test-Path -LiteralPath $junctionDestination)) 'junction alias creates no destination'
+        Assert-True ((Get-Hashes $packet.Paths) -join '|' -ceq ($before -join '|')) 'alias rejection leaves inputs byte-identical'
+    }
+
+    Invoke-Case 'cleans staged writes after deterministic late failure without changing inputs' {
+        $packet = Get-TestPacket 'late-failure'
+        $before = Get-Hashes $packet.Paths
+        $destination = Join-Path $script:TestRoot 'late-failure-output'
+        Set-TestStagedWriteFailure 1
+        try {
+            Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $destination } 'test-only deterministic failure after staged write'
+        }
+        finally {
+            Clear-TestStagedWriteFailure
+        }
+        $stagingPattern = '.' + [IO.Path]::GetFileName($destination) + '.staging-*'
+        $staging = @(Get-ChildItem -LiteralPath $script:TestRoot -Directory -Filter $stagingPattern)
+        Assert-True ((Get-Hashes $packet.Paths) -join '|' -ceq ($before -join '|')) 'late failure leaves inputs byte-identical'
+        Assert-True (-not (Test-Path -LiteralPath $destination)) 'late failure creates no final destination'
+        Assert-True ($staging.Count -eq 0) 'late failure removes its staging directory'
     }
 }
 finally {

--- a/scripts/tests/WduLifecycleProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleProjection.Tests.ps1
@@ -31,24 +31,36 @@ function Invoke-Case {
 }
 
 function Write-TestText {
-    param([string] $Path, [string] $Text)
-    [IO.File]::WriteAllText($Path, $Text, [Text.UTF8Encoding]::new($false))
+    param([string] $Path, [string] $Text, [switch] $Utf8Bom)
+    $encoding = [Text.UTF8Encoding]::new($Utf8Bom, $true)
+    $content = $encoding.GetBytes($Text)
+    $preamble = $encoding.GetPreamble()
+    $bytes = [byte[]]::new($preamble.Length + $content.Length)
+    [Array]::Copy($preamble, 0, $bytes, 0, $preamble.Length)
+    [Array]::Copy($content, 0, $bytes, $preamble.Length, $content.Length)
+    [IO.File]::WriteAllBytes($Path, $bytes)
 }
 
 function Get-TestPacket {
-    param([string] $Name, [switch] $CrLf)
+    param([string] $Name, [switch] $CrLf, [switch] $AlternatingByteBoundaries)
     $directory = Join-Path $script:TestRoot $Name
     [IO.Directory]::CreateDirectory($directory) | Out-Null
     $paths = [Collections.Generic.List[string]]::new()
+    $byteBoundaries = [Collections.Generic.List[object]]::new()
+    $index = 0
     foreach ($artifact in $script:Compiled.Artifacts) {
         $path = Join-Path $directory ($artifact.Id + '.md')
+        $lineEnding = if ($CrLf) { "`r`n" } elseif ($AlternatingByteBoundaries -and (($index % 2) -eq 1)) { "`r`n" } else { "`n" }
+        $utf8Bom = $AlternatingByteBoundaries -and (($index % 2) -eq 0)
         $outside = "# $($artifact.Id)`n`nHistorical prose, dates, #920, and contradictory counts are not interpreted.`n`n"
         $text = $outside + $script:Projections[$artifact.Id] + "`n`n$outside"
-        if ($CrLf) { $text = $text.Replace("`n", "`r`n") }
-        Write-TestText $path $text
-        $paths.Add($path)
+        if ($lineEnding -eq "`r`n") { $text = $text.Replace("`n", "`r`n") }
+        Write-TestText $path $text -Utf8Bom:$utf8Bom
+        [void]$paths.Add($path)
+        [void]$byteBoundaries.Add([pscustomobject]@{ Path = $path; HasUtf8Bom = $utf8Bom; LineEnding = $lineEnding })
+        $index++
     }
-    return [pscustomobject]@{ Directory = $directory; Paths = @($paths) }
+    return [pscustomobject]@{ Directory = $directory; Paths = @($paths); ByteBoundaries = @($byteBoundaries) }
 }
 
 function Get-Hashes {
@@ -75,6 +87,123 @@ function Clear-TestStagedWriteFailure {
     & (Get-Module WduLifecycleProjection) {
         $script:FailureAfterStagedWritesForTest = $null
     }
+}
+
+function Assert-ByteSequenceEqual {
+    param([byte[]] $Actual, [byte[]] $Expected, [string] $Message)
+    Assert-True ($Actual.Length -eq $Expected.Length) "$Message length"
+    for ($index = 0; $index -lt $Actual.Length; $index++) {
+        Assert-True ($Actual[$index] -eq $Expected[$index]) "$Message at byte $index"
+    }
+}
+
+function Find-ByteSequence {
+    param([byte[]] $Bytes, [byte[]] $Needle, [int] $StartAt = 0)
+    if ($Needle.Length -eq 0) { throw 'Test byte sequence must not be empty' }
+    for ($index = $StartAt; $index -le ($Bytes.Length - $Needle.Length); $index++) {
+        $matches = $true
+        for ($offset = 0; $offset -lt $Needle.Length; $offset++) {
+            if ($Bytes[$index + $offset] -ne $Needle[$offset]) {
+                $matches = $false
+                break
+            }
+        }
+        if ($matches) { return $index }
+    }
+    return -1
+}
+
+function Get-ByteSlice {
+    param([byte[]] $Bytes, [int] $Start, [int] $Length)
+    if ($Length -eq 0) { return [byte[]]::new(0) }
+    $slice = [byte[]]::new($Length)
+    [Array]::Copy($Bytes, $Start, $slice, 0, $Length)
+    return $slice
+}
+
+function Get-IndependentProjectionSpan {
+    param([byte[]] $Bytes, [string] $Artifact, [string] $Subject)
+    $encoding = [Text.UTF8Encoding]::new($false, $true)
+    $startMarker = $encoding.GetBytes("<!-- grace:wdu-lifecycle-projection:$Artifact`:start -->")
+    $endMarker = $encoding.GetBytes("<!-- grace:wdu-lifecycle-projection:$Artifact`:end -->")
+    $startIndex = Find-ByteSequence $Bytes $startMarker
+    $endIndex = Find-ByteSequence $Bytes $endMarker
+    Assert-True ($startIndex -ge 0) "$Subject has the independently located start marker"
+    Assert-True ($endIndex -gt $startIndex) "$Subject has the independently located end marker after its start"
+    Assert-True ((Find-ByteSequence $Bytes $startMarker ($startIndex + 1)) -lt 0) "$Subject has one start marker"
+    Assert-True ((Find-ByteSequence $Bytes $endMarker ($endIndex + 1)) -lt 0) "$Subject has one end marker"
+    return [pscustomobject]@{
+        StartIndex = $startIndex
+        EndIndex = $endIndex
+        EndLength = $endMarker.Length
+    }
+}
+
+function Get-IndependentProjectionPayload {
+    param([string] $Path, [string] $Artifact)
+    $bytes = [IO.File]::ReadAllBytes($Path)
+    $span = Get-IndependentProjectionSpan $bytes $Artifact $Path
+    $encoding = [Text.UTF8Encoding]::new($false, $true)
+    $block = $encoding.GetString((Get-ByteSlice $bytes $span.StartIndex (($span.EndIndex + $span.EndLength) - $span.StartIndex)))
+    $normalizedBlock = $block.Replace("`r`n", "`n").Replace("`r", "`n")
+    $startMarker = "<!-- grace:wdu-lifecycle-projection:$Artifact`:start -->" + "`n" + '```json' + "`n"
+    $endMarker = "`n" + '```' + "`n" + "<!-- grace:wdu-lifecycle-projection:$Artifact`:end -->"
+    Assert-True $normalizedBlock.StartsWith($startMarker, [StringComparison]::Ordinal) "$Path has the expected JSON fence after its start marker"
+    Assert-True $normalizedBlock.EndsWith($endMarker, [StringComparison]::Ordinal) "$Path has the expected JSON fence before its end marker"
+    $json = $normalizedBlock.Substring($startMarker.Length, $normalizedBlock.Length - $startMarker.Length - $endMarker.Length)
+    return [pscustomobject]@{ Payload = ($json | ConvertFrom-Json -Depth 8); Json = $json }
+}
+
+function Assert-PropertyOrder {
+    param([object] $Object, [string[]] $Expected, [string] $Message)
+    $actual = @($Object.PSObject.Properties.Name)
+    Assert-True (($actual -join '|') -ceq ($Expected -join '|')) $Message
+}
+
+function Assert-IndependentPayloadMatchesCompiler {
+    param([string] $Path, [string] $Artifact)
+    $projection = Get-IndependentProjectionPayload $Path $Artifact
+    $payload = $projection.Payload
+    $compiledArtifact = @($script:Compiled.Artifacts | Where-Object { $_.Id -ceq $Artifact })
+    Assert-True ($compiledArtifact.Count -eq 1) "compiler has exactly one artifact '$Artifact'"
+    Assert-PropertyOrder $payload @('schema', 'artifact', 'canonicalContentDigest', 'assignmentDigest', 'counts', 'requirements', 'artifactIds', 'assignment') "$Path has the complete ordered payload shape"
+    Assert-True ($payload.schema -ceq 'grace.wdu.lifecycle-projection/v2') "$Path has the fixed public schema"
+    Assert-True ($payload.artifact -ceq $Artifact) "$Path has its artifact identity"
+    Assert-True ($payload.canonicalContentDigest -ceq $script:Compiled.Digest) "$Path has the compiler canonical digest"
+    Assert-True ($payload.assignmentDigest -ceq $script:Compiled.AssignmentDigest) "$Path has the compiler assignment digest"
+    Assert-PropertyOrder $payload.counts @('rowCount', 'applicabilityKeyCount', 'requirementCount', 'artifactCount') "$Path has the complete ordered count shape"
+    foreach ($name in @('rowCount', 'applicabilityKeyCount', 'requirementCount', 'artifactCount')) {
+        Assert-True ($payload.counts.$name -eq $script:Compiled.Counts.$name) "$Path has compiler $name"
+    }
+    Assert-True (@($payload.requirements).Count -eq $script:Compiled.Requirements.Count) "$Path has every compiler requirement"
+    for ($index = 0; $index -lt $script:Compiled.Requirements.Count; $index++) {
+        Assert-PropertyOrder $payload.requirements[$index] @('id', 'owner') "$Path requirement $index has the complete ordered shape"
+        Assert-True ($payload.requirements[$index].id -ceq $script:Compiled.Requirements[$index].Id) "$Path requirement $index has the compiler ID"
+        Assert-True ($payload.requirements[$index].owner -ceq $script:Compiled.Requirements[$index].Owner) "$Path requirement $index has the compiler owner"
+    }
+    Assert-True ((@($payload.artifactIds) -join '|') -ceq (@($script:Compiled.Artifacts.Id) -join '|')) "$Path has ordered compiler artifact IDs"
+    Assert-PropertyOrder $payload.assignment @('rowIds') "$Path assignment has the complete ordered shape"
+    Assert-True ((@($payload.assignment.rowIds) -join '|') -ceq (@($compiledArtifact[0].RowIds) -join '|')) "$Path has ordered compiler assignment row IDs"
+}
+
+function Assert-IndependentOutsideBytesMatch {
+    param([string] $SourcePath, [string] $RenderedPath, [string] $Artifact)
+    $source = [IO.File]::ReadAllBytes($SourcePath)
+    $rendered = [IO.File]::ReadAllBytes($RenderedPath)
+    $sourceSpan = Get-IndependentProjectionSpan $source $Artifact $SourcePath
+    $renderedSpan = Get-IndependentProjectionSpan $rendered $Artifact $RenderedPath
+    Assert-ByteSequenceEqual (Get-ByteSlice $rendered 0 $renderedSpan.StartIndex) (Get-ByteSlice $source 0 $sourceSpan.StartIndex) "$Artifact preserves every prefix byte outside its marker pair"
+    $sourceSuffixStart = $sourceSpan.EndIndex + $sourceSpan.EndLength
+    $renderedSuffixStart = $renderedSpan.EndIndex + $renderedSpan.EndLength
+    Assert-ByteSequenceEqual (Get-ByteSlice $rendered $renderedSuffixStart ($rendered.Length - $renderedSuffixStart)) (Get-ByteSlice $source $sourceSuffixStart ($source.Length - $sourceSuffixStart)) "$Artifact preserves every suffix byte outside its marker pair"
+}
+
+function Set-TestPayloadMutation {
+    param([string] $Path, [string] $Artifact, [scriptblock] $Mutation)
+    $projection = Get-IndependentProjectionPayload $Path $Artifact
+    & $Mutation $projection.Payload
+    $replacement = $projection.Payload | ConvertTo-Json -Depth 8
+    Write-TestText $Path (Replace-Once ([IO.File]::ReadAllText($Path)) $projection.Json $replacement)
 }
 
 Import-Module $modulePath -Force
@@ -151,10 +280,11 @@ try {
         Assert-Fails { Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath @($packet.Paths + $extra) } 'artifact path name must equal'
     }
 
-    Invoke-Case 'renders a complete packet twice without changing inputs and rejects unsafe destinations before writes' {
-        $packet = Get-TestPacket 'render-input'
+    Invoke-Case 'renders all artifacts with independent byte-boundary and compiler-payload proof' {
+        $packet = Get-TestPacket 'render-input' -AlternatingByteBoundaries
         $stalePath = $packet.Paths[0]
-        Write-TestText $stalePath (Replace-Once ([IO.File]::ReadAllText($stalePath)) '"assignmentDigest": "' + $script:Compiled.AssignmentDigest + '"' '"assignmentDigest": "0000000000000000000000000000000000000000000000000000000000000000"')
+        $staleHasUtf8Bom = $packet.ByteBoundaries[0].HasUtf8Bom
+        Write-TestText $stalePath (Replace-Once ([IO.File]::ReadAllText($stalePath)) '"assignmentDigest": "' + $script:Compiled.AssignmentDigest + '"' '"assignmentDigest": "0000000000000000000000000000000000000000000000000000000000000000"') -Utf8Bom:$staleHasUtf8Bom
         $before = Get-Hashes $packet.Paths
         $first = Join-Path $script:TestRoot 'render-one'
         $second = Join-Path $script:TestRoot 'render-two'
@@ -163,7 +293,81 @@ try {
         Assert-True (($firstPaths.Count -eq $script:Compiled.Artifacts.Count) -and ($secondPaths.Count -eq $script:Compiled.Artifacts.Count)) 'both complete renders contain compiler artifacts'
         Assert-True ((Get-Hashes $packet.Paths) -join '|' -ceq ($before -join '|')) 'render leaves inputs byte-identical'
         Assert-True ((Get-Hashes $firstPaths) -join '|' -ceq ((Get-Hashes $secondPaths) -join '|')) 'complete renders are deterministic'
+        Assert-True ($packet.ByteBoundaries.Count -eq 15) 'the complete packet has all required byte-boundary cases'
+        Assert-True ((@($packet.ByteBoundaries | Where-Object { $_.HasUtf8Bom }).Count -gt 0) -and (@($packet.ByteBoundaries | Where-Object { -not $_.HasUtf8Bom }).Count -gt 0)) 'the complete packet explicitly covers UTF-8 BOM and no-BOM inputs'
+        Assert-True ((@($packet.ByteBoundaries | Where-Object { $_.LineEnding -ceq "`n" }).Count -gt 0) -and (@($packet.ByteBoundaries | Where-Object { $_.LineEnding -ceq "`r`n" }).Count -gt 0)) 'the complete packet explicitly covers LF and CRLF boundaries'
+        foreach ($boundary in $packet.ByteBoundaries) {
+            $artifact = [IO.Path]::GetFileNameWithoutExtension($boundary.Path)
+            $sourceBytes = [IO.File]::ReadAllBytes($boundary.Path)
+            $hasBom = $sourceBytes.Length -ge 3 -and $sourceBytes[0] -eq 0xEF -and $sourceBytes[1] -eq 0xBB -and $sourceBytes[2] -eq 0xBF
+            Assert-True ($hasBom -eq $boundary.HasUtf8Bom) "$artifact has its declared UTF-8 BOM boundary"
+            if ($boundary.LineEnding -ceq "`r`n") {
+                Assert-True ((Find-ByteSequence $sourceBytes ([byte[]]@(13, 10))) -ge 0) "$artifact has CRLF source boundaries"
+            }
+            else {
+                Assert-True ((Find-ByteSequence $sourceBytes ([byte[]]@(13, 10))) -lt 0) "$artifact has LF-only source boundaries"
+            }
+            foreach ($renderedPath in @((Join-Path $first ($artifact + '.md')), (Join-Path $second ($artifact + '.md')))) {
+                Assert-IndependentOutsideBytesMatch $boundary.Path $renderedPath $artifact
+                Assert-IndependentPayloadMatchesCompiler $renderedPath $artifact
+            }
+        }
         Test-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $firstPaths | Out-Null
+
+        $target = $firstPaths[0]
+        $artifact = [IO.Path]::GetFileNameWithoutExtension($target)
+        $sourcePath = @($packet.Paths | Where-Object { [IO.Path]::GetFileNameWithoutExtension($_) -ceq $artifact })[0]
+        $original = [IO.File]::ReadAllBytes($target)
+        $span = Get-IndependentProjectionSpan $original $artifact $target
+
+        $changed = [byte[]]$original.Clone()
+        $changed[$span.StartIndex - 1] = $changed[$span.StartIndex - 1] -bxor 0x01
+        [IO.File]::WriteAllBytes($target, $changed)
+        Assert-Fails { Assert-IndependentOutsideBytesMatch $sourcePath $target $artifact } 'outside its marker pair'
+
+        [IO.File]::WriteAllBytes($target, (Get-ByteSlice $original 0 ($original.Length - 1)))
+        Assert-Fails { Assert-IndependentOutsideBytesMatch $sourcePath $target $artifact } 'outside its marker pair'
+        [IO.File]::WriteAllBytes($target, $original)
+
+        Assert-True ($original[0] -eq 0xEF -and $original[1] -eq 0xBB -and $original[2] -eq 0xBF) "$artifact mutation target has a UTF-8 BOM"
+        [IO.File]::WriteAllBytes($target, (Get-ByteSlice $original 3 ($original.Length - 3)))
+        Assert-Fails { Assert-IndependentOutsideBytesMatch $sourcePath $target $artifact } 'outside its marker pair'
+        [IO.File]::WriteAllBytes($target, $original)
+
+        $crLfBoundary = @($packet.ByteBoundaries | Where-Object { $_.LineEnding -ceq "`r`n" })[0]
+        $crLfArtifact = [IO.Path]::GetFileNameWithoutExtension($crLfBoundary.Path)
+        $crLfTarget = Join-Path $first ($crLfArtifact + '.md')
+        $crLfOriginal = [IO.File]::ReadAllBytes($crLfTarget)
+        Write-TestText $crLfTarget ([IO.File]::ReadAllText($crLfTarget).Replace("`r`n", "`n"))
+        Assert-Fails { Assert-IndependentOutsideBytesMatch $crLfBoundary.Path $crLfTarget $crLfArtifact } 'outside its marker pair'
+        [IO.File]::WriteAllBytes($crLfTarget, $crLfOriginal)
+
+        $originalPayload = [IO.File]::ReadAllText($target)
+        $mutations = @(
+            @{ Name = 'schema'; Expected = 'fixed public schema'; Apply = { param($payload) $payload.schema = 'wrong.schema' } },
+            @{ Name = 'artifact identity'; Expected = 'artifact identity'; Apply = { param($payload) $payload.artifact = 'wrong-artifact' } },
+            @{ Name = 'canonical digest'; Expected = 'compiler canonical digest'; Apply = { param($payload) $payload.canonicalContentDigest = '0' * 64 } },
+            @{ Name = 'assignment digest'; Expected = 'compiler assignment digest'; Apply = { param($payload) $payload.assignmentDigest = '0' * 64 } },
+            @{ Name = 'row count'; Expected = 'compiler rowCount'; Apply = { param($payload) $payload.counts.rowCount++ } },
+            @{ Name = 'applicability key count'; Expected = 'compiler applicabilityKeyCount'; Apply = { param($payload) $payload.counts.applicabilityKeyCount++ } },
+            @{ Name = 'requirement count'; Expected = 'compiler requirementCount'; Apply = { param($payload) $payload.counts.requirementCount++ } },
+            @{ Name = 'artifact count'; Expected = 'compiler artifactCount'; Apply = { param($payload) $payload.counts.artifactCount++ } },
+            @{ Name = 'requirement omission'; Expected = 'every compiler requirement'; Apply = { param($payload) $payload.requirements = @($payload.requirements | Select-Object -Skip 1) } },
+            @{ Name = 'requirement reordering'; Expected = 'compiler ID'; Apply = { param($payload) $items = @($payload.requirements); $payload.requirements = @($items[1], $items[0]) + @($items | Select-Object -Skip 2) } },
+            @{ Name = 'requirement owner drift'; Expected = 'compiler owner'; Apply = { param($payload) $payload.requirements[0].owner = '#000' } },
+            @{ Name = 'artifact omission'; Expected = 'ordered compiler artifact IDs'; Apply = { param($payload) $payload.artifactIds = @($payload.artifactIds | Select-Object -Skip 1) } },
+            @{ Name = 'artifact reordering'; Expected = 'ordered compiler artifact IDs'; Apply = { param($payload) $items = @($payload.artifactIds); $payload.artifactIds = @($items[1], $items[0]) + @($items | Select-Object -Skip 2) } },
+            @{ Name = 'artifact ID drift'; Expected = 'ordered compiler artifact IDs'; Apply = { param($payload) $payload.artifactIds[0] = 'wrong-artifact' } },
+            @{ Name = 'assignment omission'; Expected = 'ordered compiler assignment row IDs'; Apply = { param($payload) $payload.assignment.rowIds = @($payload.assignment.rowIds | Select-Object -Skip 1) } },
+            @{ Name = 'assignment reordering'; Expected = 'ordered compiler assignment row IDs'; Apply = { param($payload) $items = @($payload.assignment.rowIds); $payload.assignment.rowIds = @($items[1], $items[0]) + @($items | Select-Object -Skip 2) } },
+            @{ Name = 'assignment row drift'; Expected = 'ordered compiler assignment row IDs'; Apply = { param($payload) $payload.assignment.rowIds[0] = 'WDU-LC-000' } }
+        )
+        foreach ($mutation in $mutations) {
+            Write-TestText $target $originalPayload
+            Set-TestPayloadMutation $target $artifact $mutation.Apply
+            Assert-Fails { Assert-IndependentPayloadMatchesCompiler $target $artifact } $mutation.Expected
+        }
+        Write-TestText $target $originalPayload
         Assert-Fails { Export-WduLifecycleProjection -CanonicalPath $canonicalPath -ArtifactPath $packet.Paths -OutputDirectory $first } 'render destination already exists'
     }
 


### PR DESCRIPTION
# Render exact WDU lifecycle projections

## Why this matters

Later Working Directory Update leaves need the epic, ADR, and implementation issues to carry the same compiled
lifecycle facts. This change provides an exact machine-block projection without interpreting free-form tracker prose.

## What changed

- Added a projection module that consumes only the merged #928 compiler result.
- Added exact marker-block checking for the 15 compiled artifact identities.
- Added explicit all-or-nothing packet rendering after complete preflight.
- Added a read-only packet command with exact artifact membership checks.
- Added focused projection and packet proof for drift, marker, membership, deterministic render, and input-preservation
  cases.

## Quality contract

Product V1. This PR owns exact machine-data projection and prepared packet proof only. It does not interpret free-form
prose, publish GitHub tracker changes, alter the lifecycle contract, or change runtime, SQLite, CLI, SDK, or generated
surfaces.

## Proof

- PowerShell parse: passed for all changed scripts.
- Projection suite: 7/7.
- Packet suite: 3/3.
- Compiler import and canonical digest: passed through the merged #928 compiler.
- Two complete renders: byte-identical.
- Prepared 15-artifact packet: exact check passed.
- MarkdownLint: 15 prepared artifacts, 0 errors with the repository line-length override.
- Applicable ADR local links: passed.
- `git diff --check`: passed.

## Prepared packet

`C:\Users\scott\AppData\Local\Temp\grace-wdu-929-packet\prepared`

The worker did not publish tracker bodies. Publication and fresh live re-export remain orchestrator-owned after the
current-head review begins.

## Docs impact

No free-form documentation changed. The prepared packet updates only machine-owned projection blocks.

## Residual risk

Current-head review, GitHub Validate, orchestrator publication, and fresh live re-export remain required.

Related to #929.
