### PR TITLE
feat(cli): add cancellable root dispatch

### DIFF
--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="Storage.SDK.Tests.fs" />
     <Compile Include="SelectProjection.CLI.Parsing.Tests.fs" />
     <Compile Include="Program.CLI.Parsing.Tests.fs" />
+    <Compile Include="Program.CLI.Host.Tests.fs" />
     <Compile Include="Program.CLI.Tests.fs" />
     <Compile Include="HistoryStorage.CLI.Tests.fs" />
     <Compile Include="LocalStateDb.Tests.fs" />

--- a/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
@@ -1,0 +1,207 @@
+namespace Grace.CLI.Tests
+
+open Grace.CLI
+open NUnit.Framework
+open Spectre.Console
+open System
+open System.CommandLine
+open System.CommandLine.Invocation
+open System.IO
+open System.Text.Json
+open System.Text.RegularExpressions
+open System.Threading
+open System.Threading.Tasks
+
+/// Covers deterministic host dispatch behavior shared by the production CLI root graph.
+[<TestFixture>]
+[<NonParallelizable>]
+module ProgramCliHostTests =
+
+    /// Runs a supplied token-aware status action through System.CommandLine.
+    type private StatusAction(handler: CancellationToken -> Task<int>) =
+        inherit AsynchronousCommandLineAction()
+
+        /// Dispatches the test status action with the token supplied by the root host.
+        override _.InvokeAsync(_: ParseResult, cancellationToken: CancellationToken) = handler cancellationToken
+
+    /// Directs Spectre.Console to the supplied writer while root invocation output is captured.
+    let private setAnsiConsoleOutput (writer: TextWriter) =
+        let settings = AnsiConsoleSettings()
+        settings.Out <- AnsiConsoleOutput(writer)
+        AnsiConsole.Console <- AnsiConsole.Create(settings)
+
+    /// Builds the controlled Cache group used to exercise the production root graph.
+    let private createCacheCommand (handler: CancellationToken -> Task<int>) =
+        let cache = Command("cache", "Inspect a local Grace Cache identity.")
+        let status = Command("status", "Report redacted local Grace Cache enrollment status.")
+        status.Action <- StatusAction(handler)
+        cache.Subcommands.Add(status)
+        cache
+
+    /// Builds the internal dependencies used by focused host tests.
+    let private dependencies (initializer: unit -> unit) (handler: CancellationToken -> Task<int>) : GraceCommand.RootDependencies =
+        { CreateCacheCommand = (fun () -> createCacheCommand handler); InitializeExecution = initializer }
+
+    /// Invokes the production root construction and run path while capturing root output.
+    let private runWithCapturedOutput (dependencies: GraceCommand.RootDependencies) (args: string array) (cancellationToken: CancellationToken) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let exitCode =
+                GraceCommand.run dependencies args cancellationToken
+                |> fun invocation -> invocation.GetAwaiter().GetResult()
+
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    /// Reads one redacted error envelope and rejects accidental duplicate command output.
+    let private assertSingleRedactedCancellation (output: string) =
+        Assert.That(Regex.Matches(output, "\\\"Error\\\"").Count, Is.EqualTo(1))
+
+        use document = JsonDocument.Parse(output)
+        let root = document.RootElement
+        Assert.That(root.GetProperty("Error").GetString(), Is.EqualTo("The command was canceled."))
+        Assert.That(output, Does.Not.Contain("OperationCanceledException"))
+        Assert.That(output, Does.Not.Contain("Stack trace"))
+
+    /// Proves the caller token reaches the selected async action without changing its normal exit code.
+    [<Test>]
+    let ``run passes the caller token to cache status and preserves its exit code`` () =
+        let mutable receivedToken = CancellationToken.None
+        let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
+
+        let handler cancellationToken =
+            receivedToken <- cancellationToken
+            Task.FromResult(37)
+
+        use cancellation = new CancellationTokenSource()
+
+        let exitCode, output = runWithCapturedOutput (dependencies initializer handler) [| "cache"; "status" |] cancellation.Token
+
+        Assert.That(exitCode, Is.EqualTo(37))
+        Assert.That(output, Is.Empty)
+        Assert.That(receivedToken.CanBeCanceled, Is.True)
+
+    /// Proves a pre-cancelled caller token produces one stable redacted nonzero root result.
+    [<Test>]
+    let ``run returns one redacted nonzero result for pre-cancelled cache status`` () =
+        let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
+
+        let handler (cancellationToken: CancellationToken) : Task<int> =
+            cancellationToken.ThrowIfCancellationRequested()
+            Task.FromResult(0)
+
+        use cancellation = new CancellationTokenSource()
+        cancellation.Cancel()
+
+        let exitCode, output = runWithCapturedOutput (dependencies initializer handler) [| "cache"; "status" |] cancellation.Token
+
+        Assert.That(exitCode, Is.Not.EqualTo(0))
+        assertSingleRedactedCancellation output
+
+    /// Proves cancellation after deterministic action entry returns one stable redacted nonzero root result.
+    [<Test>]
+    let ``run returns one redacted nonzero result after cache status action entry`` () =
+        let entered = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        let release = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
+
+        let handler (cancellationToken: CancellationToken) : Task<int> =
+            task {
+                entered.TrySetResult() |> ignore
+                do! release.Task
+                cancellationToken.ThrowIfCancellationRequested()
+                return 0
+            }
+
+        use cancellation = new CancellationTokenSource()
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let invocation = GraceCommand.run (dependencies initializer handler) [| "cache"; "status" |] cancellation.Token
+            entered.Task.GetAwaiter().GetResult()
+            cancellation.Cancel()
+            release.TrySetResult() |> ignore
+
+            let exitCode = invocation.GetAwaiter().GetResult()
+            Assert.That(exitCode, Is.Not.EqualTo(0))
+            assertSingleRedactedCancellation (writer.ToString())
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    /// Proves a token cancelled after action completion cannot overwrite the completed domain exit code.
+    [<Test>]
+    let ``run preserves a completed cache status exit when cancellation races after completion`` () =
+        let completed = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
+
+        let handler (_: CancellationToken) : Task<int> =
+            completed.TrySetResult() |> ignore
+            Task.FromResult(37)
+
+        use cancellation = new CancellationTokenSource()
+        let invocation = GraceCommand.run (dependencies initializer handler) [| "cache"; "status" |] cancellation.Token
+        completed.Task.GetAwaiter().GetResult()
+        cancellation.Cancel()
+
+        let exitCode = invocation.GetAwaiter().GetResult()
+        Assert.That(exitCode, Is.EqualTo(37))
+
+    /// Proves valid Cache status introspection bypasses all injected execution initialization and handler work.
+    [<TestCase("--schema")>]
+    [<TestCase("--examples")>]
+    let ``cache status introspection is inert before execution initialization`` introspectionOption =
+        let mutable initializerCalls = 0
+        let mutable handlerCalls = 0
+
+        let initializer () = initializerCalls <- initializerCalls + 1
+
+        let handler _ =
+            handlerCalls <- handlerCalls + 1
+            Task.FromResult(0)
+
+        let exitCode, output =
+            runWithCapturedOutput
+                (dependencies initializer handler)
+                [|
+                    "cache"
+                    "status"
+                    introspectionOption
+                |]
+                CancellationToken.None
+
+        Assert.That(exitCode, Is.EqualTo(0))
+        Assert.That(initializerCalls, Is.EqualTo(0))
+        Assert.That(handlerCalls, Is.EqualTo(0))
+        Assert.That(output, Does.Contain("Registry"))
+
+    /// Proves introspection remains strict for mutually exclusive options, unknown options, and malformed values.
+    [<TestCase("--schema", "--examples", "cache", "status")>]
+    [<TestCase("cache", "status", "--schema", "--unknown")>]
+    [<TestCase("--output", "not-an-output-mode", "cache", "status", "--schema")>]
+    [<TestCase("--output", "not-an-output-mode", "--select", "Enrollment", "cache", "status", "--schema")>]
+    let ``cache status introspection rejects invalid option combinations`` ([<ParamArray>] args: string array) =
+        let mutable initializerCalls = 0
+        let mutable handlerCalls = 0
+
+        let initializer () = initializerCalls <- initializerCalls + 1
+
+        let handler _ =
+            handlerCalls <- handlerCalls + 1
+            Task.FromResult(0)
+
+        let exitCode, _ = runWithCapturedOutput (dependencies initializer handler) args CancellationToken.None
+        Assert.That(exitCode, Is.Not.EqualTo(0))
+        Assert.That(initializerCalls, Is.EqualTo(0))
+        Assert.That(handlerCalls, Is.EqualTo(0))

