### PR TITLE
Render the exact WDU lifecycle packet

### DIFF
--- a/docs/adr/0011-working-directory-update-transaction.md
+++ b/docs/adr/0011-working-directory-update-transaction.md
@@ -92,53 +92,11 @@ The complete requirements, state model, propagation map, and proof contract are 
 The projection below is an existing contextual consumer, not proof that the replacement packet has been published.
 Issue #929 rewrites and compares all fifteen exact projection blocks from the compiler result after PR #930 merges.
 
-<!-- grace:wdu-lifecycle-projection:start -->
+<!-- grace:wdu-lifecycle-projection:adr-0011:start -->
 ```json
-{
-  "schema": "grace.wdu.lifecycle-projection/v1",
-  "artifact": "adr-0011",
-  "canonical": "docs/Working Directory Update.md#normative-branch-lifecycle-table",
-  "canonicalContentDigest": "ae3a77e28886485b49361d8836f040691e9f99228919cef87fac19b42e989d73",
-  "rowIds": [
-    "WDU-LC-200",
-    "WDU-LC-201",
-    "WDU-LC-202",
-    "WDU-LC-206",
-    "WDU-LC-207",
-    "WDU-LC-208",
-    "WDU-LC-209",
-    "WDU-LC-210",
-    "WDU-LC-212",
-    "WDU-LC-006",
-    "WDU-LC-007",
-    "WDU-LC-010",
-    "WDU-LC-015",
-    "WDU-LC-020",
-    "WDU-LC-023",
-    "WDU-LC-025",
-    "WDU-LC-026",
-    "WDU-LC-028",
-    "WDU-LC-030",
-    "WDU-LC-033",
-    "WDU-LC-035",
-    "WDU-LC-036",
-    "WDU-LC-038",
-    "WDU-LC-100",
-    "WDU-LC-101",
-    "WDU-LC-103",
-    "WDU-LC-110",
-    "WDU-LC-114",
-    "WDU-LC-120",
-    "WDU-LC-123",
-    "WDU-LC-130",
-    "WDU-LC-140",
-    "WDU-LC-143",
-    "WDU-LC-003"
-  ],
-  "proof": "Record the lasting Branch transaction lifecycle and reference canonical rows without copying their order."
-}
+{"schema":"grace.wdu.lifecycle-projection/v2","artifact":"adr-0011","canonical":"docs/Working Directory Update.md#normative-branch-lifecycle-table","canonicalContentDigest":"ae3a77e28886485b49361d8836f040691e9f99228919cef87fac19b42e989d73","assignmentDigest":"20e329bd3aa4459a01f4ed3c6ec12cf365c86df3538b0323400639b90eeee877","rowCount":70,"applicabilityKeyCount":260,"requirementCount":19,"artifactCount":15,"requirements":[{"id":"REQ-001","owner":"#923"},{"id":"REQ-002","owner":"#869"},{"id":"REQ-003","owner":"#837"},{"id":"REQ-004","owner":"#839"},{"id":"REQ-005","owner":"#869"},{"id":"REQ-006","owner":"#898"},{"id":"REQ-007","owner":"#922"},{"id":"REQ-008","owner":"#922"},{"id":"REQ-009","owner":"#838"},{"id":"REQ-010","owner":"#838"},{"id":"REQ-011","owner":"#871"},{"id":"REQ-012","owner":"#871"},{"id":"REQ-013","owner":"#900"},{"id":"REQ-014","owner":"#921"},{"id":"REQ-015","owner":"#842"},{"id":"REQ-016","owner":"#871"},{"id":"REQ-017","owner":"#846"},{"id":"REQ-018","owner":"#928"},{"id":"REQ-019","owner":"#923"}],"artifactIds":["adr-0011","epic-835","issue-842","issue-843","issue-846","issue-869","issue-898","issue-928","issue-921","issue-922","issue-923","issue-900","issue-901","issue-871","issue-872"],"assignment":{"rowIds":["WDU-LC-200","WDU-LC-201","WDU-LC-202","WDU-LC-206","WDU-LC-207","WDU-LC-208","WDU-LC-209","WDU-LC-210","WDU-LC-212","WDU-LC-006","WDU-LC-007","WDU-LC-010","WDU-LC-015","WDU-LC-020","WDU-LC-023","WDU-LC-025","WDU-LC-026","WDU-LC-028","WDU-LC-030","WDU-LC-033","WDU-LC-035","WDU-LC-036","WDU-LC-038","WDU-LC-100","WDU-LC-101","WDU-LC-103","WDU-LC-110","WDU-LC-114","WDU-LC-120","WDU-LC-123","WDU-LC-130","WDU-LC-140","WDU-LC-143","WDU-LC-003"]}}
 ```
-<!-- grace:wdu-lifecycle-projection:end -->
+<!-- grace:wdu-lifecycle-projection:adr-0011:end -->
 
 ## Consequences
 

--- a/scripts/check-wdu-lifecycle-packet.ps1
+++ b/scripts/check-wdu-lifecycle-packet.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param(
+    [string] $CanonicalPath = (Join-Path $PSScriptRoot '../docs/Working Directory Update.md'),
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $PacketDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'modules/WduLifecyclePacket.psm1') -Force
+Test-WduLifecyclePacket -CanonicalPath $CanonicalPath -PacketDirectory $PacketDirectory

