### PR TITLE
feat(cache): add one-shot Product V1 enrollment

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,12 @@ jobs:
           global-json-file: global.json
       - name: Restore NuGet packages
         run: dotnet restore "src/Grace.slnx"
+      - name: Install Linux keyring test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes dbus-x11 gnome-keyring libsecret-tools
       - name: Pre-pull Aspire images and build the solution
         shell: bash
         run: |
@@ -91,6 +97,15 @@ jobs:
 
           exit "${pull_failed}"
       - name: Test every solution project through the shared Full profile
+        shell: bash
         env:
           GRACE_TEST_SERVER_CLEANUP: "0"
-        run: pwsh ./scripts/validate.ps1 -Full -SkipFormat -SkipBuild -Configuration Release
+          GRACE_TEST_LINUX_KEYRING: "1"
+        run: |
+          set -euo pipefail
+          dbus-run-session -- bash -c '
+            set -euo pipefail
+            eval "$(printf "grace-ci-keyring-password" | gnome-keyring-daemon --unlock)"
+            eval "$(gnome-keyring-daemon --start --components=secrets)"
+            pwsh ./scripts/validate.ps1 -Full -SkipFormat -SkipBuild -Configuration Release
+          '

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -210,3 +210,16 @@ git diff --check
 
 This completed proof does not claim #914 status, #905 enrollment, R2 liveness, serving, rotation, reconciliation,
 non-Linux support, or CacheStore behavior.
+
+## R1B enrollment implementation scope
+
+Issue #905 adds the bounded one-shot enrollment transition after the completed protected identity and local status
+foundations. Its proof boundary is one parsed repository-independent command, one resolved existing bearer, one
+root-local claim, one staged P-256 identity, one selected-server nonredirecting request, strict response comparison,
+and one same-parent ready publication. It does not change server enrollment semantics, durable registration shapes,
+OpenAPI, generated clients, selection, rotation, liveness, listeners, artifacts, retries, or durable pending state.
+
+The required release evidence includes the normal solution-build claim holder, Linux service-account command proof for
+PAT, M2M, and interactive libsecret credentials, zero-request pre-effect failures, strict acceptance failures, cleanup
+ordering, and redacted shared-renderer output. Windows runs may compile and exercise parser/metadata proof but cannot
+replace the Linux root, D-Bus/GNOME keyring, claim-holder, or protected-filesystem evidence.

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -488,6 +488,40 @@ include cross-repository selection, stale or revoked registration, stale grant, 
 route, incomplete local artifact, and CacheRequired attempted Direct fallback. A successful cache hit alone is not
 proof of a safe cache path.
 
+## R1B enrollment operation
+
+The supported Product V1 enrollment profile is Linux x64 under systemd, using one system-managed service account and
+the fixed protected root `/var/lib/grace-cache`. From an administrator shell for that service account, set the selected
+server URI and use one explicit repository assignment for every repository served by the installation:
+
+```powershell
+$env:GRACE_SERVER_URI = "https://grace.example.test/api"
+grace cache enroll --owner-id <owner-guid> --repository <organization-guid>/<repository-guid> --endpoint <https-endpoint>
+```
+
+```bash
+export GRACE_SERVER_URI="https://grace.example.test/api"
+grace cache enroll --owner-id <owner-guid> --repository <organization-guid>/<repository-guid> --endpoint <https-endpoint>
+```
+
+Repeat `--repository` for additional assignments. Add `--organization-id <organization-guid>` to select the
+Organization boundary. The display name defaults to `Grace Cache`. HTTP endpoints require `--allow-http`; HTTPS does
+not. The command derives `Grace.Cache` and protocol `v1`, and it accepts an absolute server URI and endpoint URI that
+include a path.
+
+The command resolves one existing Grace credential before touching cache state: a valid `GRACE_TOKEN` PAT, complete
+M2M configuration, or the existing interactive credential. `GRACE_TOKEN_FILE` is rejected. After credential success,
+one root-local claim recovers only stale staging, creates one P-256 identity, rechecks it immediately before one
+nonredirecting enrollment request, and publishes ready state only after strict server acceptance and flushed private
+files followed by same-parent atomic rename.
+
+Failures, cancellation, redirects, timeouts, and lost responses never claim success, retry, or reconcile automatically.
+The invocation removes only its own staged attempt on a best-effort basis without hiding the primary error. A server may
+retain an inactive enrollment after an unknown outcome; it is not selected, does not block a fresh manual enrollment,
+and expires under the server lifecycle rule. Reset and re-enrollment remain the explicit operator workflow: revoke the
+server registration, remove the protected local identity as the service account, then invoke `grace cache enroll` again.
+Both success and failure output remain redacted; no private key, bearer, filesystem path, or attempt detail is emitted.
+
 ## 13. Requirements traceability ledger
 
 | ID | Requirement | Status | Likely implementation seam | Proof seam | Planning owner | Residual risk |

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -174,7 +174,7 @@ starting the watcher.
 `doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
 supports `--schema`, `--examples`, and `--select`.
 
-`cache status` and `cache enroll` are JSON-ready and share the same redacted ready-status `ReturnValue` schema.
+`cache status` and `cache enroll` are JSON-ready, support inert `--schema` and `--examples` inspection, and share the same redacted ready-status `ReturnValue` schema.
 `cache status` is repository-independent and reads only protected local Cache identity state. `cache enroll` resolves one
 existing credential before a root-local protected enrollment attempt and sends one selected-server request. Their closed
 `oneOf` schema emits `Class`, `Enrollment`, and `Key` for every state; only an enrolled ready state includes `CacheId`,

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -129,8 +129,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `207`
-- JSON-ready routed commands: `186`
+- Total leaf commands: `208`
+- JSON-ready routed commands: `187`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`
@@ -174,10 +174,12 @@ starting the watcher.
 `doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
 supports `--schema`, `--examples`, and `--select`.
 
-`cache status` is also JSON-ready. It is repository-independent and reads only protected local Cache identity state.
-Its closed `oneOf` schema emits `Class`, `Enrollment`, and `Key` for every state; only an enrolled ready state includes
-`CacheId`, `Endpoint`, `BoundaryKind`, and `RepositoryCount`. The command performs no credential lookup, server request,
-repair, cleanup, or local mutation.
+`cache status` and `cache enroll` are JSON-ready and share the same redacted ready-status `ReturnValue` schema.
+`cache status` is repository-independent and reads only protected local Cache identity state. `cache enroll` resolves one
+existing credential before a root-local protected enrollment attempt and sends one selected-server request. Their closed
+`oneOf` schema emits `Class`, `Enrollment`, and `Key` for every state; only an enrolled ready state includes `CacheId`,
+`Endpoint`, `BoundaryKind`, and `RepositoryCount`. Neither command exposes private key material, bearer credentials,
+filesystem paths, or staging details.
 
 ## Agent Recipes
 

--- a/src/Grace.CLI.CacheEnrollment.ClaimHolder/Grace.CLI.CacheEnrollment.ClaimHolder.fsproj
+++ b/src/Grace.CLI.CacheEnrollment.ClaimHolder/Grace.CLI.CacheEnrollment.ClaimHolder.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="10.1.301" />
+  </ItemGroup>
+</Project>

--- a/src/Grace.CLI.CacheEnrollment.ClaimHolder/Program.fs
+++ b/src/Grace.CLI.CacheEnrollment.ClaimHolder/Program.fs
@@ -1,0 +1,29 @@
+namespace Grace.CLI.CacheEnrollment.ClaimHolder
+
+open Grace.Cache
+open System
+open System.IO
+open System.Threading
+
+/// Hosts a normal-build test process that directly holds one production Cache enrollment claim until it is terminated.
+module Program =
+    /// Runs the direct claim holder with its protected root and a signal file used by focused process proof.
+    [<EntryPoint>]
+    let main arguments =
+        match arguments with
+        | [| root; signalPath |] ->
+            match CacheIdentity.tryAcquireEnrollmentClaim root with
+            | Error error ->
+                Console.Error.WriteLine($"Could not acquire Cache enrollment claim: {error}")
+                2
+            | Ok claim ->
+                try
+                    File.WriteAllText(signalPath, "held")
+                    use lifetime = new ManualResetEventSlim(false)
+                    lifetime.Wait()
+                    0
+                finally
+                    CacheIdentity.releaseEnrollmentClaim claim
+        | _ ->
+            Console.Error.WriteLine("Usage: Grace.CLI.CacheEnrollment.ClaimHolder <state-root> <held-signal-path>")
+            64

--- a/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
@@ -4,7 +4,7 @@ open FsUnit
 open Grace.CLI
 open NUnit.Framework
 
-/// Groups pure parser coverage for the repository-independent Cache status command.
+/// Groups pure parser coverage for repository-independent Cache commands.
 [<Parallelizable(ParallelScope.All)>]
 module CacheCliParsingTests =
 
@@ -25,3 +25,24 @@ module CacheCliParsingTests =
             ] do
             let parseResult = GraceCommand.rootCommand.Parse(args)
             parseResult.Errors.Count |> should equal 0
+
+    /// Verifies the approved enrollment grammar accepts repeated repository assignments and derived defaults without repository configuration.
+    [<Test>]
+    let ``cache enroll parser accepts required derived-boundary grammar`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "cache"
+                    "enroll"
+                    "--owner-id"
+                    "11111111-1111-1111-1111-111111111111"
+                    "--repository"
+                    "22222222-2222-2222-2222-222222222222/33333333-3333-3333-3333-333333333333"
+                    "--repository"
+                    "22222222-2222-2222-2222-222222222222/44444444-4444-4444-4444-444444444444"
+                    "--endpoint"
+                    "https://cache.example.test/enroll"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -188,8 +188,8 @@ module CacheCliTests =
             do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length)
         }
 