--- a/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.CLI.Tests
 
 open Grace.CLI
+open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
 open System

--- a/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
@@ -120,6 +120,21 @@ module ProgramCliHostTests =
         Assert.That(exitCode, Is.Not.EqualTo(0))
         assertSingleRedactedCancellation output
 
+    /// Proves a canceled action exception token renders the stable cancellation result without caller cancellation.
+    [<Test>]
+    let ``run classifies a canceled action exception token when the caller token is not canceled`` () =
+        let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
+
+        use actionCancellation = new CancellationTokenSource()
+        actionCancellation.Cancel()
+
+        let handler (_: CancellationToken) : Task<int> = Task.FromException<int>(OperationCanceledException(actionCancellation.Token))
+
+        let exitCode, output = runWithCapturedOutput (dependencies initializer handler) [| "cache"; "status" |] CancellationToken.None
+
+        Assert.That(exitCode, Is.Not.EqualTo(0))
+        assertSingleRedactedCancellation output
+
     /// Proves a rendered missing-credential result remains the only JSON output when no caller cancellation occurred.
     [<Test>]
     let ``run preserves the missing credential result without a second cancellation document`` () =
@@ -188,6 +203,45 @@ module ProgramCliHostTests =
             let exitCode = invocation.GetAwaiter().GetResult()
             Assert.That(exitCode, Is.Not.EqualTo(0))
             assertSingleRedactedCancellation (writer.ToString())
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    /// Proves a tokenless control exception keeps its rendered domain result when the caller cancels concurrently.
+    [<Test>]
+    let ``run preserves a rendered tokenless domain result when the caller cancels during cache status`` () =
+        let entered = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        let release = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
+
+        let handler (_: CancellationToken) : Task<int> =
+            task {
+                entered.TrySetResult() |> ignore
+                do! release.Task
+                Common.writeJsonErrorStdout (GraceError.Create "The domain result was already rendered." "domain-control")
+                return raise (OperationCanceledException("Domain control flow after rendering."))
+            }
+
+        use cancellation = new CancellationTokenSource()
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let invocation = GraceCommand.run (dependencies initializer handler) [| "cache"; "status" |] cancellation.Token
+            entered.Task.GetAwaiter().GetResult()
+            cancellation.Cancel()
+            release.TrySetResult() |> ignore
+
+            let exitCode = invocation.GetAwaiter().GetResult()
+            let output = writer.ToString()
+
+            Assert.That(exitCode, Is.Not.EqualTo(0))
+            Assert.That(Regex.Matches(output, "\\\"Error\\\"").Count, Is.EqualTo(1))
+            Assert.That(output, Does.Contain("The domain result was already rendered."))
+            Assert.That(output, Does.Not.Contain("The command was canceled."))
         finally
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
@@ -269,5 +323,37 @@ module ProgramCliHostTests =
 
         let exitCode, _ = runWithCapturedOutput (dependencies initializer handler) args CancellationToken.None
         Assert.That(exitCode, Is.Not.EqualTo(0))