--- a/scripts/modules/WduLifecyclePacket.psm1
+++ b/scripts/modules/WduLifecyclePacket.psm1
@@ -1,0 +1,403 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'WduLifecycleContract.psm1') -Force
+
+$script:Utf8 = [Text.UTF8Encoding]::new($false, $true)
+$script:MarkerSentinel = 'grace:wdu-lifecycle-projection'
+$script:RawExportCommand = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../get-wdu-lifecycle-projection.ps1'))
+$script:FailureAfterStagedWritesForTest = $null
+
+function Fail-Packet {
+    param([string] $Subject, [string] $Reason)
+
+    throw "WDU lifecycle packet '$Subject': $Reason"
+}
+
+function Get-Marker {
+    param([string] $Artifact, [ValidateSet('start', 'end')][string] $Kind)
+
+    "<!-- grace:wdu-lifecycle-projection:$Artifact`:$Kind -->"
+}
+
+function Find-Bytes {
+    param([byte[]] $Bytes, [byte[]] $Needle, [int] $Offset = 0)
+
+    for ($index = $Offset; $index -le $Bytes.Length - $Needle.Length; $index++) {
+        $same = $true
+        for ($needleIndex = 0; $needleIndex -lt $Needle.Length; $needleIndex++) {
+            if ($Bytes[$index + $needleIndex] -ne $Needle[$needleIndex]) {
+                $same = $false
+                break
+            }
+        }
+        if ($same) { return $index }
+    }
+
+    -1
+}
+
+function Get-LineEndingBytes {
+    param([byte[]] $Bytes)
+
+    for ($index = 0; $index -lt $Bytes.Length; $index++) {
+        if ($Bytes[$index] -eq 13 -and $index + 1 -lt $Bytes.Length -and $Bytes[$index + 1] -eq 10) {
+            return [byte[]](13, 10)
+        }
+        if ($Bytes[$index] -eq 10) { return [byte[]](10) }
+    }
+
+    [byte[]](10)
+}
+
+function Get-ArtifactMap {
+    param([object] $Compiled)
+
+    $map = [Collections.Generic.Dictionary[string, object]]::new([StringComparer]::Ordinal)
+    foreach ($artifact in $Compiled.Artifacts) {
+        if (-not $map.TryAdd($artifact.Id, $artifact)) {
+            Fail-Packet $Compiled.Digest "compiler returned duplicate artifact '$($artifact.Id)'"
+        }
+    }
+
+    $map
+}
+
+function Start-WduLifecycleRawExportProcess {
+    param(
+        [Parameter(Mandatory)][string] $CanonicalPath,
+        [Parameter(Mandatory)][string] $Artifact,
+        [Parameter(Mandatory)][string] $RawExportCommand
+    )
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = (Get-Command pwsh -CommandType Application).Source
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in @('-NoLogo', '-NoProfile', '-File', $RawExportCommand, '-CanonicalPath', $CanonicalPath, '-Artifact', $Artifact)) {
+        [void] $startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    try {
+        [void] $process.Start()
+        $stdout = [IO.MemoryStream]::new()
+        $stdoutTask = $process.StandardOutput.BaseStream.CopyToAsync($stdout)
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        return [pscustomobject]@{ Artifact = $Artifact; Process = $process; Stdout = $stdout; StdoutTask = $stdoutTask; StderrTask = $stderrTask }
+    }
+    catch {
+        $process.Dispose()
+        throw
+    }
+}
+
+function Get-WduLifecycleRawExportBytes {
+    param(
+        [Parameter(Mandatory)][string] $CanonicalPath,
+        [Parameter(Mandatory)][string[]] $Artifacts,
+        [Parameter(Mandatory)][string] $RawExportCommand
+    )
+
+    $payloads = [Collections.Generic.Dictionary[string, byte[]]]::new([StringComparer]::Ordinal)
+    foreach ($batch in @($Artifacts | ForEach-Object -Begin { $items = [Collections.Generic.List[string]]::new() } -Process {
+            $items.Add($_)
+            if ($items.Count -eq 4) { ,@($items); $items.Clear() }
+        } -End { if ($items.Count -gt 0) { ,@($items) } })) {
+        $operations = [Collections.Generic.List[object]]::new()
+        try {
+            foreach ($artifact in $batch) {
+                $operations.Add((Start-WduLifecycleRawExportProcess -CanonicalPath $CanonicalPath -Artifact $artifact -RawExportCommand $RawExportCommand))
+            }
+        foreach ($operation in $operations) {
+            $operation.Process.WaitForExit()
+            $null = $operation.StdoutTask.GetAwaiter().GetResult()
+            $stderr = $operation.StderrTask.GetAwaiter().GetResult()
+            if ($operation.Process.ExitCode -ne 0) {
+                Fail-Packet $operation.Artifact "raw export command failed with exit code $($operation.Process.ExitCode): $stderr"
+            }
+            if (-not [string]::IsNullOrEmpty($stderr)) {
+                Fail-Packet $operation.Artifact "raw export command wrote stderr: $stderr"
+            }
+            if (-not $payloads.TryAdd($operation.Artifact, $operation.Stdout.ToArray())) {
+                Fail-Packet $operation.Artifact 'raw export command received a duplicate artifact request'
+            }
+        }
+        }
+        finally {
+            foreach ($operation in $operations) {
+                $operation.Stdout.Dispose()
+                $operation.Process.Dispose()
+            }
+        }
+    }
+
+    $payloads
+}
+
+function Get-MarkerTokens {
+    param([byte[]] $Bytes, [string] $Subject)
+
+    $commentStart = [byte[]](60, 33, 45, 45)
+    $commentEnd = [byte[]](45, 45, 62)
+    $tokens = [Collections.Generic.List[object]]::new()
+    $offset = 0
+    while ($true) {
+        $start = Find-Bytes $Bytes $commentStart $offset
+        if ($start -lt 0) { break }
+        $end = Find-Bytes $Bytes $commentEnd ($start + $commentStart.Length)
+        if ($end -lt 0) {
+            $partial = $script:Utf8.GetString($Bytes, $start, $Bytes.Length - $start)
+            if ($partial.IndexOf($script:MarkerSentinel, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                Fail-Packet $Subject 'contains malformed lifecycle projection marker'
+            }
+            break
+        }
+
+        $comment = $script:Utf8.GetString($Bytes, $start, $end + $commentEnd.Length - $start)
+        if ($comment.IndexOf($script:MarkerSentinel, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            if ($comment -cmatch '^<!-- grace:wdu-lifecycle-projection:(start|end) -->$') {
+                Fail-Packet $Subject 'contains generic legacy lifecycle projection marker'
+            }
+            if ($comment -match '^<!-- grace:wdu-lifecycle-projection:(start|end) -->$') {
+                Fail-Packet $Subject 'contains case-changed lifecycle projection marker'
+            }
+            if ($comment -cmatch '^<!-- grace:wdu-lifecycle-projection:([a-z0-9-]+):(start|end) -->$') {
+                $tokens.Add([pscustomobject]@{ Artifact = $Matches[1]; Kind = $Matches[2]; Start = $start; End = $end + $commentEnd.Length })
+            }
+            elseif ($comment -match '^<!-- grace:wdu-lifecycle-projection:([a-z0-9-]+):(start|end) -->$') {
+                Fail-Packet $Subject 'contains case-changed lifecycle projection marker'
+            }
+            else {
+                Fail-Packet $Subject 'contains malformed lifecycle projection marker'
+            }
+        }
+        $offset = $end + $commentEnd.Length
+    }
+
+    @($tokens)
+}
+
+function Get-MarkerPair {
+    param([byte[]] $Bytes, [object] $Compiled, [string] $Subject)
+
+    $tokens = @(Get-MarkerTokens $Bytes $Subject)
+    if ($tokens.Count -eq 0) { Fail-Packet $Subject 'is missing lifecycle projection marker evidence' }
+    $map = Get-ArtifactMap $Compiled
+    foreach ($token in $tokens) {
+        if (-not $map.ContainsKey($token.Artifact)) {
+            Fail-Packet $Subject "contains unknown artifact marker '$($token.Artifact)'"
+        }
+    }
+    foreach ($artifactId in $map.Keys) {
+        $starts = @($tokens | Where-Object { $_.Artifact -ceq $artifactId -and $_.Kind -ceq 'start' })
+        $ends = @($tokens | Where-Object { $_.Artifact -ceq $artifactId -and $_.Kind -ceq 'end' })
+        if ($starts.Count -gt 1) { Fail-Packet $Subject "contains duplicate start marker for '$artifactId'" }
+        if ($ends.Count -gt 1) { Fail-Packet $Subject "contains duplicate end marker for '$artifactId'" }
+    }
+    if ($tokens.Count -eq 1 -and $tokens[0].Kind -eq 'end') {
+        Fail-Packet $Subject "is missing start marker for '$($tokens[0].Artifact)'"
+    }
+
+    $open = $null
+    $pairs = [Collections.Generic.List[object]]::new()
+    foreach ($token in $tokens) {
+        if ($token.Kind -eq 'start') {
+            if ($null -ne $open) { Fail-Packet $Subject 'contains nested lifecycle projection markers' }
+            $open = $token
+            continue
+        }
+        if ($null -eq $open) { Fail-Packet $Subject "contains reversed end marker for '$($token.Artifact)'" }
+        if (-not [StringComparer]::Ordinal.Equals($open.Artifact, $token.Artifact)) {
+            Fail-Packet $Subject "contains mismatched marker pair '$($open.Artifact)' and '$($token.Artifact)'"
+        }
+        $pairs.Add([pscustomobject]@{ Artifact = $open.Artifact; Start = $open.Start; End = $token.End })
+        $open = $null
+    }
+    if ($null -ne $open) { Fail-Packet $Subject "is missing end marker for '$($open.Artifact)'" }
+    if ($pairs.Count -ne 1) { Fail-Packet $Subject 'contains multiple artifact-specific projection marker pairs' }
+
+    $pairs[0]
+}
+
+function Get-ExpectedBlockBytes {
+    param(
+        [string] $Artifact,
+        [byte[]] $LineEnding,
+        [byte[]] $Payload
+    )
+
+    $parts = [Collections.Generic.List[byte[]]]::new()
+    $parts.Add($script:Utf8.GetBytes((Get-Marker $Artifact start)))
+    $parts.Add($LineEnding)
+    $parts.Add($script:Utf8.GetBytes('```json'))
+    $parts.Add($LineEnding)
+    $parts.Add($Payload)
+    $parts.Add($LineEnding)
+    $parts.Add($script:Utf8.GetBytes('```'))
+    $parts.Add($LineEnding)
+    $parts.Add($script:Utf8.GetBytes((Get-Marker $Artifact end)))
+    $length = 0
+    foreach ($part in $parts) { $length += $part.Length }
+    $result = [byte[]]::new($length)
+    $position = 0
+    foreach ($part in $parts) {
+        [Array]::Copy($part, 0, $result, $position, $part.Length)
+        $position += $part.Length
+    }
+
+    ,$result
+}
+
+function Resolve-ExistingDirectory {
+    param([string] $Path, [string] $Subject)
+
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    if (-not [IO.Directory]::Exists($fullPath)) { Fail-Packet $Subject 'does not exist as a directory' }
+    $root = [IO.Path]::GetPathRoot($fullPath)
+    $current = $root
+    $relative = $fullPath.Substring($root.Length).Trim([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    if ($relative.Length -eq 0) { return $current }
+    foreach ($part in $relative -split '[\\/]') {
+        $candidate = Join-Path $current $part
+        $directory = [IO.DirectoryInfo]::new($candidate)
+        if (-not $directory.Exists) { Fail-Packet $Subject "directory component '$part' does not exist" }
+        if (($directory.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+            $target = $directory.ResolveLinkTarget($true)
+            if ($null -eq $target) { Fail-Packet $Subject "cannot resolve reparse-point directory component '$part'" }
+            $current = [IO.Path]::GetFullPath($target.FullName)
+        }
+        else {
+            $current = $directory.FullName
+        }
+    }
+
+    $current
+}
+
+function Test-PathWithin {
+    param([string] $Candidate, [string] $Directory)
+
+    $candidateFull = [IO.Path]::GetFullPath($Candidate)
+    $directoryFull = [IO.Path]::GetFullPath($Directory).TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+    $candidateFull.StartsWith($directoryFull, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-PacketInputs {
+    param(
+        [object] $Compiled,
+        [string] $CanonicalPath,
+        [string] $PacketDirectory,
+        [string] $RawExportCommand,
+        [switch] $RequireExact
+    )
+
+    $lexicalDirectory = [IO.Path]::GetFullPath($PacketDirectory)
+    $physicalDirectory = Resolve-ExistingDirectory $lexicalDirectory $lexicalDirectory
+    $directory = [IO.DirectoryInfo]::new($physicalDirectory)
+    $map = Get-ArtifactMap $Compiled
+    $entries = @($directory.GetFileSystemInfos() | Sort-Object Name)
+    if ($entries.Count -ne $map.Count) { Fail-Packet $lexicalDirectory "must contain exactly $($map.Count) packet members" }
+    $seenNames = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $inputs = [Collections.Generic.List[object]]::new()
+    foreach ($entry in $entries) {
+        if ($entry -isnot [IO.FileInfo]) { Fail-Packet $entry.FullName 'packet member must be one declared Markdown file' }
+        if (($entry.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { Fail-Packet $entry.FullName 'packet member must not be a physical alias' }
+        if (-not $seenNames.Add($entry.Name)) { Fail-Packet $entry.FullName "packet contains duplicate physical member '$($entry.Name)'" }
+        $bytes = [IO.File]::ReadAllBytes($entry.FullName)
+        $bom = if ($bytes.Length -ge 3 -and $bytes[0] -eq 239 -and $bytes[1] -eq 187 -and $bytes[2] -eq 191) { 3 } else { 0 }
+        try { $null = $script:Utf8.GetString($bytes, $bom, $bytes.Length - $bom) } catch { Fail-Packet $entry.FullName 'must be valid UTF-8 Markdown' }
+        $pair = Get-MarkerPair $bytes $Compiled $entry.FullName
+        $expectedName = "$($pair.Artifact).md"
+        if (-not [StringComparer]::Ordinal.Equals($entry.Name, $expectedName)) { Fail-Packet $entry.FullName "packet member name must equal '$expectedName'" }
+        $artifact = $map[$pair.Artifact]
+        $inputs.Add([pscustomobject]@{ File = $entry; Bytes = $bytes; Pair = $pair; Artifact = $artifact })
+    }
+    foreach ($artifact in $Compiled.Artifacts) {
+        if (-not $seenNames.Contains("$($artifact.Id).md")) { Fail-Packet $lexicalDirectory "packet is missing required file '$($artifact.Id).md'" }
+    }
+
+    $payloads = Get-WduLifecycleRawExportBytes -CanonicalPath $CanonicalPath -Artifacts @($Compiled.Artifacts | ForEach-Object { $_.Id }) -RawExportCommand $RawExportCommand
+    foreach ($input in $inputs) {
+        $expected = Get-ExpectedBlockBytes -Artifact $input.Artifact.Id -LineEnding (Get-LineEndingBytes $input.Bytes) -Payload $payloads[$input.Artifact.Id]
+        if ($RequireExact) {
+            $actual = $input.Bytes[$input.Pair.Start..($input.Pair.End - 1)]
+            if ([Convert]::ToHexString($actual) -cne [Convert]::ToHexString($expected)) {
+                Fail-Packet $input.File.FullName "artifact '$($input.Pair.Artifact)' does not equal the exact raw projection block"
+            }
+        }
+        $input | Add-Member -NotePropertyName Expected -NotePropertyValue $expected
+    }
+
+    [pscustomobject]@{ Inputs = @($inputs); LexicalDirectory = $lexicalDirectory; PhysicalDirectory = $physicalDirectory }
+}
+
+function Test-WduLifecyclePacket {
+    param(
+        [Parameter(Mandatory)][string] $CanonicalPath,
+        [Parameter(Mandatory)][string] $PacketDirectory,
+        [string] $RawExportCommand = $script:RawExportCommand
+    )
+
+    $compiled = Read-WduLifecycleContract -Path $CanonicalPath
+    $packet = Get-PacketInputs -Compiled $compiled -CanonicalPath $CanonicalPath -PacketDirectory $PacketDirectory -RawExportCommand $RawExportCommand -RequireExact
+    foreach ($artifact in $compiled.Artifacts) {
+        $input = @($packet.Inputs | Where-Object { [StringComparer]::Ordinal.Equals($_.Artifact.Id, $artifact.Id) })[0]
+        [pscustomobject]@{ Artifact = $artifact.Id; Path = $input.File.FullName; Result = 'ExactMatch' }
+    }
+}
+
+function Export-WduLifecyclePacket {
+    param(
+        [Parameter(Mandatory)][string] $CanonicalPath,
+        [Parameter(Mandatory)][string] $PacketDirectory,
+        [Parameter(Mandatory)][string] $OutputDirectory,
+        [string] $RawExportCommand = $script:RawExportCommand
+    )
+
+    $compiled = Read-WduLifecycleContract -Path $CanonicalPath
+    $packet = Get-PacketInputs -Compiled $compiled -CanonicalPath $CanonicalPath -PacketDirectory $PacketDirectory -RawExportCommand $RawExportCommand
+    $destinationLexical = [IO.Path]::GetFullPath($OutputDirectory)
+    if (Test-Path -LiteralPath $destinationLexical) { Fail-Packet $destinationLexical 'render destination already exists' }
+    $parent = [IO.Directory]::GetParent($destinationLexical)
+    if ($null -eq $parent -or -not $parent.Exists) { Fail-Packet $destinationLexical 'render destination parent does not exist' }
+    $physicalParent = Resolve-ExistingDirectory $parent.FullName $destinationLexical
+    $leaf = [IO.Path]::GetFileName($destinationLexical)
+    if ([string]::IsNullOrEmpty($leaf)) { Fail-Packet $destinationLexical 'render destination must name a new leaf directory' }
+    $destinationPhysical = Join-Path $physicalParent $leaf
+    if ((Test-PathWithin $destinationLexical $packet.LexicalDirectory) -or (Test-PathWithin $destinationPhysical $packet.PhysicalDirectory)) {
+        Fail-Packet $destinationLexical 'render destination aliases an input artifact directory'
+    }
+
+    $staging = Join-Path $physicalParent ('.' + $leaf + '.staging-' + [guid]::NewGuid().ToString('N'))
+    try {
+        [IO.Directory]::CreateDirectory($staging) | Out-Null
+        $writes = 0
+        foreach ($input in $packet.Inputs) {
+            [byte[]] $prefix = [byte[]]::new(0)
+            if ($input.Pair.Start -gt 0) { $prefix = $input.Bytes[0..($input.Pair.Start - 1)] }
+            [byte[]] $suffix = [byte[]]::new(0)
+            if ($input.Pair.End -lt $input.Bytes.Length) { $suffix = $input.Bytes[$input.Pair.End..($input.Bytes.Length - 1)] }
+            $output = [byte[]]::new($prefix.Length + $input.Expected.Length + $suffix.Length)
+            [Array]::Copy($prefix, 0, $output, 0, $prefix.Length)
+            [Array]::Copy($input.Expected, 0, $output, $prefix.Length, $input.Expected.Length)
+            [Array]::Copy($suffix, 0, $output, $prefix.Length + $input.Expected.Length, $suffix.Length)
+            [IO.File]::WriteAllBytes((Join-Path $staging "$($input.Artifact.Id).md"), $output)
+            $writes++
+            if ($null -ne $script:FailureAfterStagedWritesForTest -and $writes -ge $script:FailureAfterStagedWritesForTest) {
+                throw 'test-only deterministic failure after staged write'
+            }
+        }
+        [IO.Directory]::Move($staging, $destinationPhysical)
+    }
+    catch {
+        if (Test-Path -LiteralPath $staging) { Remove-Item -LiteralPath $staging -Recurse -Force }
+        throw
+    }
+
+    @(Get-ChildItem -LiteralPath $destinationPhysical -File | Sort-Object Name | Select-Object -ExpandProperty FullName)
+}
+
+Export-ModuleMember -Function Test-WduLifecyclePacket, Export-WduLifecyclePacket

--- a/scripts/render-wdu-lifecycle-packet.ps1
+++ b/scripts/render-wdu-lifecycle-packet.ps1
@@ -1,0 +1,12 @@
+[CmdletBinding()]
+param(
+    [string] $CanonicalPath = (Join-Path $PSScriptRoot '../docs/Working Directory Update.md'),
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $PacketDirectory,
+    [Parameter(Mandatory)][ValidateNotNullOrEmpty()][string] $OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'modules/WduLifecyclePacket.psm1') -Force
+Export-WduLifecyclePacket -CanonicalPath $CanonicalPath -PacketDirectory $PacketDirectory -OutputDirectory $OutputDirectory

--- a/scripts/test-wdu-lifecycle-packet.ps1
+++ b/scripts/test-wdu-lifecycle-packet.ps1
@@ -1,0 +1,9 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+& (Join-Path $PSScriptRoot 'tests/WduLifecyclePacket.Tests.ps1')
+if ($?) { exit 0 }
+exit 1

--- a/scripts/tests/WduLifecyclePacket.Tests.ps1
+++ b/scripts/tests/WduLifecyclePacket.Tests.ps1
@@ -1,0 +1,233 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$canonical = Join-Path $root 'docs/Working Directory Update.md'
+$renderCommand = Join-Path $root 'scripts/render-wdu-lifecycle-packet.ps1'
+$checkCommand = Join-Path $root 'scripts/check-wdu-lifecycle-packet.ps1'
+$rawExportCommand = Join-Path $root 'scripts/get-wdu-lifecycle-projection.ps1'
+$packetModule = Join-Path $root 'scripts/modules/WduLifecyclePacket.psm1'
+$contractModule = Join-Path $root 'scripts/modules/WduLifecycleContract.psm1'
+
+function Assert-True { param([bool] $Condition, [string] $Message) if (-not $Condition) { throw "Assertion failed: $Message" } }
+function Assert-Bytes { param([byte[]] $Actual, [byte[]] $Expected, [string] $Message) Assert-True ($Actual.Length -eq $Expected.Length) "$Message length"; Assert-True ([Convert]::ToHexString($Actual) -ceq [Convert]::ToHexString($Expected)) "$Message bytes" }
+function Assert-Fails { param([scriptblock] $Action, [string] $Reason) try { & $Action | Out-Null } catch { if ($_.Exception.Message.Contains($Reason, [StringComparison]::Ordinal)) { return }; throw }; throw "Expected '$Reason'" }
+function Invoke-Case { param([string] $Name, [scriptblock] $Action) try { & $Action; $script:Passed++; Write-Host "PASS $Name" } catch { $script:Failed++; Write-Host "FAIL $Name`: $($_.Exception.Message)" -ForegroundColor Red } }
+function Get-Marker { param([string] $Artifact, [ValidateSet('start', 'end')][string] $Kind) "<!-- grace:wdu-lifecycle-projection:$Artifact`:$Kind -->" }
+function Get-Hashes { param([string] $Directory) @((Get-ChildItem -LiteralPath $Directory -File | Sort-Object Name | ForEach-Object { "$($_.Name):$((Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash)" })) }
+function Find-Bytes { param([byte[]] $Bytes, [byte[]] $Needle, [int] $Offset = 0) for ($index = $Offset; $index -le $Bytes.Length - $Needle.Length; $index++) { $same = $true; for ($needleIndex = 0; $needleIndex -lt $Needle.Length; $needleIndex++) { if ($Bytes[$index + $needleIndex] -ne $Needle[$needleIndex]) { $same = $false; break } }; if ($same) { return $index } }; -1 }
+function Get-Span { param([byte[]] $Bytes, [string] $Artifact) $utf8 = [Text.UTF8Encoding]::new($false, $true); $startMarker = $utf8.GetBytes((Get-Marker $Artifact start)); $endMarker = $utf8.GetBytes((Get-Marker $Artifact end)); $start = Find-Bytes $Bytes $startMarker; $end = Find-Bytes $Bytes $endMarker ($start + $startMarker.Length); Assert-True ($start -ge 0 -and $end -ge 0) "$Artifact marker span"; [pscustomobject]@{ Start = $start; End = $end + $endMarker.Length; StartMarkerLength = $startMarker.Length; EndMarkerStart = $end } }
+function Copy-Packet { param([string] $Source, [string] $Name) $destination = Join-Path $testRoot $Name; Copy-Item -LiteralPath $Source -Destination $destination -Recurse; $destination }
+
+function Invoke-WduExportProcess {
+    param([string] $Artifact)
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = (Get-Command pwsh -CommandType Application).Source
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in @('-NoLogo', '-NoProfile', '-File', $rawExportCommand, '-CanonicalPath', $canonical, '-Artifact', $Artifact)) { [void] $startInfo.ArgumentList.Add($argument) }
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $stdout = [IO.MemoryStream]::new()
+    try {
+        [void] $process.Start()
+        $stdoutTask = $process.StandardOutput.BaseStream.CopyToAsync($stdout)
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        $null = $stdoutTask.GetAwaiter().GetResult()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+        Assert-True ($process.ExitCode -eq 0) "$Artifact export exit"
+        Assert-True ([string]::IsNullOrEmpty($stderr)) "$Artifact export stderr"
+        return ,$stdout.ToArray()
+    }
+    finally {
+        $stdout.Dispose()
+        $process.Dispose()
+    }
+}
+
+function Get-PayloadFromBlock {
+    param([byte[]] $Bytes, [string] $Artifact)
+
+    $span = Get-Span $Bytes $Artifact
+    [byte[]] $lineEnding = if ($Bytes[$span.Start + $span.StartMarkerLength] -eq 13) { @(13, 10) } else { @(10) }
+    $payloadStart = $span.Start + $span.StartMarkerLength + $lineEnding.Length + 7 + $lineEnding.Length
+    $payloadEnd = $span.EndMarkerStart - $lineEnding.Length - 3 - $lineEnding.Length
+    Assert-True ($payloadEnd -ge $payloadStart) "$Artifact payload span"
+    return ,$Bytes[$payloadStart..($payloadEnd - 1)]
+}
+
+Import-Module $packetModule -Force
+Import-Module $contractModule -Force
+$compiled = Read-WduLifecycleContract -Path $canonical
+$artifacts = @($compiled.Artifacts | ForEach-Object { $_.Id })
+$script:Passed = 0
+$script:Failed = 0
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ('wdu-948-' + [guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($testRoot) | Out-Null
+
+try {
+    Invoke-Case 'compiler declares exactly fifteen unique artifact IDs' {
+        Assert-True ($artifacts.Count -eq 15) 'artifact count'
+        Assert-True (@($artifacts | Select-Object -Unique).Count -eq 15) 'artifact uniqueness'
+    }
+
+    $seed = Join-Path $testRoot 'seed'
+    [IO.Directory]::CreateDirectory($seed) | Out-Null
+    foreach ($artifact in $artifacts) {
+        $line = if (($artifacts.IndexOf($artifact) % 2) -eq 0) { "`r`n" } else { "`n" }
+        $bom = if ($artifact -eq 'adr-0011') { [byte[]](239, 187, 191) } else { [byte[]]::new(0) }
+        $body = "prefix-$artifact-é$line$(Get-Marker $artifact start)$line``````json$line{}$line``````$line$(Get-Marker $artifact end)$line" + "suffix-$artifact-é"
+        [IO.File]::WriteAllBytes((Join-Path $seed "$artifact.md"), [byte[]]($bom + [Text.UTF8Encoding]::new($false, $true).GetBytes($body)))
+    }
+
+    $sourceHashes = Get-Hashes $seed
+    $rendered = Join-Path $testRoot 'rendered'
+    $renderedFiles = @(& $renderCommand -CanonicalPath $canonical -PacketDirectory $seed -OutputDirectory $rendered)
+    Invoke-Case 'render command produces exactly fifteen declared packet members' {
+        Assert-True ($renderedFiles.Count -eq 15) 'rendered member count'
+        Assert-True ((@(Get-ChildItem -LiteralPath $rendered -File | Sort-Object Name | Select-Object -ExpandProperty Name) -join '|') -ceq (($artifacts | ForEach-Object { "$_` .md".Replace(' ', '') } | Sort-Object) -join '|')) 'rendered names'
+    }
+    Invoke-Case 'render preserves every source hash and does not expose a partial output' {
+        Assert-True (((Get-Hashes $seed) -join '|') -ceq ($sourceHashes -join '|')) 'source hashes'
+        Assert-True (@(Get-ChildItem -LiteralPath $rendered -File).Count -eq 15) 'complete rendered output'
+    }
+    Invoke-Case 'check command proves exact membership without writing' {
+        $before = Get-Hashes $rendered
+        $result = @(& $checkCommand -CanonicalPath $canonical -PacketDirectory $rendered)
+        Assert-True ($result.Count -eq 15) 'check count'
+        Assert-True (@($result | Where-Object { $_.Result -ceq 'ExactMatch' }).Count -eq 15) 'exact check results'
+        Assert-True (((Get-Hashes $rendered) -join '|') -ceq ($before -join '|')) 'check hashes'
+    }
+
+    foreach ($artifact in $artifacts) {
+        Invoke-Case "compares $artifact inserted bytes to a fresh #947 process" {
+            $source = [IO.File]::ReadAllBytes((Join-Path $seed "$artifact.md"))
+            $output = [IO.File]::ReadAllBytes((Join-Path $rendered "$artifact.md"))
+            $sourceSpan = Get-Span $source $artifact
+            $outputSpan = Get-Span $output $artifact
+            Assert-Bytes $output[0..($outputSpan.Start - 1)] $source[0..($sourceSpan.Start - 1)] "$artifact prefix"
+            Assert-Bytes $output[$outputSpan.End..($output.Length - 1)] $source[$sourceSpan.End..($source.Length - 1)] "$artifact suffix"
+            Assert-Bytes (Get-PayloadFromBlock $output $artifact) (Invoke-WduExportProcess $artifact) "$artifact fresh payload"
+        }
+    }
+
+    foreach ($case in @(
+            @{ Name = 'changes'; Mutate = { param([byte[]] $bytes) $copy = [byte[]]$bytes.Clone(); $copy[0] = 0x78; $copy } },
+            @{ Name = 'drops'; Mutate = { param([byte[]] $bytes) $bytes[1..($bytes.Length - 1)] } },
+            @{ Name = 'adds'; Mutate = { param([byte[]] $bytes) [byte[]](0x78) + $bytes } },
+            @{ Name = 'normalizes'; Mutate = { param([byte[]] $bytes) [Text.UTF8Encoding]::new($false, $true).GetBytes(([Text.UTF8Encoding]::new($false, $true).GetString($bytes)).Replace("`r`n", "`n")) } }
+        )) {
+        Invoke-Case "detects outside-marker byte $($case.Name)" {
+            $artifact = if ($case.Name -eq 'normalizes') { 'adr-0011' } else { 'epic-835' }
+            $source = [IO.File]::ReadAllBytes((Join-Path $seed "$artifact.md"))
+            $output = [IO.File]::ReadAllBytes((Join-Path $rendered "$artifact.md"))
+            $sourceSpan = Get-Span $source $artifact
+            $outputSpan = Get-Span $output $artifact
+            $sourceOutside = $source[0..($sourceSpan.Start - 1)] + $source[$sourceSpan.End..($source.Length - 1)]
+            $outputOutside = $output[0..($outputSpan.Start - 1)] + $output[$outputSpan.End..($output.Length - 1)]
+            $mutated = & $case.Mutate $outputOutside
+            Assert-True ([Convert]::ToHexString($sourceOutside) -ceq [Convert]::ToHexString($outputOutside)) "$artifact baseline outside bytes"
+            Assert-True ([Convert]::ToHexString($sourceOutside) -cne [Convert]::ToHexString($mutated)) "$artifact $($case.Name) is detected"
+        }
+    }
+
+    Invoke-Case 'rejects an existing output before staging' { Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $seed -OutputDirectory $rendered } 'render destination already exists' }
+    Invoke-Case 'renders deterministic byte-identical packets' {
+        $second = Join-Path $testRoot 'second'
+        & $renderCommand -CanonicalPath $canonical -PacketDirectory $seed -OutputDirectory $second | Out-Null
+        foreach ($artifact in $artifacts) { Assert-Bytes ([IO.File]::ReadAllBytes((Join-Path $rendered "$artifact.md"))) ([IO.File]::ReadAllBytes((Join-Path $second "$artifact.md"))) "$artifact deterministic" }
+    }
+
+    $markerCases = @(
+        @{ Name = 'missing start'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' start), '') }; Reason = "is missing start marker for 'adr-0011'" },
+        @{ Name = 'missing end'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' end), '') }; Reason = "is missing end marker for 'adr-0011'" },
+        @{ Name = 'missing evidence'; Mutate = { param($text) $text -replace '<!-- grace:wdu-lifecycle-projection:adr-0011:(start|end) -->', '' }; Reason = 'is missing lifecycle projection marker evidence' },
+        @{ Name = 'duplicate start'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' start), "$(Get-Marker 'adr-0011' start)`n$(Get-Marker 'adr-0011' start)") }; Reason = "contains duplicate start marker for 'adr-0011'" },
+        @{ Name = 'duplicate end'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' end), "$(Get-Marker 'adr-0011' end)`n$(Get-Marker 'adr-0011' end)") }; Reason = "contains duplicate end marker for 'adr-0011'" },
+        @{ Name = 'reversed'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' start), '<!-- temporary -->').Replace((Get-Marker 'adr-0011' end), (Get-Marker 'adr-0011' start)).Replace('<!-- temporary -->', (Get-Marker 'adr-0011' end)) }; Reason = "contains reversed end marker for 'adr-0011'" },
+        @{ Name = 'nested'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' end), "$(Get-Marker 'issue-842' start)`n$(Get-Marker 'adr-0011' end)`n$(Get-Marker 'issue-842' end)") }; Reason = 'contains nested lifecycle projection markers' },
+        @{ Name = 'mismatched'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' end), (Get-Marker 'issue-842' end)) }; Reason = "contains mismatched marker pair 'adr-0011' and 'issue-842'" },
+        @{ Name = 'unknown'; Mutate = { param($text) $text.Replace('adr-0011', 'unknown') }; Reason = "contains unknown artifact marker 'unknown'" },
+        @{ Name = 'generic'; Mutate = { param($text) $text.Replace((Get-Marker 'adr-0011' start), '<!-- grace:wdu-lifecycle-projection:start -->') }; Reason = 'contains generic legacy lifecycle projection marker' },
+        @{ Name = 'case changed'; Mutate = { param($text) $text.Replace('adr-0011:start', 'ADR-0011:start') }; Reason = 'contains case-changed lifecycle projection marker' }
+    )
+    foreach ($case in $markerCases) {
+        Invoke-Case "classifies $($case.Name) markers" {
+            $packet = Copy-Packet $seed ('marker-' + $case.Name)
+            $path = Join-Path $packet 'adr-0011.md'
+            [IO.File]::WriteAllText($path, (& $case.Mutate ([IO.File]::ReadAllText($path))), [Text.UTF8Encoding]::new($false))
+            Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $packet -OutputDirectory (Join-Path $testRoot ('out-' + $case.Name)) } $case.Reason
+        }
+    }
+
+    foreach ($case in @(
+            @{ Name = 'extra opener whitespace'; Comment = '<!--  grace:wdu-lifecycle-projection:adr-0011:start -->'; Reason = 'contains malformed lifecycle projection marker' },
+            @{ Name = 'missing opener whitespace'; Comment = '<!--grace:wdu-lifecycle-projection:adr-0011:start -->'; Reason = 'contains malformed lifecycle projection marker' },
+            @{ Name = 'delimiter whitespace'; Comment = '<!-- grace:wdu-lifecycle-projection:adr-0011: start -->'; Reason = 'contains malformed lifecycle projection marker' },
+            @{ Name = 'malformed kind'; Comment = '<!-- grace:wdu-lifecycle-projection:adr-0011:middle -->'; Reason = 'contains malformed lifecycle projection marker' },
+            @{ Name = 'case sentinel'; Comment = '<!-- Grace:Wdu-Lifecycle-Projection:adr-0011:start -->'; Reason = 'contains case-changed lifecycle projection marker' },
+            @{ Name = 'multiple comments'; Comment = '<!-- grace:wdu-lifecycle-projection:issue-842:start -->'; Reason = "is missing end marker for 'issue-842'" }
+        )) {
+        Invoke-Case "rejects valid pair plus $($case.Name)" {
+            $packet = Copy-Packet $seed ('sentinel-' + $case.Name.Replace(' ', '-'))
+            $path = Join-Path $packet 'adr-0011.md'
+            [IO.File]::AppendAllText($path, "`n$($case.Comment)", [Text.UTF8Encoding]::new($false))
+            Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $packet -OutputDirectory (Join-Path $testRoot ('sentinel-out-' + $case.Name.Replace(' ', '-'))) } $case.Reason
+        }
+    }
+    Invoke-Case 'accepts an unrelated ordinary comment' {
+        $packet = Copy-Packet $seed 'ordinary-comment'
+        [IO.File]::AppendAllText((Join-Path $packet 'adr-0011.md'), "`n<!-- ordinary human comment -->", [Text.UTF8Encoding]::new($false))
+        & $renderCommand -CanonicalPath $canonical -PacketDirectory $packet -OutputDirectory (Join-Path $testRoot 'ordinary-output') | Out-Null
+    }
+
+    foreach ($case in @(
+            @{ Name = 'missing member'; Act = { param($packet) [IO.File]::Delete((Join-Path $packet 'adr-0011.md')) }; Reason = 'must contain exactly 15 packet members' },
+            @{ Name = 'extra file'; Act = { param($packet) [IO.File]::WriteAllText((Join-Path $packet 'extra.txt'), 'unexpected') }; Reason = 'must contain exactly 15 packet members' },
+            @{ Name = 'directory member'; Act = { param($packet) [IO.Directory]::CreateDirectory((Join-Path $packet 'extra')) | Out-Null }; Reason = 'must contain exactly 15 packet members' },
+            @{ Name = 'renamed member'; Act = { param($packet) Move-Item -LiteralPath (Join-Path $packet 'adr-0011.md') -Destination (Join-Path $packet 'renamed.md') }; Reason = "packet member name must equal 'adr-0011.md'" },
+            @{ Name = 'case member'; Act = { param($packet) Move-Item -LiteralPath (Join-Path $packet 'adr-0011.md') -Destination (Join-Path $packet 'ADR-0011.md') }; Reason = "packet member name must equal 'adr-0011.md'" },
+            @{ Name = 'symbolic member'; Act = { param($packet) Remove-Item -LiteralPath (Join-Path $packet 'issue-842.md'); New-Item -ItemType SymbolicLink -Path (Join-Path $packet 'issue-842.md') -Target (Join-Path $packet 'adr-0011.md') | Out-Null }; Reason = 'packet member must not be a physical alias' }
+        )) {
+        Invoke-Case "rejects $($case.Name)" {
+            $packet = Copy-Packet $seed ('member-' + $case.Name.Replace(' ', '-'))
+            & $case.Act $packet
+            Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $packet -OutputDirectory (Join-Path $testRoot ('member-out-' + $case.Name.Replace(' ', '-'))) } $case.Reason
+        }
+    }
+
+    Invoke-Case 'rejects lexical output aliases before staging' { Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $seed -OutputDirectory (Join-Path $seed 'inside') } 'render destination aliases an input artifact directory' }
+    Invoke-Case 'rejects symbolic-link output aliases before staging' {
+        $packet = Copy-Packet $seed 'symbolic-source'; $alias = Join-Path $testRoot 'symbolic-output-alias'; New-Item -ItemType SymbolicLink -Path $alias -Target $packet | Out-Null
+        Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $packet -OutputDirectory (Join-Path $alias 'inside') } 'render destination aliases an input artifact directory'
+    }
+    Invoke-Case 'rejects junction output aliases before staging' {
+        $packet = Copy-Packet $seed 'junction-source'; $alias = Join-Path $testRoot 'junction-output-alias'; New-Item -ItemType Junction -Path $alias -Target $packet | Out-Null
+        Assert-Fails { & $renderCommand -CanonicalPath $canonical -PacketDirectory $packet -OutputDirectory (Join-Path $alias 'inside') } 'render destination aliases an input artifact directory'
+    }
+    Invoke-Case 'cleans staged writes after a deterministic late failure' {
+        $module = Get-Module WduLifecyclePacket
+        & $module { $script:FailureAfterStagedWritesForTest = 14 }
+        $failed = Join-Path $testRoot 'failed'
+        $before = Get-Hashes $seed
+        try { Assert-Fails { Export-WduLifecyclePacket -CanonicalPath $canonical -PacketDirectory $seed -OutputDirectory $failed } 'test-only deterministic failure' }
+        finally { & $module { $script:FailureAfterStagedWritesForTest = $null } }
+        Assert-True (((Get-Hashes $seed) -join '|') -ceq ($before -join '|')) 'late failure source hashes'
+        Assert-True (-not (Test-Path -LiteralPath $failed)) 'late failure output'
+        Assert-True (@(Get-ChildItem -LiteralPath $testRoot -Directory -Filter '.failed.staging-*').Count -eq 0) 'late failure residue'
+    }
+}
+finally {
+    $module = Get-Module WduLifecyclePacket
+    if ($null -ne $module) { & $module { $script:FailureAfterStagedWritesForTest = $null } }
+    if (Test-Path -LiteralPath $testRoot) { Remove-Item -LiteralPath $testRoot -Recurse -Force }
+}
+
+Write-Host "Result: $script:Passed passed; $script:Failed failed"
+if ($script:Failed -ne 0) { exit 1 }


### PR DESCRIPTION
## Purpose

Render and check one exact 15-artifact lifecycle packet using the reviewed #947 fresh-process byte command, while preserving every byte of human Markdown outside the machine marker.

This supplies the checked-in ADR and a safe tracker-publication packet without rebuilding lifecycle semantics.

Relates to #948. Parent epic: #835.

## Product V1 scope

- Payload bytes come only from fresh scripts/get-wdu-lifecycle-projection.ps1 processes.
- Exact artifact-specific marker grammar and complete 15-member packet.
- Byte-preserving check/render behavior.
- Physical path disjointness and all-or-nothing staged publication.
- ADR machine block plus a prepared 14-body tracker packet.
- No product network/GitHub mutation, raw JSON interpretation, runtime, or generalized parser/filesystem layer.

## Proof

- Wrapper-level packet suite: 53/53.
- Fresh #947 process bytes compared for all 15 artifacts.
- Prepared packet: 15/15 ExactMatch.
- ADR byte-equals prepared member.
- Source, prepared, and ADR MarkdownLint: 0.
- PowerShell parse: 5/5.
- Diff check clean.

Tracker publication and post-publication re-export proof remain orchestrator-owned and gated on exact-head review/CI.