### PR TITLE
GC-CAL-02: Host one locally complete DirectoryVersionZip through Grace.Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,10 @@ AppPackages/
 # Others
 sql/
 *.[Cc]ache
+!src/Grace.Cache/
+!src/Grace.Cache/**
+src/Grace.Cache/**/bin/
+src/Grace.Cache/**/obj/
 ClientBin/
 [Ss]tyle[Cc]op.*
 ~$*

--- a/docs/Grace Cache implementation audit.md
+++ b/docs/Grace Cache implementation audit.md
@@ -20,6 +20,12 @@ provide ancestry or host topology.
 
 ## Deferred capability
 
-No Cache host, ASP.NET route, DTO, listener, process startup, identity, enrollment, liveness, serving, grant,
-network fill, recursive metadata, complete-root publication, scheduler, retry queue, reconciliation, or generalized
-recovery is part of this issue. Those capabilities require a later outcome charter and proof plan.
+GC-CAL-02 adds one C# ASP.NET Core host and one localhost-only
+`GET /directory-version-zips/{directoryVersionId}` route. Its separate storage reader opens the existing SQLite
+database in immutable read-only mode, queries only an exact `Complete` tuple, derives the opaque final path, and verifies
+the stored size and lowercase SHA-256 before serving `application/zip`. Startup requires existing database, managed
+root, artifact directory, and schema. It does not open the writer store, acquire its process lock, create sidecars or
+directories, classify residue, clean up, or mutate.
+
+Identity, enrollment, liveness, grants, network fill, recursive metadata, complete-root publication, scheduling,
+retry queues, reconciliation, and generalized recovery remain deferred.

--- a/docs/Grace Cache.md
+++ b/docs/Grace Cache.md
@@ -1,10 +1,10 @@
-# Grace Cache storage tracer
+# Grace Cache local artifact path
 
 ## Purpose
 
-Grace Cache currently contains one internal storage tracer: a Linux x64 caller can commit one immutable
-`DirectoryVersionZip` artifact to a managed local root. The tracer exists to establish truthful filesystem and SQLite
-durability before any Cache host, route, identity, enrollment, serving, or network behavior is considered.
+Grace Cache supports one deliberately local path on Linux x64. A producer can commit one immutable
+`DirectoryVersionZip` artifact to a managed local root, and one local development caller can read a pre-existing
+verified artifact over HTTP on `127.0.0.1`.
 
 ## Supported world
 
@@ -14,6 +14,8 @@ durability before any Cache host, route, identity, enrollment, serving, or netwo
   exact byte size.
 - Only `DirectoryVersionZip` is accepted.
 - A local reset is the explicit operator action for a `Complete` disagreement.
+- `Cache__DatabasePath` and `Cache__ManagedRoot` must name pre-existing readable locations. Cache and AppHost do not
+  invent or create them.
 
 ## Lifecycle
 
@@ -30,8 +32,13 @@ The commit point is the exact `Complete` SQLite transaction after verified final
 hit. On a fresh store instance, verified `Staging` plus final bytes becomes `Complete`; other staging residue is cleaned
 to `Absent`. A `Complete` row that disagrees with its final file fails closed and retains its record for local reset.
 
-## Deliberate exclusions
+## Local read boundary
 
-This tracer has no public or hosted Cache surface. It does not include routes, listeners, identity, enrollment,
-liveness, serving, network fill, recursive metadata, complete-root publication, coalescing, scheduling, durable retry,
-reconciliation, or generalized recovery.
+`GET /directory-version-zips/{directoryVersionId}` requires `canonicalIdentity`, lowercase `sha256`, and `size` query
+values. It returns `application/zip` only when the exact supplied tuple matches a SQLite `Complete` row and the managed
+final file independently verifies to that row's exact size and SHA-256. Malformed tuples return 400. Missing,
+ineligible, conflicting, corrupt, or byte-disagreeing state returns 404 without mutation.
+
+The host exposes no write route and binds only to loopback. It does not include identity, enrollment, liveness, network
+fill, recursive metadata, complete-root publication, coalescing, scheduling, retry, reconciliation, or generalized
+recovery.

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Grace.Cache\Grace.Cache.csproj" />
     <ProjectReference Include="..\Grace.Server\Grace.Server.fsproj" />
     <ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" IsAspireProjectResource="false">
         <Aliases>Shared</Aliases>

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -106,6 +106,16 @@ public partial class Program
                 Directory.CreateDirectory(stateRoot);
                 Directory.CreateDirectory(logDirectory);
 
