### PR TITLE
Compile coercion-free WDU raw projections

### DIFF
--- a/scripts/modules/WduLifecycleRawProjection.psm1
+++ b/scripts/modules/WduLifecycleRawProjection.psm1
@@ -1,0 +1,221 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'WduLifecycleContract.psm1') -Force
+
+$script:ProjectionSchema = 'grace.wdu.lifecycle-projection/v2'
+$script:CanonicalAnchor = 'docs/Working Directory Update.md#normative-branch-lifecycle-table'
+$script:RootProperties = @(
+    'schema', 'artifact', 'canonical', 'canonicalContentDigest', 'assignmentDigest', 'rowCount',
+    'applicabilityKeyCount', 'requirementCount', 'artifactCount', 'requirements', 'artifactIds', 'assignment'
+)
+
+function Fail-RawProjection {
+    param([string] $Location, [string] $Reason)
+    throw "WDU raw lifecycle projection '$Location': $Reason"
+}
+
+function Test-OrdinalEqual {
+    param([string] $Left, [string] $Right)
+    return [StringComparer]::Ordinal.Equals($Left, $Right)
+}
+
+function Get-CompilerArtifact {
+    param([object] $Compiled, [string] $ArtifactId, [string] $Location)
+    foreach ($artifact in $Compiled.Artifacts) {
+        if (Test-OrdinalEqual $artifact.Id $ArtifactId) { return $artifact }
+    }
+    Fail-RawProjection $Location "artifact '$ArtifactId' is not declared by the lifecycle compiler"
+}
+
+function Assert-NoDuplicateProperties {
+    param([Text.Json.JsonElement] $Element, [string] $Location)
+    if ($Element.ValueKind -eq [Text.Json.JsonValueKind]::Object) {
+        $names = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($property in $Element.EnumerateObject()) {
+            if (-not $names.Add($property.Name)) {
+                Fail-RawProjection $Location "has duplicate case-equivalent property '$($property.Name)'"
+            }
+            Assert-NoDuplicateProperties $property.Value "$Location.$($property.Name)"
+        }
+        return
+    }
+    if ($Element.ValueKind -eq [Text.Json.JsonValueKind]::Array) {
+        $index = 0
+        foreach ($item in $Element.EnumerateArray()) {
+            Assert-NoDuplicateProperties $item "$Location[$index]"
+            $index++
+        }
+    }
+}
+
+function Assert-ExactProperties {
+    param([Text.Json.JsonElement] $Element, [string[]] $Expected, [string] $Location)
+    if ($Element.ValueKind -ne [Text.Json.JsonValueKind]::Object) {
+        Fail-RawProjection $Location 'must be a JSON object'
+    }
+    $properties = @($Element.EnumerateObject())
+    if ($properties.Count -ne $Expected.Count) {
+        Fail-RawProjection $Location "must contain exactly $($Expected.Count) ordered properties"
+    }
+    for ($index = 0; $index -lt $Expected.Count; $index++) {
+        if (-not (Test-OrdinalEqual $properties[$index].Name $Expected[$index])) {
+            Fail-RawProjection $Location "property at ordinal $index must be '$($Expected[$index])'"
+        }
+    }
+    return $properties
+}
+
+function Assert-JsonString {
+    param([Text.Json.JsonElement] $Element, [string] $Location)
+    if ($Element.ValueKind -ne [Text.Json.JsonValueKind]::String) {
+        Fail-RawProjection $Location 'must be a JSON string'
+    }
+    return $Element.GetString()
+}
+
+function Assert-ExactString {
+    param([Text.Json.JsonElement] $Element, [string] $Expected, [string] $Location)
+    $actual = Assert-JsonString $Element $Location
+    if (-not (Test-OrdinalEqual $actual $Expected)) {
+        Fail-RawProjection $Location "must equal '$Expected'"
+    }
+}
+
+function Assert-ExactCount {
+    param([Text.Json.JsonElement] $Element, [int] $Expected, [string] $Location)
+    if ($Element.ValueKind -ne [Text.Json.JsonValueKind]::Number) {
+        Fail-RawProjection $Location 'must be a JSON number'
+    }
+    if (-not (Test-OrdinalEqual $Element.GetRawText() ([Convert]::ToString($Expected, [Globalization.CultureInfo]::InvariantCulture)))) {
+        Fail-RawProjection $Location "must be the exact integer token $Expected"
+    }
+}
+
+function Assert-StringVector {
+    param([Text.Json.JsonElement] $Element, [string[]] $Expected, [string] $Location)
+    if ($Element.ValueKind -ne [Text.Json.JsonValueKind]::Array) {
+        Fail-RawProjection $Location 'must be a JSON array'
+    }
+    $values = @($Element.EnumerateArray())
+    if ($values.Count -ne $Expected.Count) {
+        Fail-RawProjection $Location "must contain exactly $($Expected.Count) values"
+    }
+    for ($index = 0; $index -lt $Expected.Count; $index++) {
+        Assert-ExactString $values[$index] $Expected[$index] "$Location[$index]"
+    }
+}
+
+function Assert-Requirements {
+    param([Text.Json.JsonElement] $Element, [object[]] $Expected, [string] $Location)
+    if ($Element.ValueKind -ne [Text.Json.JsonValueKind]::Array) {
+        Fail-RawProjection $Location 'must be a JSON array'
+    }
+    $requirements = @($Element.EnumerateArray())
+    if ($requirements.Count -ne $Expected.Count) {
+        Fail-RawProjection $Location "must contain exactly $($Expected.Count) values"
+    }
+    for ($index = 0; $index -lt $Expected.Count; $index++) {
+        $properties = @(Assert-ExactProperties $requirements[$index] @('id', 'owner') "$Location[$index]")
+        Assert-ExactString $properties[0].Value $Expected[$index].Id "$Location[$index].id"
+        Assert-ExactString $properties[1].Value $Expected[$index].Owner "$Location[$index].owner"
+    }
+}
+
+function New-WduLifecycleRawProjection {
+    param(
+        [Parameter(Mandatory)][ValidateNotNull()][object] $Compiled,
+        [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $Artifact
+    )
+
+    $declaredArtifact = Get-CompilerArtifact $Compiled $Artifact '$.artifact'
+    $stream = [IO.MemoryStream]::new()
+    $options = [Text.Json.JsonWriterOptions]::new()
+    $options.Indented = $false
+    $writer = [Text.Json.Utf8JsonWriter]::new($stream, $options)
+    try {
+        $writer.WriteStartObject()
+        $writer.WriteString('schema', $script:ProjectionSchema)
+        $writer.WriteString('artifact', $declaredArtifact.Id)
+        $writer.WriteString('canonical', $script:CanonicalAnchor)
+        $writer.WriteString('canonicalContentDigest', $compiled.Digest)
+        $writer.WriteString('assignmentDigest', $compiled.AssignmentDigest)
+        $writer.WriteNumber('rowCount', $compiled.Counts.rowCount)
+        $writer.WriteNumber('applicabilityKeyCount', $compiled.Counts.applicabilityKeyCount)
+        $writer.WriteNumber('requirementCount', $compiled.Counts.requirementCount)
+        $writer.WriteNumber('artifactCount', $compiled.Counts.artifactCount)
+        $writer.WritePropertyName('requirements')
+        $writer.WriteStartArray()
+        foreach ($requirement in $compiled.Requirements) {
+            $writer.WriteStartObject()
+            $writer.WriteString('id', $requirement.Id)
+            $writer.WriteString('owner', $requirement.Owner)
+            $writer.WriteEndObject()
+        }
+        $writer.WriteEndArray()
+        $writer.WritePropertyName('artifactIds')
+        $writer.WriteStartArray()
+        foreach ($compilerArtifact in $compiled.Artifacts) { $writer.WriteStringValue($compilerArtifact.Id) }
+        $writer.WriteEndArray()
+        $writer.WritePropertyName('assignment')
+        $writer.WriteStartObject()
+        $writer.WritePropertyName('rowIds')
+        $writer.WriteStartArray()
+        foreach ($rowId in $declaredArtifact.RowIds) { $writer.WriteStringValue($rowId) }
+        $writer.WriteEndArray()
+        $writer.WriteEndObject()
+        $writer.WriteEndObject()
+        $writer.Flush()
+        $bytes = $stream.ToArray()
+    }
+    finally {
+        $writer.Dispose()
+        $stream.Dispose()
+    }
+    $result = [pscustomobject]@{
+        Artifact = $declaredArtifact.Id
+        Utf8Json = [ReadOnlyMemory[byte]]::new($bytes)
+    }
+    Test-WduLifecycleRawProjection -Compiled $Compiled -Utf8Json $result.Utf8Json | Out-Null
+    return $result
+}
+
+function Test-WduLifecycleRawProjection {
+    param(
+        [Parameter(Mandatory)][ValidateNotNull()][object] $Compiled,
+        [Parameter(Mandatory)][ReadOnlyMemory[byte]] $Utf8Json
+    )
+
+    $bytes = $Utf8Json.ToArray()
+    if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+        Fail-RawProjection '$' 'must not begin with a UTF-8 BOM'
+    }
+    $options = [Text.Json.JsonDocumentOptions]::new()
+    $options.CommentHandling = [Text.Json.JsonCommentHandling]::Disallow
+    $options.AllowTrailingCommas = $false
+    try { $document = [Text.Json.JsonDocument]::Parse([ReadOnlyMemory[byte]]::new($bytes), $options) }
+    catch { Fail-RawProjection '$' "is not one valid UTF-8 JSON value: $($_.Exception.Message)" }
+    try {
+        $root = $document.RootElement
+        Assert-NoDuplicateProperties $root '$'
+        $rootProperties = @(Assert-ExactProperties $root $script:RootProperties '$')
+        Assert-ExactString $rootProperties[0].Value $script:ProjectionSchema '$.schema'
+        $artifactId = Assert-JsonString $rootProperties[1].Value '$.artifact'
+        $artifact = Get-CompilerArtifact $Compiled $artifactId '$.artifact'
+        Assert-ExactString $rootProperties[2].Value $script:CanonicalAnchor '$.canonical'
+        Assert-ExactString $rootProperties[3].Value $Compiled.Digest '$.canonicalContentDigest'
+        Assert-ExactString $rootProperties[4].Value $Compiled.AssignmentDigest '$.assignmentDigest'
+        Assert-ExactCount $rootProperties[5].Value $Compiled.Counts.rowCount '$.rowCount'
+        Assert-ExactCount $rootProperties[6].Value $Compiled.Counts.applicabilityKeyCount '$.applicabilityKeyCount'
+        Assert-ExactCount $rootProperties[7].Value $Compiled.Counts.requirementCount '$.requirementCount'
+        Assert-ExactCount $rootProperties[8].Value $Compiled.Counts.artifactCount '$.artifactCount'
+        Assert-Requirements $rootProperties[9].Value @($Compiled.Requirements) '$.requirements'
+        Assert-StringVector $rootProperties[10].Value @($Compiled.Artifacts | ForEach-Object { $_.Id }) '$.artifactIds'
+        $assignmentProperties = @(Assert-ExactProperties $rootProperties[11].Value @('rowIds') '$.assignment')
+        Assert-StringVector $assignmentProperties[0].Value @($artifact.RowIds) '$.assignment.rowIds'
+        return [pscustomobject]@{ Artifact = $artifact.Id; Result = 'ExactMatch' }
+    }
+    finally { $document.Dispose() }
+}
+
+Export-ModuleMember -Function New-WduLifecycleRawProjection, Test-WduLifecycleRawProjection

