### PR TITLE
B4.3R2a3: Preserve post-close accepted usage as isolated late work

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="OperationsEntities.fs" />
     <Compile Include="OperationsChargePreview.fs" />
     <Compile Include="OperationsBillingPeriodModel.fs" />
+    <Compile Include="OperationsBillingPeriodLateWorkModel.fs" />
     <Compile Include="OperationsDbContext.fs" />
     <Compile Include="Migrations\20260705234500_InitialOperationsSchema.fs" />
     <Compile Include="Migrations\20260707000000_AddRawUsageFactPayload.fs" />
@@ -31,6 +32,7 @@
     <Compile Include="Migrations\20260812090000_AddBillingCompletenessCoordination.fs" />
     <Compile Include="Migrations\20260812110000_AddUsageFactJournal.fs" />
     <Compile Include="Migrations\20260812130000_AddBillingPeriodClose.fs" />
+    <Compile Include="Migrations\20260812140000_AddBillingPeriodLateWork.fs" />
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
     <Compile Include="OperationsBillingPeriod.fs" />

--- a/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
+++ b/src/Grace.Operations/Grace.Operations.Data/MIGRATIONS.md
@@ -12,6 +12,9 @@ schema is intentionally narrow:
 - `ops.BillingPeriod`, `ops.Charge`, and `ops.BillingPeriodCloseEvidence` preserve one exact monthly scope, immutable
   initial postings, and immutable close evidence. The literal migration owns their SQL checks, keys, defaults,
   foreign keys, and append-only triggers; it does not implement close behavior.
+- `ops.BillingPeriodLateWork` records one `Pending` handoff for a fact newly accepted after its exact period closed.
+  Its period-and-fact identity is unique, it retains only provenance and SQL creation time, and later correction
+  processing remains outside this migration boundary.
 - The EF migrations history table lives in `ops.__EFMigrationsHistory` so operations schema state stays with the
   operations schema.
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812140000_AddBillingPeriodLateWork.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812140000_AddBillingPeriodLateWork.fs
@@ -46,7 +46,7 @@ module BillingPeriodLateWorkFrozenTarget =
         lateWork
             .Property<int>("State")
             .HasColumnType("int")
