### PR TITLE
Update solution NuGet packages and restore Azure SQL auth

### DIFF
--- a/src/Grace.Actors/Grace.Actors.fsproj
+++ b/src/Grace.Actors/Grace.Actors.fsproj
@@ -80,9 +80,9 @@
         <PackageReference Include="Azure.Storage.Common" Version="12.28.0" />
         <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
         <PackageReference Include="FSharpPlus" Version="1.9.1" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.11" />
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.12" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
         <PackageReference Include="Microsoft.Orleans.Core" Version="10.2.2" />
         <PackageReference Include="Microsoft.Orleans.Runtime" Version="10.2.2" />
         <PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="10.2.2" />
@@ -105,7 +105,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="10.1.302" />
+        <PackageReference Update="FSharp.Core" Version="10.1.400" />
     </ItemGroup>
 
 </Project>

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.5.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
+++ b/src/Grace.Aspire.AppHost/Grace.Aspire.AppHost.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);ASPIRE010</NoWarn>
     <UserSecretsId>f1167a88-7f15-49c3-8ea1-30c2608081c9</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
+++ b/src/Grace.Authorization.Tests/Grace.Authorization.Tests.fsproj
@@ -27,7 +27,7 @@
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="FsCheck" Version="3.3.4" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj
+++ b/src/Grace.CLI.LocalStateDb.Worker/Grace.CLI.LocalStateDb.Worker.fsproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
+++ b/src/Grace.CLI.Tests/Grace.CLI.Tests.fsproj
@@ -56,7 +56,7 @@
 		<PackageReference Include="FsCheck" Version="3.3.4" />
 		<PackageReference Include="FsCheck.NUnit" Version="3.3.4" />
 		<PackageReference Include="FsUnit" Version="7.1.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="NUnit" Version="4.6.1" />
 		<PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
 		<PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -77,6 +77,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.1.302" />
+		<PackageReference Update="FSharp.Core" Version="10.1.400" />
 	</ItemGroup>
 </Project>

--- a/src/Grace.CLI/Grace.CLI.fsproj
+++ b/src/Grace.CLI/Grace.CLI.fsproj
@@ -61,16 +61,16 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.11" />
 		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
 		<PackageReference Include="MessagePack" Version="3.1.8" />
 		<PackageReference Include="MessagePack.Annotations" Version="3.1.8" />
 		<PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
-		<PackageReference Include="MessagePack.NodaTime" Version="3.5.6" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+		<PackageReference Include="MessagePack.NodaTime" Version="3.5.7" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
 		<PackageReference Include="Microsoft.Identity.Client" Version="4.87.0" />
 		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.87.0" />
 		<PackageReference Include="NodaTime" Version="3.3.3" />
@@ -84,7 +84,7 @@
 		<PackageReference Include="Spectre.Console" Version="0.57.2" />
 		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.57.2" />
 		<PackageReference Include="Spectre.Console.Json" Version="0.57.2" />
-		<PackageReference Include="System.CommandLine" Version="2.0.10" />
+		<PackageReference Include="System.CommandLine" Version="2.0.11" />
 		<PackageReference Include="System.Reactive" Version="7.0.0" />
 	</ItemGroup>
 	<ItemGroup>
@@ -93,7 +93,7 @@
 		<ProjectReference Include="..\Grace.Types\Grace.Types.fsproj" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Grace.CLI.Tests" />

--- a/src/Grace.Cache.Storage.Tests/Grace.Cache.Storage.Tests.fsproj
+++ b/src/Grace.Cache.Storage.Tests/Grace.Cache.Storage.Tests.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -26,8 +26,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.11" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,6 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Cache.Storage/Grace.Cache.Storage.fsproj
+++ b/src/Grace.Cache.Storage/Grace.Cache.Storage.fsproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.11" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Cache.Tests/Grace.Cache.Tests.csproj
+++ b/src/Grace.Cache.Tests/Grace.Cache.Tests.csproj
@@ -8,8 +8,8 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">

--- a/src/Grace.Cache/Grace.Cache.fsproj
+++ b/src/Grace.Cache/Grace.Cache.fsproj
@@ -10,7 +10,7 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
     <ProjectReference Include="..\Grace.Cache.Storage\Grace.Cache.Storage.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Load/Grace.Load.fsproj
+++ b/src/Grace.Load/Grace.Load.fsproj
@@ -28,7 +28,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.1.302" />
+		<PackageReference Update="FSharp.Core" Version="10.1.400" />
 	</ItemGroup>
 
 </Project>

