### PR TITLE
Complete one-shot Grace Cache enrollment

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,6 +28,12 @@ jobs:
           global-json-file: global.json
       - name: Restore NuGet packages
         run: dotnet restore "src/Grace.slnx"
+      - name: Install Linux keyring test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes dbus-x11 gnome-keyring libsecret-tools
       - name: Pre-pull Aspire images and build the solution
         shell: bash
         run: |
@@ -91,6 +97,15 @@ jobs:
 
           exit "${pull_failed}"
       - name: Test every solution project through the shared Full profile
+        shell: bash
         env:
           GRACE_TEST_SERVER_CLEANUP: "0"
-        run: pwsh ./scripts/validate.ps1 -Full -SkipFormat -SkipBuild -Configuration Release
+          GRACE_TEST_LINUX_KEYRING: "1"
+        run: |
+          set -euo pipefail
+          dbus-run-session -- bash -c '
+            set -euo pipefail
+            eval "$(printf "grace-ci-keyring-password" | gnome-keyring-daemon --unlock)"
+            eval "$(gnome-keyring-daemon --start --components=secrets)"
+            pwsh ./scripts/validate.ps1 -Full -SkipFormat -SkipBuild -Configuration Release
+          '

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -210,3 +210,11 @@ git diff --check
 
 This completed proof does not claim #914 status, #905 enrollment, R2 liveness, serving, rotation, reconciliation,
 non-Linux support, or CacheStore behavior.
+
+## R1B enrollment implementation scope
+
+Issue #941 adds the bounded one-shot enrollment transition after the protected identity and local status foundations.
+The transition has one parsed repository-independent command, one resolved bearer, one root-local claim, one staged P-256
+identity, one selected-server nonredirecting request, strict response comparison, and one same-parent ready publication.
+It does not add server enrollment semantics, registration-shape changes, generated clients, selection, rotation, liveness,
+listeners, artifacts, retries, or durable pending state.

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -56,7 +56,7 @@ outcomes. Correctness cleanup for incomplete staging or failed commits remains p
 | #904 | Superseded status issue. | It does not own current delivery work. |
 | PR #907 | Closed superseded status implementation. | Evidence only; do not reuse it wholesale. |
 | #913 / #914 | Current docs-only correction; planned pure local status follows. | #913 reconciles this record; #914 then owns status only. |