-            .HasDefaultValue(0)
+            .HasDefaultValue(0, "DF_ops_BillingPeriodLateWork_State")
             .IsRequired()
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812140000_AddBillingPeriodLateWork.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/20260812140000_AddBillingPeriodLateWork.fs
@@ -1,0 +1,120 @@
+namespace Grace.Operations.Data.Migrations
+
+open Grace.Operations.Data
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Infrastructure
+open Microsoft.EntityFrameworkCore.Migrations
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
+
+/// Owns the frozen target declaration for the minimal Pending late-work handoff.
+[<RequireQualifiedAccess>]
+module BillingPeriodLateWorkFrozenTarget =
+
+    /// Adds the complete late-work physical contract without using runtime model helpers.
+    let apply (modelBuilder: ModelBuilder) =
+        let lateWork = modelBuilder.Entity<BillingPeriodLateWorkEntity>()
+
+        lateWork.ToTable(
+            "BillingPeriodLateWork",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodLateWorkEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodLateWork_Identity",
+                    "[BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [UsageFactId] <> '00000000-0000-0000-0000-000000000000'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodLateWork_State", "[State] = 0")
+                |> ignore
+        )
+        |> ignore
+
+        lateWork
+            .HasKey([| "BillingPeriodId"; "UsageFactId" |])
+            .HasName("PK_ops_BillingPeriodLateWork")
+        |> ignore
+
+        for name in [ "BillingPeriodId"; "UsageFactId" ] do
+            lateWork
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .ValueGeneratedNever()
+                .IsRequired()
+            |> ignore
+
+        lateWork
+            .Property<int>("State")
+            .HasColumnType("int")
+            .HasDefaultValue(0)
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriodLateWork_CreatedAtUtc")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .HasIndex([| "UsageFactId" |])
+            .HasDatabaseName("IX_ops_BillingPeriodLateWork_UsageFact")
+        |> ignore
+
+        lateWork
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        lateWork
+            .HasOne<RawUsageFactEntity>()
+            .WithMany()
+            .HasForeignKey("UsageFactId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_RawUsageFact")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+/// Adds the isolated post-close accepted-fact handoff after the direct-close schema.
+[<DbContextAttribute(typeof<OperationsDbContext>)>]
+[<Migration("20260812140000_AddBillingPeriodLateWork")>]
+type AddBillingPeriodLateWork() =
+    inherit Migration()
+
+    /// Creates the Pending handoff table and its period/raw-fact foreign-key contract.
+    override _.Up(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql(
+            """
+CREATE TABLE ops.BillingPeriodLateWork
+(
+    BillingPeriodId uniqueidentifier NOT NULL,
+    UsageFactId uniqueidentifier NOT NULL,
+    State int NOT NULL CONSTRAINT DF_ops_BillingPeriodLateWork_State DEFAULT (0),
+    CreatedAtUtc datetime2(7) NOT NULL CONSTRAINT DF_ops_BillingPeriodLateWork_CreatedAtUtc DEFAULT (SYSUTCDATETIME()),
+    CONSTRAINT PK_ops_BillingPeriodLateWork PRIMARY KEY (BillingPeriodId, UsageFactId),
+    CONSTRAINT FK_ops_BillingPeriodLateWork_BillingPeriod FOREIGN KEY (BillingPeriodId) REFERENCES ops.BillingPeriod(BillingPeriodId),
+    CONSTRAINT FK_ops_BillingPeriodLateWork_RawUsageFact FOREIGN KEY (UsageFactId) REFERENCES ops.RawUsageFact(UsageFactId),
+    CONSTRAINT CK_ops_BillingPeriodLateWork_Identity CHECK ([BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [UsageFactId] <> '00000000-0000-0000-0000-000000000000'),
+    CONSTRAINT CK_ops_BillingPeriodLateWork_State CHECK ([State] = 0)
+);
+CREATE INDEX IX_ops_BillingPeriodLateWork_UsageFact ON ops.BillingPeriodLateWork(UsageFactId);
+"""
+        )
+        |> ignore
+
+    /// Removes only the late-work table introduced by this migration.
+    override _.Down(migrationBuilder: MigrationBuilder) =
+        migrationBuilder.Sql("DROP TABLE ops.BillingPeriodLateWork;")
+        |> ignore
+
+    /// Captures the complete frozen target without reading mutable runtime configuration.
+    override _.BuildTargetModel(modelBuilder: ModelBuilder) =
+        modelBuilder.HasAnnotation("ProductVersion", "10.0.9")
+        |> ignore
+
+        BillingPeriodCloseFrozenTarget.applyPriorModel modelBuilder
+        BillingPeriodCloseFrozenTarget.apply modelBuilder
+        BillingPeriodLateWorkFrozenTarget.apply modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -1299,7 +1299,7 @@ type OperationsDbContextModelSnapshot() =
         lateWork
             .Property<int>("State")
             .HasColumnType("int")
-            .HasDefaultValue(0)
+            .HasDefaultValue(0, "DF_ops_BillingPeriodLateWork_State")
             .IsRequired()
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/Migrations/OperationsDbContextModelSnapshot.fs
@@ -1265,3 +1265,68 @@ type OperationsDbContextModelSnapshot() =
             .HasConstraintName("FK_ops_BillingPeriodCloseEvidence_BillingPeriod")
             .OnDelete(DeleteBehavior.Restrict)
         |> ignore
+
+        let lateWork = modelBuilder.Entity<BillingPeriodLateWorkEntity>()
+
+        lateWork.ToTable(
+            "BillingPeriodLateWork",
+            "ops",
+            fun (table: TableBuilder<BillingPeriodLateWorkEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodLateWork_Identity",
+                    "[BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [UsageFactId] <> '00000000-0000-0000-0000-000000000000'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodLateWork_State", "[State] = 0")
+                |> ignore
+        )
+        |> ignore
+
+        lateWork
+            .HasKey([| "BillingPeriodId"; "UsageFactId" |])
+            .HasName("PK_ops_BillingPeriodLateWork")
+        |> ignore
+
+        for name in [ "BillingPeriodId"; "UsageFactId" ] do
+            lateWork
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .ValueGeneratedNever()
+                .IsRequired()
+            |> ignore
+
+        lateWork
+            .Property<int>("State")
+            .HasColumnType("int")
+            .HasDefaultValue(0)
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriodLateWork_CreatedAtUtc")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .HasIndex([| "UsageFactId" |])
+            .HasDatabaseName("IX_ops_BillingPeriodLateWork_UsageFact")
+        |> ignore
+
+        lateWork
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        lateWork
+            .HasOne<RawUsageFactEntity>()
+            .WithMany()
+            .HasForeignKey("UsageFactId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_RawUsageFact")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodLateWorkModel.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodLateWorkModel.fs
@@ -43,7 +43,7 @@ module OperationsBillingPeriodLateWorkModel =
         lateWork
             .Property<int>("State")
             .HasColumnType("int")
-            .HasDefaultValue(0)
+            .HasDefaultValue(0, "DF_ops_BillingPeriodLateWork_State")
             .IsRequired()
         |> ignore
 

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodLateWorkModel.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriodLateWorkModel.fs
@@ -1,0 +1,76 @@
+namespace Grace.Operations.Data
+
+open Microsoft.EntityFrameworkCore
+open Microsoft.EntityFrameworkCore.Metadata.Builders
+open System
+
+/// Configures the minimal durable post-close accepted-fact handoff without correction processing.
+[<RequireQualifiedAccess>]
+module OperationsBillingPeriodLateWorkModel =
+
+    /// Adds the Pending late-work handoff keyed by the exact closed period and accepted raw fact.
+    let configure (modelBuilder: ModelBuilder) =
+        let lateWork = modelBuilder.Entity<BillingPeriodLateWorkEntity>()
+
+        lateWork.ToTable(
+            "BillingPeriodLateWork",
+            OperationsUsageSql.SchemaName,
+            fun (table: TableBuilder<BillingPeriodLateWorkEntity>) ->
+                table.HasCheckConstraint(
+                    "CK_ops_BillingPeriodLateWork_Identity",
+                    "[BillingPeriodId] <> '00000000-0000-0000-0000-000000000000' AND [UsageFactId] <> '00000000-0000-0000-0000-000000000000'"
+                )
+                |> ignore
+
+                table.HasCheckConstraint("CK_ops_BillingPeriodLateWork_State", "[State] = 0")
+                |> ignore
+        )
+        |> ignore
+
+        lateWork
+            .HasKey([| "BillingPeriodId"; "UsageFactId" |])
+            .HasName("PK_ops_BillingPeriodLateWork")
+        |> ignore
+
+        for name in [ "BillingPeriodId"; "UsageFactId" ] do
+            lateWork
+                .Property<Guid>(name)
+                .HasColumnType("uniqueidentifier")
+                .ValueGeneratedNever()
+                .IsRequired()
+            |> ignore
+
+        lateWork
+            .Property<int>("State")
+            .HasColumnType("int")
+            .HasDefaultValue(0)
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .Property<DateTime>("CreatedAtUtc")
+            .HasColumnType("datetime2(7)")
+            .HasDefaultValueSql("SYSUTCDATETIME()", "DF_ops_BillingPeriodLateWork_CreatedAtUtc")
+            .IsRequired()
+        |> ignore
+
+        lateWork
+            .HasIndex([| "UsageFactId" |])
+            .HasDatabaseName("IX_ops_BillingPeriodLateWork_UsageFact")
+        |> ignore
+
+        lateWork
+            .HasOne<BillingPeriodEntity>()
+            .WithMany()
+            .HasForeignKey("BillingPeriodId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_BillingPeriod")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore
+
+        lateWork
+            .HasOne<RawUsageFactEntity>()
+            .WithMany()
+            .HasForeignKey("UsageFactId")
+            .HasConstraintName("FK_ops_BillingPeriodLateWork_RawUsageFact")
+            .OnDelete(DeleteBehavior.Restrict)
+        |> ignore

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -702,6 +702,9 @@ type IOperationsUsageTransaction =
     /// Adds the accepted raw fact quantity to the derived minute aggregate.
     abstract AddToUsageAggregateMinuteAsync: aggregate: UsageAggregateMinute * cancellationToken: CancellationToken -> Task
 
+    /// Stages one Pending handoff when a newly inserted fact belongs to an already closed exact period.
+    abstract RecordClosedPeriodLateWorkAsync: rawFact: RawUsageFact * scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task
+
     /// Records the canonical scoped rejection unless accepted durable usage has already won.
     abstract RecordScopedUsageFactRejectionAsync: rejection: UsageFactRejection * cancellationToken: CancellationToken -> Task<UsageFactRejection option>
 
@@ -810,6 +813,36 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
         addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
         addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
 
+    /// Inserts the minimal late-work row only for the closed period in the already locked exact scope.
+    let recordClosedPeriodLateWorkAsync (rawFact: RawUsageFact) (scope: BillingCompletenessScope) cancellationToken =
+        task {
+            use command =
+                createCommand
+                    """
+INSERT INTO ops.BillingPeriodLateWork (BillingPeriodId, UsageFactId, State)
+SELECT period.BillingPeriodId, @UsageFactId, 0
+FROM ops.BillingPeriod AS period WITH (UPDLOCK, HOLDLOCK)
+WHERE period.OwnerId = @OwnerId
+  AND period.OrganizationId = @OrganizationId
+  AND period.RepositoryId = @RepositoryId
+  AND period.MonthStartUtc = @MonthStartUtc
+  AND period.NextMonthStartUtc = @NextMonthStartUtc
+  AND period.State = 2
+  AND NOT EXISTS
+  (
+      SELECT 1
+      FROM ops.BillingPeriodLateWork AS existing
+      WHERE existing.BillingPeriodId = period.BillingPeriodId
+        AND existing.UsageFactId = @UsageFactId
+  );
+"""
+
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+            addBillingCompletenessScopeParameters command scope
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
     /// Acquires the shared transaction-owned SQL lock after rejecting malformed scope input.
     let acquireBillingCompletenessScopeAsync (scope: BillingCompletenessScope) cancellationToken =
         task {
@@ -889,6 +922,8 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
                 let! _ = command.ExecuteNonQueryAsync cancellationToken
                 return ()
             }
+
+        member _.RecordClosedPeriodLateWorkAsync(rawFact, scope, cancellationToken) = recordClosedPeriodLateWorkAsync rawFact scope cancellationToken
 
         member _.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken) =
             task {
@@ -1816,6 +1851,7 @@ type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
 
                         if accepted then
                             do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
+                            do! transaction.RecordClosedPeriodLateWorkAsync(plan.RawFact, scope, operationCancellationToken)
 
                             return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
                         else
@@ -1844,6 +1880,7 @@ type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
 
                             if accepted then
                                 do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
+                                do! transaction.RecordClosedPeriodLateWorkAsync(plan.RawFact, scope, operationCancellationToken)
 
                                 return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
                             else

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -816,26 +816,7 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
     /// Inserts the minimal late-work row only for the closed period in the already locked exact scope.
     let recordClosedPeriodLateWorkAsync (rawFact: RawUsageFact) (scope: BillingCompletenessScope) cancellationToken =
         task {
-            use command =
-                createCommand
-                    """
-INSERT INTO ops.BillingPeriodLateWork (BillingPeriodId, UsageFactId, State)
-SELECT period.BillingPeriodId, @UsageFactId, 0
-FROM ops.BillingPeriod AS period WITH (UPDLOCK, HOLDLOCK)
-WHERE period.OwnerId = @OwnerId
-  AND period.OrganizationId = @OrganizationId
-  AND period.RepositoryId = @RepositoryId
-  AND period.MonthStartUtc = @MonthStartUtc
-  AND period.NextMonthStartUtc = @NextMonthStartUtc
-  AND period.State = 2
-  AND NOT EXISTS
-  (
-      SELECT 1
-      FROM ops.BillingPeriodLateWork AS existing
-      WHERE existing.BillingPeriodId = period.BillingPeriodId
-        AND existing.UsageFactId = @UsageFactId
-  );
-"""
+            use command = createCommand OperationsUsageSql.RecordClosedPeriodLateWork
 
             addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
             addBillingCompletenessScopeParameters command scope

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsDbContext.fs
@@ -795,6 +795,7 @@ module OperationsModel =
 
         OperationsChargePreviewModel.configure modelBuilder
         OperationsBillingPeriodModel.configure modelBuilder
+        OperationsBillingPeriodLateWorkModel.configure modelBuilder
 
 /// Owns the EF Core model for Grace Operations SQL Server schema evolution.
 type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
@@ -835,6 +836,10 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     /// Provides EF access to provisional charge-preview lines.
     [<DefaultValue>]
     val mutable private chargePreviewLines: DbSet<ChargePreviewLineEntity>
+
+    /// Provides EF access to the pending post-close fact handoffs.
+    [<DefaultValue>]
+    val mutable private billingPeriodLateWork: DbSet<BillingPeriodLateWorkEntity>
 
     /// Provides the EF set for immutable usage fact rows.
     member this.RawUsageFacts
@@ -880,6 +885,11 @@ type OperationsDbContext(options: DbContextOptions<OperationsDbContext>) =
     member this.ChargePreviewLines
         with get () = this.chargePreviewLines
         and set value = this.chargePreviewLines <- value
+
+    /// Provides the EF set for Pending post-close accepted-fact handoffs.
+    member this.BillingPeriodLateWork
+        with get () = this.billingPeriodLateWork
+        and set value = this.billingPeriodLateWork <- value
 
     /// Configures the Operations SQL Server schema shape that migrations must preserve.
     override _.OnModelCreating(modelBuilder: ModelBuilder) = OperationsModel.configure modelBuilder

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsEntities.fs
@@ -410,3 +410,19 @@ type BillingPeriodCloseEvidenceEntity() =
     member val PricingPreviewDigestSha256Hex = String.Empty with get, set
     member val ClosedAtUtc = DateTime.MinValue with get, set
     member val ScheduledOperationProvenance = String.Empty with get, set
+
+/// Represents one unprocessed accepted fact that arrived after its exact billing period closed.
+[<AllowNullLiteral>]
+type BillingPeriodLateWorkEntity() =
+
+    /// Identifies the already closed period that owns the later correction decision.
+    member val BillingPeriodId = Guid.Empty with get, set
+
+    /// Identifies the newly accepted raw fact without copying its payload.
+    member val UsageFactId = Guid.Empty with get, set
+
+    /// Stores the only handoff state supported by this leaf: Pending.
+    member val State = 0 with get, set
+
+    /// Stores the SQL-created UTC timestamp for the durable handoff.
+    member val CreatedAtUtc = DateTime.MinValue with get, set

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -54,18 +54,18 @@ type UsageFactJournalRejectResult =
     | RejectJournalConflict
     | RejectAlreadyAccepted
 
-/// Pauses a ProcessAsync transaction only after its raw and aggregate mutations have been staged for deterministic rollback proof.
+/// Pauses a ProcessAsync transaction only after raw, aggregate, and any closed-period late-work mutations have been staged for deterministic rollback proof.
 type internal IOperationsUsageJournalTransactionInterleaving =
 
     /// Observes the transaction-local point immediately before journal acceptance can commit.
-    abstract AfterRawAndAggregateStagedAsync: cancellationToken: CancellationToken -> Task
+    abstract AfterAcceptedFactMutationsStagedAsync: cancellationToken: CancellationToken -> Task
 
 /// Leaves production journal transactions uninterrupted when no deterministic proof interleaving is supplied.
 type private NoOperationsUsageJournalTransactionInterleaving() =
 
     interface IOperationsUsageJournalTransactionInterleaving with
 
-        member _.AfterRawAndAggregateStagedAsync(_cancellationToken) = Task.CompletedTask
+        member _.AfterAcceptedFactMutationsStagedAsync(_cancellationToken) = Task.CompletedTask
 
 /// Owns the internal Operations append, dispatch scan, and transactionally verified journal processing seam.
 type IOperationsUsageJournalStore =
@@ -153,6 +153,14 @@ type SqlOperationsUsageJournalStore private (connectionString: string, transacti
     let scopeFor (rawFact: RawUsageFact) : BillingCompletenessScope =
         BillingCompletenessScope.tryCreate rawFact.OwnerId rawFact.OrganizationId rawFact.RepositoryId rawFact.ObservedAt
         |> Result.defaultWith (fun errors -> invalidOp (String.Join("; ", errors)))
+
+    /// Adds the exact owner, organization, repository, and UTC-month scope required by shared late-work staging SQL.
+    let addBillingCompletenessScopeParameters (command: SqlCommand) (scope: BillingCompletenessScope) =
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier scope.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier scope.RepositoryId
+        addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
+        addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
 
     /// Reads a full journal row while an append or worker transaction keeps update locks on its identity.
     let readJournalForUpdateAsync (connection: SqlConnection) (transaction: SqlTransaction) (usageFactId: UsageFactId) (cancellationToken: CancellationToken) =
@@ -246,6 +254,22 @@ VALUES
             addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength aggregate.Key.StoragePoolId
             addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (toUtcDateTime aggregate.Key.BucketStart)
             addParameter command "@Quantity" SqlDbType.BigInt aggregate.Quantity
+            let! _ = command.ExecuteNonQueryAsync cancellationToken
+            return ()
+        }
+
+    /// Stages late work through the same exact-period SQL command used by ordinary and archived acceptance.
+    let recordClosedPeriodLateWorkAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (rawFact: RawUsageFact)
+        (scope: BillingCompletenessScope)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use command = createCommand connection transaction OperationsUsageSql.RecordClosedPeriodLateWork
+            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+            addBillingCompletenessScopeParameters command scope
             let! _ = command.ExecuteNonQueryAsync cancellationToken
             return ()
         }
@@ -514,8 +538,9 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
 
                                     if inserted then
                                         do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
+                                        do! recordClosedPeriodLateWorkAsync connection transaction plan.RawFact scope operationCancellationToken
 
-                                    do! transactionInterleaving.AfterRawAndAggregateStagedAsync(operationCancellationToken)
+                                    do! transactionInterleaving.AfterAcceptedFactMutationsStagedAsync(operationCancellationToken)
                                     do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
                                     do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
                                     return AcceptedFromJournal
@@ -547,6 +572,7 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
 
                                     if inserted then
                                         do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
+                                        do! recordClosedPeriodLateWorkAsync connection transaction plan.RawFact scope operationCancellationToken
 
                                     do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
                                     do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageSql.fs
@@ -250,6 +250,28 @@ WHERE NOT EXISTS
 );
 """
 
+    /// Stages the minimal Pending late-work handoff only for a newly accepted fact in the exact closed billing period.
+    [<Literal>]
+    let RecordClosedPeriodLateWork =
+        """
+INSERT INTO ops.BillingPeriodLateWork (BillingPeriodId, UsageFactId, State)
+SELECT period.BillingPeriodId, @UsageFactId, 0
+FROM ops.BillingPeriod AS period WITH (UPDLOCK, HOLDLOCK)
+WHERE period.OwnerId = @OwnerId
+  AND period.OrganizationId = @OrganizationId
+  AND period.RepositoryId = @RepositoryId
+  AND period.MonthStartUtc = @MonthStartUtc
+  AND period.NextMonthStartUtc = @NextMonthStartUtc
+  AND period.State = 2
+  AND NOT EXISTS
+  (
+      SELECT 1
+      FROM ops.BillingPeriodLateWork AS existing
+      WHERE existing.BillingPeriodId = period.BillingPeriodId
+        AND existing.UsageFactId = @UsageFactId
+  );
+"""
+
     /// Selects hot facts and partially verified facts that need archive processing or cleanup.
     [<Literal>]
     let SelectRawUsageFactsForArchive =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -81,12 +81,12 @@ type private ObservedOperationsUsageTransactionScope
                 cancellationToken
             )
 
-/// Pauses a real ProcessAsync transaction after raw and aggregate SQL writes have been staged, then lets cancellation abort it.
+/// Pauses a real ProcessAsync transaction after all accepted-fact SQL writes have been staged, then lets cancellation abort it.
 type private CancellationAfterJournalStageInterleaving() =
     let staged = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
     let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
 
-    /// Completes only after the transaction owns staged raw and aggregate mutations.
+    /// Completes only after the transaction owns staged accepted-fact mutations.
     member _.Staged = staged.Task
 
     /// Releases a non-cancelled test path without retaining any durable state.
@@ -94,7 +94,7 @@ type private CancellationAfterJournalStageInterleaving() =
 
     interface IOperationsUsageJournalTransactionInterleaving with
 
-        member _.AfterRawAndAggregateStagedAsync(cancellationToken) =
+        member _.AfterAcceptedFactMutationsStagedAsync(cancellationToken) =
             task {
                 staged.TrySetResult(()) |> ignore
                 do! release.Task.WaitAsync(cancellationToken)
@@ -902,6 +902,19 @@ VALUES
                 let acceptedFirstB = fact factIdAcceptedFirst ownerId organizationId repositoryBId observedAt
                 let scopeA = scopeFor ownerId organizationId repositoryAId observedAt
                 let scopeB = scopeFor ownerId organizationId repositoryBId observedAt
+                let billingPeriodAId = Guid.NewGuid()
+                let billingPeriodBId = Guid.NewGuid()
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        $"""
+INSERT INTO ops.BillingPeriod
+    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
+VALUES
+    ('{billingPeriodAId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryAId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2),
+    ('{billingPeriodBId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryBId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
+"""
 
                 let! accepted = store.StoreUsageFactAsync(acceptedFirstA, payloadFor acceptedFirstA, CancellationToken.None)
 
@@ -967,10 +980,22 @@ VALUES
                         connectionString
                         $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{factIdAcceptedFirst:D}' AND IsActive = 1;"
 
+                let! lateWorkAAfterConflicts =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodAId:D}' AND UsageFactId = '{factIdAcceptedFirst:D}';"
+
+                let! lateWorkBAfterConflicts =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodBId:D}' AND UsageFactId = '{factIdAcceptedFirst:D}';"
+
                 Assert.Multiple(
                     Action (fun () ->
                         Assert.That(acceptedFirstRawCount, Is.EqualTo(1))
-                        Assert.That(acceptedFirstBlockerCount, Is.EqualTo(1)))
+                        Assert.That(acceptedFirstBlockerCount, Is.EqualTo(1))
+                        Assert.That(lateWorkAAfterConflicts, Is.EqualTo(1))
+                        Assert.That(lateWorkBAfterConflicts, Is.Zero))
                 )
 
                 let factIdRejectedFirst = Guid.NewGuid()
@@ -1575,6 +1600,72 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         Assert.That(completeAfterRepair, Is.EqualTo(Complete))
                         Assert.That(activeRejectionCount, Is.Zero)
                         Assert.That(acceptedJournalCount, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves journal processing and explicit repair stage one Pending handoff only after each newly inserted raw fact enters a closed exact period.
+    [<Test>]
+    member _.JournalProcessingAndRepairStageLateWorkOnlyForNewRawFactsInClosedPeriods() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 7, 15, 12, 0)
+                let billingPeriodId = Guid.NewGuid()
+                let processedFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let repairedFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        $"""
+INSERT INTO ops.BillingPeriod
+    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
+VALUES
+    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-07-01T00:00:00', '2026-08-01T00:00:00', 2);
+"""
+
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let! appendedProcessed = journal.AppendAsync(processedFact, CancellationToken.None)
+                let! processed = journal.ProcessAsync(processedFact, payloadFor processedFact, CancellationToken.None)
+                let! replayed = journal.ProcessAsync(processedFact, payloadFor processedFact, CancellationToken.None)
+                let! appendedRepaired = journal.AppendAsync(repairedFact, CancellationToken.None)
+
+                let! rejected = journal.RejectAsync(repairedFact, payloadFor repairedFact, "deterministic repair proof", CancellationToken.None)
+
+                let! repaired = journal.RepairAsync(repairedFact, CancellationToken.None)
+
+                let! processedLateWork =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{processedFact.UsageFactId:D}';"
+
+                let! repairedLateWork =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{repairedFact.UsageFactId:D}';"
+
+                let! totalLateWork =
+                    executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}';"
+
+                match appendedProcessed with
+                | Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append result: {appendedProcessed}.")
+
+                match appendedRepaired with
+                | Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append result: {appendedRepaired}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(processed, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(replayed, Is.EqualTo(AlreadyAccepted))
+                        Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                        Assert.That(repaired, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(processedLateWork, Is.EqualTo(1))
+                        Assert.That(repairedLateWork, Is.EqualTo(1))
+                        Assert.That(totalLateWork, Is.EqualTo(2)))
                 )
             })
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -47,6 +47,8 @@ type private ObservedOperationsUsageTransaction
                 do! afterUsageAggregateAsync aggregate cancellationToken
             }
 
+        member _.RecordClosedPeriodLateWorkAsync(rawFact, scope, cancellationToken) = inner.RecordClosedPeriodLateWorkAsync(rawFact, scope, cancellationToken)
+
         member _.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken) = inner.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken)
 
         member _.RecordUnscopedUsageFactRejectionAsync(rejection, cancellationToken) = inner.RecordUnscopedUsageFactRejectionAsync(rejection, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -365,13 +365,19 @@ module private BillingCloseSchema =
 
                 entity.GetProperties()
                 |> Seq.choose (fun property ->
-                    let definition = property.GetDefaultValueSql()
+                    let definition =
+                        match property.GetDefaultValueSql() with
+                        | value when not (String.IsNullOrWhiteSpace value) -> Some(normalizeDefinition value)
+                        | _ ->
+                            match property.FindAnnotation(RelationalAnnotationNames.DefaultValue) with
+                            | null -> None
+                            | annotation when isNull annotation.Value -> None
+                            | annotation -> Some(Convert.ToString(annotation.Value, Globalization.CultureInfo.InvariantCulture))
 
-                    if String.IsNullOrWhiteSpace definition then
-                        None
-                    else
+                    definition
+                    |> Option.map (fun value ->
                         let storeObject = StoreObjectIdentifier.Table(tableName, entity.GetSchema())
-                        Some $"{table}|{property.GetColumnName(&storeObject)}|{property.GetDefaultConstraintName()}|{normalizeDefinition definition}"))
+                        $"{table}|{property.GetColumnName(&storeObject)}|{property.GetDefaultConstraintName()}|{value}")))
             |> Set.ofSeq
 
         let triggers =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodClose.Tests.fs
@@ -41,7 +41,8 @@ module private BillingCloseSchema =
     let private tables =
         Set.ofList [ "ops.BillingPeriod"
                      "ops.Charge"
-                     "ops.BillingPeriodCloseEvidence" ]
+                     "ops.BillingPeriodCloseEvidence"
+                     "ops.BillingPeriodLateWork" ]
 
     /// Names the schema-qualified tables frozen before this migration and excluded from its live catalog remainder.
     let private priorTables =
@@ -683,6 +684,7 @@ SELECT CONCAT('BillingPeriod|',(SELECT * FROM ops.BillingPeriod ORDER BY Billing
 UNION ALL SELECT CONCAT('ChargePreviewLine|',(SELECT * FROM ops.ChargePreviewLine ORDER BY ChargePreviewLineId FOR JSON PATH, INCLUDE_NULL_VALUES))
 UNION ALL SELECT CONCAT('Charge|',(SELECT * FROM ops.Charge ORDER BY ChargeId FOR JSON PATH, INCLUDE_NULL_VALUES))
 UNION ALL SELECT CONCAT('BillingPeriodCloseEvidence|',(SELECT * FROM ops.BillingPeriodCloseEvidence ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodLateWork|',(SELECT * FROM ops.BillingPeriodLateWork ORDER BY BillingPeriodId,UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
 ORDER BY 1;
 """
 
@@ -734,6 +736,10 @@ DECLARE @CurrencyPeriodId uniqueidentifier='33333333-3333-3333-3333-333333333333
 INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (@CurrencyPeriodId,NEWID(),NEWID(),NEWID(),'2026-08-01','2026-09-01',0);
 INSERT ops.ChargePreviewLine (ChargePreviewLineId,OwnerId,OrganizationId,RepositoryId,PeriodFromUtc,PeriodToUtc,FactKind,BillableUsageKindMappingId,BillableUsageKind,PricingAssignmentId,PricingPlanId,PricingRateId,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc,TotalQuantity,ChargeMicros) VALUES (@CurrencyLineId,NEWID(),NEWID(),NEWID(),'2026-08-01','2026-09-01',1,NEWID(),1,NEWID(),NEWID(),NEWID(),'USD','unit',1,1,'2026-08-01','2026-09-01',1,1);
 INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES ('44444444-4444-4444-4444-444444444444',NEWID(),NEWID(),NEWID(),'2026-09-01','2026-10-01',0),('55555555-5555-5555-5555-555555555555',NEWID(),NEWID(),NEWID(),'2026-10-01','2026-11-01',0);
+DECLARE @LatePeriodId uniqueidentifier='66666666-6666-6666-6666-666666666666', @LateFactId uniqueidentifier='dddddddd-dddd-dddd-dddd-dddddddddddd';
+INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,MonthStartUtc,NextMonthStartUtc,State) VALUES (@LatePeriodId,NEWID(),NEWID(),NEWID(),'2026-11-01','2026-12-01',2);
+INSERT ops.RawUsageFact (UsageFactId,RawPayload,CorrelationId,FactKind,OwnerId,OrganizationId,RepositoryId,StoragePoolId,Quantity,ObservedAtUtc,ArchiveState) VALUES (@LateFactId,0x01,'late-work-fixture',1,NEWID(),NEWID(),NEWID(),'pool',1,'2026-11-01',0);
+INSERT ops.BillingPeriodLateWork (BillingPeriodId,UsageFactId,State) VALUES (@LatePeriodId,@LateFactId,0);
 """
 
     /// Proves the one SQL Server diagnostic rendering normalizes without erasing quoted check-literal data.
@@ -815,6 +821,26 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
         let drift = BillingCloseSchema.compare runtime incomplete false
         Assert.That(drift, Is.Not.Empty)
 
+    /// Proves runtime, frozen target, and independently declared snapshot agree before the disposable SQL gate runs.
+    [<Test>]
+    member _.RuntimeTargetAndIndependentSnapshotAgreeForLateWork() =
+        use context = OperationsDbContextFactory.create "Server=(localdb)\\MSSQLLocalDB;Database=GraceOperationsBillingLateWorkModel;Integrated Security=true;"
+
+        let runtime =
+            context.GetService<IDesignTimeModel>().Model
+            |> BillingCloseSchema.fromModel
+
+        let target =
+            AddBillingPeriodLateWork().TargetModel
+            |> BillingCloseSchema.fromModel
+
+        let snapshot =
+            OperationsDbContextModelSnapshot().Model
+            |> BillingCloseSchema.fromModel
+
+        assertNoDrift "runtime-target" (BillingCloseSchema.compare runtime target true)
+        assertNoDrift "runtime-snapshot" (BillingCloseSchema.compare runtime snapshot true)
+
     /// Compares runtime, independently frozen migration target, independently declared snapshot, and migrated SQL catalog exactly.
     [<Test>]
     member _.RuntimeTargetSnapshotAndLiveSqlPhysicalSchemasAgreeExactly() =
@@ -830,7 +856,7 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
                     |> BillingCloseSchema.fromModelWithDatabaseDefault databaseDefaultCollation
 
                 let target =
-                    AddBillingPeriodClose().TargetModel
+                    AddBillingPeriodLateWork().TargetModel
                     |> BillingCloseSchema.fromModelWithDatabaseDefault databaseDefaultCollation
 
                 let snapshot =
@@ -975,7 +1001,7 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
         let source = IO.File.ReadAllText sourcePath
         Assert.That(source, Does.Not.Contain("BillingPeriodCloseFrozenTarget.apply"))
 
-    /// Exercises every #916 check, identity, foreign-key, and immutable-trigger rejection against one migrated SQL database.
+    /// Exercises every close and late-work physical rejection while preserving a complete valid durable snapshot.
     [<Test>]
     member _.LivePhysicalRejectionMatrixRejectsEighteenNamedInvalidStatementsAndAllowsValidRows() =
         withDatabaseAsync (fun connectionString ->
@@ -1016,9 +1042,17 @@ INSERT ops.BillingPeriod (BillingPeriodId,OwnerId,OrganizationId,RepositoryId,Mo
                         "charge delete", "DELETE FROM ops.Charge;"
                         "evidence update", "UPDATE ops.BillingPeriodCloseEvidence SET ScheduledOperationProvenance='tampered';"
                         "evidence delete", "DELETE FROM ops.BillingPeriodCloseEvidence;"
+                        "late work duplicate",
+                        "INSERT ops.BillingPeriodLateWork (BillingPeriodId,UsageFactId,State) VALUES ('66666666-6666-6666-6666-666666666666','dddddddd-dddd-dddd-dddd-dddddddddddd',0);"
+                        "late work period foreign key",
+                        "INSERT ops.BillingPeriodLateWork (BillingPeriodId,UsageFactId,State) VALUES (NEWID(),'dddddddd-dddd-dddd-dddd-dddddddddddd',0);"
+                        "late work raw fact foreign key",
+                        "INSERT ops.BillingPeriodLateWork (BillingPeriodId,UsageFactId,State) VALUES ('66666666-6666-6666-6666-666666666666',NEWID(),0);"
+                        "late work state",
+                        "INSERT ops.BillingPeriodLateWork (BillingPeriodId,UsageFactId,State) VALUES ('66666666-6666-6666-6666-666666666666','dddddddd-dddd-dddd-dddd-dddddddddddd',1);"
                     ]
 
-                Assert.That(cases.Length, Is.EqualTo(18), "The physical rejection matrix must retain every named #916 case.")
+                Assert.That(cases.Length, Is.EqualTo(22), "The physical rejection matrix must retain every named close and late-work case.")
 
                 for label, sql in cases do
                     do! rejectAndPreserveAsync connectionString label sql

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -114,6 +114,23 @@ type private StageCancellationInterleaving(stage: string, cancellation: Cancella
         member _.AfterChargeInsertionAsync _ = cancelAt "charge"
         member _.AfterCloseEvidenceStagedAsync _ = cancelAt "evidence"
 
+/// Pauses journal acceptance after late-work staging so a real cancelled token can prove the entire transaction rolls back.
+type private CancellationAfterJournalLateWorkInterleaving() =
+    let staged = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+    /// Completes only after the production transaction has staged its raw, aggregate, and late-work mutations.
+    member _.Staged = staged.Task
+
+    interface IOperationsUsageJournalTransactionInterleaving with
+
+        member _.AfterAcceptedFactMutationsStagedAsync(cancellationToken) =
+            task {
+                staged.TrySetResult() |> ignore
+                do! release.Task.WaitAsync(cancellationToken)
+            }
+            :> Task
+
 /// Retains the exact pricing identities and immutable values inserted for one close-proof scope.
 type private SeededPricing =
     {
@@ -696,6 +713,40 @@ ORDER BY 1;
             return rows |> Seq.toList
         }
 
+    /// Reads the full durable close and acceptance projection so cancellation can prove no staged mutation survives.
+    let closeAndAcceptanceProjectionAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+SELECT CONCAT('BillingPeriod|',(SELECT * FROM ops.BillingPeriod ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('ChargePreviewLine|',(SELECT * FROM ops.ChargePreviewLine ORDER BY ChargePreviewLineId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('Charge|',(SELECT * FROM ops.Charge ORDER BY ChargeId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodCloseEvidence|',(SELECT * FROM ops.BillingPeriodCloseEvidence ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('RawUsageFact|',(SELECT * FROM ops.RawUsageFact ORDER BY UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('UsageAggregateMinute|',(SELECT * FROM ops.UsageAggregateMinute ORDER BY OwnerId,OrganizationId,RepositoryId,StoragePoolId,BucketStartUtc FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('UsageFactRejection|',(SELECT * FROM ops.UsageFactRejection ORDER BY RejectionId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('UsageFactJournal|',(SELECT * FROM ops.UsageFactJournal ORDER BY UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodLateWork|',(SELECT * FROM ops.BillingPeriodLateWork ORDER BY BillingPeriodId,UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
+ORDER BY 1;
+"""
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let rows = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then rows.Add(reader.GetString 0)
+
+            return rows |> Seq.toList
+        }
+
     /// Recomputes the fact-evidence digest from independent persisted raw facts.
     let acceptedFactDigestAsync connectionString (scope: BillingCompletenessScope) =
         task {
@@ -997,6 +1048,116 @@ ORDER BY 1;
 
                         Assert.That(persisted.ClosedAtUtc, Is.GreaterThanOrEqualTo(beforeClose))
                         Assert.That(persisted.ClosedAtUtc, Is.LessThanOrEqualTo(afterClose)))
+                )
+            })
+
+    /// Proves acceptance committed before the production closer is included in its initial close without creating late work.
+    [<Test>]
+    member _.AcceptanceBeforeCloseIsIncludedWithoutLateWork() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let usageFactId = Guid.NewGuid()
+                let acceptedFact = usageFact usageFactId ownerId organizationId repositoryId (scope.MonthStart + Duration.FromDays 1) 13L
+                do! acceptFactAsync connectionString acceptedFact
+                let! pricing = addPricingAsync connectionString scope
+                let provenance = "operations-tests/acceptance-before-close/v1"
+                let expected = seededCloseExpectation scope usageFactId acceptedFact.ObservedAt 13L pricing provenance
+                let request = { Scope = scope; ScheduledOperationProvenance = provenance }
+
+                let! closeResult =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! factCount, factQuantity = acceptedScopeFactSummaryAsync connectionString scope
+                let! projections = readClosedScopeProjectionAsync connectionString scope
+                let! lateWork = countAsync connectionString $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE UsageFactId = '{usageFactId:D}';"
+                assertSeededScopeClose "acceptance-before-close" expected 13L factCount factQuantity projections
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match closeResult with
+                             | BillingPeriodCloseResult.Closed (_, 1) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(lateWork, Is.Zero))
+                )
+            })
+
+    /// Proves cancellation after real post-close late-work staging leaves every close and acceptance row byte-for-byte unchanged.
+    [<Test>]
+    member _.CancellationAfterPostCloseLateWorkStagingRollsBackTheWholeAcceptanceTransaction() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId, organizationId, repositoryId = Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()
+                let scope = scopeFor ownerId organizationId repositoryId
+                let includedFact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (scope.MonthStart + Duration.FromDays 1) 17L
+                do! acceptFactAsync connectionString includedFact
+                let! _ = addPricingAsync connectionString scope
+                let closeRequest = { Scope = scope; ScheduledOperationProvenance = "operations-tests/cancel-late-work/v1" }
+
+                let! closeResult =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(closeRequest, CancellationToken.None)
+
+                Assert.That(
+                    (match closeResult with
+                     | BillingPeriodCloseResult.Closed (_, 1) -> true
+                     | _ -> false),
+                    Is.True
+                )
+
+                let lateFact = usageFact (Guid.NewGuid()) ownerId organizationId repositoryId (scope.MonthStart + Duration.FromDays 2) 19L
+                let interleaving = CancellationAfterJournalLateWorkInterleaving()
+                let journal = SqlOperationsUsageJournalStore.CreateForTest(connectionString, interleaving :> IOperationsUsageJournalTransactionInterleaving)
+                let! appended = journal.AppendAsync(lateFact, CancellationToken.None)
+
+                match appended with
+                | Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append result: {appended}.")
+
+                let! before = closeAndAcceptanceProjectionAsync connectionString
+                use cancellation = new CancellationTokenSource()
+                let processing = journal.ProcessAsync(lateFact, Array.empty, cancellation.Token)
+                do! interleaving.Staged.WaitAsync CancellationToken.None
+                cancellation.Cancel()
+
+                let! cancelled =
+                    task {
+                        try
+                            let! _ = processing
+                            return false
+                        with
+                        | :? OperationCanceledException -> return true
+                    }
+
+                let! after = closeAndAcceptanceProjectionAsync connectionString
+
+                let! lateRawCount = countAsync connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{lateFact.UsageFactId:D}';"
+
+                let! lateAggregateCount =
+                    countAsync
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND RepositoryId = '{repositoryId:D}' AND BucketStartUtc = '2026-06-03T00:00:00';"
+
+                let! pendingJournalCount =
+                    countAsync connectionString $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{lateFact.UsageFactId:D}' AND State = 0;"
+
+                let! lateWorkCount =
+                    countAsync connectionString $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE UsageFactId = '{lateFact.UsageFactId:D}';"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(cancelled, Is.True)
+                        Assert.That((after = before), Is.True)
+                        Assert.That(lateRawCount, Is.Zero)
+                        Assert.That(lateAggregateCount, Is.Zero)
+                        Assert.That(pendingJournalCount, Is.EqualTo(1))
+                        Assert.That(lateWorkCount, Is.Zero))
                 )
             })
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -149,6 +149,10 @@ type private InMemoryOperationsUsageTransactionScope() =
                                 aggregates[aggregate.Key] <- current + aggregate.Quantity
                                 Task.CompletedTask
 