+                var cacheTargetPort = GetAvailableTcpPort();
+                var cacheUrl = "http://127.0.0.1:" + cacheTargetPort;
+                var graceCache = builder.AddProject("grace-cache", "..\\Grace.Cache\\Grace.Cache.csproj")
+                    .WithEnvironment("ASPNETCORE_URLS", cacheUrl)
+                    .WithHttpEndpoint(targetPort: cacheTargetPort, name: "http");
+                var forwardedCacheKeys = new List<string>();
+                AddOptionalEnvironment(graceCache, configuration, "Cache__DatabasePath", forwardedCacheKeys);
+                AddOptionalEnvironment(graceCache, configuration, "Cache__ManagedRoot", forwardedCacheKeys);
+                LogForwardedSettings("Grace.Cache local settings", forwardedCacheKeys);
+
                 // These get set in both Local and Azure-debug runs.
                 var orleansClusterId = configuration[getConfigKey(EnvironmentVariables.OrleansClusterId)] ?? "local";
                 var orleansServiceId = configuration[getConfigKey(EnvironmentVariables.OrleansServiceId)] ?? "grace-dev";

--- a/src/Grace.Cache.Storage/CacheArtifactStore.fs
+++ b/src/Grace.Cache.Storage/CacheArtifactStore.fs
@@ -42,6 +42,11 @@ exception internal CacheArtifactInjectedFailure of CacheArtifactEffect * CacheAr
 /// Holds one managed artifact root coupled to the already-owned private storage database.
 type CacheArtifactStore = private { Store: CacheStore; ManagedRoot: string }
 
+/// Holds pre-existing Cache locations without opening the writer store or taking its process lock.
+type CacheArtifactReader internal (databasePath: string, managedRoot: string) =
+    member internal _.DatabasePath = databasePath
+    member internal _.ManagedRoot = managedRoot
+
 /// Owns exact-tuple local artifact publication and finite restart classification.
 module CacheArtifactStore =
 
@@ -63,13 +68,16 @@ module CacheArtifactStore =
         |> sha256
 
     /// Returns the managed staging root on the same filesystem as deterministic final files.
-    let private stagingRoot store = Path.Combine(store.ManagedRoot, "staging")
+    let private stagingRoot (store: CacheArtifactStore) = Path.Combine(store.ManagedRoot, "staging")
 
     /// Returns the managed final-file root for one opaque artifact key.
-    let private finalRoot store = Path.Combine(store.ManagedRoot, "artifacts")
+    let private finalRoot (store: CacheArtifactStore) = Path.Combine(store.ManagedRoot, "artifacts")
 
     /// Returns the deterministic opaque final path for an immutable tuple.
     let private finalPath store tuple = Path.Combine(finalRoot store, artifactKey tuple + ".bin")
+
+    /// Returns the deterministic opaque final path from a read-only managed root.
+    let private readOnlyFinalPath (reader: CacheArtifactReader) tuple = Path.Combine(reader.ManagedRoot, "artifacts", artifactKey tuple + ".bin")
 
     /// Validates the exact Product V1 tuple without accepting alternate artifact kinds or digest forms.
     let private validateTuple tuple =
@@ -155,6 +163,58 @@ module CacheArtifactStore =
                 Convert
                     .ToHexString(hash.GetHashAndReset())
                     .ToLowerInvariant() = tuple.ExpectedSha256