-| #905 | Planned one-shot enrollment after #913 and #914. | It owns enrollment only after the docs and status leaves complete. |
+| [#941](https://github.com/ScottArbeit/Grace/issues/941) / [PR #950](https://github.com/ScottArbeit/Grace/pull/950) | One-shot enrollment is under review and not merged. | Owns enrollment only after the docs and status leaves complete. |
 
 ### Enrollment ambiguity disposition
 
@@ -132,8 +132,8 @@ eventual cleanup. Grace Cache adds no automatic enrollment retry or reconciliati
 - **Completed proof:** Actor persistence failure cannot advance in-memory selection; raw JSON `Health` cannot make a new
   registration healthy; inspection distinguishes missing, attempt, ready, invalid, and inaccessible without mutation;
   Linux tests restore modified modes before cleanup. PR #888 merged the implementation and proof.
-- **Current sequence:** #913 owns the canonical completion record, #914 owns pure local status only, #905 owns one-shot
-  enrollment only after #913 and #914, #857 owns signed refreshes that remain `Unhealthy`, and #625 publishes `Healthy`
+- **Current sequence:** #913 owns the canonical completion record, #914 owns pure local status only, #941 / PR #950 owns one-shot
+  enrollment under review after #913 and #914, #857 owns signed refreshes that remain `Unhealthy`, and #625 publishes `Healthy`
   only after serving readiness is proven. R1A added no serving, rotation, reconciliation, non-Linux support, or
   CacheStore behavior.
 
@@ -208,7 +208,7 @@ npx --yes markdownlint-cli2 "docs/Grace Cache.md" "docs/Grace Cache implementati
 git diff --check
 ```
 
-This completed proof does not claim #914 status, #905 enrollment, R2 liveness, serving, rotation, reconciliation,
+This completed proof does not claim #914 status, #941 / PR #950 enrollment (under review and not merged), R2 liveness, serving, rotation, reconciliation,
 non-Linux support, or CacheStore behavior.
 
 ## R1B enrollment implementation scope

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -488,6 +488,29 @@ include cross-repository selection, stale or revoked registration, stale grant, 
 route, incomplete local artifact, and CacheRequired attempted Direct fallback. A successful cache hit alone is not
 proof of a safe cache path.
 
+## R1B enrollment operation
+
+The supported Product V1 enrollment profile is Linux x64 under systemd, using one system-managed service account and the
+fixed protected root `/var/lib/grace-cache`. Set the selected server URI and provide one repository assignment for every
+repository served by the installation.
+
+```powershell
+$env:GRACE_SERVER_URI = "https://grace.example.test/api"
+grace cache enroll --owner-id <owner-guid> --repository <organization-guid>/<repository-guid> --endpoint <https-endpoint>
+```
+
+```bash
+export GRACE_SERVER_URI="https://grace.example.test/api"
+grace cache enroll --owner-id <owner-guid> --repository <organization-guid>/<repository-guid> --endpoint <https-endpoint>
+```
+
+Repeat `--repository` for additional assignments. `--organization-id` selects the Organization boundary. The display name
+defaults to `Grace Cache`; HTTP endpoints require `--allow-http`. The command resolves one existing PAT, M2M, or
+interactive credential before local effects, stages one protected P-256 identity, sends one nonredirecting request, and
+publishes ready state only after strict server acceptance. Failure, cancellation, timeout, or response loss never retries,
+reconciles, or publishes ready state. Output is redacted and never includes private key material, bearer credentials,
+protected paths, or attempt details.
+
 ## 13. Requirements traceability ledger
 
 | ID | Requirement | Status | Likely implementation seam | Proof seam | Planning owner | Residual risk |

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -103,7 +103,7 @@ evidence, and the durable owner decision.
 | #904 | Superseded status issue. | It does not own current delivery work. |
 | PR #907 | Closed superseded status implementation. | Evidence only; do not reuse it wholesale. |
 | #913 / #914 | Current docs-only correction; planned pure local status follows. | #913 reconciles this record; #914 then owns status only. |
-| #905 | Planned one-shot enrollment after #913 and #914. | It owns enrollment only after the docs and status leaves complete. |
+| #941 / PR #950 | One-shot enrollment is under review and not merged. | It owns enrollment after the docs and status leaves complete. |
 
 ### Enrollment ambiguity disposition
 
@@ -142,7 +142,7 @@ or unsupported-platform work merely because those capabilities could be useful l
 | DEC-GC-001 | Quality level | product | accepted | Product V1 governs every leaf and final release candidate. | Owner decision; each leaf declares the profile and proof. |
 | DEC-GC-002 | Cache service identity | domain | accepted | One static P-256 identity; no automatic or startup rotation. | R0 removes old rotation contract; R1 creates one static identity. |
 | DEC-GC-003 | Key custody promise | scope | accepted | OS-protected private storage and no Grace export surface; no hardware-backed claim. | R1 host and redaction proof. |
-| DEC-GC-004 | Enrollment ambiguity | product | accepted | An inactive accepted enrollment is unselectable; fresh manual enrollment is allowed; server expiry performs eventual cleanup; no automatic retry or reconciliation is added. | #886 completed the supporting implementation and proof; #905 consumes the disposition without changing it. |
+| DEC-GC-004 | Enrollment ambiguity | product | accepted | An inactive accepted enrollment is unselectable; fresh manual enrollment is allowed; server expiry performs eventual cleanup; no automatic retry or reconciliation is added. | #886 completed the supporting implementation and proof; #941 / PR #950 consumes the disposition without changing it. |
 | DEC-GC-005 | Registration liveness | architecture | accepted | One scheduler, server-issued liveness times, bounded retry, and fail-closed expiration or definitive rejection. | R2 transition and fake-clock proof. |
 | DEC-GC-006 | Artifact-grant keys | domain | accepted | Keep existing artifact-grant validation-key rollover distinct from cache service identity. | R0 inventory must not remove grant-key behavior. |
 | DEC-GC-007 | Local mutation | architecture | accepted | Later materialization prepares exact content and calls `WorkingDirectoryUpdate.run`. | #835 merge and epic refresh gate before affected leaves. |
@@ -287,8 +287,8 @@ create another local working-tree mutation, SQLite-completion, Branch/Watch-fina
   eventual cleanup.
 - **Invariant:** Grace Cache does not add automatic enrollment retry, reconciliation, background lookup, or a durable
   recovery workflow.
-- **Evidence:** #886 and PR #888 completed the static enrollment implementation and focused proof. #905 consumes this
-  disposition for one-shot enrollment.
+- **Evidence:** #886 and PR #888 completed the static enrollment implementation and focused proof. #941 / PR #950
+  consumes this disposition for one-shot enrollment and remains under review.
 
 ### GC-REQ-004 - One bounded liveness scheduler
 
@@ -524,7 +524,7 @@ protected paths, or attempt details.
 | GC-REQ-007 | Three execution-mode behaviors | required | Plan resolver, SDK, CLI, cache executor | Positive/negative mode and generated-contract proof | #625 to #630 | CacheRequired false fallback is high risk. |
 | GC-REQ-008 | Working Directory Update sequence | required | Later local materialization | Cross-epic execution proof | #628 to #630 | Blocked until #835 merge and epic refresh. |
 | GC-REQ-009 | Truthful status and diagnostics | required | #914 status and R2 process state | Status, redaction, expiry tests | #914, #857 | Must not report stale readiness. |
-| GC-REQ-010 | Reset and redaction | required | Local config/key store and enrollment output | Failure and output scans | #905 | Manual recovery is intentional. |
+| GC-REQ-010 | Reset and redaction | required | Local config/key store and enrollment output | Failure and output scans | #941 / PR #950 | Manual recovery is intentional. |
 | GC-REQ-011 | Static contract pruning | required | Shared types, routes, OpenAPI, SDK, docs | Inventory and freshness checks | #855 | Must retain artifact-grant key rollover. |
 | GC-DEF-001 | Automatic identity rotation | deferred | None | Absence scan | Future Hardened epic | Do not leave a partial surface. |
 | GC-DEF-002 | Prefetch and scheduled retention | deferred | None | Absence scan | Future work | Read-through remains the only correctness path. |
@@ -556,9 +556,9 @@ without rotation, prefetch, or scheduled retention.
    rebaseline it to static identity, regenerate contracts, and prove artifact-grant key rollover remains separate.
 2. **R1A static enrollment identity (#886 / PR #888)**: Implemented and proven; its merged evidence establishes the
    completed static identity foundation.
-3. **R1 record, status, and enrollment (#913, #914, #905)**: #913 reconciles the canonical record; #914 then owns
-   pure local status only; #905 then owns one-shot enrollment only.
-4. **R2 registration liveness (#857)**: Starts after #905 and its Tier-2 server timestamp, response-class, selection, and clock
+3. **R1 record, status, and enrollment (#913, #914, #941 / PR #950)**: #913 reconciles the canonical record; #914 then
+   owns pure local status only; #941 / PR #950 owns one-shot enrollment while the pull request is under review.
+4. **R2 registration liveness (#857)**: Starts after #941 / PR #950 and its Tier-2 server timestamp, response-class, selection, and clock
    table are complete. Its signed refreshes remain Unhealthy; it does not publish Healthy.
 5. **Runtime/artifact serving (#625)**: May proceed independently where write sets do not overlap with #835; it owns storage,
    grant verification, the miss-fill-serve-hit tracer, and Healthy publication only after serving readiness is proven.
@@ -576,7 +576,7 @@ high-conflict surfaces. Parallel work requires both independent user behavior an
   OpenAPI/SDK, documentation, tests, serializers, AOT roots, and command catalogs. It distinguishes cache service
   identity from artifact-grant validation keys.
 - **R1 completion sequence:** #913 records the completed #886 / PR #888 disposition, #914 implements status only, and
-  #905 implements enrollment only after #913 and #914. No leaf adds automatic retry or reconciliation.
+  #941 / PR #950 implements enrollment after #913 and #914. It remains open for review; no leaf adds automatic retry or reconciliation.
 - **R2:** Before code, produce the exact current registration response, timestamp, revocation/access, selection,
   capability, and clock transition table. It names one bounded retry schedule and its expiry cap.
 - **All leaves:** Declare owned paths, forbidden paths, state/time model where needed, propagation dispositions, focused
@@ -605,7 +605,7 @@ sequencing, and owner interruption rules are explicit. The recovery topology may
 
 This verdict does not make R2 or later semantic work ready to code. The portable specification contract says Plan-ready
 supports implementation planning, while `dev-process` requires each issue to complete Tier-2 research and the issue-level
-Implementation Readiness Gate. #913, #914, and #905 retain their declared docs, status, and enrollment boundaries; the
+Implementation Readiness Gate. #913, #914, and #941 / PR #950 retain their declared docs, status, and enrollment boundaries; the
 R2 exact liveness table remains a leaf-level gate.
 
 ### Passed criteria
@@ -620,7 +620,7 @@ R2 exact liveness table remains a leaf-level gate.
 
 - The requested project specification profile is absent at the required starting commit. Its absence is recorded for
   later repository restoration; this document does not infer missing profile rules.
-- #914 status and #905 one-shot enrollment remain planned replacement leaves after #913's documentation correction.
+- #914 status remains planned; #941 one-shot enrollment is under review in PR #950 and is not merged yet.
 - R2 still needs exact current server liveness response classes, timestamps, and selection timing on its branch head.
 - Cache host, SQLite/filesystem implementation, artifact route execution, and the local Working Directory Update seam
   do not exist on this epic head. They are planned work, not present behavior.

--- a/docs/Machine-readable CLI output.md
+++ b/docs/Machine-readable CLI output.md
@@ -129,8 +129,8 @@ Rejected selectors return a JSON error envelope. They do not produce partial out
 
 The final registry-backed inventory covers every CLI leaf command with exactly one disposition:
 
-- Total leaf commands: `207`
-- JSON-ready routed commands: `186`
+- Total leaf commands: `208`
+- JSON-ready routed commands: `187`
 - Intentionally human-only commands: `1`
 - Deferred routed commands with explicit V2 scope: `11`
 - Source-only/unrouted commands: `9`
@@ -174,10 +174,10 @@ starting the watcher.
 `doctor` is included in the JSON-ready routed count. It emits `DoctorReportDto` in the common Grace result envelope and
 supports `--schema`, `--examples`, and `--select`.
 
-`cache status` is also JSON-ready. It is repository-independent and reads only protected local Cache identity state.
-Its closed `oneOf` schema emits `Class`, `Enrollment`, and `Key` for every state; only an enrolled ready state includes
-`CacheId`, `Endpoint`, `BoundaryKind`, and `RepositoryCount`. The command performs no credential lookup, server request,
-repair, cleanup, or local mutation.
+`cache status` and `cache enroll` are JSON-ready, support inert `--schema` and `--examples` inspection, and share the
+same redacted ready-status `ReturnValue` schema. `cache status` reads only protected local Cache identity state. `cache`
+`enroll` resolves one credential before one root-local attempt and sends one selected-server request. Neither command
+exposes private key material, bearer credentials, filesystem paths, or staging details.
 
 ## Agent Recipes
 

--- a/src/Grace.CLI.CacheEnrollment.ClaimHolder/Grace.CLI.CacheEnrollment.ClaimHolder.fsproj
+++ b/src/Grace.CLI.CacheEnrollment.ClaimHolder/Grace.CLI.CacheEnrollment.ClaimHolder.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="10.1.301" />
+  </ItemGroup>
+</Project>

--- a/src/Grace.CLI.CacheEnrollment.ClaimHolder/Program.fs
+++ b/src/Grace.CLI.CacheEnrollment.ClaimHolder/Program.fs
@@ -1,0 +1,29 @@
+namespace Grace.CLI.CacheEnrollment.ClaimHolder
+
+open Grace.Cache
+open System
+open System.IO
+open System.Threading
+
+/// Hosts a normal-build test process that retains one production Cache enrollment claim until termination.
+module Program =
+    /// Runs the claim holder with its protected root and a signal file used by focused cross-process proof.
+    [<EntryPoint>]
+    let main arguments =
+        match arguments with
+        | [| root; signalPath |] ->
+            match CacheIdentity.tryAcquireEnrollmentClaim root with
+            | Error error ->
+                Console.Error.WriteLine($"Could not acquire Cache enrollment claim: {error}")
+                2
+            | Ok claim ->
+                try
+                    File.WriteAllText(signalPath, "held")
+                    use lifetime = new ManualResetEventSlim(false)
+                    lifetime.Wait()
+                    0
+                finally
+                    CacheIdentity.releaseEnrollmentClaim claim
+        | _ ->
+            Console.Error.WriteLine("Usage: Grace.CLI.CacheEnrollment.ClaimHolder <state-root> <held-signal-path>")
+            64

--- a/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Parsing.Tests.fs
@@ -4,7 +4,7 @@ open FsUnit
 open Grace.CLI
 open NUnit.Framework
 
-/// Groups pure parser coverage for the repository-independent Cache status command.
+/// Groups pure parser coverage for repository-independent Cache commands.
 [<Parallelizable(ParallelScope.All)>]
 module CacheCliParsingTests =
 
@@ -25,3 +25,24 @@ module CacheCliParsingTests =
             ] do
             let parseResult = GraceCommand.rootCommand.Parse(args)
             parseResult.Errors.Count |> should equal 0
+
+    /// Verifies the approved enrollment grammar accepts repeated repository assignments without repository configuration.
+    [<Test>]
+    let ``cache enroll parser accepts derived-boundary grammar`` () =
+        let parseResult =
+            GraceCommand.rootCommand.Parse(
+                [|
+                    "cache"
+                    "enroll"
+                    "--owner-id"
+                    "11111111-1111-1111-1111-111111111111"
+                    "--repository"
+                    "22222222-2222-2222-2222-222222222222/33333333-3333-3333-3333-333333333333"
+                    "--repository"
+                    "22222222-2222-2222-2222-222222222222/44444444-4444-4444-4444-444444444444"
+                    "--endpoint"
+                    "https://cache.example.test/enroll"
+                |]
+            )
+
+        parseResult.Errors.Count |> should equal 0

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -18,6 +18,7 @@ open System.IO
 open System.Net
 open System.Net.Sockets
 open System.Text.Json
+open System.Text.Json.Nodes
 open System.Text
 open System.Threading
 open System.Threading.Tasks
@@ -261,8 +262,65 @@ module CacheCliTests =
             do! stream.WriteAsync(bytes, 0, bytes.Length)
         }
 
+    /// Writes a redirect response with a valid target so selected-server transport proof can reject redirect following.
+    let private writeEnrollmentRedirect (client: TcpClient) (location: string) =
+        task {
+            use stream = client.GetStream()
+
+            let headers =
+                $"HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                |> Encoding.ASCII.GetBytes
+
+            do! stream.WriteAsync(headers, 0, headers.Length)
+        }
+
+    /// Hosts exactly one selected-server enrollment request and exposes its complete request evidence to a root-command test.
+    let private withSingleEnrollmentServer (respond: EnrollmentRequest -> TcpClient -> Task) (action: Uri -> ConcurrentQueue<EnrollmentRequest> -> unit) =
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        let requests = ConcurrentQueue<EnrollmentRequest>()
+        listener.Start()
+        let serverUri = Uri($"http://127.0.0.1:{(listener.LocalEndpoint :?> IPEndPoint).Port}")
+
+        let serverTask =
+            Task.Run(
+                Func<Task> (fun () ->
+                    task {
+                        let! client = listener.AcceptTcpClientAsync()
+                        use client = client
+                        let! request = readEnrollmentRequest client
+                        requests.Enqueue(request)
+                        do! respond request client
+                    })
+            )
+
+        try
+            action serverUri requests
+        finally
+            listener.Stop()
+
+            serverTask.Wait(TimeSpan.FromSeconds(10.0))
+            |> ignore
+
+    /// Runs the production root with a caller-controlled cancellation token while retaining captured output.
+    let private runProductionEnrollmentWithCancellation (args: string array) (cancellationToken: CancellationToken) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let exitCode =
+                GraceCommand.run (GraceCommand.productionDependencies ()) args cancellationToken
+                |> fun invocation -> invocation.GetAwaiter().GetResult()
+
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
     /// Hosts one selected server and its OAuth endpoints for real production-credential root-dispatch tests.
-    let private withProductionEnrollmentServer (action: Uri -> ConcurrentQueue<EnrollmentRequest> -> unit) =
+    let private withProductionEnrollmentServerResponse (m2mTokenResponse: (int * string) option) (action: Uri -> ConcurrentQueue<EnrollmentRequest> -> unit) =
         use listener = new TcpListener(IPAddress.Loopback, 0)
         use cancellation = new CancellationTokenSource()
         let requests = ConcurrentQueue<EnrollmentRequest>()
@@ -292,7 +350,9 @@ module CacheCliTests =
                             | "/oauth/token" when request.Body.Contains("device_code", StringComparison.Ordinal) ->
                                 200,
                                 "{\"access_token\":\"interactive-access-token\",\"refresh_token\":\"interactive-refresh-token\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}"
-                            | "/oauth/token" -> 200, "{\"access_token\":\"m2m-access-token\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+                            | "/oauth/token" ->
+                                m2mTokenResponse
+                                |> Option.defaultValue (200, "{\"access_token\":\"m2m-access-token\",\"expires_in\":3600,\"token_type\":\"Bearer\"}")
                             | "/cache/enroll" ->
                                 let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
 
@@ -321,6 +381,9 @@ module CacheCliTests =
             serverTask.Wait(TimeSpan.FromSeconds(5.0))
             |> ignore
 
+    /// Hosts the standard successful OAuth and enrollment responses for production root-dispatch tests.
+    let private withProductionEnrollmentServer (action: Uri -> ConcurrentQueue<EnrollmentRequest> -> unit) = withProductionEnrollmentServerResponse None action
+
     /// Applies isolated producer settings so a root-dispatch test uses exactly the requested credential mechanism.
     let private withCredentialEnvironment (values: (string * string option) list) (action: unit -> 'T) =
         let originalValues =
@@ -335,6 +398,25 @@ module CacheCliTests =
         finally
             originalValues
             |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value))
+
+    /// Applies one PAT-only production credential environment with all OIDC producers disabled.
+    let private withPatCredential (serverUri: Uri) (action: unit -> 'T) =
+        let pat = Grace.Types.PersonalAccessToken.formatToken "cache-test-user" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withCredentialEnvironment
+            [
+                Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                Constants.EnvironmentVariables.GraceToken, Some pat
+                Constants.EnvironmentVariables.GraceAuthOidcAuthority, None
+                Constants.EnvironmentVariables.GraceAuthOidcAudience, None
+                Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+            ]
+            action
 
     /// Runs an action with one temporary environment variable value.
     let private withEnv (name: string) (value: string option) (action: unit -> 'T) =
@@ -1107,6 +1189,45 @@ module CacheCliTests =
                 fun request ->
                     let accepted = acceptedResponse request
                     Accepted { accepted with ReturnValue = { accepted.ReturnValue with Class = "UnexpectedResult" } }
+                "null envelope", (fun _ -> Accepted Unchecked.defaultof<GraceReturnValue<CacheRegistrationResult>>)
+                "null result",
+                fun request ->
+                    let accepted = acceptedResponse request
+                    Accepted { accepted with ReturnValue = Unchecked.defaultof<CacheRegistrationResult> }
+                "null public key",
+                fun request ->
+                    let accepted = acceptedResponse request
+                    let registration = accepted.ReturnValue.Registration |> Option.get
+
+                    Accepted
+                        { accepted with
+                            ReturnValue =
+                                { accepted.ReturnValue with Registration = Some { registration with PublicKey = Unchecked.defaultof<CacheIdentityPublicKey> } }
+                        }
+                "null repository scopes",
+                fun request ->
+                    let accepted = acceptedResponse request
+                    let registration = accepted.ReturnValue.Registration |> Option.get
+                    Accepted { accepted with ReturnValue = { accepted.ReturnValue with Registration = Some { registration with RepositoryScopes = null } } }
+                "null repository scope element",
+                fun request ->
+                    let accepted = acceptedResponse request
+                    let registration = accepted.ReturnValue.Registration |> Option.get
+
+                    Accepted
+                        { accepted with
+                            ReturnValue =
+                                { accepted.ReturnValue with
+                                    Registration =
+                                        Some
+                                            { registration with
+                                                RepositoryScopes =
+                                                    [|
+                                                        Unchecked.defaultof<CacheRepositoryScope>
+                                                    |]
+                                            }
+                                }
+                        }
             ]
 
         for name, makeOutcome in cases do
@@ -1176,7 +1297,7 @@ module CacheCliTests =
                             use client = client
                             let! request = readEnrollmentRequest client
                             received.TrySetResult(request) |> ignore
-                            do! writeEnrollmentResponse client 302 "{\"redirect\":true}"
+                            do! writeEnrollmentRedirect client "http://127.0.0.1:9/redirected"
                         })
                 )
 
@@ -1200,6 +1321,427 @@ module CacheCliTests =
                 Assert.That(serverTask.Wait(TimeSpan.FromSeconds(5.0)), Is.True)
             finally
                 listener.Stop())
+
+    /// Proves the real selected-server transport classifies timeout, connection loss, and response loss without retry.
+    [<Test>]
+    let ``Linux cache enroll keeps real transport loss terminal and redacted`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let cases: (string * (EnrollmentRequest -> TcpClient -> Task)) list =
+            [
+                "timeout", (fun _ _ -> Task.Delay(TimeSpan.FromSeconds(3.0)))
+                "connection loss", (fun _ _ -> Task.CompletedTask)
+                "response loss",
+                (fun _ client ->
+                    task {
+                        use stream = client.GetStream()
+
+                        let headers =
+                            Encoding.ASCII.GetBytes("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\nConnection: close\r\n\r\n{")
+
+                        do! stream.WriteAsync(headers, 0, headers.Length)
+                    })
+            ]
+
+        for name, respond in cases do
+            withRoot (fun root _ ->
+                withSingleEnrollmentServer respond (fun serverUri requests ->
+                    withPatCredential serverUri (fun () ->
+                        let exitCode, output = runProductionEnrollment enrollmentArguments
+                        Assert.That(exitCode, Is.Not.EqualTo(0), $"{name}: {output}")
+                        Assert.That(requests.Count, Is.EqualTo(1), $"{name} retried transport.")
+                        let request = requests.ToArray()[0]
+                        Assert.That(request.Method, Is.EqualTo("POST"))
+                        Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+
+                        Assert.That(
+                            request.Authorization
+                            |> Option.defaultValue String.Empty,
+                            Does.StartWith("Bearer ")
+                        )
+
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        assertRedactedError exitCode output
+                        assertRedacted output (protectedValues root))))
+
+    /// Proves selected-server URI path bases compose one enrollment route instead of discarding the configured base path.
+    [<Test>]
+    let ``Linux cache enroll composes the selected server path base exactly once`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            withSingleEnrollmentServer
+                (fun request client ->
+                    task {
+                        let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+
+                        let response =
+                            acceptedResponse enrollment
+                            |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
+
+                        do! writeEnrollmentResponse client 200 response
+                    })
+                (fun serverUri requests ->
+                    let pathBase = Uri(serverUri, "api")
+
+                    withPatCredential pathBase (fun () ->
+                        let exitCode, output = runProductionEnrollment enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        Assert.That(requests.Count, Is.EqualTo(1))
+                        let request = requests.ToArray()[0]
+                        Assert.That(request.Method, Is.EqualTo("POST"))
+                        Assert.That(request.Path, Is.EqualTo("/api/cache/enroll"))
+
+                        Assert.That(
+                            request.Authorization
+                            |> Option.defaultValue String.Empty,
+                            Does.StartWith("Bearer ")
+                        )
+
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled")))))
+
+    /// Proves cancellation after the real request reaches the selected server stays indeterminate and never publishes ready state.
+    [<Test>]
+    let ``Linux cache enroll treats post-start cancellation as indeterminate`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            use cancellation = new CancellationTokenSource()
+
+            withSingleEnrollmentServer
+                (fun _ _ ->
+                    task {
+                        try
+                            do! Task.Delay(Timeout.InfiniteTimeSpan, cancellation.Token)
+                        with
+                        | :? OperationCanceledException -> ()
+                    })
+                (fun serverUri requests ->
+                    withPatCredential serverUri (fun () ->
+                        let invocation = Task.Run(Func<int * string>(fun () -> runProductionEnrollmentWithCancellation enrollmentArguments cancellation.Token))
+
+                        Assert.That(SpinWait.SpinUntil((fun () -> requests.Count = 1), TimeSpan.FromSeconds(5.0)), Is.True)
+                        cancellation.Cancel()
+                        let exitCode, output = invocation.GetAwaiter().GetResult()
+                        Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                        Assert.That(output, Does.Contain("outcome is unknown after transport started"))
+                        Assert.That(requests.Count, Is.EqualTo(1))
+                        let request = requests.ToArray()[0]
+                        Assert.That(request.Method, Is.EqualTo("POST"))
+                        Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+
+                        Assert.That(
+                            request.Authorization
+                            |> Option.defaultValue String.Empty,
+                            Does.StartWith("Bearer ")
+                        )
+
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        assertRedactedError exitCode output
+                        assertRedacted output (protectedValues root))))
+
+    /// Proves null and incomplete 2xx response bodies received through the real SDK transport remain typed and redacted.
+    [<Test>]
+    let ``Linux cache enroll rejects incomplete real accepted response graphs`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let mutateBody (mutate: JsonNode -> unit) (request: CacheEnrollmentRequest) =
+            let node =
+                acceptedResponse request
+                |> fun response -> JsonSerializer.Serialize(response, Constants.JsonSerializerOptions)
+                |> JsonNode.Parse
+
+            mutate node
+            node.ToJsonString(Constants.JsonSerializerOptions)
+
+        let cases: (string * (JsonNode -> unit)) list =
+            [
+                "null return value", (fun node -> node["ReturnValue"] <- null)
+                "missing registration",
+                fun node ->
+                    let result = node[ "ReturnValue" ].AsObject()
+                    result["Registration"] <- null
+                "missing public key",
+                fun node ->
+                    let result = node[ "ReturnValue" ].AsObject()
+                    let registration = result[ "Registration" ].AsObject()
+                    registration["PublicKey"] <- null
+                "missing repository scopes",
+                fun node ->
+                    let result = node[ "ReturnValue" ].AsObject()
+                    let registration = result[ "Registration" ].AsObject()
+                    registration["RepositoryScopes"] <- null
+                "null repository scope element",
+                fun node ->
+                    let result = node[ "ReturnValue" ].AsObject()
+                    let registration = result[ "Registration" ].AsObject()
+                    let scopes = JsonArray()
+                    scopes.Add(null)
+                    registration["RepositoryScopes"] <- scopes
+                "missing required display name",
+                fun node ->
+                    let result = node[ "ReturnValue" ].AsObject()
+                    let registration = result[ "Registration" ].AsObject()
+                    registration["DisplayName"] <- null
+            ]
+
+        for name, mutate in cases do
+            withRoot (fun root _ ->
+                withSingleEnrollmentServer
+                    (fun request client ->
+                        let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+                        writeEnrollmentResponse client 200 (mutateBody mutate enrollment))
+                    (fun serverUri requests ->
+                        withPatCredential serverUri (fun () ->
+                            let exitCode, output = runProductionEnrollment enrollmentArguments
+                            Assert.That(exitCode, Is.Not.EqualTo(0), $"{name}: {output}")
+                            Assert.That(requests.Count, Is.EqualTo(1))
+                            let request = requests.ToArray()[0]
+                            Assert.That(request.Method, Is.EqualTo("POST"))
+                            Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+
+                            Assert.That(
+                                request.Authorization
+                                |> Option.defaultValue String.Empty,
+                                Does.StartWith("Bearer ")
+                            )
+
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                            assertRedactedError exitCode output
+                            assertRedacted output (protectedValues root))))
+
+    /// Proves immutable server-response mismatches cannot publish the staged identity after a real selected-server POST.
+    [<Test>]
+    let ``Linux cache enroll rejects immutable real accepted response mismatches`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let cases =
+            [
+                "display name", "DisplayName", JsonValue.Create("different-cache") :> JsonNode
+                "endpoint", "Endpoint", JsonValue.Create("https://different.example.test") :> JsonNode
+                "protocol", "ProtocolVersion", JsonValue.Create("v2") :> JsonNode
+            ]
+
+        for name, field, replacement in cases do
+            withRoot (fun root _ ->
+                withSingleEnrollmentServer
+                    (fun request client ->
+                        task {
+                            let node =
+                                JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+                                |> acceptedResponse
+                                |> fun response -> JsonSerializer.Serialize(response, Constants.JsonSerializerOptions)
+                                |> JsonNode.Parse
+
+                            let result = node[ "ReturnValue" ].AsObject()
+                            let registration = result[ "Registration" ].AsObject()
+                            registration[field] <- replacement.DeepClone()
+                            do! writeEnrollmentResponse client 200 (node.ToJsonString(Constants.JsonSerializerOptions))
+                        })
+                    (fun serverUri requests ->
+                        withPatCredential serverUri (fun () ->
+                            let exitCode, output = runProductionEnrollment enrollmentArguments
+                            Assert.That(exitCode, Is.Not.EqualTo(0), $"{name}: {output}")
+                            Assert.That(requests.Count, Is.EqualTo(1))
+                            let request = requests.ToArray()[0]
+                            Assert.That(request.Method, Is.EqualTo("POST"))
+                            Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+
+                            Assert.That(
+                                request.Authorization
+                                |> Option.defaultValue String.Empty,
+                                Does.StartWith("Bearer ")
+                            )
+
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                            assertRedactedError exitCode output
+                            assertRedacted output (protectedValues root))))
+
+    /// Proves a lost staged identity after the real response cannot be published through the root command.
+    [<Test>]
+    let ``Linux cache enroll does not publish after the claimed staged identity is lost`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            withSingleEnrollmentServer
+                (fun request client ->
+                    task {
+                        let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+
+                        let response =
+                            acceptedResponse enrollment
+                            |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
+
+                        do! writeEnrollmentResponse client 200 response
+                    })
+                (fun serverUri requests ->
+                    withEnv Constants.EnvironmentVariables.GraceServerUri (Some serverUri.AbsoluteUri) (fun () ->
+                        let dependencies =
+                            enrollmentDependencies
+                                root
+                                (fun _ -> Task.FromResult(Ok "lost-claim-token"))
+                                (fun request uri bearer correlationId cancellationToken ->
+                                    CacheRegistration.Enroll(request, uri, bearer, correlationId, cancellationToken))
+                                (fun phase ->
+                                    if phase = CacheCommand.EnrollmentPhase.BeforeReadyCommit then
+                                        Directory.Delete(Path.Combine(root, "attempt"), true)
+
+                                    Task.FromResult(()))
+                                CacheIdentity.commitClaimedReady
+
+                        let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+                        Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                        Assert.That(requests.Count, Is.EqualTo(1))
+                        let request = requests.ToArray()[0]
+                        Assert.That(request.Method, Is.EqualTo("POST"))
+                        Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+                        Assert.That(request.Authorization, Is.EqualTo(Some "Bearer lost-claim-token"))
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        assertRedactedError exitCode output
+                        assertRedacted output (Array.append (protectedValues root) [| "lost-claim-token" |]))))
+
+    /// Proves an actual protected local registration write failure remains non-ready and cleans only the staged attempt.
+    [<Test>]
+    let ``Linux cache enroll handles a real protected local write failure`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            withSingleEnrollmentServer
+                (fun request client ->
+                    task {
+                        let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+
+                        let response =
+                            acceptedResponse enrollment
+                            |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
+
+                        do! writeEnrollmentResponse client 200 response
+                    })
+                (fun serverUri requests ->
+                    withEnv Constants.EnvironmentVariables.GraceServerUri (Some serverUri.AbsoluteUri) (fun () ->
+                        let dependencies =
+                            enrollmentDependencies
+                                root
+                                (fun _ -> Task.FromResult(Ok "local-write-token"))
+                                (fun request uri bearer correlationId cancellationToken ->
+                                    CacheRegistration.Enroll(request, uri, bearer, correlationId, cancellationToken))
+                                (fun phase ->
+                                    if phase = CacheCommand.EnrollmentPhase.BeforeReadyCommit then
+                                        File.SetUnixFileMode(Path.Combine(root, "attempt"), UnixFileMode.UserRead ||| UnixFileMode.UserExecute)
+
+                                    Task.FromResult(()))
+                                CacheIdentity.commitClaimedReady
+
+                        let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+                        Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                        Assert.That(requests.Count, Is.EqualTo(1))
+                        let request = requests.ToArray()[0]
+                        Assert.That(request.Method, Is.EqualTo("POST"))
+                        Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+                        Assert.That(request.Authorization, Is.EqualTo(Some "Bearer local-write-token"))
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                        Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        assertRedactedError exitCode output
+                        assertRedacted output (Array.append (protectedValues root) [| "local-write-token" |]))))
+
+    /// Proves missing and failed production credential producers make no enrollment request and redact Normal and JSON output.
+    [<Test>]
+    let ``Linux cache enroll rejects production credential failures before enrollment transport`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let normalArguments = enrollmentArguments[2..]
+
+        let runAbsent modeArguments =
+            withRoot (fun root _ ->
+                withProductionEnrollmentServer (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, None
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+                        ]
+                        (fun () ->
+                            let exitCode, output = runProductionEnrollment modeArguments
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+
+                            let enrollmentRequests =
+                                requests.ToArray()
+                                |> Array.filter (fun request -> request.Path = "/cache/enroll")
+
+                            Assert.That(enrollmentRequests.Length, Is.EqualTo(0))
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                            assertRedacted output (protectedValues root)
+
+                            if modeArguments = enrollmentArguments then assertRedactedError exitCode output)))
+
+        runAbsent normalArguments
+        runAbsent enrollmentArguments
+
+        let runFailedM2m modeArguments =
+            withRoot (fun root _ ->
+                withProductionEnrollmentServerResponse (Some(400, "{\"error\":\"invalid_client\"}")) (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, None
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, Some "failed-m2m-client"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, Some "failed-m2m-secret"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+                        ]
+                        (fun () ->
+                            let exitCode, output = runProductionEnrollment modeArguments
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                            Assert.That(output, Does.Contain("Machine-to-machine authentication failed."))
+                            Assert.That(requests.Count, Is.EqualTo(1))
+                            let request = requests.ToArray()[0]
+                            Assert.That(request.Method, Is.EqualTo("POST"))
+                            Assert.That(request.Path, Is.EqualTo("/oauth/token"))
+                            Assert.That(request.Authorization, Is.EqualTo(None))
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                            assertRedacted
+                                output
+                                (Array.append
+                                    (protectedValues root)
+                                    [|
+                                        "failed-m2m-client"
+                                        "failed-m2m-secret"
+                                    |])
+
+                            if modeArguments = enrollmentArguments then assertRedactedError exitCode output)))
+
+        runFailedM2m normalArguments
+        runFailedM2m enrollmentArguments
 
     /// Proves PAT and M2M credential producers each supply one bearer to the selected server through the production root graph.
     [<Test>]
@@ -1270,7 +1812,7 @@ module CacheCliTests =
                         Assert.That((paths = [| "/oauth/token"; "/cache/enroll" |]), Is.True)
                         Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled")))))
 
-    /// Proves the normal-build holder owns the protected enrollment claim until its exact process is killed and joined.
+    /// Proves a live normal-build claim holder blocks GraceCommand enrollment, then exact holder termination permits one ready retry.
     [<Test>]
     let ``Linux claim holder blocks enrollment claim then releases a retry`` () =
         if not (OperatingSystem.IsLinux()) then
@@ -1313,21 +1855,46 @@ module CacheCliTests =
 
                 Assert.That(File.Exists(signalPath), Is.True, "The holder did not acquire the production claim.")
 
-                match CacheIdentity.tryAcquireEnrollmentClaim root with
-                | Error CacheIdentityError.StateUnavailable -> ()
-                | Error error -> Assert.Fail($"Expected a conflicting claim failure, received {error}.")
-                | Ok claim ->
-                    CacheIdentity.releaseEnrollmentClaim claim
-                    Assert.Fail("A second process acquired the claim while the holder was live.")
+                let beforeConflict = snapshot root
 
-                holderProcess.Kill()
-                Assert.That(holderProcess.WaitForExit(10000), Is.True, "The exact claim-holder process did not exit.")
+                withSingleEnrollmentServer
+                    (fun request client ->
+                        task {
+                            let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
 
-                let retry =
-                    CacheIdentity.tryAcquireEnrollmentClaim root
-                    |> requireOk
+                            let response =
+                                acceptedResponse enrollment
+                                |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
 
-                CacheIdentity.releaseEnrollmentClaim retry
+                            do! writeEnrollmentResponse client 200 response
+                        })
+                    (fun serverUri requests ->
+                        withPatCredential serverUri (fun () ->
+                            let conflictExit, conflictOutput = runProductionEnrollment enrollmentArguments
+                            Assert.That(conflictExit, Is.Not.EqualTo(0), conflictOutput)
+                            Assert.That(requests.Count, Is.EqualTo(0), "A competing command reached enrollment transport.")
+                            Assert.That(snapshot root = beforeConflict, Is.True, "A competing command changed the holder's protected state.")
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                            assertRedactedError conflictExit conflictOutput
+                            assertRedacted conflictOutput (protectedValues root)
+
+                            holderProcess.Kill()
+                            Assert.That(holderProcess.WaitForExit(10000), Is.True, "The exact claim-holder process did not exit.")
+
+                            let retryExit, retryOutput = runProductionEnrollment enrollmentArguments
+                            Assert.That(retryExit, Is.EqualTo(0), retryOutput)
+                            Assert.That(requests.Count, Is.EqualTo(1))
+                            let request = requests.ToArray()[0]
+                            Assert.That(request.Method, Is.EqualTo("POST"))
+                            Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+
+                            Assert.That(
+                                request.Authorization
+                                |> Option.defaultValue String.Empty,
+                                Does.StartWith("Bearer ")
+                            )
+
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled"))))
             finally
                 if not holderProcess.HasExited then
                     holderProcess.Kill()
@@ -1371,6 +1938,53 @@ module CacheCliTests =
                                                        "device" |]
 
                         Assert.That(loginExit, Is.EqualTo(0), loginOutput)
+
+                        let beforePartialM2m = snapshot root
+                        let normalArguments = enrollmentArguments[2..]
+
+                        withCredentialEnvironment
+                            [
+                                Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, Some "cache-partial-client-should-not-appear"
+                                Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                            ]
+                            (fun () ->
+                                let normalExit, normalOutput = runProductionEnrollment normalArguments
+                                let jsonExit, jsonOutput = runProductionEnrollment enrollmentArguments
+                                Assert.That(normalExit, Is.Not.EqualTo(0), normalOutput)
+                                Assert.That(jsonExit, Is.Not.EqualTo(0), jsonOutput)
+                                Assert.That(normalOutput, Does.Contain("Machine-to-machine authentication configuration is incomplete."))
+                                Assert.That(jsonOutput, Does.Contain("Machine-to-machine authentication configuration is incomplete."))
+                                Assert.That(snapshot root = beforePartialM2m, Is.True)
+
+                                assertRedacted
+                                    normalOutput
+                                    (Array.append
+                                        (protectedValues root)
+                                        [|
+                                            "cache-partial-client-should-not-appear"
+                                        |])
+
+                                assertRedacted
+                                    jsonOutput
+                                    (Array.append
+                                        (protectedValues root)
+                                        [|
+                                            "cache-partial-client-should-not-appear"
+                                        |]))
+
+                        let requestPathsAfterPartialM2m =
+                            requests.ToArray()
+                            |> Array.map (fun request -> request.Path)
+
+                        Assert.That(
+                            (requestPathsAfterPartialM2m = [|
+                                "/oauth/device/code"
+                                "/oauth/token"
+                            |]),
+                            Is.True,
+                            "Partial M2M configuration fell through to the interactive credential or enrollment transport."
+                        )
+
                         let exitCode, output = runProductionEnrollment enrollmentArguments
                         Assert.That(exitCode, Is.EqualTo(0), output)
                         let requests = requests.ToArray()

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -146,6 +146,35 @@ module CacheCliTests =
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
 
+    /// Runs the production credential resolver through a fresh Cache factory and the only root-command entry point.
+    let private runProductionEnrollmentWithCredentialDependencies
+        (credentialDependencies: Auth.CacheEnrollmentCredentialDependencies)
+        (args: string array)
+        (cancellationToken: CancellationToken)
+        =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let rootDependencies: GraceCommand.RootDependencies =
+                {
+                    CreateCacheCommand = (fun () -> CacheCommand.create (CacheCommand.productionDependencies (Some credentialDependencies)))
+                    InitializeExecution = (fun () -> ())
+                    AfterCommandExit = (fun _ -> Task.FromResult(()))
+                }
+
+            let exitCode =
+                GraceCommand.run rootDependencies args cancellationToken
+                |> fun invocation -> invocation.GetAwaiter().GetResult()
+
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
     /// Reads a complete loopback HTTP request including fixed-length and chunked request bodies.
     let private readEnrollmentRequest (client: TcpClient) =
         task {
@@ -1128,7 +1157,7 @@ module CacheCliTests =
         if not (OperatingSystem.IsLinux()) then
             Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
 
-        let runCancelled phase =
+        let runCancelled phase arguments =
             withRoot (fun root _ ->
                 use cancellation = new CancellationTokenSource()
                 let before = snapshot root
@@ -1164,16 +1193,198 @@ module CacheCliTests =
 
                 if phase = "credential" then cancellation.Cancel()
 
-                let exitCode, output = runEnrollment dependencies enrollmentArguments cancellation.Token
+                let exitCode, output = runEnrollment dependencies arguments cancellation.Token
                 Assert.That(exitCode, Is.Not.EqualTo(0), output)
                 Assert.That(output, Does.Contain("cancelled"))
                 Assert.That(postCount, Is.EqualTo(0))
                 Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
                 Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False))
 
-        runCancelled "credential"
-        runCancelled "before-claim"
-        runCancelled "after-staging"
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            runCancelled "credential" arguments
+            runCancelled "before-claim" arguments
+            runCancelled "after-staging" arguments
+
+    /// Proves a credential result completed after caller cancellation cannot reach the claim or enrollment transport.
+    [<Test>]
+    let ``Linux cache enroll rejects delayed credential completion after caller cancellation`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            withRoot (fun root _ ->
+                use cancellation = new CancellationTokenSource()
+                let before = snapshot root
+                let credentialEntered = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+                let credential = TaskCompletionSource<Result<string, string>>(TaskCreationOptions.RunContinuationsAsynchronously)
+                let mutable postCount = 0
+
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        (fun _ ->
+                            credentialEntered.TrySetResult(()) |> ignore
+                            credential.Task)
+                        (fun _ _ _ _ _ ->
+                            postCount <- postCount + 1
+                            Task.FromResult(Rejected(GraceError.Create "Unexpected enrollment POST." "cache-test")))
+                        (fun _ -> Task.FromResult(()))
+                        CacheIdentity.commitClaimedReady
+
+                let invocation = Task.Run(Func<int * string>(fun () -> runEnrollment dependencies arguments cancellation.Token))
+                credentialEntered.Task.GetAwaiter().GetResult()
+                cancellation.Cancel()
+                credential.SetResult(Ok "delayed-credential-secret")
+                let exitCode, output = invocation.GetAwaiter().GetResult()
+                Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                Assert.That(output, Does.Contain("cancelled"))
+                Assert.That(postCount, Is.EqualTo(0))
+                Assert.That(snapshot root = before, Is.True, "Delayed credentials changed the protected root.")
+                Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                assertRedacted output (Array.append (protectedValues root) [| "delayed-credential-secret" |])
+
+                if arguments = enrollmentArguments then assertRedactedError exitCode output)
+
+    /// Proves a credential producer cancellation without caller cancellation remains a redacted credential failure before local effects.
+    [<Test>]
+    let ``Linux cache enroll classifies provider cancellation as a credential failure`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let normalArguments = enrollmentArguments[2..]
+
+        for arguments in [ normalArguments; enrollmentArguments ] do
+            withRoot (fun root _ ->
+                let before = snapshot root
+                let mutable postCount = 0
+                let providerSecret = "provider-cancellation-secret"
+
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        (fun _ -> Task.FromException<Result<string, string>>(TaskCanceledException(providerSecret)))
+                        (fun _ _ _ _ _ ->
+                            postCount <- postCount + 1
+                            Task.FromResult(Rejected(GraceError.Create "Unexpected enrollment POST." "cache-test")))
+                        (fun _ -> Task.FromResult(()))
+                        CacheIdentity.commitClaimedReady
+
+                let exitCode, output = runEnrollment dependencies arguments CancellationToken.None
+                Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
+                Assert.That(postCount, Is.EqualTo(0))
+                Assert.That(snapshot root = before, Is.True, "Credential failure changed the protected root.")
+                Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                assertRedacted output (Array.append (protectedValues root) [| providerSecret |])
+
+                if arguments = enrollmentArguments then assertRedactedError exitCode output)
+
+    /// Proves malformed enrollment operands and invalid selected-server configuration do not reach credential or local-effect phases.
+    [<Test>]
+    let ``Linux cache enroll rejects invalid grammar before credentials or protected effects`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let without optionName values =
+            let index =
+                values
+                |> Array.findIndex (fun value -> value = optionName)
+
+            Array.append values[0 .. index - 1] values[index + 2 ..]
+
+        let replace optionName replacement values =
+            let index =
+                values
+                |> Array.findIndex (fun value -> value = optionName)
+
+            let copy = Array.copy values
+            copy[index + 1] <- replacement
+            copy
+
+        let cases =
+            [
+                "missing owner", without "--owner-id" enrollmentArguments, Some "https://grace.example.test"
+                "malformed owner", replace "--owner-id" "not-a-guid" enrollmentArguments, Some "https://grace.example.test"
+                "malformed organization", replace "--organization-id" "not-a-guid" enrollmentArguments, Some "https://grace.example.test"
+                "empty organization", replace "--organization-id" " " enrollmentArguments, Some "https://grace.example.test"
+                "malformed repository", replace "--repository" "not-a-repository" enrollmentArguments, Some "https://grace.example.test"
+                "missing endpoint", without "--endpoint" enrollmentArguments, Some "https://grace.example.test"
+                "HTTP endpoint without allow-http",
+                enrollmentArguments
+                |> Array.filter (fun value -> value <> "--allow-http"),
+                Some "https://grace.example.test"
+                "invalid server URI", enrollmentArguments, Some "not-an-absolute-uri"
+            ]
+
+        for name, arguments, serverUri in cases do
+            withRoot (fun root _ ->
+                withEnv Constants.EnvironmentVariables.GraceServerUri serverUri (fun () ->
+                    let before = snapshot root
+                    let mutable credentialCount = 0
+                    let mutable postCount = 0
+
+                    let dependencies =
+                        enrollmentDependencies
+                            root
+                            (fun _ ->
+                                credentialCount <- credentialCount + 1
+                                Task.FromResult(Ok "unexpected-credential"))
+                            (fun _ _ _ _ _ ->
+                                postCount <- postCount + 1
+                                Task.FromResult(Rejected(GraceError.Create "Unexpected enrollment POST." "cache-test")))
+                            (fun _ -> Task.FromResult(()))
+                            CacheIdentity.commitClaimedReady
+
+                    let exitCode, output = runEnrollment dependencies arguments CancellationToken.None
+                    Assert.That(exitCode, Is.Not.EqualTo(0), $"{name}: {output}")
+                    Assert.That(credentialCount, Is.EqualTo(0), $"{name} reached credential resolution.")
+                    Assert.That(postCount, Is.EqualTo(0), $"{name} reached enrollment transport.")
+                    Assert.That(snapshot root = before, Is.True, $"{name} changed the protected root.")
+                    Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                    Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                    assertRedacted output (Array.append (protectedValues root) [| "unexpected-credential" |])))
+
+    /// Proves an invalid existing ready state is terminal before credential resolution and cannot publish another enrollment.
+    [<Test>]
+    let ``Linux cache enroll keeps an invalid ready state fail closed through the root graph`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            createInvalid root
+            let before = snapshot root
+            let mutable credentialCount = 0
+            let mutable postCount = 0
+
+            let dependencies =
+                enrollmentDependencies
+                    root
+                    (fun _ ->
+                        credentialCount <- credentialCount + 1
+                        Task.FromResult(Ok "unexpected-credential"))
+                    (fun _ _ _ _ _ ->
+                        postCount <- postCount + 1
+                        Task.FromResult(Rejected(GraceError.Create "Unexpected enrollment POST." "cache-test")))
+                    (fun _ -> Task.FromResult(()))
+                    CacheIdentity.commitClaimedReady
+
+            let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+            Assert.That(credentialCount, Is.EqualTo(0))
+            Assert.That(postCount, Is.EqualTo(0))
+            Assert.That(snapshot root = before, Is.True)
+            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("invalid"))
+            assertRedacted output (Array.append (protectedValues root) [| "unexpected-credential" |]))
 
     /// Proves an attempt created before its key write is reclaimed only after this root command holds the exclusive claim.
     [<Test>]
@@ -1565,14 +1776,29 @@ module CacheCliTests =
         if not (OperatingSystem.IsLinux()) then
             Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
 
-        let cases =
+        let registration (node: JsonNode) =
+            let result = node[ "ReturnValue" ].AsObject()
+            result[ "Registration" ].AsObject()
+
+        let cases: (string * (JsonNode -> unit)) list =
             [
-                "display name", "DisplayName", JsonValue.Create("different-cache") :> JsonNode
-                "endpoint", "Endpoint", JsonValue.Create("https://different.example.test") :> JsonNode
-                "protocol", "ProtocolVersion", JsonValue.Create("v2") :> JsonNode
+                "outer result class", (fun node -> node[ "ReturnValue" ].AsObject()["Class"] <- JsonValue.Create("UnexpectedResult"))
+                "returned enrollment status", (fun node -> node[ "ReturnValue" ].AsObject()["Status"] <- JsonValue.Create("NotEnrolled"))
+                "public key",
+                fun node ->
+                    let publicKeyNode = (registration node)["PublicKey"]
+                    let publicKey = publicKeyNode.AsObject()
+                    publicKey["PublicKeyX"] <- JsonValue.Create("different-public-key")
+                "owner", (fun node -> (registration node)["OwnerId"] <- JsonValue.Create("99999999-9999-9999-9999-999999999999"))
+                "organization", (fun node -> (registration node)["OrganizationId"] <- JsonValue.Create("99999999-9999-9999-9999-999999999999"))
+                "repository scopes", (fun node -> (registration node)["RepositoryScopes"] <- JsonArray())
+                "endpoint", (fun node -> (registration node)["Endpoint"] <- JsonValue.Create("https://different.example.test"))
+                "display name", (fun node -> (registration node)["DisplayName"] <- JsonValue.Create("different-cache"))
+                "software version", (fun node -> (registration node)["SoftwareVersion"] <- JsonValue.Create("different-version"))
+                "protocol version", (fun node -> (registration node)["ProtocolVersion"] <- JsonValue.Create("v2"))
             ]
 
-        for name, field, replacement in cases do
+        for name, mutate in cases do
             withRoot (fun root _ ->
                 withSingleEnrollmentServer
                     (fun request client ->
@@ -1583,9 +1809,7 @@ module CacheCliTests =
                                 |> fun response -> JsonSerializer.Serialize(response, Constants.JsonSerializerOptions)
                                 |> JsonNode.Parse
 
-                            let result = node[ "ReturnValue" ].AsObject()
-                            let registration = result[ "Registration" ].AsObject()
-                            registration[field] <- replacement.DeepClone()
+                            mutate node
                             do! writeEnrollmentResponse client 200 (node.ToJsonString(Constants.JsonSerializerOptions))
                         })
                     (fun serverUri requests ->
@@ -1653,6 +1877,40 @@ module CacheCliTests =
                         assertRedactedError exitCode output
                         assertRedacted output (Array.append (protectedValues root) [| "lost-claim-token" |]))))
 
+    /// Proves replacement of the staged key cannot be mistaken for this invocation's identity during ready publication.
+    [<Test>]
+    let ``Linux cache enroll does not publish a replaced staged key`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            let mutable postCount = 0
+
+            let dependencies =
+                enrollmentDependencies
+                    root
+                    (fun _ -> Task.FromResult(Ok "replaced-key-token"))
+                    (fun request _ _ _ _ ->
+                        postCount <- postCount + 1
+                        Task.FromResult(Accepted(acceptedResponse request)))
+                    (fun phase ->
+                        if phase = CacheCommand.EnrollmentPhase.BeforeReadyCommit then
+                            let keyPath = Path.Combine(root, "attempt", "identity.pk8")
+                            File.WriteAllBytes(keyPath, [| 1uy; 2uy; 3uy |])
+                            File.SetUnixFileMode(keyPath, UnixFileMode.UserRead ||| UnixFileMode.UserWrite)
+
+                        Task.FromResult(()))
+                    CacheIdentity.commitClaimedReady
+
+            let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+            Assert.That(postCount, Is.EqualTo(1))
+            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+            Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
+            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.True, "Cleanup deleted the replaced staged key.")
+            assertRedactedError exitCode output
+            assertRedacted output (Array.append (protectedValues root) [| "replaced-key-token" |]))
+
     /// Proves a real claimed registration-file collision after acceptance stays non-ready and cleans only this staged attempt.
     [<Test>]
     let ``Linux cache enroll handles a real protected local write failure`` () =
