### PR TITLE
B4.3R2b: Close zero-fact periods from collective pricing coverage

### DIFF
--- a/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="OperationsData.fs" />
     <Compile Include="OperationsAcceptedFactMutation.fs" />
     <Compile Include="OperationsAcceptedUsageStore.fs" />
+    <Compile Include="OperationsZeroFactPricingCoverage.fs" />
     <Compile Include="OperationsBillingPeriod.fs" />
     <Compile Include="OperationsUsageJournal.fs" />
   </ItemGroup>

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -1,5 +1,6 @@
 namespace Grace.Operations.Data
 
+open Grace.Types.Usage
 open Microsoft.Data.SqlClient
 open NodaTime
 open System
@@ -60,6 +61,12 @@ type internal IBillingPeriodCloseTransactionInterleaving =
     /// Runs after immutable close evidence is staged but before the period is marked closed.
     abstract AfterCloseEvidenceStagedAsync: cancellationToken: CancellationToken -> Task
 
+    /// Runs after one required kind's pricing boundaries are captured and before its effective rows are selected.
+    abstract AfterZeroFactPricingBoundaryEnumerationAsync: factKind: UsageFactKind * cancellationToken: CancellationToken -> Task
+
+    /// Runs immediately before a captured boundary is evaluated against the same serializable pricing view.
+    abstract BeforeZeroFactPricingSelectionAsync: factKind: UsageFactKind * boundary: DateTime * cancellationToken: CancellationToken -> Task
+
 /// Provides production execution with no injected work between close-transaction stages.
 type private NoBillingPeriodCloseTransactionInterleaving() =
     interface IBillingPeriodCloseTransactionInterleaving with
@@ -69,6 +76,17 @@ type private NoBillingPeriodCloseTransactionInterleaving() =
         member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
         member _.AfterChargeInsertionAsync _ = Task.CompletedTask
         member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+        member _.AfterZeroFactPricingBoundaryEnumerationAsync(_, _) = Task.CompletedTask
+        member _.BeforeZeroFactPricingSelectionAsync(_, _, _) = Task.CompletedTask
+
+/// Adapts close-transaction test stages to the pricing evaluator without widening the evaluator's SQL contract.
+type private ZeroFactPricingCoverageInterleaving(transactionInterleaving: IBillingPeriodCloseTransactionInterleaving) =
+    interface IZeroFactPricingCoverageInterleaving with
+        member _.AfterBoundaryEnumerationAsync(factKind, cancellationToken) =
+            transactionInterleaving.AfterZeroFactPricingBoundaryEnumerationAsync(factKind, cancellationToken)
+
+        member _.BeforeSelectionAsync(factKind, boundary, cancellationToken) =
+            transactionInterleaving.BeforeZeroFactPricingSelectionAsync(factKind, boundary, cancellationToken)
 
 /// Reads the database clock on the connection and transaction that already hold the scope lock.
 type internal IBillingPeriodCloseClock =
@@ -588,7 +606,12 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
                             let! facts = readPricedFactsAsync connection transaction request.Scope cancellationToken
 
                             if List.isEmpty facts then
-                                let coverage = SqlZeroFactPricingCoverage() :> IZeroFactPricingCoverage
+                                use pricingCatalogIsolation = command connection transaction "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;"
+
+                                let! _ = pricingCatalogIsolation.ExecuteNonQueryAsync cancellationToken
+
+                                let coverage =
+                                    SqlZeroFactPricingCoverage(ZeroFactPricingCoverageInterleaving(transactionInterleaving)) :> IZeroFactPricingCoverage
 
                                 match! coverage.EvaluateAsync(connection, transaction, request.Scope, cancellationToken) with
                                 | Incomplete diagnostic -> raise (ZeroFactPricingCoverageException(diagnostic))

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsBillingPeriod.fs
@@ -36,9 +36,9 @@ module internal BillingPeriodCloseEligibility =
         let threshold = nextMonthStartUtc.AddHours(if isFinal then 72.0 else 24.0)
         databaseUtcNow >= threshold
 
-/// Signals that nonempty close must not infer the deferred collective zero-fact pricing decision.
-type private ZeroFactCoveragePendingException() =
-    inherit InvalidOperationException("ZeroFactCoveragePending")
+/// Signals that an empty close lacks one required collective pricing grain.
+type private ZeroFactPricingCoverageException(diagnostic: string) =
+    inherit InvalidOperationException(diagnostic)
 
 /// Exposes the internal transaction stages used by real-SQL rollback and contention proofs.
 type internal IBillingPeriodCloseTransactionInterleaving =
@@ -586,7 +586,13 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
                             return Blocked diagnostic
                         | None ->
                             let! facts = readPricedFactsAsync connection transaction request.Scope cancellationToken
-                            if List.isEmpty facts then raise (ZeroFactCoveragePendingException())
+
+                            if List.isEmpty facts then
+                                let coverage = SqlZeroFactPricingCoverage() :> IZeroFactPricingCoverage
+
+                                match! coverage.EvaluateAsync(connection, transaction, request.Scope, cancellationToken) with
+                                | Incomplete diagnostic -> raise (ZeroFactPricingCoverageException(diagnostic))
+                                | Complete -> ()
 
                             let previewScope: ChargePreviewScope =
                                 {
@@ -625,7 +631,7 @@ ELSE SELECT CAST(NULL AS nvarchar(400));
                 do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
                 do! transaction.CommitAsync cancellationToken
                 return Blocked ex.Message
-            | :? ZeroFactCoveragePendingException as ex ->
+            | :? ZeroFactPricingCoverageException as ex ->
                 do! setDiagnosticAsync connection transaction (billingPeriodId request.Scope) (Some ex.Message) cancellationToken
                 do! transaction.CommitAsync cancellationToken
                 return Blocked ex.Message

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsZeroFactPricingCoverage.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsZeroFactPricingCoverage.fs
@@ -20,8 +20,16 @@ type internal IZeroFactPricingCoverage =
         connection: SqlConnection * transaction: SqlTransaction * scope: BillingCompletenessScope * cancellationToken: CancellationToken ->
             Task<ZeroFactPricingCoverageResult>
 
-/// Evaluates the current SQL pricing catalog at every effective boundary that can affect an empty period close.
-type internal SqlZeroFactPricingCoverage() =
+/// Exposes only the zero-fact evaluator stages needed by real-SQL cancellation and catalog-serialization proofs.
+type internal IZeroFactPricingCoverageInterleaving =
+    /// Runs after one required kind's pricing boundaries are captured and before its effective rows are selected.
+    abstract AfterBoundaryEnumerationAsync: factKind: UsageFactKind * cancellationToken: CancellationToken -> Task
+
+    /// Runs immediately before a captured boundary is evaluated against the same serializable pricing view.
+    abstract BeforeSelectionAsync: factKind: UsageFactKind * boundary: DateTime * cancellationToken: CancellationToken -> Task
+
+/// Evaluates the current serializable SQL pricing catalog at every effective boundary that can affect an empty period close.
+type internal SqlZeroFactPricingCoverage(transactionInterleaving: IZeroFactPricingCoverageInterleaving) =
 
     /// Creates a SQL command tied to the already locked close transaction.
     let command (connection: SqlConnection) (transaction: SqlTransaction) text =
@@ -62,38 +70,47 @@ type internal SqlZeroFactPricingCoverage() =
 WITH BoundaryRows AS
 (
     SELECT @MonthStartUtc AS BoundaryUtc
-    UNION ALL SELECT @NextMonthStartUtc
     UNION ALL SELECT assignment.EffectiveFromUtc FROM ops.PricingAssignment AS assignment
         WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-          AND assignment.EffectiveFromUtc < @NextMonthStartUtc
+          AND assignment.EffectiveFromUtc > @MonthStartUtc AND assignment.EffectiveFromUtc < @NextMonthStartUtc
           AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > @MonthStartUtc)
     UNION ALL SELECT assignment.EffectiveToUtc FROM ops.PricingAssignment AS assignment
         WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
           AND assignment.EffectiveToUtc IS NOT NULL AND assignment.EffectiveToUtc > @MonthStartUtc AND assignment.EffectiveToUtc < @NextMonthStartUtc
-    UNION ALL SELECT pricingPlan.EffectiveFromUtc FROM ops.PricingPlan AS pricingPlan INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=pricingPlan.PricingPlanId
-        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-          AND pricingPlan.EffectiveFromUtc < @NextMonthStartUtc AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc > @MonthStartUtc)
-    UNION ALL SELECT pricingPlan.EffectiveToUtc FROM ops.PricingPlan AS pricingPlan INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=pricingPlan.PricingPlanId
-        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-          AND pricingPlan.EffectiveToUtc IS NOT NULL AND pricingPlan.EffectiveToUtc > @MonthStartUtc AND pricingPlan.EffectiveToUtc < @NextMonthStartUtc
+    UNION ALL SELECT pricingPlan.EffectiveFromUtc FROM ops.PricingPlan AS pricingPlan
+        WHERE pricingPlan.EffectiveFromUtc > @MonthStartUtc AND pricingPlan.EffectiveFromUtc < @NextMonthStartUtc
+          AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc > @MonthStartUtc)
+          AND EXISTS (SELECT 1 FROM ops.PricingAssignment AS assignment WHERE assignment.PricingPlanId=pricingPlan.PricingPlanId
+              AND assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+              AND assignment.EffectiveFromUtc < @NextMonthStartUtc AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > @MonthStartUtc))
+    UNION ALL SELECT pricingPlan.EffectiveToUtc FROM ops.PricingPlan AS pricingPlan
+        WHERE pricingPlan.EffectiveToUtc IS NOT NULL AND pricingPlan.EffectiveToUtc > @MonthStartUtc AND pricingPlan.EffectiveToUtc < @NextMonthStartUtc
+          AND EXISTS (SELECT 1 FROM ops.PricingAssignment AS assignment WHERE assignment.PricingPlanId=pricingPlan.PricingPlanId
+              AND assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+              AND assignment.EffectiveFromUtc < @NextMonthStartUtc AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > @MonthStartUtc))
     UNION ALL SELECT mapping.EffectiveFromUtc FROM ops.BillableUsageKindMapping AS mapping