--- a/scripts/tests/WduLifecycleRawProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleRawProjection.Tests.ps1
@@ -1,0 +1,254 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$modulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleRawProjection.psm1'
+$contractModulePath = Join-Path $repositoryRoot 'scripts/modules/WduLifecycleContract.psm1'
+$canonicalPath = Join-Path $repositoryRoot 'docs/Working Directory Update.md'
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw "Assertion failed: $Message" }
+}
+
+function Assert-Fails {
+    param([scriptblock] $Body, [string] $Contains)
+    try { & $Body | Out-Null }
+    catch {
+        Assert-True $_.Exception.Message.Contains($Contains, [StringComparison]::Ordinal) "failure should contain '$Contains': $($_.Exception.Message)"
+        return
+    }
+    throw "Expected failure containing '$Contains'"
+}
+
+function Invoke-Case {
+    param([string] $Name, [scriptblock] $Body)
+    try { & $Body; $script:Passed++; Write-Host "PASS $Name" }
+    catch { $script:Failed++; Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red }
+}
+
+function Get-Utf8 {
+    param([string] $Json)
+    return [ReadOnlyMemory[byte]]::new([Text.UTF8Encoding]::new($false, $true).GetBytes($Json))
+}
+
+function Get-Json {
+    param([object] $Projection)
+    return [Text.UTF8Encoding]::new($false, $true).GetString($Projection.Utf8Json.ToArray())
+}
+
+function Replace-Once {
+    param([string] $Text, [string] $Old, [string] $New)
+    $index = $Text.IndexOf($Old, [StringComparison]::Ordinal)
+    if ($index -lt 0) { throw "Test anchor not found: $Old" }
+    return $Text.Remove($index, $Old.Length).Insert($index, $New)
+}
+
+function Replace-ArrayValue {
+    param([string] $Json, [string] $Name, [string] $Replacement)
+    $prefix = '"' + $Name + '":['
+    $start = $Json.IndexOf($prefix, [StringComparison]::Ordinal)
+    if ($start -lt 0) { throw "Test array anchor not found: $Name" }
+    $open = $start + $prefix.Length - 1
+    $depth = 0
+    $inString = $false
+    $escaped = $false
+    for ($index = $open; $index -lt $Json.Length; $index++) {
+        $character = $Json[$index]
+        if ($inString) {
+            if ($escaped) { $escaped = $false; continue }
+            if ($character -eq '\') { $escaped = $true; continue }
+            if ($character -eq '"') { $inString = $false }
+            continue
+        }
+        if ($character -eq '"') { $inString = $true; continue }
+        if ($character -eq '[') { $depth++; continue }
+        if ($character -eq ']') {
+            $depth--
+            if ($depth -eq 0) { return $Json.Remove($open, $index - $open + 1).Insert($open, $Replacement) }
+        }
+    }
+    throw "Test array has no closing bracket: $Name"
+}
+
+function Invoke-Mutation {
+    param([object] $Projection, [scriptblock] $Mutation, [string] $Expected)
+    $json = Get-Json $Projection
+    $mutated = & $Mutation $json
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $mutated) } $Expected
+}
+
+function Assert-IndependentRawPayload {
+    param([object] $Projection, [object] $Compiled)
+    $document = [Text.Json.JsonDocument]::Parse($Projection.Utf8Json)
+    try {
+        $root = $document.RootElement
+        Assert-True ($root.ValueKind -eq [Text.Json.JsonValueKind]::Object) "$($Projection.Artifact) root is an object"
+        $properties = @($root.EnumerateObject())
+        $expectedNames = @('schema', 'artifact', 'canonical', 'canonicalContentDigest', 'assignmentDigest', 'rowCount', 'applicabilityKeyCount', 'requirementCount', 'artifactCount', 'requirements', 'artifactIds', 'assignment')
+        Assert-True ($properties.Count -eq $expectedNames.Count) "$($Projection.Artifact) has twelve root properties"
+        for ($index = 0; $index -lt $expectedNames.Count; $index++) {
+            Assert-True ([StringComparer]::Ordinal.Equals($properties[$index].Name, $expectedNames[$index])) "$($Projection.Artifact) root property $index is ordered"
+        }
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[0].Value.GetString(), 'grace.wdu.lifecycle-projection/v2')) "$($Projection.Artifact) schema is fixed"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[1].Value.GetString(), $Projection.Artifact)) "$($Projection.Artifact) identity is exact"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[2].Value.GetString(), 'docs/Working Directory Update.md#normative-branch-lifecycle-table')) "$($Projection.Artifact) canonical anchor is fixed"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[3].Value.GetString(), $Compiled.Digest)) "$($Projection.Artifact) digest comes from compiler"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[4].Value.GetString(), $Compiled.AssignmentDigest)) "$($Projection.Artifact) assignment digest comes from compiler"
+        $expectedCounts = @($Compiled.Counts.rowCount, $Compiled.Counts.applicabilityKeyCount, $Compiled.Counts.requirementCount, $Compiled.Counts.artifactCount)
+        foreach ($index in 5..8) {
+            Assert-True ($properties[$index].Value.ValueKind -eq [Text.Json.JsonValueKind]::Number) "$($Projection.Artifact) count $index is numeric"
+            Assert-True ($properties[$index].Value.GetRawText() -ceq [Convert]::ToString($expectedCounts[$index - 5], [Globalization.CultureInfo]::InvariantCulture)) "$($Projection.Artifact) count $index is exact"
+        }
+        $requirements = @($properties[9].Value.EnumerateArray())
+        Assert-True ($requirements.Count -eq $Compiled.Requirements.Count) "$($Projection.Artifact) has all requirement pairs"
+        for ($index = 0; $index -lt $requirements.Count; $index++) {
+            $pair = @($requirements[$index].EnumerateObject())
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[0].Name, 'id')) "$($Projection.Artifact) requirement $index ID name"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[1].Name, 'owner')) "$($Projection.Artifact) requirement $index owner name"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[0].Value.GetString(), $Compiled.Requirements[$index].Id)) "$($Projection.Artifact) requirement $index ID"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[1].Value.GetString(), $Compiled.Requirements[$index].Owner)) "$($Projection.Artifact) requirement $index owner"
+        }
+        $artifactIds = @($properties[10].Value.EnumerateArray())
+        Assert-True ($artifactIds.Count -eq $Compiled.Artifacts.Count) "$($Projection.Artifact) has all artifact IDs"
+        for ($index = 0; $index -lt $artifactIds.Count; $index++) {
+            Assert-True ([StringComparer]::Ordinal.Equals($artifactIds[$index].GetString(), $Compiled.Artifacts[$index].Id)) "$($Projection.Artifact) artifact ID $index"
+        }
+        $compilerArtifact = @($Compiled.Artifacts | Where-Object { [StringComparer]::Ordinal.Equals($_.Id, $Projection.Artifact) })
+        $assignmentProperties = @($properties[11].Value.EnumerateObject())
+        Assert-True ($properties[11].Value.ValueKind -eq [Text.Json.JsonValueKind]::Object) "$($Projection.Artifact) assignment is an object"
+        Assert-True ($assignmentProperties.Count -eq 1) "$($Projection.Artifact) assignment has one property"
+        Assert-True ([StringComparer]::Ordinal.Equals($assignmentProperties[0].Name, 'rowIds')) "$($Projection.Artifact) assignment property is rowIds"
+        Assert-True ($assignmentProperties[0].Value.ValueKind -eq [Text.Json.JsonValueKind]::Array) "$($Projection.Artifact) row IDs are an array"
+        $rowIds = @($assignmentProperties[0].Value.EnumerateArray())
+        Assert-True ($compilerArtifact.Count -eq 1) "$($Projection.Artifact) compiler artifact is unique"
+        Assert-True ($rowIds.Count -eq $compilerArtifact[0].RowIds.Count) "$($Projection.Artifact) assignment count"
+        for ($index = 0; $index -lt $rowIds.Count; $index++) {
+            Assert-True ([StringComparer]::Ordinal.Equals($rowIds[$index].GetString(), $compilerArtifact[0].RowIds[$index])) "$($Projection.Artifact) row ID $index"
+        }
+    }
+    finally { $document.Dispose() }
+}
+
+Import-Module $modulePath -Force
+Import-Module $contractModulePath -Force
+$script:Compiled = Read-WduLifecycleContract -Path $canonicalPath
+$script:Projections = @($script:Compiled.Artifacts | ForEach-Object { New-WduLifecycleRawProjection -Compiled $script:Compiled -Artifact $_.Id })
+$script:Passed = 0
+$script:Failed = 0
+
+Invoke-Case 'exports only the raw compiler and validator' {
+    $exports = @(Get-Command -Module WduLifecycleRawProjection | Select-Object -ExpandProperty Name)
+    Assert-True ($exports.Count -eq 2) 'module has two public commands'
+    Assert-True ($exports -contains 'New-WduLifecycleRawProjection') 'compiler is exported'
+    Assert-True ($exports -contains 'Test-WduLifecycleRawProjection') 'validator is exported'
+}
+
+Invoke-Case 'compiles all fifteen artifacts deterministically and validates raw tokens' {
+    Assert-True ($script:Compiled.Counts.rowCount -eq 70) 'compiler row count is 70'
+    Assert-True ($script:Compiled.Counts.applicabilityKeyCount -eq 260) 'compiler applicability count is 260'
+    Assert-True ($script:Compiled.Requirements.Count -eq 19) 'compiler requirement count is 19'
+    Assert-True ($script:Compiled.Artifacts.Count -eq 15) 'compiler artifact count is 15'
+    Assert-True ([StringComparer]::Ordinal.Equals($script:Compiled.Digest, 'ae3a77e28886485b49361d8836f040691e9f99228919cef87fac19b42e989d73')) 'compiler digest is exact'
+    Assert-True ([StringComparer]::Ordinal.Equals($script:Compiled.AssignmentDigest, '20e329bd3aa4459a01f4ed3c6ec12cf365c86df3538b0323400639b90eeee877')) 'assignment digest is exact'
+    foreach ($projection in $script:Projections) {
+        $second = New-WduLifecycleRawProjection -Compiled $script:Compiled -Artifact $projection.Artifact
+        Assert-True ([Convert]::ToHexString($projection.Utf8Json.ToArray()) -ceq [Convert]::ToHexString($second.Utf8Json.ToArray())) "$($projection.Artifact) bytes are deterministic"
+        $validated = Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json $projection.Utf8Json
+        Assert-True ([StringComparer]::Ordinal.Equals($validated.Artifact, $projection.Artifact)) "$($projection.Artifact) validates itself"
+        Assert-IndependentRawPayload $projection $script:Compiled
+    }
+}
+
+$baseline = $script:Projections[0]
+Invoke-Case 'rejects root array and scalar raw values' {
+    $json = Get-Json $baseline
+    foreach ($candidate in @("[$json]", 'null', '"projection"', '70')) {
+        Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $candidate) } 'JSON object'
+    }
+}
+
+Invoke-Case 'rejects duplicate and case-equivalent root and nested properties' {
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2",' '"schema":"grace.wdu.lifecycle-projection/v2","schema":"grace.wdu.lifecycle-projection/v2",' } 'duplicate case-equivalent'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2",' '"schema":"grace.wdu.lifecycle-projection/v2","Schema":"grace.wdu.lifecycle-projection/v2",' } 'duplicate case-equivalent'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"id":"REQ-001","owner":"#923"' '"id":"REQ-001","Id":"REQ-001","owner":"#923"' } 'duplicate case-equivalent'
+}
+
+Invoke-Case 'rejects missing extra reordered and incorrectly cased properties' {
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table",' '' } 'ordered properties'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2",' '"schema":"grace.wdu.lifecycle-projection/v2","extra":true,' } 'ordered properties'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2","artifact"' '"artifact"' } 'ordered properties'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2"' '"Schema":"grace.wdu.lifecycle-projection/v2"' } 'property at ordinal'
+}
+
+Invoke-Case 'rejects count coercion token kinds and values' {
+    foreach ($replacement in @('"70"', '70.0', '7e1', 'null', '71')) {
+        Invoke-Mutation $baseline { param($json) Replace-Once $json '"rowCount":70' ('"rowCount":' + $replacement) } 'rowCount'
+    }
+}
+
+Invoke-Case 'rejects scalar object and null where every required array belongs' {
+    foreach ($name in @('requirements', 'artifactIds')) {
+        foreach ($replacement in @('"joined"', '{}', 'null')) {
+            Invoke-Mutation $baseline { param($json) Replace-ArrayValue $json $name $replacement } $name
+        }
+    }
+    foreach ($replacement in @('"joined"', '{}', 'null')) {
+        Invoke-Mutation $baseline { param($json) Replace-ArrayValue $json 'rowIds' $replacement } 'rowIds'
+    }
+}
+
+Invoke-Case 'rejects requirement and artifact vector drift' {
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '{"id":"REQ-001","owner":"#923"},' '' } 'requirements'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '{"id":"REQ-001","owner":"#923"},{"id":"REQ-002","owner":"#869"}' '{"id":"REQ-002","owner":"#869"},{"id":"REQ-001","owner":"#923"}' } 'requirements[0].id'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '{"id":"REQ-001","owner":"#923"},' '{"id":"REQ-001","owner":"#923"},{"id":"REQ-001","owner":"#923"},' } 'requirements'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"id":"REQ-001","owner":"#923"' '"id":"REQ-001","owner":"#999"' } 'requirements[0].owner'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"id":"REQ-001","owner":"#923"' '"id":"REQ-001","owner":"#923","extra":true' } 'ordered properties'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"REQ-001"' '"req-001"' } 'requirements[0].id'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"adr-0011","epic-835"' '"epic-835","adr-0011"' } 'artifactIds[0]'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"artifactIds":["adr-0011",' '"artifactIds":[' } 'artifactIds'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"artifactIds":["adr-0011",' '"artifactIds":["adr-0011","adr-0011",' } 'artifactIds'
+    Invoke-Mutation $baseline { param($json) Replace-Once $json '"artifactIds":["adr-0011"' '"artifactIds":["ADR-0011"' } 'artifactIds[0]'
+}
+
+Invoke-Case 'rejects assignment row drift for every compiler artifact' {
+    foreach ($projection in $script:Projections) {
+        $artifact = @($script:Compiled.Artifacts | Where-Object { [StringComparer]::Ordinal.Equals($_.Id, $projection.Artifact) })[0]
+        $first = $artifact.RowIds[0]
+        $second = $artifact.RowIds[1]
+        Invoke-Mutation $projection { param($json) Replace-Once $json ('"' + $first + '",') '' } 'assignment.rowIds'
+        Invoke-Mutation $projection { param($json) Replace-Once $json ('"' + $first + '","' + $second + '"') ('"' + $second + '","' + $first + '"') } 'assignment.rowIds[0]'
+        Invoke-Mutation $projection { param($json) Replace-Once $json ('"' + $first + '",') ('"' + $first + '","' + $first + '",') } 'assignment.rowIds'
+        Invoke-Mutation $projection { param($json) Replace-Once $json ('"' + $first + '"') ('"' + $first.ToLowerInvariant() + '"') } 'assignment.rowIds[0]'
+    }
+}
+
+Invoke-Case 'rejects trailing tokens comments BOM and malformed UTF-8' {
+    $json = Get-Json $baseline
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 ($json + '{}')) } 'one valid UTF-8 JSON value'
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 ($json + '/*comment*/')) } 'one valid UTF-8 JSON value'
+    $bom = [byte[]](0xEF, 0xBB, 0xBF) + $baseline.Utf8Json.ToArray()
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json ([ReadOnlyMemory[byte]]::new($bom)) } 'UTF-8 BOM'
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json ([ReadOnlyMemory[byte]]::new([byte[]](0xFF))) } 'one valid UTF-8 JSON value'
+}
+
+Invoke-Case 'rejects raw shapes PowerShell can coerce into apparent equality' {
+    $json = Get-Json $baseline
+    $array = "[$json]" | ConvertFrom-Json
+    Assert-True ([StringComparer]::Ordinal.Equals($array.schema, 'grace.wdu.lifecycle-projection/v2')) 'PowerShell unwraps one element array property access'
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 "[$json]") } 'JSON object'
+    $stringCountJson = Replace-Once $json '"rowCount":70' '"rowCount":"70"'
+    $stringCount = $stringCountJson | ConvertFrom-Json
+    Assert-True ($stringCount.rowCount -eq 70) 'PowerShell coerces the string count in comparison'
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $stringCountJson) } 'rowCount'
+    $scalarArrayJson = Replace-ArrayValue $json 'artifactIds' '"adr-0011,epic-835"'
+    $scalarArray = $scalarArrayJson | ConvertFrom-Json
+    Assert-True ($scalarArray.artifactIds -is [string]) 'PowerShell exposes a scalar where the JSON contract requires an array'
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $scalarArrayJson) } 'artifactIds'
+}
+
+Write-Host "Result: $script:Passed passed; $script:Failed failed"
+if ($script:Failed -ne 0) { exit 1 }