+        Assert.That(initializerCalls, Is.EqualTo(0))
+        Assert.That(handlerCalls, Is.EqualTo(0))
+
+    /// Proves execution selection prevents both introspection documents without activating execution dependencies.
+    [<TestCase("--schema")>]
+    [<TestCase("--examples")>]
+    let ``cache status introspection selector incompatibility emits one error and no document`` introspectionOption =
+        let mutable initializerCalls = 0
+        let mutable handlerCalls = 0
+
+        let initializer () = initializerCalls <- initializerCalls + 1
+
+        let handler _ =
+            handlerCalls <- handlerCalls + 1
+            Task.FromResult(0)
+
+        let exitCode, output =
+            runWithCapturedOutput
+                (dependencies initializer handler)
+                [|
+                    "cache"
+                    "status"
+                    introspectionOption
+                    "--select"
+                    "Enrollment"
+                |]
+                CancellationToken.None
+
+        Assert.That(exitCode, Is.Not.EqualTo(0))
+        Assert.That(Regex.Matches(output, "\\\"Error\\\"").Count, Is.EqualTo(1))
+        Assert.That(output, Does.Contain("--select cannot be used with --schema or --examples."))
+        Assert.That(output, Does.Not.Contain("Registry"))
         Assert.That(initializerCalls, Is.EqualTo(0))
         Assert.That(handlerCalls, Is.EqualTo(0))