@@ -1698,6 +1956,7 @@ module CacheCliTests =
                         Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
                         Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
                         Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False, "Best-effort cleanup did not remove the claimed attempt.")
+                        Assert.That(output, Does.Contain("Cache enrollment was accepted but local ready state could not be committed."))
                         assertRedactedError exitCode output
                         assertRedacted output (Array.append (protectedValues root) [| "local-write-token" |]))))
 
@@ -1786,6 +2045,54 @@ module CacheCliTests =
 
         runFailedM2m normalArguments
         runFailedM2m enrollmentArguments
+
+    /// Proves an invalid configured PAT is terminal and cannot fall through to a usable lower-priority M2M producer.
+    [<Test>]
+    let ``Linux cache enroll preserves invalid PAT precedence over machine credentials`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            withRoot (fun root _ ->
+                withProductionEnrollmentServer (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, Some "invalid-pat-secret"
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, Some "lower-priority-m2m-client"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, Some "lower-priority-m2m-secret"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, Some "cache.enroll"
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+                        ]
+                        (fun () ->
+                            let before = snapshot root
+                            let exitCode, output = runProductionEnrollment arguments
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                            Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(requests.Count, Is.EqualTo(0), "Invalid PAT fell through to M2M or enrollment transport.")
+                            Assert.That(snapshot root = before, Is.True)
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+
+                            assertRedacted
+                                output
+                                (Array.append
+                                    (protectedValues root)
+                                    [|
+                                        "invalid-pat-secret"
+                                        "lower-priority-m2m-client"
+                                        "lower-priority-m2m-secret"
+                                    |])
+
+                            if arguments = enrollmentArguments then assertRedactedError exitCode output)))
 
     /// Proves PAT and M2M credential producers each supply one bearer to the selected server through the production root graph.
     [<Test>]
@@ -1946,6 +2253,265 @@ module CacheCliTests =
 
                 if File.Exists(signalPath) then File.Delete(signalPath))
 
+    /// Proves a provider-side M2M cancellation is a redacted credential failure when the root caller did not cancel.
+    [<Test>]
+    let ``Linux cache enroll maps an M2M provider TaskCanceledException without caller cancellation`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            withRoot (fun root _ ->
+                withProductionEnrollmentServer (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, None
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, Some "timeout-m2m-client"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, Some "timeout-m2m-secret"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+                        ]
+                        (fun () ->
+                            let before = snapshot root
+                            use callerCancellation = new CancellationTokenSource()
+                            let mutable providerSawCallerCancellation = true
+                            let mutable providerCalls = 0
+                            let productionDependencies = Auth.cacheEnrollmentCredentialDependencies ()
+
+                            let credentialDependencies =
+                                { productionDependencies with
+                                    PostFormAsync =
+                                        fun _ _ ->
+                                            providerCalls <- providerCalls + 1
+                                            providerSawCallerCancellation <- callerCancellation.IsCancellationRequested
+
+                                            Task.FromException<Result<string, string>>(
+                                                TaskCanceledException("provider timeout must not become caller cancellation")
+                                            )
+                                }
+
+                            let exitCode, output = runProductionEnrollmentWithCredentialDependencies credentialDependencies arguments callerCancellation.Token
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                            Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(providerCalls, Is.EqualTo(1))
+                            Assert.That(providerSawCallerCancellation, Is.False)
+                            Assert.That(requests.Count, Is.EqualTo(0), "Credential failure reached cache enrollment transport.")
+                            Assert.That(snapshot root = before, Is.True, "Credential failure changed the protected root.")
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                            assertRedacted
+                                output
+                                (Array.append
+                                    (protectedValues root)
+                                    [|
+                                        "timeout-m2m-client"
+                                        "timeout-m2m-secret"
+                                    |])
+
+                            if arguments = enrollmentArguments then assertRedactedError exitCode output)))
+
+    /// Proves an expired real-keyring credential maps a refresh-provider failure before Cache enrollment effects.
+    [<Test>]
+    let ``Linux cache enroll maps expired GNOME keyring refresh failure without fallback`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        if
+            Environment.GetEnvironmentVariable("GRACE_TEST_LINUX_KEYRING")
+            <> "1"
+        then
+            Assert.Ignore("This proof requires the D-Bus and GNOME keyring session configured by validate.yml.")
+
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            withRoot (fun root _ ->
+                withProductionEnrollmentServer (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, None
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "cache-expired-interactive-client"
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, Some "openid offline_access"
+                        ]
+                        (fun () ->
+                            let loginExit, loginOutput =
+                                runProductionEnrollment [| "authenticate"
+                                                           "login"
+                                                           "--auth"
+                                                           "device" |]
+
+                            Assert.That(loginExit, Is.EqualTo(0), loginOutput)
+                            let before = snapshot root
+                            let requestCountBeforeEnrollment = requests.Count
+                            let mutable refreshCalls = 0
+                            let productionDependencies = Auth.cacheEnrollmentCredentialDependencies ()
+
+                            let credentialDependencies =
+                                { productionDependencies with
+                                    CurrentInstant =
+                                        fun () ->
+                                            SystemClock
+                                                .Instance
+                                                .GetCurrentInstant()
+                                                .Plus(Duration.FromHours(2.0))
+                                    PostFormAsync =
+                                        fun _ formValues ->
+                                            refreshCalls <- refreshCalls + 1
+
+                                            Assert.That(
+                                                formValues
+                                                |> List.contains ("grant_type", "refresh_token"),
+                                                Is.True
+                                            )
+
+                                            Task.FromException<Result<string, string>>(TaskCanceledException("expired interactive refresh provider timeout"))
+                                }
+
+                            let exitCode, output = runProductionEnrollmentWithCredentialDependencies credentialDependencies arguments CancellationToken.None
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                            Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(refreshCalls, Is.EqualTo(1))
+                            Assert.That(requests.Count, Is.EqualTo(requestCountBeforeEnrollment), "Refresh failure reached cache enrollment transport.")
+                            Assert.That(snapshot root = before, Is.True, "Credential failure changed the protected root.")
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                            assertRedacted output (protectedValues root)
+
+                            if arguments = enrollmentArguments then assertRedactedError exitCode output)))
+
+    /// Proves secure-store persistence verification failure is redacted before a Cache enrollment claim or request.
+    [<Test>]
+    let ``Linux cache enroll maps secure-store verification failure before local effects`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        if
+            Environment.GetEnvironmentVariable("GRACE_TEST_LINUX_KEYRING")
+            <> "1"
+        then
+            Assert.Ignore("This proof requires the D-Bus and GNOME keyring session configured by validate.yml.")
+
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            withRoot (fun root _ ->
+                withProductionEnrollmentServer (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, None
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "cache-secure-store-client"
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, Some "openid offline_access"
+                        ]
+                        (fun () ->
+                            let before = snapshot root
+                            let productionDependencies = Auth.cacheEnrollmentCredentialDependencies ()
+
+                            let credentialDependencies =
+                                { productionDependencies with
+                                    VerifyPersistence = fun _ -> raise (InvalidOperationException("secure-store verification failure"))
+                                }
+
+                            let exitCode, output = runProductionEnrollmentWithCredentialDependencies credentialDependencies arguments CancellationToken.None
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                            Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(requests.Count, Is.EqualTo(0), "Secure-store failure reached cache enrollment transport.")
+                            Assert.That(snapshot root = before, Is.True, "Credential failure changed the protected root.")
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+
+                            assertRedacted
+                                output
+                                (Array.append
+                                    (protectedValues root)
+                                    [|
+                                        "secure-store verification failure"
+                                    |])
+
+                            if arguments = enrollmentArguments then assertRedactedError exitCode output)))
+
+    /// Proves token-lock failure is redacted before a Cache enrollment claim or request.
+    [<Test>]
+    let ``Linux cache enroll maps token-lock failure before local effects`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        if
+            Environment.GetEnvironmentVariable("GRACE_TEST_LINUX_KEYRING")
+            <> "1"
+        then
+            Assert.Ignore("This proof requires the D-Bus and GNOME keyring session configured by validate.yml.")
+
+        for arguments in
+            [
+                enrollmentArguments[2..]
+                enrollmentArguments
+            ] do
+            withRoot (fun root _ ->
+                withProductionEnrollmentServer (fun serverUri requests ->
+                    withCredentialEnvironment
+                        [
+                            Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceToken, None
+                            Constants.EnvironmentVariables.GraceTokenFile, None
+                            Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                            Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                            Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "cache-token-lock-client"
+                            Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                            Constants.EnvironmentVariables.GraceAuthOidcCliScopes, Some "openid offline_access"
+                        ]
+                        (fun () ->
+                            let before = snapshot root
+                            let productionDependencies = Auth.cacheEnrollmentCredentialDependencies ()
+
+                            let credentialDependencies =
+                                { productionDependencies with
+                                    WithTokenLock = fun _ _ -> Task.FromException<Result<string option, string>>(IOException("token-lock persistence failure"))
+                                }
+
+                            let exitCode, output = runProductionEnrollmentWithCredentialDependencies credentialDependencies arguments CancellationToken.None
+                            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                            Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(requests.Count, Is.EqualTo(0), "Token-lock failure reached cache enrollment transport.")
+                            Assert.That(snapshot root = before, Is.True, "Credential failure changed the protected root.")
+                            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                            assertRedacted output (Array.append (protectedValues root) [| "token-lock persistence failure" |])
+
+                            if arguments = enrollmentArguments then assertRedactedError exitCode output)))
+
     /// Proves the Linux libsecret-backed interactive credential is read from the real GNOME keyring before one enrollment POST.
     [<Test>]
     let ``Linux cache enroll uses the real GNOME keyring interactive credential once`` () =
@@ -1985,6 +2551,28 @@ module CacheCliTests =
 
                         let beforePartialM2m = snapshot root
                         let normalArguments = enrollmentArguments[2..]
+
+                        withEnv Constants.EnvironmentVariables.GraceToken (Some "invalid-pat-with-keyring-secret") (fun () ->
+                            let normalExit, normalOutput = runProductionEnrollment normalArguments
+                            let jsonExit, jsonOutput = runProductionEnrollment enrollmentArguments
+                            Assert.That(normalExit, Is.Not.EqualTo(0), normalOutput)
+                            Assert.That(jsonExit, Is.Not.EqualTo(0), jsonOutput)
+                            Assert.That(normalOutput, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(jsonOutput, Does.Contain("Cache enrollment credentials could not be resolved."))
+                            Assert.That(snapshot root = beforePartialM2m, Is.True)
+
+                            Assert.That(
+                                (requests.ToArray()
+                                 |> Array.map (fun request -> request.Path) = [|
+                                    "/oauth/device/code"
+                                    "/oauth/token"
+                                |]),
+                                Is.True,
+                                "Invalid PAT fell through to the real interactive credential or enrollment transport."
+                            )
+
+                            assertRedacted normalOutput (Array.append (protectedValues root) [| "invalid-pat-with-keyring-secret" |])
+                            assertRedacted jsonOutput (Array.append (protectedValues root) [| "invalid-pat-with-keyring-secret" |]))
 
                         withCredentialEnvironment
                             [

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -3,13 +3,24 @@ namespace Grace.CLI.Tests
 open Grace.Cache
 open Grace.CLI
 open Grace.CLI.Command
+open Grace.SDK
+open Grace.Shared
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open NodaTime
 open NUnit.Framework
 open Spectre.Console
 open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+open System.Diagnostics
 open System.IO
 open System.Net
 open System.Net.Sockets
 open System.Text.Json
+open System.Text
+open System.Threading
+open System.Threading.Tasks
 
 /// Covers serialized root-command behavior for pure local Cache status.
 [<TestFixture>]
@@ -34,6 +45,296 @@ module CacheCliTests =
         finally
             Console.SetOut(originalOut)
             setAnsiConsoleOutput originalOut
+
+    /// Runs an enrollment command through the single production root graph with controlled Cache collaborators.
+    let private runEnrollment (dependencies: CacheCommand.Dependencies) (args: string array) (cancellationToken: CancellationToken) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let rootDependencies: GraceCommand.RootDependencies =
+                {
+                    CreateCacheCommand = (fun () -> CacheCommand.create dependencies)
+                    InitializeExecution = (fun () -> ())
+                    AfterCommandExit = (fun _ -> Task.FromResult(()))
+                }
+
+            let exitCode =
+                GraceCommand.run rootDependencies args cancellationToken
+                |> fun invocation -> invocation.GetAwaiter().GetResult()
+
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    /// Supplies the closed Product V1 enrollment grammar with a local HTTP endpoint used by root-dispatch tests.
+    let private enrollmentArguments =
+        [|
+            "--output"
+            "Json"
+            "cache"
+            "enroll"
+            "--owner-id"
+            "22222222-2222-2222-2222-222222222222"
+            "--organization-id"
+            "33333333-3333-3333-3333-333333333333"
+            "--repository"
+            "33333333-3333-3333-3333-333333333333/44444444-4444-4444-4444-444444444444"
+            "--endpoint"
+            "http://cache.example.test"
+            "--allow-http"
+        |]
+
+    /// Produces the strictly accepted response corresponding to the exact staged request.
+    let private acceptedResponse (request: CacheEnrollmentRequest) =
+        let now = SystemClock.Instance.GetCurrentInstant()
+
+        let registration =
+            {
+                Class = nameof CacheRegistration
+                CacheId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+                DisplayName = request.DisplayName
+                BoundaryKind = request.BoundaryKind
+                OwnerId = request.OwnerId
+                OrganizationId = request.OrganizationId
+                RepositoryScopes = request.RepositoryScopes |> Seq.toArray
+                PublicKey = request.PublicKey
+                Endpoint = request.Endpoint
+                AllowHttpEndpoint = request.AllowHttpEndpoint
+                Health = CacheHealthStatus.Unhealthy
+                SoftwareVersion = request.SoftwareVersion
+                ProtocolVersion = request.ProtocolVersion
+                PrefetchSupported = request.PrefetchSupported
+                EnrolledBy = "cache-test"
+                EnrolledAt = now
+                LastRefreshedAt = now
+                RefreshAfter = now.Plus(Duration.FromHours(1))
+                ExpiresAt = now.Plus(Duration.FromHours(2))
+                RevokedAt = None
+            }
+
+        CacheRegistrationResult.Create(CacheRegistrationRefreshStatus.Enrolled, Some registration, "enrolled")
+        |> fun result -> GraceReturnValue.Create result "cache-test-correlation"
+
+    /// Supplies deterministic enrollment collaborators while retaining the production Cache command and root graph.
+    let private enrollmentDependencies root resolveBearer sendEnrollment onPhase commitReady : CacheCommand.Dependencies =
+        { StateRoot = root; ResolveBearer = resolveBearer; SendEnrollment = sendEnrollment; CommitReady = commitReady; OnPhase = onPhase }
+
+    /// Captures a loopback request made by the production credential and selected-server transport path.
+    type private EnrollmentRequest = { Method: string; Path: string; Authorization: string option; Body: string }
+
+    /// Runs the production Cache collaborators through the sole root construction and run entry points.
+    let private runProductionEnrollment (args: string array) =
+        use writer = new StringWriter()
+        let originalOut = Console.Out
+
+        try
+            Console.SetOut(writer)
+            setAnsiConsoleOutput writer
+
+            let exitCode =
+                GraceCommand.run (GraceCommand.productionDependencies ()) args CancellationToken.None
+                |> fun invocation -> invocation.GetAwaiter().GetResult()
+
+            exitCode, writer.ToString()
+        finally
+            Console.SetOut(originalOut)
+            setAnsiConsoleOutput originalOut
+
+    /// Reads a complete loopback HTTP request including fixed-length and chunked request bodies.
+    let private readEnrollmentRequest (client: TcpClient) =
+        task {
+            let stream = client.GetStream()
+            use reader = new StreamReader(stream, Encoding.UTF8, false, 4096, true)
+            let! requestLine = reader.ReadLineAsync()
+
+            if String.IsNullOrWhiteSpace(requestLine) then
+                return { Method = String.Empty; Path = String.Empty; Authorization = None; Body = String.Empty }
+            else
+                let parts = requestLine.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                let headers = Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                let mutable header = reader.ReadLine()
+
+                while not (String.IsNullOrEmpty(header)) do
+                    let separator = header.IndexOf(':')
+
+                    if separator > 0 then
+                        headers[header.Substring(0, separator).Trim()] <- header.Substring(separator + 1).Trim()
+
+                    header <- reader.ReadLine()
+
+                let readCharacters count =
+                    task {
+                        let characters = Array.zeroCreate<char> count
+                        let mutable offset = 0
+
+                        while offset < count do
+                            let! read = reader.ReadAsync(characters, offset, count - offset)
+
+                            if read = 0 then
+                                failwith "The loopback responder received an incomplete request body."
+
+                            offset <- offset + read
+
+                        return String(characters)
+                    }
+
+                let contentLength =
+                    match headers.TryGetValue("Content-Length") with
+                    | true, value ->
+                        match Int32.TryParse(value) with
+                        | true, length when length > 0 -> length
+                        | _ -> 0
+                    | false, _ -> 0
+
+                let readChunkedBody () =
+                    task {
+                        let body = StringBuilder()
+                        let mutable complete = false
+
+                        while not complete do
+                            let! sizeLine = reader.ReadLineAsync()
+                            let sizeText = sizeLine.Split(';', 2)[0]
+
+                            match Int32.TryParse(sizeText, System.Globalization.NumberStyles.HexNumber, System.Globalization.CultureInfo.InvariantCulture) with
+                            | true, size when size > 0 ->
+                                let! chunk = readCharacters size
+                                body.Append(chunk) |> ignore
+                                let! terminator = reader.ReadLineAsync()
+
+                                if not (String.IsNullOrEmpty(terminator)) then
+                                    failwith "The loopback responder received an invalid chunk terminator."
+                            | true, 0 ->
+                                let! terminator = reader.ReadLineAsync()
+
+                                if not (String.IsNullOrEmpty(terminator)) then
+                                    failwith "The loopback responder received unsupported chunk trailers."
+
+                                complete <- true
+                            | _ -> failwith "The loopback responder received an invalid chunk size."
+
+                        return body.ToString()
+                    }
+
+                let isChunked =
+                    match headers.TryGetValue("Transfer-Encoding") with
+                    | true, value -> value.Contains("chunked", StringComparison.OrdinalIgnoreCase)
+                    | false, _ -> false
+
+                let! body =
+                    if contentLength > 0 then readCharacters contentLength
+                    elif isChunked then readChunkedBody ()
+                    else Task.FromResult(String.Empty)
+
+                return
+                    {
+                        Method = if parts.Length > 0 then parts[0] else String.Empty
+                        Path = if parts.Length > 1 then parts[1] else String.Empty
+                        Authorization =
+                            match headers.TryGetValue("Authorization") with
+                            | true, value -> Some value
+                            | false, _ -> None
+                        Body = body
+                    }
+        }
+
+    /// Writes one HTTP response without redirect following or additional server requests.
+    let private writeEnrollmentResponse (client: TcpClient) (statusCode: int) (body: string) =
+        task {
+            use stream = client.GetStream()
+            let bytes = Encoding.UTF8.GetBytes(body)
+
+            let status =
+                if statusCode = 200 then "OK"
+                elif statusCode = 302 then "Found"
+                else "Bad Request"
+
+            let headers =
+                $"HTTP/1.1 {statusCode} {status}\r\nContent-Type: application/json\r\nContent-Length: {bytes.Length}\r\nConnection: close\r\n\r\n"
+                |> Encoding.ASCII.GetBytes
+
+            do! stream.WriteAsync(headers, 0, headers.Length)
+            do! stream.WriteAsync(bytes, 0, bytes.Length)
+        }
+
+    /// Hosts one selected server and its OAuth endpoints for real production-credential root-dispatch tests.
+    let private withProductionEnrollmentServer (action: Uri -> ConcurrentQueue<EnrollmentRequest> -> unit) =
+        use listener = new TcpListener(IPAddress.Loopback, 0)
+        use cancellation = new CancellationTokenSource()
+        let requests = ConcurrentQueue<EnrollmentRequest>()
+        listener.Start()
+        let serverUri = Uri($"http://127.0.0.1:{(listener.LocalEndpoint :?> IPEndPoint).Port}")
+
+        let rec serve () =
+            task {
+                if not cancellation.IsCancellationRequested then
+                    try
+                        let! client =
+                            listener
+                                .AcceptTcpClientAsync(cancellation.Token)
+                                .AsTask()
+
+                        use client = client
+                        let! request = readEnrollmentRequest client
+                        requests.Enqueue(request)
+
+                        let response =
+                            match request.Path with
+                            | "/oauth/device/code" ->
+                                200,
+                                "{\"device_code\":\"cache-device-code\",\"user_code\":\"CACHE\",\"verification_uri\":\""
+                                + serverUri.AbsoluteUri
+                                + "\",\"expires_in\":120,\"interval\":1}"
+                            | "/oauth/token" when request.Body.Contains("device_code", StringComparison.Ordinal) ->
+                                200,
+                                "{\"access_token\":\"interactive-access-token\",\"refresh_token\":\"interactive-refresh-token\",\"expires_in\":3600,\"scope\":\"openid offline_access\",\"token_type\":\"Bearer\"}"
+                            | "/oauth/token" -> 200, "{\"access_token\":\"m2m-access-token\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+                            | "/cache/enroll" ->
+                                let enrollment = JsonSerializer.Deserialize<CacheEnrollmentRequest>(request.Body, Constants.JsonSerializerOptions)
+
+                                let body =
+                                    acceptedResponse enrollment
+                                    |> fun result -> JsonSerializer.Serialize(result, Constants.JsonSerializerOptions)
+
+                                200, body
+                            | _ -> 400, "{\"error\":\"unexpected_request\"}"
+
+                        do! writeEnrollmentResponse client (fst response) (snd response)
+                        return! serve ()
+                    with
+                    | :? OperationCanceledException
+                    | :? ObjectDisposedException -> return ()
+            }
+
+        let serverTask = Task.Run(Func<Task>(fun () -> serve ()))
+
+        try
+            action serverUri requests
+        finally
+            cancellation.Cancel()
+            listener.Stop()
+
+            serverTask.Wait(TimeSpan.FromSeconds(5.0))
+            |> ignore
+
+    /// Applies isolated producer settings so a root-dispatch test uses exactly the requested credential mechanism.
+    let private withCredentialEnvironment (values: (string * string option) list) (action: unit -> 'T) =
+        let originalValues =
+            values
+            |> List.map (fun (name, _) -> name, Environment.GetEnvironmentVariable(name))
+
+        try
+            values
+            |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value |> Option.toObj))
+
+            action ()
+        finally
+            originalValues
+            |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value))
 
     /// Runs an action with one temporary environment variable value.
     let private withEnv (name: string) (value: string option) (action: unit -> 'T) =
@@ -211,7 +512,9 @@ module CacheCliTests =
             CacheCommand.setStateRootForTests root
             Environment.CurrentDirectory <- repositoryRoot
 
-            withEnv "USERPROFILE" (Some home) (fun () -> withEnv "HOME" (Some home) (fun () -> action root repositoryRoot))
+            withEnv "USERPROFILE" (Some home) (fun () ->
+                withEnv "HOME" (Some home) (fun () ->
+                    withEnv Constants.EnvironmentVariables.GraceServerUri (Some "http://127.0.0.1:9") (fun () -> action root repositoryRoot)))
         finally
             Environment.CurrentDirectory <- originalDirectory
             CacheCommand.resetStateRootForTests ()
@@ -602,3 +905,494 @@ module CacheCliTests =
                     .GetArrayLength(),
                 Is.GreaterThanOrEqualTo(3)
             ))
+
+    /// Proves the enrolled result is committed once and rendered through every supported output mode and selector.
+    [<Test>]
+    let ``Linux cache enroll commits one accepted root-dispatch attempt and renders every output mode`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        for mode in
+            [
+                "Normal"
+                "Minimal"
+                "Silent"
+                "Verbose"
+                "Json"
+            ] do
+            withRoot (fun root _ ->
+                let mutable bearerCount = 0
+                let mutable postCount = 0
+
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        (fun _ ->
+                            bearerCount <- bearerCount + 1
+                            Task.FromResult(Ok "pat-test-token"))
+                        (fun request _ bearer _ _ ->
+                            postCount <- postCount + 1
+                            Assert.That(bearer, Is.EqualTo("pat-test-token"))
+                            Task.FromResult(Accepted(acceptedResponse request)))
+                        (fun _ -> Task.FromResult(()))
+                        CacheIdentity.commitClaimedReady
+
+                let arguments = Array.copy enrollmentArguments
+                arguments[1] <- mode
+                let exitCode, output = runEnrollment dependencies arguments CancellationToken.None
+                Assert.That(exitCode, Is.EqualTo(0), $"{mode}: {output}")
+                Assert.That(bearerCount, Is.EqualTo(1))
+                Assert.That(postCount, Is.EqualTo(1))
+                Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled"))
+
+                match mode with
+                | "Normal" -> Assert.That(output, Does.Contain("Enrollment: enrolled"))
+                | "Verbose" -> Assert.That(output, Does.Contain("Enrollment: enrolled"))
+                | "Json" ->
+                    use document = JsonDocument.Parse(output)
+
+                    Assert.That(
+                        document
+                            .RootElement
+                            .GetProperty("ReturnValue")
+                            .GetProperty("Enrollment")
+                            .GetString(),
+                        Is.EqualTo("enrolled")
+                    )
+                | "Minimal"
+                | "Silent" -> Assert.That(output, Is.Empty)
+                | _ -> Assert.Fail($"Unsupported output mode {mode}")
+
+                let rootWithSelector = Path.Combine(Path.GetTempPath(), $"grace-cache-select-{Guid.NewGuid():N}")
+
+                Directory.CreateDirectory(rootWithSelector)
+                |> ignore
+
+                try
+                    File.SetUnixFileMode(
+                        rootWithSelector,
+                        UnixFileMode.UserRead
+                        ||| UnixFileMode.UserWrite
+                        ||| UnixFileMode.UserExecute
+                    )
+
+                    let selectorDependencies = { dependencies with StateRoot = rootWithSelector }
+                    let selectorArguments = Array.append arguments [| "--select"; "Enrollment" |]
+                    let selectedExit, selectedOutput = runEnrollment selectorDependencies selectorArguments CancellationToken.None
+                    Assert.That(selectedExit, Is.EqualTo(0), $"{mode} selector: {selectedOutput}")
+                    Assert.That(selectedOutput.Trim(), Is.EqualTo("\"enrolled\""))
+                finally
+                    if Directory.Exists(rootWithSelector) then
+                        Directory.Delete(rootWithSelector, true))
+
+    /// Proves credential failures happen before a protected claim, staged key, or POST and leave a prior ready state unchanged.
+    [<Test>]
+    let ``Linux cache enroll rejects missing and failed credentials before effects`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        for credentialResult in
+            [
+                Error "Authentication required."
+                Ok ""
+            ] do
+            withRoot (fun root _ ->
+                let before = snapshot root
+                let mutable postCount = 0
+
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        (fun _ -> Task.FromResult(credentialResult))
+                        (fun _ _ _ _ _ ->
+                            postCount <- postCount + 1
+                            Task.FromResult(Rejected(GraceError.Create "Unexpected POST." "cache-test")))
+                        (fun _ -> Task.FromResult(()))
+                        CacheIdentity.commitClaimedReady
+
+                let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+                Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                Assert.That(postCount, Is.EqualTo(0))
+                Assert.That(snapshot root = before, Is.True)
+                Assert.That(output, Does.Not.Contain("identity.pk8")))
+
+        withRoot (fun root _ ->
+            createReady root |> ignore
+            let before = snapshot root
+            let mutable bearerCount = 0
+            let mutable postCount = 0
+
+            let dependencies =
+                enrollmentDependencies
+                    root
+                    (fun _ ->
+                        bearerCount <- bearerCount + 1
+                        Task.FromResult(Error "Authentication required."))
+                    (fun _ _ _ _ _ ->
+                        postCount <- postCount + 1
+                        Task.FromResult(Rejected(GraceError.Create "Unexpected POST." "cache-test")))
+                    (fun _ -> Task.FromResult(()))
+                    CacheIdentity.commitClaimedReady
+
+            let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+            Assert.That(bearerCount, Is.EqualTo(0))
+            Assert.That(postCount, Is.EqualTo(0))
+            Assert.That(snapshot root = before, Is.True))
+
+    /// Proves cancellation before transport is truthful and removes the staged attempt without issuing a request.
+    [<Test>]
+    let ``Linux cache enroll cancellation phases clean local state before transport`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let runCancelled phase =
+            withRoot (fun root _ ->
+                use cancellation = new CancellationTokenSource()
+                let before = snapshot root
+                let mutable postCount = 0
+
+                let resolveBearer (cancellationToken: CancellationToken) =
+                    if phase = "credential" then
+                        task {
+                            do! Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                            return Ok "not-reached"
+                        }
+                    else
+                        Task.FromResult(Ok "phase-token")
+
+                let onPhase current =
+                    if (phase = "before-claim"
+                        && current = CacheCommand.EnrollmentPhase.CredentialResolved)
+                       || (phase = "after-staging"
+                           && current = CacheCommand.EnrollmentPhase.AttemptStaged) then
+                        cancellation.Cancel()
+
+                    Task.FromResult(())
+
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        resolveBearer
+                        (fun _ _ _ _ _ ->
+                            postCount <- postCount + 1
+                            Task.FromResult(Rejected(GraceError.Create "Unexpected POST." "cache-test")))
+                        onPhase
+                        CacheIdentity.commitClaimedReady
+
+                if phase = "credential" then cancellation.Cancel()
+
+                let exitCode, output = runEnrollment dependencies enrollmentArguments cancellation.Token
+                Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                Assert.That(output, Does.Contain("cancelled"))
+                Assert.That(postCount, Is.EqualTo(0))
+                Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False))
+
+        runCancelled "credential"
+        runCancelled "before-claim"
+        runCancelled "after-staging"
+
+    /// Proves terminal definite and indeterminate transport outcomes do not retry or publish ready state.
+    [<Test>]
+    let ``Linux cache enroll preserves truthful state for rejected indeterminate and malformed responses`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let cases =
+            [
+                "rejected", (fun (_: CacheEnrollmentRequest) -> Rejected(GraceError.Create "Selected server rejected enrollment." "cache-test"))
+                "indeterminate", (fun _ -> Indeterminate(GraceError.Create "Cache enrollment outcome is unknown after transport started." "cache-test"))
+                "malformed",
+                fun request ->
+                    let accepted = acceptedResponse request
+                    Accepted { accepted with ReturnValue = { accepted.ReturnValue with Class = "UnexpectedResult" } }
+            ]
+
+        for name, makeOutcome in cases do
+            withRoot (fun root _ ->
+                let mutable postCount = 0
+
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        (fun _ -> Task.FromResult(Ok "transport-token"))
+                        (fun request _ _ _ _ ->
+                            postCount <- postCount + 1
+                            Task.FromResult(makeOutcome request))
+                        (fun _ -> Task.FromResult(()))
+                        CacheIdentity.commitClaimedReady
+
+                let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+                Assert.That(exitCode, Is.Not.EqualTo(0), $"{name}: {output}")
+                Assert.That(postCount, Is.EqualTo(1), $"{name} retried transport.")
+                Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                Assert.That(File.Exists(Path.Combine(root, "enrollment.claim")), Is.True))
+
+    /// Proves an accepted response cannot report ready state when the final local publication fails.
+    [<Test>]
+    let ``Linux cache enroll removes the attempt when ready publication fails`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            let mutable postCount = 0
+
+            let dependencies =
+                enrollmentDependencies
+                    root
+                    (fun _ -> Task.FromResult(Ok "commit-token"))
+                    (fun request _ _ _ _ ->
+                        postCount <- postCount + 1
+                        Task.FromResult(Accepted(acceptedResponse request)))
+                    (fun _ -> Task.FromResult(()))
+                    (fun _ _ _ -> Error CacheIdentityError.StateUnavailable)
+
+            let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+            Assert.That(exitCode, Is.Not.EqualTo(0), output)
+            Assert.That(postCount, Is.EqualTo(1))
+            Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+            Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+            Assert.That(File.Exists(Path.Combine(root, "enrollment.claim")), Is.True))
+
+    /// Proves the selected-server SDK transport rejects one redirect response without following it or publishing ready state.
+    [<Test>]
+    let ``Linux cache enroll rejects a selected-server redirect without a second POST`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            use listener = new TcpListener(IPAddress.Loopback, 0)
+            listener.Start()
+            let serverUri = Uri($"http://127.0.0.1:{(listener.LocalEndpoint :?> IPEndPoint).Port}")
+            let received = TaskCompletionSource<EnrollmentRequest>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+            let serverTask =
+                Task.Run(
+                    Func<Task> (fun () ->
+                        task {
+                            let! client = listener.AcceptTcpClientAsync()
+                            use client = client
+                            let! request = readEnrollmentRequest client
+                            received.TrySetResult(request) |> ignore
+                            do! writeEnrollmentResponse client 302 "{\"redirect\":true}"
+                        })
+                )
+
+            try
+                let dependencies =
+                    enrollmentDependencies
+                        root
+                        (fun _ -> Task.FromResult(Ok "redirect-token"))
+                        (fun request _ bearer correlationId cancellationToken ->
+                            CacheRegistration.Enroll(request, serverUri, bearer, correlationId, cancellationToken))
+                        (fun _ -> Task.FromResult(()))
+                        CacheIdentity.commitClaimedReady
+
+                let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+                Assert.That(exitCode, Is.Not.EqualTo(0), output)
+                let request = received.Task.GetAwaiter().GetResult()
+                Assert.That(request.Method, Is.EqualTo("POST"))
+                Assert.That(request.Path, Is.EqualTo("/cache/enroll"))
+                Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
+                Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                Assert.That(serverTask.Wait(TimeSpan.FromSeconds(5.0)), Is.True)
+            finally
+                listener.Stop())
+
+    /// Proves PAT and M2M credential producers each supply one bearer to the selected server through the production root graph.
+    [<Test>]
+    let ``Linux cache enroll uses production PAT and machine credentials exactly once`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        let clearInteractive =
+            [
+                Constants.EnvironmentVariables.GraceTokenFile, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliClientId, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                Constants.EnvironmentVariables.GraceAuthOidcCliScopes, None
+            ]
+
+        let assertSingleEnrollment expectedBearer (requests: ConcurrentQueue<EnrollmentRequest>) =
+            let enrollmentRequests =
+                requests.ToArray()
+                |> Array.filter (fun request -> request.Path = "/cache/enroll")
+
+            Assert.That(enrollmentRequests.Length, Is.EqualTo(1))
+            Assert.That(enrollmentRequests[0].Method, Is.EqualTo("POST"))
+            Assert.That(enrollmentRequests[0].Authorization, Is.EqualTo(Some $"Bearer {expectedBearer}"))
+
+        let pat = Grace.Types.PersonalAccessToken.formatToken "cache-test-user" (Guid.NewGuid()) (Array.zeroCreate 32)
+
+        withRoot (fun root _ ->
+            withProductionEnrollmentServer (fun serverUri requests ->
+                withCredentialEnvironment
+                    ([
+                        Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceToken, Some pat
+                        Constants.EnvironmentVariables.GraceAuthOidcAuthority, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                     ]
+                     @ clearInteractive)
+                    (fun () ->
+                        let exitCode, output = runProductionEnrollment enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        assertSingleEnrollment pat requests
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled")))))
+
+        withRoot (fun root _ ->
+            withProductionEnrollmentServer (fun serverUri requests ->
+                withCredentialEnvironment
+                    ([
+                        Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceToken, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, Some "cache-m2m-client"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, Some "cache-m2m-secret"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, Some "cache.enroll"
+                     ]
+                     @ clearInteractive)
+                    (fun () ->
+                        let exitCode, output = runProductionEnrollment enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        assertSingleEnrollment "m2m-access-token" requests
+
+                        let paths =
+                            requests.ToArray()
+                            |> Array.map (fun request -> request.Path)
+
+                        Assert.That((paths = [| "/oauth/token"; "/cache/enroll" |]), Is.True)
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled")))))
+
+    /// Proves the normal-build holder owns the protected enrollment claim until its exact process is killed and joined.
+    [<Test>]
+    let ``Linux claim holder blocks enrollment claim then releases a retry`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Claim-holder process proof requires Linux protected-root semantics.")
+
+        withRoot (fun root _ ->
+            let holder =
+                Path.GetFullPath(
+                    Path.Combine(
+                        AppContext.BaseDirectory,
+                        "..",
+                        "..",
+                        "..",
+                        "..",
+                        "Grace.CLI.CacheEnrollment.ClaimHolder",
+                        "bin",
+                        "Release",
+                        "net10.0",
+                        "Grace.CLI.CacheEnrollment.ClaimHolder.dll"
+                    )
+                )
+
+            Assert.That(File.Exists(holder), Is.True, "The normal build did not produce the Cache enrollment claim holder.")
+            let signalPath = Path.Combine(Path.GetTempPath(), $"grace-cache-holder-{Guid.NewGuid():N}")
+            use holderProcess = new Process()
+            holderProcess.StartInfo.FileName <- "dotnet"
+            holderProcess.StartInfo.UseShellExecute <- false
+            holderProcess.StartInfo.CreateNoWindow <- true
+            holderProcess.StartInfo.ArgumentList.Add(holder)
+            holderProcess.StartInfo.ArgumentList.Add(root)
+            holderProcess.StartInfo.ArgumentList.Add(signalPath)
+
+            try
+                Assert.That(holderProcess.Start(), Is.True)
+                let deadline = DateTime.UtcNow.AddSeconds(10.0)
+
+                while not (File.Exists(signalPath))
+                      && DateTime.UtcNow < deadline do
+                    Thread.Sleep(50)
+
+                Assert.That(File.Exists(signalPath), Is.True, "The holder did not acquire the production claim.")
+
+                match CacheIdentity.tryAcquireEnrollmentClaim root with
+                | Error CacheIdentityError.StateUnavailable -> ()
+                | Error error -> Assert.Fail($"Expected a conflicting claim failure, received {error}.")
+                | Ok claim ->
+                    CacheIdentity.releaseEnrollmentClaim claim
+                    Assert.Fail("A second process acquired the claim while the holder was live.")
+
+                holderProcess.Kill()
+                Assert.That(holderProcess.WaitForExit(10000), Is.True, "The exact claim-holder process did not exit.")
+
+                let retry =
+                    CacheIdentity.tryAcquireEnrollmentClaim root
+                    |> requireOk
+
+                CacheIdentity.releaseEnrollmentClaim retry
+            finally
+                if not holderProcess.HasExited then
+                    holderProcess.Kill()
+                    holderProcess.WaitForExit(10000) |> ignore
+
+                if File.Exists(signalPath) then File.Delete(signalPath))
+
+    /// Proves the Linux libsecret-backed interactive credential is read from the real GNOME keyring before one enrollment POST.
+    [<Test>]
+    let ``Linux cache enroll uses the real GNOME keyring interactive credential once`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        if
+            Environment.GetEnvironmentVariable("GRACE_TEST_LINUX_KEYRING")
+            <> "1"
+        then
+            Assert.Ignore("This proof requires the D-Bus and GNOME keyring session configured by validate.yml.")
+
+        withRoot (fun root _ ->
+            withProductionEnrollmentServer (fun serverUri requests ->
+                withCredentialEnvironment
+                    [
+                        Constants.EnvironmentVariables.GraceServerUri, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceToken, None
+                        Constants.EnvironmentVariables.GraceTokenFile, None
+                        Constants.EnvironmentVariables.GraceAuthOidcAuthority, Some serverUri.AbsoluteUri
+                        Constants.EnvironmentVariables.GraceAuthOidcAudience, Some "https://grace.test/api"
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientId, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mClientSecret, None
+                        Constants.EnvironmentVariables.GraceAuthOidcM2mScopes, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliClientId, Some "cache-interactive-client"
+                        Constants.EnvironmentVariables.GraceAuthOidcCliRedirectPort, None
+                        Constants.EnvironmentVariables.GraceAuthOidcCliScopes, Some "openid offline_access"
+                    ]
+                    (fun () ->
+                        let loginExit, loginOutput =
+                            runProductionEnrollment [| "authenticate"
+                                                       "login"
+                                                       "--auth"
+                                                       "device" |]
+
+                        Assert.That(loginExit, Is.EqualTo(0), loginOutput)
+                        let exitCode, output = runProductionEnrollment enrollmentArguments
+                        Assert.That(exitCode, Is.EqualTo(0), output)
+                        let requests = requests.ToArray()
+
+                        let enrollments =
+                            requests
+                            |> Array.filter (fun request -> request.Path = "/cache/enroll")
+
+                        Assert.That(enrollments.Length, Is.EqualTo(1))
+                        Assert.That(enrollments[0].Authorization, Is.EqualTo(Some "Bearer interactive-access-token"))
+
+                        let paths =
+                            requests
+                            |> Array.map (fun request -> request.Path)
+
+                        Assert.That(
+                            (paths = [|
+                                "/oauth/device/code"
+                                "/oauth/token"
+                                "/cache/enroll"
+                            |]),
+                            Is.True
+                        )
+
+                        Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled")))))

--- a/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Cache.CLI.Tests.fs
@@ -1175,6 +1175,48 @@ module CacheCliTests =
         runCancelled "before-claim"
         runCancelled "after-staging"
 
+    /// Proves an attempt created before its key write is reclaimed only after this root command holds the exclusive claim.
+    [<Test>]
+    let ``Linux cache enroll recovers an incomplete stale attempt only after its claim`` () =
+        if not (OperatingSystem.IsLinux()) then
+            Assert.Ignore("Cache enrollment Product V1 supports Linux only.")
+
+        withRoot (fun root _ ->
+            let attempt = Path.Combine(root, "attempt")
+            Directory.CreateDirectory(attempt) |> ignore
+
+            File.SetUnixFileMode(
+                attempt,
+                UnixFileMode.UserRead
+                ||| UnixFileMode.UserWrite
+                ||| UnixFileMode.UserExecute
+            )
+
+            let mutable postCount = 0
+            let mutable attemptExistedBeforeClaim = false
+
+            let dependencies =
+                enrollmentDependencies
+                    root
+                    (fun _ -> Task.FromResult(Ok "stale-attempt-token"))
+                    (fun request _ _ _ _ ->
+                        postCount <- postCount + 1
+                        Task.FromResult(Accepted(acceptedResponse request)))
+                    (fun phase ->
+                        if phase = CacheCommand.EnrollmentPhase.CredentialResolved then
+                            attemptExistedBeforeClaim <- Directory.Exists(attempt)
+
+                        Task.FromResult(()))
+                    CacheIdentity.commitClaimedReady
+
+            let exitCode, output = runEnrollment dependencies enrollmentArguments CancellationToken.None
+            Assert.That(exitCode, Is.EqualTo(0), output)
+            Assert.That(attemptExistedBeforeClaim, Is.True, "Preflight deleted the incomplete attempt before its claim.")
+            Assert.That(postCount, Is.EqualTo(1))
+            Assert.That(Directory.Exists(attempt), Is.False)
+            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("enrolled"))
+            assertRedacted output (Array.append (protectedValues root) [| "stale-attempt-token" |]))
+
     /// Proves terminal definite and indeterminate transport outcomes do not retry or publish ready state.
     [<Test>]
     let ``Linux cache enroll preserves truthful state for rejected indeterminate and malformed responses`` () =
@@ -1611,7 +1653,7 @@ module CacheCliTests =
                         assertRedactedError exitCode output
                         assertRedacted output (Array.append (protectedValues root) [| "lost-claim-token" |]))))
 
-    /// Proves an actual protected local registration write failure remains non-ready and cleans only the staged attempt.
+    /// Proves a real claimed registration-file collision after acceptance stays non-ready and cleans only this staged attempt.
     [<Test>]
     let ``Linux cache enroll handles a real protected local write failure`` () =
         if not (OperatingSystem.IsLinux()) then
@@ -1639,7 +1681,9 @@ module CacheCliTests =
                                     CacheRegistration.Enroll(request, uri, bearer, correlationId, cancellationToken))
                                 (fun phase ->
                                     if phase = CacheCommand.EnrollmentPhase.BeforeReadyCommit then
-                                        File.SetUnixFileMode(Path.Combine(root, "attempt"), UnixFileMode.UserRead ||| UnixFileMode.UserExecute)
+                                        let registration = Path.Combine(root, "attempt", "registration.json")
+                                        File.WriteAllText(registration, "foreign-registration")
+                                        File.SetUnixFileMode(registration, UnixFileMode.UserRead ||| UnixFileMode.UserWrite)
 
                                     Task.FromResult(()))
                                 CacheIdentity.commitClaimedReady
@@ -1653,7 +1697,7 @@ module CacheCliTests =
                         Assert.That(request.Authorization, Is.EqualTo(Some "Bearer local-write-token"))
                         Assert.That((CacheIdentity.status root).Enrollment, Is.Not.EqualTo("enrolled"))
                         Assert.That(Directory.Exists(Path.Combine(root, "ready")), Is.False)
-                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False)
+                        Assert.That(Directory.Exists(Path.Combine(root, "attempt")), Is.False, "Best-effort cleanup did not remove the claimed attempt.")
                         assertRedactedError exitCode output
                         assertRedacted output (Array.append (protectedValues root) [| "local-write-token" |]))))
 