--- a/scripts/tests/WduLifecycleRawProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleRawProjection.Tests.ps1
@@ -236,10 +236,55 @@ Invoke-Case 'rejects duplicate and case-equivalent root and nested properties' {
     Invoke-Mutation $baseline { param($json) Replace-Once $json '"id":"REQ-001","owner":"#923"' '"id":"REQ-001","Id":"REQ-001","owner":"#923"' } 'duplicate case-equivalent'
 }
 
-Invoke-Case 'rejects missing extra reordered and incorrectly cased properties' {
+Invoke-Case 'rejects missing extra genuinely reordered and incorrectly cased properties' {
     Invoke-Mutation $baseline { param($json) Replace-Once $json '"canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table",' '' } 'ordered properties'
     Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2",' '"schema":"grace.wdu.lifecycle-projection/v2","extra":true,' } 'ordered properties'
-    Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2","artifact"' '"artifact"' } 'ordered properties'
+    $rootPairSwap = Replace-Once (Get-Json $baseline) '"schema":"grace.wdu.lifecycle-projection/v2","artifact":"adr-0011"' '"artifact":"adr-0011","schema":"grace.wdu.lifecycle-projection/v2"'
+    $baselineDocument = [Text.Json.JsonDocument]::Parse((Get-Json $baseline))
+    $rootDocument = [Text.Json.JsonDocument]::Parse($rootPairSwap)
+    try {
+        $baselineRootProperties = @($baselineDocument.RootElement.EnumerateObject())
+        $rootProperties = @($rootDocument.RootElement.EnumerateObject())
+        Assert-True ($rootProperties.Count -eq 12) 'root pair swap retains all twelve properties'
+        foreach ($rootProperty in $rootProperties) {
+            $baselineProperty = @($baselineRootProperties | Where-Object { [StringComparer]::Ordinal.Equals($_.Name, $rootProperty.Name) })
+            Assert-True ($baselineProperty.Count -eq 1) "root pair swap retains property $($rootProperty.Name)"
+            Assert-True ($rootProperty.Value.GetRawText() -ceq $baselineProperty[0].Value.GetRawText()) "root pair swap retains exact $($rootProperty.Name) value"
+        }
+        Assert-True ([StringComparer]::Ordinal.Equals($rootProperties[0].Name, 'artifact')) 'root pair swap moves complete artifact pair first'
+        Assert-True ([StringComparer]::Ordinal.Equals($rootProperties[0].Value.GetString(), 'adr-0011')) 'root pair swap retains artifact value'
+        Assert-True ([StringComparer]::Ordinal.Equals($rootProperties[1].Name, 'schema')) 'root pair swap moves complete schema pair second'
+        Assert-True ([StringComparer]::Ordinal.Equals($rootProperties[1].Value.GetString(), 'grace.wdu.lifecycle-projection/v2')) 'root pair swap retains schema value'
+    }
+    finally {
+        $rootDocument.Dispose()
+        $baselineDocument.Dispose()
+    }
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $rootPairSwap) } "WDU raw lifecycle projection '$': property at ordinal 0 must be 'schema'"
+    $nestedPairSwap = Replace-Once (Get-Json $baseline) '"id":"REQ-001","owner":"#923"' '"owner":"#923","id":"REQ-001"'
+    $nestedBaselineDocument = [Text.Json.JsonDocument]::Parse((Get-Json $baseline))
+    $nestedDocument = [Text.Json.JsonDocument]::Parse($nestedPairSwap)
+    try {
+        $nestedBaselineProperties = @($nestedBaselineDocument.RootElement.GetProperty('requirements')[0].EnumerateObject())
+        $nestedProperties = @($nestedDocument.RootElement.GetProperty('requirements')[0].EnumerateObject())
+        Assert-True ($nestedProperties.Count -eq 2) 'nested pair swap retains both requirement properties'
+        foreach ($nestedProperty in $nestedProperties) {
+            $nestedBaselineProperty = @($nestedBaselineProperties | Where-Object { [StringComparer]::Ordinal.Equals($_.Name, $nestedProperty.Name) })
+            Assert-True ($nestedBaselineProperty.Count -eq 1) "nested pair swap retains property $($nestedProperty.Name)"
+            Assert-True ($nestedProperty.Value.GetRawText() -ceq $nestedBaselineProperty[0].Value.GetRawText()) "nested pair swap retains exact $($nestedProperty.Name) value"
+        }
+        Assert-True ([StringComparer]::Ordinal.Equals($nestedProperties[0].Name, 'owner')) 'nested pair swap moves complete owner pair first'
+        Assert-True ([StringComparer]::Ordinal.Equals($nestedProperties[0].Value.GetString(), '#923')) 'nested pair swap retains owner value'
+        Assert-True ([StringComparer]::Ordinal.Equals($nestedProperties[1].Name, 'id')) 'nested pair swap moves complete ID pair second'
+        Assert-True ([StringComparer]::Ordinal.Equals($nestedProperties[1].Value.GetString(), 'REQ-001')) 'nested pair swap retains ID value'
+    }
+    finally {
+        $nestedDocument.Dispose()
+        $nestedBaselineDocument.Dispose()
+    }
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $nestedPairSwap) } "WDU raw lifecycle projection '$.requirements[0]': property at ordinal 0 must be 'id'"
+    $oldDeletionMutation = Replace-Once (Get-Json $baseline) '"schema":"grace.wdu.lifecycle-projection/v2","artifact"' '"artifact"'
+    Assert-Fails { Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json (Get-Utf8 $oldDeletionMutation) } 'must contain exactly 12 ordered properties'
     Invoke-Mutation $baseline { param($json) Replace-Once $json '"schema":"grace.wdu.lifecycle-projection/v2"' '"Schema":"grace.wdu.lifecycle-projection/v2"' } 'property at ordinal'
 }
 