+
+    /// Opens SQLite without create or write capability for one read-only operation.
+    let private openReadOnlyConnection databasePath =
+        let connectionString =
+            SqliteConnectionStringBuilder(
+                DataSource = Uri(databasePath).AbsoluteUri + "?immutable=1",
+                Mode = SqliteOpenMode.ReadOnly,
+                Cache = SqliteCacheMode.Private,
+                Pooling = false
+            )
+                .ToString()
+
+        let connection = new SqliteConnection(connectionString)
+        connection.Open()
+        connection
+
+    /// Checks that the existing artifact-state table can support exact read queries without initializing schema.
+    let private validateReadSchema (connection: SqliteConnection) =
+        use command = connection.CreateCommand()
+
+        command.CommandText <-
+            "SELECT artifact_key, kind, canonical_identity, directory_version_id, expected_sha256, expected_size, state, operation_identity FROM cache_artifact_states LIMIT 0;"
+
+        use _reader = command.ExecuteReader()
+        ()
+
+    /// Reads only an exact Complete row and never classifies or changes other durable residue.
+    let private hasExactCompleteRow (connection: SqliteConnection) tuple =
+        use command = connection.CreateCommand()
+
+        command.CommandText <-
+            "SELECT 1 FROM cache_artifact_states WHERE artifact_key = @key AND kind = @kind AND canonical_identity = @identity AND directory_version_id = @directoryVersionId AND expected_sha256 = @sha256 AND expected_size = @size AND state = 'Complete' AND operation_identity IS NULL LIMIT 1;"
+
+        command.Parameters.AddWithValue("@key", artifactKey tuple)
+        |> ignore
+
+        command.Parameters.AddWithValue("@kind", tuple.Kind)
+        |> ignore
+
+        command.Parameters.AddWithValue("@identity", tuple.CanonicalIdentity)
+        |> ignore
+
+        command.Parameters.AddWithValue("@directoryVersionId", tuple.DirectoryVersionId)
+        |> ignore
+
+        command.Parameters.AddWithValue("@sha256", tuple.ExpectedSha256)
+        |> ignore
+
+        command.Parameters.AddWithValue("@size", tuple.ExpectedSize)
+        |> ignore
+
+        command.ExecuteScalar() <> null
 
     /// Clears the one-operation staging area before a fresh classification or write advances.
     let private clearStaging store =
@@ -371,6 +431,62 @@ module CacheArtifactStore =
         match validateTuple tuple with
         | Error message -> Rejected message
         | Ok () -> classify store tuple
+
+    /// Opens only pre-existing readable Cache locations and fails without creating a database, root, lock, or schema.
+    let createReader databasePath managedRoot =
+        if String.IsNullOrWhiteSpace databasePath then
+            invalidArg (nameof databasePath) "Cache database path is required."
+
+        if String.IsNullOrWhiteSpace managedRoot then
+            invalidArg (nameof managedRoot) "Managed artifact root is required."
+
+        let database = Path.GetFullPath(databasePath)
+
+        let root =
+            Path
+                .GetFullPath(managedRoot)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+
+        let artifacts = Path.Combine(root, "artifacts")
+
+        if not (File.Exists database) then
+            invalidOp "The configured Cache database must already exist."
+
+        if
+            not (Directory.Exists root)
+            || not (Directory.Exists artifacts)
+        then
+            invalidOp "The configured Cache managed root and artifact directory must already exist."
+
+        Directory.EnumerateFileSystemEntries(root)
+        |> Seq.tryHead
+        |> ignore
+
+        Directory.EnumerateFileSystemEntries(artifacts)
+        |> Seq.tryHead
+        |> ignore
+
+        use connection = openReadOnlyConnection database
+        validateReadSchema connection
+        CacheArtifactReader(database, root)
+
+    /// Returns a final path only when the request exactly selects Complete metadata and independently verified bytes.
+    let read (reader: CacheArtifactReader) tuple =
+        match validateTuple tuple with
+        | Error message -> Rejected message
+        | Ok () ->
+            use connection = openReadOnlyConnection reader.DatabasePath
+
+            if not (hasExactCompleteRow connection tuple) then
+                Absent
+            else
+                let path = readOnlyFinalPath reader tuple
+
+                try
+                    if verifyFile path tuple then Hit path else Absent
+                with
+                | :? IOException
+                | :? UnauthorizedAccessException -> Absent
 
     /// Commits one streamed immutable artifact in the proven effect order and exposes success only after recheck.
     let private commitInternal store tuple (source: Stream) failurePoint =