@@ -1720,7 +1764,7 @@ module CacheCliTests =
                         (fun () ->
                             let exitCode, output = runProductionEnrollment modeArguments
                             Assert.That(exitCode, Is.Not.EqualTo(0), output)
-                            Assert.That(output, Does.Contain("Machine-to-machine authentication failed."))
+                            Assert.That(output, Does.Contain("Cache enrollment credentials could not be resolved."))
                             Assert.That(requests.Count, Is.EqualTo(1))
                             let request = requests.ToArray()[0]
                             Assert.That(request.Method, Is.EqualTo("POST"))
@@ -1952,8 +1996,8 @@ module CacheCliTests =
                                 let jsonExit, jsonOutput = runProductionEnrollment enrollmentArguments
                                 Assert.That(normalExit, Is.Not.EqualTo(0), normalOutput)
                                 Assert.That(jsonExit, Is.Not.EqualTo(0), jsonOutput)
-                                Assert.That(normalOutput, Does.Contain("Machine-to-machine authentication configuration is incomplete."))
-                                Assert.That(jsonOutput, Does.Contain("Machine-to-machine authentication configuration is incomplete."))
+                                Assert.That(normalOutput, Does.Contain("Cache enrollment credentials could not be resolved."))
+                                Assert.That(jsonOutput, Does.Contain("Cache enrollment credentials could not be resolved."))
                                 Assert.That(snapshot root = beforePartialM2m, Is.True)
 
                                 assertRedacted

--- a/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/CommandOutputContract.CLI.Tests.fs
@@ -134,12 +134,27 @@ module CommandOutputContractRegistryTests =
     let private auditParseArgs (entry: CommandContractEntry) =
         let commandPath = entry.Identity.CommandPath |> List.toArray
 
-        [|
-            yield "--output"
-            yield "Json"
-            yield! commandPath
-            yield! auditPlaceholderArgs entry
-        |]
+        match entry.Identity.CommandId with
+        | "cache.enroll" ->
+            [|
+                "--output"
+                "Json"
+                "cache"
+                "enroll"
+                "--owner-id"
+                "11111111-1111-1111-1111-111111111111"
+                "--repository"
+                "22222222-2222-2222-2222-222222222222/33333333-3333-3333-3333-333333333333"
+                "--endpoint"
+                "https://cache.example.test"
+            |]
+        | _ ->
+            [|
+                yield "--output"
+                yield "Json"
+                yield! commandPath
+                yield! auditPlaceholderArgs entry
+            |]
 
     /// Counts by for test assertions.
     let private countBy behavior =
@@ -239,16 +254,16 @@ module CommandOutputContractRegistryTests =
     [<Test>]
     let ``registry contains accepted inventory totals`` () =
         CommandOutputContract.entries.Length
-        |> should equal 207
+        |> should equal 208
 
         CommandOutputContract.routedEntries.Length
-        |> should equal 198
+        |> should equal 199
 
         CommandOutputContract.sourceOnlyEntries.Length
         |> should equal 9
 
         countBy CommonRenderOutputEnvelope
-        |> should equal 186
+        |> should equal 187
 
         countBy ImmediateJsonErrorOnly |> should equal 1
 
@@ -290,7 +305,7 @@ module CommandOutputContractRegistryTests =
 
         let deleted = 0
 
-        jsonReady |> should equal 186
+        jsonReady |> should equal 187
         intentionallyHumanOnly |> should equal 1
         deferredV2 |> should equal 11
         sourceOnly |> should equal 9
@@ -467,7 +482,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 186
+        commonEntries.Length |> should equal 187
 
         for entry in commonEntries do
             match entry.EnvelopeContract with
@@ -486,7 +501,7 @@ module CommandOutputContractRegistryTests =
             CommandOutputContract.entries
             |> List.filter (fun entry -> entry.CurrentJsonBehavior = CommonRenderOutputEnvelope)
 
-        commonEntries.Length |> should equal 186
+        commonEntries.Length |> should equal 187
 
         let parserInvalidEntries =
             commonEntries

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -75,6 +75,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Grace.CLI\Grace.CLI.fsproj" />
+		<ProjectReference Include="..\Grace.CLI.CacheEnrollment.ClaimHolder\Grace.CLI.CacheEnrollment.ClaimHolder.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.CLI.LocalStateDb.Worker\Grace.CLI.LocalStateDb.Worker.fsproj" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\Grace.SDK\Grace.SDK.fsproj" />
 		<ProjectReference Include="..\Grace.Cache\Grace.Cache.fsproj" />

--- a/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Host.Tests.fs
@@ -1,6 +1,7 @@
 namespace Grace.CLI.Tests
 
 open Grace.CLI
+open Grace.CLI.Command
 open Grace.Types.Common
 open NUnit.Framework
 open Spectre.Console
@@ -358,3 +359,30 @@ module ProgramCliHostTests =
         Assert.That(output, Does.Not.Contain("Registry"))
         Assert.That(initializerCalls, Is.EqualTo(0))
         Assert.That(handlerCalls, Is.EqualTo(0))
+
+    /// Requires enrollment introspection to use the production root graph without execution initialization or local effects.
+    [<TestCase("--schema")>]
+    [<TestCase("--examples")>]
+    let ``cache enroll introspection is inert through the production root graph`` introspectionOption =
+        let mutable initializerCalls = 0
+
+        let dependencies: GraceCommand.RootDependencies =
+            {
+                CreateCacheCommand = (fun () -> CacheCommand.Build)
+                InitializeExecution = (fun () -> initializerCalls <- initializerCalls + 1)
+                AfterCommandExit = (fun _ -> Task.FromResult(()))
+            }
+
+        let exitCode, output =
+            runWithCapturedOutput
+                dependencies
+                [|
+                    "cache"
+                    "enroll"
+                    introspectionOption
+                |]
+                CancellationToken.None
+
+        Assert.That(exitCode, Is.EqualTo(0))
+        Assert.That(initializerCalls, Is.EqualTo(0))
+        Assert.That(output, Does.Contain("cache.enroll"))

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -322,8 +322,14 @@ module Auth =
             | None -> return! tryGetOidcCliConfigFromServer correlationId
         }
 