-        WHERE mapping.FactKind=@FactKind AND mapping.EffectiveFromUtc < @NextMonthStartUtc
+        WHERE mapping.FactKind=@FactKind AND mapping.EffectiveFromUtc > @MonthStartUtc AND mapping.EffectiveFromUtc < @NextMonthStartUtc
           AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc > @MonthStartUtc)
     UNION ALL SELECT mapping.EffectiveToUtc FROM ops.BillableUsageKindMapping AS mapping
         WHERE mapping.FactKind=@FactKind AND mapping.EffectiveToUtc IS NOT NULL
           AND mapping.EffectiveToUtc > @MonthStartUtc AND mapping.EffectiveToUtc < @NextMonthStartUtc
     UNION ALL SELECT rate.EffectiveFromUtc FROM ops.PricingRate AS rate
-        INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=rate.PricingPlanId
-        INNER JOIN ops.BillableUsageKindMapping AS mapping ON mapping.BillableUsageKind=rate.BillableUsageKind
-        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-          AND mapping.FactKind=@FactKind AND rate.EffectiveFromUtc < @NextMonthStartUtc
+        WHERE rate.EffectiveFromUtc > @MonthStartUtc AND rate.EffectiveFromUtc < @NextMonthStartUtc
           AND (rate.EffectiveToUtc IS NULL OR rate.EffectiveToUtc > @MonthStartUtc)
+          AND EXISTS (SELECT 1 FROM ops.PricingAssignment AS assignment WHERE assignment.PricingPlanId=rate.PricingPlanId
+              AND assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+              AND assignment.EffectiveFromUtc < @NextMonthStartUtc AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > @MonthStartUtc))
+          AND EXISTS (SELECT 1 FROM ops.BillableUsageKindMapping AS mapping WHERE mapping.FactKind=@FactKind
+              AND mapping.BillableUsageKind=rate.BillableUsageKind AND mapping.EffectiveFromUtc < @NextMonthStartUtc
+              AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc > @MonthStartUtc))
     UNION ALL SELECT rate.EffectiveToUtc FROM ops.PricingRate AS rate