-    /// Constructs a strictly accepted enrollment response from the exact production request sent by the CLI.
-    let private acceptedEnrollmentResponse (request: ReceivedRequest) =
+    /// Constructs a strictly accepted enrollment response after applying the production server's display-name normalization.
+    let private acceptedEnrollmentResponseWithDisplayName (normalizeDisplayName: string -> string) (request: ReceivedRequest) =
         let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
         Assert.That(enrollment, Is.Not.Null, "The enrollment responder received an invalid request body.")
         let now = SystemClock.Instance.GetCurrentInstant()
@@ -198,7 +198,7 @@ module CacheCliTests =
             {
                 Class = nameof CacheRegistration
                 CacheId = Guid.Parse("11111111-1111-1111-1111-111111111111")
-                DisplayName = enrollment.DisplayName
+                DisplayName = normalizeDisplayName enrollment.DisplayName
                 BoundaryKind = enrollment.BoundaryKind
                 OwnerId = enrollment.OwnerId
                 OrganizationId = enrollment.OrganizationId
@@ -222,8 +222,11 @@ module CacheCliTests =
         |> fun result -> GraceReturnValue.Create result "test-correlation"
         |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
 
+    /// Constructs a strictly accepted enrollment response from the exact production request sent by the CLI.
+    let private acceptedEnrollmentResponse (request: ReceivedRequest) = acceptedEnrollmentResponseWithDisplayName id request
+
     /// Hosts local OAuth and enrollment endpoints used to prove real credential producers through root command dispatch.
-    let private withEnrollmentResponder (action: Uri -> ConcurrentQueue<ReceivedRequest> -> unit) =
+    let private withEnrollmentResponderWith enrollmentResponse (action: Uri -> ConcurrentQueue<ReceivedRequest> -> unit) =
         use listener = new TcpListener(IPAddress.Loopback, 0)
         use cancellation = new CancellationTokenSource()
         let requests = ConcurrentQueue<ReceivedRequest>()
@@ -256,7 +259,7 @@ module CacheCliTests =
                                 200,
                                 "{\"access_token\":\"interactive-access-token\",\"refresh_token\":\"interactive-refresh-token\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}"
                             | "/oauth/token" -> 200, "{\"access_token\":\"m2m-access-token\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
-                            | "/cache/enroll" -> 200, acceptedEnrollmentResponse request
+                            | "/cache/enroll" -> 200, enrollmentResponse request
                             | _ -> 404, "{\"error\":\"not_found\"}"
 
                         do! writeResponse client (fst response) (snd response)
@@ -276,6 +279,28 @@ module CacheCliTests =
 
             if not (serverTask.Wait(TimeSpan.FromSeconds(5.0))) then
                 Assert.Fail("Timed out waiting for the local OAuth/enrollment responder to stop.")
+
+    /// Hosts the standard strict enrollment responder used by credential and output tests.
+    let private withEnrollmentResponder (action: Uri -> ConcurrentQueue<ReceivedRequest> -> unit) =
+        withEnrollmentResponderWith acceptedEnrollmentResponse action
+
+    /// Applies an isolated PAT-only credential environment to an enrollment command test.
+    let private withPatEnrollmentEnvironment (serverUri: Uri) (pat: string) action =
+        withEnvironment
+            [
+                Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                Constants.EnvironmentVariables.GraceToken, Some pat
+                Constants.EnvironmentVariables.GraceTokenFile, None
+                Constants.EnvironmentVariables.GraceAuthOidcAuthority, None
+                Constants.EnvironmentVariables.GraceAuthOidcAudience, None
+                Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+            ]
+            action
 
     /// Supplies the closed Product V1 enrollment grammar with one Linux HTTP test endpoint.
     let private enrollmentArguments =
@@ -1053,3 +1078,126 @@ module CacheCliTests =
                                 "/cache/enroll"
                             |]
                             requestPaths)))
+
+    /// Verifies an explicitly empty organization selector fails before credential lookup, transport, or protected-state effects.
+    [<Test>]
+    let ``Linux cache enroll rejects an explicit empty organization id before effects`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let pat = Grace.Types.PersonalAccessToken.formatToken "cache-test-user" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withRoot (fun root _ ->
+            let before = snapshot root
+            let arguments = Array.copy enrollmentArguments
+            arguments[7] <- Guid.Empty.ToString("D")
+
+            withEnrollmentResponder (fun serverUri requests ->
+                withPatEnrollmentEnvironment serverUri pat (fun () ->
+                    let exitCode, output = run arguments
+                    assertRedactedError exitCode output
+                    Assert.That(output, Does.Contain("--organization-id must be a non-empty GUID when supplied."))
+                    Assert.That(requests.IsEmpty, Is.True, "An invalid organization selector made an enrollment request.")
+                    Assert.That(snapshot root = before, Is.True, "An invalid organization selector changed protected state."))))
+
+    /// Verifies request canonicalization matches server display-name normalization before strict response comparison.
+    [<Test>]
+    let ``Linux cache enroll canonicalizes padded display names before the request`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let pat = Grace.Types.PersonalAccessToken.formatToken "cache-test-user" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withRoot (fun root _ ->
+            withEnrollmentResponderWith (acceptedEnrollmentResponseWithDisplayName (fun displayName -> displayName.Trim())) (fun serverUri requests ->
+                withPatEnrollmentEnvironment serverUri pat (fun () ->
+                    let arguments =
+                        Array.append
+                            enrollmentArguments
+                            [|
+                                "--display-name"
+                                "  Seattle cache  "
+                            |]
+
+                    let exitCode, output = run arguments
+                    Assert.That(exitCode, Is.EqualTo(0), output)
+                    assertSuccessfulEnrollment pat root requests
+                    let firstRequest: ReceivedRequest = requests.ToArray() |> Array.head
+                    let sent = JsonSerializer.Deserialize<CacheEnrollmentRequest>(firstRequest.Body, Constants.JsonSerializerOptions)
+                    Assert.That(sent.DisplayName, Is.EqualTo("Seattle cache")))))
+
+    /// Verifies the enrollment success value follows the existing Cache-status renderer in every supported output mode.
+    [<Test>]
+    let ``Linux cache enroll renders the ready status in every output mode and preserves selectors`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let pat = Grace.Types.PersonalAccessToken.formatToken "cache-test-user" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        for mode in
+            [
+                "Normal"
+                "Minimal"
+                "Silent"
+                "Verbose"
+                "Json"
+            ] do
+            withRoot (fun root _ ->
+                withEnrollmentResponder (fun serverUri requests ->
+                    withPatEnrollmentEnvironment serverUri pat (fun () ->
+                        let arguments = Array.copy enrollmentArguments
+                        arguments[1] <- mode
+                        let exitCode, output = run arguments
+                        Assert.That(exitCode, Is.EqualTo(0), $"{mode}: {output}")
+                        assertSuccessfulEnrollment pat root requests
+
+                        match mode with
+                        | "Normal" -> Assert.That(output, Does.Contain("Enrollment: enrolled"))
+                        | "Verbose" ->
+                            Assert.That(output, Does.Contain("Enrollment: enrolled"))
+                            Assert.That(output, Does.Contain("EventTime:"))
+                        | "Json" -> assertStatus "enrolled" "available" 0 output
+                        | "Minimal"
+                        | "Silent" -> Assert.That(output, Is.Empty)
+                        | _ -> Assert.Fail($"Unexpected output mode {mode}"))))
+
+        for mode in
+            [
+                "Normal"
+                "Minimal"
+                "Silent"
+                "Verbose"
+                "Json"
+            ] do
+            withRoot (fun root _ ->
+                withEnrollmentResponder (fun serverUri requests ->
+                    withPatEnrollmentEnvironment serverUri pat (fun () ->
+                        let arguments = Array.append enrollmentArguments [| "--select"; "Enrollment" |]
+                        arguments[1] <- mode
+                        let exitCode, output = run arguments
+                        Assert.That(exitCode, Is.EqualTo(0), $"{mode} selector: {output}")
+                        assertSuccessfulEnrollment pat root requests
+                        Assert.That(output.Trim(), Is.EqualTo("\"enrolled\""), $"{mode} selector must override human output."))))
+
+    /// Verifies bare enrollment introspection bypasses mutation validation and reports the finalized local-and-server contract.
+    [<Test>]
+    let ``Linux cache enroll schema and examples are inert and describe the completed contract`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            let before = snapshot root
+
+            for arguments in
+                [
+                    [| "cache"; "enroll"; "--schema" |]
+                    [| "cache"; "enroll"; "--examples" |]
+                ] do
+                let exitCode, output = run arguments
+                Assert.That(exitCode, Is.EqualTo(0), output)
+                use document = JsonDocument.Parse(output)
+                let registry = document.RootElement.GetProperty("Registry")
+                Assert.That(registry.GetProperty("ExecutionScope").GetString(), Is.EqualTo("composite_local_server"))
+                Assert.That(registry.GetProperty("Schema").GetString(), Is.EqualTo("ExistingBehavior"))
+                Assert.That(registry.GetProperty("Examples").GetString(), Is.EqualTo("ExistingBehavior"))
+                Assert.That(snapshot root = before, Is.True, "Enrollment introspection changed protected state."))

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -3,18 +3,31 @@ namespace Grace.CLI.Tests
 open Grace.Cache
 open Grace.CLI
 open Grace.CLI.Command