-    /// Tries to map get oidc m2m config and returns a GraceError instead of throwing on unsupported input.
-    let private tryGetOidcM2mConfig () =
+    /// Distinguishes no M2M settings from an unsafe partial M2M configuration before credential fallback is selected.
+    type private OidcM2mConfiguration =
+        | Absent
+        | Partial
+        | Complete of OidcM2mConfig
+
+    /// Reads the required M2M settings while preserving whether the producer was absent or incomplete.
+    let private oidcM2mConfiguration () =
         match tryGetEnv Constants.EnvironmentVariables.GraceAuthOidcAuthority,
               tryGetEnv Constants.EnvironmentVariables.GraceAuthOidcAudience,
               tryGetEnv Constants.EnvironmentVariables.GraceAuthOidcM2mClientId,
@@ -335,7 +341,7 @@ module Auth =
                 | Some raw when not (String.IsNullOrWhiteSpace raw) -> parseScopes raw
                 | _ -> []
 
-            Some
+            Complete
                 {
                     Authority = normalizeAuthority authority
                     Audience = audience.Trim()
@@ -343,7 +349,15 @@ module Auth =
                     ClientSecret = clientSecret
                     Scopes = scopes
                 }
-        | _ -> None
+        | _, _, None, None -> Absent
+        | _ -> Partial
+
+    /// Reads complete OIDC M2M settings for established flows that may fall back to interactive authentication.
+    let private tryGetOidcM2mConfig () =
+        match oidcM2mConfiguration () with
+        | Complete config -> Some config
+        | Absent
+        | Partial -> None
 
     /// Tries to map get grace token from env and returns a GraceError instead of throwing on unsupported input.
     let private tryGetGraceTokenFromEnv () =