--- a/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
@@ -40,7 +40,22 @@ module ProgramCliHostTests =
 
     /// Builds the internal dependencies used by focused host tests.
     let private dependencies (initializer: unit -> unit) (handler: CancellationToken -> Task<int>) : GraceCommand.RootDependencies =
-        { CreateCacheCommand = (fun () -> createCacheCommand handler); InitializeExecution = initializer }
+        { CreateCacheCommand = (fun () -> createCacheCommand handler); InitializeExecution = initializer; AfterCommandExit = (fun _ -> Task.FromResult(())) }
+
+    /// Runs a synchronous test action while temporarily replacing selected process environment variables.
+    let private withEnvironmentVariables (updates: (string * string option) list) (action: unit -> unit) =
+        let originalValues =
+            updates
+            |> List.map (fun (name, _) -> name, Environment.GetEnvironmentVariable(name))
+
+        try
+            for name, value in updates do
+                Environment.SetEnvironmentVariable(name, value |> Option.toObj)
+
+            action ()
+        finally
+            for name, value in originalValues do
+                Environment.SetEnvironmentVariable(name, value)
 
     /// Invokes the production root construction and run path while capturing root output.
     let private runWithCapturedOutput (dependencies: GraceCommand.RootDependencies) (args: string array) (cancellationToken: CancellationToken) =
@@ -105,6 +120,43 @@ module ProgramCliHostTests =
         Assert.That(exitCode, Is.Not.EqualTo(0))
         assertSingleRedactedCancellation output
 
+    /// Proves a rendered missing-credential result remains the only JSON output when no caller cancellation occurred.
+    [<Test>]
+    let ``run preserves the missing credential result without a second cancellation document`` () =
+        let initializer () = ()
+
+        let environmentToClear =
+            [
+                "GRACE_TOKEN", None
+                "GRACE_TOKEN_FILE", None
+                "GRACE_SERVER_URI", None
+                "grace__auth__oidc__authority", None
+                "grace__auth__oidc__audience", None
+                "grace__auth__oidc__m2m_client_id", None
+                "grace__auth__oidc__m2m_client_secret", None
+                "grace__auth__oidc__cli_client_id", None
+            ]
+
+        withEnvironmentVariables environmentToClear (fun () ->
+            let exitCode, output =
+                runWithCapturedOutput
+                    (dependencies initializer (fun _ -> Task.FromResult(0)))
+                    [|
+                        "--output"
+                        "Json"
+                        "authenticate"
+                        "token"
+                        "create"
+                        "--name"
+                        "missing-credential"
+                    |]
+                    CancellationToken.None
+
+            Assert.That(exitCode, Is.Not.EqualTo(0))
+            Assert.That(Regex.Matches(output, "\\\"Error\\\"").Count, Is.EqualTo(1))
+            Assert.That(output, Does.Contain("Authentication is not configured."))
+            Assert.That(output, Does.Not.Contain("The command was canceled.")))
+
     /// Proves cancellation after deterministic action entry returns one stable redacted nonzero root result.
     [<Test>]
     let ``run returns one redacted nonzero result after cache status action entry`` () =
@@ -140,20 +192,32 @@ module ProgramCliHostTests =
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
 
-    /// Proves a token cancelled after action completion cannot overwrite the completed domain exit code.
+    /// Proves a caller cancellation after the root records domain exit cannot overwrite that exit code.
     [<Test>]
-    let ``run preserves a completed cache status exit when cancellation races after completion`` () =
-        let completed = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+    let ``run preserves a completed cache status exit after the root records it`` () =
+        let afterCommandExit = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        let releaseRoot = TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
         let initializer () = Assert.Fail("Cache status must not initialize execution dependencies.")
 
-        let handler (_: CancellationToken) : Task<int> =
-            completed.TrySetResult() |> ignore
-            Task.FromResult(37)
+        let handler (_: CancellationToken) : Task<int> = Task.FromResult(37)
 
         use cancellation = new CancellationTokenSource()
