### PR TITLE
B4.3R2a3R2: Adopt the atomic late-work mutation across acceptance transactions

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="Migrations\OperationsDbContextModelSnapshot.fs" />
     <Compile Include="OperationsData.fs" />
     <Compile Include="OperationsAcceptedFactMutation.fs" />
+    <Compile Include="OperationsAcceptedUsageStore.fs" />
     <Compile Include="OperationsBillingPeriod.fs" />
     <Compile Include="OperationsUsageJournal.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsAcceptedFactMutation.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsAcceptedFactMutation.fs
@@ -7,12 +7,6 @@ open System.Data
 open System.Threading
 open System.Threading.Tasks
 
-/// Distinguishes a same-scope no-op from a newly staged fact before or after an exact billing-period close.
-type internal AcceptedFactMutationOutcome =
-    | ExistingSameScope
-    | InsertedIntoOpenPeriod
-    | InsertedIntoClosedPeriod
-
 /// Observes the single point after all accepted-fact SQL mutations have staged and before control returns to a caller.
 type internal IAcceptedFactMutationInterleaving =
     abstract AfterAcceptedFactMutationsStagedAsync: AcceptedFactMutationOutcome * CancellationToken -> Task
@@ -66,6 +60,26 @@ type internal SqlAcceptedFactMutation(interleaving: IAcceptedFactMutationInterle
         addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
         addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
 
+    /// Adds immutable raw-fact fields for archive replay, which deliberately keeps the hot SQL payload empty.
+    let addArchivedReplayRawFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
+        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
+        addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
+        addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
+        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
+        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
+        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
+        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength rawFact.StoragePoolId
+        addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
+        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
+
+    /// Adds verified archive-pointer fields required by the replay-only raw fact command.
+    let addArchivedReplayPointerParameters (command: SqlCommand) (pointer: RawUsageFactArchivePointer) =
+        addStringParameter command "@ArchiveBlobName" OperationsUsageSql.ArchiveBlobNameMaxLength pointer.BlobName
+        let checksum = command.Parameters.Add("@ArchiveChecksumSha256Hex", SqlDbType.Char, OperationsUsageSql.ArchiveChecksumSha256HexLength)
+        checksum.Value <- pointer.ChecksumSha256Hex
+        addParameter command "@ArchiveByteLength" SqlDbType.BigInt pointer.ByteLength
+        addParameter command "@ArchiveStateArchived" SqlDbType.Int (int RawUsageFactArchiveState.Archived)
+
     /// Adds exact owner, organization, repository, and UTC-month fields shared by identity and late-work staging.
     let addScopeParameters (command: SqlCommand) (scope: BillingCompletenessScope) =
         addParameter command "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
@@ -85,10 +99,19 @@ type internal SqlAcceptedFactMutation(interleaving: IAcceptedFactMutationInterle
         }
 
     /// Inserts raw fact truth only when its durable identity has not already been accepted.
-    let tryInsertRawFactAsync connection transaction rawFact cancellationToken =
+    let tryInsertRawFactAsync connection transaction rawFact rawInsertion cancellationToken =
         task {
-            use command = createCommand connection transaction OperationsUsageSql.TryInsertRawUsageFact
-            addRawFactParameters command rawFact
+            use command =
+                match rawInsertion with
+                | HotRawFact -> createCommand connection transaction OperationsUsageSql.TryInsertRawUsageFact
+                | ArchivedReplayRawFact _ -> createCommand connection transaction OperationsUsageSql.TryInsertReplayedArchivedRawUsageFact
+
+            match rawInsertion with
+            | HotRawFact -> addRawFactParameters command rawFact
+            | ArchivedReplayRawFact pointer ->
+                addArchivedReplayRawFactParameters command rawFact
+                addArchivedReplayPointerParameters command pointer
+
             let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
             return rowsAffected = 1
         }
@@ -162,6 +185,16 @@ type internal SqlAcceptedFactMutation(interleaving: IAcceptedFactMutationInterle
         if not matchesRawFact then
             invalidArg (nameof aggregate) "Accepted-fact mutation aggregate must exactly match the raw fact identity, UTC-minute bucket, and quantity."
 
+    /// Rejects an archive replay adapter whose pointer cannot preserve the immutable raw fact identity.
+    let validateRawInsertion (rawFact: RawUsageFact) rawInsertion =
+        match rawInsertion with
+        | HotRawFact -> ()
+        | ArchivedReplayRawFact pointer when pointer.UsageFactId = rawFact.UsageFactId -> ()
+        | ArchivedReplayRawFact pointer ->
+            invalidArg
+                (nameof rawInsertion)
+                $"Archive replay pointer UsageFactId '{pointer.UsageFactId}' does not match raw UsageFactId '{rawFact.UsageFactId}'."
+
     /// Stages raw fact, rejection repair, aggregate, and conditional Pending handoff using only the caller-owned transaction.
     member _.AcceptAsync
         (
@@ -169,6 +202,7 @@ type internal SqlAcceptedFactMutation(interleaving: IAcceptedFactMutationInterle
             transaction: SqlTransaction,
             plan: UsageFactPersistencePlan,
             scope: BillingCompletenessScope,
+            rawInsertion: AcceptedFactRawInsertion,
             cancellationToken: CancellationToken
         ) =
         task {
@@ -180,9 +214,10 @@ type internal SqlAcceptedFactMutation(interleaving: IAcceptedFactMutationInterle
 
             validateRawFactScope plan.RawFact scope
             validateAggregateMatchesRawFact plan.RawFact plan.Aggregate
+            validateRawInsertion plan.RawFact rawInsertion
 
             do! ensureRawIdentityAsync connection transaction plan.RawFact.UsageFactId scope cancellationToken
-            let! inserted = tryInsertRawFactAsync connection transaction plan.RawFact cancellationToken
+            let! inserted = tryInsertRawFactAsync connection transaction plan.RawFact rawInsertion cancellationToken
 
             if not inserted then
                 do! ensureRawIdentityAsync connection transaction plan.RawFact.UsageFactId scope cancellationToken
@@ -195,3 +230,14 @@ type internal SqlAcceptedFactMutation(interleaving: IAcceptedFactMutationInterle
                 do! interleaving.AfterAcceptedFactMutationsStagedAsync(outcome, cancellationToken)
                 return outcome
         }
+
+    /// Stages the ordinary hot-payload accepted fact shape retained by the #937 primitive contract.
+    member this.AcceptAsync
+        (
+            connection: SqlConnection,
+            transaction: SqlTransaction,
+            plan: UsageFactPersistencePlan,
+            scope: BillingCompletenessScope,
+            cancellationToken: CancellationToken
+        ) =
+        this.AcceptAsync(connection, transaction, plan, scope, HotRawFact, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsAcceptedUsageStore.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsAcceptedUsageStore.fs
@@ -1,0 +1,169 @@
+namespace Grace.Operations.Data
+
+open Grace.Types.Common
+open Grace.Types.Usage
+open Microsoft.Data.SqlClient
+open System
+open System.Threading
+open System.Threading.Tasks
+
+/// Adapts the merged accepted-fact SQL mutation to the existing Operations usage transaction interface.
+type private SqlAcceptedFactMutationExecutor(interleaving: IAcceptedFactMutationInterleaving) =
+    let mutation = SqlAcceptedFactMutation(interleaving)
+
+    interface IAcceptedFactMutationExecutor with
+
+        member _.AcceptAsync(connection, transaction, plan, scope, rawInsertion, cancellationToken) =
+            mutation.AcceptAsync(connection, transaction, plan, scope, rawInsertion, cancellationToken)
+
+/// Runs Operations usage mutations in one caller-owned Azure SQL transaction using the shared accepted-fact mutation.
+type SqlOperationsUsageTransactionScope private (connectionString: string, acceptedFactMutationExecutor: IAcceptedFactMutationExecutor) =
+
+    /// Opens the SQL connection for one Operations usage transaction.
+    let openConnectionAsync cancellationToken =
+        task {
+            let connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync cancellationToken
+            return connection
+        }
+
+    /// Rolls back a failed transaction while preserving its primary error.
+    let rollbackIgnoringFailuresAsync (transaction: SqlTransaction) =
+        task {
+            try
+                do! transaction.RollbackAsync CancellationToken.None
+            with
+            | _ -> ()
+        }
+
+    /// Creates the production transaction scope without a test interleaving.
+    new(connectionString: string) = SqlOperationsUsageTransactionScope(connectionString, SqlAcceptedFactMutationExecutor(null) :> IAcceptedFactMutationExecutor)
+
+    /// Creates a transaction scope that exposes the shared post-staging interleaving for real-SQL rollback proof.
+    static member internal CreateForTest(connectionString, interleaving) =
+        SqlOperationsUsageTransactionScope(connectionString, SqlAcceptedFactMutationExecutor(interleaving) :> IAcceptedFactMutationExecutor)
+
+    interface IOperationsUsageTransactionScope with
+
+        member _.ExecuteAsync(operation, cancellationToken) =
+            task {
+                use! connection = openConnectionAsync cancellationToken
+                let! databaseTransaction = connection.BeginTransactionAsync cancellationToken
+                use transaction = databaseTransaction :?> SqlTransaction
+                let operationsTransaction = SqlOperationsUsageTransaction(connection, transaction, acceptedFactMutationExecutor)
+
+                try
+                    let! result = operation operationsTransaction cancellationToken
+                    do! transaction.CommitAsync cancellationToken
+                    return result
+                with
+                | ex ->
+                    do! rollbackIgnoringFailuresAsync transaction
+                    return raise ex
+            }
+
+/// Persists online and archived usage through one caller transaction and the merged accepted-fact mutation.
+type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
+
+    /// Acquires the central scope lock derived from accepted fact data before any completeness-affecting mutation.
+    let acquireScopeAsync (transaction: IOperationsUsageTransaction) (rawFact: RawUsageFact) cancellationToken =
+        task {
+            match BillingCompletenessScope.tryCreate rawFact.OwnerId rawFact.OrganizationId rawFact.RepositoryId rawFact.ObservedAt with
+            | Error errors -> return invalidOp (String.Join("; ", errors))
+            | Ok scope ->
+                do! transaction.AcquireBillingCompletenessScopeAsync(scope, cancellationToken)
+                return scope
+        }
+
+    /// Projects the shared mutation outcome into the existing online storage result without duplicating accepted SQL.
+    let persistenceResult plan outcome =
+        match outcome with
+        | ExistingSameScope -> { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = plan.RawFact.UsageFactId; Aggregate = None }
+        | InsertedIntoOpenPeriod
+        | InsertedIntoClosedPeriod -> { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
+
+    /// Persists one plan through the caller transaction and a narrow raw-insertion adapter.
+    let acceptAsync plan rawInsertion cancellationToken =
+        task {
+            let operation (transaction: IOperationsUsageTransaction) operationCancellationToken =
+                task {
+                    let! scope = acquireScopeAsync transaction plan.RawFact operationCancellationToken
+                    let acceptedFactTransaction = transaction :?> IAcceptedFactMutationTransaction
+
+                    let! outcome = acceptedFactTransaction.AcceptUsageFactAsync(plan, scope, rawInsertion, operationCancellationToken)
+                    return persistenceResult plan outcome
+                }
+
+            return! transactionScope.ExecuteAsync(operation, cancellationToken)
+        }
+
+    /// Stores a usage fact exactly once by durable `UsageFactId` and projects aggregates only for newly accepted facts.
+    member _.StoreUsageFactAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactPersistencePlan.tryCreate fact rawPayload with
+            | Error errors -> return Error errors
+            | Ok plan ->
+                let! result = acceptAsync plan HotRawFact cancellationToken
+                return Ok result
+        }
+
+    /// Replays an archived usage fact into raw index and aggregate state without restoring hot SQL payload bytes.
+    member _.ReplayArchivedUsageFactAsync(fact: UsageFact, rawPayload: byte array, pointer: RawUsageFactArchivePointer, cancellationToken: CancellationToken) =
+        task {
+            if pointer.UsageFactId <> fact.UsageFactId then
+                return Error [ $"Replay pointer UsageFactId '{pointer.UsageFactId}' does not match payload UsageFactId '{fact.UsageFactId}'." ]
+            else
+                match UsageFactPersistencePlan.tryCreate fact rawPayload with
+                | Error errors -> return Error errors
+                | Ok plan ->
+                    let! result = acceptAsync plan (ArchivedReplayRawFact pointer) cancellationToken
+                    return Ok result
+        }
+
+    /// Records a scoped blocker under the same lock as accepted usage, or preserves partial evidence without a scope.
+    member _.RecordUsageFactRejectionAsync(rejection: UsageFactRejection, cancellationToken: CancellationToken) =
+        task {
+            match UsageFactRejection.validate rejection with
+            | Error errors -> return Error errors
+            | Ok validRejection ->
+                let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
+                    task {
+                        match validRejection.Scope with
+                        | Some scope ->
+                            do! transaction.AcquireBillingCompletenessScopeAsync(scope, operationCancellationToken)
+
+                            do!
+                                transaction.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(
+                                    validRejection.UsageFactId.Value,
+                                    scope,
+                                    operationCancellationToken
+                                )
+
+                            return! transaction.RecordScopedUsageFactRejectionAsync(validRejection, operationCancellationToken)
+                        | None ->
+                            do! transaction.RecordUnscopedUsageFactRejectionAsync(validRejection, operationCancellationToken)
+                            return None
+                    }
+
+                let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
+                return Ok result
+        }
+
+    /// Reads completeness after acquiring the same transaction-owned lock used by mutations for the exact scope.
+    member _.EvaluateBillingCompletenessAsync(scope: BillingCompletenessScope, cancellationToken: CancellationToken) =
+        match BillingCompletenessScope.validate scope with
+        | Error errors -> Task.FromException<BillingCompletenessResult>(ArgumentException(String.Join("; ", errors), nameof scope))
+        | Ok validScope ->
+            let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
+                task {
+                    do! transaction.AcquireBillingCompletenessScopeAsync(validScope, operationCancellationToken)
+                    let! blocked = transaction.HasActiveScopedUsageFactRejectionAsync(validScope, operationCancellationToken)
+                    let! journalBlocked = transaction.HasUnresolvedUsageFactJournalAsync(validScope, operationCancellationToken)
+
+                    return
+                        if blocked then BlockedByActiveScopedRejection
+                        elif journalBlocked then BlockedByUnresolvedUsageFactJournal
+                        else Complete
+                }
+
+            transactionScope.ExecuteAsync(operation, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -716,24 +716,11 @@ type IOperationsUsageTransaction =
     abstract EnsureUsageFactIdMatchesBillingCompletenessScopeAsync:
         usageFactId: UsageFactId * scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task
 
-    /// Attempts to insert the raw fact, returning `false` when `UsageFactId` already exists.
-    abstract TryInsertRawUsageFactAsync: rawFact: RawUsageFact * cancellationToken: CancellationToken -> Task<bool>
-
-    /// Attempts to insert an archived replay fact without restoring hot SQL payload bytes.
-    abstract TryInsertReplayedArchivedUsageFactAsync:
-        rawFact: RawUsageFact * pointer: RawUsageFactArchivePointer * cancellationToken: CancellationToken -> Task<bool>
-
-    /// Adds the accepted raw fact quantity to the derived minute aggregate.
-    abstract AddToUsageAggregateMinuteAsync: aggregate: UsageAggregateMinute * cancellationToken: CancellationToken -> Task
-
     /// Records the canonical scoped rejection unless accepted durable usage has already won.
     abstract RecordScopedUsageFactRejectionAsync: rejection: UsageFactRejection * cancellationToken: CancellationToken -> Task<UsageFactRejection option>
 
     /// Persists partial rejection evidence without manufacturing a billing scope.
     abstract RecordUnscopedUsageFactRejectionAsync: rejection: UsageFactRejection * cancellationToken: CancellationToken -> Task
-
-    /// Repairs all active blockers for an accepted exact fact while the scope lock remains held.
-    abstract ResolveScopedUsageFactRejectionAsync: usageFactId: UsageFactId * scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task
 
     /// Reads active scoped rejection evidence while the caller holds the central scope lock.
     abstract HasActiveScopedUsageFactRejectionAsync: scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task<bool>
@@ -789,51 +776,6 @@ type internal SqlOperationsUsageTransaction(connection: SqlConnection, transacti
     let toInstant (dateTime: DateTime) =
         DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
         |> Instant.FromDateTimeUtc
-
-    /// Adds the raw usage fact parameters expected by `OperationsUsageSql.TryInsertRawUsageFact`.
-    let addRawUsageFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
-        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
-        addRawPayloadParameter command rawFact.RawPayload
-        addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
-        addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
-        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
-        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
-        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
-        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength rawFact.StoragePoolId
-        addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
-        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
-
-    /// Adds raw fact parameters for archive replay inserts that intentionally omit hot payload bytes.
-    let addReplayedRawUsageFactParameters (command: SqlCommand) (rawFact: RawUsageFact) =
-        addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier rawFact.UsageFactId
-        addStringParameter command "@CorrelationId" OperationsUsageSql.CorrelationIdMaxLength rawFact.CorrelationId
-        addParameter command "@FactKind" SqlDbType.Int (int rawFact.FactKind)
-        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier rawFact.OwnerId
-        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier rawFact.OrganizationId
-        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier rawFact.RepositoryId
-        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength rawFact.StoragePoolId
-        addParameter command "@Quantity" SqlDbType.BigInt rawFact.Quantity
-        addParameter command "@ObservedAtUtc" SqlDbType.DateTime2 (toUtcDateTime rawFact.ObservedAt)
-
-    /// Adds archive pointer parameters for replay inserts that keep hot payload bytes out of SQL.
-    let addReplayedArchivePointerParameters (command: SqlCommand) (pointer: RawUsageFactArchivePointer) =
-        addStringParameter command "@ArchiveBlobName" OperationsUsageSql.ArchiveBlobNameMaxLength pointer.BlobName
-
-        let checksumParameter = command.Parameters.Add("@ArchiveChecksumSha256Hex", SqlDbType.Char, OperationsUsageSql.ArchiveChecksumSha256HexLength)
-
-        checksumParameter.Value <- pointer.ChecksumSha256Hex
-        addParameter command "@ArchiveByteLength" SqlDbType.BigInt pointer.ByteLength
-        addParameter command "@ArchiveStateArchived" SqlDbType.Int (int RawUsageFactArchiveState.Archived)
-
-    /// Adds the aggregate parameters expected by `OperationsUsageSql.AddToUsageAggregateMinute`.
-    let addUsageAggregateMinuteParameters (command: SqlCommand) (aggregate: UsageAggregateMinute) =
-        addParameter command "@FactKind" SqlDbType.Int (int aggregate.Key.FactKind)
-        addParameter command "@OwnerId" SqlDbType.UniqueIdentifier aggregate.Key.OwnerId
-        addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier aggregate.Key.OrganizationId
-        addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier aggregate.Key.RepositoryId
-        addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength aggregate.Key.StoragePoolId
-        addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (toUtcDateTime aggregate.Key.BucketStart)
-        addParameter command "@Quantity" SqlDbType.BigInt aggregate.Quantity
 
     /// Adds complete owner, organization, repository, and UTC-month parameters from the sole scope contract.
     let addBillingCompletenessScopeParameters (command: SqlCommand) (scope: BillingCompletenessScope) =
@@ -900,31 +842,6 @@ type internal SqlOperationsUsageTransaction(connection: SqlConnection, transacti
 
         member _.AcceptUsageFactAsync(plan, scope, rawInsertion, cancellationToken) =
             acceptedFactMutationExecutor.AcceptAsync(connection, transaction, plan, scope, rawInsertion, cancellationToken)
-
-        member _.TryInsertRawUsageFactAsync(rawFact, cancellationToken) =
-            task {
-                use command = createCommand OperationsUsageSql.TryInsertRawUsageFact
-                addRawUsageFactParameters command rawFact
-                let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
-                return rowsAffected = 1
-            }
-
-        member _.TryInsertReplayedArchivedUsageFactAsync(rawFact, pointer, cancellationToken) =
-            task {
-                use command = createCommand OperationsUsageSql.TryInsertReplayedArchivedRawUsageFact
-                addReplayedRawUsageFactParameters command rawFact
-                addReplayedArchivePointerParameters command pointer
-                let! rowsAffected = command.ExecuteNonQueryAsync cancellationToken
-                return rowsAffected = 1
-            }
-
-        member _.AddToUsageAggregateMinuteAsync(aggregate, cancellationToken) =
-            task {
-                use command = createCommand OperationsUsageSql.AddToUsageAggregateMinute
-                addUsageAggregateMinuteParameters command aggregate
-                let! _ = command.ExecuteNonQueryAsync cancellationToken
-                return ()
-            }
 
         member _.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken) =
             task {
@@ -995,14 +912,6 @@ type internal SqlOperationsUsageTransaction(connection: SqlConnection, transacti
                      |> Option.defaultValue DBNull.Value)
 
                 addStringParameter command "@Reason" OperationsUsageSql.ArchiveFailureReasonMaxLength rejection.Reason
-                let! _ = command.ExecuteNonQueryAsync cancellationToken
-                return ()
-            }
-
-        member _.ResolveScopedUsageFactRejectionAsync(usageFactId, scope, cancellationToken) =
-            task {
-                use command = createCommand OperationsUsageSql.ResolveScopedUsageFactRejection
-                addScopedUsageFactRejectionParameters command usageFactId scope
                 let! _ = command.ExecuteNonQueryAsync cancellationToken
                 return ()
             }

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsData.fs
@@ -682,6 +682,30 @@ module UsageFactPersistencePlan =
         let rawPayload = JsonSerializer.SerializeToUtf8Bytes<UsageFact>(fact, Constants.JsonSerializerOptions)
         tryCreate fact rawPayload
 
+/// Distinguishes a same-scope accepted-fact replay from a new fact staged before or after its exact billing-period close.
+type internal AcceptedFactMutationOutcome =
+    | ExistingSameScope
+    | InsertedIntoOpenPeriod
+    | InsertedIntoClosedPeriod
+
+/// Selects the one raw-row shape the shared accepted-fact mutation must persist without exposing SQL to a caller.
+type internal AcceptedFactRawInsertion =
+    | HotRawFact
+    | ArchivedReplayRawFact of RawUsageFactArchivePointer
+
+/// Invokes the merged accepted-fact mutation through a caller-owned SQL connection and transaction.
+type internal IAcceptedFactMutationExecutor =
+
+    /// Stages accepted raw, rejection repair, aggregate, and conditional Pending work without committing the caller transaction.
+    abstract AcceptAsync:
+        connection: SqlConnection *
+        transaction: SqlTransaction *
+        plan: UsageFactPersistencePlan *
+        scope: BillingCompletenessScope *
+        rawInsertion: AcceptedFactRawInsertion *
+        cancellationToken: CancellationToken ->
+            Task<AcceptedFactMutationOutcome>
+
 /// Represents the commands available inside one durable operations usage transaction.
 type IOperationsUsageTransaction =
 
@@ -717,6 +741,15 @@ type IOperationsUsageTransaction =
     /// Reads exact-scope Pending or Rejected journal rows while the caller holds the central scope lock.
     abstract HasUnresolvedUsageFactJournalAsync: scope: BillingCompletenessScope * cancellationToken: CancellationToken -> Task<bool>
 
+/// Extends the existing transaction with the internal shared-mutation adapter required by accepted-fact callers.
+type internal IAcceptedFactMutationTransaction =
+    inherit IOperationsUsageTransaction
+
+    /// Stages the one shared accepted-fact mutation through the caller's current transaction.
+    abstract AcceptUsageFactAsync:
+        plan: UsageFactPersistencePlan * scope: BillingCompletenessScope * rawInsertion: AcceptedFactRawInsertion * cancellationToken: CancellationToken ->
+            Task<AcceptedFactMutationOutcome>
+
 /// Runs operations usage mutations inside one storage transaction boundary.
 type IOperationsUsageTransactionScope =
 
@@ -724,7 +757,7 @@ type IOperationsUsageTransactionScope =
     abstract ExecuteAsync<'T> : operation: (IOperationsUsageTransaction -> CancellationToken -> Task<'T>) * cancellationToken: CancellationToken -> Task<'T>
 
 /// Executes operations usage SQL commands through an already-open SQL connection and transaction.
-type private SqlOperationsUsageTransaction(connection: SqlConnection, transaction: SqlTransaction) =
+type internal SqlOperationsUsageTransaction(connection: SqlConnection, transaction: SqlTransaction, acceptedFactMutationExecutor: IAcceptedFactMutationExecutor) =
 
     /// Adds a SQL parameter and assigns either the supplied value or database null.
     let addParameter (command: SqlCommand) name sqlDbType value =
@@ -858,12 +891,15 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
             IsActive = reader.GetBoolean(reader.GetOrdinal("IsActive"))
         }
 
-    interface IOperationsUsageTransaction with
+    interface IAcceptedFactMutationTransaction with
 
         member _.AcquireBillingCompletenessScopeAsync(scope, cancellationToken) = acquireBillingCompletenessScopeAsync scope cancellationToken
 
         member _.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(usageFactId, scope, cancellationToken) =
             ensureUsageFactIdMatchesBillingCompletenessScopeAsync usageFactId scope cancellationToken
+
+        member _.AcceptUsageFactAsync(plan, scope, rawInsertion, cancellationToken) =
+            acceptedFactMutationExecutor.AcceptAsync(connection, transaction, plan, scope, rawInsertion, cancellationToken)
 
         member _.TryInsertRawUsageFactAsync(rawFact, cancellationToken) =
             task {
@@ -987,45 +1023,6 @@ type private SqlOperationsUsageTransaction(connection: SqlConnection, transactio
                 addParameter command "@RejectedState" SqlDbType.Int 2
                 let! result = command.ExecuteScalarAsync cancellationToken
                 return Convert.ToBoolean result
-            }
-
-/// Runs operations usage mutations inside a concrete Azure SQL transaction boundary.
-type SqlOperationsUsageTransactionScope(connectionString: string) =
-
-    /// Opens a SQL connection for one operations usage transaction.
-    let openConnectionAsync cancellationToken =
-        task {
-            let connection = new SqlConnection(connectionString)
-            do! connection.OpenAsync cancellationToken
-            return connection
-        }
-
-    /// Rolls back a failed transaction while preserving the original failure when rollback also fails.
-    let rollbackIgnoringFailuresAsync (transaction: SqlTransaction) =
-        task {
-            try
-                do! transaction.RollbackAsync CancellationToken.None
-            with
-            | _ -> ()
-        }
-
-    interface IOperationsUsageTransactionScope with
-
-        member _.ExecuteAsync(operation, cancellationToken) =
-            task {
-                use! connection = openConnectionAsync cancellationToken
-                let! dbTransaction = connection.BeginTransactionAsync cancellationToken
-                use transaction = dbTransaction :?> SqlTransaction
-                let operationsTransaction = SqlOperationsUsageTransaction(connection, transaction)
-
-                try
-                    let! result = operation operationsTransaction cancellationToken
-                    do! transaction.CommitAsync cancellationToken
-                    return result
-                with
-                | ex ->
-                    do! rollbackIgnoringFailuresAsync transaction
-                    return raise ex
             }
 
 /// Lists and updates archive state through reviewed SQL commands that preserve Blob authority ordering.
@@ -1787,117 +1784,3 @@ type OperationsUsageSchemaInitializationBarrier(schema: IOperationsUsageSchemaIn
     interface IOperationsUsageSchemaInitializer with
 
         member this.EnsureCreatedAsync(cancellationToken) = this.EnsureCreatedAsync cancellationToken
-
-/// Persists usage facts through a transaction-scoped raw insert and aggregate projection.
-type OperationsUsageStore(transactionScope: IOperationsUsageTransactionScope) =
-
-    /// Acquires the central scope lock derived from accepted fact data before any completeness-affecting mutation.
-    let acquireScopeAsync (transaction: IOperationsUsageTransaction) (rawFact: RawUsageFact) cancellationToken =
-        task {
-            match BillingCompletenessScope.tryCreate rawFact.OwnerId rawFact.OrganizationId rawFact.RepositoryId rawFact.ObservedAt with
-            | Error errors -> return invalidOp (String.Join("; ", errors))
-            | Ok scope ->
-                do! transaction.AcquireBillingCompletenessScopeAsync(scope, cancellationToken)
-                return scope
-        }
-
-    /// Stores a usage fact exactly once by durable `UsageFactId` and projects aggregates only for newly accepted facts.
-    member _.StoreUsageFactAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
-        task {
-            match UsageFactPersistencePlan.tryCreate fact rawPayload with
-            | Error errors -> return Error errors
-            | Ok plan ->
-                let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
-                    task {
-                        let! scope = acquireScopeAsync transaction plan.RawFact operationCancellationToken
-                        do! transaction.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(plan.RawFact.UsageFactId, scope, operationCancellationToken)
-                        do! transaction.ResolveScopedUsageFactRejectionAsync(plan.RawFact.UsageFactId, scope, operationCancellationToken)
-                        let! accepted = transaction.TryInsertRawUsageFactAsync(plan.RawFact, operationCancellationToken)
-
-                        if accepted then
-                            do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
-
-                            return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
-                        else
-                            return { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = plan.RawFact.UsageFactId; Aggregate = None }
-                    }
-
-                let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
-                return Ok result
-        }
-
-    /// Replays an archived usage fact into raw index and aggregate state without restoring hot SQL payload bytes.
-    member _.ReplayArchivedUsageFactAsync(fact: UsageFact, rawPayload: byte array, pointer: RawUsageFactArchivePointer, cancellationToken: CancellationToken) =
-        task {
-            if pointer.UsageFactId <> fact.UsageFactId then
-                return Error [ $"Replay pointer UsageFactId '{pointer.UsageFactId}' does not match payload UsageFactId '{fact.UsageFactId}'." ]
-            else
-                match UsageFactPersistencePlan.tryCreate fact rawPayload with
-                | Error errors -> return Error errors
-                | Ok plan ->
-                    let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
-                        task {
-                            let! scope = acquireScopeAsync transaction plan.RawFact operationCancellationToken
-                            do! transaction.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(plan.RawFact.UsageFactId, scope, operationCancellationToken)
-                            do! transaction.ResolveScopedUsageFactRejectionAsync(plan.RawFact.UsageFactId, scope, operationCancellationToken)
-                            let! accepted = transaction.TryInsertReplayedArchivedUsageFactAsync(plan.RawFact, pointer, operationCancellationToken)
-
-                            if accepted then
-                                do! transaction.AddToUsageAggregateMinuteAsync(plan.Aggregate, operationCancellationToken)
-
-                                return { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = plan.RawFact.UsageFactId; Aggregate = Some plan.Aggregate }
-                            else
-                                return { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = plan.RawFact.UsageFactId; Aggregate = None }
-                        }
-
-                    let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
-                    return Ok result
-        }
-
-    /// Records a scoped blocker under the same lock as accepted usage, or preserves partial evidence without a scope.
-    member _.RecordUsageFactRejectionAsync(rejection: UsageFactRejection, cancellationToken: CancellationToken) =
-        task {
-            match UsageFactRejection.validate rejection with
-            | Error errors -> return Error errors
-            | Ok validRejection ->
-                let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
-                    task {
-                        match validRejection.Scope with
-                        | Some scope ->
-                            do! transaction.AcquireBillingCompletenessScopeAsync(scope, operationCancellationToken)
-
-                            do!
-                                transaction.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(
-                                    validRejection.UsageFactId.Value,
-                                    scope,
-                                    operationCancellationToken
-                                )
-
-                            return! transaction.RecordScopedUsageFactRejectionAsync(validRejection, operationCancellationToken)
-                        | None ->
-                            do! transaction.RecordUnscopedUsageFactRejectionAsync(validRejection, operationCancellationToken)
-                            return None
-                    }
-
-                let! result = transactionScope.ExecuteAsync(operation, cancellationToken)
-                return Ok result
-        }
-
-    /// Reads completeness after acquiring the same transaction-owned lock used by mutations for the exact scope.
-    member _.EvaluateBillingCompletenessAsync(scope: BillingCompletenessScope, cancellationToken: CancellationToken) =
-        match BillingCompletenessScope.validate scope with
-        | Error errors -> Task.FromException<BillingCompletenessResult>(ArgumentException(String.Join("; ", errors), nameof scope))
-        | Ok validScope ->
-            let operation (transaction: IOperationsUsageTransaction) (operationCancellationToken: CancellationToken) =
-                task {
-                    do! transaction.AcquireBillingCompletenessScopeAsync(validScope, operationCancellationToken)
-                    let! blocked = transaction.HasActiveScopedUsageFactRejectionAsync(validScope, operationCancellationToken)
-                    let! journalBlocked = transaction.HasUnresolvedUsageFactJournalAsync(validScope, operationCancellationToken)
-
-                    return
-                        if blocked then BlockedByActiveScopedRejection
-                        elif journalBlocked then BlockedByUnresolvedUsageFactJournal
-                        else Complete
-                }
-
-            transactionScope.ExecuteAsync(operation, cancellationToken)

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsUsageJournal.fs
@@ -54,18 +54,16 @@ type UsageFactJournalRejectResult =
     | RejectJournalConflict
     | RejectAlreadyAccepted
 
-/// Pauses a ProcessAsync transaction only after its raw and aggregate mutations have been staged for deterministic rollback proof.
+/// Reuses the shared post-staging interleaving before a journal terminal transition can commit.
 type internal IOperationsUsageJournalTransactionInterleaving =
-
-    /// Observes the transaction-local point immediately before journal acceptance can commit.
-    abstract AfterRawAndAggregateStagedAsync: cancellationToken: CancellationToken -> Task
+    inherit IAcceptedFactMutationInterleaving
 
 /// Leaves production journal transactions uninterrupted when no deterministic proof interleaving is supplied.
 type private NoOperationsUsageJournalTransactionInterleaving() =
 
     interface IOperationsUsageJournalTransactionInterleaving with
 
-        member _.AfterRawAndAggregateStagedAsync(_cancellationToken) = Task.CompletedTask
+        member _.AfterAcceptedFactMutationsStagedAsync(_, _cancellationToken) = Task.CompletedTask
 
 /// Owns the internal Operations append, dispatch scan, and transactionally verified journal processing seam.
 type IOperationsUsageJournalStore =
@@ -90,6 +88,8 @@ type IOperationsUsageJournalStore =
 
 /// Stores immutable usage facts in the SQL journal and treats Service Bus delivery as a retryable signal only.
 type SqlOperationsUsageJournalStore private (connectionString: string, transactionInterleaving: IOperationsUsageJournalTransactionInterleaving) =
+
+    let acceptedFactMutation = SqlAcceptedFactMutation(transactionInterleaving :> IAcceptedFactMutationInterleaving)
 
     /// Opens the SQL connection used by one append, scan, or processing transaction.
     let openConnectionAsync cancellationToken =
@@ -226,30 +226,6 @@ VALUES
             return ()
         }
 
-    /// Adds the accepted fact to raw usage only when a prior durable raw identity does not already exist.
-    let tryInsertRawAsync (connection: SqlConnection) (transaction: SqlTransaction) (rawFact: RawUsageFact) (cancellationToken: CancellationToken) =
-        task {
-            use command = createCommand connection transaction OperationsUsageSql.TryInsertRawUsageFact
-            addFactParameters command rawFact
-            let! rows = command.ExecuteNonQueryAsync cancellationToken
-            return rows = 1
-        }
-
-    /// Adds the newly accepted quantity to the minute aggregate under the same journal processing transaction.
-    let addAggregateAsync (connection: SqlConnection) (transaction: SqlTransaction) (aggregate: UsageAggregateMinute) (cancellationToken: CancellationToken) =
-        task {
-            use command = createCommand connection transaction OperationsUsageSql.AddToUsageAggregateMinute
-            addParameter command "@FactKind" SqlDbType.Int (int aggregate.Key.FactKind)
-            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier aggregate.Key.OwnerId
-            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier aggregate.Key.OrganizationId
-            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier aggregate.Key.RepositoryId
-            addStringParameter command "@StoragePoolId" OperationsUsageSql.StoragePoolIdMaxLength aggregate.Key.StoragePoolId
-            addParameter command "@BucketStartUtc" SqlDbType.DateTime2 (toUtcDateTime aggregate.Key.BucketStart)
-            addParameter command "@Quantity" SqlDbType.BigInt aggregate.Quantity
-            let! _ = command.ExecuteNonQueryAsync cancellationToken
-            return ()
-        }
-
     /// Marks one still-unresolved matching journal row Accepted only after raw and aggregate persistence succeeded.
     let markAcceptedAsync (connection: SqlConnection) (transaction: SqlTransaction) (usageFactId: UsageFactId) (cancellationToken: CancellationToken) =
         task {
@@ -320,26 +296,6 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
 
             if not hasRow then
                 invalidOp "A Pending journal fact cannot become Rejected after accepted raw usage already exists."
-        }
-
-    /// Releases rejected completeness evidence only inside the same successful accepted processing transaction.
-    let resolveRejectionAsync
-        (connection: SqlConnection)
-        (transaction: SqlTransaction)
-        (usageFactId: UsageFactId)
-        (scope: BillingCompletenessScope)
-        (cancellationToken: CancellationToken)
-        =
-        task {
-            use command = createCommand connection transaction OperationsUsageSql.ResolveScopedUsageFactRejection
-            addParameter command "@UsageFactId" SqlDbType.UniqueIdentifier usageFactId
-            addParameter command "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
-            addParameter command "@OrganizationId" SqlDbType.UniqueIdentifier scope.OrganizationId
-            addParameter command "@RepositoryId" SqlDbType.UniqueIdentifier scope.RepositoryId
-            addParameter command "@MonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime scope.MonthStart)
-            addParameter command "@NextMonthStartUtc" SqlDbType.DateTime2 (toUtcDateTime (BillingCompletenessScope.nextMonthStart scope))
-            let! _ = command.ExecuteNonQueryAsync cancellationToken
-            return ()
         }
 
     /// Rolls back a failed processing transaction without replacing its original error.
@@ -490,7 +446,7 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
                         }
         }
 
-    /// Processes only a matching journalled fact and atomically commits raw, aggregate, rejection repair, and Accepted.
+    /// Processes only a matching journalled fact and commits Accepted only after the shared mutation stages successfully.
     member _.ProcessAsync(fact: UsageFact, rawPayload: byte array, cancellationToken: CancellationToken) =
         task {
             match UsageFactPersistencePlan.tryCreateCanonical fact with
@@ -510,13 +466,8 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
                                 | Some entry when entry.State = UsageFactJournalState.Accepted -> return AlreadyAccepted
                                 | Some entry when entry.State = UsageFactJournalState.Rejected -> return UsageFactJournalProcessResult.AlreadyRejected
                                 | Some _ ->
-                                    let! inserted = tryInsertRawAsync connection transaction plan.RawFact operationCancellationToken
+                                    let! _ = acceptedFactMutation.AcceptAsync(connection, transaction, plan, scope, operationCancellationToken)
 
-                                    if inserted then
-                                        do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
-
-                                    do! transactionInterleaving.AfterRawAndAggregateStagedAsync(operationCancellationToken)
-                                    do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
                                     do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
                                     return AcceptedFromJournal
                             })
@@ -543,12 +494,8 @@ WHERE UsageFactId = @UsageFactId AND State = 0;
                                 | Some entry when entry.State = UsageFactJournalState.Accepted -> return AlreadyAccepted
                                 | Some entry when entry.State = UsageFactJournalState.Pending -> return JournalConflict
                                 | Some _ ->
-                                    let! inserted = tryInsertRawAsync connection transaction plan.RawFact operationCancellationToken
+                                    let! _ = acceptedFactMutation.AcceptAsync(connection, transaction, plan, scope, operationCancellationToken)
 
-                                    if inserted then
-                                        do! addAggregateAsync connection transaction plan.Aggregate operationCancellationToken
-
-                                    do! resolveRejectionAsync connection transaction plan.RawFact.UsageFactId scope operationCancellationToken
                                     do! markAcceptedAsync connection transaction plan.RawFact.UsageFactId operationCancellationToken
                                     return AcceptedFromJournal
                             })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -44,23 +44,9 @@ type private ObservedOperationsUsageTransaction
                 return outcome
             }
 
-        member _.TryInsertRawUsageFactAsync(rawFact, cancellationToken) = inner.TryInsertRawUsageFactAsync(rawFact, cancellationToken)
-
-        member _.TryInsertReplayedArchivedUsageFactAsync(rawFact, pointer, cancellationToken) =
-            inner.TryInsertReplayedArchivedUsageFactAsync(rawFact, pointer, cancellationToken)
-
-        member _.AddToUsageAggregateMinuteAsync(aggregate, cancellationToken) =
-            task {
-                do! inner.AddToUsageAggregateMinuteAsync(aggregate, cancellationToken)
-                do! afterUsageAggregateAsync aggregate cancellationToken
-            }
-
         member _.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken) = inner.RecordScopedUsageFactRejectionAsync(rejection, cancellationToken)
 
         member _.RecordUnscopedUsageFactRejectionAsync(rejection, cancellationToken) = inner.RecordUnscopedUsageFactRejectionAsync(rejection, cancellationToken)