@@ -1006,6 +1020,61 @@ module Auth =
                         | Ok (Some cliConfig) ->
                             let! tokenResult = tryGetInteractiveTokenAsync cliConfig
                             return tokenResult
+                        | Error error -> return Error error.Error
+        }
+
+    /// Resolves Cache enrollment credentials without allowing partial M2M settings to fall through to interactive state.
+    let internal tryGetAccessTokenForCacheEnrollment () =
+        task {
+            match tryGetGraceTokenFromEnv () with
+            | Error message -> return Error message
+            | Ok (Some token) -> return Ok(Some token)
+            | Ok None ->
+                match tryGetEnv Constants.EnvironmentVariables.GraceTokenFile with
+                | Some _ ->
+                    return
+                        Error
+                            $"Local token files are no longer supported. Remove {Constants.EnvironmentVariables.GraceTokenFile} and set {Constants.EnvironmentVariables.GraceToken} instead."
+                | None ->
+                    match oidcM2mConfiguration () with
+                    | Partial -> return Error "Machine-to-machine authentication configuration is incomplete."
+                    | Complete m2mConfig ->
+                        let endpoint = buildEndpoint m2mConfig.Authority "oauth/token"
+
+                        let formValues =
+                            [
+                                "grant_type", "client_credentials"
+                                "client_id", m2mConfig.ClientId
+                                "client_secret", m2mConfig.ClientSecret
+                                "audience", m2mConfig.Audience
+                            ]
+                            |> fun values ->
+                                if List.isEmpty m2mConfig.Scopes then
+                                    values
+                                else
+                                    values
+                                    @ [
+                                        "scope", String.Join(" ", m2mConfig.Scopes)
+                                    ]
+
+                        let! response = postFormAsync endpoint formValues
+
+                        match response with
+                        | Ok json ->
+                            match parseTokenResponse json with
+                            | Ok token when not (String.IsNullOrWhiteSpace token.AccessToken) -> return Ok(Some token.AccessToken)
+                            | _ -> return Error "Machine-to-machine authentication failed."
+                        | Error _ -> return Error "Machine-to-machine authentication failed."
+                    | Absent ->
+                        let correlationId = ensureNonEmptyCorrelationId String.Empty
+                        let! cliConfigResult = tryGetOidcCliConfig correlationId
+
+                        match cliConfigResult with
+                        | Ok None ->
+                            return
+                                Error
+                                    $"Authentication is not configured. Set {Constants.EnvironmentVariables.GraceAuthOidcAuthority}, {Constants.EnvironmentVariables.GraceAuthOidcAudience}, and {Constants.EnvironmentVariables.GraceAuthOidcCliClientId} (or provide GRACE_TOKEN / M2M credentials)."
+                        | Ok (Some cliConfig) -> return! tryGetInteractiveTokenAsync cliConfig
                         | Error error -> return Error error.Error
         }
 

--- a/src/Grace.CLI/Command/Auth.CLI.fs
+++ b/src/Grace.CLI/Command/Auth.CLI.fs
@@ -79,6 +79,16 @@ module Auth =
     /// Defines structured data exchanged by CLI helpers.
     type TokenStore = { Helper: MsalCacheHelper; StorageProperties: StorageCreationProperties; LockFilePath: string; InProcessLock: SemaphoreSlim }
 
+    /// Supplies the private credential operations used by Cache enrollment while keeping production wiring and root-dispatch tests aligned.
+    type internal CacheEnrollmentCredentialDependencies =
+        {
+            PostFormAsync: string -> (string * string) list -> Task<Result<string, string>>
+            GetTokenStoreAsync: OidcCliConfig -> Task<TokenStore>
+            VerifyPersistence: TokenStore -> unit
+            WithTokenLock: TokenStore -> (unit -> Task<Result<string option, string>>) -> Task<Result<string option, string>>
+            CurrentInstant: unit -> Instant
+        }
+
     /// Defines structured data exchanged by CLI helpers.
     type AuthStatusGraceTokenSource = { Present: bool option; Valid: bool option; Error: string option }
 
@@ -443,6 +453,17 @@ module Auth =
             | ex -> return Error $"Secure token storage is unavailable: {ex.Message}"
         }
 
+    /// Verifies interactive secure storage through the dependencies selected for Cache enrollment root-dispatch proof.
+    let private verifyCacheEnrollmentSecureStoreAsync (dependencies: CacheEnrollmentCredentialDependencies) (config: OidcCliConfig) =
+        task {
+            try
+                let! store = dependencies.GetTokenStoreAsync config
+                dependencies.VerifyPersistence store
+                return Ok store
+            with
+            | ex -> return Error $"Secure token storage is unavailable: {ex.Message}"
+        }
+
     /// Updates CLI authentication state for with token lock while keeping token handling centralized.
     let private withTokenLock (store: TokenStore) (action: unit -> Task<'T>) =
         task {
@@ -587,6 +608,16 @@ module Auth =
                 else
                     let message = tryReadOAuthError body |> Option.defaultValue body
                     return Error message
+        }
+
+    /// Supplies production credential dependencies without changing the established HTTP, secure-store, lock, or clock behavior.
+    let internal cacheEnrollmentCredentialDependencies () : CacheEnrollmentCredentialDependencies =
+        {
+            PostFormAsync = postFormAsync
+            GetTokenStoreAsync = getTokenStoreAsync
+            VerifyPersistence = fun store -> store.Helper.VerifyPersistence()
+            WithTokenLock = withTokenLock
+            CurrentInstant = getCurrentInstant
         }
 
     /// Tries to map launch browser and returns a GraceError instead of throwing on unsupported input.
@@ -906,7 +937,7 @@ module Auth =
         }
 
     /// Tries to map refresh token async and returns a GraceError instead of throwing on unsupported input.
-    let private tryRefreshTokenAsync (config: OidcCliConfig) (bundle: TokenBundle) =
+    let private tryRefreshTokenAsync (dependencies: CacheEnrollmentCredentialDependencies) (config: OidcCliConfig) (bundle: TokenBundle) =
         task {
             if String.IsNullOrWhiteSpace bundle.RefreshToken then
                 return Error "Refresh token missing. Run 'grace authenticate login' again."
@@ -921,7 +952,7 @@ module Auth =
                         "audience", config.Audience
                     ]
 
-                let! response = postFormAsync endpoint formValues
+                let! response = dependencies.PostFormAsync endpoint formValues
 
                 match response with
                 | Error message -> return Error message
@@ -929,7 +960,7 @@ module Auth =
                     match parseTokenResponse json with
                     | Error message -> return Error message
                     | Ok refreshed ->
-                        let now = getCurrentInstant ()
+                        let now = dependencies.CurrentInstant()
                         let updated = applyRefreshToken bundle refreshed now
                         return Ok updated
         }
@@ -937,25 +968,25 @@ module Auth =
     let private safetyWindow = Duration.FromSeconds(90.0)
 
     /// Tries to map get interactive token async and returns a GraceError instead of throwing on unsupported input.
-    let private tryGetInteractiveTokenAsync (config: OidcCliConfig) =
+    let private tryGetInteractiveTokenAsync (dependencies: CacheEnrollmentCredentialDependencies) (config: OidcCliConfig) =
         task {
-            let! storeResult = verifySecureStoreAsync config
+            let! storeResult = verifyCacheEnrollmentSecureStoreAsync dependencies config
 
             match storeResult with
             | Error message -> return Error message
             | Ok store ->
                 return!
-                    withTokenLock store (fun () ->
+                    dependencies.WithTokenLock store (fun () ->
                         task {
                             match tryLoadTokenBundle store with
                             | None -> return Ok None
                             | Some bundle ->
-                                let now = getCurrentInstant ()
+                                let now = dependencies.CurrentInstant()
 
                                 if bundle.AccessTokenExpiresAt > now.Plus(safetyWindow) then
                                     return Ok(Some bundle.AccessToken)
                                 else
-                                    let! refreshResult = tryRefreshTokenAsync config bundle
+                                    let! refreshResult = tryRefreshTokenAsync dependencies config bundle
 
                                     match refreshResult with
                                     | Ok updated ->
@@ -1018,13 +1049,13 @@ module Auth =
                                 Error
                                     $"Authentication is not configured. Set {Constants.EnvironmentVariables.GraceAuthOidcAuthority}, {Constants.EnvironmentVariables.GraceAuthOidcAudience}, and {Constants.EnvironmentVariables.GraceAuthOidcCliClientId} (or provide GRACE_TOKEN / M2M credentials)."
                         | Ok (Some cliConfig) ->
-                            let! tokenResult = tryGetInteractiveTokenAsync cliConfig
+                            let! tokenResult = tryGetInteractiveTokenAsync (cacheEnrollmentCredentialDependencies ()) cliConfig
                             return tokenResult
                         | Error error -> return Error error.Error
         }
 
     /// Resolves Cache enrollment credentials without allowing partial M2M settings to fall through to interactive state.
-    let internal tryGetAccessTokenForCacheEnrollment () =
+    let internal tryGetAccessTokenForCacheEnrollmentWith (dependencies: CacheEnrollmentCredentialDependencies) =
         task {
             match tryGetGraceTokenFromEnv () with
             | Error message -> return Error message
@@ -1057,7 +1088,7 @@ module Auth =
                                         "scope", String.Join(" ", m2mConfig.Scopes)
                                     ]
 
-                        let! response = postFormAsync endpoint formValues
+                        let! response = dependencies.PostFormAsync endpoint formValues
 
                         match response with
                         | Ok json ->
@@ -1074,9 +1105,12 @@ module Auth =
                             return
                                 Error
                                     $"Authentication is not configured. Set {Constants.EnvironmentVariables.GraceAuthOidcAuthority}, {Constants.EnvironmentVariables.GraceAuthOidcAudience}, and {Constants.EnvironmentVariables.GraceAuthOidcCliClientId} (or provide GRACE_TOKEN / M2M credentials)."
-                        | Ok (Some cliConfig) -> return! tryGetInteractiveTokenAsync cliConfig
+                        | Ok (Some cliConfig) -> return! tryGetInteractiveTokenAsync dependencies cliConfig
                         | Error error -> return Error error.Error
         }
+
+    /// Resolves Cache enrollment credentials through the established production auth collaborators.
+    let internal tryGetAccessTokenForCacheEnrollment () = tryGetAccessTokenForCacheEnrollmentWith (cacheEnrollmentCredentialDependencies ())
 
     /// Tries to map get access token for sdk and returns a GraceError instead of throwing on unsupported input.
     let private tryGetAccessTokenForSdk () =

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -2,9 +2,13 @@ namespace Grace.CLI.Command
 
 open Grace.Cache
 open Grace.CLI.Common
+open Grace.SDK
 open Grace.Shared
+open Grace.Types.CacheRegistration
 open Grace.Types.Common
 open Spectre.Console
+open System
+open System.Collections.Generic
 open System.CommandLine
 open System.CommandLine.Invocation
 open System.CommandLine.Parsing
@@ -12,7 +16,7 @@ open System.Text.Json.Nodes
 open System.Threading
 open System.Threading.Tasks
 
-/// Groups the repository-independent, read-only Grace Cache status command.
+/// Groups repository-independent Grace Cache enrollment and local status commands.
 module CacheCommand =
 
     /// Holds the protected state root with a test-only override for isolated root-command proof.
@@ -94,10 +98,394 @@ module CacheCommand =
         /// Executes the status projection without accessing repository or SDK state.
         override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> = statusHandler parseResult cancellationToken
 
-    /// Builds the repository-independent Cache command group.
-    let Build =
+    /// Defines parser-optional administrator operands whose presence is checked only after typed introspection routing.
+    module private EnrollOptions =
+        let ownerId = Option<Guid>("--owner-id", Description = "Owner GUID.")
+
+        let organizationId = Option<Guid>("--organization-id", Description = "Optional organization GUID selecting the organization boundary.")
+
+        let repositories =
+            Option<string array>("--repository", Description = "Repository assignment as organization-GUID/repository-GUID.", Arity = ArgumentArity.ZeroOrMore)
+
+        let endpoint = Option<string>("--endpoint", Description = "Absolute HTTP or HTTPS Cache endpoint.")
+        let displayName = Option<string>("--display-name", DefaultValueFactory = (fun _ -> "Grace Cache"), Description = "Cache display name.")
+        let allowHttp = Option<bool>("--allow-http", Description = "Permit an HTTP endpoint.")
+
+    /// Identifies the deterministic points at which focused root-dispatch tests may coordinate a single enrollment.
+    type internal EnrollmentPhase =
+        | CredentialResolved
+        | AttemptStaged
+        | TransportStarted
+        | BeforeReadyCommit
+
+    /// Supplies the internal collaborators for one fresh Cache command graph.
+    type internal Dependencies =
+        {
+            StateRoot: string
+            ResolveBearer: CancellationToken -> Task<Result<string, string>>
+            SendEnrollment: CacheEnrollmentRequest -> Uri -> string -> string -> CancellationToken -> Task<CacheEnrollmentTransportOutcome>
+            CommitReady: CacheIdentity.CacheEnrollmentClaim -> string -> CacheAcceptedRegistration -> Result<unit, CacheIdentityError>
+            OnPhase: EnrollmentPhase -> Task<unit>
+        }
+
+    /// Parses one canonical organization/repository assignment without names, empty IDs, or ambiguous separators.
+    let private tryRepositoryScope (value: string) =
+        if String.IsNullOrWhiteSpace(value) then
+            None
+        else
+            match value.Split('/', StringSplitOptions.None) with
+            | [| organization; repository |] ->
+                match Guid.TryParseExact(organization, "D"), Guid.TryParseExact(repository, "D") with
+                | (true, organizationId), (true, repositoryId) when
+                    organizationId <> Guid.Empty
+                    && repositoryId <> Guid.Empty
+                    ->
+                    Some(CacheRepositoryScope.Create(organizationId, repositoryId))
+                | _ -> None
+            | _ -> None
+
+    /// Builds the exact server request from the approved derived-boundary grammar and staged public key.
+    let private requestFromArguments (parseResult: ParseResult) (publicKey: Grace.Cache.CacheIdentityPublicKey) =
+        let correlationId = getCorrelationId parseResult
+        let ownerId = parseResult.GetValue(EnrollOptions.ownerId)
+        let parsedOrganizationId = parseResult.GetValue(EnrollOptions.organizationId)
+        let hasExplicitOrganizationId = not (isNull (parseResult.GetResult(EnrollOptions.organizationId)))
+        let organizationId = if parsedOrganizationId = Guid.Empty then None else Some parsedOrganizationId
+        let endpoint = parseResult.GetValue(EnrollOptions.endpoint)
+        let allowHttp = parseResult.GetValue(EnrollOptions.allowHttp)
+
+        let displayName =
+            parseResult.GetValue(EnrollOptions.displayName)
+            |> Option.ofObj
+            |> Option.defaultValue ""
+            |> fun value -> value.Trim()
+
+        let repositoryValues =
+            parseResult.GetValue(EnrollOptions.repositories)
+            |> Option.ofObj
+            |> Option.defaultValue Array.empty
+
+        let scopes = repositoryValues |> Array.map tryRepositoryScope
+
+        if ownerId = Guid.Empty then
+            Error(GraceError.Create "--owner-id must be a non-empty GUID." correlationId)
+        elif hasExplicitOrganizationId
+             && parsedOrganizationId = Guid.Empty then
+            Error(GraceError.Create "--organization-id must be a non-empty GUID when supplied." correlationId)
+        elif repositoryValues.Length = 0
+             || scopes |> Array.exists Option.isNone then
+            Error(GraceError.Create "At least one --repository value must be organization-GUID/repository-GUID." correlationId)
+        elif String.IsNullOrWhiteSpace(displayName) then
+            Error(GraceError.Create "--display-name must not be empty." correlationId)
+        else
+            match endpoint
+                  |> Option.ofObj
+                  |> Option.bind (fun value ->
+                      match Uri.TryCreate(value, UriKind.Absolute) with
+                      | true, uri -> Some uri
+                      | _ -> None)
+                with
+            | None -> Error(GraceError.Create "--endpoint must be an absolute HTTP or HTTPS URI." correlationId)
+            | Some uri when
+                uri.Scheme <> Uri.UriSchemeHttp
+                && uri.Scheme <> Uri.UriSchemeHttps
+                ->
+                Error(GraceError.Create "--endpoint must be an absolute HTTP or HTTPS URI." correlationId)
+            | Some uri when uri.Scheme = Uri.UriSchemeHttp && not allowHttp -> Error(GraceError.Create "HTTP --endpoint requires --allow-http." correlationId)
+            | Some uri ->
+                let request =
+                    {
+                        Class = nameof CacheEnrollmentRequest
+                        DisplayName = displayName
+                        BoundaryKind =
+                            if organizationId.IsSome then
+                                CacheBoundaryKind.Organization
+                            else
+                                CacheBoundaryKind.Owner
+                        OwnerId = ownerId
+                        OrganizationId = organizationId
+                        RepositoryScopes = List<CacheRepositoryScope>(scopes |> Array.choose id)
+                        PublicKey = Grace.Types.CacheRegistration.CacheIdentityPublicKey.Create(publicKey.PublicKeyX, publicKey.PublicKeyY)
+                        Endpoint = uri.AbsoluteUri
+                        AllowHttpEndpoint = allowHttp
+                        SoftwareVersion = "Grace.Cache"
+                        ProtocolVersion = "v1"
+                        PrefetchSupported = false
+                    }
+
+                match Lifecycle.validateEnrollmentRequest request with
+                | Ok () -> Ok request
+                | Error errors -> Error(GraceError.Create (String.concat " " errors) correlationId)
+
+    /// Reads the selected server URI without repository configuration or invocation-history access.
+    let private configuredServerUri parseResult =
+        match Uri.TryCreate(Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri), UriKind.Absolute) with
+        | true, uri when
+            uri.Scheme = Uri.UriSchemeHttp
+            || uri.Scheme = Uri.UriSchemeHttps
+            ->
+            Ok uri
+        | _ ->
+            Error(GraceError.Create ($"Set {Constants.EnvironmentVariables.GraceServerUri} to an absolute HTTP or HTTPS URI.") (getCorrelationId parseResult))
+
+    /// Compares immutable request facts and the staged P-256 public key before accepted state can be published.
+    let private matchesAcceptedRegistration (request: CacheEnrollmentRequest) (registration: CacheRegistration) =
+        not (isNull (box registration))
+        && registration.Class = nameof CacheRegistration
+        && registration.CacheId <> Guid.Empty
+        && registration.Health = CacheHealthStatus.Unhealthy
+        && not (String.IsNullOrWhiteSpace(registration.EnrolledBy))
+        && registration.EnrolledAt
+           <= registration.LastRefreshedAt
+        && registration.LastRefreshedAt < registration.RefreshAfter
+        && registration.RefreshAfter < registration.ExpiresAt
+        && registration.RevokedAt.IsNone
+        && registration.DisplayName = request.DisplayName
+        && registration.BoundaryKind = request.BoundaryKind
+        && registration.OwnerId = request.OwnerId
+        && registration.OrganizationId = request.OrganizationId
+        && registration.Endpoint = request.Endpoint
+        && registration.AllowHttpEndpoint = request.AllowHttpEndpoint
+        && registration.SoftwareVersion = request.SoftwareVersion
+        && registration.ProtocolVersion = request.ProtocolVersion
+        && registration.PrefetchSupported = request.PrefetchSupported
+        && not (isNull (box registration.PublicKey))
+        && registration.PublicKey.Class = request.PublicKey.Class
+        && registration.PublicKey.Algorithm = request.PublicKey.Algorithm
+        && registration.PublicKey.Curve = request.PublicKey.Curve
+        && registration.PublicKey.PublicKeyX = request.PublicKey.PublicKeyX
+        && registration.PublicKey.PublicKeyY = request.PublicKey.PublicKeyY
+        && registration.RepositoryScopes.Length = request.RepositoryScopes.Count
+        && Array.forall2
+            (fun (actual: CacheRepositoryScope) (expected: CacheRepositoryScope) ->
+                actual.Class = expected.Class
+                && actual.OrganizationId = expected.OrganizationId
+                && actual.RepositoryId = expected.RepositoryId)
+            registration.RepositoryScopes
+            (request.RepositoryScopes |> Seq.toArray)
+
+    /// Converts accepted server facts to the redacted private-ready representation.
+    let private acceptedRegistration (registration: CacheRegistration) : CacheAcceptedRegistration =
+        {
+            CacheId = registration.CacheId
+            DisplayName = registration.DisplayName
+            BoundaryKind = string registration.BoundaryKind
+            OwnerId = registration.OwnerId
+            OrganizationId = registration.OrganizationId
+            RepositoryScopes =
+                registration.RepositoryScopes
+                |> Array.map (fun scope -> { OrganizationId = scope.OrganizationId; RepositoryId = scope.RepositoryId })
+            Endpoint = registration.Endpoint
+            ProtocolVersion = registration.ProtocolVersion
+            PublicKey = { PublicKeyX = registration.PublicKey.PublicKeyX; PublicKeyY = registration.PublicKey.PublicKeyY }
+        }
+
+    /// Writes the redacted ready status through the shared output contract after one successful publication.
+    let private renderEnrollmentSuccess parseResult root =
+        let status = CacheIdentity.status root
+
+        if
+            not (hasSelect parseResult)
+            && parseResult |> hasOutput
+        then
+            renderHumanStatus status
+
+        let renderExitCode =
+            GraceReturnValue.Create (statusValue status) (getCorrelationId parseResult)
+            |> Ok
+            |> renderOutput parseResult
+
+        if renderExitCode <> 0 then renderExitCode
+        elif status.Enrollment = "enrolled" then 0
+        else -1
+
+    /// Runs the bounded one-bearer, one-claim, one-attempt, one-POST enrollment transition.
+    let private enrollTransition (dependencies: Dependencies) (parseResult: ParseResult) (cancellationToken: CancellationToken) =
+        task {
+            let correlationId = getCorrelationId parseResult
+            let placeholder: Grace.Cache.CacheIdentityPublicKey = { PublicKeyX = String.replicate 43 "a"; PublicKeyY = String.replicate 43 "a" }
+            let mutable transportStarted = false
+
+            match requestFromArguments parseResult placeholder, configuredServerUri parseResult with
+            | Error error, _
+            | _, Error error -> return renderOutput parseResult (Error error)
+            | Ok _, Ok serverUri ->
+                match CacheIdentity.inspectEnrollmentRoot dependencies.StateRoot with
+                | Error _ -> return renderOutput parseResult (Error(GraceError.Create "The protected Grace Cache state root is unavailable." correlationId))
+                | Ok CacheIdentityInspection.Ready ->
+                    return renderOutput parseResult (Error(GraceError.Create "The protected Grace Cache state root is already enrolled." correlationId))
+                | Ok (CacheIdentityInspection.Invalid
+                | CacheIdentityInspection.Inaccessible) ->
+                    return renderOutput parseResult (Error(GraceError.Create "The protected Grace Cache state root is invalid or inaccessible." correlationId))
+                | Ok (CacheIdentityInspection.Missing
+                | CacheIdentityInspection.AttemptPresent) ->
+                    try
+                        let! bearerResult = dependencies.ResolveBearer cancellationToken
+
+                        match bearerResult with
+                        | Error message -> return renderOutput parseResult (Error(GraceError.Create message correlationId))
+                        | Ok bearer when String.IsNullOrWhiteSpace(bearer) ->
+                            return
+                                renderOutput
+                                    parseResult
+                                    (Error(GraceError.Create "Authentication required. Run 'grace authenticate login' and try again." correlationId))
+                        | Ok bearer ->
+                            do! dependencies.OnPhase CredentialResolved
+                            cancellationToken.ThrowIfCancellationRequested()
+
+                            match CacheIdentity.tryAcquireEnrollmentClaim dependencies.StateRoot with
+                            | Error _ ->
+                                return renderOutput parseResult (Error(GraceError.Create "Cache enrollment could not acquire its local claim." correlationId))
+                            | Ok claim ->
+                                let mutable stagedKey: Grace.Cache.CacheIdentityPublicKey option = None
+                                let mutable committed = false
+
+                                try
+                                    match CacheIdentity.discardStaleAttempt claim dependencies.StateRoot with
+                                    | Error _ ->
+                                        return
+                                            renderOutput
+                                                parseResult
+                                                (Error(GraceError.Create "A stale Cache enrollment attempt could not be safely cleared." correlationId))
+                                    | Ok () ->
+                                        cancellationToken.ThrowIfCancellationRequested()
+
+                                        match CacheIdentity.createClaimedAttempt claim dependencies.StateRoot with
+                                        | Error _ ->
+                                            return
+                                                renderOutput
+                                                    parseResult
+                                                    (Error(GraceError.Create "Cache enrollment could not stage its protected identity." correlationId))
+                                        | Ok publicKey ->
+                                            stagedKey <- Some publicKey
+                                            do! dependencies.OnPhase AttemptStaged
+                                            cancellationToken.ThrowIfCancellationRequested()
+
+                                            match requestFromArguments parseResult publicKey,
+                                                  CacheIdentity.validateClaimedAttempt claim dependencies.StateRoot publicKey
+                                                with
+                                            | Error error, _ -> return renderOutput parseResult (Error error)
+                                            | _, Error _ ->
+                                                return
+                                                    renderOutput
+                                                        parseResult
+                                                        (Error(GraceError.Create "Cache enrollment local state changed before the request." correlationId))
+                                            | Ok request, Ok () ->
+                                                do! dependencies.OnPhase TransportStarted
+                                                cancellationToken.ThrowIfCancellationRequested()
+                                                transportStarted <- true
+                                                let! outcome = dependencies.SendEnrollment request serverUri bearer correlationId cancellationToken
+
+                                                match outcome with
+                                                | Rejected error
+                                                | Indeterminate error -> return renderOutput parseResult (Error error)
+                                                | Accepted response ->
+                                                    match response.ReturnValue.Class, response.ReturnValue.Status, response.ReturnValue.Registration with
+                                                    | resultClass, CacheRegistrationRefreshStatus.Enrolled, Some registration when
+                                                        resultClass = nameof CacheRegistrationResult
+                                                        && matchesAcceptedRegistration request registration
+                                                        ->
+                                                        do! dependencies.OnPhase BeforeReadyCommit
+                                                        cancellationToken.ThrowIfCancellationRequested()
+
+                                                        match CacheIdentity.validateClaimedAttempt claim dependencies.StateRoot publicKey with
+                                                        | Error _ ->
+                                                            return
+                                                                renderOutput
+                                                                    parseResult
+                                                                    (Error(
+                                                                        GraceError.Create
+                                                                            "Cache enrollment local state changed before ready publication."
+                                                                            correlationId
+                                                                    ))
+                                                        | Ok () ->
+                                                            match dependencies.CommitReady claim dependencies.StateRoot (acceptedRegistration registration) with
+                                                            | Ok () ->
+                                                                committed <- true
+                                                                return renderEnrollmentSuccess parseResult dependencies.StateRoot
+                                                            | Error _ ->
+                                                                return
+                                                                    renderOutput
+                                                                        parseResult
+                                                                        (Error(
+                                                                            GraceError.Create
+                                                                                "Cache enrollment was accepted but local ready state could not be committed."
+                                                                                correlationId
+                                                                        ))
+                                                    | _ ->
+                                                        return
+                                                            renderOutput
+                                                                parseResult
+                                                                (Error(
+                                                                    GraceError.Create
+                                                                        "Cache enrollment response did not strictly accept the staged identity."
+                                                                        correlationId
+                                                                ))
+                                finally
+                                    if not committed then
+                                        CacheIdentity.discardClaimedAttempt claim dependencies.StateRoot stagedKey
+
+                                    CacheIdentity.releaseEnrollmentClaim claim
+                    with
+                    | :? OperationCanceledException ->
+                        let message =
+                            if transportStarted then
+                                "Cache enrollment outcome is unknown after transport started."
+                            else
+                                "Cache enrollment was cancelled."
+
+                        return renderOutput parseResult (Error(GraceError.Create message correlationId))
+        }
+
+    /// Invokes the one-shot cache enrollment action through the token-aware root graph.
+    type internal Enroll(dependencies: Dependencies) =
+        inherit AsynchronousCommandLineAction()
+
+        /// Executes the bounded enrollment transition.
+        override _.InvokeAsync(parseResult: ParseResult, cancellationToken: CancellationToken) : Task<int> =
+            enrollTransition dependencies parseResult cancellationToken
+
+    /// Creates the production collaborators for a fresh Cache command graph.
+    let internal productionDependencies () =
+        {
+            StateRoot = stateRoot
+            ResolveBearer =
+                fun cancellationToken ->
+                    task {
+                        cancellationToken.ThrowIfCancellationRequested()
+                        let! bearer = Auth.tryGetAccessToken ()
+                        cancellationToken.ThrowIfCancellationRequested()
+
+                        let normalized: Result<string, string> =
+                            match bearer with
+                            | Some value when not (String.IsNullOrWhiteSpace(value)) -> Result.Ok value
+                            | _ -> Result.Error "Authentication required. Run 'grace authenticate login' and try again."
+
+                        return normalized
+                    }
+            SendEnrollment =
+                (fun request serverUri bearer correlationId cancellationToken ->
+                    CacheRegistration.Enroll(request, serverUri, bearer, correlationId, cancellationToken))
+            CommitReady = CacheIdentity.commitClaimedReady
+            OnPhase = (fun _ -> Task.FromResult(()))
+        }
+
+    /// Creates a fresh Cache command graph for one production root or focused root-dispatch test.
+    let internal create (dependencies: Dependencies) =
         let cache = Command("cache", "Inspect a local Grace Cache identity.")
         let status = Command("status", "Report redacted local Grace Cache enrollment status.")
+        let enroll = Command("enroll", "Enroll one protected Grace Cache identity.")
         status.Action <- Status()
+        enroll.Options.Add(EnrollOptions.ownerId)
+        enroll.Options.Add(EnrollOptions.organizationId)
+        enroll.Options.Add(EnrollOptions.repositories)
+        enroll.Options.Add(EnrollOptions.endpoint)
+        enroll.Options.Add(EnrollOptions.displayName)
+        enroll.Options.Add(EnrollOptions.allowHttp)
+        enroll.Action <- Enroll(dependencies)
         cache.Subcommands.Add(status)
+        cache.Subcommands.Add(enroll)
         cache
+
+    /// Retains a production Cache graph for existing parser-focused callers.
+    let Build = create (productionDependencies ())

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -228,13 +228,23 @@ module CacheCommand =
         | _ ->
             Error(GraceError.Create ($"Set {Constants.EnvironmentVariables.GraceServerUri} to an absolute HTTP or HTTPS URI.") (getCorrelationId parseResult))
 
+    /// Checks a required string before later response comparison accesses the value.
+    let private hasRequiredText (value: string) = not (String.IsNullOrWhiteSpace(value))
+
     /// Compares immutable request facts and the staged P-256 public key before accepted state can be published.
     let private matchesAcceptedRegistration (request: CacheEnrollmentRequest) (registration: CacheRegistration) =
         not (isNull (box registration))
+        && not (isNull (box request))
+        && not (isNull (box request.PublicKey))
+        && hasRequiredText registration.Class
         && registration.Class = nameof CacheRegistration
         && registration.CacheId <> Guid.Empty
         && registration.Health = CacheHealthStatus.Unhealthy
-        && not (String.IsNullOrWhiteSpace(registration.EnrolledBy))
+        && hasRequiredText registration.EnrolledBy
+        && hasRequiredText registration.DisplayName
+        && hasRequiredText registration.Endpoint
+        && hasRequiredText registration.SoftwareVersion
+        && hasRequiredText registration.ProtocolVersion
         && registration.EnrolledAt
            <= registration.LastRefreshedAt
         && registration.LastRefreshedAt < registration.RefreshAfter
@@ -250,12 +260,24 @@ module CacheCommand =
         && registration.ProtocolVersion = request.ProtocolVersion
         && registration.PrefetchSupported = request.PrefetchSupported
         && not (isNull (box registration.PublicKey))
+        && hasRequiredText registration.PublicKey.Class
+        && hasRequiredText registration.PublicKey.Algorithm
+        && hasRequiredText registration.PublicKey.Curve
+        && hasRequiredText registration.PublicKey.PublicKeyX
+        && hasRequiredText registration.PublicKey.PublicKeyY
         && registration.PublicKey.Class = request.PublicKey.Class
         && registration.PublicKey.Algorithm = request.PublicKey.Algorithm
         && registration.PublicKey.Curve = request.PublicKey.Curve
         && registration.PublicKey.PublicKeyX = request.PublicKey.PublicKeyX
         && registration.PublicKey.PublicKeyY = request.PublicKey.PublicKeyY
+        && not (isNull registration.RepositoryScopes)
         && registration.RepositoryScopes.Length = request.RepositoryScopes.Count
+        && registration.RepositoryScopes
+           |> Array.forall (fun scope ->
+               not (isNull (box scope))
+               && hasRequiredText scope.Class
+               && scope.OrganizationId <> Guid.Empty
+               && scope.RepositoryId <> Guid.Empty)
         && Array.forall2
             (fun (actual: CacheRepositoryScope) (expected: CacheRepositoryScope) ->
                 actual.Class = expected.Class
@@ -379,7 +401,10 @@ module CacheCommand =
                                                 match outcome with
                                                 | Rejected error
                                                 | Indeterminate error -> return renderOutput parseResult (Error error)
-                                                | Accepted response ->
+                                                | Accepted response when
+                                                    not (isNull (box response))
+                                                    && not (isNull (box response.ReturnValue))
+                                                    ->
                                                     match response.ReturnValue.Class, response.ReturnValue.Status, response.ReturnValue.Registration with
                                                     | resultClass, CacheRegistrationRefreshStatus.Enrolled, Some registration when
                                                         resultClass = nameof CacheRegistrationResult
@@ -421,6 +446,15 @@ module CacheCommand =
                                                                         "Cache enrollment response did not strictly accept the staged identity."
                                                                         correlationId
                                                                 ))