--- a/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
+++ b/src/Grace.Operations.Data/Grace.Operations.Data.fsproj
@@ -23,6 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
+++ b/src/Grace.Operations.Tests/Grace.Operations.Tests.fsproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="FsUnit" Version="7.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -44,6 +44,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
+++ b/src/Grace.Operations.Worker/Grace.Operations.Worker.fsproj
@@ -25,10 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.61.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Operations/Grace.Operations.fsproj
+++ b/src/Grace.Operations/Grace.Operations.fsproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.SDK/Grace.SDK.fsproj
+++ b/src/Grace.SDK/Grace.SDK.fsproj
@@ -62,7 +62,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.1.302" />
+		<PackageReference Update="FSharp.Core" Version="10.1.400" />
 	</ItemGroup>
 
 </Project>

--- a/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
+++ b/src/Grace.Server.Tests/Grace.Server.Tests.fsproj
@@ -62,15 +62,15 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.5.0" />
     <PackageReference Include="FSharp.Control.TaskSeq" Version="1.1.1" />
     <PackageReference Include="FsCheck" Version="3.3.4" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.4" />
     <PackageReference Include="FsUnit" Version="7.1.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -92,7 +92,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
+++ b/src/Grace.Server.Unit.Tests/Grace.Server.Unit.Tests.fsproj
@@ -88,7 +88,7 @@
     <PackageReference Include="FsCheck" Version="3.3.4" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.4" />
     <PackageReference Include="FsUnit" Version="7.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -107,7 +107,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 
 </Project>

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -134,8 +134,8 @@
 		<ProjectReference Include="..\Grace.Shared\Grace.Shared.fsproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Asp.Versioning.Mvc" Version="10.0.1" />
-		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
+		<PackageReference Include="Asp.Versioning.Mvc" Version="10.2.1" />
+		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.2.1" />
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.3" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
@@ -146,12 +146,12 @@
 		<PackageReference Include="Giraffe" Version="8.3.0" />
 		<PackageReference Include="MessagePack" Version="3.1.8" />
 		<PackageReference Include="MessagePack.Annotations" Version="3.1.8" />
-		<PackageReference Include="MessagePack.NodaTime" Version="3.5.6" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
-		<PackageReference Include="Microsoft.OpenApi" Version="3.9.0" />
+		<PackageReference Include="MessagePack.NodaTime" Version="3.5.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
+		<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.11" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.1" />
+		<PackageReference Include="Microsoft.OpenApi" Version="3.10.0" />
 		<PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.2" />
 		<PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.2" />
 		<PackageReference Include="Microsoft.Orleans.Persistence.Cosmos" Version="10.2.2" />
@@ -174,10 +174,10 @@
 		<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
-		<PackageReference Include="StackExchange.Redis" Version="3.1.0" />
+		<PackageReference Include="StackExchange.Redis" Version="3.1.13" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="FSharp.Core" Version="10.1.302" />
+		<PackageReference Update="FSharp.Core" Version="10.1.400" />
 	</ItemGroup>
 	<ItemGroup>
 		<InternalsVisibleTo Include="Grace.Server.Tests" />

--- a/src/Grace.Shared/Grace.Shared.fsproj
+++ b/src/Grace.Shared/Grace.Shared.fsproj
@@ -90,9 +90,9 @@
         <PackageReference Include="MessagePack" Version="3.1.8" />
         <PackageReference Include="MessagePack.Annotations" Version="3.1.8" />
         <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
-        <PackageReference Include="MessagePack.NodaTime" Version="3.5.6" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.10" />
+        <PackageReference Include="MessagePack.NodaTime" Version="3.5.7" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
         <PackageReference Include="Microsoft.Orleans.Core" Version="10.2.2" />
         <PackageReference Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
         <PackageReference Include="Microsoft.Orleans.Serialization.FSharp" Version="10.2.2" />
@@ -111,7 +111,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="10.1.302" />
+        <PackageReference Update="FSharp.Core" Version="10.1.400" />
     </ItemGroup>
 
 </Project>

--- a/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
+++ b/src/Grace.Types.Tests/Grace.Types.Tests.fsproj
@@ -41,8 +41,8 @@
     <PackageReference Include="FsUnit" Version="7.1.1" />
     <PackageReference Include="FsCheck" Version="3.3.4" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
@@ -61,6 +61,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.1.302" />
+    <PackageReference Update="FSharp.Core" Version="10.1.400" />
   </ItemGroup>
 </Project>