+open Grace.Shared
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.Diagnostics
 open System.IO
 open System.Net
 open System.Net.Sockets
+open System.Text
 open System.Text.Json
+open System.Threading
+open System.Threading.Tasks
 
 /// Covers serialized root-command behavior for pure local Cache status.
 [<TestFixture>]
 [<NonParallelizable>]
 module CacheCliTests =
+
+    /// Captures one loopback request made by a production credential or enrollment path.
+    type private ReceivedRequest = { Method: string; Path: string; Authorization: string option; Body: string }
 
     /// Sets AnsiConsole output for root-command tests that capture stdout.
     let private setAnsiConsoleOutput writer =
@@ -47,6 +60,264 @@ module CacheCliTests =
             action ()
         finally
             Environment.SetEnvironmentVariable(name, original)
+
+    /// Applies a complete isolated credential environment for one root-command test.
+    let private withEnvironment (values: (string * string option) list) (action: unit -> 'T) =
+        let rec apply remaining =
+            match remaining with
+            | [] -> action ()
+            | (name, value) :: tail -> withEnv name value (fun () -> apply tail)
+
+        apply values
+
+    /// Reads one complete HTTP/1.1 request from the loopback credential responder.
+    let private readRequest (client: TcpClient) =
+        task {
+            let stream = client.GetStream()
+            use reader = new StreamReader(stream, Encoding.UTF8, false, 4096, true)
+            let! requestLine = reader.ReadLineAsync()
+
+            if String.IsNullOrWhiteSpace(requestLine) then
+                return { Method = String.Empty; Path = String.Empty; Authorization = None; Body = String.Empty }
+            else
+                let requestParts = requestLine.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                let headers = Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                let mutable headerLine = reader.ReadLine()
+
+                while not (String.IsNullOrEmpty(headerLine)) do
+                    let separator = headerLine.IndexOf(':')
+
+                    if separator > 0 then
+                        headers[headerLine.Substring(0, separator).Trim()] <- headerLine.Substring(separator + 1).Trim()
+
+                    headerLine <- reader.ReadLine()
+
+                let contentLength =
+                    match headers.TryGetValue("Content-Length") with
+                    | true, value ->
+                        match Int32.TryParse(value) with
+                        | true, parsed when parsed > 0 -> parsed
+                        | _ -> 0
+                    | false, _ -> 0
+
+                let readCharacters count =
+                    task {
+                        let characters = Array.zeroCreate<char> count
+                        let mutable offset = 0
+
+                        while offset < count do
+                            let! read = reader.ReadAsync(characters, offset, count - offset)
+
+                            if read = 0 then
+                                failwith "The loopback responder received an incomplete HTTP request body."
+                            else
+                                offset <- offset + read
+
+                        return String(characters)
+                    }
+
+                let readChunkedBody () =
+                    task {
+                        let body = StringBuilder()
+                        let mutable finished = false
+
+                        while not finished do
+                            let! sizeLine = reader.ReadLineAsync()
+
+                            if String.IsNullOrWhiteSpace(sizeLine) then
+                                failwith "The loopback responder received an incomplete chunked HTTP request body."
+
+                            let sizeText = sizeLine.Split(';', 2)[0]
+
+                            match Int32.TryParse(sizeText, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) with
+                            | true, size when size > 0 ->
+                                let! chunk = readCharacters size
+                                body.Append(chunk) |> ignore
+                                let! terminator = reader.ReadLineAsync()
+
+                                if not (String.IsNullOrEmpty(terminator)) then
+                                    failwith "The loopback responder received an invalid chunk terminator."
+                            | true, 0 ->
+                                let! terminator = reader.ReadLineAsync()
+
+                                if not (String.IsNullOrEmpty(terminator)) then
+                                    failwith "The loopback responder received unsupported HTTP chunk trailers."
+
+                                finished <- true
+                            | _ -> failwith $"The loopback responder received an invalid HTTP chunk size '{sizeText}'."
+
+                        return body.ToString()
+                    }
+
+                let isChunked =
+                    match headers.TryGetValue("Transfer-Encoding") with
+                    | true, value -> value.Contains("chunked", StringComparison.OrdinalIgnoreCase)
+                    | false, _ -> false
+
+                let! body =
+                    if contentLength > 0 then readCharacters contentLength
+                    elif isChunked then readChunkedBody ()
+                    else Task.FromResult(String.Empty)
+
+                let authorization =
+                    match headers.TryGetValue("Authorization") with
+                    | true, value -> Some value
+                    | false, _ -> None
+
+                return
+                    {
+                        Method = if requestParts.Length > 0 then requestParts[0] else String.Empty
+                        Path = if requestParts.Length > 1 then requestParts[1] else String.Empty
+                        Authorization = authorization
+                        Body = body
+                    }
+        }
+
+    /// Writes one compact JSON response from the loopback credential responder.
+    let private writeResponse (client: TcpClient) (statusCode: int) (body: string) =
+        task {
+            use stream = client.GetStream()
+            let bodyBytes = Encoding.UTF8.GetBytes(body)
+            let reasonPhrase = if statusCode = 200 then "OK" else "Not Found"
+
+            let headers =
+                $"HTTP/1.1 {statusCode} {reasonPhrase}\r\nContent-Type: application/json\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n"
+                |> Encoding.ASCII.GetBytes
+
+            do! stream.WriteAsync(headers, 0, headers.Length)
+            do! stream.WriteAsync(bodyBytes, 0, bodyBytes.Length)
+        }
+
+    /// Constructs a strictly accepted enrollment response from the exact production request sent by the CLI.
+    let private acceptedEnrollmentResponse (request: ReceivedRequest) =
+        let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+        Assert.That(enrollment, Is.Not.Null, "The enrollment responder received an invalid request body.")
+        let now = SystemClock.Instance.GetCurrentInstant()
+
+        let registration =
+            {
+                Class = nameof CacheRegistration
+                CacheId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                DisplayName = enrollment.DisplayName
+                BoundaryKind = enrollment.BoundaryKind
+                OwnerId = enrollment.OwnerId
+                OrganizationId = enrollment.OrganizationId
+                RepositoryScopes = enrollment.RepositoryScopes |> Seq.toArray
+                PublicKey = enrollment.PublicKey
+                Endpoint = enrollment.Endpoint
+                AllowHttpEndpoint = enrollment.AllowHttpEndpoint
+                Health = CacheHealthStatus.Unhealthy
+                SoftwareVersion = enrollment.SoftwareVersion
+                ProtocolVersion = enrollment.ProtocolVersion
+                PrefetchSupported = enrollment.PrefetchSupported
+                EnrolledBy = "test-admin"
+                EnrolledAt = now
+                LastRefreshedAt = now
+                RefreshAfter = now.Plus(Duration.FromHours(1))
+                ExpiresAt = now.Plus(Duration.FromHours(2))
+                RevokedAt = None
+            }
+
+        CacheRegistrationResult.Create(CacheRegistrationRefreshStatus.Enrolled, Some registration, "enrolled")
+        |> fun result -> GraceReturnValue.Create result "test-correlation"
+        |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
+
+    /// Hosts local OAuth and enrollment endpoints used to prove real credential producers through root command dispatch.
+    let private withEnrollmentResponder (action: Uri -> ConcurrentQueue<ReceivedRequest> -> unit) =
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        use cancellation = new CancellationTokenSource()
+        let requests = ConcurrentQueue<ReceivedRequest>()
+        listener.Start()
+        let port = (listener.LocalEndpoint :?> IPEndPoint).Port
+        let authority = Uri($"http://127.0.0.1:{port}")
+
+        let deviceCodeResponse =
+            "{\"device_code\":\"device-code\",\"user_code\":\"ABCD\",\"verification_uri\":\""
+            + authority.AbsoluteUri
+            + "\",\"expires_in\":120,\"interval\":1}"
+
+        let rec serve () =
+            task {
+                if not cancellation.IsCancellationRequested then
+                    try
+                        let! client =
+                            listener
+                                .AcceptTcpClientAsync(cancellation.Token)
+                                .AsTask()
+
+                        use client = client
+                        let! request = readRequest client
+                        requests.Enqueue(request)
+
+                        let response =
+                            match request.Path with
+                            | "/oauth/device/code" -> 200, deviceCodeResponse
+                            | "/oauth/token" when request.Body.Contains("urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code") ->
+                                200,
+                                "{\"access_token\":\"interactive-access-token\",\"refresh_token\":\"interactive-refresh-token\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}"
+                            | "/oauth/token" -> 200, "{\"access_token\":\"m2m-access-token\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+                            | "/cache/enroll" -> 200, acceptedEnrollmentResponse request
+                            | _ -> 404, "{\"error\":\"not_found\"}"
+
+                        do! writeResponse client (fst response) (snd response)
+                        return! serve ()
+                    with
+                    | :? OperationCanceledException -> return ()
+                    | :? ObjectDisposedException -> return ()
+            }
+
+        let serverTask = Task.Run(Func<Task>(fun () -> serve ()))
+
+        try
+            action authority requests
+        finally
+            cancellation.Cancel()
+            listener.Stop()
+
+            if not (serverTask.Wait(TimeSpan.FromSeconds(5.0))) then
+                Assert.Fail("Timed out waiting for the local OAuth/enrollment responder to stop.")
+
+    /// Supplies the closed Product V1 enrollment grammar with one Linux HTTP test endpoint.
+    let private enrollmentArguments =
+        [|
+            "--output"
+            "Json"
+            "cache"
+            "enroll"
+            "--owner-id"
+            "22222222-2222-2222-2222-222222222222"
+            "--organization-id"
+            "33333333-3333-3333-3333-333333333333"
+            "--repository"
+            "33333333-3333-3333-3333-333333333333/44444444-4444-4444-4444-444444444444"
+            "--endpoint"
+            "http://cache.example.test"
+            "--allow-http"
+        |]
+
+    /// Checks the shared redacted ready-status result and the one exact authenticated enrollment effect.
+    let private assertSuccessfulEnrollment (expectedBearer: string) (root: string) (requests: ConcurrentQueue<ReceivedRequest>) =
+        let enrollmentRequests =
+            requests.ToArray()
+            |> Array.filter (fun request -> request.Path = "/cache/enroll")
+
+        Assert.That(enrollmentRequests.Length, Is.EqualTo(1), "The supported producer must make exactly one enrollment POST.")
+        let request = enrollmentRequests[0]
+        Assert.That(request.Method, Is.EqualTo("POST"))
+        Assert.That(request.Authorization, Is.EqualTo(Some(String.Concat("Bearer ", expectedBearer))))
+
+        match CacheIdentity.status root with
+        | status when
+            status.Enrollment = "enrolled"
+            && status.Key = "available"
+            ->
+            ()
+        | status -> Assert.Fail($"Enrollment did not publish ready protected state: {status.Enrollment}/{status.Key}.")
+
+    /// Verifies a credential producer made the expected ordered local OAuth and enrollment requests.
+    let private assertRequestPaths (expected: string array) (actual: string array) =
+        Assert.That(actual.Length, Is.EqualTo(expected.Length))
+        Assert.That(Array.forall2 (=) expected actual, Is.True)
 
     /// Captures a file's existence and immutable-on-read metadata without reading its contents.
     let private snapshotFile (path: string) =
@@ -602,3 +873,183 @@ module CacheCliTests =
                     .GetArrayLength(),
                 Is.GreaterThanOrEqualTo(3)
             ))