--- a/scripts/tests/WduLifecycleRawProjection.Tests.ps1
+++ b/scripts/tests/WduLifecycleRawProjection.Tests.ps1
@@ -82,61 +82,103 @@ function Invoke-Mutation {
 }
 
 function Assert-IndependentRawPayload {
-    param([object] $Projection, [object] $Compiled)
+    param([object] $Projection, [object] $ExpectedArtifact, [object] $Compiled)
     $document = [Text.Json.JsonDocument]::Parse($Projection.Utf8Json)
     try {
         $root = $document.RootElement
-        Assert-True ($root.ValueKind -eq [Text.Json.JsonValueKind]::Object) "$($Projection.Artifact) root is an object"
+        Assert-True ([StringComparer]::Ordinal.Equals($Projection.Artifact, $ExpectedArtifact.Id)) "returned Artifact equals requested $($ExpectedArtifact.Id)"
+        Assert-True ($root.ValueKind -eq [Text.Json.JsonValueKind]::Object) "$($ExpectedArtifact.Id) root is an object"
         $properties = @($root.EnumerateObject())
         $expectedNames = @('schema', 'artifact', 'canonical', 'canonicalContentDigest', 'assignmentDigest', 'rowCount', 'applicabilityKeyCount', 'requirementCount', 'artifactCount', 'requirements', 'artifactIds', 'assignment')
-        Assert-True ($properties.Count -eq $expectedNames.Count) "$($Projection.Artifact) has twelve root properties"
+        Assert-True ($properties.Count -eq $expectedNames.Count) "$($ExpectedArtifact.Id) has twelve root properties"
         for ($index = 0; $index -lt $expectedNames.Count; $index++) {
-            Assert-True ([StringComparer]::Ordinal.Equals($properties[$index].Name, $expectedNames[$index])) "$($Projection.Artifact) root property $index is ordered"
+            Assert-True ([StringComparer]::Ordinal.Equals($properties[$index].Name, $expectedNames[$index])) "$($ExpectedArtifact.Id) root property $index is ordered"
         }
-        Assert-True ([StringComparer]::Ordinal.Equals($properties[0].Value.GetString(), 'grace.wdu.lifecycle-projection/v2')) "$($Projection.Artifact) schema is fixed"
-        Assert-True ([StringComparer]::Ordinal.Equals($properties[1].Value.GetString(), $Projection.Artifact)) "$($Projection.Artifact) identity is exact"
-        Assert-True ([StringComparer]::Ordinal.Equals($properties[2].Value.GetString(), 'docs/Working Directory Update.md#normative-branch-lifecycle-table')) "$($Projection.Artifact) canonical anchor is fixed"
-        Assert-True ([StringComparer]::Ordinal.Equals($properties[3].Value.GetString(), $Compiled.Digest)) "$($Projection.Artifact) digest comes from compiler"
-        Assert-True ([StringComparer]::Ordinal.Equals($properties[4].Value.GetString(), $Compiled.AssignmentDigest)) "$($Projection.Artifact) assignment digest comes from compiler"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[0].Value.GetString(), 'grace.wdu.lifecycle-projection/v2')) "$($ExpectedArtifact.Id) schema is fixed"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[1].Value.GetString(), $ExpectedArtifact.Id)) "raw $.artifact equals requested $($ExpectedArtifact.Id)"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[2].Value.GetString(), 'docs/Working Directory Update.md#normative-branch-lifecycle-table')) "$($ExpectedArtifact.Id) canonical anchor is fixed"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[3].Value.GetString(), $Compiled.Digest)) "$($ExpectedArtifact.Id) digest comes from compiler"
+        Assert-True ([StringComparer]::Ordinal.Equals($properties[4].Value.GetString(), $Compiled.AssignmentDigest)) "$($ExpectedArtifact.Id) assignment digest comes from compiler"
         $expectedCounts = @($Compiled.Counts.rowCount, $Compiled.Counts.applicabilityKeyCount, $Compiled.Counts.requirementCount, $Compiled.Counts.artifactCount)
         foreach ($index in 5..8) {
-            Assert-True ($properties[$index].Value.ValueKind -eq [Text.Json.JsonValueKind]::Number) "$($Projection.Artifact) count $index is numeric"
-            Assert-True ($properties[$index].Value.GetRawText() -ceq [Convert]::ToString($expectedCounts[$index - 5], [Globalization.CultureInfo]::InvariantCulture)) "$($Projection.Artifact) count $index is exact"
+            Assert-True ($properties[$index].Value.ValueKind -eq [Text.Json.JsonValueKind]::Number) "$($ExpectedArtifact.Id) count $index is numeric"
+            Assert-True ($properties[$index].Value.GetRawText() -ceq [Convert]::ToString($expectedCounts[$index - 5], [Globalization.CultureInfo]::InvariantCulture)) "$($ExpectedArtifact.Id) count $index is exact"
         }
         $requirements = @($properties[9].Value.EnumerateArray())