-
-        member _.ResolveScopedUsageFactRejectionAsync(usageFactId, scope, cancellationToken) =
-            inner.ResolveScopedUsageFactRejectionAsync(usageFactId, scope, cancellationToken)
 
         member _.HasActiveScopedUsageFactRejectionAsync(scope, cancellationToken) = inner.HasActiveScopedUsageFactRejectionAsync(scope, cancellationToken)
 
@@ -284,6 +270,97 @@ type OperationsBillingCompletenessTests() =
             command.CommandText <- commandText
             let! value = command.ExecuteScalarAsync CancellationToken.None
             return value :?> byte array
+        }
+
+    /// Captures the immutable close projection independently from accepted-fact state for rollback and conflict proofs.
+    let immutableClosedProjectionAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+SELECT CONCAT('BillingPeriod|', (SELECT * FROM ops.BillingPeriod ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('ChargePreviewLine|', (SELECT * FROM ops.ChargePreviewLine ORDER BY ChargePreviewLineId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('Charge|', (SELECT * FROM ops.Charge ORDER BY ChargeId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodCloseEvidence|', (SELECT * FROM ops.BillingPeriodCloseEvidence ORDER BY BillingPeriodId FOR JSON PATH, INCLUDE_NULL_VALUES))
+ORDER BY 1;
+"""
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let values = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then values.Add(reader.GetString 0)
+
+            return values |> Seq.toList
+        }
+
+    /// Inserts a closed period and complete immutable close projection directly for this adoption-only SQL fixture.
+    let seedClosedProjectionAsync connectionString ownerId organizationId repositoryId =
+        task {
+            let billingPeriodId = Guid.NewGuid()
+
+            do!
+                executeNonQueryAsync
+                    connectionString
+                    $"""
+DECLARE @PreviewLineId uniqueidentifier = NEWID();
+INSERT INTO ops.BillingPeriod
+    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
+VALUES
+    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
+INSERT INTO ops.ChargePreviewLine
+    (ChargePreviewLineId, OwnerId, OrganizationId, RepositoryId, PeriodFromUtc, PeriodToUtc, FactKind, BillableUsageKindMappingId, BillableUsageKind, PricingAssignmentId, PricingPlanId, PricingRateId, CurrencyCode, UnitName, UnitQuantity, UnitPriceMicros, EffectiveFromUtc, EffectiveToUtc, TotalQuantity, ChargeMicros)
+VALUES
+    (@PreviewLineId, '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 1, NEWID(), 1, NEWID(), NEWID(), NEWID(), 'USD', 'fixture-unit', 1, 1, '2026-08-01T00:00:00', '2026-09-01T00:00:00', 1, 1);
+INSERT INTO ops.Charge
+    (ChargeId, OwnerId, OrganizationId, RepositoryId, BillingPeriodId, ChargePreviewLineId, PeriodFromUtc, PeriodToUtc, FactKind, BillableUsageKindMappingId, BillableUsageKind, PricingAssignmentId, PricingPlanId, PricingRateId, CurrencyCode, UnitName, UnitQuantity, UnitPriceMicros, EffectiveFromUtc, EffectiveToUtc, TotalQuantity, ChargeMicros)
+SELECT NEWID(), OwnerId, OrganizationId, RepositoryId, '{billingPeriodId:D}', ChargePreviewLineId, PeriodFromUtc, PeriodToUtc, FactKind, BillableUsageKindMappingId, BillableUsageKind, PricingAssignmentId, PricingPlanId, PricingRateId, CurrencyCode, UnitName, UnitQuantity, UnitPriceMicros, EffectiveFromUtc, EffectiveToUtc, TotalQuantity, ChargeMicros
+FROM ops.ChargePreviewLine
+WHERE ChargePreviewLineId = @PreviewLineId;
+INSERT INTO ops.BillingPeriodCloseEvidence
+    (BillingPeriodId, AcceptedFactDigestSha256Hex, PricingPreviewDigestSha256Hex, ClosedAtUtc, ScheduledOperationProvenance)
+VALUES
+    ('{billingPeriodId:D}', REPLICATE('A', 64), REPLICATE('B', 64), '2026-09-01T00:00:00', 'adoption-fixture');
+"""
+
+            return billingPeriodId
+        }
+
+    /// Reads the raw, aggregate, rejection, late-work, and journal rows that the shared mutation may change.
+    let acceptedFactProjectionAsync connectionString =
+        task {
+            use connection = new SqlConnection(connectionString)
+            do! connection.OpenAsync CancellationToken.None
+            use command = connection.CreateCommand()
+
+            command.CommandText <-
+                """
+SELECT CONCAT('RawUsageFact|', (SELECT * FROM ops.RawUsageFact ORDER BY UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('UsageAggregateMinute|', (SELECT * FROM ops.UsageAggregateMinute ORDER BY OwnerId, OrganizationId, RepositoryId, FactKind, StoragePoolId, BucketStartUtc FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('UsageFactRejection|', (SELECT * FROM ops.UsageFactRejection ORDER BY RejectionId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('BillingPeriodLateWork|', (SELECT * FROM ops.BillingPeriodLateWork ORDER BY BillingPeriodId, UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
+UNION ALL SELECT CONCAT('UsageFactJournal|', (SELECT * FROM ops.UsageFactJournal ORDER BY UsageFactId FOR JSON PATH, INCLUDE_NULL_VALUES))
+ORDER BY 1;
+"""
+
+            use! reader = command.ExecuteReaderAsync CancellationToken.None
+            let values = ResizeArray<string>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync CancellationToken.None
+                reading <- hasRow
+
+                if hasRow then values.Add(reader.GetString 0)
+
+            return values |> Seq.toList
         }
 
     /// Reads whether SQL Server reports the named production operation has a waiting application-lock request.
@@ -1681,9 +1758,13 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 let rejectedRepairFact = fact repairUsageFactId ownerId organizationId repositoryBId observedAt
                 let store = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
                 let journal = SqlOperationsUsageJournalStore(connectionString)
+                let! _ = seedClosedProjectionAsync connectionString ownerId organizationId repositoryAId
+                let! _ = seedClosedProjectionAsync connectionString ownerId organizationId repositoryBId
 
                 let! _ = store.StoreUsageFactAsync(acceptedProcessFact, payloadFor acceptedProcessFact, CancellationToken.None)
                 let! appendedProcess = journal.AppendAsync(pendingProcessFact, CancellationToken.None)
+                let! immutableBeforeProcess = immutableClosedProjectionAsync connectionString
+                let! acceptedBeforeProcess = acceptedFactProjectionAsync connectionString
 
                 let! processRejected =
                     task {
@@ -1695,9 +1776,14 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         | :? SqlException -> return true
                     }
 
+                let! immutableAfterProcess = immutableClosedProjectionAsync connectionString
+                let! acceptedAfterProcess = acceptedFactProjectionAsync connectionString
+
                 let! _ = store.StoreUsageFactAsync(acceptedRepairFact, payloadFor acceptedRepairFact, CancellationToken.None)
                 let! appendedRepair = journal.AppendAsync(rejectedRepairFact, CancellationToken.None)
                 let! rejected = journal.RejectAsync(rejectedRepairFact, payloadFor rejectedRepairFact, "cross-scope repair regression", CancellationToken.None)
+                let! immutableBeforeRepair = immutableClosedProjectionAsync connectionString
+                let! acceptedBeforeRepair = acceptedFactProjectionAsync connectionString
 
                 let! repairRejected =
                     task {
@@ -1708,6 +1794,9 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         | :? InvalidOperationException -> return true
                         | :? SqlException -> return true
                     }
+
+                let! immutableAfterRepair = immutableClosedProjectionAsync connectionString
+                let! acceptedAfterRepair = acceptedFactProjectionAsync connectionString
 
                 let! rawA =
                     executeInt32Async
@@ -1743,7 +1832,90 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         Assert.That(rawB, Is.Zero)
                         Assert.That(processJournalState, Is.EqualTo(int UsageFactJournalState.Pending))
                         Assert.That(repairJournalState, Is.EqualTo(int UsageFactJournalState.Rejected))
-                        Assert.That(repairActiveRejection, Is.EqualTo(1)))
+                        Assert.That(repairActiveRejection, Is.EqualTo(1))
+                        Assert.That<string list>(acceptedAfterProcess, Is.EqualTo<string list>(acceptedBeforeProcess))
+                        Assert.That<string list>(immutableAfterProcess, Is.EqualTo<string list>(immutableBeforeProcess))
+                        Assert.That<string list>(acceptedAfterRepair, Is.EqualTo<string list>(acceptedBeforeRepair))
+                        Assert.That<string list>(immutableAfterRepair, Is.EqualTo<string list>(immutableBeforeRepair)))
+                )
+            })
+
+    /// Proves online and archived replay reject a cross-scope reused identity without changing closed projections or accepted state.
+    [<Test>]
+    member _.OnlineAndArchivedReplayRejectCrossScopeIdentityAgainstDirectClosedSnapshots() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryAId = Guid.NewGuid()
+                let repositoryBId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let onlineUsageFactId = Guid.NewGuid()
+                let replayUsageFactId = Guid.NewGuid()
+                let acceptedOnlineFact = fact onlineUsageFactId ownerId organizationId repositoryAId observedAt
+                let conflictingOnlineFact = fact onlineUsageFactId ownerId organizationId repositoryBId observedAt
+                let acceptedReplayFact = fact replayUsageFactId ownerId organizationId repositoryAId observedAt
+                let conflictingReplayFact = fact replayUsageFactId ownerId organizationId repositoryBId observedAt
+                let store = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+                let! _ = seedClosedProjectionAsync connectionString ownerId organizationId repositoryAId
+                let! _ = seedClosedProjectionAsync connectionString ownerId organizationId repositoryBId
+                let! _ = store.StoreUsageFactAsync(acceptedOnlineFact, payloadFor acceptedOnlineFact, CancellationToken.None)
+                let! immutableBeforeOnline = immutableClosedProjectionAsync connectionString
+                let! acceptedBeforeOnline = acceptedFactProjectionAsync connectionString
+
+                let! onlineRejected =
+                    task {
+                        try
+                            let! _ = store.StoreUsageFactAsync(conflictingOnlineFact, payloadFor conflictingOnlineFact, CancellationToken.None)
+                            return false
+                        with
+                        | :? InvalidOperationException -> return true
+                        | :? SqlException -> return true
+                    }
+
+                let! immutableAfterOnline = immutableClosedProjectionAsync connectionString
+                let! acceptedAfterOnline = acceptedFactProjectionAsync connectionString
+
+                let replayPointer =
+                    {
+                        UsageFactId = replayUsageFactId
+                        BlobName = "usage-facts/v1/cross-scope.jsonl.gz"
+                        ChecksumSha256Hex = String.replicate 64 "a"
+                        ByteLength = 4096L
+                    }
+
+                let! _ = store.ReplayArchivedUsageFactAsync(acceptedReplayFact, payloadFor acceptedReplayFact, replayPointer, CancellationToken.None)
+                let! immutableBeforeReplay = immutableClosedProjectionAsync connectionString
+                let! acceptedBeforeReplay = acceptedFactProjectionAsync connectionString
+
+                let! replayRejected =
+                    task {
+                        try
+                            let! _ =
+                                store.ReplayArchivedUsageFactAsync(
+                                    conflictingReplayFact,
+                                    payloadFor conflictingReplayFact,
+                                    replayPointer,
+                                    CancellationToken.None
+                                )
+
+                            return false
+                        with
+                        | :? InvalidOperationException -> return true
+                        | :? SqlException -> return true
+                    }
+
+                let! immutableAfterReplay = immutableClosedProjectionAsync connectionString
+                let! acceptedAfterReplay = acceptedFactProjectionAsync connectionString
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(onlineRejected, Is.True)
+                        Assert.That(replayRejected, Is.True)
+                        Assert.That<string list>(acceptedAfterOnline, Is.EqualTo<string list>(acceptedBeforeOnline))
+                        Assert.That<string list>(immutableAfterOnline, Is.EqualTo<string list>(immutableBeforeOnline))
+                        Assert.That<string list>(acceptedAfterReplay, Is.EqualTo<string list>(acceptedBeforeReplay))
+                        Assert.That<string list>(immutableAfterReplay, Is.EqualTo<string list>(immutableBeforeReplay)))
                 )
             })
 
@@ -1756,19 +1928,10 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 let organizationId = Guid.NewGuid()
                 let repositoryId = Guid.NewGuid()
                 let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
-                let billingPeriodId = Guid.NewGuid()
                 let processedFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
                 let repairedFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId (observedAt + Duration.FromSeconds(1L))
 
-                do!
-                    executeNonQueryAsync
-                        connectionString
-                        $"""
-INSERT INTO ops.BillingPeriod
-    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
-VALUES
-    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
-"""
+                let! billingPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId repositoryId
 
                 let journal = SqlOperationsUsageJournalStore(connectionString)
                 let! appendedProcessed = journal.AppendAsync(processedFact, CancellationToken.None)
@@ -1814,6 +1977,201 @@ VALUES
                         Assert.That(repairedLateWork, Is.EqualTo(1))
                         Assert.That(aggregateCount, Is.EqualTo(1))
                         Assert.That(aggregateQuantity, Is.EqualTo(8192)))
+                )
+            })
+
+    /// Proves every acceptance wrapper independently stages one closed-period handoff and converges its same-scope replay.
+    [<Test>]
+    member _.EveryAcceptedFactWrapperStagesOneClosedPeriodHandoffAndConvergesItsSameScopeReplay() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let onlineRepositoryId = Guid.NewGuid()
+                let replayRepositoryId = Guid.NewGuid()
+                let processRepositoryId = Guid.NewGuid()
+                let repairRepositoryId = Guid.NewGuid()
+                let onlineFact = fact (Guid.NewGuid()) ownerId organizationId onlineRepositoryId observedAt
+                let replayFact = fact (Guid.NewGuid()) ownerId organizationId replayRepositoryId observedAt
+                let processFact = fact (Guid.NewGuid()) ownerId organizationId processRepositoryId observedAt
+                let repairFact = fact (Guid.NewGuid()) ownerId organizationId repairRepositoryId observedAt
+                let store = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let! onlinePeriodId = seedClosedProjectionAsync connectionString ownerId organizationId onlineRepositoryId
+                let! replayPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId replayRepositoryId
+                let! processPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId processRepositoryId
+                let! repairPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId repairRepositoryId
+                let! immutableBefore = immutableClosedProjectionAsync connectionString
+
+                let replayPointer =
+                    {
+                        UsageFactId = replayFact.UsageFactId
+                        BlobName = "usage-facts/v1/closed-wrapper.jsonl.gz"
+                        ChecksumSha256Hex = String.replicate 64 "a"
+                        ByteLength = 4096L
+                    }
+
+                let! onlineFirst = store.StoreUsageFactAsync(onlineFact, payloadFor onlineFact, CancellationToken.None)
+                let! onlineDuplicate = store.StoreUsageFactAsync(onlineFact, payloadFor onlineFact, CancellationToken.None)
+                let! replayFirst = store.ReplayArchivedUsageFactAsync(replayFact, payloadFor replayFact, replayPointer, CancellationToken.None)
+                let! replayDuplicate = store.ReplayArchivedUsageFactAsync(replayFact, payloadFor replayFact, replayPointer, CancellationToken.None)
+                let! appendedProcess = journal.AppendAsync(processFact, CancellationToken.None)
+                let! processed = journal.ProcessAsync(processFact, payloadFor processFact, CancellationToken.None)
+                let! processedDuplicate = journal.ProcessAsync(processFact, payloadFor processFact, CancellationToken.None)
+                let! appendedRepair = journal.AppendAsync(repairFact, CancellationToken.None)
+                let! rejected = journal.RejectAsync(repairFact, payloadFor repairFact, "closed-wrapper repair", CancellationToken.None)
+                let! repaired = journal.RepairAsync(repairFact, CancellationToken.None)
+                let! repairedDuplicate = journal.RepairAsync(repairFact, CancellationToken.None)
+
+                let! rawOnline =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{onlineFact.UsageFactId:D}' AND RepositoryId = '{onlineRepositoryId:D}';"
+
+                let! rawReplay =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{replayFact.UsageFactId:D}' AND RepositoryId = '{replayRepositoryId:D}' AND ArchiveState = 2 AND RawPayload IS NULL;"
+
+                let! rawProcess =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{processFact.UsageFactId:D}' AND RepositoryId = '{processRepositoryId:D}';"
+
+                let! rawRepair =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{repairFact.UsageFactId:D}' AND RepositoryId = '{repairRepositoryId:D}';"
+
+                let! aggregateOnline =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND RepositoryId = '{onlineRepositoryId:D}';"
+
+                let! aggregateReplay =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND RepositoryId = '{replayRepositoryId:D}';"
+
+                let! aggregateProcess =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND RepositoryId = '{processRepositoryId:D}';"
+
+                let! aggregateRepair =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND RepositoryId = '{repairRepositoryId:D}';"
+
+                let! handoffOnline =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{onlinePeriodId:D}' AND UsageFactId = '{onlineFact.UsageFactId:D}' AND State = 0;"
+
+                let! handoffReplay =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{replayPeriodId:D}' AND UsageFactId = '{replayFact.UsageFactId:D}' AND State = 0;"
+
+                let! handoffProcess =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{processPeriodId:D}' AND UsageFactId = '{processFact.UsageFactId:D}' AND State = 0;"
+
+                let! handoffRepair =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{repairPeriodId:D}' AND UsageFactId = '{repairFact.UsageFactId:D}' AND State = 0;"
+
+                let! processJournal =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{processFact.UsageFactId:D}' AND State = 1;"
+
+                let! repairJournal =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{repairFact.UsageFactId:D}' AND State = 1;"
+
+                let! repairedRejection =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{repairFact.UsageFactId:D}' AND IsActive = 0;"
+
+                let! immutableAfter = immutableClosedProjectionAsync connectionString
+
+                let onlineAccepted =
+                    match onlineFirst with
+                    | Ok { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = usageFactId; Aggregate = Some _ } when
+                        usageFactId = onlineFact.UsageFactId
+                        ->
+                        true
+                    | _ -> false
+
+                let onlineIdempotent =
+                    match onlineDuplicate with
+                    | Ok { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = usageFactId; Aggregate = None } when
+                        usageFactId = onlineFact.UsageFactId
+                        ->
+                        true
+                    | _ -> false
+
+                let replayAccepted =
+                    match replayFirst with
+                    | Ok { Status = UsageFactPersistenceStatus.Accepted; UsageFactId = usageFactId; Aggregate = Some _ } when
+                        usageFactId = replayFact.UsageFactId
+                        ->
+                        true
+                    | _ -> false
+
+                let replayIdempotent =
+                    match replayDuplicate with
+                    | Ok { Status = UsageFactPersistenceStatus.AlreadyProcessed; UsageFactId = usageFactId; Aggregate = None } when
+                        usageFactId = replayFact.UsageFactId
+                        ->
+                        true
+                    | _ -> false
+
+                let processAppended =
+                    match appendedProcess with
+                    | Ok AppendedPending -> true
+                    | _ -> false
+
+                let repairAppended =
+                    match appendedRepair with
+                    | Ok AppendedPending -> true
+                    | _ -> false
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(onlineAccepted, Is.True)
+                        Assert.That(onlineIdempotent, Is.True)
+                        Assert.That(replayAccepted, Is.True)
+                        Assert.That(replayIdempotent, Is.True)
+                        Assert.That(processAppended, Is.True)
+                        Assert.That(processed, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(processedDuplicate, Is.EqualTo(AlreadyAccepted))
+                        Assert.That(repairAppended, Is.True)
+                        Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                        Assert.That(repaired, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(repairedDuplicate, Is.EqualTo(AlreadyAccepted))
+                        Assert.That(rawOnline, Is.EqualTo(1))
+                        Assert.That(rawReplay, Is.EqualTo(1))
+                        Assert.That(rawProcess, Is.EqualTo(1))
+                        Assert.That(rawRepair, Is.EqualTo(1))
+                        Assert.That(aggregateOnline, Is.EqualTo(4096))
+                        Assert.That(aggregateReplay, Is.EqualTo(4096))
+                        Assert.That(aggregateProcess, Is.EqualTo(4096))
+                        Assert.That(aggregateRepair, Is.EqualTo(4096))
+                        Assert.That(handoffOnline, Is.EqualTo(1))
+                        Assert.That(handoffReplay, Is.EqualTo(1))
+                        Assert.That(handoffProcess, Is.EqualTo(1))
+                        Assert.That(handoffRepair, Is.EqualTo(1))
+                        Assert.That(processJournal, Is.EqualTo(1))
+                        Assert.That(repairJournal, Is.EqualTo(1))
+                        Assert.That(repairedRejection, Is.EqualTo(1))
+                        Assert.That<string list>(immutableAfter, Is.EqualTo<string list>(immutableBefore)))
                 )
             })
 
@@ -1904,13 +2262,14 @@ VALUES
                 let repositoryId = Guid.NewGuid()
                 let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
                 let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
-                let scope = scopeFor ownerId organizationId repositoryId observedAt
                 let interleaving = CancellationAfterAcceptedFactStageInterleaving()
+                let! billingPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId repositoryId
+                let! immutableBefore = immutableClosedProjectionAsync connectionString
 
                 let journal = SqlOperationsUsageJournalStore.CreateForTest(connectionString, interleaving :> IOperationsUsageJournalTransactionInterleaving)
 
-                let completeness = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
                 let! appended = journal.AppendAsync(usageFact, CancellationToken.None)
+                let! acceptedBefore = acceptedFactProjectionAsync connectionString
                 use cancellation = new CancellationTokenSource()
                 let processing = journal.ProcessAsync(usageFact, payloadFor usageFact, cancellation.Token)
 
@@ -1927,22 +2286,13 @@ VALUES
                             | :? OperationCanceledException -> return true
                         }
 
-                    let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+                    let! acceptedAfter = acceptedFactProjectionAsync connectionString
+                    let! immutableAfter = immutableClosedProjectionAsync connectionString
 
-                    let! aggregateCount =
+                    let! lateWorkCount =
                         executeInt32Async
                             connectionString
-                            $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
-
-                    let! pendingJournalCount =
-                        executeInt32Async
-                            connectionString
-                            $"SELECT COUNT(*) FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND State = 0;"
-
-                    let! rejectionEvidenceCount =
-                        executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
-
-                    let! completenessAfterCancellation = completeness.EvaluateBillingCompletenessAsync(scope, CancellationToken.None)
+                            $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{usageFact.UsageFactId:D}';"
 
                     let appendedPending =
                         match appended with
@@ -1953,11 +2303,9 @@ VALUES
                         Action (fun () ->
                             Assert.That(appendedPending, Is.True)
                             Assert.That(cancelled, Is.True)
-                            Assert.That(rawCount, Is.Zero)
-                            Assert.That(aggregateCount, Is.Zero)
-                            Assert.That(pendingJournalCount, Is.EqualTo(1))
-                            Assert.That(rejectionEvidenceCount, Is.Zero)
-                            Assert.That(completenessAfterCancellation, Is.EqualTo(BlockedByUnresolvedUsageFactJournal)))
+                            Assert.That(lateWorkCount, Is.Zero)
+                            Assert.That<string list>(acceptedAfter, Is.EqualTo<string list>(acceptedBefore))
+                            Assert.That<string list>(immutableAfter, Is.EqualTo<string list>(immutableBefore)))
                     )
                 finally
                     interleaving.Release()
@@ -1972,19 +2320,11 @@ VALUES
                 let organizationId = Guid.NewGuid()
                 let repositoryId = Guid.NewGuid()
                 let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
-                let billingPeriodId = Guid.NewGuid()
                 let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
                 let interleaving = CancellationAfterAcceptedFactStageInterleaving()
 
-                do!
-                    executeNonQueryAsync
-                        connectionString
-                        $"""
-INSERT INTO ops.BillingPeriod
-    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
-VALUES
-    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
-"""
+                let! billingPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId repositoryId
+                let! immutableBefore = immutableClosedProjectionAsync connectionString
 
                 let store =
                     OperationsUsageStore(SqlOperationsUsageTransactionScope.CreateForTest(connectionString, interleaving :> IAcceptedFactMutationInterleaving))
@@ -2025,6 +2365,8 @@ VALUES
                             connectionString
                             $"SELECT COUNT(*) FROM ops.BillingPeriod WHERE BillingPeriodId = '{billingPeriodId:D}' AND State = 2;"
 
+                    let! immutableAfter = immutableClosedProjectionAsync connectionString
+
                     Assert.Multiple(
                         Action (fun () ->
                             Assert.That(cancelled, Is.True)
@@ -2032,7 +2374,8 @@ VALUES
                             Assert.That(aggregateCount, Is.Zero)
                             Assert.That(rejectionCount, Is.Zero)
                             Assert.That(lateWorkCount, Is.Zero)
-                            Assert.That(closedPeriodCount, Is.EqualTo(1)))
+                            Assert.That(closedPeriodCount, Is.EqualTo(1))
+                            Assert.That<string list>(immutableAfter, Is.EqualTo<string list>(immutableBefore)))
                     )
                 finally
                     interleaving.Release()
@@ -2060,15 +2403,8 @@ VALUES
 
                 let interleaving = CancellationAfterAcceptedFactStageInterleaving()
 
-                do!
-                    executeNonQueryAsync
-                        connectionString
-                        $"""
-INSERT INTO ops.BillingPeriod
-    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
-VALUES
-    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
-"""
+                let! billingPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId repositoryId
+                let! immutableBefore = immutableClosedProjectionAsync connectionString
 
                 let store =
                     OperationsUsageStore(SqlOperationsUsageTransactionScope.CreateForTest(connectionString, interleaving :> IAcceptedFactMutationInterleaving))
@@ -2109,6 +2445,8 @@ VALUES
                             connectionString
                             $"SELECT COUNT(*) FROM ops.BillingPeriod WHERE BillingPeriodId = '{billingPeriodId:D}' AND State = 2;"
 
+                    let! immutableAfter = immutableClosedProjectionAsync connectionString
+
                     Assert.Multiple(
                         Action (fun () ->
                             Assert.That(cancelled, Is.True)
@@ -2116,7 +2454,8 @@ VALUES
                             Assert.That(aggregateCount, Is.Zero)
                             Assert.That(rejectionCount, Is.Zero)
                             Assert.That(lateWorkCount, Is.Zero)
-                            Assert.That(closedPeriodCount, Is.EqualTo(1)))
+                            Assert.That(closedPeriodCount, Is.EqualTo(1))
+                            Assert.That<string list>(immutableAfter, Is.EqualTo<string list>(immutableBefore)))
                     )
                 finally
                     interleaving.Release()
@@ -2133,9 +2472,12 @@ VALUES
                 let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
                 let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
                 let interleaving = CancellationAfterAcceptedFactStageInterleaving()
+                let! billingPeriodId = seedClosedProjectionAsync connectionString ownerId organizationId repositoryId
+                let! immutableBefore = immutableClosedProjectionAsync connectionString
                 let journal = SqlOperationsUsageJournalStore.CreateForTest(connectionString, interleaving :> IOperationsUsageJournalTransactionInterleaving)
                 let! _ = journal.AppendAsync(usageFact, CancellationToken.None)
                 let! rejected = journal.RejectAsync(usageFact, payloadFor usageFact, "repair cancellation", CancellationToken.None)
+                let! acceptedBefore = acceptedFactProjectionAsync connectionString
                 use cancellation = new CancellationTokenSource()
                 let repair = journal.RepairAsync(usageFact, cancellation.Token)
 
@@ -2152,29 +2494,21 @@ VALUES
                             | :? OperationCanceledException -> return true
                         }
 
-                    let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
-                    let! aggregateCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}';"
-
-                    let! rejectionCount =
+                    let! lateWorkCount =
                         executeInt32Async
                             connectionString
-                            $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND IsActive = 1;"
+                            $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{usageFact.UsageFactId:D}';"
 
-                    let! lateWorkCount =
-                        executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
-
-                    let! journalState =
-                        executeInt32Async connectionString $"SELECT State FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+                    let! acceptedAfter = acceptedFactProjectionAsync connectionString
+                    let! immutableAfter = immutableClosedProjectionAsync connectionString
 
                     Assert.Multiple(
                         Action (fun () ->
                             Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
                             Assert.That(cancelled, Is.True)
-                            Assert.That(rawCount, Is.Zero)
-                            Assert.That(aggregateCount, Is.Zero)
-                            Assert.That(rejectionCount, Is.EqualTo(1))
                             Assert.That(lateWorkCount, Is.Zero)
-                            Assert.That(journalState, Is.EqualTo(int UsageFactJournalState.Rejected)))
+                            Assert.That<string list>(acceptedAfter, Is.EqualTo<string list>(acceptedBefore))
+                            Assert.That<string list>(immutableAfter, Is.EqualTo<string list>(immutableBefore)))
                     )
                 finally
                     interleaving.Release()

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingCompleteness.Tests.fs
@@ -24,7 +24,7 @@ type private ObservedOperationsUsageTransaction
         afterUsageAggregateAsync: UsageAggregateMinute -> CancellationToken -> Task
     ) =
 
-    interface IOperationsUsageTransaction with
+    interface IAcceptedFactMutationTransaction with
 
         member _.AcquireBillingCompletenessScopeAsync(scope, cancellationToken) =
             task {
@@ -35,6 +35,14 @@ type private ObservedOperationsUsageTransaction
 
         member _.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(usageFactId, scope, cancellationToken) =
             inner.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(usageFactId, scope, cancellationToken)
+
+        member _.AcceptUsageFactAsync(plan, scope, rawInsertion, cancellationToken) =
+            task {
+                let acceptedFactTransaction = inner :?> IAcceptedFactMutationTransaction
+                let! outcome = acceptedFactTransaction.AcceptUsageFactAsync(plan, scope, rawInsertion, cancellationToken)
+                do! afterUsageAggregateAsync plan.Aggregate cancellationToken
+                return outcome
+            }
 
         member _.TryInsertRawUsageFactAsync(rawFact, cancellationToken) = inner.TryInsertRawUsageFactAsync(rawFact, cancellationToken)
 
@@ -79,12 +87,12 @@ type private ObservedOperationsUsageTransactionScope
                 cancellationToken
             )
 
-/// Pauses a real ProcessAsync transaction after raw and aggregate SQL writes have been staged, then lets cancellation abort it.
-type private CancellationAfterJournalStageInterleaving() =
+/// Pauses a real ProcessAsync transaction at the shared accepted-fact staging point, then lets cancellation abort it.
+type private CancellationAfterAcceptedFactStageInterleaving() =
     let staged = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
     let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
 
-    /// Completes only after the transaction owns staged raw and aggregate mutations.
+    /// Completes only after the transaction owns all staged accepted-fact mutations.
     member _.Staged = staged.Task
 
     /// Releases a non-cancelled test path without retaining any durable state.
@@ -92,7 +100,7 @@ type private CancellationAfterJournalStageInterleaving() =
 
     interface IOperationsUsageJournalTransactionInterleaving with
 
-        member _.AfterRawAndAggregateStagedAsync(cancellationToken) =
+        member _.AfterAcceptedFactMutationsStagedAsync(_, cancellationToken) =
             task {
                 staged.TrySetResult(()) |> ignore
                 do! release.Task.WaitAsync(cancellationToken)
@@ -1486,6 +1494,11 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                         connectionString
                         $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
 
+                let! aggregateQuantity =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
                 let! acceptedJournalCount =
                     executeInt32Async
                         connectionString
@@ -1650,6 +1663,160 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 )
             })
 
+    /// Proves ProcessAsync and RepairAsync cannot terminally accept a journal row whose immutable UsageFactId is already bound to another scope.
+    [<Test>]
+    member _.JournalProcessAndRepairRejectCrossScopeRawIdentityBeforeTerminalTransition() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryAId = Guid.NewGuid()
+                let repositoryBId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let processUsageFactId = Guid.NewGuid()
+                let repairUsageFactId = Guid.NewGuid()
+                let acceptedProcessFact = fact processUsageFactId ownerId organizationId repositoryAId observedAt
+                let pendingProcessFact = fact processUsageFactId ownerId organizationId repositoryBId observedAt
+                let acceptedRepairFact = fact repairUsageFactId ownerId organizationId repositoryAId observedAt
+                let rejectedRepairFact = fact repairUsageFactId ownerId organizationId repositoryBId observedAt
+                let store = OperationsUsageStore(SqlOperationsUsageTransactionScope connectionString)
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+
+                let! _ = store.StoreUsageFactAsync(acceptedProcessFact, payloadFor acceptedProcessFact, CancellationToken.None)
+                let! appendedProcess = journal.AppendAsync(pendingProcessFact, CancellationToken.None)
+
+                let! processRejected =
+                    task {
+                        try
+                            let! _ = journal.ProcessAsync(pendingProcessFact, payloadFor pendingProcessFact, CancellationToken.None)
+                            return false
+                        with
+                        | :? InvalidOperationException -> return true
+                        | :? SqlException -> return true
+                    }
+
+                let! _ = store.StoreUsageFactAsync(acceptedRepairFact, payloadFor acceptedRepairFact, CancellationToken.None)
+                let! appendedRepair = journal.AppendAsync(rejectedRepairFact, CancellationToken.None)
+                let! rejected = journal.RejectAsync(rejectedRepairFact, payloadFor rejectedRepairFact, "cross-scope repair regression", CancellationToken.None)
+
+                let! repairRejected =
+                    task {
+                        try
+                            let! _ = journal.RepairAsync(rejectedRepairFact, CancellationToken.None)
+                            return false
+                        with
+                        | :? InvalidOperationException -> return true
+                        | :? SqlException -> return true
+                    }
+
+                let! rawA =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId IN ('{processUsageFactId:D}', '{repairUsageFactId:D}') AND RepositoryId = '{repositoryAId:D}';"
+
+                let! rawB =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId IN ('{processUsageFactId:D}', '{repairUsageFactId:D}') AND RepositoryId = '{repositoryBId:D}';"
+
+                let! processJournalState =
+                    executeInt32Async connectionString $"SELECT State FROM ops.UsageFactJournal WHERE UsageFactId = '{processUsageFactId:D}';"
+
+                let! repairJournalState =
+                    executeInt32Async connectionString $"SELECT State FROM ops.UsageFactJournal WHERE UsageFactId = '{repairUsageFactId:D}';"
+
+                let! repairActiveRejection =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{repairUsageFactId:D}' AND RepositoryId = '{repositoryBId:D}' AND IsActive = 1;"
+
+                match appendedProcess, appendedRepair with
+                | Ok AppendedPending, Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append results: process={appendedProcess}; repair={appendedRepair}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                        Assert.That(processRejected, Is.True)
+                        Assert.That(repairRejected, Is.True)
+                        Assert.That(rawA, Is.EqualTo(2))
+                        Assert.That(rawB, Is.Zero)
+                        Assert.That(processJournalState, Is.EqualTo(int UsageFactJournalState.Pending))
+                        Assert.That(repairJournalState, Is.EqualTo(int UsageFactJournalState.Rejected))
+                        Assert.That(repairActiveRejection, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves journal ProcessAsync and RepairAsync each use the shared closed-period handoff exactly once for a newly accepted raw fact.
+    [<Test>]
+    member _.JournalProcessAndRepairStageOnePendingLateWorkForNewClosedPeriodFacts() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let billingPeriodId = Guid.NewGuid()
+                let processedFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let repairedFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId (observedAt + Duration.FromSeconds(1L))
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        $"""
+INSERT INTO ops.BillingPeriod
+    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
+VALUES
+    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
+"""
+
+                let journal = SqlOperationsUsageJournalStore(connectionString)
+                let! appendedProcessed = journal.AppendAsync(processedFact, CancellationToken.None)
+                let! processed = journal.ProcessAsync(processedFact, payloadFor processedFact, CancellationToken.None)
+                let! replayed = journal.ProcessAsync(processedFact, payloadFor processedFact, CancellationToken.None)
+                let! appendedRepaired = journal.AppendAsync(repairedFact, CancellationToken.None)
+                let! rejected = journal.RejectAsync(repairedFact, payloadFor repairedFact, "closed-period repair", CancellationToken.None)
+                let! repaired = journal.RepairAsync(repairedFact, CancellationToken.None)
+                let! duplicateRepair = journal.RepairAsync(repairedFact, CancellationToken.None)
+
+                let! processedLateWork =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{processedFact.UsageFactId:D}' AND State = 0;"
+
+                let! repairedLateWork =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{repairedFact.UsageFactId:D}' AND State = 0;"
+
+                let! aggregateCount =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                let! aggregateQuantity =
+                    executeInt32Async
+                        connectionString
+                        $"SELECT Quantity FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                match appendedProcessed, appendedRepaired with
+                | Ok AppendedPending, Ok AppendedPending -> ()
+                | _ -> Assert.Fail($"Unexpected journal append results: process={appendedProcessed}; repair={appendedRepaired}.")
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(processed, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(replayed, Is.EqualTo(AlreadyAccepted))
+                        Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                        Assert.That(repaired, Is.EqualTo(AcceptedFromJournal))
+                        Assert.That(duplicateRepair, Is.EqualTo(AlreadyAccepted))
+                        Assert.That(processedLateWork, Is.EqualTo(1))
+                        Assert.That(repairedLateWork, Is.EqualTo(1))
+                        Assert.That(aggregateCount, Is.EqualTo(1))
+                        Assert.That(aggregateQuantity, Is.EqualTo(8192)))
+                )
+            })
+
     /// Proves deterministic SQL failures after staged rejection or raw/aggregate work roll back all journal transition effects.
     [<Test>]
     member _.JournalTransactionFailuresLeavePendingTruthAndCompletenessBlocked() =
@@ -1738,7 +1905,7 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                 let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
                 let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
                 let scope = scopeFor ownerId organizationId repositoryId observedAt
-                let interleaving = CancellationAfterJournalStageInterleaving()
+                let interleaving = CancellationAfterAcceptedFactStageInterleaving()
 
                 let journal = SqlOperationsUsageJournalStore.CreateForTest(connectionString, interleaving :> IOperationsUsageJournalTransactionInterleaving)
 
@@ -1791,6 +1958,223 @@ WHERE RejectionId = '{rejection.RejectionId:D}'
                             Assert.That(pendingJournalCount, Is.EqualTo(1))
                             Assert.That(rejectionEvidenceCount, Is.Zero)
                             Assert.That(completenessAfterCancellation, Is.EqualTo(BlockedByUnresolvedUsageFactJournal)))
+                    )
+                finally
+                    interleaving.Release()
+            })
+
+    /// Proves online storage cancels only after the shared mutation stages and rolls back raw, aggregate, and Pending work together.
+    [<Test>]
+    member _.OnlineStoreCancellationAfterSharedAcceptedFactStageRollsBackClosedPeriodWork() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let billingPeriodId = Guid.NewGuid()
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let interleaving = CancellationAfterAcceptedFactStageInterleaving()
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        $"""
+INSERT INTO ops.BillingPeriod
+    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
+VALUES
+    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
+"""
+
+                let store =
+                    OperationsUsageStore(SqlOperationsUsageTransactionScope.CreateForTest(connectionString, interleaving :> IAcceptedFactMutationInterleaving))
+
+                use cancellation = new CancellationTokenSource()
+                let write = store.StoreUsageFactAsync(usageFact, payloadFor usageFact, cancellation.Token)
+
+                try
+                    do! interleaving.Staged.WaitAsync(TimeSpan.FromSeconds(10.0))
+                    cancellation.Cancel()
+
+                    let! cancelled =
+                        task {
+                            try
+                                let! _ = write
+                                return false
+                            with
+                            | :? OperationCanceledException -> return true
+                        }
+
+                    let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! aggregateCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                    let! rejectionCount =
+                        executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! lateWorkCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! closedPeriodCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.BillingPeriod WHERE BillingPeriodId = '{billingPeriodId:D}' AND State = 2;"
+
+                    Assert.Multiple(
+                        Action (fun () ->
+                            Assert.That(cancelled, Is.True)
+                            Assert.That(rawCount, Is.Zero)
+                            Assert.That(aggregateCount, Is.Zero)
+                            Assert.That(rejectionCount, Is.Zero)
+                            Assert.That(lateWorkCount, Is.Zero)
+                            Assert.That(closedPeriodCount, Is.EqualTo(1)))
+                    )
+                finally
+                    interleaving.Release()
+            })
+
+    /// Proves archived replay cancels at the same shared stage and cannot leave an archived raw row, aggregate, or Pending work behind.
+    [<Test>]
+    member _.ArchivedReplayCancellationAfterSharedAcceptedFactStageRollsBackClosedPeriodWork() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let billingPeriodId = Guid.NewGuid()
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+
+                let pointer =
+                    {
+                        UsageFactId = usageFact.UsageFactId
+                        BlobName = "usage-facts/v1/cancellation.jsonl.gz"
+                        ChecksumSha256Hex = String.replicate 64 "a"
+                        ByteLength = 123L
+                    }
+
+                let interleaving = CancellationAfterAcceptedFactStageInterleaving()
+
+                do!
+                    executeNonQueryAsync
+                        connectionString
+                        $"""
+INSERT INTO ops.BillingPeriod
+    (BillingPeriodId, OwnerId, OrganizationId, RepositoryId, MonthStartUtc, NextMonthStartUtc, State)
+VALUES
+    ('{billingPeriodId:D}', '{ownerId:D}', '{organizationId:D}', '{repositoryId:D}', '2026-08-01T00:00:00', '2026-09-01T00:00:00', 2);
+"""
+
+                let store =
+                    OperationsUsageStore(SqlOperationsUsageTransactionScope.CreateForTest(connectionString, interleaving :> IAcceptedFactMutationInterleaving))
+
+                use cancellation = new CancellationTokenSource()
+                let replay = store.ReplayArchivedUsageFactAsync(usageFact, payloadFor usageFact, pointer, cancellation.Token)
+
+                try
+                    do! interleaving.Staged.WaitAsync(TimeSpan.FromSeconds(10.0))
+                    cancellation.Cancel()
+
+                    let! cancelled =
+                        task {
+                            try
+                                let! _ = replay
+                                return false
+                            with
+                            | :? OperationCanceledException -> return true
+                        }
+
+                    let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! aggregateCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}' AND OrganizationId = '{organizationId:D}' AND RepositoryId = '{repositoryId:D}';"
+
+                    let! rejectionCount =
+                        executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! lateWorkCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE BillingPeriodId = '{billingPeriodId:D}' AND UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! closedPeriodCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.BillingPeriod WHERE BillingPeriodId = '{billingPeriodId:D}' AND State = 2;"
+
+                    Assert.Multiple(
+                        Action (fun () ->
+                            Assert.That(cancelled, Is.True)
+                            Assert.That(rawCount, Is.Zero)
+                            Assert.That(aggregateCount, Is.Zero)
+                            Assert.That(rejectionCount, Is.Zero)
+                            Assert.That(lateWorkCount, Is.Zero)
+                            Assert.That(closedPeriodCount, Is.EqualTo(1)))
+                    )
+                finally
+                    interleaving.Release()
+            })
+
+    /// Proves explicit journal repair remains Rejected when cancellation interrupts the shared accepted-fact stage.
+    [<Test>]
+    member _.JournalRepairCancellationAfterSharedAcceptedFactStagePreservesRejectedTruth() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let ownerId = Guid.NewGuid()
+                let organizationId = Guid.NewGuid()
+                let repositoryId = Guid.NewGuid()
+                let observedAt = Instant.FromUtc(2026, 8, 4, 12, 0)
+                let usageFact = fact (Guid.NewGuid()) ownerId organizationId repositoryId observedAt
+                let interleaving = CancellationAfterAcceptedFactStageInterleaving()
+                let journal = SqlOperationsUsageJournalStore.CreateForTest(connectionString, interleaving :> IOperationsUsageJournalTransactionInterleaving)
+                let! _ = journal.AppendAsync(usageFact, CancellationToken.None)
+                let! rejected = journal.RejectAsync(usageFact, payloadFor usageFact, "repair cancellation", CancellationToken.None)
+                use cancellation = new CancellationTokenSource()
+                let repair = journal.RepairAsync(usageFact, cancellation.Token)
+
+                try
+                    do! interleaving.Staged.WaitAsync(TimeSpan.FromSeconds(10.0))
+                    cancellation.Cancel()
+
+                    let! cancelled =
+                        task {
+                            try
+                                let! _ = repair
+                                return false
+                            with
+                            | :? OperationCanceledException -> return true
+                        }
+
+                    let! rawCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.RawUsageFact WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+                    let! aggregateCount = executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.UsageAggregateMinute WHERE OwnerId = '{ownerId:D}';"
+
+                    let! rejectionCount =
+                        executeInt32Async
+                            connectionString
+                            $"SELECT COUNT(*) FROM ops.UsageFactRejection WHERE UsageFactId = '{usageFact.UsageFactId:D}' AND IsActive = 1;"
+
+                    let! lateWorkCount =
+                        executeInt32Async connectionString $"SELECT COUNT(*) FROM ops.BillingPeriodLateWork WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    let! journalState =
+                        executeInt32Async connectionString $"SELECT State FROM ops.UsageFactJournal WHERE UsageFactId = '{usageFact.UsageFactId:D}';"
+
+                    Assert.Multiple(
+                        Action (fun () ->
+                            Assert.That(rejected, Is.EqualTo(RejectedFromJournal))
+                            Assert.That(cancelled, Is.True)
+                            Assert.That(rawCount, Is.Zero)
+                            Assert.That(aggregateCount, Is.Zero)
+                            Assert.That(rejectionCount, Is.EqualTo(1))
+                            Assert.That(lateWorkCount, Is.Zero)
+                            Assert.That(journalState, Is.EqualTo(int UsageFactJournalState.Rejected)))
                     )
                 finally
                     interleaving.Release()

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -143,49 +143,12 @@ type private InMemoryOperationsUsageTransactionScope() =
                                         return InsertedIntoOpenPeriod
                             }
 
-                        member _.TryInsertRawUsageFactAsync(rawFact, insertCancellationToken) =
-                            insertCancellationToken.ThrowIfCancellationRequested()
-
-                            if rawFacts.ContainsKey rawFact.UsageFactId then
-                                Task.FromResult false
-                            else
-                                rawFacts.Add(rawFact.UsageFactId, rawFact)
-                                Task.FromResult true
-
-                        member _.TryInsertReplayedArchivedUsageFactAsync(rawFact, _pointer, insertCancellationToken) =
-                            insertCancellationToken.ThrowIfCancellationRequested()
-
-                            if rawFacts.ContainsKey rawFact.UsageFactId then
-                                Task.FromResult false
-                            else
-                                rawFacts.Add(rawFact.UsageFactId, { rawFact with RawPayload = Array.empty })
-                                Task.FromResult true
-
-                        member _.AddToUsageAggregateMinuteAsync(aggregate, updateCancellationToken) =
-                            updateCancellationToken.ThrowIfCancellationRequested()
-
-                            if failNextAggregateUpdate then
-                                failNextAggregateUpdate <- false
-                                Task.FromException(InvalidOperationException("forced aggregate failure"))
-                            else
-                                let current =
-                                    match aggregates.TryGetValue aggregate.Key with
-                                    | true, quantity -> quantity
-                                    | false, _ -> 0L
-
-                                aggregates[aggregate.Key] <- current + aggregate.Quantity
-                                Task.CompletedTask
-
                         member _.RecordScopedUsageFactRejectionAsync(_rejection, rejectionCancellationToken) =
                             rejectionCancellationToken.ThrowIfCancellationRequested()
                             Task.FromResult(None)
 
                         member _.RecordUnscopedUsageFactRejectionAsync(_rejection, rejectionCancellationToken) =
                             rejectionCancellationToken.ThrowIfCancellationRequested()
-                            Task.CompletedTask
-
-                        member _.ResolveScopedUsageFactRejectionAsync(_usageFactId, _scope, repairCancellationToken) =
-                            repairCancellationToken.ThrowIfCancellationRequested()
                             Task.CompletedTask
 
                         member _.HasActiveScopedUsageFactRejectionAsync(_scope, readCancellationToken) =

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsUsageStorage.Tests.fs
@@ -107,7 +107,7 @@ type private InMemoryOperationsUsageTransactionScope() =
                 let aggregates = Dictionary<UsageAggregateMinuteKey, int64>(state.Aggregates)
 
                 let transaction =
-                    { new IOperationsUsageTransaction with
+                    { new IAcceptedFactMutationTransaction with
                         member _.AcquireBillingCompletenessScopeAsync(_scope, lockCancellationToken) =
                             lockCancellationToken.ThrowIfCancellationRequested()
                             Task.CompletedTask
@@ -115,6 +115,33 @@ type private InMemoryOperationsUsageTransactionScope() =
                         member _.EnsureUsageFactIdMatchesBillingCompletenessScopeAsync(_usageFactId, _scope, scopeCancellationToken) =
                             scopeCancellationToken.ThrowIfCancellationRequested()
                             Task.CompletedTask
+
+                        member _.AcceptUsageFactAsync(plan, _scope, rawInsertion, acceptedFactCancellationToken) =
+                            task {
+                                acceptedFactCancellationToken.ThrowIfCancellationRequested()
+
+                                if rawFacts.ContainsKey plan.RawFact.UsageFactId then
+                                    return ExistingSameScope
+                                else
+                                    let rawFact =
+                                        match rawInsertion with
+                                        | HotRawFact -> plan.RawFact
+                                        | ArchivedReplayRawFact _ -> { plan.RawFact with RawPayload = Array.empty }
+
+                                    rawFacts.Add(rawFact.UsageFactId, rawFact)
+
+                                    if failNextAggregateUpdate then
+                                        failNextAggregateUpdate <- false
+                                        return raise (InvalidOperationException("forced aggregate failure"))
+                                    else
+                                        let current =
+                                            match aggregates.TryGetValue plan.Aggregate.Key with
+                                            | true, quantity -> quantity
+                                            | false, _ -> 0L
+
+                                        aggregates[plan.Aggregate.Key] <- current + plan.Aggregate.Quantity
+                                        return InsertedIntoOpenPeriod
+                            }
 
                         member _.TryInsertRawUsageFactAsync(rawFact, insertCancellationToken) =
                             insertCancellationToken.ThrowIfCancellationRequested()


### PR DESCRIPTION
# Adopt the atomic late-work mutation across acceptance transactions

## Purpose

Make online storage, archived replay, journal processing, and explicit journal repair use the same accepted-fact
mutation so scope binding, aggregation, rejection repair, handoff staging, and rollback cannot drift by caller.

Related to #938. Depends on merged #937. Parent replacement packet: #908. Epic chain: #554 -> #560 -> #576 -> #864.

## Included

- One internal transaction adapter for online storage and archived replay.
- Shared mutation adoption in journal `ProcessAsync` and `RepairAsync` before terminal Accepted state.
- Archived-replay raw insertion without restoring hot payload bytes.
- Cross-scope conflicts abort before journal terminal changes.
- All four wrappers use the shared post-staging interleaving for cancellation rollback proof.
- Historical journal conflict, journal positive/duplicate, all-four-wrapper cancellation, primitive, and storage
  regressions.

## Boundaries

- No production-close/two-scope convergence matrix; #939 owns it.
- No correction claiming, pricing, posting, retry, completion, hosted discovery, public surface, second lifecycle,
  payload copy, or actor coupling.

## Review status

- Implementation/fix workers started: **1** under epic #554's 4+1 policy.
- Head: `347ab8fa769ff75ea60ea0295c9c7e685d39bed5`.
- Historical Process/Repair cross-scope regression failed five assertions before adoption and is GREEN after adoption.
- Focused real-SQL journal/wrapper matrix: 6/6 passed, zero skipped.
- Primitive regression: 2/2 passed, zero skipped. Storage regression: 26/26 passed.
- Targeted Fantomas, Operations Tests Release build, and `git diff --check` passed.
- Evidence limitation: the final bounded six-case run has captured console totals but no retained TRX because the worker
  used the console logger. The unfiltered assembly is not claimed after two owned VSTest hosts failed to return a
  summary and were stopped.
- Fresh exact-head review and GitHub `Validate` are required before merge.