+                                                | Accepted _ ->
+                                                    return
+                                                        renderOutput
+                                                            parseResult
+                                                            (Error(
+                                                                GraceError.Create
+                                                                    "Cache enrollment response did not strictly accept the staged identity."
+                                                                    correlationId
+                                                            ))
                                 finally
                                     if not committed then
                                         CacheIdentity.discardClaimedAttempt claim dependencies.StateRoot stagedKey
@@ -453,13 +487,15 @@ module CacheCommand =
                 fun cancellationToken ->
                     task {
                         cancellationToken.ThrowIfCancellationRequested()
-                        let! bearer = Auth.tryGetAccessToken ()
+                        let! bearer = Auth.tryGetAccessTokenForCacheEnrollment ()
                         cancellationToken.ThrowIfCancellationRequested()
 
                         let normalized: Result<string, string> =
                             match bearer with
-                            | Some value when not (String.IsNullOrWhiteSpace(value)) -> Result.Ok value
-                            | _ -> Result.Error "Authentication required. Run 'grace authenticate login' and try again."
+                            | Ok (Some value) when not (String.IsNullOrWhiteSpace(value)) -> Result.Ok value
+                            | Error message -> Result.Error message
+                            | Ok (Some _) -> Result.Error "Authentication required. Run 'grace authenticate login' and try again."
+                            | Ok None -> Result.Error "Authentication required. Run 'grace authenticate login' and try again."
 
                         return normalized
                     }

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -343,7 +343,15 @@ module CacheCommand =
                 | CacheIdentityInspection.AttemptPresent
                 | CacheIdentityInspection.IncompleteAttempt) ->
                     try
-                        let! bearerResult = dependencies.ResolveBearer cancellationToken
+                        let! bearerResult =
+                            task {
+                                try
+                                    return! dependencies.ResolveBearer cancellationToken
+                                with
+                                | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
+                                    return raise (OperationCanceledException(cancellationToken))
+                                | :? OperationCanceledException -> return Result.Error "Cache enrollment credentials could not be resolved."
+                            }
 
                         match bearerResult with
                         | Error message -> return renderOutput parseResult (Error(GraceError.Create message correlationId))
@@ -481,7 +489,7 @@ module CacheCommand =
             enrollTransition dependencies parseResult cancellationToken
 
     /// Creates the production collaborators for a fresh Cache command graph.
-    let internal productionDependencies () =
+    let internal productionDependencies (credentialDependencies: Auth.CacheEnrollmentCredentialDependencies option) =
         {
             StateRoot = stateRoot
             ResolveBearer =
@@ -489,7 +497,12 @@ module CacheCommand =
                     task {
                         try
                             cancellationToken.ThrowIfCancellationRequested()
-                            let! bearer = Auth.tryGetAccessTokenForCacheEnrollment ()
+
+                            let dependencies =
+                                credentialDependencies
+                                |> Option.defaultWith Auth.cacheEnrollmentCredentialDependencies
+
+                            let! bearer = Auth.tryGetAccessTokenForCacheEnrollmentWith dependencies
                             cancellationToken.ThrowIfCancellationRequested()
 
                             return
@@ -497,7 +510,9 @@ module CacheCommand =
                                 | Ok (Some value) when not (String.IsNullOrWhiteSpace(value)) -> Result.Ok value
                                 | _ -> Result.Error "Cache enrollment credentials could not be resolved."
                         with
-                        | :? OperationCanceledException -> return raise (OperationCanceledException())
+                        | :? OperationCanceledException when cancellationToken.IsCancellationRequested ->
+                            return raise (OperationCanceledException(cancellationToken))
+                        | :? OperationCanceledException -> return Result.Error "Cache enrollment credentials could not be resolved."
                         | _ -> return Result.Error "Cache enrollment credentials could not be resolved."
                     }
             SendEnrollment =
@@ -525,4 +540,4 @@ module CacheCommand =
         cache
 
     /// Retains a production Cache graph for existing parser-focused callers.
-    let Build = create (productionDependencies ())
+    let Build = create (productionDependencies None)

--- a/src/Grace.CLI/Command/Cache.CLI.fs
+++ b/src/Grace.CLI/Command/Cache.CLI.fs
@@ -340,7 +340,8 @@ module CacheCommand =
                 | CacheIdentityInspection.Inaccessible) ->
                     return renderOutput parseResult (Error(GraceError.Create "The protected Grace Cache state root is invalid or inaccessible." correlationId))
                 | Ok (CacheIdentityInspection.Missing
-                | CacheIdentityInspection.AttemptPresent) ->
+                | CacheIdentityInspection.AttemptPresent
+                | CacheIdentityInspection.IncompleteAttempt) ->
                     try
                         let! bearerResult = dependencies.ResolveBearer cancellationToken
 