-        Assert-True ($requirements.Count -eq $Compiled.Requirements.Count) "$($Projection.Artifact) has all requirement pairs"
+        Assert-True ($requirements.Count -eq $Compiled.Requirements.Count) "$($ExpectedArtifact.Id) has all requirement pairs"
         for ($index = 0; $index -lt $requirements.Count; $index++) {
             $pair = @($requirements[$index].EnumerateObject())
-            Assert-True ([StringComparer]::Ordinal.Equals($pair[0].Name, 'id')) "$($Projection.Artifact) requirement $index ID name"
-            Assert-True ([StringComparer]::Ordinal.Equals($pair[1].Name, 'owner')) "$($Projection.Artifact) requirement $index owner name"
-            Assert-True ([StringComparer]::Ordinal.Equals($pair[0].Value.GetString(), $Compiled.Requirements[$index].Id)) "$($Projection.Artifact) requirement $index ID"
-            Assert-True ([StringComparer]::Ordinal.Equals($pair[1].Value.GetString(), $Compiled.Requirements[$index].Owner)) "$($Projection.Artifact) requirement $index owner"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[0].Name, 'id')) "$($ExpectedArtifact.Id) requirement $index ID name"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[1].Name, 'owner')) "$($ExpectedArtifact.Id) requirement $index owner name"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[0].Value.GetString(), $Compiled.Requirements[$index].Id)) "$($ExpectedArtifact.Id) requirement $index ID"
+            Assert-True ([StringComparer]::Ordinal.Equals($pair[1].Value.GetString(), $Compiled.Requirements[$index].Owner)) "$($ExpectedArtifact.Id) requirement $index owner"
         }
         $artifactIds = @($properties[10].Value.EnumerateArray())