-        let invocation = GraceCommand.run (dependencies initializer handler) [| "cache"; "status" |] cancellation.Token
-        completed.Task.GetAwaiter().GetResult()
+
+        let controlledDependencies =
+            { dependencies initializer handler with
+                AfterCommandExit =
+                    fun exitCode ->
+                        task {
+                            Assert.That(exitCode, Is.EqualTo(37))
+                            afterCommandExit.TrySetResult() |> ignore
+                            do! releaseRoot.Task
+                        }
+            }
+
+        let invocation = GraceCommand.run controlledDependencies [| "cache"; "status" |] cancellation.Token
+        afterCommandExit.Task.GetAwaiter().GetResult()
         cancellation.Cancel()
+        releaseRoot.TrySetResult() |> ignore
 
         let exitCode = invocation.GetAwaiter().GetResult()
         Assert.That(exitCode, Is.EqualTo(37))
@@ -186,8 +250,10 @@ module ProgramCliHostTests =
         Assert.That(handlerCalls, Is.EqualTo(0))
         Assert.That(output, Does.Contain("Registry"))
 
-    /// Proves introspection remains strict for mutually exclusive options, unknown options, and malformed values.
+    /// Proves introspection remains strict for mutually exclusive options, execution selectors, unknown options, and malformed values.
     [<TestCase("--schema", "--examples", "cache", "status")>]
+    [<TestCase("cache", "status", "--schema", "--select", "Enrollment")>]
+    [<TestCase("cache", "status", "--examples", "--select", "Enrollment")>]
     [<TestCase("cache", "status", "--schema", "--unknown")>]
     [<TestCase("--output", "not-an-output-mode", "cache", "status", "--schema")>]
     [<TestCase("--output", "not-an-output-mode", "--select", "Enrollment", "cache", "status", "--schema")>]

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1568,7 +1568,7 @@ module GraceCommand =
                     return returnValue
                 with
                 | IntrospectionExit exitCode -> return exitCode
-                | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
+                | :? OperationCanceledException as ex when ex.CancellationToken.IsCancellationRequested ->
                     let correlationId =
                         if isNull parseResult then
                             generateCorrelationId ()

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -28,6 +28,7 @@ open System.IO
 open System.Linq
 open System.Text.Json
 open System.Text.RegularExpressions
+open System.Threading
 open System.Threading.Tasks
 open Microsoft.Extensions.Caching.Memory
 open System.CommandLine.Help
@@ -226,22 +227,17 @@ module GraceCommand =
             let groupPath = path |> List.take (path.Length - 1)
             CommandOutputContract.commandIdentity groupPath commandName
 
-    /// Defines root parser introspection request from tokens behavior for Grace CLI startup and help output.
-    let private introspectionRequestFromTokens (args: string array) =
-        let tokens =
-            if isNull args then
-                Array.empty
-            else
-                args
-                |> Array.takeWhile (fun token -> not (token.Equals("--", StringComparison.Ordinal)))
+    /// Determines whether the parser recognized one occurrence of the supplied root option.
+    let private isOptionRequested (option: Option) (parseResult: ParseResult) =
+        let optionResult = parseResult.GetResult(option)
 
-        /// Defines the contains option used by this command parser.
-        let containsOption optionName =
-            tokens
-            |> Array.exists (fun token -> token.Equals(optionName, StringComparison.OrdinalIgnoreCase))
+        not (isNull optionResult)
+        && optionResult.IdentifierTokenCount > 0
 
-        let schema = containsOption OptionName.Schema
-        let examples = containsOption OptionName.Examples
+    /// Classifies the parsed introspection options without inspecting parser message text.
+    let private introspectionRequest (parseResult: ParseResult) =
+        let schema = isOptionRequested Options.schema parseResult
+        let examples = isOptionRequested Options.examples parseResult
 
         match schema, examples with
         | false, false -> None
@@ -255,20 +251,24 @@ module GraceCommand =
         Common.writeJsonErrorStdout error
         -1
 
-    /// Evaluates is ignorable introspection parse error against parsed options and command state.
-    let private isIgnorableIntrospectionParseError (error: ParseError) =
-        error.Message.StartsWith("Required argument missing for command:", StringComparison.Ordinal)
+    /// Identifies a missing required command argument through System.CommandLine parser metadata.
+    let private isMissingRequiredArgument (error: ParseError) =
+        match error.SymbolResult with
+        | :? ArgumentResult as argumentResult ->
+            argumentResult.Tokens.Count = 0
+            && argumentResult.Argument.Arity.MinimumNumberOfValues > 0
+        | _ -> false
 