--- a/src/Grace.Types/Grace.Types.fsproj
+++ b/src/Grace.Types/Grace.Types.fsproj
@@ -62,10 +62,10 @@
         <PackageReference Include="MessagePack" Version="3.1.8" />
         <PackageReference Include="MessagePack.Annotations" Version="3.1.8" />
         <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
-        <PackageReference Include="MessagePack.NodaTime" Version="3.5.6" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.10" />
+        <PackageReference Include="MessagePack.NodaTime" Version="3.5.7" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
         <PackageReference Include="MimeTypeMapOfficial" Version="1.0.17" />
         <PackageReference Include="MimeTypes" Version="2.5.2" />
         <PackageReference Include="Nanoid" Version="3.1.0" />
@@ -77,7 +77,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="10.1.302" />
+        <PackageReference Update="FSharp.Core" Version="10.1.400" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Outcome

Updates every applicable stable direct NuGet dependency across the 23 projects in `src/Grace.slnx` and restores the existing `DebugAzure` Azure SQL authentication path without adding a Grace-specific credential workaround.

Closes #981

## Run contract

- Delivery: mainline slice to `main`
- Exact base: `1feadce3cedf75f8dbc43002db077e7e0a5f1fbf`
- Baseline Admissibility: ADMISSIBLE; restore and Release solution build passed with 0 warnings/errors
- Quality: Product V1, current solution and existing `DebugAzure` topology
- Primary invariant: one internally compatible solution package graph while preserving `Active Directory Default` and production managed-identity behavior
- Algorithm readiness: N/A
- Non-goals preserved: no credential selector, token callback, infrastructure/resource, SQL schema, topology, public contract, out-of-solution project, or unrelated refactor change

## Changes

- Updated applicable direct dependencies in 22 solution-member project files; `Grace.Orleans.CodeGen` had no available update.
- Aligned the AppHost SDK and all restored Aspire AppHost/hosting/orchestration assets at 13.5.0.
- Suppressed only Aspire 13.5 diagnostic ASPIRE010 to retain the existing package-based DebugAzure topology instead of opting into the different CLI-bundle toolchain.
- Kept repeated families aligned, including Aspire 13.5.0, FSharp.Core 10.1.400, Microsoft.NET.Test.Sdk 18.9.0, Microsoft/ASP.NET Core 10.0.11, SQLite 10.0.11/3.0.5, and MessagePack.NodaTime 3.5.7.
- Preserved `OpenTelemetry.Exporter.Prometheus.AspNetCore 1.15.3-beta.1`; configured sources report no replacement.
- Added the issue-approved narrow direct `Azure.Core 1.61.0` reference to `Grace.Operations.Worker` because ordinary direct updates still resolved 1.60.0.

Final worker graph: Azure.Core 1.61.0, Azure.Identity 1.21.0, Azure.Messaging.ServiceBus 7.20.2, and aligned SqlClient/Extensions.Azure 7.0.2.

## Proof

- Forced/no-cache restore: passed all 23 projects without package warnings.
- `pwsh ./scripts/validate.ps1 -Full`: passed in 4m34s; build 0 warnings/errors; Operations 26/26, Types 175/175, Cache.Storage 26/26, Cache 7/7, Authorization 54/54, Server.Unit 1050/1050, CLI 1416 passed with 1 intentional skip, Server.Tests 275/275.
- Fresh `DebugAzure`: operations worker logged normal `grace-usage` / `grace-usage-collector` startup followed by `Application started`; stderr was empty. No provider, credential-chain, type-load, or method-load failure occurred.
- Final outdated inventory: only the intentional Prometheus beta `Not found at the sources` row.
- `git diff --check`: passed.

An initial Full run exposed an ambient `GRACE_SERVER_URI=http://localhost:5000` test-environment override and a downstream Aspire timeout cascade. The CLI failure reproduced on exact base and candidate and passed when the variable was cleared process-locally; the first Aspire restart test passed in isolation. No compatibility adaptation was warranted.

## Review and CI

- Final head: `b09c0c85688875113fd444d42a1684efd6e44aee`
- R1: `REPAIR`, one accepted P2 Aspire SDK-alignment item
- R2: `VERIFIED`; frozen ledger item closed with no direct repair regression
- GitHub `Validate / full`: passed on the final head

## Docs and residual risk

No documentation change is required because commands, runtime configuration, and authentication semantics are unchanged. The only accepted residual risk is the intentional Prometheus exporter beta exception because the configured sources report no replacement.