+
+    /// Verifies the normal-build holder directly owns the production root claim until its exact process is terminated and joined.
+    [<Test>]
+    let ``Linux claim holder blocks then releases the production enrollment claim`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Claim-holder process proof requires Linux protected-root semantics.")
+
+        withRoot (fun root _ ->
+            let holder =
+                Path.GetFullPath(
+                    Path.Combine(
+                        AppContext.BaseDirectory,
+                        "..",
+                        "..",
+                        "..",
+                        "..",
+                        "Grace.CLI.CacheEnrollment.ClaimHolder",
+                        "bin",
+                        "Release",
+                        "net10.0",
+                        "Grace.CLI.CacheEnrollment.ClaimHolder.dll"
+                    )
+                )
+
+            Assert.That(File.Exists(holder), Is.True, "The normal solution build did not produce the enrollment claim holder.")
+            let signalPath = Path.Combine(Path.GetTempPath(), $"grace-cache-claim-holder-{Guid.NewGuid():N}")
+            use holderProcess = new Process()
+            holderProcess.StartInfo.FileName <- "dotnet"
+            holderProcess.StartInfo.UseShellExecute <- false
+            holderProcess.StartInfo.CreateNoWindow <- true
+            holderProcess.StartInfo.ArgumentList.Add(holder)
+            holderProcess.StartInfo.ArgumentList.Add(root)
+            holderProcess.StartInfo.ArgumentList.Add(signalPath)
+
+            try
+                Assert.That(holderProcess.Start(), Is.True)
+                let deadline = DateTime.UtcNow.AddSeconds(10.0)
+
+                while not (File.Exists(signalPath))
+                      && DateTime.UtcNow < deadline do
+                    Thread.Sleep(50)
+
+                Assert.That(File.Exists(signalPath), Is.True, "The holder did not report its acquired production claim.")
+
+                match CacheIdentity.tryAcquireEnrollmentClaim root with
+                | Error CacheIdentityError.StateUnavailable -> ()
+                | Error error -> Assert.Fail($"Expected a conflicting claim to fail safely, received {error}.")
+                | Ok claim ->
+                    CacheIdentity.releaseEnrollmentClaim claim
+                    Assert.Fail("A second holder acquired the production claim while the direct holder was alive.")
+
+                holderProcess.Kill()
+                Assert.That(holderProcess.WaitForExit(10000), Is.True, "The exact direct claim holder did not exit after termination.")
+
+                let retry =
+                    CacheIdentity.tryAcquireEnrollmentClaim root
+                    |> requireOk
+
+                CacheIdentity.releaseEnrollmentClaim retry
+            finally
+                if not holderProcess.HasExited then
+                    holderProcess.Kill()
+                    holderProcess.WaitForExit(10000) |> ignore
+
+                if File.Exists(signalPath) then File.Delete(signalPath))
+
+    /// Verifies GRACE_TOKEN resolves before root effects and completes one authenticated enrollment POST.
+    [<Test>]
+    let ``Linux cache enroll dispatches a PAT through the selected server once`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let pat = Grace.Types.PersonalAccessToken.formatToken "cache-test-user" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withRoot (fun root _ ->
+            withEnrollmentResponder (fun serverUri requests ->
+                withEnvironment
+                    [
+                        Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceToken, Some pat
+                        Constants.EnvironmentVariables.GraceTokenFile, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAuthority, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+                    ]
+                    (fun () ->
+                        let exitCode, output = run enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        assertSuccessfulEnrollment pat root requests)))
+
+    /// Verifies the existing M2M client-credential producer resolves once before root effects and completes enrollment.
+    [<Test>]
+    let ``Linux cache enroll dispatches M2M through the selected server once`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            withEnrollmentResponder (fun serverUri requests ->
+                withEnvironment
+                    [
+                        Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceToken, None
+                        Constants.EnvironmentVariables.GraceTokenFile, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, Some "cache-m2m-client"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, Some "cache-m2m-secret"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, Some "cache.enroll"
+                        Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+                    ]
+                    (fun () ->
+                        let exitCode, output = run enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        assertSuccessfulEnrollment "m2m-access-token" root requests
+
+                        let requestPaths =
+                            requests.ToArray()
+                            |> Array.map (fun request -> request.Path)
+
+                        assertRequestPaths [| "/oauth/token"; "/cache/enroll" |] requestPaths)))
+
+    /// Verifies a real Linux libsecret-backed interactive token is written, loaded, and dispatched through cache enrollment.
+    [<Test>]
+    let ``Linux cache enroll dispatches the real GNOME keyring interactive credential once`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        if
+            Environment.GetEnvironmentVariable("GRACE_TEST_LINUX_KEYRING")
+            <> "1"
+        then
+            Assert.Ignore("This proof requires the D-Bus and GNOME keyring session configured by validate.yml.")
+
+        withRoot (fun root _ ->
+            withEnrollmentResponder (fun serverUri requests ->
+                withEnvironment
+                    [
+                        Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceToken, None
+                        Constants.EnvironmentVariables.GraceTokenFile, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "cache-interactive-client"
+                        Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliScopes, Some "openid offline_access"
+                    ]
+                    (fun () ->
+                        let loginExit, loginOutput =
+                            run [| "authenticate"
+                                   "login"
+                                   "--auth"
+                                   "device" |]
+
+                        Assert.That(loginExit, Is.EqualTo(0), loginOutput)
+
+                        let exitCode, output = run enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        assertSuccessfulEnrollment "interactive-access-token" root requests
+
+                        let requestPaths =
+                            requests.ToArray()
+                            |> Array.map (fun request -> request.Path)
+
+                        assertRequestPaths
+                            [|
+                                "/oauth/device/code"
+                                "/oauth/token"
+                                "/cache/enroll"
+                            |]
+                            requestPaths)))

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -134,12 +134,27 @@ module CommandOutputContractRegistryTests =
     let private auditParseArgs (entry: CommandContractEntry) =
         let commandPath = entry.Identity.CommandPath |> List.toArray
 
-        [|
-            yield "--output"
-            yield "Json"
-            yield! commandPath
-            yield! auditPlaceholderArgs entry
-        |]
+        match entry.Identity.CommandId with
+        | "cache.enroll" ->
+            [|
+                "--output"
+                "Json"
+                "cache"
+                "enroll"
+                "--owner-id"
+                "11111111-1111-1111-1111-111111111111"
+                "--repository"
+                "22222222-2222-2222-2222-222222222222/33333333-3333-3333-3333-333333333333"
+                "--endpoint"
+                "https://cache.example.test"
+            |]
+        | _ ->
+            [|
+                yield "--output"
+                yield "Json"
+                yield! commandPath
+                yield! auditPlaceholderArgs entry
+            |]
 
     /// Counts by for test assertions.
     let private countBy behavior =
@@ -239,16 +254,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 207
+        |> should equal 208
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 198
+        |> should equal 199
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 186
+        |> should equal 187
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -290,7 +305,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 186
+        jsonReady |> should equal 187
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -467,7 +482,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 186
+        commonEntries.Length |> should equal 187
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -486,7 +501,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 186
+        commonEntries.Length |> should equal 187
 
         let parserInvalidEntries =
             commonEntries

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -5,6 +5,7 @@
 		<Prefer32Bit>false</Prefer32Bit>
 		<LangVersion>preview</LangVersion>
 		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
 		<GenerateProgramFile>false</GenerateProgramFile>
 		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
 		<SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