-    /// Evaluates has blocking introspection parse errors against parsed options and command state.
+    /// Determines whether introspection has a parser failure other than a missing execution argument.
     let private hasBlockingIntrospectionParseErrors (parseResult: ParseResult) =
         parseResult.Errors
-        |> Seq.exists (isIgnorableIntrospectionParseError >> not)
+        |> Seq.exists (isMissingRequiredArgument >> not)
 
-    /// Writes introspection parse error data through the CLI output contract.
-    let private writeIntrospectionParseError (parseResult: ParseResult) =
+    /// Writes the typed blocking parser failures for schema and examples requests.
+    let private writeBlockingIntrospectionParseErrors (parseResult: ParseResult) =
         let message =
             parseResult.Errors
-            |> Seq.filter (isIgnorableIntrospectionParseError >> not)
+            |> Seq.filter (isMissingRequiredArgument >> not)
             |> Seq.map (fun error -> error.Message)
             |> String.concat Environment.NewLine
 
@@ -853,7 +853,11 @@ module GraceCommand =
 
         current
 
-    let rootCommand =
+    /// Supplies the small set of host dependencies needed to construct and execute the production root graph.
+    type internal RootDependencies = { CreateCacheCommand: unit -> Command; InitializeExecution: unit -> unit }
+
+    /// Builds the Grace command graph from host dependencies shared by production and focused host tests.
+    let internal createRoot (dependencies: RootDependencies) =
         // Create the root of the command tree.
         let rootCommand = new RootCommand("Grace Version Control System")
 
@@ -882,7 +886,7 @@ module GraceCommand =
         rootCommand.Subcommands.Add(Auth.Build)
         rootCommand.Subcommands.Add(Maintenance.Build)
         rootCommand.Subcommands.Add(Doctor.Build)
-        rootCommand.Subcommands.Add(CacheCommand.Build)
+        rootCommand.Subcommands.Add(dependencies.CreateCacheCommand())
         rootCommand.Subcommands.Add(WorkItemCommand.Build)
         rootCommand.Subcommands.Add(ReviewCommand.Build)
         rootCommand.Subcommands.Add(CandidateCommand.Build)
@@ -900,6 +904,19 @@ module GraceCommand =
         Alias.Subcommands.Add(ListAliases)
         rootCommand.Subcommands.Add(Alias)
         rootCommand
+
+    /// Performs the process-wide initialization required by commands other than the pure local Cache status leaf.
+    let private initializeProductionExecution () =
+        Auth.configureSdkAuth ()
+        Services.configureSdkClientIdentity ()
+        Services.resetInvocationCorrelationId ()
+        Common.resetLifecycleWarningSuppression ()
+
+    /// Provides the production command factory and execution initialization for the retained root command value.
+    let private productionDependencies = { CreateCacheCommand = (fun () -> CacheCommand.Build); InitializeExecution = initializeProductionExecution }
+
+    /// Retains the production root command graph for existing callers and parser tests.
+    let rootCommand = createRoot productionDependencies
 
     ///// Converts tokens to the exact casing defined in their options, enabling case-insensitive parsing on Windows.
     //let caseInsensitiveMiddleware (rootCommand: Command, isCaseInsensitive) =
@@ -1032,6 +1049,10 @@ module GraceCommand =
             Set.contains "cache" commands
             && Set.contains "status" commands
 
+    /// Invokes an asynchronous command action through the configured root exception boundary.
+    let private invokeAsync (parseResult: ParseResult) (invocationConfiguration: InvocationConfiguration) (cancellationToken: CancellationToken) =
+        parseResult.InvokeAsync(invocationConfiguration, cancellationToken)
+
     /// Models feedback section values passed between the parser and program handlers.
     type FeedbackSection(action: HelpAction) =
         inherit SynchronousCommandLineAction()
@@ -1051,9 +1072,14 @@ module GraceCommand =
 
             result
 
-    /// This is the main entry point for Grace CLI.
-    [<EntryPoint>]
-    let main args =
+    /// Executes one Grace command graph with caller cancellation and the production invocation configuration.
+    let internal run (dependencies: RootDependencies) (args: string array) (cancellationToken: CancellationToken) =
+        let rootCommand = createRoot dependencies
+
+        let invocationConfiguration = InvocationConfiguration()
+        invocationConfiguration.EnableDefaultExceptionHandler <- false
+        invocationConfiguration.ProcessTerminationTimeout <- Nullable(TimeSpan.FromSeconds(2.0))
+
         let startTime = getCurrentInstant ()
 
         // Create a MemoryCache instance.