--- a/src/Grace.Cache.Tests/DirectoryVersionZipEndpointTests.cs
+++ b/src/Grace.Cache.Tests/DirectoryVersionZipEndpointTests.cs
@@ -1,0 +1,288 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using Grace.Cache.Storage;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace Grace.Cache.Tests;
+
+/// <summary>Proves the localhost Cache host serves only independently verified Complete DirectoryVersion ZIP bytes.</summary>
+[TestFixture]
+public sealed class DirectoryVersionZipEndpointTests
+{
+    /// <summary>Commits through the writer, then proves the exact HTTP contract and read-only filesystem behavior.</summary>
+    [Test]
+    public async Task ExactCompleteTupleReturnsZipBytesAndOtherTuplesFailClosed()
+    {
+        using var fixture = CacheHostFixture.Create();
+        var before = fixture.Snapshot();
+        await using var factory = fixture.CreateFactory();
+        using var client = factory.CreateClient();
+
+        using (var response = await client.GetAsync(fixture.ExactRequestUri))
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+                Assert.That(response.Content.Headers.ContentType?.MediaType, Is.EqualTo("application/zip"));
+            });
+            Assert.That(await response.Content.ReadAsByteArrayAsync(), Is.EqualTo(fixture.Payload));
+        }
+
+        foreach (var request in fixture.MalformedRequestUris)
+        {
+            using var response = await client.GetAsync(request);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest), request);
+        }
+
+        foreach (var request in fixture.AbsentRequestUris)
+        {
+            using var response = await client.GetAsync(request);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound), request);
+            Assert.That(await response.Content.ReadAsByteArrayAsync(), Is.Empty, request);
+        }
+
+        using (var response = await client.PutAsync(fixture.ExactRequestUri, new ByteArrayContent(fixture.Payload)))
+        {
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.MethodNotAllowed));
+        }
+
+        Assert.That(fixture.Snapshot(), Is.EqualTo(before), "Cache startup or requests changed the database or managed root.");
+    }
+
+    /// <summary>Confirms a Complete row whose final bytes changed fails closed without repairing either authority.</summary>
+    [Test]
+    public async Task CompleteByteDisagreementReturnsNotFoundWithoutMutation()
+    {
+        using var fixture = CacheHostFixture.Create();
+        File.WriteAllBytes(fixture.FinalPath, "different-cache-bytes"u8.ToArray());
+        var before = fixture.Snapshot();
+        await using var factory = fixture.CreateFactory();
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync(fixture.ExactRequestUri);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        Assert.That(await response.Content.ReadAsByteArrayAsync(), Is.Empty);
+        Assert.That(fixture.Snapshot(), Is.EqualTo(before));
+    }
+
+    /// <summary>Confirms absent, Staging, and malformed Complete metadata are never served or changed.</summary>
+    [TestCase("Absent")]
+    [TestCase("Staging")]
+    [TestCase("Corrupt")]
+    public async Task IneligibleDatabaseStateReturnsNotFoundWithoutMutation(string state)
+    {
+        using var fixture = CacheHostFixture.Create();
+        fixture.MakeIneligible(state);
+        var before = fixture.Snapshot();
+        await using var factory = fixture.CreateFactory();
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync(fixture.ExactRequestUri);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+        Assert.That(await response.Content.ReadAsByteArrayAsync(), Is.Empty);
+        Assert.That(fixture.Snapshot(), Is.EqualTo(before));
+    }
+
+    /// <summary>Confirms missing required locations fail startup without creating a database, root, schema, or lock.</summary>
+    [Test]
+    public void MissingLocationsFailStartupWithoutCreation()
+    {
+        var parent = Path.Combine(Path.GetTempPath(), "grace-cache-read-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(parent);
+        var databasePath = Path.Combine(parent, "missing", "cache.db");
+        var managedRoot = Path.Combine(parent, "missing", "managed");
+        using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.UseSetting("Cache:DatabasePath", databasePath)
+                .UseSetting("Cache:ManagedRoot", managedRoot));
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(() => factory.CreateClient());
+            Assert.That(Directory.GetFileSystemEntries(parent), Is.Empty);
+        }
+        finally
+        {
+            Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    /// <summary>Confirms Kestrel replaces a supplied wildcard hostname with the IPv4 loopback listener.</summary>
+    [Test]
+    public async Task ProcessListenerIsLoopbackOnly()
+    {
+        using var fixture = CacheHostFixture.Create();
+        var port = CacheHostFixture.GetAvailablePort();
+        using var process = fixture.StartProcess(port);
+
+        try
+        {
+            var listeningLine = await process.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            while (listeningLine is not null && !listeningLine.Contains("Now listening on:", StringComparison.Ordinal))
+                listeningLine = await process.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.That(listeningLine, Does.Contain($"http://127.0.0.1:{port}"));
+            using var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") };
+            using var response = await client.GetAsync(fixture.ExactRequestUri);
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        }
+        finally
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            await process.WaitForExitAsync();
+        }
+    }
+}
+
+/// <summary>Owns one pre-existing committed artifact and the configuration supplied to the read-only host.</summary>
+internal sealed class CacheHostFixture : IDisposable
+{
+    /// <summary>Captures the isolated writer output consumed by one read-only host.</summary>
+    private CacheHostFixture(string root, string databasePath, string managedRoot, string finalPath, byte[] payload, CacheArtifactTuple tuple)
+    {
+        Root = root;
+        DatabasePath = databasePath;
+        ManagedRoot = managedRoot;
+        FinalPath = finalPath;
+        Payload = payload;
+        Tuple = tuple;
+    }
+
+    /// <summary>Gets the isolated directory removed after the host and SQLite pools close.</summary>
+    private string Root { get; }
+    /// <summary>Gets the pre-existing SQLite database supplied to Cache startup.</summary>
+    internal string DatabasePath { get; }
+    /// <summary>Gets the pre-existing managed artifact root supplied to Cache startup.</summary>
+    internal string ManagedRoot { get; }
+    /// <summary>Gets the opaque writer-produced file used for byte-disagreement proof.</summary>
+    internal string FinalPath { get; }
+    /// <summary>Gets the exact committed bytes expected from a successful response.</summary>
+    internal byte[] Payload { get; }
+    /// <summary>Gets the immutable tuple committed through the existing writer.</summary>
+    private CacheArtifactTuple Tuple { get; }
+
+    /// <summary>Gets the exact supported GET request for the committed tuple.</summary>
+    internal string ExactRequestUri =>
+        $"/directory-version-zips/{Uri.EscapeDataString(Tuple.DirectoryVersionId)}" +
+        $"?canonicalIdentity={Uri.EscapeDataString(Tuple.CanonicalIdentity)}" +
+        $"&sha256={Tuple.ExpectedSha256}&size={Tuple.ExpectedSize}";
+
+    /// <summary>Gets malformed requests that must fail binding or tuple validation with 400.</summary>
+    internal IEnumerable<string> MalformedRequestUris =>
+    [
+        $"/directory-version-zips/{Tuple.DirectoryVersionId}?sha256={Tuple.ExpectedSha256}&size={Tuple.ExpectedSize}",
+        ExactRequestUri.Replace(Tuple.ExpectedSha256, Tuple.ExpectedSha256.ToUpperInvariant(), StringComparison.Ordinal),
+        ExactRequestUri.Replace($"size={Tuple.ExpectedSize}", "size=not-a-number", StringComparison.Ordinal),
+    ];
+
+    /// <summary>Gets valid but non-matching tuples that must fail closed with 404.</summary>
+    internal IEnumerable<string> AbsentRequestUris =>
+    [
+        ExactRequestUri.Replace(Tuple.DirectoryVersionId, "directory-version-absent", StringComparison.Ordinal),
+        ExactRequestUri.Replace(Tuple.ExpectedSha256, new string('0', 64), StringComparison.Ordinal),
+        ExactRequestUri.Replace($"size={Tuple.ExpectedSize}", $"size={Tuple.ExpectedSize + 1}", StringComparison.Ordinal),
+        ExactRequestUri.Replace("zip%2Fhttp", "zip%2Fconflict", StringComparison.Ordinal),
+    ];
+
+    /// <summary>Commits one artifact through the existing writer and releases writer ownership before host startup.</summary>
+    internal static CacheHostFixture Create()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "grace-cache-read-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var databasePath = Path.Combine(root, "cache.db");
+        var managedRoot = Path.Combine(root, "managed");
+        var payload = "grace-cache-directory-version-zip\n"u8.ToArray();
+        var tuple = new CacheArtifactTuple(
+            "DirectoryVersionZip",
+            "artifact://grace/root/zip/http",
+            "directory-version-http-001",
+            Convert.ToHexString(SHA256.HashData(payload)).ToLowerInvariant(),
+            payload.LongLength);
+        var openResult = CacheStoreModule.openStore(databasePath);
+        if (openResult is not CacheStoreOpenResult.Opened opened)
+            throw new InvalidOperationException("The isolated Cache writer store did not open.");
+        var writer = CacheArtifactStoreModule.create(opened.store, managedRoot);
+        using (var source = new MemoryStream(payload, writable: false))
+        {
+            if (!CacheArtifactStoreModule.commit(writer, tuple, source).IsFilled)
+                throw new InvalidOperationException("The isolated Cache artifact did not commit.");
+        }
+        var finalPath = CacheArtifactStoreModule.inspect(writer, tuple) is CacheArtifactOutcome.Hit hit
+            ? hit.finalPath
+            : throw new InvalidOperationException("The committed Cache artifact did not reopen as a verified hit.");
+        CacheStoreModule.disposeStore(opened.store);
+        SqliteConnection.ClearAllPools();
+        return new CacheHostFixture(root, databasePath, managedRoot, finalPath, payload, tuple);
+    }
+
+    /// <summary>Reserves then releases a local port for the bounded child-process listener proof.</summary>
+    internal static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>Starts the built Cache host with a wildcard URL that production code must narrow to loopback.</summary>
+    internal Process StartProcess(int port)
+    {
+        var hostAssembly = typeof(Program).Assembly.Location;
+        var startInfo = new ProcessStartInfo("dotnet", $"\"{hostAssembly}\"")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        startInfo.Environment["Cache__DatabasePath"] = DatabasePath;
+        startInfo.Environment["Cache__ManagedRoot"] = ManagedRoot;
+        startInfo.Environment["ASPNETCORE_URLS"] = $"http://0.0.0.0:{port}";
+        return Process.Start(startInfo) ?? throw new InvalidOperationException("The Cache host process did not start.");
+    }
+
+    /// <summary>Creates an in-process host using only the two required pre-existing Cache locations.</summary>
+    internal WebApplicationFactory<Program> CreateFactory() =>
+        new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+            builder.UseSetting("Cache:DatabasePath", DatabasePath)
+                .UseSetting("Cache:ManagedRoot", ManagedRoot));
+
+    /// <summary>Arranges one non-serving durable state before the read-only host starts.</summary>
+    internal void MakeIneligible(string state)
+    {
+        using var connection = new SqliteConnection($"Data Source={DatabasePath};Mode=ReadWrite;Pooling=False");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = state switch
+        {
+            "Absent" => "DELETE FROM cache_artifact_states;",
+            "Staging" => "UPDATE cache_artifact_states SET state = 'Staging', operation_identity = 'test-operation';",
+            "Corrupt" => "UPDATE cache_artifact_states SET operation_identity = 'invalid-complete-operation';",
+            _ => throw new ArgumentOutOfRangeException(nameof(state)),
+        };
+        command.ExecuteNonQuery();
+        SqliteConnection.ClearAllPools();
+    }
+
+    /// <summary>Hashes every database and managed-root file so startup or request mutations cannot pass unnoticed.</summary>
+    internal string Snapshot()
+    {
+        var entries = Directory.GetFiles(Root, "*", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path => $"{Path.GetRelativePath(Root, path)}:{Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)))}");
+        return string.Join("\n", entries);
+    }
+
+    /// <summary>Clears test-only writer pools and removes the isolated fixture directory.</summary>
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        Directory.Delete(Root, recursive: true);
+    }
+}