@@ -74,6 +75,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Grace.CLI\Grace.CLI.fsproj" />
+		<ProjectReference Include="..\Grace.CLI.CacheEnrollment.ClaimHolder\Grace.CLI.CacheEnrollment.ClaimHolder.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.CLI.LocalStateDb.Worker\Grace.CLI.LocalStateDb.Worker.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
 		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -2,9 +2,13 @@ namespace Grace.CLI.Command
 
 open Grace.Cache
 open Grace.CLI.Common
+open Grace.SDK
 open Grace.Shared
+open Grace.Types.CacheRegistration
 open Grace.Types.Common
 open Spectre.Console
+open System
+open System.Collections.Generic
 open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
@@ -12,7 +16,7 @@ open System.Text.Json.Nodes
 open System.Threading
 open System.Threading.Tasks
 
-/// Groups the repository-independent, read-only Grace Cache status command.
+/// Groups repository-independent Grace Cache enrollment and local status commands.
 module CacheCommand =
 
     /// Holds the protected state root with a test-only override for isolated root-command proof.
@@ -94,9 +98,325 @@ module CacheCommand =
         /// Executes the status projection without accessing repository or SDK state.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> = statusHandler parseResult cancellationToken
 
+    /// Defines only the administrator-supplied enrollment grammar; protocol and software facts remain implementation-derived.
+    module private EnrollOptions =
+        let ownerId = Option<Guid>("--owner-id", Description = "Owner GUID.", Required = true)
+        let organizationId = Option<Guid>("--organization-id", Description = "Optional organization GUID selecting the organization boundary.")
+
+        let repositories =
+            Option<string array>(
+                "--repository",
+                Description = "Repository assignment as organization-GUID/repository-GUID.",
+                Arity = ArgumentArity.OneOrMore,
+                Required = true
+            )
+
+        let endpoint = Option<string>("--endpoint", Description = "Absolute HTTP or HTTPS Cache endpoint.", Required = true)
+        let displayName = Option<string>("--display-name", DefaultValueFactory = (fun _ -> "Grace Cache"), Description = "Cache display name.")
+        let allowHttp = Option<bool>("--allow-http", Description = "Permit an HTTP endpoint.")
+
+    /// Parses one canonical organization/repository assignment without accepting names, empty IDs, or ambiguous separators.
+    let private tryRepositoryScope (value: string) =
+        match value.Split('/', StringSplitOptions.None) with
+        | [| organization; repository |] ->
+            match Guid.TryParseExact(organization, "D"), Guid.TryParseExact(repository, "D") with
+            | (true, organizationId), (true, repositoryId) when
+                organizationId <> Guid.Empty
+                && repositoryId <> Guid.Empty
+                ->
+                Some(CacheRepositoryScope.Create(organizationId, repositoryId))
+            | _ -> None
+        | _ -> None
+
+    /// Builds the exact server request from the approved derived-boundary grammar and the current staged public key.
+    let private requestFromArguments (parseResult: ParseResult) (publicKey: Grace.Cache.CacheIdentityPublicKey) =
+        let correlationId = getCorrelationId parseResult
+        let ownerId = parseResult.GetValue(EnrollOptions.ownerId)
+        let parsedOrganizationId = parseResult.GetValue(EnrollOptions.organizationId)
+        let organizationId = if parsedOrganizationId = Guid.Empty then None else Some parsedOrganizationId
+        let endpoint = parseResult.GetValue(EnrollOptions.endpoint)
+        let allowHttp = parseResult.GetValue(EnrollOptions.allowHttp)
+
+        let repositoryValues =
+            parseResult.GetValue(EnrollOptions.repositories)
+            |> Option.ofObj
+            |> Option.defaultValue Array.empty
+
+        let scopes = repositoryValues |> Array.map tryRepositoryScope
+
+        if ownerId = Guid.Empty then
+            Error(GraceError.Create "--owner-id must be a non-empty GUID." correlationId)
+        elif scopes |> Array.exists Option.isNone then
+            Error(GraceError.Create "Each --repository value must be organization-GUID/repository-GUID." correlationId)
+        else
+            match Uri.TryCreate(endpoint, UriKind.Absolute) with
+            | false, _ -> Error(GraceError.Create "--endpoint must be an absolute HTTP or HTTPS URI." correlationId)
+            | true, uri when
+                uri.Scheme <> Uri.UriSchemeHttp
+                && uri.Scheme <> Uri.UriSchemeHttps
+                ->
+                Error(GraceError.Create "--endpoint must be an absolute HTTP or HTTPS URI." correlationId)
+            | true, uri when uri.Scheme = Uri.UriSchemeHttp && not allowHttp -> Error(GraceError.Create "HTTP --endpoint requires --allow-http." correlationId)
+            | true, uri ->
+                let request =
+                    {
+                        Class = nameof CacheEnrollmentRequest
+                        DisplayName = parseResult.GetValue(EnrollOptions.displayName)
+                        BoundaryKind =
+                            if organizationId.IsSome then
+                                CacheBoundaryKind.Organization
+                            else
+                                CacheBoundaryKind.Owner
+                        OwnerId = ownerId
+                        OrganizationId = organizationId
+                        RepositoryScopes = List<CacheRepositoryScope>(scopes |> Array.choose id)
+                        PublicKey = Grace.Types.CacheRegistration.CacheIdentityPublicKey.Create(publicKey.PublicKeyX, publicKey.PublicKeyY)
+                        Endpoint = uri.AbsoluteUri
+                        AllowHttpEndpoint = allowHttp
+                        SoftwareVersion = "Grace.Cache"
+                        ProtocolVersion = "v1"
+                        PrefetchSupported = false
+                    }
+
+                match Lifecycle.validateEnrollmentRequest request with
+                | Ok () -> Ok request
+                | Error errors -> Error(GraceError.Create (String.concat " " errors) correlationId)
+
+    /// Reads the selected server URI without consulting repository configuration or local invocation history.
+    let private configuredServerUri parseResult =
+        match Uri.TryCreate(Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri), UriKind.Absolute) with
+        | true, uri when
+            uri.Scheme = Uri.UriSchemeHttp
+            || uri.Scheme = Uri.UriSchemeHttps
+            ->
+            Ok uri
+        | _ ->
+            Error(GraceError.Create ($"Set {Constants.EnvironmentVariables.GraceServerUri} to an absolute HTTP or HTTPS URI.") (getCorrelationId parseResult))
+
+    /// Requires the existing credential precedence to produce one concrete bearer before cache-root effects begin.
+    let private resolveBearer (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            cancellationToken.ThrowIfCancellationRequested()
+            let! result = Grace.CLI.Command.Auth.tryGetAccessToken ()
+            cancellationToken.ThrowIfCancellationRequested()
+
+            match result with
+            | Ok (Some bearer) when not (String.IsNullOrWhiteSpace bearer) -> return Ok bearer
+            | Ok _ -> return Error(GraceError.Create "Authentication required. Run 'grace authenticate login' and try again." (getCorrelationId parseResult))
+            | Error message -> return Error(GraceError.Create message (getCorrelationId parseResult))
+        }
+
+    /// Compares every immutable request fact and staged P-256 public key before server acceptance can publish ready state.
+    let private matchesAcceptedRegistration (request: CacheEnrollmentRequest) (registration: CacheRegistration) =
+        not (isNull (box registration))
+        && registration.Class = nameof CacheRegistration
+        && registration.CacheId <> Guid.Empty
+        && registration.Health = CacheHealthStatus.Unhealthy
+        && not (String.IsNullOrWhiteSpace registration.EnrolledBy)
+        && registration.EnrolledAt
+           <= registration.LastRefreshedAt
+        && registration.LastRefreshedAt < registration.RefreshAfter
+        && registration.RefreshAfter < registration.ExpiresAt
+        && registration.RevokedAt.IsNone
+        && registration.DisplayName = request.DisplayName
+        && registration.BoundaryKind = request.BoundaryKind
+        && registration.OwnerId = request.OwnerId
+        && registration.OrganizationId = request.OrganizationId
+        && registration.Endpoint = request.Endpoint
+        && registration.AllowHttpEndpoint = request.AllowHttpEndpoint
+        && registration.SoftwareVersion = request.SoftwareVersion
+        && registration.ProtocolVersion = request.ProtocolVersion
+        && registration.PrefetchSupported = request.PrefetchSupported
+        && not (isNull (box registration.PublicKey))
+        && registration.PublicKey.Class = request.PublicKey.Class
+        && registration.PublicKey.Algorithm = request.PublicKey.Algorithm
+        && registration.PublicKey.Curve = request.PublicKey.Curve
+        && registration.PublicKey.PublicKeyX = request.PublicKey.PublicKeyX
+        && registration.PublicKey.PublicKeyY = request.PublicKey.PublicKeyY
+        && registration.RepositoryScopes.Length = request.RepositoryScopes.Count
+        && Array.forall2
+            (fun (actual: CacheRepositoryScope) (expected: CacheRepositoryScope) ->
+                actual.Class = expected.Class
+                && actual.OrganizationId = expected.OrganizationId
+                && actual.RepositoryId = expected.RepositoryId)
+            registration.RepositoryScopes
+            (request.RepositoryScopes |> Seq.toArray)
+
+    /// Converts one strictly accepted server registration into the redacted local-ready representation without retaining server lifecycle fields.
+    let private acceptedRegistration (registration: CacheRegistration) : Grace.Cache.CacheAcceptedRegistration =
+        {
+            CacheId = registration.CacheId
+            DisplayName = registration.DisplayName
+            BoundaryKind = string registration.BoundaryKind
+            OwnerId = registration.OwnerId
+            OrganizationId = registration.OrganizationId
+            RepositoryScopes =
+                registration.RepositoryScopes
+                |> Array.map (fun (scope: CacheRepositoryScope) -> { OrganizationId = scope.OrganizationId; RepositoryId = scope.RepositoryId })
+            Endpoint = registration.Endpoint
+            ProtocolVersion = registration.ProtocolVersion
+            PublicKey = { PublicKeyX = registration.PublicKey.PublicKeyX; PublicKeyY = registration.PublicKey.PublicKeyY }
+        }
+
+    /// Emits one redacted enrollment success value through the same renderer and status projection used by cache.status.
+    let private renderEnrollmentSuccess parseResult =
+        let status = CacheIdentity.status stateRoot
+
+        let renderExitCode =
+            GraceReturnValue.Create (statusValue status) (getCorrelationId parseResult)
+            |> Ok
+            |> renderOutput parseResult
+
+        if renderExitCode <> 0 then renderExitCode
+        elif status.Enrollment = "enrolled" then 0
+        else -1
+
+    /// Completes the one-shot enrollment transition without retries, reconciliation, repository configuration, or invocation history.
+    let private enrollHandler (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            let placeholder: Grace.Cache.CacheIdentityPublicKey = { PublicKeyX = String.replicate 43 "a"; PublicKeyY = String.replicate 43 "a" }
+
+            match requestFromArguments parseResult placeholder, configuredServerUri parseResult with
+            | Error error, _
+            | _, Error error -> return renderOutput parseResult (Error error)
+            | Ok _, Ok serverUri ->
+                match CacheIdentity.inspectEnrollmentRoot stateRoot with
+                | Error _ ->
+                    return
+                        renderOutput
+                            parseResult
+                            (Error(GraceError.Create "The protected Grace Cache state root is unavailable." (getCorrelationId parseResult)))
+                | Ok CacheIdentityInspection.Ready ->
+                    return
+                        renderOutput
+                            parseResult
+                            (Error(GraceError.Create "The protected Grace Cache state root is already enrolled." (getCorrelationId parseResult)))
+                | Ok (CacheIdentityInspection.Invalid
+                | CacheIdentityInspection.Inaccessible) ->
+                    return
+                        renderOutput
+                            parseResult
+                            (Error(GraceError.Create "The protected Grace Cache state root is invalid or inaccessible." (getCorrelationId parseResult)))
+                | Ok (CacheIdentityInspection.Missing
+                | CacheIdentityInspection.AttemptPresent) ->
+                    let! bearerResult = resolveBearer parseResult cancellationToken
+
+                    match bearerResult with
+                    | Error error -> return renderOutput parseResult (Error error)
+                    | Ok bearer ->
+                        cancellationToken.ThrowIfCancellationRequested()
+
+                        match CacheIdentity.tryAcquireEnrollmentClaim stateRoot with
+                        | Error _ ->
+                            return
+                                renderOutput
+                                    parseResult
+                                    (Error(GraceError.Create "Cache enrollment could not acquire its local claim." (getCorrelationId parseResult)))
+                        | Ok claim ->
+                            let mutable stagedKey: Grace.Cache.CacheIdentityPublicKey option = None
+                            let mutable committed = false
+
+                            try
+                                let staleRecovery =
+                                    match CacheIdentity.inspectEnrollmentRoot stateRoot with
+                                    | Ok CacheIdentityInspection.AttemptPresent -> CacheIdentity.discardStaleAttempt claim stateRoot
+                                    | Ok CacheIdentityInspection.Missing -> Ok()
+                                    | _ -> Error CacheIdentityError.StateUnavailable
+
+                                match staleRecovery with
+                                | Error _ ->
+                                    return
+                                        renderOutput
+                                            parseResult
+                                            (Error(
+                                                GraceError.Create "A stale Cache enrollment attempt could not be safely cleared." (getCorrelationId parseResult)
+                                            ))
+                                | Ok () ->
+                                    cancellationToken.ThrowIfCancellationRequested()
+
+                                    match CacheIdentity.createClaimedAttempt claim stateRoot with
+                                    | Error _ ->
+                                        return
+                                            renderOutput
+                                                parseResult
+                                                (Error(
+                                                    GraceError.Create "Cache enrollment could not stage its protected identity." (getCorrelationId parseResult)
+                                                ))
+                                    | Ok publicKey ->
+                                        stagedKey <- Some publicKey
+                                        cancellationToken.ThrowIfCancellationRequested()
+
+                                        match requestFromArguments parseResult publicKey, CacheIdentity.validateClaimedAttempt claim stateRoot publicKey with
+                                        | Error error, _ -> return renderOutput parseResult (Error error)
+                                        | _, Error _ ->
+                                            return
+                                                renderOutput
+                                                    parseResult
+                                                    (Error(
+                                                        GraceError.Create
+                                                            "Cache enrollment local state changed before the request."
+                                                            (getCorrelationId parseResult)
+                                                    ))
+                                        | Ok request, Ok () ->
+                                            let! response =
+                                                CacheRegistration.Enroll(request, serverUri, bearer, getCorrelationId parseResult, cancellationToken)
+
+                                            match response with
+                                            | Error error -> return renderOutput parseResult (Error error)
+                                            | Ok response ->
+                                                match response.ReturnValue.Class, response.ReturnValue.Status, response.ReturnValue.Registration with
+                                                | resultClass, CacheRegistrationRefreshStatus.Enrolled, Some registration when
+                                                    resultClass = nameof CacheRegistrationResult
+                                                    && matchesAcceptedRegistration request registration
+                                                    ->
+                                                    match CacheIdentity.commitClaimedReady claim stateRoot (acceptedRegistration registration) with
+                                                    | Ok () ->
+                                                        committed <- true
+                                                        return renderEnrollmentSuccess parseResult
+                                                    | Error _ ->
+                                                        return
+                                                            renderOutput
+                                                                parseResult
+                                                                (Error(
+                                                                    GraceError.Create
+                                                                        "Cache enrollment was accepted but local ready state could not be committed."
+                                                                        (getCorrelationId parseResult)
+                                                                ))
+                                                | _ ->
+                                                    return
+                                                        renderOutput
+                                                            parseResult
+                                                            (Error(
+                                                                GraceError.Create
+                                                                    "Cache enrollment response did not strictly accept the staged identity."
+                                                                    (getCorrelationId parseResult)
+                                                            ))
+                            finally
+                                if not committed then
+                                    CacheIdentity.discardClaimedAttempt claim stateRoot stagedKey
+
+                                CacheIdentity.releaseEnrollmentClaim claim
+        }
+
+    /// Invokes the one-shot cache enrollment action through repository-independent root dispatch.
+    type Enroll() =
+        inherit AsynchronousCommandLineAction()
+
+        /// Executes the bounded enrollment transition.
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> = enrollHandler parseResult cancellationToken
+
     /// Builds the repository-independent Cache command group.
     let Build =
         let cache = Command("cache", "Inspect a local Grace Cache identity.")