@@ -1178,20 +1204,14 @@ module GraceCommand =
                     parseResult <- rootCommand.Parse(argvToParse)
                     parseSucceeded <- parseResult.Errors.Count = 0
 
-                    if not (parseResult |> isGraceCacheStatus) then
-                        Auth.configureSdkAuth ()
-                        Services.configureSdkClientIdentity ()
-                        Services.resetInvocationCorrelationId ()
-                        Common.resetLifecycleWarningSuppression ()
-
-                    match introspectionRequestFromTokens argvToParse with
+                    match introspectionRequest parseResult with
                     | Some (Ok kind) ->
                         isIntrospection <- true
                         Services.parseResult <- parseResult
 
                         returnValue <-
                             if hasBlockingIntrospectionParseErrors parseResult then
-                                writeIntrospectionParseError parseResult
+                                writeBlockingIntrospectionParseErrors parseResult
                             else
                                 handleIntrospectionRequest parseResult kind
 
@@ -1204,6 +1224,9 @@ module GraceCommand =
                     | None ->
                         // Write the ParseResult to Services as global context for the CLI.
                         Services.parseResult <- parseResult
+
+                        if not (parseResult |> isGraceCacheStatus) then
+                            dependencies.InitializeExecution()
 
                         if parseResult.Errors.Count > 0
                            && isJsonOutputRequestedFromTokens argvToParse then
@@ -1393,7 +1416,7 @@ module GraceCommand =
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
                     else if parseResult |> isGraceCacheStatus then
-                        let! invokedReturnValue = parseResult.InvokeAsync()
+                        let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                         returnValue <- invokedReturnValue
                     else if parseResult |> isGraceDoctor then
                         let invokedReturnValue = parseResult.Invoke()
@@ -1436,7 +1459,7 @@ module GraceCommand =
                                     | None -> ()
 
                                 // Now we can invoke the command!
-                                let! invokedReturnValue = parseResult.InvokeAsync()
+                                let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                                 returnValue <- invokedReturnValue
 
                                 // Stuff to do after the command has been invoked:
@@ -1499,7 +1522,7 @@ module GraceCommand =
                                     |> List.exists (fun allowed -> topLevel.Equals(allowed, comparison))))
 
                         if isAllowed then
-                            let! invokedReturnValue = parseResult.InvokeAsync()
+                            let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                             returnValue <- invokedReturnValue
                             ()
                         else
@@ -1528,6 +1551,16 @@ module GraceCommand =
                     return returnValue
                 with
                 | IntrospectionExit exitCode -> return exitCode
+                | :? OperationCanceledException ->
+                    let correlationId =
+                        if isNull parseResult then
+                            generateCorrelationId ()
+                        else
+                            getCorrelationId parseResult
+
+                    Common.writeJsonErrorStdout (GraceError.Create "The command was canceled." correlationId)
+                    returnValue <- -1
+                    return returnValue
                 | ex ->
                     if isJsonOutputRequestedFromTokens argvNormalized then
                         returnValue <- writeJsonException parseResult ex
@@ -1567,4 +1600,9 @@ module GraceCommand =
                    && parseResult |> isGraceWatchForeground then
                     deleteGraceWatchIpcFileIfOwned ()
         })
-            .Result
+
+    /// Starts the production root graph with process cancellation handled by System.CommandLine invocation configuration.
+    [<EntryPoint>]
+    let main args =
+        run productionDependencies args CancellationToken.None
+        |> fun invocation -> invocation.GetAwaiter().GetResult()

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -274,6 +274,13 @@ module GraceCommand =
 
         writeIntrospectionError parseResult message
 
+    /// Rejects execution projection selection for schema and examples requests before document rendering.
+    let private tryGetIntrospectionExecutionSelectorError (parseResult: ParseResult) =
+        if isOptionRequested Options.select parseResult then
+            Some "--select cannot be used with --schema or --examples."
+        else
+            None
+
     /// Coordinates the introspection request command path, including validation, service calls, and output.
     let private handleIntrospectionRequest (parseResult: ParseResult) kind =
         let identity = commandIdentityFromCommandResult parseResult.CommandResult
