### PR TITLE
Bootstrap DebugAzure authorization safely

### DIFF
--- a/scripts/start-debugazure.ps1
+++ b/scripts/start-debugazure.ps1
@@ -10,7 +10,8 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-$bootstrapUsersVariable = "grace__authz__bootstrap__system_admin_users"
+$bootstrapModeVariable = "GRACE_DEBUGAZURE_BOOTSTRAP_MODE"
+$bootstrapUserIdVariable = "GRACE_DEBUGAZURE_BOOTSTRAP_USER_ID"
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $appHostProject = Join-Path $repoRoot "src\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj"
 $cliProject = Join-Path $repoRoot "src\Grace.CLI\Grace.CLI.fsproj"
@@ -41,15 +42,18 @@ function Stop-AppHostProcess {
 function Start-AppHostProcess {
     param([AllowNull()][string] $BootstrapUserId)
 
-    $originalBootstrapUsers = [Environment]::GetEnvironmentVariable($bootstrapUsersVariable, "Process")
+    $originalBootstrapMode = [Environment]::GetEnvironmentVariable($bootstrapModeVariable, "Process")
+    $originalBootstrapUserId = [Environment]::GetEnvironmentVariable($bootstrapUserIdVariable, "Process")
 
     try {
         if ([string]::IsNullOrWhiteSpace($BootstrapUserId)) {
-            [Environment]::SetEnvironmentVariable($bootstrapUsersVariable, $null, "Process")
+            [Environment]::SetEnvironmentVariable($bootstrapModeVariable, "Suppress", "Process")
+            [Environment]::SetEnvironmentVariable($bootstrapUserIdVariable, $null, "Process")
             Write-Status "Starting DebugAzure without bootstrap authorization."
         }
         else {
-            [Environment]::SetEnvironmentVariable($bootstrapUsersVariable, $BootstrapUserId, "Process")
+            [Environment]::SetEnvironmentVariable($bootstrapModeVariable, "ExactUser", "Process")
+            [Environment]::SetEnvironmentVariable($bootstrapUserIdVariable, $BootstrapUserId, "Process")
             Write-Status "Restarting DebugAzure with the authenticated user as the one-time bootstrap candidate."
         }
 
@@ -63,7 +67,8 @@ function Start-AppHostProcess {
             -PassThru
     }
     finally {
-        [Environment]::SetEnvironmentVariable($bootstrapUsersVariable, $originalBootstrapUsers, "Process")
+        [Environment]::SetEnvironmentVariable($bootstrapModeVariable, $originalBootstrapMode, "Process")
+        [Environment]::SetEnvironmentVariable($bootstrapUserIdVariable, $originalBootstrapUserId, "Process")
     }
 }
 

--- a/scripts/start-debugazure.ps1
+++ b/scripts/start-debugazure.ps1
@@ -1,0 +1,207 @@
+[CmdletBinding()]
+param(
+    [string] $GraceServerUri = "http://localhost:5000",
+    [ValidateRange(30, 1800)]
+    [int] $StartupTimeoutSeconds = 300,
+    [ValidateSet("Debug", "Release")]
+    [string] $Configuration = "Debug"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$bootstrapUsersVariable = "grace__authz__bootstrap__system_admin_users"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$appHostProject = Join-Path $repoRoot "src\Grace.Aspire.AppHost\Grace.Aspire.AppHost.csproj"
+$cliProject = Join-Path $repoRoot "src\Grace.CLI\Grace.CLI.fsproj"
+$cliPath = Join-Path $repoRoot "src\Grace.CLI\bin\$Configuration\net10.0\grace.exe"
+$logDirectory = Join-Path $repoRoot ".grace\logs"
+$runId = [Guid]::NewGuid().ToString("N").Substring(0, 8)
+$stdoutPath = Join-Path $logDirectory "start-debugazure-$runId.stdout.log"
+$stderrPath = Join-Path $logDirectory "start-debugazure-$runId.stderr.log"
+
+function Write-Status {
+    param([Parameter(Mandatory)][string] $Message)
+
+    Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $Message"
+}
+
+function Stop-AppHostProcess {
+    param([Parameter(Mandatory)][System.Diagnostics.Process] $Process)
+
+    if ($Process.HasExited) {
+        return
+    }
+
+    Write-Status "Stopping Aspire AppHost process tree (PID $($Process.Id))."
+    $Process.Kill($true)
+    $Process.WaitForExit()
+}
+
+function Start-AppHostProcess {
+    param([AllowNull()][string] $BootstrapUserId)
+
+    $originalBootstrapUsers = [Environment]::GetEnvironmentVariable($bootstrapUsersVariable, "Process")
+
+    try {
+        if ([string]::IsNullOrWhiteSpace($BootstrapUserId)) {
+            [Environment]::SetEnvironmentVariable($bootstrapUsersVariable, $null, "Process")
+            Write-Status "Starting DebugAzure without bootstrap authorization."
+        }
+        else {
+            [Environment]::SetEnvironmentVariable($bootstrapUsersVariable, $BootstrapUserId, "Process")
+            Write-Status "Restarting DebugAzure with the authenticated user as the one-time bootstrap candidate."
+        }
+
+        return Start-Process `
+            -FilePath "dotnet" `
+            -ArgumentList @("run", "--project", $appHostProject, "--launch-profile", "DebugAzure") `
+            -WorkingDirectory $repoRoot `
+            -WindowStyle Hidden `
+            -RedirectStandardOutput $stdoutPath `
+            -RedirectStandardError $stderrPath `
+            -PassThru
+    }
+    finally {
+        [Environment]::SetEnvironmentVariable($bootstrapUsersVariable, $originalBootstrapUsers, "Process")
+    }
+}
+
+function ConvertFrom-GraceJson {
+    param([Parameter(Mandatory)][string] $Text)
+
+    $jsonStart = $Text.IndexOf('{')
+    if ($jsonStart -lt 0) {
+        throw "Grace CLI did not return JSON."
+    }
+
+    return $Text.Substring($jsonStart) | ConvertFrom-Json
+}
+
+function Invoke-GraceJson {
+    param([Parameter(Mandatory)][string[]] $Arguments)
+
+    $originalServerUri = $env:GRACE_SERVER_URI
+
+    try {
+        $env:GRACE_SERVER_URI = $GraceServerUri
+        $outputLines = @(& $cliPath @Arguments 2>&1 | ForEach-Object { "$_" })
+        $exitCode = $LASTEXITCODE
+        $output = $outputLines -join [Environment]::NewLine
+
+        if ($exitCode -ne 0) {
+            throw "Grace CLI exited with code $exitCode. $output"
+        }
+
+        return ConvertFrom-GraceJson -Text $output
+    }
+    finally {
+        $env:GRACE_SERVER_URI = $originalServerUri
+    }
+}
+
+function Wait-GraceIdentity {
+    param([Parameter(Mandatory)][System.Diagnostics.Process] $Process)
+
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($StartupTimeoutSeconds)
+    $lastError = $null
+    $lastStatusAt = [DateTimeOffset]::MinValue
+
+    Write-Status "Waiting for Grace authentication at $GraceServerUri."
+
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            throw "Aspire AppHost exited with code $($Process.ExitCode). See $stderrPath."
+        }
+
+        try {
+            $oidcConfigUri = "$($GraceServerUri.TrimEnd('/'))/authenticate/oidc/config"
+            $response = Invoke-WebRequest -Uri $oidcConfigUri -TimeoutSec 3 -SkipHttpErrorCheck
+            if ($response.StatusCode -ne 200) {
+                throw "Grace readiness endpoint returned HTTP $($response.StatusCode)."
+            }
+
+            $whoAmI = Invoke-GraceJson -Arguments @("authenticate", "whoami", "--output", "Json")
+            $userId = [string] $whoAmI.ReturnValue.GraceUserId
+
+            if (-not [string]::IsNullOrWhiteSpace($userId)) {
+                Write-Status "Grace authenticated the current CLI identity."
+                return $userId
+            }
+        }
+        catch {
+            $lastError = $_.Exception.Message
+        }
+
+        if (([DateTimeOffset]::UtcNow - $lastStatusAt).TotalSeconds -ge 15) {
+            Write-Status "Grace Server is not ready yet; continuing to wait."
+            $lastStatusAt = [DateTimeOffset]::UtcNow
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    throw "Grace did not authenticate the current CLI identity within $StartupTimeoutSeconds seconds. Last result: $lastError"
+}
+
+function Test-SystemAdmin {
+    $result = Invoke-GraceJson -Arguments @(
+        "authorize", "check",
+        "--resource", "system",
+        "--operation", "SystemAdmin",
+        "--output", "Json"
+    )
+
+    return $result.ReturnValue.PSObject.Properties.Name -contains "allowed"
+}
+
+New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+
+Write-Status "Building Grace CLI ($Configuration)."
+& dotnet build $cliProject -c $Configuration --nologo
+if ($LASTEXITCODE -ne 0) {
+    throw "Grace CLI build failed with exit code $LASTEXITCODE."
+}
+
+$appHostProcess = $null
+
+try {
+    $appHostProcess = Start-AppHostProcess
+    $currentUserId = Wait-GraceIdentity -Process $appHostProcess
+
+    Write-Status "Checking whether the current identity already has SystemAdmin."
+    if (Test-SystemAdmin) {
+        Write-Status "Authorization is already configured. DebugAzure is ready."
+    }
+    else {
+        Write-Status "SystemAdmin is not currently granted. Testing the empty-environment bootstrap path once."
+        Stop-AppHostProcess -Process $appHostProcess
+        $appHostProcess = Start-AppHostProcess -BootstrapUserId $currentUserId
+        $restartedUserId = Wait-GraceIdentity -Process $appHostProcess
+
+        if ($restartedUserId -ne $currentUserId) {
+            throw "The authenticated Grace user changed during bootstrap restart."
+        }
+
+        Write-Status "Rechecking SystemAdmin after the bootstrap restart."
+        if (-not (Test-SystemAdmin)) {
+            Stop-AppHostProcess -Process $appHostProcess
+            throw "This environment already has authorization state. An existing SystemAdmin must grant access to the current identity."
+        }
+
+        Write-Status "The new environment granted SystemAdmin to the current authenticated identity."
+    }
+
+    Write-Status "DebugAzure remains running as PID $($appHostProcess.Id)."
+    Write-Status "Standard output: $stdoutPath"
+    Write-Status "Standard error:  $stderrPath"
+}
+catch {
+    if ($null -ne $appHostProcess) {
+        Stop-AppHostProcess -Process $appHostProcess
+    }
+
+    Write-Error $_
+    exit 1
+}

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -30,4 +30,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Grace.Server.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -30,6 +30,12 @@ public partial class Program
     private const string GraceUsageCollectorSubscriptionResourceName = "grace-usage-collector-subscription";
     private const string OperationalFactsProcessorSubscriptionSettingName = "grace__azure_service_bus__operational_facts_processor_subscription";
     private const string OperationsSqlConnectionStringSettingName = "grace__operations__sql__connectionstring";
+    internal const string DebugAzureBootstrapModeEnvironmentVariable = "GRACE_DEBUGAZURE_BOOTSTRAP_MODE";
+    internal const string DebugAzureBootstrapUserIdEnvironmentVariable = "GRACE_DEBUGAZURE_BOOTSTRAP_USER_ID";
+    internal const string DebugAzureBootstrapModeSuppress = "Suppress";
+    internal const string DebugAzureBootstrapModeExactUser = "ExactUser";
+
+    internal sealed record AuthorizationBootstrapSettings(string? Users, string? Groups);
 
     private static void Main(string[] args)
     {
@@ -148,8 +154,17 @@ public partial class Program
                 var forwardedAuthKeys = new List<string>();
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAuthority, forwardedAuthKeys);
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAudience, forwardedAuthKeys);
-                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, forwardedAuthKeys);
-                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups, forwardedAuthKeys);
+                var authorizationBootstrapSettings = ResolveAuthorizationBootstrapSettings(configuration, isAzureDebugRun);
+                AddOptionalEnvironment(
+                    graceServer,
+                    EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers,
+                    authorizationBootstrapSettings.Users,
+                    forwardedAuthKeys);
+                AddOptionalEnvironment(
+                    graceServer,
+                    EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups,
+                    authorizationBootstrapSettings.Groups,
+                    forwardedAuthKeys);
                 LogForwardedSettings("Grace.Server auth settings", forwardedAuthKeys);
 
                 if (isTestRun && !useFixedTestPorts)
@@ -563,8 +578,17 @@ public partial class Program
                 var forwardedAuthKeys = new List<string>();
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAuthority, forwardedAuthKeys);
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAudience, forwardedAuthKeys);
-                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, forwardedAuthKeys);
-                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups, forwardedAuthKeys);
+                var authorizationBootstrapSettings = ResolveAuthorizationBootstrapSettings(configuration, false);
+                AddOptionalEnvironment(
+                    graceServer,
+                    EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers,
+                    authorizationBootstrapSettings.Users,
+                    forwardedAuthKeys);
+                AddOptionalEnvironment(
+                    graceServer,
+                    EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups,
+                    authorizationBootstrapSettings.Groups,
+                    forwardedAuthKeys);
                 LogForwardedSettings("Grace.Server auth settings", forwardedAuthKeys);
 
                 Console.WriteLine("Grace.Server publish/production environment configured (Azure resources with MI by default).");
@@ -688,12 +712,56 @@ public partial class Program
         string name,
         IList<string> forwardedKeys)
     {
-        var value = ResolveSetting(configuration, name);
+        AddOptionalEnvironment(resource, name, ResolveSetting(configuration, name), forwardedKeys);
+    }
+
+    private static void AddOptionalEnvironment(
+        IResourceBuilder<ProjectResource> resource,
+        string name,
+        string? value,
+        IList<string> forwardedKeys)
+    {
         if (!string.IsNullOrWhiteSpace(value))
         {
             resource.WithEnvironment(name, value);
             forwardedKeys?.Add(name);
         }
+    }
+
+    internal static AuthorizationBootstrapSettings ResolveAuthorizationBootstrapSettings(
+        IConfiguration configuration,
+        bool allowDebugAzureOverride)
+    {
+        if (allowDebugAzureOverride)
+        {
+            var mode = Environment.GetEnvironmentVariable(DebugAzureBootstrapModeEnvironmentVariable);
+
+            if (DebugAzureBootstrapModeSuppress.Equals(mode, StringComparison.Ordinal))
+            {
+                return new AuthorizationBootstrapSettings(null, null);
+            }
+
+            if (DebugAzureBootstrapModeExactUser.Equals(mode, StringComparison.Ordinal))
+            {
+                var exactUserId = Environment.GetEnvironmentVariable(DebugAzureBootstrapUserIdEnvironmentVariable);
+                if (string.IsNullOrWhiteSpace(exactUserId) || exactUserId.Contains(';'))
+                {
+                    throw new InvalidOperationException(
+                        $"{DebugAzureBootstrapModeExactUser} mode requires exactly one non-empty bootstrap user ID.");
+                }
+
+                return new AuthorizationBootstrapSettings(exactUserId, null);
+            }
+
+            if (!string.IsNullOrWhiteSpace(mode))
+            {
+                throw new InvalidOperationException($"Unsupported DebugAzure bootstrap mode '{mode}'.");
+            }
+        }
+
+        return new AuthorizationBootstrapSettings(
+            ResolveSetting(configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers),
+            ResolveSetting(configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups));
     }
 
     private static void LogForwardedSettings(string label, IList<string> forwardedKeys)

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -148,6 +148,8 @@ public partial class Program
                 var forwardedAuthKeys = new List<string>();
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAuthority, forwardedAuthKeys);
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAudience, forwardedAuthKeys);
+                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, forwardedAuthKeys);
+                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups, forwardedAuthKeys);
                 LogForwardedSettings("Grace.Server auth settings", forwardedAuthKeys);
 
                 if (isTestRun && !useFixedTestPorts)
@@ -561,6 +563,8 @@ public partial class Program
                 var forwardedAuthKeys = new List<string>();
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAuthority, forwardedAuthKeys);
                 AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthOidcAudience, forwardedAuthKeys);
+                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, forwardedAuthKeys);
+                AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups, forwardedAuthKeys);
                 LogForwardedSettings("Grace.Server auth settings", forwardedAuthKeys);
 
                 Console.WriteLine("Grace.Server publish/production environment configured (Azure resources with MI by default).");

--- a/src/Grace.CLI.Tests/Program.CLI.Tests.fs
+++ b/src/Grace.CLI.Tests/Program.CLI.Tests.fs
@@ -2,6 +2,8 @@ namespace Grace.CLI.Tests
 
 open FsUnit
 open Grace.CLI
+open Grace.SDK
+open Grace.Shared
 open NUnit.Framework
 open System
 
@@ -80,6 +82,14 @@ module CommandParsingTests =
             action ()
         finally
             Environment.SetEnvironmentVariable(name, original)
+
+    /// Verifies that SDK POST requests can resolve Grace Server without repository configuration.
+    [<Test>]
+    let ``SDK server URI prefers GRACE_SERVER_URI`` () =
+        withEnvironmentVariable
+            Constants.EnvironmentVariables.GraceServerUri
+            (Some "https://grace.example.test")
+            (fun () -> Grace.SDK.Common.resolveGraceServerUri () |> should equal "https://grace.example.test")
 
     /// Verifies that resolve invocation source prefers explicit source over environment.
     [<Test>]
@@ -608,6 +618,31 @@ module HelpDoesNotReadConfigTests =
             |> should equal RepositoryId.Empty
 
             graceIds.BranchId |> should equal BranchId.Empty
+            graceIds.HasOrganization |> should equal false
+            graceIds.HasRepository |> should equal false
+            graceIds.HasBranch |> should equal false)
+
+    /// Verifies that a system permission preflight does not require repository-local Grace configuration.
+    [<Test>]
+    let ``authz check system scope does not require graceconfig`` () =
+        withTempDir (fun _ ->
+            let parseResult =
+                GraceCommand.rootCommand.Parse(
+                    [|
+                        "authorize"
+                        "check"
+                        "--resource"
+                        "system"
+                        "--operation"
+                        "SystemAdmin"
+                    |]
+                )
+
+            parseResult.Errors.Count |> should equal 0
+
+            let graceIds = Command.Access.normalizeCheckPermissionIds parseResult "system"
+
+            graceIds.HasOwner |> should equal false
             graceIds.HasOrganization |> should equal false
             graceIds.HasRepository |> should equal false
             graceIds.HasBranch |> should equal false)

--- a/src/Grace.CLI/Command/Access.CLI.fs
+++ b/src/Grace.CLI/Command/Access.CLI.fs
@@ -295,6 +295,13 @@ module Access =
         |> getNormalizedIdsAndNames
         |> clearImplicitChildScopeIds parseResult
 
+    /// Resolves no local scope for system checks and preserves configured ids for narrower permission checks.
+    let internal normalizeCheckPermissionIds (parseResult: ParseResult) (resourceKind: string) =
+        if resourceKind.Equals("system", StringComparison.OrdinalIgnoreCase) then
+            GraceIds.Default
+        else
+            parseResult |> getNormalizedIdsAndNames
+
     /// Formats scope values into the text shown in Spectre.Console tables or command output.
     let private formatScope (scope: Scope) =
         match scope with
@@ -959,8 +966,8 @@ module Access =
                 try
                     if parseResult |> verbose then printParseResult parseResult
 
-                    let graceIds = parseResult |> getNormalizedIdsAndNames
                     let resourceKind = parseResult.GetValue(Options.resourceKindRequired)
+                    let graceIds = normalizeCheckPermissionIds parseResult resourceKind
 
                     let pathValue =
                         parseResult.GetValue(Options.pathOptional)

--- a/src/Grace.CLI/Program.CLI.fs
+++ b/src/Grace.CLI/Program.CLI.fs
@@ -1506,7 +1506,19 @@ module GraceCommand =
                                 && (commandLineage
                                     |> Seq.exists (fun cmd -> cmd.Name.Equals("bootstrap", comparison)))
 
+                            let isSystemAuthorizationCheck =
+                                (commandLineage
+                                 |> Seq.exists (fun cmd -> cmd.Name.Equals("authorize", comparison)))
+                                && (commandLineage
+                                    |> Seq.exists (fun cmd -> cmd.Name.Equals("check", comparison)))
+                                && String.Equals(
+                                    parseResult.GetValue<string>(OptionName.ResourceKind),
+                                    "system",
+                                    comparison
+                                )
+
                             isAgentBootstrap
+                            || isSystemAuthorizationCheck
                             || (commandLineage
                                 |> Seq.exists (fun cmd ->
                                     allowedCommands

--- a/src/Grace.SDK/Common.SDK.fs
+++ b/src/Grace.SDK/Common.SDK.fs
@@ -28,6 +28,15 @@ open Microsoft.Extensions.Caching.Memory
 /// Shared Grace Server HTTP helpers used by endpoint-specific SDK modules.
 module Common =
 
+    /// Resolves Grace Server from the process environment before falling back to repository configuration.
+    let internal resolveGraceServerUri () =
+        let environmentUri = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
+
+        if String.IsNullOrWhiteSpace(environmentUri) then
+            string (Current().ServerUri)
+        else
+            environmentUri.Trim()
+
     /// <summary>
     /// Sends GET commands to Grace Server.
     /// </summary>
@@ -44,9 +53,7 @@ module Common =
                 do! Auth.addAuthorizationHeader httpClient
                 let startTime = getCurrentInstant ()
 
-                let graceServerUri = Environment.GetEnvironmentVariable(Constants.EnvironmentVariables.GraceServerUri)
-
-                let serverUri = Uri($"{graceServerUri}/{route}")
+                let serverUri = Uri($"{resolveGraceServerUri ()}/{route}")
 
                 let! response = Constants.DefaultAsyncRetryPolicy.ExecuteAsync(fun _ -> httpClient.GetAsync(new Uri($"{serverUri}")))
 
@@ -86,7 +93,7 @@ module Common =
                 //checkMemoryCache ()
                 use httpClient = ClientIdentity.getHttpClient parameters.CorrelationId
                 do! Auth.addAuthorizationHeader httpClient
-                let serverUriWithRoute = Uri($"{Current().ServerUri}/{route}")
+                let serverUriWithRoute = Uri($"{resolveGraceServerUri ()}/{route}")
                 let startTime = getCurrentInstant ()
                 let! response = httpClient.PostAsync(serverUriWithRoute, createJsonContent parameters)
 

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -107,3 +107,27 @@ type OperationalFactsPublisherAppHostTests() =
                     Does.Contain(".WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, operationalFactsProcessorSubscription)")
                 ))
         )
+
+    /// Verifies Aspire forwards explicit authorization bootstrap settings without embedding a fixed Azure identity.
+    [<Test>]
+    member _.AppHostForwardsExplicitAuthorizationBootstrapSettings() =
+        let appHostSource = appHostSource ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(
+                    appHostSource,
+                    Does.Contain(
+                        "AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, forwardedAuthKeys);"
+                    )
+                )
+
+                Assert.That(
+                    appHostSource,
+                    Does.Contain(
+                        "AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups, forwardedAuthKeys);"
+                    )
+                )
+
+                Assert.That(appHostSource, Does.Not.Contain("GraceAuthzBootstrapSystemAdminUsers, \"test-admin\"")))
+        )

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -1,16 +1,33 @@
 namespace Grace.Server.Tests
 
 open Grace.Shared
+open Microsoft.Extensions.Configuration
 open NUnit.Framework
 open System
 open System.IO
 
 /// Covers Aspire AppHost wiring for the operational usage facts Service Bus topic.
 [<TestFixture>]
+[<NonParallelizable>]
 type OperationalFactsPublisherAppHostTests() =
 
     /// Reads the AppHost source so focused wiring assertions stay on the Aspire-facing test surface.
     let appHostSource () = File.ReadAllText(Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "..", "Grace.Aspire.AppHost", "Program.Aspire.AppHost.cs")))
+
+    /// Runs an assertion while restoring every process-level environment value it changes.
+    let withEnvironmentVariables (values: (string * string) list) assertion =
+        let originals =
+            values
+            |> List.map (fun (name, _) -> name, Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Process))
+
+        try
+            values
+            |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Process))
+
+            assertion ()
+        finally
+            originals
+            |> List.iter (fun (name, value) -> Environment.SetEnvironmentVariable(name, value, EnvironmentVariableTarget.Process))
 
     /// Verifies DebugAzure gives an explicitly configured storage account precedence over ambient connection strings.
     [<Test>]
@@ -108,26 +125,53 @@ type OperationalFactsPublisherAppHostTests() =
                 ))
         )
 
-    /// Verifies Aspire forwards explicit authorization bootstrap settings without embedding a fixed Azure identity.
+    /// Verifies wrapper startup suppresses retained principals and retry forwards only the authenticated user.
     [<Test>]
-    member _.AppHostForwardsExplicitAuthorizationBootstrapSettings() =
-        let appHostSource = appHostSource ()
+    member _.DebugAzureWrapperOwnsAuthorizationBootstrapPrecedence() =
+        let usersName = Constants.EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers
+        let groupsName = Constants.EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups
 
-        Assert.Multiple(
-            Action (fun () ->
-                Assert.That(
-                    appHostSource,
-                    Does.Contain(
-                        "AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminUsers, forwardedAuthKeys);"
-                    )
+        withEnvironmentVariables
+            [
+                usersName, "configured-user"
+                groupsName, "configured-group"
+                Program.DebugAzureBootstrapModeEnvironmentVariable, null
+                Program.DebugAzureBootstrapUserIdEnvironmentVariable, null
+            ]
+            (fun () ->
+                let configuration = ConfigurationBuilder().Build()
+
+                Environment.SetEnvironmentVariable(
+                    Program.DebugAzureBootstrapModeEnvironmentVariable,
+                    Program.DebugAzureBootstrapModeSuppress
                 )
 
-                Assert.That(
-                    appHostSource,
-                    Does.Contain(
-                        "AddOptionalEnvironment(graceServer, configuration, EnvironmentVariables.GraceAuthzBootstrapSystemAdminGroups, forwardedAuthKeys);"
-                    )
+                let suppressed = Program.ResolveAuthorizationBootstrapSettings(configuration, true)
+                Assert.That(suppressed.Users, Is.Null)
+                Assert.That(suppressed.Groups, Is.Null)
+
+                Environment.SetEnvironmentVariable(
+                    Program.DebugAzureBootstrapModeEnvironmentVariable,
+                    Program.DebugAzureBootstrapModeExactUser
                 )
 
-                Assert.That(appHostSource, Does.Not.Contain("GraceAuthzBootstrapSystemAdminUsers, \"test-admin\"")))
-        )
+                Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapUserIdEnvironmentVariable, "authenticated-user")
+
+                let retry = Program.ResolveAuthorizationBootstrapSettings(configuration, true)
+                Assert.That(retry.Users, Is.EqualTo("authenticated-user"))
+                Assert.That(retry.Users.Split(';'), Has.Length.EqualTo(1))
+                Assert.That(retry.Groups, Is.Null)
+
+                Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapUserIdEnvironmentVariable, "first-user;second-user")
+
+                Assert.Throws<InvalidOperationException>(
+                    Action(fun () -> Program.ResolveAuthorizationBootstrapSettings(configuration, true) |> ignore)
+                )
+                |> ignore
+
+                Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapModeEnvironmentVariable, null)
+                Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapUserIdEnvironmentVariable, null)
+
+                let directStart = Program.ResolveAuthorizationBootstrapSettings(configuration, true)
+                Assert.That(directStart.Users, Is.EqualTo("configured-user"))
+                Assert.That(directStart.Groups, Is.EqualTo("configured-group")))

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -55,6 +55,19 @@ DOTNET_ENVIRONMENT=Development dotnet run
 The CLI host prints connection details for each emulator (Azurite, Redis,
 Cosmos, Service Bus) as they start.
 
+### DebugAzure
+
+Start the Azure-backed profile through its authorization-aware wrapper:
+
+```powershell
+pwsh ./scripts/start-debugazure.ps1
+```
+
+The wrapper checks the current Grace CLI identity and existing `SystemAdmin` access. For a new environment with no
+system assignments, it performs one bounded restart that offers the authenticated identity for bootstrap. An established
+environment is never reassigned by this flow; an existing SystemAdmin must grant access. Successful startup leaves
+Aspire running and reports its process ID and log paths.
+
 ## Verify Components
 
 Open `http://localhost:18888` and confirm the following resources show

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -34,6 +34,33 @@ The Aspire dashboard defaults to <http://localhost:18888> and OTLP export defaul
 - `grace__auth__oidc__authority`
 - `grace__auth__oidc__audience`
 - `grace__auth__oidc__cli_client_id` (publish mode)
+- `grace__authz__bootstrap__system_admin_users`
+- `grace__authz__bootstrap__system_admin_groups`
+
+## DebugAzure Authorization Startup
+
+Use `scripts/start-debugazure.ps1` to start the Azure-backed development profile. The script builds the CLI, starts
+Aspire, waits for `grace authenticate whoami`, and checks `SystemAdmin` on the system resource.
+
+PowerShell:
+
+```powershell
+pwsh ./scripts/start-debugazure.ps1
+```
+
+bash / zsh:
+
+```bash
+pwsh ./scripts/start-debugazure.ps1
+```
+
+If the current identity is already authorized, startup does not change authorization. If the check is denied, the
+script restarts Aspire once with that exact authenticated Grace user ID as a bootstrap candidate. Grace seeds the
+assignment only when the durable system assignment list is empty. If assignments already exist, the restart cannot
+grant access and the script stops with a message that an existing SystemAdmin must grant the role.
+
+The script never uses the DebugLocal `test-admin` fallback and does not print tokens or the bootstrap user ID. Successful
+startup leaves Aspire running and prints its process ID plus stdout and stderr log paths under `.grace/logs`.
 
 ## DebugLocal Onboarding Variables
 


### PR DESCRIPTION
# Bootstrap DebugAzure authorization safely

Closes #977.

## Why

An authenticated developer could start a fresh `DebugAzure` environment but still be unable to run protected Grace
CLI commands. Startup needed to distinguish an already-configured environment from a genuinely empty one without
granting access over existing authorization state.

## What changed

- Added `scripts/start-debugazure.ps1` to authenticate the current CLI identity, check system `SystemAdmin`, and perform
  at most one bootstrap restart.
- Forwarded explicit bootstrap user and group settings from Aspire to Grace Server without fixed Azure identities.
- Allowed the narrow system authorization preflight to run without repository-local `graceconfig.json`.
- Made shared SDK GET and POST routing prefer `GRACE_SERVER_URI` before repository configuration.
- Documented the `DebugAzure` startup behavior and diagnostics.

## Proof

- `Grace.CLI.Tests` `CommandParsingTests`: 215 passed.
- `Grace.Server.Tests` `OperationalFactsPublisherAppHostTests`: 5 passed.
- PowerShell parser passed for `scripts/start-debugazure.ps1`.
- MarkdownLint passed for both changed documentation files.
- Live fresh-environment sequence: denied, one bootstrap restart, then `SystemAdmin` allowed.
- Live stable-environment restart: existing `SystemAdmin` allowed on the first check with no bootstrap value.
- Live system check passed from an empty directory with only `GRACE_SERVER_URI` configured.

## Scope

- No new server route or durable authorization model.
- No DebugLocal fallback identity is used for Azure.
- Redis connectivity changes are tracked separately in #976.