-        Assert-True ($artifactIds.Count -eq $Compiled.Artifacts.Count) "$($Projection.Artifact) has all artifact IDs"
+        Assert-True ($artifactIds.Count -eq $Compiled.Artifacts.Count) "$($ExpectedArtifact.Id) has all artifact IDs"
         for ($index = 0; $index -lt $artifactIds.Count; $index++) {
-            Assert-True ([StringComparer]::Ordinal.Equals($artifactIds[$index].GetString(), $Compiled.Artifacts[$index].Id)) "$($Projection.Artifact) artifact ID $index"
+            Assert-True ([StringComparer]::Ordinal.Equals($artifactIds[$index].GetString(), $Compiled.Artifacts[$index].Id)) "$($ExpectedArtifact.Id) artifact ID $index"
         }
-        $compilerArtifact = @($Compiled.Artifacts | Where-Object { [StringComparer]::Ordinal.Equals($_.Id, $Projection.Artifact) })
         $assignmentProperties = @($properties[11].Value.EnumerateObject())
-        Assert-True ($properties[11].Value.ValueKind -eq [Text.Json.JsonValueKind]::Object) "$($Projection.Artifact) assignment is an object"
-        Assert-True ($assignmentProperties.Count -eq 1) "$($Projection.Artifact) assignment has one property"
-        Assert-True ([StringComparer]::Ordinal.Equals($assignmentProperties[0].Name, 'rowIds')) "$($Projection.Artifact) assignment property is rowIds"
-        Assert-True ($assignmentProperties[0].Value.ValueKind -eq [Text.Json.JsonValueKind]::Array) "$($Projection.Artifact) row IDs are an array"
+        Assert-True ($properties[11].Value.ValueKind -eq [Text.Json.JsonValueKind]::Object) "$($ExpectedArtifact.Id) assignment is an object"
+        Assert-True ($assignmentProperties.Count -eq 1) "$($ExpectedArtifact.Id) assignment has one property"
+        Assert-True ([StringComparer]::Ordinal.Equals($assignmentProperties[0].Name, 'rowIds')) "$($ExpectedArtifact.Id) assignment property is rowIds"
+        Assert-True ($assignmentProperties[0].Value.ValueKind -eq [Text.Json.JsonValueKind]::Array) "$($ExpectedArtifact.Id) row IDs are an array"
         $rowIds = @($assignmentProperties[0].Value.EnumerateArray())