@@ -486,18 +487,18 @@ module CacheCommand =
             ResolveBearer =
                 fun cancellationToken ->
                     task {
-                        cancellationToken.ThrowIfCancellationRequested()
-                        let! bearer = Auth.tryGetAccessTokenForCacheEnrollment ()
-                        cancellationToken.ThrowIfCancellationRequested()
+                        try
+                            cancellationToken.ThrowIfCancellationRequested()
+                            let! bearer = Auth.tryGetAccessTokenForCacheEnrollment ()
+                            cancellationToken.ThrowIfCancellationRequested()
 
-                        let normalized: Result<string, string> =
-                            match bearer with
-                            | Ok (Some value) when not (String.IsNullOrWhiteSpace(value)) -> Result.Ok value
-                            | Error message -> Result.Error message
-                            | Ok (Some _) -> Result.Error "Authentication required. Run 'grace authenticate login' and try again."
-                            | Ok None -> Result.Error "Authentication required. Run 'grace authenticate login' and try again."
-
-                        return normalized
+                            return
+                                match bearer with
+                                | Ok (Some value) when not (String.IsNullOrWhiteSpace(value)) -> Result.Ok value
+                                | _ -> Result.Error "Cache enrollment credentials could not be resolved."
+                        with
+                        | :? OperationCanceledException -> return raise (OperationCanceledException())
+                        | _ -> return Result.Error "Cache enrollment credentials could not be resolved."
                     }
             SendEnrollment =
                 (fun request serverUri bearer correlationId cancellationToken ->

--- a/src/Grace.CLI/CommandOutputContract.CLI.fs
+++ b/src/Grace.CLI/CommandOutputContract.CLI.fs
@@ -705,14 +705,16 @@ module CommandOutputContract =
     /// Builds command-output contract metadata for return value contract for so automation can rely on stable JSON shapes.
     let private returnValueContractFor (identity: CommandIdentity) (envelopeContract: EnvelopeContract) =
         match identity.CommandId, envelopeContract with
-        | "cache.status", ExistingGraceResultEnvelope NoServerDto ->
+        | ("cache.enroll"
+          | "cache.status"),
+          ExistingGraceResultEnvelope _ ->
             supportedReturnValueContract
                 "CacheStatusDto"
                 "Grace.CLI.Command.CacheCommand"
                 cacheStatusSchema
                 cacheStatusExample
                 [
-                    "The command reads local protected identity state without a repository, server request, credential lookup, or mutation."
+                    "The command never exposes private key material, filesystem paths, or enrollment attempt details."
                     "CacheId, Endpoint, BoundaryKind, and RepositoryCount are present only when Enrollment is enrolled."
                 ]
         | "maintenance.check-ignore-entries", ExistingGraceResultEnvelope RequiresCliDto ->
@@ -1057,6 +1059,7 @@ module CommandOutputContract =
                 if
                     identity.CommandId.Equals("doctor", StringComparison.Ordinal)
                     || identity.CommandId.Equals("cache.status", StringComparison.Ordinal)
+                    || identity.CommandId.Equals("cache.enroll", StringComparison.Ordinal)
                 then
                     { JsonMode = ExistingBehavior; Schema = ExistingBehavior; Examples = ExistingBehavior; Select = ExistingBehavior }
                 else
@@ -1186,6 +1189,7 @@ module CommandOutputContract =
             row [ "branch" ] "switch" true true human_progress_only_success progress_local_workflow composite_local_server RequiresCliDto
             row [ "branch" ] "tag" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto
             row [ "branch" ] "update-parent-branch" true false common_renderOutput_envelope read_or_mutating_verify server_via_sdk ReuseExistingApiOrSdkDto
+            row [ "cache" ] "enroll" true true common_renderOutput_envelope mutating_state_transition composite_local_server RequiresCliDto
             row [ "cache" ] "status" true false common_renderOutput_envelope read_list_search local_client NoServerDto
             row [ "candidate" ] "attestations" true false common_renderOutput_envelope read_list_search server_via_sdk ReuseExistingApiOrSdkDto
             row [ "candidate" ] "cancel" true true common_renderOutput_envelope mutating_state_transition server_via_sdk ReuseExistingApiOrSdkDto

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -923,7 +923,7 @@ module GraceCommand =
     /// Creates fresh production root collaborators for the one supported Grace command graph.
     let internal productionDependencies () =
         {
-            CreateCacheCommand = (fun () -> CacheCommand.create (CacheCommand.productionDependencies ()))
+            CreateCacheCommand = (fun () -> CacheCommand.create (CacheCommand.productionDependencies None))
             InitializeExecution = initializeProductionExecution
             AfterCommandExit = (fun _ -> Task.FromResult(()))
         }

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -920,15 +920,16 @@ module GraceCommand =
         Common.resetLifecycleWarningSuppression ()
 
     /// Provides the production command factory and execution initialization for the retained root command value.
-    let private productionDependencies =
+    /// Creates fresh production root collaborators for the one supported Grace command graph.
+    let internal productionDependencies () =
         {
-            CreateCacheCommand = (fun () -> CacheCommand.Build)
+            CreateCacheCommand = (fun () -> CacheCommand.create (CacheCommand.productionDependencies ()))
             InitializeExecution = initializeProductionExecution
             AfterCommandExit = (fun _ -> Task.FromResult(()))
         }
 
     /// Retains the production root command graph for existing callers and parser tests.
-    let rootCommand = createRoot productionDependencies
+    let rootCommand = createRoot (productionDependencies ())
 
     ///// Converts tokens to the exact casing defined in their options, enabling case-insensitive parsing on Windows.
     //let caseInsensitiveMiddleware (rootCommand: Command, isCaseInsensitive) =
@@ -1060,6 +1061,18 @@ module GraceCommand =
 
             Set.contains "cache" commands
             && Set.contains "status" commands
+
+    /// Checks whether the parsed command belongs to the repository-independent Cache command group.
+    let isGraceCacheCommand (parseResult: ParseResult) =
+        if isNull parseResult then
+            false
+        else
+            let commands =
+                Seq.append [ parseResult.CommandResult.Command ] (parseResult.CommandResult.Command.Parents.OfType<Command>())
+                |> Seq.map (fun command -> command.Name)
+                |> Set.ofSeq
+
+            Set.contains "cache" commands
 
     /// Invokes an asynchronous command action through the configured root exception boundary.
     let private invokeAsync (parseResult: ParseResult) (invocationConfiguration: InvocationConfiguration) (cancellationToken: CancellationToken) =
@@ -1257,7 +1270,7 @@ module GraceCommand =
 
                         if
                             not (parseResult |> isGraceDoctor)
-                            && not (parseResult |> isGraceCacheStatus)
+                            && not (parseResult |> isGraceCacheCommand)
                         then
                             LocalStateDb.setVerbose (parseResult |> verbose)
 
@@ -1429,7 +1442,7 @@ module GraceCommand =
 
                         Console.Write(finalHelpText)
                         returnValue <- invokeResult
-                    else if parseResult |> isGraceCacheStatus then
+                    else if parseResult |> isGraceCacheCommand then
                         let! invokedReturnValue = invokeAsync parseResult invocationConfiguration cancellationToken
                         returnValue <- invokedReturnValue
                         do! dependencies.AfterCommandExit returnValue
@@ -1601,7 +1614,7 @@ module GraceCommand =
                 if
                     not isIntrospection
                     && not (parseResult |> isGraceDoctor)
-                    && not (parseResult |> isGraceCacheStatus)
+                    && not (parseResult |> isGraceCacheCommand)
                 then
                     HistoryStorage.tryRecordInvocation
                         {
@@ -1624,5 +1637,5 @@ module GraceCommand =
     /// Starts the production root graph with process cancellation handled by System.CommandLine invocation configuration.
     [<EntryPoint>]
     let main args =
-        run productionDependencies args CancellationToken.None
+        run (productionDependencies ()) args CancellationToken.None
         |> fun invocation -> invocation.GetAwaiter().GetResult()

--- a/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
@@ -164,6 +164,18 @@ type CacheIdentityTests() =
         assertInvalidStagedKey (fun privateBytes -> privateBytes[0 .. (privateBytes.Length - 2)])
         assertInvalidStagedKey (fun privateBytes -> Array.append privateBytes [| 0uy |])
 
+    /// Verifies a process terminated before its staged key exists is distinct from malformed ready or staged state.
+    [<Test>]
+    member _.``inspect distinguishes an empty incomplete attempt from invalid identity state``() =
+        withLinuxRoot (fun root ->
+            let attempt = Path.Combine(root, "attempt")
+            Directory.CreateDirectory(attempt) |> ignore
+            File.SetUnixFileMode(attempt, directoryMode)
+
+            requireInspection CacheIdentityInspection.IncompleteAttempt (CacheIdentity.inspect root)
+            Assert.That((CacheIdentity.status root).Enrollment, Is.EqualTo("notEnrolled"))
+            Assert.That((CacheIdentity.status root).Key, Is.EqualTo("missing")))
+
     /// Verifies matching accepted facts publish one same-parent ready marker with protected key and configuration modes.
     [<Test>]
     member _.``commitReady publishes only a matching protected ready identity``() =

--- a/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
+++ b/src/Grace.Cache.Tests/CacheIdentity.Tests.fs
@@ -467,3 +467,33 @@ type CacheIdentityTests() =
             CacheIdentity.discardAttempt root
             requireInspection CacheIdentityInspection.Missing (CacheIdentity.inspect root)
             Assert.DoesNotThrow(Action(fun () -> CacheIdentity.discardAttempt root)))
+
+    /// Verifies one live claim serializes staging, cleanup, and a later retry without deleting another invocation's state.
+    [<Test>]
+    member _.``enrollment claim serializes staging and releases for retry``() =
+        withLinuxRoot (fun root ->
+            let first =
+                CacheIdentity.tryAcquireEnrollmentClaim root
+                |> requireOk
+
+            try
+                CacheIdentity.tryAcquireEnrollmentClaim root
+                |> requireStateUnavailable
+
+                let publicKey =
+                    CacheIdentity.createClaimedAttempt first root
+                    |> requireOk
+
+                CacheIdentity.validateClaimedAttempt first root publicKey
+                |> requireOk
+
+                CacheIdentity.discardClaimedAttempt first root (Some publicKey)
+                requireInspection CacheIdentityInspection.Missing (CacheIdentity.inspect root)
+            finally
+                CacheIdentity.releaseEnrollmentClaim first
+
+            let retry =
+                CacheIdentity.tryAcquireEnrollmentClaim root
+                |> requireOk
+
+            CacheIdentity.releaseEnrollmentClaim retry)

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -94,6 +94,9 @@ module internal CacheIdentity =
     [<Literal>]
     let private RegistrationFileName = "registration.json"
 
+    [<Literal>]
+    let private EnrollmentClaimFileName = "enrollment.claim"
+
     let private directoryMode =
         UnixFileMode.UserRead
         ||| UnixFileMode.UserWrite
@@ -696,6 +699,44 @@ module internal CacheIdentity =
                 with
                 | _ -> Error CacheIdentityError.StateUnavailable
 
+    /// Holds the exclusive root-local file handle for one complete Cache enrollment attempt.
+    type internal CacheEnrollmentClaim = private { Root: string; Stream: FileStream }
+
+    /// Acquires the protected root-local claim that serializes stale cleanup, staging, ready publication, and cleanup.
+    let tryAcquireEnrollmentClaim root =
+        match validateRoot root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let claimPath = child root EnrollmentClaimFileName
+                let stream = new FileStream(claimPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)
+                File.SetUnixFileMode(claimPath, fileMode)
+
+                match inspectMode claimPath fileMode with
+                | Ok () -> Ok { Root = root; Stream = stream }
+                | Error _ ->
+                    stream.Dispose()
+                    Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Releases the claim after all effects owned by this enrollment invocation are complete.
+    let releaseEnrollmentClaim claim =
+        if not (isNull (box claim)) then
+            try
+                claim.Stream.Dispose()
+            with
+            | _ -> ()
+
+    /// Confirms that a live claim still belongs to this root immediately before a protected transition.
+    let private validateEnrollmentClaim claim root =
+        if isNull (box claim)
+           || not (String.Equals(claim.Root, root, StringComparison.Ordinal))
+           || claim.Stream.SafeFileHandle.IsClosed then
+            Error CacheIdentityError.StateUnavailable
+        else
+            validateRoot root
+
     /// Keeps the private parsed ready registration with its opaque inspection classification for one read-only inspection.
     type private CacheIdentityInspectionDetail =
         | Missing
@@ -809,5 +850,81 @@ module internal CacheIdentity =
                 let attempt = child root AttemptDirectoryName
 
                 if Directory.Exists(attempt) then Directory.Delete(attempt, true)
+            with
+            | _ -> ()
+
+    /// Inspects enrollment state only after validating the supported protected-root requirements.
+    let inspectEnrollmentRoot root =
+        match validateRoot root with
+        | Error error -> Error error
+        | Ok () -> inspect root
+
+    /// Removes one stale attempt while retaining the exclusive claim that prevents foreign cleanup.
+    let discardStaleAttempt claim root =
+        match validateEnrollmentClaim claim root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let attempt = child root AttemptDirectoryName
+
+                if Directory.Exists(attempt) then Directory.Delete(attempt, true)
+
+                match inspect root with
+                | Ok CacheIdentityInspection.Missing -> Ok()
+                | _ -> Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Stages one P-256 identity while the caller owns the claim for its full enrollment lifecycle.
+    let createClaimedAttempt claim root =
+        match validateEnrollmentClaim claim root with
+        | Error error -> Error error
+        | Ok () -> createAttempt root
+
+    /// Rechecks the live claim and exact staged P-256 key before external or ready-publication effects.
+    let validateClaimedAttempt claim root (expectedPublicKey: CacheIdentityPublicKey) =
+        match validateEnrollmentClaim claim root with
+        | Error error -> Error error
+        | Ok () ->
+            try
+                let identityPath = child (child root AttemptDirectoryName) IdentityFileName
+
+                match File.ReadAllBytes(identityPath) |> tryImportP256 with
+                | Some (x, y) when
+                    String.Equals(base64Url x, expectedPublicKey.PublicKeyX, StringComparison.Ordinal)
+                    && String.Equals(base64Url y, expectedPublicKey.PublicKeyY, StringComparison.Ordinal)
+                    ->
+                    Ok()
+                | _ -> Error CacheIdentityError.StateUnavailable
+            with
+            | _ -> Error CacheIdentityError.StateUnavailable
+
+    /// Publishes ready state only while this invocation still owns the validated staged identity.
+    let commitClaimedReady claim root configuration =
+        match validateClaimedAttempt claim root configuration.PublicKey with
+        | Error error -> Error error
+        | Ok () -> commitReady root configuration
+
+    /// Best-effort cleanup removes only the claimed invocation's matching staged identity.
+    let discardClaimedAttempt claim root (expectedPublicKey: CacheIdentityPublicKey option) =
+        match validateEnrollmentClaim claim root with
+        | Error _ -> ()
+        | Ok () ->
+            try
+                let attempt = child root AttemptDirectoryName
+                let identityPath = child attempt IdentityFileName
+
+                let matchesExpected =
+                    match expectedPublicKey with
+                    | None -> true
+                    | Some expected ->
+                        match File.ReadAllBytes(identityPath) |> tryImportP256 with
+                        | Some (x, y) ->
+                            String.Equals(base64Url x, expected.PublicKeyX, StringComparison.Ordinal)
+                            && String.Equals(base64Url y, expected.PublicKeyY, StringComparison.Ordinal)
+                        | None -> false
+
+                if Directory.Exists(attempt) && matchesExpected then
+                    Directory.Delete(attempt, true)
             with
             | _ -> ()

--- a/src/Grace.Cache/CacheIdentity.fs
+++ b/src/Grace.Cache/CacheIdentity.fs
@@ -53,6 +53,7 @@ type private CacheReadyRegistration =
 type internal CacheIdentityInspection =
     | Missing
     | AttemptPresent
+    | IncompleteAttempt
     | Ready
     | Invalid
     | Inaccessible
@@ -599,16 +600,22 @@ module internal CacheIdentity =
     let private inspectAttempt attempt =
         let identityPath = child attempt IdentityFileName
 
-        match inspectMode attempt directoryMode, inspectMode identityPath fileMode with
-        | Error CacheIdentityInspection.Inaccessible, _
-        | _, Error CacheIdentityInspection.Inaccessible -> CacheIdentityInspection.Inaccessible
-        | Error _, _
-        | _, Error _ -> CacheIdentityInspection.Invalid
-        | Ok (), Ok () ->
+        match inspectMode attempt directoryMode with
+        | Error CacheIdentityInspection.Inaccessible -> CacheIdentityInspection.Inaccessible
+        | Error _ -> CacheIdentityInspection.Invalid
+        | Ok () ->
             try
-                match File.ReadAllBytes(identityPath) |> tryImportP256 with
-                | Some _ -> CacheIdentityInspection.AttemptPresent
-                | None -> CacheIdentityInspection.Invalid
+                match Directory.GetFileSystemEntries(attempt) with
+                | [||] -> CacheIdentityInspection.IncompleteAttempt
+                | [| entry |] when String.Equals(entry, identityPath, StringComparison.Ordinal) ->
+                    match inspectMode identityPath fileMode with
+                    | Error CacheIdentityInspection.Inaccessible -> CacheIdentityInspection.Inaccessible
+                    | Error _ -> CacheIdentityInspection.Invalid
+                    | Ok () ->
+                        match File.ReadAllBytes(identityPath) |> tryImportP256 with
+                        | Some _ -> CacheIdentityInspection.AttemptPresent
+                        | None -> CacheIdentityInspection.Invalid
+                | _ -> CacheIdentityInspection.Invalid
             with
             | :? UnauthorizedAccessException -> CacheIdentityInspection.Inaccessible
             | :? IOException -> CacheIdentityInspection.Inaccessible
@@ -741,6 +748,7 @@ module internal CacheIdentity =
     type private CacheIdentityInspectionDetail =
         | Missing
         | AttemptPresent
+        | IncompleteAttempt
         | Ready of CacheReadyRegistration
         | Invalid
         | Inaccessible
@@ -804,6 +812,7 @@ module internal CacheIdentity =
                     | Ok true, Ok false ->
                         match inspectAttempt attempt with
                         | CacheIdentityInspection.AttemptPresent -> Ok CacheIdentityInspectionDetail.AttemptPresent
+                        | CacheIdentityInspection.IncompleteAttempt -> Ok CacheIdentityInspectionDetail.IncompleteAttempt
                         | CacheIdentityInspection.Inaccessible -> Ok CacheIdentityInspectionDetail.Inaccessible
                         | _ -> Ok CacheIdentityInspectionDetail.Invalid
                     | Ok false, Ok true -> Ok(inspectReady ready)
@@ -814,6 +823,7 @@ module internal CacheIdentity =
         |> Result.map (function
             | CacheIdentityInspectionDetail.Missing -> CacheIdentityInspection.Missing
             | CacheIdentityInspectionDetail.AttemptPresent -> CacheIdentityInspection.AttemptPresent
+            | CacheIdentityInspectionDetail.IncompleteAttempt -> CacheIdentityInspection.IncompleteAttempt
             | CacheIdentityInspectionDetail.Ready _ -> CacheIdentityInspection.Ready
             | CacheIdentityInspectionDetail.Invalid -> CacheIdentityInspection.Invalid
             | CacheIdentityInspectionDetail.Inaccessible -> CacheIdentityInspection.Inaccessible)
@@ -826,6 +836,7 @@ module internal CacheIdentity =
         match inspectDetail root with
         | Ok CacheIdentityInspectionDetail.Missing -> nonReady "notEnrolled" "missing"
         | Ok CacheIdentityInspectionDetail.AttemptPresent -> nonReady "notEnrolled" "available"
+        | Ok CacheIdentityInspectionDetail.IncompleteAttempt -> nonReady "notEnrolled" "missing"
         | Ok (CacheIdentityInspectionDetail.Ready registration) ->
             {
                 Class = "Grace.Cache.Status"

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -26,6 +26,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Grace.CLI.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Grace.CLI.CacheEnrollment.ClaimHolder</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.SDK/CacheRegistration.SDK.fs
+++ b/src/Grace.SDK/CacheRegistration.SDK.fs
@@ -1,0 +1,80 @@
+namespace Grace.SDK
+
+open Grace.Shared
+open Grace.Shared.Utilities
+open Grace.Types.CacheRegistration
+open Grace.Types.Common
+open System
+open System.IO
+open System.Net.Http
+open System.Net.Http.Headers
+open System.Net.Http.Json
+open System.Threading
+
+/// Classifies the terminal result of the single cache enrollment transport attempt.
+type CacheEnrollmentTransportOutcome =
+    /// The server returned a success response whose body is available for strict CLI validation.
+    | Accepted of GraceReturnValue<CacheRegistrationResult>
+    /// The selected server definitely rejected the request or returned an unusable protocol response.
+    | Rejected of GraceError
+    /// The connection, response, timeout, or caller cancellation occurred after transport began and server acceptance is unknown.
+    | Indeterminate of GraceError
+
+/// Sends the single selected-server request used to enroll a static Grace Cache identity.
+type CacheRegistration() =
+    /// Posts one enrollment request with an already-resolved bearer, disabled redirects, and no retry or configuration lookup.
+    static member Enroll(request: CacheEnrollmentRequest, serverUri: Uri, bearer: string, correlationId: string, cancellationToken: CancellationToken) =
+        task {
+            if obj.ReferenceEquals(request, null) then
+                return Rejected(GraceError.Create "Cache enrollment request is required." correlationId)
+            elif isNull serverUri || not serverUri.IsAbsoluteUri then
+                return Rejected(GraceError.Create "Cache enrollment requires an absolute Grace Server URI." correlationId)
+            elif String.IsNullOrWhiteSpace bearer then
+                return Rejected(GraceError.Create "Cache enrollment requires an authenticated bearer credential." correlationId)
+            else
+                try
+                    use handler = new SocketsHttpHandler(AllowAutoRedirect = false)
+
+                    use client =
+                        new HttpClient(handler)
+                        |> ClientIdentity.applyHeaders
+
+                    client.DefaultRequestHeaders.TryAddWithoutValidation(Constants.CorrelationIdHeaderKey, correlationId)
+                    |> ignore
+
+                    client.DefaultRequestHeaders.Authorization <- AuthenticationHeaderValue("Bearer", bearer)
+                    use content = createJsonContent request
+
+                    try
+                        use! response = client.PostAsync(Uri($"{serverUri.AbsoluteUri.TrimEnd('/')}/cache/enroll"), content, cancellationToken)
+
+                        if not response.IsSuccessStatusCode then
+                            return Rejected(GraceError.Create "Cache enrollment was rejected by the selected Grace Server." correlationId)
+                        else
+                            try
+                                let! result =
+                                    response.Content.ReadFromJsonAsync<GraceReturnValue<CacheRegistrationResult>>(
+                                        Constants.JsonSerializerOptions,
+                                        cancellationToken
+                                    )
+
+                                return
+                                    if obj.ReferenceEquals(result, null) then
+                                        Rejected(GraceError.Create "Cache enrollment returned an empty response." correlationId)
+                                    else
+                                        Accepted result
+                            with
+                            | :? OperationCanceledException ->
+                                return Indeterminate(GraceError.Create "Cache enrollment outcome is unknown after transport started." correlationId)
+                            | :? HttpRequestException
+                            | :? IOException ->
+                                return Indeterminate(GraceError.Create "Cache enrollment outcome is unknown after transport started." correlationId)
+                            | _ -> return Rejected(GraceError.Create "Cache enrollment returned an invalid response." correlationId)
+                    with
+                    | :? OperationCanceledException
+                    | :? HttpRequestException
+                    | :? IOException -> return Indeterminate(GraceError.Create "Cache enrollment outcome is unknown after transport started." correlationId)
+                    | _ -> return Indeterminate(GraceError.Create "Cache enrollment outcome is unknown after transport started." correlationId)
+                with
+                | _ -> return Rejected(GraceError.Create "Cache enrollment could not prepare the selected-server request." correlationId)
+        }

--- a/src/Grace.SDK/CacheRegistration.SDK.fs
+++ b/src/Grace.SDK/CacheRegistration.SDK.fs
@@ -39,6 +39,9 @@ type CacheRegistration() =
                         new HttpClient(handler)
                         |> ClientIdentity.applyHeaders
 
+                    // A bounded one-shot call makes transport loss terminal and testable without adding retry behavior.
+                    client.Timeout <- TimeSpan.FromSeconds(2.0)
+
                     client.DefaultRequestHeaders.TryAddWithoutValidation(Constants.CorrelationIdHeaderKey, correlationId)
                     |> ignore
 

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -20,6 +20,7 @@
         <Compile Include="ClientIdentity.SDK.fs" />
         <Compile Include="Auth.SDK.fs" />
         <Compile Include="Common.SDK.fs" />
+        <Compile Include="CacheRegistration.SDK.fs" />
         <Compile Include="PersonalAccessToken.SDK.fs" />
         <Compile Include="LocalPlanner.SDK.fs" />
         <Compile Include="Storage.SDK.fs" />

--- a/src/Grace.slnx
+++ b/src/Grace.slnx
@@ -12,6 +12,7 @@
   <Project Path="Grace.Aspire.AppHost/Grace.Aspire.AppHost.fsproj" />
   <Project Path="Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj" />
   <Project Path="Grace.CLI.Tests/Grace.CLI.Tests.fsproj" />
+  <Project Path="Grace.CLI.CacheEnrollment.ClaimHolder/Grace.CLI.CacheEnrollment.ClaimHolder.fsproj" />
   <Project Path="Grace.CLI/Grace.CLI.fsproj" />
   <Project Path="Grace.Cache.Tests/Grace.Cache.Tests.fsproj" />
   <Project Path="Grace.Cache/Grace.Cache.fsproj" />


### PR DESCRIPTION
## Purpose

Complete Product V1 one-shot Grace Cache enrollment through the merged cancellable CLI root, so a Linux service operator can establish protected local ready state with one nonredirecting server request and truthful failure behavior.

Relates to #941. Targets the ME3 integration branch; #941 will be closed manually after merge.

## What changed

- Adds `grace cache enroll` with approved owner, organization, repository, endpoint, credential, and output behavior.
- Adds protected claim, staged key, strict response validation, atomic ready publication, typed indeterminate transport outcomes, and no retry or automated reconciliation.
- Adds focused Windows and Linux proof, a real GNOME keyring path, cross-process contention proof, output metadata, CI support, and Product V1 documentation.

## Validation

- Windows focused Cache CLI: 12 passed, 2 expected Linux skips.
- Linux Docker focused Cache CLI: 12 passed, 2 expected skips.
- Linux D-Bus/GNOME keyring: 12 passed, 1 expected unsupported-host skip.
- Linux CacheIdentity: 9 passed, 1 expected privilege skip.
- Command-output metadata: 23 passed.
- Release builds, targeted Fantomas, MarkdownLint, and `git diff --check` passed.

## Review Status

- Head: `a9789ca557ff69bc006f3aefe91106f1822446c6`
- Worker starts: 5, exceptional final closure. Every remaining item is named in one bounded credential-failure family; no worker 6 is permitted.
- Fresh review sessions: 3; completed substantive cycles: 2 in the same credential/failure-proof family. Conditional worker 4 owns one finite closure ledger.
- Exact-head GitHub Validate passed. Fresh review found one behavior defect and finite missing assertions; conditional worker 4 is assigned.
- Product V1 excludes retry, automated enrollment reconciliation, rotation, listener/serving, prefetch, and platform parity.