@@ -854,7 +861,7 @@ module GraceCommand =
         current
 
     /// Supplies the small set of host dependencies needed to construct and execute the production root graph.
-    type internal RootDependencies = { CreateCacheCommand: unit -> Command; InitializeExecution: unit -> unit }
+    type internal RootDependencies = { CreateCacheCommand: unit -> Command; InitializeExecution: unit -> unit; AfterCommandExit: int -> Task<unit> }
 
     /// Builds the Grace command graph from host dependencies shared by production and focused host tests.
     let internal createRoot (dependencies: RootDependencies) =
@@ -913,7 +920,12 @@ module GraceCommand =
         Common.resetLifecycleWarningSuppression ()
 
     /// Provides the production command factory and execution initialization for the retained root command value.
-    let private productionDependencies = { CreateCacheCommand = (fun () -> CacheCommand.Build); InitializeExecution = initializeProductionExecution }
+    let private productionDependencies =
+        {
+            CreateCacheCommand = (fun () -> CacheCommand.Build)
+            InitializeExecution = initializeProductionExecution
+            AfterCommandExit = (fun _ -> Task.FromResult(()))
+        }
 
     /// Retains the production root command graph for existing callers and parser tests.
     let rootCommand = createRoot productionDependencies
@@ -1213,7 +1225,9 @@ module GraceCommand =
                             if hasBlockingIntrospectionParseErrors parseResult then
                                 writeBlockingIntrospectionParseErrors parseResult
                             else
-                                handleIntrospectionRequest parseResult kind
+                                match tryGetIntrospectionExecutionSelectorError parseResult with
+                                | Some message -> writeIntrospectionError parseResult message
+                                | None -> handleIntrospectionRequest parseResult kind
 
                         raise (IntrospectionExit returnValue)
                     | Some (Error message) ->
@@ -1418,6 +1432,7 @@ module GraceCommand =
                     else if parseResult |> isGraceCacheStatus then
                         let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                         returnValue <- invokedReturnValue
+                        do! dependencies.AfterCommandExit returnValue
                     else if parseResult |> isGraceDoctor then
                         let invokedReturnValue = parseResult.Invoke()
                         returnValue <- invokedReturnValue
@@ -1461,6 +1476,7 @@ module GraceCommand =
                                 // Now we can invoke the command!
                                 let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                                 returnValue <- invokedReturnValue
+                                do! dependencies.AfterCommandExit returnValue
 
                                 // Stuff to do after the command has been invoked:
 
@@ -1524,6 +1540,7 @@ module GraceCommand =
                         if isAllowed then
                             let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                             returnValue <- invokedReturnValue
+                            do! dependencies.AfterCommandExit returnValue
                             ()
                         else
                             let message = getLocalizedString StringResourceName.GraceConfigFileNotFound
@@ -1551,7 +1568,7 @@ module GraceCommand =
                     return returnValue
                 with
                 | IntrospectionExit exitCode -> return exitCode
-                | :? OperationCanceledException ->
+                | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
                     let correlationId =
                         if isNull parseResult then
                             generateCorrelationId ()
@@ -1559,6 +1576,9 @@ module GraceCommand =
                             getCorrelationId parseResult
 
                     Common.writeJsonErrorStdout (GraceError.Create "The command was canceled." correlationId)
+                    returnValue <- -1
+                    return returnValue
+                | :? OperationCanceledException ->
                     returnValue <- -1
                     return returnValue
                 | ex ->


### PR DESCRIPTION
## Why this matters

Grace CLI commands need one production root path that propagates caller cancellation and supports inert command introspection. This prerequisite makes later cache-enrollment cancellation behavior deterministic and testable without adding public test controls.

## What changed

- adds one internal root dependency/builder/run boundary while retaining the production root value
- dispatches selected actions with an explicit invocation configuration and caller cancellation token
- routes valid schema/examples introspection before execution initialization using typed parser metadata
- adds deterministic host tests for token propagation, cancellation, introspection effects, parser failures, and legacy routing

## Validation

- targeted Fantomas passed
- Release Grace.CLI.Tests build passed with zero warnings/errors
- focused host tests: 10 passed
- full Grace.CLI.Tests: 738 passed, 4 expected Linux-only skips
- git diff --check passed

Relates to #940.
Targets the Epic #601 integration branch.