-        Assert-True ($compilerArtifact.Count -eq 1) "$($Projection.Artifact) compiler artifact is unique"
-        Assert-True ($rowIds.Count -eq $compilerArtifact[0].RowIds.Count) "$($Projection.Artifact) assignment count"
+        Assert-True ($rowIds.Count -eq $ExpectedArtifact.RowIds.Count) "$($ExpectedArtifact.Id) assignment count"
         for ($index = 0; $index -lt $rowIds.Count; $index++) {
-            Assert-True ([StringComparer]::Ordinal.Equals($rowIds[$index].GetString(), $compilerArtifact[0].RowIds[$index])) "$($Projection.Artifact) row ID $index"
+            Assert-True ([StringComparer]::Ordinal.Equals($rowIds[$index].GetString(), $ExpectedArtifact.RowIds[$index])) "raw assignment $($ExpectedArtifact.Id) row ID $index equals requested artifact"
         }
     }
     finally { $document.Dispose() }
 }
 
+function Assert-ReturnedArtifactBindings {
+    param([object[]] $ProjectionBindings)
+    for ($index = 0; $index -lt $ProjectionBindings.Count; $index++) {
+        $binding = $ProjectionBindings[$index]
+        Assert-True ([StringComparer]::Ordinal.Equals($binding.Projection.Artifact, $binding.ExpectedArtifact.Id)) "projection $index returned Artifact equals requested $($binding.ExpectedArtifact.Id)"
+    }
+}
+
+function Assert-ExactArtifactOrder {
+    param([string[]] $ActualArtifactIds, [string[]] $ExpectedArtifactIds)
+    Assert-True ($ActualArtifactIds.Count -eq $ExpectedArtifactIds.Count) 'returned artifact vector has exactly fifteen IDs'
+    for ($index = 0; $index -lt $ExpectedArtifactIds.Count; $index++) {
+        Assert-True ([StringComparer]::Ordinal.Equals($ActualArtifactIds[$index], $ExpectedArtifactIds[$index])) "returned artifact order $index equals compiler order"
+    }
+}
+
+function Assert-UniqueArtifactIds {
+    param([string[]] $ArtifactIds)
+    $uniqueIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($artifactId in $ArtifactIds) {
+        Assert-True ($uniqueIds.Add($artifactId)) "returned artifact IDs must be unique: $artifactId"
+    }
+}
+
+function Assert-ExactProjectionBindings {
+    param([object[]] $ProjectionBindings, [object] $Compiled)
+    Assert-True ($ProjectionBindings.Count -eq $Compiled.Artifacts.Count) 'projection bindings retain all fifteen requested artifacts'
+    Assert-ReturnedArtifactBindings $ProjectionBindings
+    $actualArtifactIds = @($ProjectionBindings | ForEach-Object { $_.Projection.Artifact })
+    $expectedArtifactIds = @($Compiled.Artifacts | ForEach-Object { $_.Id })
+    Assert-ExactArtifactOrder $actualArtifactIds $expectedArtifactIds
+    Assert-UniqueArtifactIds $actualArtifactIds
+    foreach ($binding in $ProjectionBindings) {
+        Assert-IndependentRawPayload $binding.Projection $binding.ExpectedArtifact $Compiled
+    }
+}
+
 Import-Module $modulePath -Force
 Import-Module $contractModulePath -Force
 $script:Compiled = Read-WduLifecycleContract -Path $canonicalPath