+                        member _.RecordClosedPeriodLateWorkAsync(_rawFact, _scope, lateWorkCancellationToken) =
+                            lateWorkCancellationToken.ThrowIfCancellationRequested()
+                            Task.CompletedTask
+
                         member _.RecordScopedUsageFactRejectionAsync(_rejection, rejectionCancellationToken) =
                             rejectionCancellationToken.ThrowIfCancellationRequested()
                             Task.FromResult(None)


### PR DESCRIPTION
# Preserve post-close accepted usage as isolated late work

## Purpose

Ensure a valid fact accepted after its exact billing period closes is never discarded, while keeping correction
processing and pricing out of this leaf.

Related to #918. Parent replacement packet: #908. Epic chain: #554 -> #560 -> #576 -> #864.

## Current checkpoint

- Adds minimal `BillingPeriodLateWork` persistence keyed by period and usage fact, with Pending-only state, database
  creation time, and restrictive period/raw-fact foreign keys.
- Adds runtime configuration, one literal migration with complete frozen target, and an independently declared snapshot.
- Stages late work inside the shared accepted-fact transaction only after a new raw fact is inserted, covering ordinary
  storage and archived replay through their shared implementation.
- Copies no usage payload and introduces no correction-processing lifecycle.

## Boundaries

- No correction claiming, pricing, posting, retry, completion, manual adjustment, settlement, hosted discovery, or
  public surface.
- No second journal, payload copy, direct actor-to-SQL coupling, compatibility path, or wholesale PR #911 reuse.

## Review status

- Implementation/fix workers started: **1** under epic #554's 4+1 policy.
- Head `93c32333` is a coherent schema/transaction-staging checkpoint, not a completion candidate.
- Targeted Fantomas, Operations Data and Tests Release builds, MarkdownLint, and diff checks passed.
- Schema fixture: 6 passed and 2 explicit SQL-environment skips; storage fixture: 26/26 passed.
- Remaining required proof: disposable-SQL four-way parity/live rejection, acceptance-first and close-first interleavings,
  duplicate/replay, two-closed-scope conflict, and cancellation after late-work staging with complete rollback.
- Worker 2 is assigned to complete that finite ledger and repair defects it exposes.
- Worker 3 remains the final normal implementation/proof slot; structural audit is required after worker 3 before any
  worker 4. Worker 4 must be a completion candidate, and worker 5 is only a finite post-candidate review/CI reserve.

## Documentation impact

Internal migration documentation records the Pending-only handoff and its later #865 ownership. No public or generated
contract changed.