+        let enroll = Command("enroll", "Enroll one protected Grace Cache identity.")
+        enroll.Options.Add(EnrollOptions.ownerId)
+        enroll.Options.Add(EnrollOptions.organizationId)
+        enroll.Options.Add(EnrollOptions.repositories)
+        enroll.Options.Add(EnrollOptions.endpoint)
+        enroll.Options.Add(EnrollOptions.displayName)
+        enroll.Options.Add(EnrollOptions.allowHttp)
+        enroll.Action <- Enroll()
+        cache.Subcommands.Add(enroll)
         let status = Command("status", "Report redacted local Grace Cache enrollment status.")
         status.Action <- Status()
         cache.Subcommands.Add(status)

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -133,9 +133,14 @@ module CacheCommand =
         let correlationId = getCorrelationId parseResult
         let ownerId = parseResult.GetValue(EnrollOptions.ownerId)
         let parsedOrganizationId = parseResult.GetValue(EnrollOptions.organizationId)
+        let hasExplicitOrganizationId = not (isNull (parseResult.GetResult("--organization-id")))
         let organizationId = if parsedOrganizationId = Guid.Empty then None else Some parsedOrganizationId
         let endpoint = parseResult.GetValue(EnrollOptions.endpoint)
         let allowHttp = parseResult.GetValue(EnrollOptions.allowHttp)
+
+        let displayName =
+            (parseResult.GetValue(EnrollOptions.displayName))
+                .Trim()
 
         let repositoryValues =
             parseResult.GetValue(EnrollOptions.repositories)
@@ -146,6 +151,9 @@ module CacheCommand =
 
         if ownerId = Guid.Empty then
             Error(GraceError.Create "--owner-id must be a non-empty GUID." correlationId)
+        elif hasExplicitOrganizationId
+             && parsedOrganizationId = Guid.Empty then
+            Error(GraceError.Create "--organization-id must be a non-empty GUID when supplied." correlationId)
         elif scopes |> Array.exists Option.isNone then
             Error(GraceError.Create "Each --repository value must be organization-GUID/repository-GUID." correlationId)
         else