-        INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=rate.PricingPlanId
-        INNER JOIN ops.BillableUsageKindMapping AS mapping ON mapping.BillableUsageKind=rate.BillableUsageKind
-        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
-          AND mapping.FactKind=@FactKind AND rate.EffectiveToUtc IS NOT NULL
-          AND rate.EffectiveToUtc > @MonthStartUtc AND rate.EffectiveToUtc < @NextMonthStartUtc
+        WHERE rate.EffectiveToUtc IS NOT NULL AND rate.EffectiveToUtc > @MonthStartUtc AND rate.EffectiveToUtc < @NextMonthStartUtc
+          AND EXISTS (SELECT 1 FROM ops.PricingAssignment AS assignment WHERE assignment.PricingPlanId=rate.PricingPlanId
+              AND assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+              AND assignment.EffectiveFromUtc < @NextMonthStartUtc AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > @MonthStartUtc))
+          AND EXISTS (SELECT 1 FROM ops.BillableUsageKindMapping AS mapping WHERE mapping.FactKind=@FactKind
+              AND mapping.BillableUsageKind=rate.BillableUsageKind AND mapping.EffectiveFromUtc < @NextMonthStartUtc
+              AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc > @MonthStartUtc))
 )
 SELECT DISTINCT BoundaryUtc FROM BoundaryRows WHERE BoundaryUtc IS NOT NULL ORDER BY BoundaryUtc;
 """
@@ -244,10 +261,12 @@ SELECT DISTINCT BoundaryUtc FROM BoundaryRows WHERE BoundaryUtc IS NOT NULL ORDE
                       && result = Complete do
                     let factKind = requiredFactKinds[factKindIndex]
                     let! boundaries = boundariesAsync connection transaction scope factKind cancellationToken
+                    do! transactionInterleaving.AfterBoundaryEnumerationAsync(factKind, cancellationToken)
                     let mutable boundaryIndex = 0
 
                     while boundaryIndex < boundaries.Length
                           && result = Complete do
+                        do! transactionInterleaving.BeforeSelectionAsync(factKind, boundaries[boundaryIndex], cancellationToken)
                         let! missing = firstIncompleteBoundaryAsync connection transaction scope factKind boundaries[boundaryIndex] cancellationToken
 
                         match missing with

--- a/src/Grace.Operations/Grace.Operations.Data/OperationsZeroFactPricingCoverage.fs
+++ b/src/Grace.Operations/Grace.Operations.Data/OperationsZeroFactPricingCoverage.fs
@@ -1,0 +1,260 @@
+namespace Grace.Operations.Data
+
+open Grace.Types.Usage
+open Microsoft.Data.SqlClient
+open System
+open System.Data
+open System.Globalization
+open System.Threading
+open System.Threading.Tasks
+
+/// Reports whether every supported usage-fact kind has a complete pricing grain throughout one empty billing month.
+type internal ZeroFactPricingCoverageResult =
+    | Complete
+    | Incomplete of diagnostic: string
+
+/// Evaluates collective effective-dated pricing coverage using the connection and transaction that already hold a billing scope lock.
+type internal IZeroFactPricingCoverage =
+    /// Checks every supported fact kind without creating any durable coverage state.
+    abstract EvaluateAsync:
+        connection: SqlConnection * transaction: SqlTransaction * scope: BillingCompletenessScope * cancellationToken: CancellationToken ->
+            Task<ZeroFactPricingCoverageResult>
+
+/// Evaluates the current SQL pricing catalog at every effective boundary that can affect an empty period close.
+type internal SqlZeroFactPricingCoverage() =
+
+    /// Creates a SQL command tied to the already locked close transaction.
+    let command (connection: SqlConnection) (transaction: SqlTransaction) text =
+        let value = connection.CreateCommand()
+        value.Transaction <- transaction
+        value.CommandText <- text
+        value
+
+    /// Adds the exact half-open billing scope used by every coverage query.
+    let addScope (command: SqlCommand) (scope: BillingCompletenessScope) =
+        command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+        command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+        command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+        command.Parameters.Add("@MonthStartUtc", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+
+        command.Parameters.Add("@NextMonthStartUtc", SqlDbType.DateTime2).Value <- (BillingCompletenessScope.nextMonthStart scope)
+            .ToDateTimeUtc()
+
+    /// Renders a bounded retry diagnostic from the first uncovered grain.
+    let diagnostic layer (factKind: UsageFactKind) (boundary: DateTime) =
+        let timestamp = boundary.ToString("O", CultureInfo.InvariantCulture)
+        $"{layer}:{factKind}:{timestamp}"
+
+    /// Reads every time at which one selected pricing prerequisite can begin or end within the billing month.
+    let boundariesAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (factKind: UsageFactKind)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    """
+WITH BoundaryRows AS
+(
+    SELECT @MonthStartUtc AS BoundaryUtc
+    UNION ALL SELECT @NextMonthStartUtc
+    UNION ALL SELECT assignment.EffectiveFromUtc FROM ops.PricingAssignment AS assignment
+        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+          AND assignment.EffectiveFromUtc < @NextMonthStartUtc
+          AND (assignment.EffectiveToUtc IS NULL OR assignment.EffectiveToUtc > @MonthStartUtc)
+    UNION ALL SELECT assignment.EffectiveToUtc FROM ops.PricingAssignment AS assignment
+        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+          AND assignment.EffectiveToUtc IS NOT NULL AND assignment.EffectiveToUtc > @MonthStartUtc AND assignment.EffectiveToUtc < @NextMonthStartUtc
+    UNION ALL SELECT pricingPlan.EffectiveFromUtc FROM ops.PricingPlan AS pricingPlan INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=pricingPlan.PricingPlanId
+        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+          AND pricingPlan.EffectiveFromUtc < @NextMonthStartUtc AND (pricingPlan.EffectiveToUtc IS NULL OR pricingPlan.EffectiveToUtc > @MonthStartUtc)
+    UNION ALL SELECT pricingPlan.EffectiveToUtc FROM ops.PricingPlan AS pricingPlan INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=pricingPlan.PricingPlanId
+        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+          AND pricingPlan.EffectiveToUtc IS NOT NULL AND pricingPlan.EffectiveToUtc > @MonthStartUtc AND pricingPlan.EffectiveToUtc < @NextMonthStartUtc
+    UNION ALL SELECT mapping.EffectiveFromUtc FROM ops.BillableUsageKindMapping AS mapping
+        WHERE mapping.FactKind=@FactKind AND mapping.EffectiveFromUtc < @NextMonthStartUtc
+          AND (mapping.EffectiveToUtc IS NULL OR mapping.EffectiveToUtc > @MonthStartUtc)
+    UNION ALL SELECT mapping.EffectiveToUtc FROM ops.BillableUsageKindMapping AS mapping
+        WHERE mapping.FactKind=@FactKind AND mapping.EffectiveToUtc IS NOT NULL
+          AND mapping.EffectiveToUtc > @MonthStartUtc AND mapping.EffectiveToUtc < @NextMonthStartUtc
+    UNION ALL SELECT rate.EffectiveFromUtc FROM ops.PricingRate AS rate
+        INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=rate.PricingPlanId
+        INNER JOIN ops.BillableUsageKindMapping AS mapping ON mapping.BillableUsageKind=rate.BillableUsageKind
+        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+          AND mapping.FactKind=@FactKind AND rate.EffectiveFromUtc < @NextMonthStartUtc
+          AND (rate.EffectiveToUtc IS NULL OR rate.EffectiveToUtc > @MonthStartUtc)
+    UNION ALL SELECT rate.EffectiveToUtc FROM ops.PricingRate AS rate
+        INNER JOIN ops.PricingAssignment AS assignment ON assignment.PricingPlanId=rate.PricingPlanId
+        INNER JOIN ops.BillableUsageKindMapping AS mapping ON mapping.BillableUsageKind=rate.BillableUsageKind
+        WHERE assignment.OwnerId=@OwnerId AND assignment.OrganizationId=@OrganizationId AND assignment.RepositoryId=@RepositoryId
+          AND mapping.FactKind=@FactKind AND rate.EffectiveToUtc IS NOT NULL
+          AND rate.EffectiveToUtc > @MonthStartUtc AND rate.EffectiveToUtc < @NextMonthStartUtc
+)
+SELECT DISTINCT BoundaryUtc FROM BoundaryRows WHERE BoundaryUtc IS NOT NULL ORDER BY BoundaryUtc;
+"""
+
+            addScope read scope
+            read.Parameters.Add("@FactKind", SqlDbType.Int).Value <- int factKind
+            use! reader = read.ExecuteReaderAsync cancellationToken
+            let values = ResizeArray<DateTime>()
+            let mutable reading = true
+
+            while reading do
+                let! hasRow = reader.ReadAsync cancellationToken
+                reading <- hasRow
+
+                if hasRow then values.Add(reader.GetDateTime 0)
+
+            return values |> Seq.toList
+        }
+
+    /// Selects the same assignment row that effective fact pricing would select at one timestamp.
+    let selectedAssignmentAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (boundary: DateTime)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT TOP (1) PricingPlanId FROM ops.PricingAssignment WHERE OwnerId=@OwnerId AND OrganizationId=@OrganizationId AND RepositoryId=@RepositoryId AND EffectiveFromUtc<=@ObservedAtUtc AND (EffectiveToUtc IS NULL OR @ObservedAtUtc<EffectiveToUtc) ORDER BY EffectiveFromUtc DESC,PricingAssignmentId ASC;"
+
+            addScope read scope
+            read.Parameters.Add("@ObservedAtUtc", SqlDbType.DateTime2).Value <- boundary
+            let! value = read.ExecuteScalarAsync cancellationToken
+            return if isNull value || Convert.IsDBNull value then None else Some(value :?> Guid)
+        }
+
+    /// Selects the referenced effective plan using the catalog's stable latest-start ordering.
+    let selectedPlanAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (pricingPlanId: Guid)
+        (boundary: DateTime)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT TOP (1) PricingPlanId FROM ops.PricingPlan WHERE PricingPlanId=@PricingPlanId AND EffectiveFromUtc<=@ObservedAtUtc AND (EffectiveToUtc IS NULL OR @ObservedAtUtc<EffectiveToUtc) ORDER BY EffectiveFromUtc DESC,PricingPlanId ASC;"
+
+            read.Parameters.Add("@PricingPlanId", SqlDbType.UniqueIdentifier).Value <- pricingPlanId
+            read.Parameters.Add("@ObservedAtUtc", SqlDbType.DateTime2).Value <- boundary
+            let! value = read.ExecuteScalarAsync cancellationToken
+            return if isNull value || Convert.IsDBNull value then None else Some(value :?> Guid)
+        }
+
+    /// Selects the effective mapping for the required supported fact kind.
+    let selectedMappingAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (factKind: UsageFactKind)
+        (boundary: DateTime)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT TOP (1) BillableUsageKind FROM ops.BillableUsageKindMapping WHERE FactKind=@FactKind AND EffectiveFromUtc<=@ObservedAtUtc AND (EffectiveToUtc IS NULL OR @ObservedAtUtc<EffectiveToUtc) ORDER BY EffectiveFromUtc DESC,BillableUsageKindMappingId ASC;"
+
+            read.Parameters.Add("@FactKind", SqlDbType.Int).Value <- int factKind
+            read.Parameters.Add("@ObservedAtUtc", SqlDbType.DateTime2).Value <- boundary
+            let! value = read.ExecuteScalarAsync cancellationToken
+
+            return
+                if isNull value || Convert.IsDBNull value then
+                    None
+                else
+                    Some(Convert.ToInt32(value, CultureInfo.InvariantCulture))
+        }
+
+    /// Selects the effective rate for the exact selected plan and billable usage kind.
+    let selectedRateAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (pricingPlanId: Guid)
+        (billableUsageKind: int)
+        (boundary: DateTime)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            use read =
+                command
+                    connection
+                    transaction
+                    "SELECT TOP (1) PricingRateId FROM ops.PricingRate WHERE PricingPlanId=@PricingPlanId AND BillableUsageKind=@BillableUsageKind AND EffectiveFromUtc<=@ObservedAtUtc AND (EffectiveToUtc IS NULL OR @ObservedAtUtc<EffectiveToUtc) ORDER BY EffectiveFromUtc DESC,PricingRateId ASC;"
+
+            read.Parameters.Add("@PricingPlanId", SqlDbType.UniqueIdentifier).Value <- pricingPlanId
+            read.Parameters.Add("@BillableUsageKind", SqlDbType.Int).Value <- billableUsageKind
+            read.Parameters.Add("@ObservedAtUtc", SqlDbType.DateTime2).Value <- boundary
+            let! value = read.ExecuteScalarAsync cancellationToken
+            return not (isNull value || Convert.IsDBNull value)
+        }
+
+    /// Finds the first missing layer for a supported fact kind at a deterministic month boundary.
+    let firstIncompleteBoundaryAsync
+        (connection: SqlConnection)
+        (transaction: SqlTransaction)
+        (scope: BillingCompletenessScope)
+        (factKind: UsageFactKind)
+        (boundary: DateTime)
+        (cancellationToken: CancellationToken)
+        =
+        task {
+            let! assignment = selectedAssignmentAsync connection transaction scope boundary cancellationToken
+
+            match assignment with
+            | None -> return Some(diagnostic "MissingAssignment" factKind boundary)
+            | Some pricingPlanId ->
+                let! plan = selectedPlanAsync connection transaction pricingPlanId boundary cancellationToken
+
+                match plan with
+                | None -> return Some(diagnostic "MissingPricingPlan" factKind boundary)
+                | Some _ ->
+                    let! mapping = selectedMappingAsync connection transaction factKind boundary cancellationToken
+
+                    match mapping with
+                    | None -> return Some(diagnostic "MissingMapping" factKind boundary)
+                    | Some billableUsageKind ->
+                        let! hasRate = selectedRateAsync connection transaction pricingPlanId billableUsageKind boundary cancellationToken
+                        return if hasRate then None else Some(diagnostic "MissingRate" factKind boundary)
+        }
+
+    interface IZeroFactPricingCoverage with
+        member _.EvaluateAsync(connection, transaction, scope, cancellationToken) =
+            task {
+                let requiredFactKinds = UsageFact.SupportedV1FactKinds |> Array.sortBy int
+                let mutable result = Complete
+                let mutable factKindIndex = 0
+
+                while factKindIndex < requiredFactKinds.Length
+                      && result = Complete do
+                    let factKind = requiredFactKinds[factKindIndex]
+                    let! boundaries = boundariesAsync connection transaction scope factKind cancellationToken
+                    let mutable boundaryIndex = 0
+
+                    while boundaryIndex < boundaries.Length
+                          && result = Complete do
+                        let! missing = firstIncompleteBoundaryAsync connection transaction scope factKind boundaries[boundaryIndex] cancellationToken
+
+                        match missing with
+                        | Some diagnostic -> result <- Incomplete diagnostic
+                        | None -> boundaryIndex <- boundaryIndex + 1
+
+                    factKindIndex <- factKindIndex + 1
+
+                return result
+            }

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -57,6 +57,8 @@ type private ClockOrderingInterleaving() =
         member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
         member _.AfterChargeInsertionAsync _ = Task.CompletedTask
         member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+        member _.AfterZeroFactPricingBoundaryEnumerationAsync(_, _) = Task.CompletedTask
+        member _.BeforeZeroFactPricingSelectionAsync(_, _, _) = Task.CompletedTask
 
 /// Holds one production close after its exact SQL lock grant so a second production call can be observed waiting.
 type private ContentionInterleaving(holdAfterGrant: bool) =
@@ -93,6 +95,8 @@ type private ContentionInterleaving(holdAfterGrant: bool) =
         member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
         member _.AfterChargeInsertionAsync _ = Task.CompletedTask
         member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+        member _.AfterZeroFactPricingBoundaryEnumerationAsync(_, _) = Task.CompletedTask
+        member _.BeforeZeroFactPricingSelectionAsync(_, _, _) = Task.CompletedTask
 
 /// Supplies one controlled database instant for policy-boundary tests without changing the production clock proof.
 type private FixedBillingPeriodCloseClock(databaseUtcNow: DateTime) =
@@ -115,6 +119,36 @@ type private StageCancellationInterleaving(stage: string, cancellation: Cancella
         member _.AfterPreviewReplacementAsync _ = cancelAt "preview"
         member _.AfterChargeInsertionAsync _ = cancelAt "charge"
         member _.AfterCloseEvidenceStagedAsync _ = cancelAt "evidence"
+        member _.AfterZeroFactPricingBoundaryEnumerationAsync(_, _) = cancelAt "boundaries"
+        member _.BeforeZeroFactPricingSelectionAsync(_, _, _) = cancelAt "selection"
+
+/// Pauses a production empty-period close after it has captured pricing boundaries on its own SQL transaction.
+type private PricingBoundaryPauseInterleaving() =
+    let enumerated = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+    let release = TaskCompletionSource<unit>(TaskCreationOptions.RunContinuationsAsynchronously)
+
+    /// Completes after the production coverage query has read its first required-kind boundary set.
+    member _.Enumerated = enumerated.Task
+
+    /// Lets the production coverage evaluator continue from its captured boundary set.
+    member _.Release() = release.TrySetResult() |> ignore
+
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.BeforeScopeLockAcquisitionAsync(_, _, _) = Task.CompletedTask
+        member _.AfterScopeLockGrantedAsync(_, _, _) = Task.CompletedTask
+        member _.AfterDatabaseClockReadAsync(_, _, _) = Task.CompletedTask
+        member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
+        member _.AfterChargeInsertionAsync _ = Task.CompletedTask
+        member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+
+        member _.AfterZeroFactPricingBoundaryEnumerationAsync(_, cancellationToken) =
+            task {
+                enumerated.TrySetResult() |> ignore
+                do! release.Task.WaitAsync(cancellationToken)
+            }
+            :> Task
+
+        member _.BeforeZeroFactPricingSelectionAsync(_, _, _) = Task.CompletedTask
 
 /// Records the exact accepted-fact scope lock requested by a production store while delegating every SQL mutation.
 type private ScopeRecordingOperationsUsageTransaction(inner: IOperationsUsageTransaction, scopes: ResizeArray<BillingCompletenessScope>) =
@@ -1759,6 +1793,199 @@ ORDER BY 1;
                             |> List.exists (fun row -> row.Contains("\"State\":2")),
                             Is.True
                         ))
+                )
+            })
+
+    /// Proves a concurrent valid pricing repair cannot commit a new gap between serializable boundary capture and selection.
+    [<Test>]
+    member _.ZeroFactCoverageSerializesConcurrentGapRepairBeforeAnyCloseEffects() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/zero-fact-serializable-catalog/v1" }
+                let interleaving = PricingBoundaryPauseInterleaving()
+                use cancellation = new CancellationTokenSource()
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                let close = closer.CloseAsync(request, cancellation.Token)
+                do! interleaving.Enumerated.WaitAsync(TimeSpan.FromSeconds 30.0)
+                use writerConnection = new SqlConnection(connectionString)
+                do! writerConnection.OpenAsync CancellationToken.None
+                use writer = writerConnection.CreateCommand()
+                let gapStart = scope.MonthStart.ToDateTimeUtc().AddDays 14.0
+                let afterGap = gapStart.AddTicks 1L
+
+                writer.CommandText <-
+                    "UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@AfterGap);"
+
+                writer.Parameters.Add("@GapStart", SqlDbType.DateTime2).Value <- gapStart
+                writer.Parameters.Add("@AfterGap", SqlDbType.DateTime2).Value <- afterGap
+                writer.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
+                writer.Parameters.Add("@ReplacementId", SqlDbType.UniqueIdentifier).Value <- Guid.NewGuid()
+                writer.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+                writer.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+                writer.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+                writer.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                let repair = writer.ExecuteNonQueryAsync CancellationToken.None
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(close.IsCompleted, Is.False)
+                        Assert.That(repair.IsCompleted, Is.False, "The serializable pricing read must hold the concurrent gap repair until close ends."))
+                )
+
+                cancellation.Cancel()
+
+                Assert.CatchAsync<OperationCanceledException>(Func<Task>(fun () -> close :> Task))
+                |> ignore
+
+                let! _ = repair.WaitAsync(TimeSpan.FromSeconds 30.0)
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! preview = countAsync connectionString "SELECT COUNT(*) FROM ops.ChargePreviewLine;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                let! retry =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(preview, Is.Zero)
+                        Assert.That(evidence, Is.Zero)
+
+                        Assert.That(
+                            (match retry with
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith("MissingAssignment:", StringComparison.Ordinal) -> true
+                             | _ -> false),
+                            Is.True,
+                            "A retry after the committed repair must re-enumerate pricing and reject the one-tick assignment gap."
+                        ))
+                )
+            })
+
+    /// Proves cancellation during pricing enumeration or effective selection rolls back the whole empty-period close.
+    [<TestCase("boundaries")>]
+    [<TestCase("selection")>]
+    member _.ZeroFactCoverageCancellationLeavesNoProjection(stage: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! _ = addPricingAsync connectionString scope
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-cancellation-{stage}/v1" }
+                let! before = closeProjectionAsync connectionString
+                use cancellation = new CancellationTokenSource()
+                let interleaving = StageCancellationInterleaving(stage, cancellation)
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                Assert.CatchAsync<OperationCanceledException>(Func<Task>(fun () -> closer.CloseAsync(request, cancellation.Token) :> Task))
+                |> ignore
+
+                let! after = closeProjectionAsync connectionString
+                Assert.That(cancellation.IsCancellationRequested, Is.True)
+                Assert.That(after, Is.EqualTo(before :> obj))
+            })
+
+    /// Proves every required pricing layer is selected at MonthStart rather than only after its first interior boundary.
+    [<TestCase("assignment", "MissingAssignment")>]
+    [<TestCase("plan", "MissingPricingPlan")>]
+    [<TestCase("mapping", "MissingMapping")>]
+    [<TestCase("rate", "MissingRate")>]
+    member _.ZeroFactCoverageIncludesMonthStartInEveryPricingLayer(layer: string, expectedDiagnostic: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    match layer with
+                    | "assignment" -> "UPDATE ops.PricingAssignment SET EffectiveFromUtc=@InteriorStart WHERE PricingAssignmentId=@AssignmentId;"
+                    | "plan" -> "UPDATE ops.PricingPlan SET EffectiveFromUtc=@InteriorStart WHERE PricingPlanId=@PlanId;"
+                    | "mapping" -> "UPDATE ops.BillableUsageKindMapping SET EffectiveFromUtc=@InteriorStart WHERE BillableUsageKindMappingId=@MappingId;"
+                    | "rate" -> "UPDATE ops.PricingRate SET EffectiveFromUtc=@InteriorStart WHERE PricingRateId=@RateId;"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
+
+                command.Parameters.Add("@InteriorStart", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc().AddTicks 1L
+                command.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
+                command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-month-start-{layer}/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith($"{expectedDiagnostic}:", StringComparison.Ordinal) ->
+                                 true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(evidence, Is.Zero))
+                )
+            })
+
+    /// Proves exact NextMonth end timestamps are not treated as a selectable instant in the half-open pricing month.
+    [<Test>]
+    member _.ZeroFactCoverageExcludesNextMonthStartAcrossAllPricingLayers() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+
+                let nextMonthStart =
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    "UPDATE ops.PricingAssignment SET EffectiveToUtc=@NextMonthStart WHERE PricingAssignmentId=@AssignmentId; UPDATE ops.PricingPlan SET EffectiveToUtc=@NextMonthStart WHERE PricingPlanId=@PlanId; UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=@NextMonthStart WHERE BillableUsageKindMappingId=@MappingId; UPDATE ops.PricingRate SET EffectiveToUtc=@NextMonthStart WHERE PricingRateId=@RateId;"
+
+                command.Parameters.Add("@NextMonthStart", SqlDbType.DateTime2).Value <- nextMonthStart
+                command.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
+                command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/zero-fact-next-month-excluded/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Closed (_, 0) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(evidence, Is.EqualTo(1)))
                 )
             })
 

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -150,6 +150,26 @@ type private PricingBoundaryPauseInterleaving() =
 
         member _.BeforeZeroFactPricingSelectionAsync(_, _, _) = Task.CompletedTask
 
+/// Retains the actual pricing-selection instants reached by one production empty-period close.
+type private PricingSelectionRecordingInterleaving() =
+    let selections = ResizeArray<DateTime>()
+
+    /// Gets the ordered selection instants supplied through the production close interleaving.
+    member _.Selections = selections |> Seq.toList
+
+    interface IBillingPeriodCloseTransactionInterleaving with
+        member _.BeforeScopeLockAcquisitionAsync(_, _, _) = Task.CompletedTask
+        member _.AfterScopeLockGrantedAsync(_, _, _) = Task.CompletedTask
+        member _.AfterDatabaseClockReadAsync(_, _, _) = Task.CompletedTask
+        member _.AfterPreviewReplacementAsync _ = Task.CompletedTask
+        member _.AfterChargeInsertionAsync _ = Task.CompletedTask
+        member _.AfterCloseEvidenceStagedAsync _ = Task.CompletedTask
+        member _.AfterZeroFactPricingBoundaryEnumerationAsync(_, _) = Task.CompletedTask
+
+        member _.BeforeZeroFactPricingSelectionAsync(_, boundary, _) =
+            selections.Add boundary
+            Task.CompletedTask
+
 /// Records the exact accepted-fact scope lock requested by a production store while delegating every SQL mutation.
 type private ScopeRecordingOperationsUsageTransaction(inner: IOperationsUsageTransaction, scopes: ResizeArray<BillingCompletenessScope>) =
 
@@ -1796,14 +1816,17 @@ ORDER BY 1;
                 )
             })
 
-    /// Proves a concurrent valid pricing repair cannot commit a new gap between serializable boundary capture and selection.
-    [<Test>]
-    member _.ZeroFactCoverageSerializesConcurrentGapRepairBeforeAnyCloseEffects() =
+    /// Proves every pricing catalog range remains serializable from boundary capture through cancellation and retry.
+    [<TestCase("assignment", "MissingAssignment")>]
+    [<TestCase("plan", "MissingPricingPlan")>]
+    [<TestCase("mapping", "MissingMapping")>]
+    [<TestCase("rate", "MissingRate")>]
+    member _.ZeroFactCoverageSerializesConcurrentRangeWritesBeforeAnyCloseEffects(layer: string, expectedDiagnostic: string) =
         withDatabaseAsync (fun connectionString ->
             task {
                 let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
                 let! pricing = addPricingAsync connectionString scope
-                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/zero-fact-serializable-catalog/v1" }
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-serializable-{layer}/v1" }
                 let interleaving = PricingBoundaryPauseInterleaving()
                 use cancellation = new CancellationTokenSource()
 
@@ -1817,14 +1840,33 @@ ORDER BY 1;
                 use writer = writerConnection.CreateCommand()
                 let gapStart = scope.MonthStart.ToDateTimeUtc().AddDays 14.0
                 let afterGap = gapStart.AddTicks 1L
+                let replacementPlanId = Guid.NewGuid()
+                let replacementRateId = Guid.NewGuid()
+                let replacementAssignmentId = Guid.NewGuid()
+                let replacementMappingId = Guid.NewGuid()
 
                 writer.CommandText <-
-                    "UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@AfterGap);"
+                    match layer with
+                    | "assignment" ->
+                        "UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementAssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@AfterGap);"
+                    | "plan" ->
+                        "UPDATE ops.PricingPlan SET EffectiveToUtc=@GapStart WHERE PricingPlanId=@PlanId; INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@ReplacementPlanId,@ReplacementPlanCode,'replacement',@AfterGap);"
+                    | "mapping" ->
+                        "UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=@GapStart WHERE BillableUsageKindMappingId=@MappingId; INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@ReplacementMappingId,1,101,'replacement',@AfterGap);"
+                    | "rate" ->
+                        "UPDATE ops.PricingRate SET EffectiveToUtc=@GapStart WHERE PricingRateId=@RateId; INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementRateId,@PlanId,101,'USD','byte-minute',1,2,@AfterGap);"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
 
                 writer.Parameters.Add("@GapStart", SqlDbType.DateTime2).Value <- gapStart
                 writer.Parameters.Add("@AfterGap", SqlDbType.DateTime2).Value <- afterGap
                 writer.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
-                writer.Parameters.Add("@ReplacementId", SqlDbType.UniqueIdentifier).Value <- Guid.NewGuid()
+                writer.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                writer.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                writer.Parameters.Add("@ReplacementAssignmentId", SqlDbType.UniqueIdentifier).Value <- replacementAssignmentId
+                writer.Parameters.Add("@ReplacementPlanId", SqlDbType.UniqueIdentifier).Value <- replacementPlanId
+                writer.Parameters.Add("@ReplacementPlanCode", SqlDbType.NVarChar, 128).Value <- $"serializable-{replacementPlanId:N}"
+                writer.Parameters.Add("@ReplacementMappingId", SqlDbType.UniqueIdentifier).Value <- replacementMappingId
+                writer.Parameters.Add("@ReplacementRateId", SqlDbType.UniqueIdentifier).Value <- replacementRateId
                 writer.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
                 writer.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
                 writer.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
@@ -1834,7 +1876,7 @@ ORDER BY 1;
                 Assert.Multiple(
                     Action (fun () ->
                         Assert.That(close.IsCompleted, Is.False)
-                        Assert.That(repair.IsCompleted, Is.False, "The serializable pricing read must hold the concurrent gap repair until close ends."))
+                        Assert.That(repair.IsCompleted, Is.False, $"The serializable {layer} range read must hold the concurrent write until close ends."))
                 )
 
                 cancellation.Cancel()
@@ -1859,10 +1901,95 @@ ORDER BY 1;
 
                         Assert.That(
                             (match retry with
-                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith("MissingAssignment:", StringComparison.Ordinal) -> true
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith($"{expectedDiagnostic}:", StringComparison.Ordinal) ->
+                                 true
                              | _ -> false),
                             Is.True,
-                            "A retry after the committed repair must re-enumerate pricing and reject the one-tick assignment gap."
+                            $"A retry after the committed {layer} write must re-enumerate pricing and reject the one-tick gap."
+                        ))
+                )
+            })
+
+    /// Proves missing mapping and rate key ranges block a concurrent insert until the canceled close releases its serializable view.
+    [<TestCase("mapping", "MissingMapping")>]
+    [<TestCase("rate", "MissingRate")>]
+    member _.ZeroFactCoverageSerializesMissingKeyInsertionBeforeAnyCloseEffects(layer: string, expectedDiagnostic: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                use preparation = new SqlConnection(connectionString)
+                do! preparation.OpenAsync CancellationToken.None
+                use remove = preparation.CreateCommand()
+
+                remove.CommandText <-
+                    match layer with
+                    | "mapping" -> "DELETE FROM ops.BillableUsageKindMapping WHERE BillableUsageKindMappingId=@MappingId;"
+                    | "rate" -> "DELETE FROM ops.PricingRate WHERE PricingRateId=@RateId;"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
+
+                remove.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                remove.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                let! _ = remove.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-serializable-missing-{layer}/v1" }
+                let interleaving = PricingBoundaryPauseInterleaving()
+                use cancellation = new CancellationTokenSource()
+
+                let closer =
+                    SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser
+
+                let close = closer.CloseAsync(request, cancellation.Token)
+                do! interleaving.Enumerated.WaitAsync(TimeSpan.FromSeconds 30.0)
+                use writerConnection = new SqlConnection(connectionString)
+                do! writerConnection.OpenAsync CancellationToken.None
+                use writer = writerConnection.CreateCommand()
+
+                writer.CommandText <-
+                    match layer with
+                    | "mapping" ->
+                        "INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@MappingId,1,101,'replacement',@MonthStart);"
+                    | "rate" ->
+                        "INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@RateId,@PlanId,101,'USD','byte-minute',1,2,@MonthStart);"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
+
+                writer.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                writer.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                writer.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                writer.Parameters.Add("@MonthStart", SqlDbType.DateTime2).Value <- scope.MonthStart.ToDateTimeUtc()
+                let insert = writer.ExecuteNonQueryAsync CancellationToken.None
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(close.IsCompleted, Is.False)
+                        Assert.That(insert.IsCompleted, Is.False, $"The serializable missing-{layer} range must hold the insertion until close ends."))
+                )
+
+                cancellation.Cancel()
+
+                Assert.CatchAsync<OperationCanceledException>(Func<Task>(fun () -> close :> Task))
+                |> ignore
+
+                let! _ = insert.WaitAsync(TimeSpan.FromSeconds 30.0)
+                let! preview = countAsync connectionString "SELECT COUNT(*) FROM ops.ChargePreviewLine;"
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                let! retry =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(preview, Is.Zero)
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(evidence, Is.Zero)
+
+                        Assert.That(
+                            (match retry with
+                             | BillingPeriodCloseResult.Closed (_, 0) -> true
+                             | _ -> false),
+                            Is.True,
+                            $"A retry after the released missing-{layer} insertion must reread the current catalog and close."
                         ))
                 )
             })
@@ -1985,6 +2112,124 @@ ORDER BY 1;
                             Is.True
                         )
 
+                        Assert.That(evidence, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves historical effective rows do not become pricing-selection points for the current half-open billing month.
+    [<Test>]
+    member _.ZeroFactCoverageSelectsOnlyMonthStartAndInteriorPointsAcrossHistoricalPricingFamilies() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                let monthStartUtc = scope.MonthStart.ToDateTimeUtc()
+
+                let nextMonthStartUtc =
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+
+                let interior = monthStartUtc.AddDays 14.0
+                let prePlanStart = monthStartUtc.AddMonths(-4)
+                let prePlanEnd = monthStartUtc.AddMonths(-3)
+                let preAssignmentStart = monthStartUtc.AddMonths(-3)
+                let preAssignmentEnd = monthStartUtc.AddMonths(-2)
+                let preMappingStart = monthStartUtc.AddMonths(-2)
+                let preMappingEnd = monthStartUtc.AddMonths(-1)
+                let preRateStart = monthStartUtc.AddMonths(-1)
+                let preRateEnd = monthStartUtc.AddTicks -1L
+                let historicalPlanId = Guid.NewGuid()
+                let interiorPlanId = Guid.NewGuid()
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use seed = connection.CreateCommand()
+
+                seed.CommandText <-
+                    "INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc,EffectiveToUtc) VALUES (@HistoricalPlanId,@HistoricalPlanCode,'historical',@PrePlanStart,@PrePlanEnd); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc,EffectiveToUtc) VALUES (@HistoricalRateId,@HistoricalPlanId,101,'USD','byte-minute',1,2,@PreRateStart,@PreRateEnd); INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc,EffectiveToUtc) VALUES (@HistoricalAssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@HistoricalPlanId,@PreAssignmentStart,@PreAssignmentEnd); INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc,EffectiveToUtc) VALUES (@HistoricalMappingId,1,101,'historical',@PreMappingStart,@PreMappingEnd); UPDATE ops.PricingPlan SET EffectiveToUtc=@Interior WHERE PricingPlanId=@PlanId; INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@InteriorPlanId,@InteriorPlanCode,'interior',@Interior); UPDATE ops.PricingRate SET EffectiveToUtc=@Interior WHERE PricingRateId=@RateId; INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@InteriorRateId,@InteriorPlanId,101,'USD','byte-minute',1,2,@Interior); UPDATE ops.PricingAssignment SET EffectiveToUtc=@Interior WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@InteriorAssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@InteriorPlanId,@Interior); UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=@Interior WHERE BillableUsageKindMappingId=@MappingId; INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@InteriorMappingId,1,101,'interior',@Interior);"
+
+                let add name dbType value = seed.Parameters.Add(name, dbType).Value <- value
+                add "@HistoricalPlanId" SqlDbType.UniqueIdentifier historicalPlanId
+                add "@HistoricalPlanCode" SqlDbType.NVarChar $"historical-{historicalPlanId:N}"
+                add "@HistoricalRateId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+                add "@HistoricalAssignmentId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+                add "@HistoricalMappingId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+                add "@InteriorPlanId" SqlDbType.UniqueIdentifier interiorPlanId
+                add "@InteriorPlanCode" SqlDbType.NVarChar $"interior-{interiorPlanId:N}"
+                add "@InteriorRateId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+                add "@InteriorAssignmentId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+                add "@InteriorMappingId" SqlDbType.UniqueIdentifier (Guid.NewGuid())
+                add "@PlanId" SqlDbType.UniqueIdentifier pricing.PricingPlanId
+                add "@RateId" SqlDbType.UniqueIdentifier pricing.PricingRateId
+                add "@AssignmentId" SqlDbType.UniqueIdentifier pricing.PricingAssignmentId
+                add "@MappingId" SqlDbType.UniqueIdentifier pricing.BillableUsageKindMappingId
+                add "@OwnerId" SqlDbType.UniqueIdentifier scope.OwnerId
+                add "@OrganizationId" SqlDbType.UniqueIdentifier scope.OrganizationId
+                add "@RepositoryId" SqlDbType.UniqueIdentifier scope.RepositoryId
+                add "@PrePlanStart" SqlDbType.DateTime2 prePlanStart
+                add "@PrePlanEnd" SqlDbType.DateTime2 prePlanEnd
+                add "@PreAssignmentStart" SqlDbType.DateTime2 preAssignmentStart
+                add "@PreAssignmentEnd" SqlDbType.DateTime2 preAssignmentEnd
+                add "@PreMappingStart" SqlDbType.DateTime2 preMappingStart
+                add "@PreMappingEnd" SqlDbType.DateTime2 preMappingEnd
+                add "@PreRateStart" SqlDbType.DateTime2 preRateStart
+                add "@PreRateEnd" SqlDbType.DateTime2 preRateEnd
+                add "@Interior" SqlDbType.DateTime2 interior
+                let! _ = seed.ExecuteNonQueryAsync CancellationToken.None
+                let interleaving = PricingSelectionRecordingInterleaving()
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/zero-fact-historical-selection-points/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser.CreateForTest(connectionString, interleaving :> IBillingPeriodCloseTransactionInterleaving) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let selectionPoint value = DateTime.SpecifyKind(value, DateTimeKind.Unspecified)
+
+                let expectedSelections =
+                    [
+                        selectionPoint monthStartUtc
+                        selectionPoint interior
+                    ]
+
+                let excluded =
+                    [
+                        prePlanStart
+                        prePlanEnd
+                        preAssignmentStart
+                        preAssignmentEnd
+                        preMappingStart
+                        preMappingEnd
+                        preRateStart
+                        preRateEnd
+                        nextMonthStartUtc
+                    ]
+                    |> List.map selectionPoint
+
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            result,
+                            Is.EqualTo(
+                                BillingPeriodCloseResult.Closed(
+                                    (match result with
+                                     | BillingPeriodCloseResult.Closed (periodId, _) -> periodId
+                                     | _ -> Guid.Empty),
+                                    0
+                                )
+                            )
+                        )
+
+                        Assert.That(interleaving.Selections, Is.EqualTo<DateTime list>(expectedSelections))
+
+                        Assert.That(
+                            excluded
+                            |> List.exists (fun point -> interleaving.Selections |> List.contains point),
+                            Is.False
+                        )
+
+                        Assert.That(charges, Is.Zero)
                         Assert.That(evidence, Is.EqualTo(1)))
                 )
             })
@@ -2167,5 +2412,161 @@ ORDER BY 1;
 
                         Assert.That(charges, Is.Zero)
                         Assert.That(evidence, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves every independently missing, ineffective, and one-tick-gapped pricing family reports its first failure then repairs to one zero close.
+    [<TestCase("missing-assignment", "MissingAssignment")>]
+    [<TestCase("ineffective-assignment", "MissingAssignment")>]
+    [<TestCase("missing-plan", "MissingPricingPlan")>]
+    [<TestCase("ineffective-plan", "MissingPricingPlan")>]
+    [<TestCase("missing-mapping", "MissingMapping")>]
+    [<TestCase("missing-rate", "MissingRate")>]
+    [<TestCase("gap-assignment", "MissingAssignment")>]
+    [<TestCase("gap-plan", "MissingPricingPlan")>]
+    [<TestCase("gap-mapping", "MissingMapping")>]
+    [<TestCase("gap-rate", "MissingRate")>]
+    member _.ZeroFactCoverageRepairsEveryIndependentFailureAndReplaysOnce(caseName: string, expectedLayer: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                let monthStartUtc = scope.MonthStart.ToDateTimeUtc()
+
+                let nextMonthStartUtc =
+                    (BillingCompletenessScope.nextMonthStart scope)
+                        .ToDateTimeUtc()
+
+                let gapStart = monthStartUtc.AddDays 14.0
+                let afterGap = gapStart.AddTicks 1L
+                let preMonthStart = monthStartUtc.AddMonths(-1)
+                let replacementPlanId = Guid.NewGuid()
+                let replacementRateId = Guid.NewGuid()
+                let replacementAssignmentId = Guid.NewGuid()
+                let replacementMappingId = Guid.NewGuid()
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use breakCommand = connection.CreateCommand()
+
+                breakCommand.CommandText <-
+                    match caseName with
+                    | "missing-assignment" -> "DELETE FROM ops.PricingAssignment WHERE PricingAssignmentId=@AssignmentId;"
+                    | "ineffective-assignment" -> "UPDATE ops.PricingAssignment SET EffectiveFromUtc=@NextMonthStart WHERE PricingAssignmentId=@AssignmentId;"
+                    | "missing-plan" -> "UPDATE ops.PricingPlan SET EffectiveFromUtc=@PreMonthStart,EffectiveToUtc=@MonthStart WHERE PricingPlanId=@PlanId;"
+                    | "ineffective-plan" -> "UPDATE ops.PricingPlan SET EffectiveFromUtc=@NextMonthStart WHERE PricingPlanId=@PlanId;"
+                    | "missing-mapping" -> "DELETE FROM ops.BillableUsageKindMapping WHERE BillableUsageKindMappingId=@MappingId;"
+                    | "missing-rate" -> "DELETE FROM ops.PricingRate WHERE PricingRateId=@RateId;"
+                    | "gap-assignment" ->
+                        "UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementAssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@AfterGap);"
+                    | "gap-plan" ->
+                        "UPDATE ops.PricingPlan SET EffectiveToUtc=@GapStart WHERE PricingPlanId=@PlanId; INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@ReplacementPlanId,@ReplacementPlanCode,'replacement',@AfterGap); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementRateId,@ReplacementPlanId,101,'USD','byte-minute',1,2,@AfterGap); UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementAssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@ReplacementPlanId,@GapStart);"
+                    | "gap-mapping" ->
+                        "UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=@GapStart WHERE BillableUsageKindMappingId=@MappingId; INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@ReplacementMappingId,1,101,'replacement',@AfterGap);"
+                    | "gap-rate" ->
+                        "UPDATE ops.PricingRate SET EffectiveToUtc=@GapStart WHERE PricingRateId=@RateId; INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementRateId,@PlanId,101,'USD','byte-minute',1,2,@AfterGap);"
+                    | _ -> invalidArg (nameof caseName) $"Unknown pricing failure '{caseName}'."
+
+                let addParameters (command: SqlCommand) =
+                    command.Parameters.Add("@MonthStart", SqlDbType.DateTime2).Value <- monthStartUtc
+                    command.Parameters.Add("@NextMonthStart", SqlDbType.DateTime2).Value <- nextMonthStartUtc
+                    command.Parameters.Add("@PreMonthStart", SqlDbType.DateTime2).Value <- preMonthStart
+                    command.Parameters.Add("@GapStart", SqlDbType.DateTime2).Value <- gapStart
+                    command.Parameters.Add("@AfterGap", SqlDbType.DateTime2).Value <- afterGap
+                    command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                    command.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
+                    command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                    command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                    command.Parameters.Add("@ReplacementPlanId", SqlDbType.UniqueIdentifier).Value <- replacementPlanId
+                    command.Parameters.Add("@ReplacementRateId", SqlDbType.UniqueIdentifier).Value <- replacementRateId
+                    command.Parameters.Add("@ReplacementAssignmentId", SqlDbType.UniqueIdentifier).Value <- replacementAssignmentId
+                    command.Parameters.Add("@ReplacementMappingId", SqlDbType.UniqueIdentifier).Value <- replacementMappingId
+                    command.Parameters.Add("@ReplacementPlanCode", SqlDbType.NVarChar, 128).Value <- $"repair-{replacementPlanId:N}"
+                    command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+                    command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+                    command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+
+                addParameters breakCommand
+                let! _ = breakCommand.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-repair-{caseName}/v1" }
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! blocked = closer.CloseAsync(request, CancellationToken.None)
+                let! previewBeforeRepair = countAsync connectionString "SELECT COUNT(*) FROM ops.ChargePreviewLine;"
+                let! chargeBeforeRepair = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidenceBeforeRepair = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! terminalBeforeRepair = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2;"
+
+                let boundary =
+                    if caseName.StartsWith("gap-", StringComparison.Ordinal) then
+                        gapStart
+                    else
+                        monthStartUtc
+
+                let expectedDiagnostic =
+                    $"{expectedLayer}:{UsageFactKind.RepositoryStorageBytesMinute}:{DateTime.SpecifyKind(boundary, DateTimeKind.Unspecified):O}"
+
+                use repairCommand = connection.CreateCommand()
+
+                repairCommand.CommandText <-
+                    match caseName with
+                    | "missing-assignment" ->
+                        "INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@AssignmentId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@MonthStart);"
+                    | "ineffective-assignment" -> "UPDATE ops.PricingAssignment SET EffectiveFromUtc=@MonthStart WHERE PricingAssignmentId=@AssignmentId;"
+                    | "missing-plan" -> "UPDATE ops.PricingPlan SET EffectiveFromUtc=@MonthStart,EffectiveToUtc=NULL WHERE PricingPlanId=@PlanId;"
+                    | "ineffective-plan" -> "UPDATE ops.PricingPlan SET EffectiveFromUtc=@MonthStart WHERE PricingPlanId=@PlanId;"
+                    | "missing-mapping" ->
+                        "INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@MappingId,1,101,'Storage byte minute',@MonthStart);"
+                    | "missing-rate" ->
+                        "INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@RateId,@PlanId,101,'USD','byte-minute',1,2,@MonthStart);"
+                    | "gap-assignment" ->
+                        "DELETE FROM ops.PricingAssignment WHERE PricingAssignmentId=@ReplacementAssignmentId; UPDATE ops.PricingAssignment SET EffectiveToUtc=NULL WHERE PricingAssignmentId=@AssignmentId;"
+                    | "gap-plan" ->
+                        "DELETE FROM ops.PricingAssignment WHERE PricingAssignmentId=@ReplacementAssignmentId; DELETE FROM ops.PricingRate WHERE PricingRateId=@ReplacementRateId; DELETE FROM ops.PricingPlan WHERE PricingPlanId=@ReplacementPlanId; UPDATE ops.PricingAssignment SET EffectiveToUtc=NULL WHERE PricingAssignmentId=@AssignmentId; UPDATE ops.PricingPlan SET EffectiveToUtc=NULL WHERE PricingPlanId=@PlanId;"
+                    | "gap-mapping" ->
+                        "DELETE FROM ops.BillableUsageKindMapping WHERE BillableUsageKindMappingId=@ReplacementMappingId; UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=NULL WHERE BillableUsageKindMappingId=@MappingId;"
+                    | "gap-rate" ->
+                        "DELETE FROM ops.PricingRate WHERE PricingRateId=@ReplacementRateId; UPDATE ops.PricingRate SET EffectiveToUtc=NULL WHERE PricingRateId=@RateId;"
+                    | _ -> invalidArg (nameof caseName) $"Unknown pricing failure '{caseName}'."
+
+                addParameters repairCommand
+                let! _ = repairCommand.ExecuteNonQueryAsync CancellationToken.None
+                let! repaired = closer.CloseAsync(request, CancellationToken.None)
+                let! replay = closer.CloseAsync(request, CancellationToken.None)
+                let! zeroCharges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                let! cleared =
+                    countAsync
+                        connectionString
+                        "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2 AND RetryDiagnostic IS NULL AND RetryDiagnosticAtUtc IS NULL;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            blocked,
+                            Is.EqualTo(BillingPeriodCloseResult.Blocked expectedDiagnostic),
+                            $"{caseName} must report its exact first bounded diagnostic."
+                        )
+
+                        Assert.That(previewBeforeRepair, Is.Zero)
+                        Assert.That(chargeBeforeRepair, Is.Zero)
+                        Assert.That(evidenceBeforeRepair, Is.Zero)
+                        Assert.That(terminalBeforeRepair, Is.Zero)
+
+                        Assert.That(
+                            repaired,
+                            Is.EqualTo(
+                                BillingPeriodCloseResult.Closed(
+                                    (match repaired with
+                                     | BillingPeriodCloseResult.Closed (periodId, _) -> periodId
+                                     | _ -> Guid.Empty),
+                                    0
+                                )
+                            )
+                        )
+
+                        Assert.That(replay, Is.EqualTo(repaired), $"{caseName} replay must converge after the repair.")
+                        Assert.That(zeroCharges, Is.Zero)
+                        Assert.That(evidence, Is.EqualTo(1))
+                        Assert.That(cleared, Is.EqualTo(1), $"{caseName} diagnostic clears only with the successful close."))
                 )
             })

--- a/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
+++ b/src/Grace.Operations/Grace.Operations.Tests/OperationsBillingPeriodCloseBehavior.Tests.fs
@@ -1620,7 +1620,7 @@ ORDER BY 1;
                 )
             })
 
-    /// Proves distinct owners and sibling repositories close independently, zero facts remain nonterminal, and a fresh closer replays without reposting.
+    /// Proves distinct owners and sibling repositories close independently, missing zero-fact coverage remains nonterminal, and a fresh closer replays without reposting.
     [<Test>]
     member _.OwnersSiblingRepositoriesZeroFactsAndRestartRemainIsolatedAndIdempotent() =
         withDatabaseAsync (fun connectionString ->
@@ -1669,7 +1669,7 @@ ORDER BY 1;
                 assertSeededScopeClose "owner A/repository B" expectedSibling 3L siblingFactCount siblingFactQuantity siblingProjections
 
                 let! zeroFactPending =
-                    countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0,1) AND RetryDiagnostic='ZeroFactCoveragePending';"
+                    countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0,1) AND RetryDiagnostic LIKE 'MissingAssignment:%';"
 
                 Assert.Multiple(
                     Action (fun () ->
@@ -1690,7 +1690,7 @@ ORDER BY 1;
 
                         Assert.That(
                             (match zeroFactResult with
-                             | BillingPeriodCloseResult.Blocked "ZeroFactCoveragePending" -> true
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith("MissingAssignment:", StringComparison.Ordinal) -> true
                              | _ -> false),
                             Is.True
                         )
@@ -1699,5 +1699,246 @@ ORDER BY 1;
                         Assert.That(charges, Is.EqualTo(3))
                         Assert.That(evidence, Is.EqualTo(3))
                         Assert.That(zeroFactPending, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves an empty period posts one zero-line close only after the complete supported-kind pricing chain is present.
+    [<Test>]
+    member _.ZeroFactCloseRequiresCompletePricingThenClosesOnceAtZero() =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let request = { Scope = scope; ScheduledOperationProvenance = "operations-tests/zero-fact-coverage/v1" }
+                let closer = SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser
+                let! red = closer.CloseAsync(request, CancellationToken.None)
+                let! periodBeforeRepair = closeProjectionAsync connectionString
+                let! _ = addPricingAsync connectionString scope
+                let! green = closer.CloseAsync(request, CancellationToken.None)
+                let! replay = closer.CloseAsync(request, CancellationToken.None)
+                let! periodAfterClose = closeProjectionAsync connectionString
+                let! chargeCount = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidenceCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! nullDiagnosticCount = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State=2 AND RetryDiagnostic IS NULL;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match red with
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith("MissingAssignment:", StringComparison.Ordinal) -> true
+                             | _ -> false),
+                            Is.True,
+                            "No assignment must be the first bounded coverage failure, not an empty-set success."
+                        )
+
+                        Assert.That(
+                            periodBeforeRepair
+                            |> List.exists (fun row -> row.Contains("MissingAssignment:")),
+                            Is.True
+                        )
+
+                        Assert.That(
+                            (match green with
+                             | BillingPeriodCloseResult.Closed (_, 0) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(
+                            (match replay with
+                             | BillingPeriodCloseResult.Closed (_, 0) -> true
+                             | _ -> false),
+                            Is.True
+                        )
+
+                        Assert.That(chargeCount, Is.Zero)
+                        Assert.That(evidenceCount, Is.EqualTo(1))
+                        Assert.That(nullDiagnosticCount, Is.EqualTo(1))
+
+                        Assert.That(
+                            periodAfterClose
+                            |> List.exists (fun row -> row.Contains("\"State\":2")),
+                            Is.True
+                        ))
+                )
+            })
+
+    /// Proves each independently incomplete pricing layer blocks an otherwise complete empty-period close.
+    [<TestCase("assignment", "MissingAssignment")>]
+    [<TestCase("plan", "MissingPricingPlan")>]
+    [<TestCase("mapping", "MissingMapping")>]
+    [<TestCase("rate", "MissingRate")>]
+    member _.ZeroFactCoverageRejectsOneTickGapInEachPricingLayer(layer: string, expectedDiagnostic: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                let gapStart = scope.MonthStart.ToDateTimeUtc().AddDays 14.0
+                let afterGap = gapStart.AddTicks 1L
+                let replacementPlanId = Guid.NewGuid()
+                let replacementId = Guid.NewGuid()
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    match layer with
+                    | "assignment" ->
+                        "UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@AfterGap);"
+                    | "plan" ->
+                        "UPDATE ops.PricingPlan SET EffectiveToUtc=@GapStart WHERE PricingPlanId=@PlanId; INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@ReplacementPlanId,@ReplacementPlanCode,'replacement',@AfterGap); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementId,@ReplacementPlanId,101,'USD','byte-minute',1,2,@GapStart); UPDATE ops.PricingAssignment SET EffectiveToUtc=@GapStart WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementId,@OwnerId,@OrganizationId,@RepositoryId,@ReplacementPlanId,@GapStart);"
+                    | "mapping" ->
+                        "UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=@GapStart WHERE BillableUsageKindMappingId=@MappingId; INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@ReplacementId,1,101,'replacement',@AfterGap);"
+                    | "rate" ->
+                        "UPDATE ops.PricingRate SET EffectiveToUtc=@GapStart WHERE PricingRateId=@RateId; INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementId,@PlanId,101,'USD','byte-minute',1,2,@AfterGap);"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
+
+                command.Parameters.Add("@GapStart", SqlDbType.DateTime2).Value <- gapStart
+                command.Parameters.Add("@AfterGap", SqlDbType.DateTime2).Value <- afterGap
+                command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                command.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
+                command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                command.Parameters.Add("@ReplacementId", SqlDbType.UniqueIdentifier).Value <- replacementId
+                command.Parameters.Add("@ReplacementPlanId", SqlDbType.UniqueIdentifier).Value <- replacementPlanId
+                command.Parameters.Add("@ReplacementPlanCode", SqlDbType.NVarChar, 128).Value <- $"replacement-{replacementPlanId:N}"
+                command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+                command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+                command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-gap-{layer}/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+                let! openPeriods = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriod WHERE State IN (0,1);"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith($"{expectedDiagnostic}:", StringComparison.Ordinal) ->
+                                 true
+                             | _ -> false),
+                            Is.True,
+                            $"A one-tick {layer} gap must not be hidden by another pricing layer."
+                        )
+
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(evidence, Is.Zero)
+                        Assert.That(openPeriods, Is.EqualTo(1)))
+                )
+            })
+
+    /// Proves required supported kinds are never inferred from the mapping or rate rows that happen to exist.
+    [<TestCase("mapping", "MissingMapping")>]
+    [<TestCase("rate", "MissingRate")>]
+    member _.ZeroFactCoverageRejectsEmptyMappingOrRateSet(layer: string, expectedDiagnostic: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    match layer with
+                    | "mapping" -> "DELETE FROM ops.BillableUsageKindMapping WHERE BillableUsageKindMappingId=@MappingId;"
+                    | "rate" -> "DELETE FROM ops.PricingRate WHERE PricingRateId=@RateId;"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
+
+                command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-empty-{layer}/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Blocked diagnostic when diagnostic.StartsWith($"{expectedDiagnostic}:", StringComparison.Ordinal) ->
+                                 true
+                             | _ -> false),
+                            Is.True,
+                            $"An empty {layer} set must be a required-kind failure, not a successful empty coverage set."
+                        )
+
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(evidence, Is.Zero))
+                )
+            })
+
+    /// Proves adjacent half-open pricing windows remain complete at every independently varied pricing layer.
+    [<TestCase("assignment")>]
+    [<TestCase("plan")>]
+    [<TestCase("mapping")>]
+    [<TestCase("rate")>]
+    member _.ZeroFactCoverageAcceptsAdjacentWindowsInEachPricingLayer(layer: string) =
+        withDatabaseAsync (fun connectionString ->
+            task {
+                let scope = scopeFor (Guid.NewGuid()) (Guid.NewGuid()) (Guid.NewGuid())
+                let! pricing = addPricingAsync connectionString scope
+                let boundary = scope.MonthStart.ToDateTimeUtc().AddDays 14.0
+                let replacementPlanId = Guid.NewGuid()
+                let replacementId = Guid.NewGuid()
+                use connection = new SqlConnection(connectionString)
+                do! connection.OpenAsync CancellationToken.None
+                use command = connection.CreateCommand()
+
+                command.CommandText <-
+                    match layer with
+                    | "assignment" ->
+                        "UPDATE ops.PricingAssignment SET EffectiveToUtc=@Boundary WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementId,@OwnerId,@OrganizationId,@RepositoryId,@PlanId,@Boundary);"
+                    | "plan" ->
+                        "UPDATE ops.PricingPlan SET EffectiveToUtc=@Boundary WHERE PricingPlanId=@PlanId; INSERT INTO ops.PricingPlan (PricingPlanId,PlanCode,DisplayName,EffectiveFromUtc) VALUES (@ReplacementPlanId,@ReplacementPlanCode,'replacement',@Boundary); INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementId,@ReplacementPlanId,101,'USD','byte-minute',1,2,@Boundary); UPDATE ops.PricingAssignment SET EffectiveToUtc=@Boundary WHERE PricingAssignmentId=@AssignmentId; INSERT INTO ops.PricingAssignment (PricingAssignmentId,OwnerId,OrganizationId,RepositoryId,PricingPlanId,EffectiveFromUtc) VALUES (@ReplacementId,@OwnerId,@OrganizationId,@RepositoryId,@ReplacementPlanId,@Boundary);"
+                    | "mapping" ->
+                        "UPDATE ops.BillableUsageKindMapping SET EffectiveToUtc=@Boundary WHERE BillableUsageKindMappingId=@MappingId; INSERT INTO ops.BillableUsageKindMapping (BillableUsageKindMappingId,FactKind,BillableUsageKind,DisplayName,EffectiveFromUtc) VALUES (@ReplacementId,1,101,'replacement',@Boundary);"
+                    | "rate" ->
+                        "UPDATE ops.PricingRate SET EffectiveToUtc=@Boundary WHERE PricingRateId=@RateId; INSERT INTO ops.PricingRate (PricingRateId,PricingPlanId,BillableUsageKind,CurrencyCode,UnitName,UnitQuantity,UnitPriceMicros,EffectiveFromUtc) VALUES (@ReplacementId,@PlanId,101,'USD','byte-minute',1,2,@Boundary);"
+                    | _ -> invalidArg (nameof layer) $"Unknown pricing layer '{layer}'."
+
+                command.Parameters.Add("@Boundary", SqlDbType.DateTime2).Value <- boundary
+                command.Parameters.Add("@PlanId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingPlanId
+                command.Parameters.Add("@AssignmentId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingAssignmentId
+                command.Parameters.Add("@MappingId", SqlDbType.UniqueIdentifier).Value <- pricing.BillableUsageKindMappingId
+                command.Parameters.Add("@RateId", SqlDbType.UniqueIdentifier).Value <- pricing.PricingRateId
+                command.Parameters.Add("@ReplacementId", SqlDbType.UniqueIdentifier).Value <- replacementId
+                command.Parameters.Add("@ReplacementPlanId", SqlDbType.UniqueIdentifier).Value <- replacementPlanId
+                command.Parameters.Add("@ReplacementPlanCode", SqlDbType.NVarChar, 128).Value <- $"replacement-{replacementPlanId:N}"
+                command.Parameters.Add("@OwnerId", SqlDbType.UniqueIdentifier).Value <- scope.OwnerId
+                command.Parameters.Add("@OrganizationId", SqlDbType.UniqueIdentifier).Value <- scope.OrganizationId
+                command.Parameters.Add("@RepositoryId", SqlDbType.UniqueIdentifier).Value <- scope.RepositoryId
+                let! _ = command.ExecuteNonQueryAsync CancellationToken.None
+                let request = { Scope = scope; ScheduledOperationProvenance = $"operations-tests/zero-fact-adjacent-{layer}/v1" }
+
+                let! result =
+                    (SqlBillingPeriodCloser(connectionString) :> IBillingPeriodCloser)
+                        .CloseAsync(request, CancellationToken.None)
+
+                let! charges = countAsync connectionString "SELECT COUNT(*) FROM ops.Charge;"
+                let! evidence = countAsync connectionString "SELECT COUNT(*) FROM ops.BillingPeriodCloseEvidence;"
+
+                Assert.Multiple(
+                    Action (fun () ->
+                        Assert.That(
+                            (match result with
+                             | BillingPeriodCloseResult.Closed (_, 0) -> true
+                             | _ -> false),
+                            Is.True,
+                            $"Adjacent {layer} rows must cover the half-open month without a synthetic gap."
+                        )
+
+                        Assert.That(charges, Is.Zero)
+                        Assert.That(evidence, Is.EqualTo(1)))
                 )
             })


### PR DESCRIPTION
# Close zero-fact periods from complete collective pricing coverage

## Purpose

Allow an exact billing period with no accepted facts to close at zero only when every supported Product V1 usage kind
has complete pricing coverage across the entire half-open month. Missing pricing remains visible and retryable instead
of becoming an empty-set success.

Related to #909. Parent replacement issue: #864.

## Included

- One transaction-bound collective pricing-coverage evaluator invoked only by the existing zero-fact close branch.
- Required fact kinds come from `UsageFact.SupportedV1FactKinds`.
- Effective assignment, referenced plan, mapping, and rate boundaries partition the month.
- Existing deterministic effective selection semantics are reused at each segment.
- The zero-fact catalog view is serializable within the existing close transaction; fact-bearing close retains its
  prior isolation behavior.
- Missing layers keep the period nonterminal with a bounded diagnostic and no Charge or close evidence.
- Complete coverage closes once at zero and clears the obsolete diagnostic only after success.

## Boundaries

- No hosted discovery, paging, scheduler, durable coverage cache, new precedence, new fact kind, public surface,
  correction flow, or compatibility behavior.
- Fact-bearing pricing and close semantics remain unchanged.

## Review status

- Implementation/fix workers started: **3** under epic #554's 4+1 policy.
- Candidate head: `59042cdcd6df620d7051da8f7f7093c21ab38e8c`.
- Review 1's stable-catalog and half-open-boundary findings are closed.
- Review 2 found no production defect and supplied the finite completion proof ledger.
- Retained real-SQL evidence: repair matrix 10/10; finite range/repair ledger 18/18; historical-point exclusion 1/1;
  complete `ZeroFactCoverage` filter 34/34; all zero-skip.
- Targeted Fantomas, matching single-node Release build, `git diff --check`, base freshness, and complete Product V1
  self-review passed.
- Post-worker-3 audit found no remaining invariant or proof family, so no worker 4 or split is indicated.
- Fresh completion review 3 and exact-head GitHub `Validate` are in progress; both must pass before merge.
