### PR TITLE
Enable Entra authentication for Grace operations SQL

### DIFF
--- a/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageReference Update="FSharp.Core" Version="10.1.302" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Enable Entra authentication for Grace operations SQL

Closes #979.

## Why

The infrastructure-lab Bicep emits an operations SQL connection string using `Active Directory Default`, but the data
project packaged only the SQL client abstraction. The worker therefore retried a local missing-provider exception and
never reached Azure SQL authentication.

## Change

- Add `Microsoft.Data.SqlClient.Extensions.Azure` 7.0.2 to `Grace.Operations.Data`, aligned with
  `Microsoft.Data.SqlClient` 7.0.2.
- No runtime logic, SQL schema, Bicep, public contract, or infrastructure change.

## Run facts

- Delivery mode: mainline slice.
- Exact base: `8cb57542fe6ee05ac04e5c0b01497853911693e9`.
- Candidate head: `89c4c453ee5d185e745f0f4f2d931bd7abb0928f`.
- Baseline admissibility: ADMISSIBLE.
- Quality contract: Product V1 limited to existing `DebugAzure` and production-style Entra SQL configuration.
- Algorithm proof: N/A; deterministic dependency packaging only.
- Issue and delivery delta: one package reference in one owned project file.

## Proof

- RED: the pre-change dependency graph included `Microsoft.Data.SqlClient.Extensions.Abstractions` 7.0.2 but not
  `Microsoft.Data.SqlClient.Extensions.Azure`; the live worker repeated the exact missing-provider exception.
- `dotnet build src/Grace.Operations.Worker/Grace.Operations.Worker.fsproj --configuration Release`
  - Passed with zero warnings and zero errors.
- Final dependency graph resolves `Microsoft.Data.SqlClient.Extensions.Azure` 7.0.2.
- Final worker output contains `Microsoft.Data.SqlClient.Extensions.Azure.dll`.
- Live `DebugAzure` replacement from this branch:
  - Grace startup completed and recognized that SystemAdmin authorization was already configured.
  - Operations worker remained running.
  - Missing-provider error count: 0.
  - The worker reached actual token acquisition and reported a distinct local developer-credential failure, proving the
    repaired provider was loaded and invoked.
- `git diff --check` passed.

## Review and CI

- R1 discovery review: pending.
- GitHub `Validate`: pending on this pull-request revision.

## Residual risk and follow-up

The local worker still cannot acquire an Azure SQL token through `ActiveDirectoryDefault`; it falls through to managed
identity, which is unavailable on the workstation. That is a separate environment/authentication issue and is not
hidden by this repair. Redis and the user-owned `grace-cache` state remain out of scope.

Documentation impact: none. The advertised configuration and behavior do not change; this repair packages its required
runtime implementation.