--- a/src/Grace.Cache.Tests/Grace.Cache.Tests.csproj
+++ b/src/Grace.Cache.Tests/Grace.Cache.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Grace.Cache\Grace.Cache.csproj" />
+    <ProjectReference Include="..\Grace.Cache.Storage\Grace.Cache.Storage.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/Grace.Cache/Grace.Cache.csproj
+++ b/src/Grace.Cache/Grace.Cache.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    <Description>Localhost-only read boundary for verified Grace Cache artifacts.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Grace.Cache.Storage\Grace.Cache.Storage.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/Grace.Cache/Program.cs
+++ b/src/Grace.Cache/Program.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using Grace.Cache.Storage;
+
+var builder = WebApplication.CreateBuilder(args);
+var configuredUrl = builder.Configuration["ASPNETCORE_URLS"];
+var listenPort = 0;
+if (!string.IsNullOrWhiteSpace(configuredUrl))
+{
+    var urls = configuredUrl.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    if (urls.Length != 1 || !Uri.TryCreate(urls[0], UriKind.Absolute, out var uri))
+        throw new InvalidOperationException("Grace.Cache accepts exactly one valid ASPNETCORE_URLS listener.");
+    listenPort = uri.Port;
+}
+builder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Loopback, listenPort));
+
+var databasePath = builder.Configuration["Cache:DatabasePath"]
+    ?? throw new InvalidOperationException("Cache__DatabasePath is required.");
+var managedRoot = builder.Configuration["Cache:ManagedRoot"]
+    ?? throw new InvalidOperationException("Cache__ManagedRoot is required.");
+var reader = CacheArtifactStoreModule.createReader(databasePath, managedRoot);
+
+var app = builder.Build();
+
+app.MapGet(
+    "/directory-version-zips/{directoryVersionId}",
+    (string directoryVersionId, string canonicalIdentity, string sha256, long size) =>
+    {
+        var tuple = new CacheArtifactTuple(
+            "DirectoryVersionZip",
+            canonicalIdentity,
+            directoryVersionId,
+            sha256,
+            size);
+
+        return CacheArtifactStoreModule.read(reader, tuple) switch
+        {
+            CacheArtifactOutcome.Hit hit => Results.File(hit.finalPath, "application/zip"),
+            CacheArtifactOutcome.Rejected rejected => Results.BadRequest(rejected.message),
+            _ => Results.NotFound(),
+        };
+    });
+
+app.Run();
+
+/// <summary>Exposes the localhost Cache host entry point to focused in-process HTTP tests.</summary>
+public partial class Program;