-$script:Projections = @($script:Compiled.Artifacts | ForEach-Object { New-WduLifecycleRawProjection -Compiled $script:Compiled -Artifact $_.Id })
+$script:ProjectionBindings = @(
+    foreach ($expectedArtifact in $script:Compiled.Artifacts) {
+        $projection = New-WduLifecycleRawProjection -Compiled $script:Compiled -Artifact $expectedArtifact.Id
+        [pscustomobject]@{ ExpectedArtifact = $expectedArtifact; Projection = $projection }
+    }
+)
+$script:Projections = @($script:ProjectionBindings | ForEach-Object { $_.Projection })
 $script:Passed = 0
 $script:Failed = 0
 
@@ -154,13 +196,30 @@ Invoke-Case 'compiles all fifteen artifacts deterministically and validates raw 
     Assert-True ($script:Compiled.Artifacts.Count -eq 15) 'compiler artifact count is 15'
     Assert-True ([StringComparer]::Ordinal.Equals($script:Compiled.Digest, 'ae3a77e28886485b49361d8836f040691e9f99228919cef87fac19b42e989d73')) 'compiler digest is exact'
     Assert-True ([StringComparer]::Ordinal.Equals($script:Compiled.AssignmentDigest, '20e329bd3aa4459a01f4ed3c6ec12cf365c86df3538b0323400639b90eeee877')) 'assignment digest is exact'
-    foreach ($projection in $script:Projections) {
-        $second = New-WduLifecycleRawProjection -Compiled $script:Compiled -Artifact $projection.Artifact
-        Assert-True ([Convert]::ToHexString($projection.Utf8Json.ToArray()) -ceq [Convert]::ToHexString($second.Utf8Json.ToArray())) "$($projection.Artifact) bytes are deterministic"
+    foreach ($binding in $script:ProjectionBindings) {
+        $expectedArtifact = $binding.ExpectedArtifact
+        $projection = $binding.Projection
+        $second = New-WduLifecycleRawProjection -Compiled $script:Compiled -Artifact $expectedArtifact.Id
+        Assert-True ([Convert]::ToHexString($projection.Utf8Json.ToArray()) -ceq [Convert]::ToHexString($second.Utf8Json.ToArray())) "$($expectedArtifact.Id) bytes are deterministic"
         $validated = Test-WduLifecycleRawProjection -Compiled $script:Compiled -Utf8Json $projection.Utf8Json
-        Assert-True ([StringComparer]::Ordinal.Equals($validated.Artifact, $projection.Artifact)) "$($projection.Artifact) validates itself"
-        Assert-IndependentRawPayload $projection $script:Compiled
+        Assert-True ([StringComparer]::Ordinal.Equals($validated.Artifact, $expectedArtifact.Id)) "$($expectedArtifact.Id) validates itself"
     }
+    Assert-ExactProjectionBindings $script:ProjectionBindings $script:Compiled
+}
+
+Invoke-Case 'rejects replacement of all requested outputs with the first valid projection' {
+    $firstProjection = $script:ProjectionBindings[0].Projection
+    $replacedBindings = @(
+        foreach ($binding in $script:ProjectionBindings) {
+            [pscustomobject]@{ ExpectedArtifact = $binding.ExpectedArtifact; Projection = $firstProjection }
+        }
+    )
+    $expectedArtifactIds = @($script:Compiled.Artifacts | ForEach-Object { $_.Id })
+    $replacedArtifactIds = @($replacedBindings | ForEach-Object { $_.Projection.Artifact })
+    Assert-True ($replacedBindings.Count -eq 15) 'replacement reproducer contains fifteen outputs'
+    Assert-Fails { Assert-ReturnedArtifactBindings $replacedBindings } 'returned Artifact equals requested'
+    Assert-Fails { Assert-ExactArtifactOrder $replacedArtifactIds $expectedArtifactIds } 'returned artifact order'
+    Assert-Fails { Assert-UniqueArtifactIds $replacedArtifactIds } 'returned artifact IDs must be unique'
 }
 
 $baseline = $script:Projections[0]


### PR DESCRIPTION
# Compile coercion-free WDU raw projections

## Why this matters

Later Working Directory Update packet tooling needs raw machine payloads whose root kind, property identity, token kinds,
order, and values cannot be changed silently by PowerShell conversion. This replacement isolates that contract from
Markdown and filesystem publication.

## What changed

- Added a raw `System.Text.Json` writer for all 15 #928 artifacts.
- Added coercion-free raw-token validation for the exact ordered projection schema.
- Added focused positive and mutation proof for roots, duplicate/case-equivalent properties, token kinds, counts,
  requirement-owner pairs, artifact order, assignments, comments, trailing JSON, BOM, and malformed UTF-8.
- Kept Markdown markers, packet files, ADR/tracker changes, and publication out of this leaf.

## Quality contract

Product V1. Merged #928 is the sole lifecycle-dependent input. Fixed schema and canonical identifiers are wire constants;
all digests, counts, requirements, artifacts, and assignments come from #928.

## Proof

- PowerShell parse: passed.
- Focused raw compiler/validator suite: 11/11.
- Direct compiler: 70 rows / 260 applicability keys / 19 requirements / 15 artifacts.
- Exact complete-plan and assignment digests: passed.
- All 15 payloads compiled twice byte-identically and were independently inspected with `JsonDocument`.
- Assignment mutations cover omission, reordering, duplication, and casing for every artifact class.
- `git diff --check`: passed.

## Scope

Only the raw projection module and its focused test changed. No Markdown, filesystem packet, runtime, SQLite, CLI, SDK,
OpenAPI, generated-client, network, or GitHub publication path was added.

## Residual risk

Current-head review and GitHub Validate remain required. #936 will consume this closed output and own markers,
byte-preserving filesystem rendering, ADR propagation, and tracker publication.

Related to #935.