@@ -161,7 +169,7 @@ module CacheCommand =
                 let request =
                     {
                         Class = nameof CacheEnrollmentRequest
-                        DisplayName = parseResult.GetValue(EnrollOptions.displayName)
+                        DisplayName = displayName
                         BoundaryKind =
                             if organizationId.IsSome then
                                 CacheBoundaryKind.Organization
@@ -262,6 +270,12 @@ module CacheCommand =
     let private renderEnrollmentSuccess parseResult =
         let status = CacheIdentity.status stateRoot
 
+        if
+            not (hasSelect parseResult)
+            && parseResult |> hasOutput
+        then
+            renderHumanStatus status
+
         let renderExitCode =
             GraceReturnValue.Create (statusValue status) (getCorrelationId parseResult)
             |> Ok
@@ -271,8 +285,8 @@ module CacheCommand =
         elif status.Enrollment = "enrolled" then 0
         else -1
 
-    /// Completes the one-shot enrollment transition without retries, reconciliation, repository configuration, or invocation history.
-    let private enrollHandler (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+    /// Executes the one-shot enrollment transition without retries, reconciliation, repository configuration, or invocation history.
+    let private enrollTransition (parseResult: ParseResult) (cancellationToken: CancellationToken) =
         task {
             let placeholder: Grace.Cache.CacheIdentityPublicKey = { PublicKeyX = String.replicate 43 "a"; PublicKeyY = String.replicate 43 "a" }
 
@@ -396,6 +410,16 @@ module CacheCommand =
                                     CacheIdentity.discardClaimedAttempt claim stateRoot stagedKey
 
                                 CacheIdentity.releaseEnrollmentClaim claim
+        }
+
+    /// Projects cancellation from every enrollment phase through the redacted Cache output contract after claimed cleanup completes.
+    let private enrollHandler (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            try
+                return! enrollTransition parseResult cancellationToken
+            with
+            | :? OperationCanceledException ->
+                return renderOutput parseResult (Error(GraceError.Create "Cache enrollment was cancelled." (getCorrelationId parseResult)))
         }
 
     /// Invokes the one-shot cache enrollment action through repository-independent root dispatch.

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -705,14 +705,16 @@ module CommandOutputContract =
     /// Builds command-output contract metadata for return value contract for so automation can rely on stable JSON shapes.
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
-        | "cache.status", ExistingGraceResultEnvelope NoServerDto ->
+        | ("cache.enroll"
+          | "cache.status"),
+          ExistingGraceResultEnvelope _ ->
             supportedReturnValueContract
                 "CacheStatusDto"
                 "Grace.CLI.Command.CacheCommand"
                 cacheStatusSchema
                 cacheStatusExample
                 [
-                    "The command reads local protected identity state without a repository, server request, credential lookup, or mutation."
+                    "The command never exposes private key material, filesystem paths, or enrollment attempt details."
                     "CacheId, Endpoint, BoundaryKind, and RepositoryCount are present only when Enrollment is enrolled."
                 ]
         | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
@@ -1090,6 +1092,8 @@ module CommandOutputContract =
 
     let entries =
         [
+            row [ "cache" ] "enroll" true true common_renderOutput_envelope mutating_state_transition server_via_sdk RequiresCliDto
+            row [ "cache" ] "status" true false common_renderOutput_envelope read_list_search local_client NoServerDto
             row [ "authorize" ] "can" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "grant-role" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
@@ -1186,7 +1190,6 @@ module CommandOutputContract =
             row [ "branch" ] "switch" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "branch" ] "tag" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "update-parent-branch" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
-            row [ "cache" ] "status" true false common_renderOutput_envelope read_list_search local_client NoServerDto
             row [ "candidate" ] "attestations" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate" ] "cancel" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate"; "gate" ] "rerun" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -1059,6 +1059,7 @@ module CommandOutputContract =
                 if
                     identity.CommandId.Equals("doctor", StringComparison.Ordinal)
                     || identity.CommandId.Equals("cache.status", StringComparison.Ordinal)
+                    || identity.CommandId.Equals("cache.enroll", StringComparison.Ordinal)
                 then
                     { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
                 else
@@ -1092,7 +1093,7 @@ module CommandOutputContract =
 
     let entries =
         [
-            row [ "cache" ] "enroll" true true common_renderOutput_envelope mutating_state_transition server_via_sdk RequiresCliDto
+            row [ "cache" ] "enroll" true true common_renderOutput_envelope mutating_state_transition composite_local_server RequiresCliDto
             row [ "cache" ] "status" true false common_renderOutput_envelope read_list_search local_client NoServerDto
             row [ "authorize" ] "can" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "authorize" ] "check" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -258,6 +258,7 @@ module GraceCommand =
     /// Evaluates is ignorable introspection parse error against parsed options and command state.
     let private isIgnorableIntrospectionParseError (error: ParseError) =
         error.Message.StartsWith("Required argument missing for command:", StringComparison.Ordinal)
+        || error.Message.StartsWith("Required option missing for command:", StringComparison.Ordinal)
 
     /// Evaluates has blocking introspection parse errors against parsed options and command state.
     let private hasBlockingIntrospectionParseErrors (parseResult: ParseResult) =

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1019,8 +1019,8 @@ module GraceCommand =
         else
             false
 
-    /// Checks whether the parsed command is the pure local Cache status leaf.
-    let isGraceCacheStatus (parseResult: ParseResult) =
+    /// Checks whether the parsed command belongs to the repository-independent Cache command group.
+    let isGraceCache (parseResult: ParseResult) =
         if isNull parseResult then
             false
         else
@@ -1030,7 +1030,6 @@ module GraceCommand =
                 |> Set.ofSeq
 
             Set.contains "cache" commands
-            && Set.contains "status" commands
 
     /// Models feedback section values passed between the parser and program handlers.
     type FeedbackSection(action: HelpAction) =
@@ -1178,11 +1177,10 @@ module GraceCommand =
                     parseResult <- rootCommand.Parse(argvToParse)
                     parseSucceeded <- parseResult.Errors.Count = 0
 
-                    if not (parseResult |> isGraceCacheStatus) then
-                        Auth.configureSdkAuth ()
-                        Services.configureSdkClientIdentity ()
-                        Services.resetInvocationCorrelationId ()
-                        Common.resetLifecycleWarningSuppression ()
+                    Auth.configureSdkAuth ()
+                    Services.configureSdkClientIdentity ()
+                    Services.resetInvocationCorrelationId ()
+                    Common.resetLifecycleWarningSuppression ()
 
                     match introspectionRequestFromTokens argvToParse with
                     | Some (Ok kind) ->
@@ -1220,7 +1218,7 @@ module GraceCommand =
 
                         if
                             not (parseResult |> isGraceDoctor)
-                            && not (parseResult |> isGraceCacheStatus)
+                            && not (parseResult |> isGraceCache)
                         then
                             LocalStateDb.setVerbose (parseResult |> verbose)
 
@@ -1392,7 +1390,7 @@ module GraceCommand =
 
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
-                    else if parseResult |> isGraceCacheStatus then
+                    else if parseResult |> isGraceCache then
                         let! invokedReturnValue = parseResult.InvokeAsync()
                         returnValue <- invokedReturnValue
                     else if parseResult |> isGraceDoctor then
@@ -1548,7 +1546,7 @@ module GraceCommand =
                 if
                     not isIntrospection
                     && not (parseResult |> isGraceDoctor)
-                    && not (parseResult |> isGraceCacheStatus)
+                    && not (parseResult |> isGraceCache)
                 then
                     HistoryStorage.tryRecordInvocation
                         {

--- a/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
@@ -467,3 +467,33 @@ type CacheIdentityTests() =
             CacheIdentity.discardAttempt root
             requireInspection CacheIdentityInspection.Missing (CacheIdentity.inspect root)
             Assert.DoesNotThrow(Action(fun () -> CacheIdentity.discardAttempt root)))
+
+    /// Verifies a live root claim blocks a second process-equivalent owner and safely releases for a later enrollment attempt.
+    [<Test>]
+    member _.``enrollment claim serializes staging and releases for retry``() =
+        withLinuxRoot (fun root ->
+            let first =
+                CacheIdentity.tryAcquireEnrollmentClaim root
+                |> requireOk
+
+            try
+                CacheIdentity.tryAcquireEnrollmentClaim root
+                |> requireStateUnavailable
+
+                let publicKey =
+                    CacheIdentity.createClaimedAttempt first root
+                    |> requireOk
+
+                CacheIdentity.validateClaimedAttempt first root publicKey
+                |> requireOk
+
+                CacheIdentity.discardClaimedAttempt first root (Some publicKey)
+                requireInspection CacheIdentityInspection.Missing (CacheIdentity.inspect root)
+            finally
+                CacheIdentity.releaseEnrollmentClaim first
+
+            let retry =
+                CacheIdentity.tryAcquireEnrollmentClaim root
+                |> requireOk
+
+            CacheIdentity.releaseEnrollmentClaim retry)

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -94,6 +94,9 @@ module internal CacheIdentity =
     [<Literal>]
     let private RegistrationFileName = "registration.json"
 
+    [<Literal>]
+    let private EnrollmentClaimFileName = "enrollment.claim"
+
     let private directoryMode =
         UnixFileMode.UserRead
         ||| UnixFileMode.UserWrite
@@ -649,6 +652,44 @@ module internal CacheIdentity =
                 with
                 | _ -> Error CacheIdentityError.StateUnavailable
 
+    /// Holds the one root-local file handle that serializes a complete Cache enrollment attempt.
+    type internal CacheEnrollmentClaim = private { Root: string; Stream: FileStream }
+
+    /// Acquires the exclusive root-local claim used from stale recovery through accepted publication and cleanup.
+    let tryAcquireEnrollmentClaim root =
+        match validateRoot root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let claimPath = child root EnrollmentClaimFileName
+                let stream = new FileStream(claimPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+                File.SetUnixFileMode(claimPath, fileMode)
+
+                match inspectMode claimPath fileMode with
+                | Ok () -> Ok { Root = root; Stream = stream }
+                | Error _ ->
+                    stream.Dispose()
+                    Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Releases the root-local enrollment claim after its caller has finished all protected local effects.
+    let releaseEnrollmentClaim claim =
+        if not (isNull (box claim)) then
+            try
+                claim.Stream.Dispose()
+            with
+            | _ -> ()
+
+    /// Confirms the caller still owns the same live root-local enrollment claim before a protected transition.
+    let private validateEnrollmentClaim claim root =
+        if isNull (box claim)
+           || not (String.Equals(claim.Root, root, StringComparison.Ordinal))
+           || claim.Stream.SafeFileHandle.IsClosed then
+            Error CacheIdentityError.StateUnavailable
+        else
+            validateRoot root
+
     /// Publishes an accepted registration only after its key fingerprint matches the staged private key and all modes are protected.
     let commitReady root configuration =
         match validateRoot root, tryExpectedFingerprint configuration with
@@ -809,5 +850,81 @@ module internal CacheIdentity =
                 let attempt = child root AttemptDirectoryName
 
                 if Directory.Exists(attempt) then Directory.Delete(attempt, true)
+            with
+            | _ -> ()
+
+    /// Inspects a protected root only after validating its Linux service-account security requirements.
+    let inspectEnrollmentRoot root =
+        match validateRoot root with
+        | Error error -> Error error
+        | Ok () -> inspect root
+
+    /// Removes a stale attempt while retaining the exclusive root-local claim that prevents another command from racing it.
+    let discardStaleAttempt claim root =
+        match validateEnrollmentClaim claim root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let attempt = child root AttemptDirectoryName
+
+                if Directory.Exists(attempt) then Directory.Delete(attempt, true)
+
+                match inspect root with
+                | Ok CacheIdentityInspection.Missing -> Ok()
+                | _ -> Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Stages one P-256 identity while the caller retains the claim that owns its complete enrollment lifecycle.
+    let createClaimedAttempt claim root =
+        match validateEnrollmentClaim claim root with
+        | Error error -> Error error
+        | Ok () -> createAttempt root
+
+    /// Rechecks the live claim and exact staged P-256 public key immediately before the enrollment POST or ready publication.
+    let validateClaimedAttempt claim root (expectedPublicKey: CacheIdentityPublicKey) =
+        match validateEnrollmentClaim claim root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let identityPath = child (child root AttemptDirectoryName) IdentityFileName
+
+                match File.ReadAllBytes(identityPath) |> tryImportP256 with
+                | Some (x, y) when
+                    String.Equals(base64Url x, expectedPublicKey.PublicKeyX, StringComparison.Ordinal)
+                    && String.Equals(base64Url y, expectedPublicKey.PublicKeyY, StringComparison.Ordinal)
+                    ->
+                    Ok()
+                | _ -> Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Publishes ready state only while the command still owns its validated staged identity claim.
+    let commitClaimedReady claim root configuration =
+        match validateClaimedAttempt claim root configuration.PublicKey with
+        | Error error -> Error error
+        | Ok () -> commitReady root configuration
+
+    /// Removes only the claimed invocation's staged attempt without replacing its primary failure.
+    let discardClaimedAttempt claim root (expectedPublicKey: CacheIdentityPublicKey option) =
+        match validateEnrollmentClaim claim root with
+        | Error _ -> ()
+        | Ok () ->
+            try
+                let attempt = child root AttemptDirectoryName
+                let identityPath = child attempt IdentityFileName
+
+                let matchesExpected =
+                    match expectedPublicKey with
+                    | None -> true
+                    | Some expected ->
+                        match File.ReadAllBytes(identityPath) |> tryImportP256 with
+                        | Some (x, y) ->
+                            String.Equals(base64Url x, expected.PublicKeyX, StringComparison.Ordinal)
+                            && String.Equals(base64Url y, expected.PublicKeyY, StringComparison.Ordinal)
+                        | None -> false
+
+                if Directory.Exists(attempt) && matchesExpected then
+                    Directory.Delete(attempt, true)
             with
             | _ -> ()

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -26,6 +26,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Grace.CLI.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Grace.CLI.CacheEnrollment.ClaimHolder</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.SDK/CacheRegistration.SDK.fs
+++ b/src/Grace.SDK/CacheRegistration.SDK.fs
@@ -1,0 +1,53 @@
+namespace Grace.SDK
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open System
+open System.Net.Http
+open System.Net.Http.Headers
+open System.Net.Http.Json
+open System.Threading
+
+/// Sends the single selected-server request used to enroll a static Grace Cache identity.
+type CacheRegistration() =
+    /// Posts one enrollment request with the caller-selected server and already-resolved bearer, without redirects, retries, or configuration lookup.
+    static member Enroll(request: CacheEnrollmentRequest, serverUri: Uri, bearer: string, correlationId: string, cancellationToken: CancellationToken) =
+        task {
+            if obj.ReferenceEquals(request, null) then
+                return Error(GraceError.Create "Cache enrollment request is required." correlationId)
+            elif isNull serverUri || not serverUri.IsAbsoluteUri then
+                return Error(GraceError.Create "Cache enrollment requires an absolute Grace Server URI." correlationId)
+            elif String.IsNullOrWhiteSpace bearer then
+                return Error(GraceError.Create "Cache enrollment requires an authenticated bearer credential." correlationId)
+            else
+                try
+                    use handler = new SocketsHttpHandler(AllowAutoRedirect = false)
+
+                    use client =
+                        new HttpClient(handler)
+                        |> ClientIdentity.applyHeaders
+
+                    client.DefaultRequestHeaders.TryAddWithoutValidation(Constants.CorrelationIdHeaderKey, correlationId)
+                    |> ignore
+
+                    client.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", bearer)
+                    use content = createJsonContent request
+                    use! response = client.PostAsync(Uri($"{serverUri.AbsoluteUri.TrimEnd('/')}/cache/enroll"), content, cancellationToken)
+
+                    if response.IsSuccessStatusCode then
+                        let! result =
+                            response.Content.ReadFromJsonAsync<GraceReturnValue<CacheRegistrationResult>>(Constants.JsonSerializerOptions, cancellationToken)
+
+                        return
+                            if obj.ReferenceEquals(result, null) then
+                                Error(GraceError.Create "Cache enrollment returned an empty response." correlationId)
+                            else
+                                Ok result
+                    else
+                        return Error(GraceError.Create "Cache enrollment was rejected by the selected Grace Server." correlationId)
+                with
+                | :? OperationCanceledException as error -> return raise error
+                | _ -> return Error(GraceError.Create "Cache enrollment could not reach the selected Grace Server." correlationId)
+        }

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -17,7 +17,8 @@
 	</PropertyGroup>
 	<ItemGroup>
         <None Include="instructions.md" />
-        <Compile Include="ClientIdentity.SDK.fs" />
+		<Compile Include="ClientIdentity.SDK.fs" />
+		<Compile Include="CacheRegistration.SDK.fs" />
         <Compile Include="Auth.SDK.fs" />
         <Compile Include="Common.SDK.fs" />
         <Compile Include="PersonalAccessToken.SDK.fs" />

--- a/src/Grace.slnx
+++ b/src/Grace.slnx
@@ -13,6 +13,7 @@
   <Project Path="Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj" />
   <Project Path="Grace.CLI.Tests/Grace.CLI.Tests.fsproj" />
   <Project Path="Grace.CLI/Grace.CLI.fsproj" />
+  <Project Path="Grace.CLI.CacheEnrollment.ClaimHolder/Grace.CLI.CacheEnrollment.ClaimHolder.fsproj" />
   <Project Path="Grace.Cache.Tests/Grace.Cache.Tests.fsproj" />
   <Project Path="Grace.Cache/Grace.Cache.fsproj" />
   <Project Path="Grace.Load/Grace.Load.fsproj" />


### PR DESCRIPTION
## Why this matters

Grace Cache needs one explicit, repository-independent Product V1 enrollment command that can establish protected local identity and register once with Grace Server before later liveness and serving work.

## What changed

- adds `grace cache enroll` with the approved owner/organization/repository grammar and selected server URI
- resolves one existing PAT, M2M, or interactive credential before protected local effects
- stages a protected P-256 identity, sends one nonredirecting enrollment POST, validates the complete response, and publishes ready state atomically
- adds stable machine-readable output metadata, Linux service-user proof, real GNOME keyring/libsecret proof, and the normal-build cross-process claim holder
- updates the Product V1 operator documentation and implementation audit

## Validation

- Release `src/Grace.slnx` build passed; zero errors and the existing `ASPIRE001` warning only
- Windows focused CLI fixtures: 26 passed, 8 expected Linux-only skips
- Linux root-dispatch proof: 8 passed, 1 expected unsupported-host skip, including PAT, M2M, and interactive keyring paths
- Linux cache identity proof: 9 passed, 1 expected root-context skip
- targeted Fantomas, MarkdownLint, and `git diff --check` passed

Relates to #905.
Targets the Epic #601 integration branch; it does not close #905 until merged there and reconciled by the orchestrator.