--- a/src/Grace.slnx
+++ b/src/Grace.slnx
@@ -13,6 +13,8 @@
   <Project Path="Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj" />
   <Project Path="Grace.Cache.Storage.Tests/Grace.Cache.Storage.Tests.fsproj" />
   <Project Path="Grace.Cache.Storage/Grace.Cache.Storage.fsproj" />
+  <Project Path="Grace.Cache.Tests/Grace.Cache.Tests.csproj" />
+  <Project Path="Grace.Cache/Grace.Cache.csproj" />
   <Project Path="Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj" />
   <Project Path="Grace.CLI.Tests/Grace.CLI.Tests.fsproj" />
   <Project Path="Grace.CLI/Grace.CLI.fsproj" />


### PR DESCRIPTION
# GC-CAL-02: Host one locally complete DirectoryVersionZip through Grace.Cache

Closes #970

## Outcome

Adds one localhost-only, read-only `Grace.Cache` HTTP path for a pre-existing `DirectoryVersionZip`. A `200` is returned only when the exact supplied tuple matches an existing SQLite `Complete` row and the opaque managed final file independently verifies to the stored size and lowercase SHA-256.

## Delivery and scope

- Mainline slice from `origin/main@ebfe99d452ecfa797301d3600c2e9e8b24764dfc` to `main`.
- Head: `0276b7d991328c1d5eb7297854a7df8fb7ed7dcf`.
- Product V1 narrowed to one Linux x64, quiescent, local Cache root and one local HTTP caller.
- Adds the no-write storage reader, one `GET /directory-version-zips/{directoryVersionId}` route, C# Aspire AppHost composition, focused tests, solution membership, and Cache documentation.
- The owner-authorized `.gitignore` exception makes only `src/Grace.Cache` source visible while retaining `bin` and `obj` ignores.

## Explicit non-goals

No writes, schema/root/lock creation, recovery, cleanup, network fill, identity, enrollment, liveness, CachePreferred, prefetch, legacy integration, or changes to Server, actors, CLI, SDK, Types, Shared, OpenAPI, generated clients, or the obsolete F# AppHost.

## Proof

- Targeted Fantomas passed for `CacheArtifactStore.fs`.
- `Grace.Cache.Storage.Tests`: 26 passed.
- `Grace.Cache.Tests`: 7 passed, covering exact `200 application/zip`, malformed `400`, ineligible `404`, no mutation, startup failure without location creation, `PUT` rejection, and loopback-only Kestrel.
- Solution restore and Release build passed with zero warnings and zero errors.
- Changed documentation passes MarkdownLint; scope scan and `git diff --check` pass.

## Required completion gates

- GitHub `Validate` must pass on the current PR head.
- One independent R1 Discovery Review produces the frozen ledger.
- R2 runs only if R1 accepts repairs.

## Residual risk

This is intentionally one Linux x64 local, quiescent Cache root with no remote or lifecycle service.
