### PR TITLE
Secure the infrastructure lab Redis connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ ASPIRE_RESOURCE_MODE=Local
 # Redis
 # grace__redis__host=127.0.0.1
 # grace__redis__port=6379
+# grace__redis__tls=false
+# grace__redis__username=
+# grace__redis__password=
+# grace__redis__ca_certificate=
 
 # Orleans
 # orleans_cluster_id=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,15 @@ Orleans:
 - `grace__redis__port`
   - Redis port.
 
+- `grace__redis__tls`
+  - Enables certificate-validated Redis TLS.
+
+- `grace__redis__username` and `grace__redis__password`
+  - Redis ACL credential required when TLS is enabled.
+
+- `grace__redis__ca_certificate`
+  - Base64-encoded PEM custom root required when TLS is enabled.
+
 Redis:
 
 - <https://redis.io/docs/latest/>

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,7 +7,7 @@ Both entry points share focused resource modules, but they make different capaci
 
 | Profile | Cosmos DB | Azure SQL Database | Azure Managed Redis | Intended use |
 | --- | --- | --- | --- | --- |
-| `main.lab.bicep` | Serverless | General Purpose serverless | Private ACI Redis container | Short-lived infrastructure practice |
+| `main.lab.bicep` | Serverless | General Purpose serverless | TLS-only ACI Redis container | Short-lived infrastructure practice |
 | `main.production.bicep` | Provisioned throughput | Provisioned compute | Caller-selected SKU, two-node high availability | Development or production design input |
 
 The production-shaped profile deliberately has no parameter file. It requires explicit Cosmos throughput, SQL SKU and
@@ -23,13 +23,14 @@ The lab profile creates these top-level billable resources in one disposable res
 - Cosmos DB for NoSQL serverless account, database, and `/PartitionKey` container
 - Service Bus Standard namespace with partitioned Grace event and operational-usage topics and subscriptions
 - Azure SQL Database General Purpose serverless database with Microsoft Entra-only administration
-- Private Azure Container Instances group running `redis:7.4-alpine`
+- Public TLS-only Azure Container Instances group running `redis:7.4-alpine`
 
 The template grants the signed-in developer the Storage blob/table, Cosmos DB data contributor, and Service Bus data
 owner roles needed by Grace's `DefaultAzureCredential` development path. It does not emit resource keys or passwords.
-The Redis container has no public IP address. `DebugAzure` continues to use its local Redis container while exercising
-the lab's real Azure Storage, Cosmos DB, Service Bus, and SQL resources. The production-shaped profile retains Azure
-Managed Redis because ACI is only a fast disposable lab substitute.
+The Redis container exposes only port 6380 on a certificate-valid public DNS name. Each runner invocation generates a
+short-lived CA, server certificate, ACL username, and password, deploys them through secure Bicep parameters, starts
+`DebugAzure`, and completes an authenticated TLS `PING` before clearing parent-process secrets and reporting readiness.
+The production-shaped profile retains Azure Managed Redis because ACI is only a fast disposable lab substitute.
 
 ## Cost boundary
 
@@ -61,6 +62,9 @@ pwsh ./scripts/Invoke-GraceInfrastructureLab.ps1 `
 
 Review the complete `what-if` result before deployment. It must contain only the resource types listed above plus their
 child resources, deployments, and role assignments.
+
+`Deploy` also starts `DebugAzure` and leaves it running after the authenticated Redis readiness proof. Generated Redis
+credentials and private keys are never written to the repository or printed by the runner.
 
 PowerShell:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -64,7 +64,9 @@ Review the complete `what-if` result before deployment. It must contain only the
 child resources, deployments, and role assignments.
 
 `Deploy` also starts `DebugAzure` and leaves it running after the authenticated Redis readiness proof. Generated Redis
-credentials and private keys are never written to the repository or printed by the runner.
+credentials and private keys are never written to the repository or printed by the runner. Stop any existing
+`DebugAzure` process first: deployment fails before rotating credentials when `http://localhost:5000` already has a
+listener, so an older child cannot satisfy readiness for the new run.
 
 PowerShell:
 

--- a/infra/main.lab.bicep
+++ b/infra/main.lab.bicep
@@ -17,6 +17,22 @@ param developerPrincipalName string
 @description('Public IPv4 address allowed to connect to Azure SQL during the lab run.')
 param clientIpAddress string = ''
 
+@secure()
+@description('Base64-encoded PEM certificate for the per-run lab CA.')
+param redisCaCertificate string
+
+@secure()
+@description('Base64-encoded PEM certificate for the Redis TLS server.')
+param redisServerCertificate string
+
+@secure()
+@description('Base64-encoded PEM private key for the Redis TLS server.')
+param redisServerPrivateKey string
+
+@secure()
+@description('Base64-encoded Redis ACL file containing the generated per-run credential.')
+param redisAclFile string
+
 @description('Common tags added to disposable lab resources.')
 param tags object = {
   environment: 'infrastructure-lab'
@@ -84,8 +100,13 @@ module sql 'modules/sql.bicep' = {
 module redisContainer 'modules/redis-container.bicep' = {
   name: 'redis-container'
   params: {
+    aclFile: redisAclFile
+    caCertificate: redisCaCertificate
+    dnsNameLabel: redisContainerGroupName
     location: location
     name: redisContainerGroupName
+    serverCertificate: redisServerCertificate
+    serverPrivateKey: redisServerPrivateKey
     tags: tags
   }
 }
@@ -103,3 +124,5 @@ output serviceBusGraceUsageSubscription string = serviceBus.outputs.graceUsageSu
 output sqlConnectionString string = sql.outputs.entraConnectionString
 output redisContainerGroupName string = redisContainer.outputs.containerGroupName
 output redisContainerImage string = redisContainer.outputs.image
+output redisEndpoint string = redisContainer.outputs.fqdn
+output redisTlsPort int = redisContainer.outputs.tlsPort

--- a/infra/modules/redis-container.bicep
+++ b/infra/modules/redis-container.bicep
@@ -7,6 +7,25 @@ param location string
 @description('Tags applied to the Redis container group.')
 param tags object
 
+@description('Globally unique DNS label whose FQDN is present in the generated server certificate.')
+param dnsNameLabel string
+
+@secure()
+@description('Base64-encoded PEM certificate for the per-run lab CA.')
+param caCertificate string
+
+@secure()
+@description('Base64-encoded PEM certificate for the Redis TLS server.')
+param serverCertificate string
+
+@secure()
+@description('Base64-encoded PEM private key for the Redis TLS server.')
+param serverPrivateKey string
+
+@secure()
+@description('Base64-encoded Redis ACL file containing the generated per-run credential.')
+param aclFile string
+
 @description('Public Redis image used only by the disposable infrastructure lab.')
 param image string = 'redis:7.4-alpine'
 
@@ -21,6 +40,20 @@ resource redisContainerGroup 'Microsoft.ContainerInstance/containerGroups@2023-0
         properties: {
           command: [
             'redis-server'
+            '--port'
+            '0'
+            '--tls-port'
+            '6380'
+            '--tls-cert-file'
+            '/redis-secrets/server.crt'
+            '--tls-key-file'
+            '/redis-secrets/server.key'
+            '--tls-ca-cert-file'
+            '/redis-secrets/ca.crt'
+            '--tls-auth-clients'
+            'no'
+            '--aclfile'
+            '/redis-secrets/users.acl'
             '--save'
             ''
             '--appendonly'
@@ -29,19 +62,55 @@ resource redisContainerGroup 'Microsoft.ContainerInstance/containerGroups@2023-0
             'yes'
           ]
           image: image
+          ports: [
+            {
+              port: 6380
+              protocol: 'TCP'
+            }
+          ]
           resources: {
             requests: {
               cpu: json('0.5')
               memoryInGB: json('0.5')
             }
           }
+          volumeMounts: [
+            {
+              mountPath: '/redis-secrets'
+              name: 'redis-secrets'
+              readOnly: true
+            }
+          ]
         }
       }
     ]
+    ipAddress: {
+      dnsNameLabel: dnsNameLabel
+      ports: [
+        {
+          port: 6380
+          protocol: 'TCP'
+        }
+      ]
+      type: 'Public'
+    }
     osType: 'Linux'
     restartPolicy: 'Always'
+    volumes: [
+      {
+        name: 'redis-secrets'
+        secret: {
+          'ca.crt': caCertificate
+          'server.crt': serverCertificate
+          'server.key': serverPrivateKey
+          'users.acl': aclFile
+        }
+      }
+    ]
   }
 }
 
 output containerGroupName string = redisContainerGroup.name
+output fqdn string = redisContainerGroup.properties.ipAddress.fqdn
 output image string = image
+output tlsPort int = 6380

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -104,6 +104,10 @@ Assert-PatternAbsent $labRunner "ResourceGroupName\s*=\s*'rg-grace-infra-lab-\d{
 Assert-Pattern $labRunner "readEnvironmentVariable\('GRACE_LAB_REDIS_SERVER_PRIVATE_KEY'\)" 'The runner must resolve the Redis private key through inherited environment.'
 Assert-Pattern $labRunner 'Test-RedisTlsReadiness\s+-Material' 'The runner must complete authenticated TLS PING before readiness.'
 Assert-Pattern $labRunner 'Test-RedisTlsReadiness[\s\S]*Clear-LabRedisSecrets[\s\S]*readiness passed' 'The runner must clear parent Redis secrets before reporting readiness.'
+Assert-Pattern $labRunner '''grace__azure_storage__account_name''\s*=\s*\$outputs\.storageAccountName\.value' 'The runner must override the exact Storage setting consumed by DebugAzure.'
+Assert-Pattern $labRunner '''grace__azurecosmosdb__endpoint''\s*=\s*\$outputs\.cosmosEndpoint\.value' 'The runner must override the exact Cosmos endpoint setting consumed by DebugAzure.'
+Assert-Pattern $labRunner "'deployment', 'group', 'create'[\s\S]*Clear-LabRedisDeploymentSecrets[\s\S]*Deployment completed; launching DebugAzure" 'The runner must clear deployment-only Redis material after deployment and before launching DebugAzure.'
+Assert-Pattern $labRunner "'deployment', 'group', 'create'[\s\S]*Clear-LabRedisDeploymentSecrets[\s\S]*& pwsh -NoProfile -File" 'The DebugAzure child must be launched only after deployment-only Redis secrets are cleared.'
 Assert-PatternAbsent $labRunner 'redis(ServerPrivateKey|AclFile|Password)=\$' 'The runner must not place secure Redis values in Azure CLI arguments.'
 Assert-PatternAbsent $labRunner 'Write-(Host|LabStatus)[^\r\n]*(Password|ServerKeyBase64|AclBase64|CaBase64)' 'The runner must not write generated Redis material to status output.'
 

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -76,7 +76,16 @@ Assert-PatternAbsent $productionTemplate "skuName:\s*'GP_S_" 'The production-sha
 
 Assert-Pattern $redisContainerModule 'Microsoft\.ContainerInstance/containerGroups' 'The lab Redis module must deploy Azure Container Instances.'
 Assert-Pattern $redisContainerModule "image string = 'redis:7\.4-alpine'" 'The lab Redis module must pin its disposable Redis image tag.'
-Assert-PatternAbsent $redisContainerModule 'ipAddress\s*:' 'The lab Redis container must not expose a public IP address.'
+Assert-Pattern $redisContainerModule "--port'[\s\S]*'0'" 'The lab Redis container must disable its plaintext listener.'
+Assert-Pattern $redisContainerModule "--tls-port'[\s\S]*'6380'" 'The lab Redis container must listen on the accepted TLS port.'
+Assert-Pattern $redisContainerModule "--aclfile'" 'The lab Redis container must load its generated ACL from a mounted secret.'
+Assert-Pattern $redisContainerModule "type:\s*'Public'" 'The lab Redis container must expose its certificate hostname publicly.'
+Assert-Pattern $redisContainerModule 'ports:\s*\[[\s\S]*port:\s*6380' 'The lab Redis container must expose TLS port 6380.'
+Assert-PatternAbsent $redisContainerModule 'port:\s*6379' 'The lab Redis container must not expose plaintext port 6379.'
+Assert-Pattern $redisContainerModule '@secure\(\)[\s\S]*param caCertificate' 'The lab Redis CA input must be a secure Bicep parameter.'
+Assert-Pattern $redisContainerModule '@secure\(\)[\s\S]*param serverPrivateKey' 'The lab Redis private key input must be a secure Bicep parameter.'
+Assert-Pattern $redisContainerModule '@secure\(\)[\s\S]*param aclFile' 'The lab Redis ACL input must be a secure Bicep parameter.'
+Assert-PatternAbsent $redisContainerModule 'output\s+\w*(password|privateKey|acl|certificate)' 'The lab Redis module must not output generated secure material.'
 
 Assert-Pattern $serviceBusModule 'graceUsageTopicName' 'The Service Bus module must use GraceUsage vocabulary for its usage topic.'
 Assert-Pattern $serviceBusModule 'graceUsageSubscriptionName' 'The Service Bus module must use GraceUsage vocabulary for its usage subscription.'
@@ -92,6 +101,11 @@ Assert-PatternAbsent $serviceBusModule 'enablePartitioning:\s*false' 'The Servic
 Assert-Pattern $labRunner "DeploymentSuffix\s*=\s*\(Get-Date\s+-Format\s+'yyyyMMdd'\)" 'The lab runner must derive its default deployment suffix at runtime.'
 Assert-PatternAbsent $labRunner "DeploymentSuffix\s*=\s*'\d{8}'" 'The lab runner must not embed a dated deployment suffix.'
 Assert-PatternAbsent $labRunner "ResourceGroupName\s*=\s*'rg-grace-infra-lab-\d{8}'" 'The lab runner must not embed a dated resource group name.'
+Assert-Pattern $labRunner "readEnvironmentVariable\('GRACE_LAB_REDIS_SERVER_PRIVATE_KEY'\)" 'The runner must resolve the Redis private key through inherited environment.'
+Assert-Pattern $labRunner 'Test-RedisTlsReadiness\s+-Material' 'The runner must complete authenticated TLS PING before readiness.'
+Assert-Pattern $labRunner 'Test-RedisTlsReadiness[\s\S]*Clear-LabRedisSecrets[\s\S]*readiness passed' 'The runner must clear parent Redis secrets before reporting readiness.'
+Assert-PatternAbsent $labRunner 'redis(ServerPrivateKey|AclFile|Password)=\$' 'The runner must not place secure Redis values in Azure CLI arguments.'
+Assert-PatternAbsent $labRunner 'Write-(Host|LabStatus)[^\r\n]*(Password|ServerKeyBase64|AclBase64|CaBase64)' 'The runner must not write generated Redis material to status output.'
 
 $expectedInventory = @(
     [pscustomobject]@{ name = 'expected-redis'; type = 'Microsoft.ContainerInstance/containerGroups' }

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -10,6 +10,7 @@ $productionTemplatePath = Join-Path $infraRoot 'main.production.bicep'
 $serviceBusModulePath = Join-Path $infraRoot 'modules\service-bus.bicep'
 $redisContainerModulePath = Join-Path $infraRoot 'modules\redis-container.bicep'
 $labRunnerPath = Join-Path (Split-Path -Parent $infraRoot) 'scripts\Invoke-GraceInfrastructureLab.ps1'
+$startDebugAzurePath = Join-Path (Split-Path -Parent $infraRoot) 'scripts\start-debugazure.ps1'
 $inventoryAssertionsPath = Join-Path (Split-Path -Parent $infraRoot) 'scripts\GraceInfrastructureLab.Inventory.ps1'
 . $inventoryAssertionsPath
 
@@ -108,6 +109,7 @@ Assert-Pattern $labRunner '''grace__azure_storage__account_name''\s*=\s*\$output
 Assert-Pattern $labRunner '''grace__azurecosmosdb__endpoint''\s*=\s*\$outputs\.cosmosEndpoint\.value' 'The runner must override the exact Cosmos endpoint setting consumed by DebugAzure.'
 Assert-Pattern $labRunner "'deployment', 'group', 'create'[\s\S]*Clear-LabRedisDeploymentSecrets[\s\S]*Deployment completed; launching DebugAzure" 'The runner must clear deployment-only Redis material after deployment and before launching DebugAzure.'
 Assert-Pattern $labRunner "'deployment', 'group', 'create'[\s\S]*Clear-LabRedisDeploymentSecrets[\s\S]*& pwsh -NoProfile -File" 'The DebugAzure child must be launched only after deployment-only Redis secrets are cleared.'
+Assert-Pattern $labRunner "-PreflightOnly[\s\S]*Invoke-BicepBuilds[\s\S]*'deployment', 'group', 'create'" 'Deploy must reject a pre-existing Grace Server listener before rotating Azure credentials.'
 Assert-PatternAbsent $labRunner 'redis(ServerPrivateKey|AclFile|Password)=\$' 'The runner must not place secure Redis values in Azure CLI arguments.'
 Assert-PatternAbsent $labRunner 'Write-(Host|LabStatus)[^\r\n]*(Password|ServerKeyBase64|AclBase64|CaBase64)' 'The runner must not write generated Redis material to status output.'
 
@@ -146,6 +148,29 @@ catch {
     if ($_.Exception.Message -notmatch 'unexpected top-level: stale-storage') {
         throw
     }
+}
+
+$occupiedListener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+$occupiedListener.Start()
+$occupiedPort = ([Net.IPEndPoint] $occupiedListener.LocalEndpoint).Port
+$occupiedUri = "http://127.0.0.1:$occupiedPort"
+try {
+    $occupiedOutput = @(& pwsh -NoProfile -File $startDebugAzurePath -GraceServerUri $occupiedUri -PreflightOnly 2>&1)
+    if ($LASTEXITCODE -eq 0) {
+        throw 'DebugAzure preflight accepted an occupied Grace Server URI.'
+    }
+
+    if (($occupiedOutput -join [Environment]::NewLine) -notmatch 'already has a listener') {
+        throw 'DebugAzure preflight did not explain that the configured URI was already occupied.'
+    }
+}
+finally {
+    $occupiedListener.Stop()
+}
+
+$availableOutput = @(& pwsh -NoProfile -File $startDebugAzurePath -GraceServerUri $occupiedUri -PreflightOnly 2>&1)
+if ($LASTEXITCODE -ne 0 -or ($availableOutput -join [Environment]::NewLine) -notmatch 'is available for a new DebugAzure child') {
+    throw 'DebugAzure preflight rejected an available Grace Server URI.'
 }
 
 Write-Host 'Infrastructure profile assertions passed.' -ForegroundColor Green

--- a/scripts/Invoke-GraceInfrastructureLab.ps1
+++ b/scripts/Invoke-GraceInfrastructureLab.ps1
@@ -42,6 +42,7 @@ $sqlServerName = "grace-sql-lab-$normalizedSuffix"
 $redisContainerGroupName = "grace-redis-lab-$normalizedSuffix"
 $redisDnsName = "$redisContainerGroupName.$($Location.ToLowerInvariant()).azurecontainer.io"
 $redisTlsPort = 6380
+$graceServerUri = 'http://localhost:5000'
 $redisParameterEnvironmentVariables = @(
     'GRACE_LAB_REDIS_CA_CERTIFICATE',
     'GRACE_LAB_REDIS_SERVER_CERTIFICATE',
@@ -593,6 +594,14 @@ switch ($Action) {
     }
     'Deploy' {
         Write-LabStatus 'Preparing to deploy the disposable infrastructure lab.'
+        Write-LabStatus "Rejecting any pre-existing Grace Server listener at '$graceServerUri'."
+        & pwsh -NoProfile -File (Join-Path $PSScriptRoot 'start-debugazure.ps1') `
+            -GraceServerUri $graceServerUri `
+            -PreflightOnly
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Stop the existing DebugAzure process before deploying new Redis credentials.'
+        }
+
         Invoke-BicepBuilds
         Register-LabResourceProviders
         New-LabResourceGroup
@@ -642,7 +651,7 @@ switch ($Action) {
                 [Environment]::SetEnvironmentVariable($setting.Key, [string] $setting.Value, 'Process')
             }
 
-            & pwsh -NoProfile -File (Join-Path $PSScriptRoot 'start-debugazure.ps1')
+            & pwsh -NoProfile -File (Join-Path $PSScriptRoot 'start-debugazure.ps1') -GraceServerUri $graceServerUri
             if ($LASTEXITCODE -ne 0) {
                 throw 'DebugAzure failed before Redis readiness could be proven.'
             }

--- a/scripts/Invoke-GraceInfrastructureLab.ps1
+++ b/scripts/Invoke-GraceInfrastructureLab.ps1
@@ -210,6 +210,16 @@ function Clear-LabRedisSecrets {
     }
 }
 
+function Clear-LabRedisDeploymentSecrets {
+    <#
+    .SYNOPSIS
+    Removes deployment-only certificate, private-key, and ACL inputs before any DebugAzure child process is launched.
+    #>
+    foreach ($name in $redisParameterEnvironmentVariables) {
+        [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+    }
+}
+
 function Test-RedisTlsReadiness {
     <#
     .SYNOPSIS
@@ -595,17 +605,26 @@ switch ($Action) {
             $arguments = Get-DeploymentArguments -SecureParameterPath $secureParameterPath
             Write-LabStatus 'Submitting the lab deployment. Most resources provide no intermediate ARM progress.'
             Invoke-AzureCli (@('deployment', 'group', 'create') + $arguments + @('--output', 'none')) | Out-Null
+            Clear-LabRedisDeploymentSecrets
             Write-LabStatus 'Deployment completed; launching DebugAzure with the matching process-scoped Redis material.'
 
             $outputs = Invoke-AzureCli @(
                 'deployment', 'group', 'show', '--resource-group', $ResourceGroupName, '--name', $deploymentName,
                 '--query', 'properties.outputs', '--output', 'json'
             ) | ConvertFrom-Json
+            foreach ($staleAlias in @(
+                'grace__azure_storage_account_name',
+                'grace__azure_cosmos_db__endpoint',
+                'grace__azure_cosmos_db__database_name',
+                'grace__azure_cosmos_db__container_name')) {
+                [Environment]::SetEnvironmentVariable($staleAlias, $null, 'Process')
+            }
+
             $debugAzureSettings = @{
-                'grace__azure_storage_account_name' = $outputs.storageAccountName.value
-                'grace__azure_cosmos_db__endpoint' = $outputs.cosmosEndpoint.value
-                'grace__azure_cosmos_db__database_name' = $outputs.cosmosDatabaseName.value
-                'grace__azure_cosmos_db__container_name' = $outputs.cosmosContainerName.value
+                'grace__azure_storage__account_name' = $outputs.storageAccountName.value
+                'grace__azurecosmosdb__endpoint' = $outputs.cosmosEndpoint.value
+                'grace__azurecosmosdb__database_name' = $outputs.cosmosDatabaseName.value
+                'grace__azurecosmosdb__container_name' = $outputs.cosmosContainerName.value
                 'grace__azure_service_bus__namespace' = "$($outputs.serviceBusNamespace.value).servicebus.windows.net"
                 'grace__azure_service_bus__topic' = $outputs.serviceBusEventTopic.value
                 'grace__azure_service_bus__subscription' = $outputs.serviceBusEventSubscription.value

--- a/scripts/Invoke-GraceInfrastructureLab.ps1
+++ b/scripts/Invoke-GraceInfrastructureLab.ps1
@@ -40,6 +40,14 @@ $cosmosName = "grace-cosmos-lab-$normalizedSuffix"
 $serviceBusName = "grace-sb-lab-$normalizedSuffix"
 $sqlServerName = "grace-sql-lab-$normalizedSuffix"
 $redisContainerGroupName = "grace-redis-lab-$normalizedSuffix"
+$redisDnsName = "$redisContainerGroupName.$($Location.ToLowerInvariant()).azurecontainer.io"
+$redisTlsPort = 6380
+$redisParameterEnvironmentVariables = @(
+    'GRACE_LAB_REDIS_CA_CERTIFICATE',
+    'GRACE_LAB_REDIS_SERVER_CERTIFICATE',
+    'GRACE_LAB_REDIS_SERVER_PRIVATE_KEY',
+    'GRACE_LAB_REDIS_ACL_FILE'
+)
 
 function Write-LabStatus {
     <#
@@ -70,6 +78,207 @@ function Invoke-AzureCli {
     }
 
     return $output
+}
+
+function New-LabRedisMaterial {
+    <#
+    .SYNOPSIS
+    Creates one process-scoped CA, hostname certificate, ACL identity, and strong Redis password.
+    #>
+    $now = [DateTimeOffset]::UtcNow
+    $username = 'grace-lab'
+    $passwordBytes = [Security.Cryptography.RandomNumberGenerator]::GetBytes(32)
+    $password = [Convert]::ToBase64String($passwordBytes)
+    [Array]::Clear($passwordBytes)
+
+    $caKey = [Security.Cryptography.RSA]::Create(3072)
+    $serverKey = [Security.Cryptography.RSA]::Create(3072)
+    $caCertificate = $null
+    $serverCertificate = $null
+    try {
+        $caRequest = [Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            'CN=Grace Infrastructure Lab Redis CA',
+            $caKey,
+            [Security.Cryptography.HashAlgorithmName]::SHA256,
+            [Security.Cryptography.RSASignaturePadding]::Pkcs1)
+        $caRequest.CertificateExtensions.Add(
+            [Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($true, $false, 0, $true))
+        $caRequest.CertificateExtensions.Add(
+            [Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new(
+                [Security.Cryptography.X509Certificates.X509KeyUsageFlags]::KeyCertSign,
+                $true))
+        $caCertificate = $caRequest.CreateSelfSigned($now.AddMinutes(-5), $now.AddDays(2))
+
+        $serverRequest = [Security.Cryptography.X509Certificates.CertificateRequest]::new(
+            "CN=$redisDnsName",
+            $serverKey,
+            [Security.Cryptography.HashAlgorithmName]::SHA256,
+            [Security.Cryptography.RSASignaturePadding]::Pkcs1)
+        $subjectNames = [Security.Cryptography.X509Certificates.SubjectAlternativeNameBuilder]::new()
+        $subjectNames.AddDnsName($redisDnsName)
+        $serverRequest.CertificateExtensions.Add($subjectNames.Build())
+        $serverRequest.CertificateExtensions.Add(
+            [Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($false, $false, 0, $true))
+        $serverRequest.CertificateExtensions.Add(
+            [Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new(
+                [Security.Cryptography.X509Certificates.X509KeyUsageFlags]::DigitalSignature,
+                $true))
+        $serverAuthenticationOids = [Security.Cryptography.OidCollection]::new()
+        $serverAuthenticationOids.Add([Security.Cryptography.Oid]::new('1.3.6.1.5.5.7.3.1')) | Out-Null
+        $serverRequest.CertificateExtensions.Add(
+            [Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension]::new(
+                $serverAuthenticationOids,
+                $true))
+        $serialNumber = [Security.Cryptography.RandomNumberGenerator]::GetBytes(16)
+        $serverCertificate = $serverRequest.Create($caCertificate, $now.AddMinutes(-5), $now.AddDays(1), $serialNumber)
+        [Array]::Clear($serialNumber)
+
+        $caPem = $caCertificate.ExportCertificatePem()
+        $serverPem = $serverCertificate.ExportCertificatePem()
+        $serverKeyPem = $serverKey.ExportPkcs8PrivateKeyPem()
+        $acl = "user default off`nuser $username on >$password ~* +@all`n"
+
+        return [pscustomobject]@{
+            Username = $username
+            Password = $password
+            CaPem = $caPem
+            CaBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($caPem))
+            ServerBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($serverPem))
+            ServerKeyBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($serverKeyPem))
+            AclBase64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($acl))
+        }
+    }
+    finally {
+        if ($null -ne $caCertificate) { $caCertificate.Dispose() }
+        if ($null -ne $serverCertificate) { $serverCertificate.Dispose() }
+        $caKey.Dispose()
+        $serverKey.Dispose()
+    }
+}
+
+function New-SecureRedisParameterFile {
+    <#
+    .SYNOPSIS
+    Creates a non-secret Bicep parameter shim that reads secure values from the runner process environment.
+    #>
+    param(
+        [Parameter(Mandatory)][pscustomobject] $Identity,
+        [Parameter(Mandatory)][string] $PublicIpAddress
+    )
+
+    $parameterPath = Join-Path (Split-Path -Parent $labTemplatePath) ".grace-lab-$PID.bicepparam"
+    $escapedPrincipalName = $Identity.userPrincipalName.Replace("'", "''")
+    $content = @"
+using './main.lab.bicep'
+
+param deploymentSuffix = '$DeploymentSuffix'
+param location = '$Location'
+param developerPrincipalId = '$($Identity.id)'
+param developerPrincipalName = '$escapedPrincipalName'
+param clientIpAddress = '$PublicIpAddress'
+param redisCaCertificate = readEnvironmentVariable('GRACE_LAB_REDIS_CA_CERTIFICATE')
+param redisServerCertificate = readEnvironmentVariable('GRACE_LAB_REDIS_SERVER_CERTIFICATE')
+param redisServerPrivateKey = readEnvironmentVariable('GRACE_LAB_REDIS_SERVER_PRIVATE_KEY')
+param redisAclFile = readEnvironmentVariable('GRACE_LAB_REDIS_ACL_FILE')
+"@
+    [IO.File]::WriteAllText($parameterPath, $content, [Text.UTF8Encoding]::new($false))
+    return $parameterPath
+}
+
+function Set-LabRedisDeploymentEnvironment {
+    <#
+    .SYNOPSIS
+    Places the generated secure deployment values in inherited process environment variables.
+    #>
+    param([Parameter(Mandatory)][pscustomobject] $Material)
+
+    [Environment]::SetEnvironmentVariable($redisParameterEnvironmentVariables[0], $Material.CaBase64, 'Process')
+    [Environment]::SetEnvironmentVariable($redisParameterEnvironmentVariables[1], $Material.ServerBase64, 'Process')
+    [Environment]::SetEnvironmentVariable($redisParameterEnvironmentVariables[2], $Material.ServerKeyBase64, 'Process')
+    [Environment]::SetEnvironmentVariable($redisParameterEnvironmentVariables[3], $Material.AclBase64, 'Process')
+}
+
+function Clear-LabRedisSecrets {
+    <#
+    .SYNOPSIS
+    Removes generated Redis deployment and client secrets from the runner process.
+    #>
+    foreach ($name in $redisParameterEnvironmentVariables + @(
+        'grace__redis__host', 'grace__redis__port', 'grace__redis__tls',
+        'grace__redis__username', 'grace__redis__password', 'grace__redis__ca_certificate')) {
+        [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+    }
+}
+
+function Test-RedisTlsReadiness {
+    <#
+    .SYNOPSIS
+    Proves TLS hostname and custom-root validation, ACL authentication, and PING against the deployed endpoint.
+    #>
+    param([Parameter(Mandatory)][pscustomobject] $Material)
+
+    $trustedRoot = [Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromPem($Material.CaPem)
+    $tcpClient = [Net.Sockets.TcpClient]::new()
+    try {
+        $tcpClient.ReceiveTimeout = 30000
+        $tcpClient.SendTimeout = 30000
+        $tcpClient.ConnectAsync($redisDnsName, $redisTlsPort).WaitAsync([TimeSpan]::FromSeconds(30)).GetAwaiter().GetResult()
+        $validation = [Net.Security.RemoteCertificateValidationCallback] {
+            param($sender, $certificate, $chain, $policyErrors)
+
+            if ($null -eq $certificate -or
+                $policyErrors.HasFlag([Net.Security.SslPolicyErrors]::RemoteCertificateNameMismatch)) {
+                return $false
+            }
+
+            $serverCertificate = [Security.Cryptography.X509Certificates.X509Certificate2]::new($certificate)
+            $customChain = [Security.Cryptography.X509Certificates.X509Chain]::new()
+            try {
+                $customChain.ChainPolicy.TrustMode = [Security.Cryptography.X509Certificates.X509ChainTrustMode]::CustomRootTrust
+                $customChain.ChainPolicy.CustomTrustStore.Add($trustedRoot)
+                $customChain.ChainPolicy.RevocationMode = [Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+                return $customChain.Build($serverCertificate)
+            }
+            finally {
+                $customChain.Dispose()
+                $serverCertificate.Dispose()
+            }
+        }
+
+        $tlsStream = [Net.Security.SslStream]::new($tcpClient.GetStream(), $false, $validation)
+        try {
+            $tlsStream.ReadTimeout = 30000
+            $tlsStream.WriteTimeout = 30000
+            $options = [Net.Security.SslClientAuthenticationOptions]::new()
+            $options.TargetHost = $redisDnsName
+            $options.EnabledSslProtocols = [Security.Authentication.SslProtocols]::Tls12 -bor [Security.Authentication.SslProtocols]::Tls13
+            $tlsStream.AuthenticateAsClient($options)
+
+            $writer = [IO.StreamWriter]::new($tlsStream, [Text.UTF8Encoding]::new($false), 1024, $true)
+            $reader = [IO.StreamReader]::new($tlsStream, [Text.UTF8Encoding]::new($false), $false, 1024, $true)
+            try {
+                $writer.NewLine = "`r`n"
+                $writer.Write("*3`r`n`$4`r`nAUTH`r`n`$$($Material.Username.Length)`r`n$($Material.Username)`r`n`$$($Material.Password.Length)`r`n$($Material.Password)`r`n")
+                $writer.Write("*1`r`n`$4`r`nPING`r`n")
+                $writer.Flush()
+
+                if ($reader.ReadLine() -ne '+OK' -or $reader.ReadLine() -ne '+PONG') {
+                    throw 'Redis did not accept the generated ACL credential and authenticated PING.'
+                }
+            }
+            finally {
+                $reader.Dispose()
+                $writer.Dispose()
+            }
+        }
+        finally {
+            $tlsStream.Dispose()
+        }
+    }
+    finally {
+        $tcpClient.Dispose()
+        $trustedRoot.Dispose()
+    }
 }
 
 function Set-VerifiedSubscription {
@@ -213,22 +422,14 @@ function Get-DeploymentArguments {
     #>
     param(
         [Parameter(Mandatory)]
-        [pscustomobject] $Identity,
-
-        [Parameter(Mandatory)]
-        [string] $PublicIpAddress
+        [string] $SecureParameterPath
     )
 
     Write-LabStatus "Preparing deployment '$deploymentName' with suffix '$DeploymentSuffix'."
     return @(
         '--resource-group', $ResourceGroupName,
         '--name', $deploymentName,
-        '--template-file', $labTemplatePath,
-        '--parameters',
-        "deploymentSuffix=$DeploymentSuffix",
-        "developerPrincipalId=$($Identity.id)",
-        "developerPrincipalName=$($Identity.userPrincipalName)",
-        "clientIpAddress=$PublicIpAddress"
+        '--parameters', $SecureParameterPath
     )
 }
 
@@ -324,18 +525,20 @@ function Test-LabResources {
         throw "SQL lab configuration differs from GP_S_Gen5_1, 60-minute auto-pause, and 0.5 minimum vCore."
     }
 
-    Write-LabStatus 'Verifying the private Azure Container Instances Redis process.'
+    Write-LabStatus 'Verifying the TLS-only Azure Container Instances Redis process.'
     $redisConfiguration = Invoke-AzureCli @(
         'container', 'show', '--resource-group', $ResourceGroupName, '--name', $redisContainerGroupName,
-        '--query', '{provisioningState:provisioningState,state:instanceView.state,image:containers[0].image,publicIp:ipAddress.ip}',
+        '--query', '{provisioningState:provisioningState,state:instanceView.state,image:containers[0].image,fqdn:ipAddress.fqdn,ports:ipAddress.ports[].port}',
         '--output', 'json'
     ) | ConvertFrom-Json
     if ($redisConfiguration.provisioningState -ne 'Succeeded' -or $redisConfiguration.state -ne 'Running' -or
         $redisConfiguration.image -ne 'redis:7.4-alpine') {
         throw "Redis container '$redisContainerGroupName' is not running the expected redis:7.4-alpine image."
     }
-    if (-not [string]::IsNullOrWhiteSpace($redisConfiguration.publicIp)) {
-        throw "Redis container '$redisContainerGroupName' unexpectedly exposes public IP '$($redisConfiguration.publicIp)'."
+    if ($redisConfiguration.fqdn -ne $redisDnsName -or
+        @($redisConfiguration.ports).Count -ne 1 -or
+        @($redisConfiguration.ports)[0] -ne $redisTlsPort) {
+        throw "Redis container '$redisContainerGroupName' does not expose only the expected TLS endpoint."
     }
 
     $resources | Sort-Object type | Format-Table name, type, sku -AutoSize
@@ -361,12 +564,22 @@ switch ($Action) {
         New-LabResourceGroup
         $identity = Get-DeveloperIdentity
         $publicIpAddress = Get-ValidatedClientIpAddress
-        $arguments = Get-DeploymentArguments -Identity $identity -PublicIpAddress $publicIpAddress
-        Write-LabStatus 'Validating the lab deployment with Azure Resource Manager.'
-        Invoke-AzureCli (@('deployment', 'group', 'validate') + $arguments + @('--output', 'none')) | Out-Null
-        Write-LabStatus 'ARM validation passed; calculating the proposed changes.'
-        Invoke-AzureCli (@('deployment', 'group', 'what-if') + $arguments + @('--no-pretty-print'))
-        Write-LabStatus 'What-if action completed.'
+        $redisMaterial = New-LabRedisMaterial
+        $secureParameterPath = New-SecureRedisParameterFile -Identity $identity -PublicIpAddress $publicIpAddress
+        try {
+            Set-LabRedisDeploymentEnvironment -Material $redisMaterial
+            $arguments = Get-DeploymentArguments -SecureParameterPath $secureParameterPath
+            Write-LabStatus 'Validating the lab deployment with Azure Resource Manager.'
+            Invoke-AzureCli (@('deployment', 'group', 'validate') + $arguments + @('--output', 'none')) | Out-Null
+            Write-LabStatus 'ARM validation passed; calculating the proposed changes.'
+            Invoke-AzureCli (@('deployment', 'group', 'what-if') + $arguments + @('--no-pretty-print'))
+            Write-LabStatus 'What-if action completed.'
+        }
+        finally {
+            Clear-LabRedisSecrets
+            Remove-Item -LiteralPath $secureParameterPath -Force -ErrorAction SilentlyContinue
+            $redisMaterial = $null
+        }
     }
     'Deploy' {
         Write-LabStatus 'Preparing to deploy the disposable infrastructure lab.'
@@ -375,10 +588,61 @@ switch ($Action) {
         New-LabResourceGroup
         $identity = Get-DeveloperIdentity
         $publicIpAddress = Get-ValidatedClientIpAddress
-        $arguments = Get-DeploymentArguments -Identity $identity -PublicIpAddress $publicIpAddress
-        Write-LabStatus 'Submitting the lab deployment. Most resources provide no intermediate ARM progress.'
-        Invoke-AzureCli (@('deployment', 'group', 'create') + $arguments + @('--output', 'json'))
-        Write-LabStatus 'Deployment action completed successfully.'
+        $redisMaterial = New-LabRedisMaterial
+        $secureParameterPath = New-SecureRedisParameterFile -Identity $identity -PublicIpAddress $publicIpAddress
+        try {
+            Set-LabRedisDeploymentEnvironment -Material $redisMaterial
+            $arguments = Get-DeploymentArguments -SecureParameterPath $secureParameterPath
+            Write-LabStatus 'Submitting the lab deployment. Most resources provide no intermediate ARM progress.'
+            Invoke-AzureCli (@('deployment', 'group', 'create') + $arguments + @('--output', 'none')) | Out-Null
+            Write-LabStatus 'Deployment completed; launching DebugAzure with the matching process-scoped Redis material.'
+
+            $outputs = Invoke-AzureCli @(
+                'deployment', 'group', 'show', '--resource-group', $ResourceGroupName, '--name', $deploymentName,
+                '--query', 'properties.outputs', '--output', 'json'
+            ) | ConvertFrom-Json
+            $debugAzureSettings = @{
+                'grace__azure_storage_account_name' = $outputs.storageAccountName.value
+                'grace__azure_cosmos_db__endpoint' = $outputs.cosmosEndpoint.value
+                'grace__azure_cosmos_db__database_name' = $outputs.cosmosDatabaseName.value
+                'grace__azure_cosmos_db__container_name' = $outputs.cosmosContainerName.value
+                'grace__azure_service_bus__namespace' = "$($outputs.serviceBusNamespace.value).servicebus.windows.net"
+                'grace__azure_service_bus__topic' = $outputs.serviceBusEventTopic.value
+                'grace__azure_service_bus__subscription' = $outputs.serviceBusEventSubscription.value
+                'grace__azure_service_bus__operational_facts_topic' = $outputs.serviceBusGraceUsageTopic.value
+                'grace__azure_service_bus__operational_facts_processor_subscription' = $outputs.serviceBusGraceUsageSubscription.value
+                'grace__operations__sql__connectionstring' = $outputs.sqlConnectionString.value
+                'grace__redis__host' = $redisDnsName
+                'grace__redis__port' = "$redisTlsPort"
+                'grace__redis__tls' = 'true'
+                'grace__redis__username' = $redisMaterial.Username
+                'grace__redis__password' = $redisMaterial.Password
+                'grace__redis__ca_certificate' = $redisMaterial.CaBase64
+            }
+            foreach ($setting in $debugAzureSettings.GetEnumerator()) {
+                [Environment]::SetEnvironmentVariable($setting.Key, [string] $setting.Value, 'Process')
+            }
+
+            & pwsh -NoProfile -File (Join-Path $PSScriptRoot 'start-debugazure.ps1')
+            if ($LASTEXITCODE -ne 0) {
+                throw 'DebugAzure failed before Redis readiness could be proven.'
+            }
+
+            Write-LabStatus 'Proving authenticated Redis PING with certificate and hostname validation.'
+            Test-RedisTlsReadiness -Material $redisMaterial
+            Clear-LabRedisSecrets
+            $debugAzureSettings = $null
+            $redisMaterial = $null
+            Write-LabStatus 'DebugAzure Redis readiness passed and parent-process secrets were cleared.'
+        }
+        catch {
+            Clear-LabRedisSecrets
+            throw
+        }
+        finally {
+            Remove-Item -LiteralPath $secureParameterPath -Force -ErrorAction SilentlyContinue
+            $redisMaterial = $null
+        }
     }
     'Verify' {
         Write-LabStatus 'Verifying the live lab resource inventory and SKU choices.'

--- a/scripts/start-debugazure.ps1
+++ b/scripts/start-debugazure.ps1
@@ -4,7 +4,8 @@ param(
     [ValidateRange(30, 1800)]
     [int] $StartupTimeoutSeconds = 300,
     [ValidateSet("Debug", "Release")]
-    [string] $Configuration = "Debug"
+    [string] $Configuration = "Debug",
+    [switch] $PreflightOnly
 )
 
 Set-StrictMode -Version Latest
@@ -25,6 +26,38 @@ function Write-Status {
     param([Parameter(Mandatory)][string] $Message)
 
     Write-Host "[$(Get-Date -Format 'HH:mm:ss')] $Message"
+}
+
+function Assert-GraceServerUriAvailable {
+    <#
+    .SYNOPSIS
+    Rejects a pre-existing Grace Server listener so readiness cannot be satisfied by an older DebugAzure child.
+    #>
+    $serverUri = $null
+    if (-not [Uri]::TryCreate($GraceServerUri, [UriKind]::Absolute, [ref] $serverUri) -or
+        $serverUri.Scheme -notin @('http', 'https')) {
+        throw "GraceServerUri must be an absolute HTTP or HTTPS URI."
+    }
+
+    $tcpClient = [Net.Sockets.TcpClient]::new()
+    $listenerDetected = $false
+    try {
+        $tcpClient.ConnectAsync($serverUri.Host, $serverUri.Port).WaitAsync([TimeSpan]::FromSeconds(1)).GetAwaiter().GetResult()
+        $listenerDetected = $true
+    }
+    catch [Net.Sockets.SocketException] {
+        $listenerDetected = $false
+    }
+    catch [TimeoutException] {
+        $listenerDetected = $false
+    }
+    finally {
+        $tcpClient.Dispose()
+    }
+
+    if ($listenerDetected) {
+        throw "Grace Server URI '$GraceServerUri' already has a listener. Stop the existing DebugAzure process before deployment."
+    }
 }
 
 function Stop-AppHostProcess {
@@ -159,6 +192,12 @@ function Test-SystemAdmin {
     )
 
     return $result.ReturnValue.PSObject.Properties.Name -contains "allowed"
+}
+
+Assert-GraceServerUriAvailable
+if ($PreflightOnly) {
+    Write-Status "Grace Server URI '$GraceServerUri' is available for a new DebugAzure child."
+    return
 }
 
 New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -92,7 +92,8 @@ public partial class Program
                 .WithContainerName(redisContainerName)
                 //.WithLifetime(ContainerLifetime.Session)
                 .WithEnvironment("ACCEPT_EULA", "Y")
-                .WithEndpoint(targetPort: 6379, port: 6379);
+                .WithEndpoint(targetPort: 6379, port: 6379, name: "tcp", scheme: "tcp");
+            var redisEndpoint = redis.GetEndpoint("tcp");
             if (isTestRun)
             {
                 redis.WithLifetime(ContainerLifetime.Session);
@@ -143,8 +144,6 @@ public partial class Program
                     .WithEnvironment(EnvironmentVariables.DirectoryVersionContainerName, "directoryversions")
                     .WithEnvironment(EnvironmentVariables.DiffContainerName, "diffs")
                     .WithEnvironment(EnvironmentVariables.ZipFileContainerName, "zipfiles")
-                    .WithEnvironment(EnvironmentVariables.RedisHost, "127.0.0.1")
-                    .WithEnvironment(EnvironmentVariables.RedisPort, "6379")
                     .WithEnvironment(EnvironmentVariables.OrleansClusterId, orleansClusterId)
                     .WithEnvironment(EnvironmentVariables.OrleansServiceId, orleansServiceId)
                     .WithEnvironment(EnvironmentVariables.GracePubSubSystem, pubSubSystem)
@@ -190,6 +189,18 @@ public partial class Program
                     // DebugLocal (default): containers/emulators
                     // -------------------------
                     Console.WriteLine("Configuring Grace.Server for DebugLocal with local emulators.");
+                    graceServer.WithEnvironment(async context =>
+                    {
+                        var endpoint = await redisEndpoint.GetValueAsync(context.CancellationToken);
+                        if (string.IsNullOrWhiteSpace(endpoint))
+                        {
+                            throw new InvalidOperationException("Aspire did not allocate the local Redis endpoint.");
+                        }
+
+                        var endpointUri = new Uri(endpoint);
+                        context.EnvironmentVariables[EnvironmentVariables.RedisHost] = endpointUri.Host;
+                        context.EnvironmentVariables[EnvironmentVariables.RedisPort] = endpointUri.Port.ToString();
+                    });
                     var azuriteDataPath = Path.Combine(stateRoot, "azurite");
                     var cosmosCertPath = Path.Combine(stateRoot, "cosmos-cert");
                     var serviceBusConfigPath = Path.Combine(stateRoot, "servicebus");

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -652,7 +652,7 @@ public partial class Program
         }
     }
 
-    private static string? ResolveSetting(IConfiguration configuration, string name)
+    internal static string? ResolveSetting(IConfiguration configuration, string name)
     {
         var value = Environment.GetEnvironmentVariable(name);
         if (string.IsNullOrWhiteSpace(value))

--- a/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
+++ b/src/Grace.Aspire.AppHost/Program.Aspire.AppHost.cs
@@ -458,6 +458,25 @@ public partial class Program
                         GetRequiredSetting(configuration, OperationalFactsProcessorSubscriptionSettingName);
                     var serviceBusSubscription = ResolveSetting(configuration, EnvironmentVariables.AzureServiceBusSubscription);
                     var operationsSqlConnectionString = GetRequiredSetting(configuration, OperationsSqlConnectionStringSettingName);
+                    var redisHost = ResolveSetting(configuration, EnvironmentVariables.RedisHost);
+                    var redisPort = ResolveSetting(configuration, EnvironmentVariables.RedisPort);
+                    var redisTls = ResolveSetting(configuration, EnvironmentVariables.RedisTls);
+                    var redisUsername = ResolveSetting(configuration, EnvironmentVariables.RedisUsername);
+                    var redisPassword = ResolveSetting(configuration, EnvironmentVariables.RedisPassword);
+                    var redisCaCertificate = ResolveSetting(configuration, EnvironmentVariables.RedisCaCertificate);
+
+                    if (!string.IsNullOrWhiteSpace(redisHost))
+                    {
+                        if (!IsTruthy(redisTls)
+                            || string.IsNullOrWhiteSpace(redisPort)
+                            || string.IsNullOrWhiteSpace(redisUsername)
+                            || string.IsNullOrWhiteSpace(redisPassword)
+                            || string.IsNullOrWhiteSpace(redisCaCertificate))
+                        {
+                            throw new InvalidOperationException(
+                                "DebugAzure Redis requires explicit TLS, port, ACL username, password, and CA settings.");
+                        }
+                    }
 
                     graceServer
                         .WithEnvironment(EnvironmentVariables.AzureStorageAccountName, azureStorageAccountName)
@@ -471,6 +490,12 @@ public partial class Program
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusOperationalFactsTopic, operationalFactsTopic)
                         .WithEnvironment(OperationalFactsProcessorSubscriptionSettingName, operationalFactsProcessorSubscription)
                         .WithEnvironment(EnvironmentVariables.AzureServiceBusSubscription, serviceBusSubscription)
+                        .WithEnvironment(EnvironmentVariables.RedisHost, redisHost ?? "127.0.0.1")
+                        .WithEnvironment(EnvironmentVariables.RedisPort, redisPort ?? "6379")
+                        .WithEnvironment(EnvironmentVariables.RedisTls, redisTls)
+                        .WithEnvironment(EnvironmentVariables.RedisUsername, redisUsername)
+                        .WithEnvironment(EnvironmentVariables.RedisPassword, redisPassword)
+                        .WithEnvironment(EnvironmentVariables.RedisCaCertificate, redisCaCertificate)
                         .WithEnvironment(EnvironmentVariables.GraceLogDirectory, logDirectory)
                         .WithEnvironment(EnvironmentVariables.DebugEnvironment, "Azure");
 
@@ -489,6 +514,9 @@ public partial class Program
                     Console.WriteLine("  - Azure Storage: using DefaultAzureCredential.");
                     Console.WriteLine("  - Azure Cosmos: using DefaultAzureCredential.");
                     Console.WriteLine("  - Azure Service Bus: using DefaultAzureCredential.");
+                    Console.WriteLine(string.IsNullOrWhiteSpace(redisHost)
+                        ? "  - Redis: using the local unauthenticated container."
+                        : "  - Redis: using the TLS-authenticated infrastructure lab endpoint.");
                     Console.WriteLine($"  - Operational facts processor subscription: {operationalFactsProcessorSubscription}.");
                     Console.WriteLine("  - Aspire dashboard at http://localhost:18888");
                     Console.WriteLine($"  - OTLP endpoint {otlpEndpoint}");

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -41,6 +41,21 @@ type OperationalFactsPublisherAppHostTests() =
                 Assert.That(appHostSource, Does.Contain("Using Azure Storage account: {azureStorageAccountName}")))
         )
 
+    /// Verifies DebugAzure forwards every explicit secure Redis setting without logging credential values.
+    [<Test>]
+    member _.DebugAzureForwardsTlsRedisSettingsWithoutSecretDiagnostics() =
+        let appHostSource = appHostSource ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(appHostSource, Does.Contain(".WithEnvironment(EnvironmentVariables.RedisTls, redisTls)"))
+                Assert.That(appHostSource, Does.Contain(".WithEnvironment(EnvironmentVariables.RedisUsername, redisUsername)"))
+                Assert.That(appHostSource, Does.Contain(".WithEnvironment(EnvironmentVariables.RedisPassword, redisPassword)"))
+                Assert.That(appHostSource, Does.Contain(".WithEnvironment(EnvironmentVariables.RedisCaCertificate, redisCaCertificate)"))
+                Assert.That(appHostSource, Does.Not.Contain("Console.WriteLine(redisPassword"))
+                Assert.That(appHostSource, Does.Not.Contain("Console.WriteLine(redisCaCertificate")))
+        )
+
     /// Verifies that AppHost provisions and forwards the same operational facts topic name.
     [<Test>]
     member _.AppHostConfiguresOperationalFactsTopicConsistently() =
@@ -84,10 +99,7 @@ type OperationalFactsPublisherAppHostTests() =
                 Assert.That(appHostSource, Does.Contain("GraceEventSubscriptionResourceName = \"grace-event-subscription\""))
                 Assert.That(appHostSource, Does.Contain("OperationalFactsTopicResourceName = \"grace-operational-facts-topic\""))
 
-                Assert.That(
-                    appHostSource,
-                    Does.Contain("GraceUsageCollectorSubscriptionResourceName = \"grace-usage-collector-subscription\"")
-                )
+                Assert.That(appHostSource, Does.Contain("GraceUsageCollectorSubscriptionResourceName = \"grace-usage-collector-subscription\""))
 
                 Assert.That(appHostSource, Does.Contain("serviceBus.AddServiceBusTopic(GraceEventTopicResourceName, serviceBusTopicName)"))
 
@@ -141,19 +153,13 @@ type OperationalFactsPublisherAppHostTests() =
             (fun () ->
                 let configuration = ConfigurationBuilder().Build()
 
-                Environment.SetEnvironmentVariable(
-                    Program.DebugAzureBootstrapModeEnvironmentVariable,
-                    Program.DebugAzureBootstrapModeSuppress
-                )
+                Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapModeEnvironmentVariable, Program.DebugAzureBootstrapModeSuppress)
 
                 let suppressed = Program.ResolveAuthorizationBootstrapSettings(configuration, true)
                 Assert.That(suppressed.Users, Is.Null)
                 Assert.That(suppressed.Groups, Is.Null)
 
-                Environment.SetEnvironmentVariable(
-                    Program.DebugAzureBootstrapModeEnvironmentVariable,
-                    Program.DebugAzureBootstrapModeExactUser
-                )
+                Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapModeEnvironmentVariable, Program.DebugAzureBootstrapModeExactUser)
 
                 Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapUserIdEnvironmentVariable, "authenticated-user")
 
@@ -165,7 +171,9 @@ type OperationalFactsPublisherAppHostTests() =
                 Environment.SetEnvironmentVariable(Program.DebugAzureBootstrapUserIdEnvironmentVariable, "first-user;second-user")
 
                 Assert.Throws<InvalidOperationException>(
-                    Action(fun () -> Program.ResolveAuthorizationBootstrapSettings(configuration, true) |> ignore)
+                    Action (fun () ->
+                        Program.ResolveAuthorizationBootstrapSettings(configuration, true)
+                        |> ignore)
                 )
                 |> ignore
 

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -56,6 +56,20 @@ type OperationalFactsPublisherAppHostTests() =
                 Assert.That(appHostSource, Does.Not.Contain("Console.WriteLine(redisCaCertificate")))
         )
 
+    /// Verifies DebugLocal resolves Redis host and port from Aspire's allocated endpoint instead of fixed defaults.
+    [<Test>]
+    member _.DebugLocalForwardsAllocatedRedisEndpoint() =
+        let appHostSource = appHostSource ()
+
+        Assert.Multiple(
+            Action (fun () ->
+                Assert.That(appHostSource, Does.Contain("var redisEndpoint = redis.GetEndpoint(\"tcp\");"))
+                Assert.That(appHostSource, Does.Contain("await redisEndpoint.GetValueAsync(context.CancellationToken)"))
+                Assert.That(appHostSource, Does.Contain("context.EnvironmentVariables[EnvironmentVariables.RedisHost] = endpointUri.Host;"))
+
+                Assert.That(appHostSource, Does.Contain("context.EnvironmentVariables[EnvironmentVariables.RedisPort] = endpointUri.Port.ToString();")))
+        )
+
     /// Verifies a fresh exact process setting wins over stale configuration inherited from an earlier lab run.
     [<Test>]
     member _.DebugAzureExactProcessSettingOverridesStaleConfiguration() =

--- a/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
+++ b/src/Grace.Server.Tests/OperationalFactsPublisher.AppHost.Tests.fs
@@ -56,6 +56,19 @@ type OperationalFactsPublisherAppHostTests() =
                 Assert.That(appHostSource, Does.Not.Contain("Console.WriteLine(redisCaCertificate")))
         )
 
+    /// Verifies a fresh exact process setting wins over stale configuration inherited from an earlier lab run.
+    [<Test>]
+    member _.DebugAzureExactProcessSettingOverridesStaleConfiguration() =
+        let settingName = Constants.EnvironmentVariables.AzureStorageAccountName
+
+        let configuration =
+            ConfigurationBuilder()
+                .AddInMemoryCollection(dict [ Grace.Shared.Utilities.getConfigKey settingName, "gracelab-stale" ])
+                .Build()
+
+        withEnvironmentVariables [ settingName, "gracelab-fresh" ] (fun () ->
+            Assert.That(Program.ResolveSetting(configuration, settingName), Is.EqualTo("gracelab-fresh")))
+
     /// Verifies that AppHost provisions and forwards the same operational facts topic name.
     [<Test>]
     member _.AppHostConfiguresOperationalFactsTopicConsistently() =

--- a/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
@@ -7,6 +7,8 @@ open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
 open NUnit.Framework
 open System
+open System.Security.Cryptography
+open System.Security.Cryptography.X509Certificates
 open System.Threading
 
 /// Covers the provider-neutral Redis recent-result wire contract without starting Redis.
@@ -31,6 +33,22 @@ type RepositoryCounterRecentResultTests() =
         Assert.That(configuration.AsyncTimeout, Is.EqualTo(int connectionTimeout.TotalMilliseconds))
         Assert.That(requiresReadinessProbe false, Is.True)
         Assert.That(requiresReadinessProbe true, Is.False)
+
+    /// Verifies the lab endpoint enables TLS, keeps hostname validation, and supplies the generated ACL identity.
+    [<Test>]
+    member _.SecureLabConfigurationUsesTlsAclAndCustomRoot() =
+        use key = RSA.Create(2048)
+        let request = CertificateRequest("CN=Grace Lab CA", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+        request.CertificateExtensions.Add(X509BasicConstraintsExtension(true, false, 0, true))
+        use certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddMinutes(-1.0), DateTimeOffset.UtcNow.AddHours(1.0))
+        let caPem = certificate.ExportCertificatePem()
+
+        let configuration = configurationForSecureEndpoint "redis.example.test" 6380 "grace" "secret" caPem
+
+        Assert.That(configuration.Ssl, Is.True)
+        Assert.That(configuration.SslHost, Is.EqualTo("redis.example.test"))
+        Assert.That(configuration.User, Is.EqualTo("grace"))
+        Assert.That(configuration.Password, Is.EqualTo("secret"))
 
     /// Verifies cached changes round-trip without inventing a zero for missing or malformed values.
     [<Test>]
@@ -104,4 +122,14 @@ type RepositoryCounterRecentResultTests() =
                 )
 
             Assert.That(confirmed, Is.False)
+        }
+
+    /// Verifies the startup warmup remains a no-op when Redis is intentionally absent.
+    [<Test>]
+    member _.UnavailableRedisWarmupCompletesWithoutConnection() =
+        task {
+            let recent = UnavailableRepositoryCounterRecentResult() :> IRepositoryCounterRecentResult
+            let warmup = RedisRepositoryCounterRecentResultWarmup(recent) :> Microsoft.Extensions.Hosting.IHostedService
+
+            do! warmup.StartAsync(CancellationToken.None)
         }

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -6,9 +6,12 @@ open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
+open Microsoft.Extensions.Hosting
 open StackExchange.Redis
 open System
 open System.Globalization
+open System.Net.Security
+open System.Security.Cryptography.X509Certificates
 open System.Text
 open System.Threading
 open System.Threading.Tasks
@@ -36,6 +39,35 @@ module RepositoryCounterRecentResult =
             )
 
         configuration.EndPoints.Add(host, port)
+        configuration
+
+    /// Builds certificate-validated Redis TLS configuration for the disposable Azure infrastructure lab.
+    let configurationForSecureEndpoint (host: string) (port: int) (username: string) (password: string) (caCertificatePem: string) =
+        let configuration = configurationForEndpoint host port
+        let trustedRoot = X509Certificate2.CreateFromPem caCertificatePem
+
+        configuration.Ssl <- true
+        configuration.SslHost <- host
+        configuration.User <- username
+        configuration.Password <- password
+
+        configuration.add_CertificateValidation (
+            RemoteCertificateValidationCallback (fun _ certificate _ policyErrors ->
+                if isNull certificate
+                   || policyErrors.HasFlag SslPolicyErrors.RemoteCertificateNameMismatch then
+                    false
+                else
+                    use serverCertificate = new X509Certificate2(certificate)
+                    use chain = new X509Chain()
+                    chain.ChainPolicy.TrustMode <- X509ChainTrustMode.CustomRootTrust
+
+                    chain.ChainPolicy.CustomTrustStore.Add trustedRoot
+                    |> ignore
+
+                    chain.ChainPolicy.RevocationMode <- X509RevocationMode.NoCheck
+                    chain.Build serverCertificate)
+        )
+
         configuration
 
     /// Requires an explicit readiness probe when StackExchange.Redis returns its reconnecting multiplexer before a socket is connected.
@@ -112,9 +144,7 @@ module RepositoryCounterRecentResult =
                 Task.FromResult false
 
     /// Uses one lazy StackExchange.Redis connection with native reconnect, readiness proof, bounded commands, and structured failure evidence.
-    type RedisRepositoryCounterRecentResult(host: string, port: int, log: ILogger) =
-
-        let configuration = configurationForEndpoint host port
+    type RedisRepositoryCounterRecentResult private (configuration: ConfigurationOptions, log: ILogger) =
 
         let connection = lazy (task { return! ConnectionMultiplexer.ConnectAsync configuration })
 
@@ -138,7 +168,27 @@ module RepositoryCounterRecentResult =
             log.LogWarning(error, "Redis repository counter recent-result {Operation} failed; using nonauthoritative fallback {Fallback}.", operation, fallback)
 
         /// Creates the Redis accelerator with a no-op logger for focused callers that intentionally omit structured diagnostics.
-        new(host: string, port: int) = new RedisRepositoryCounterRecentResult(host, port, NullLogger.Instance)
+        new(host: string, port: int) = new RedisRepositoryCounterRecentResult(configurationForEndpoint host port, NullLogger.Instance)
+
+        /// Creates the Redis accelerator for the existing unauthenticated local development endpoint.
+        new(host: string, port: int, log: ILogger) = new RedisRepositoryCounterRecentResult(configurationForEndpoint host port, log)
+
+        /// Creates the Redis accelerator for the TLS-only lab endpoint with its generated ACL credential and custom root.
+        new(host: string, port: int, username: string, password: string, caCertificatePem: string, log: ILogger) =
+            new RedisRepositoryCounterRecentResult(configurationForSecureEndpoint host port username password caCertificatePem, log)
+
+        /// Completes an explicit authenticated PING before Grace reports the configured Redis integration ready.
+        member _.PingAsync(cancellationToken: CancellationToken) =
+            task {
+                let! redisDatabase = database cancellationToken
+
+                let! _ =
+                    redisDatabase
+                        .PingAsync()
+                        .WaitAsync(connectionTimeout, cancellationToken)
+
+                return ()
+            }
 
         interface IRepositoryCounterRecentResult with
             member _.TryGetAsync(repositoryId, storagePoolId, manifestAddress, operationId, (cancellationToken: CancellationToken)) =
@@ -201,3 +251,15 @@ module RepositoryCounterRecentResult =
                 if connection.IsValueCreated
                    && connection.Value.IsCompletedSuccessfully then
                     connection.Value.Result.Dispose()
+
+    /// Requires the configured Redis endpoint to complete PING during Grace host startup.
+    type RedisRepositoryCounterRecentResultWarmup(recentResult: IRepositoryCounterRecentResult) =
+        interface IHostedService with
+            /// Waits for Redis only when the configured recent-result implementation uses the Redis accelerator.
+            member _.StartAsync(cancellationToken: CancellationToken) : Task =
+                match recentResult with
+                | :? RedisRepositoryCounterRecentResult as redis -> redis.PingAsync cancellationToken
+                | _ -> Task.CompletedTask
+
+            /// Adds no shutdown work because the registered recent-result singleton owns its multiplexer lifetime.
+            member _.StopAsync(_: CancellationToken) = Task.CompletedTask

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -2191,6 +2191,7 @@ module Application =
                 let redisHost = configuration.GetValue<string>(getConfigKey Constants.EnvironmentVariables.RedisHost)
 
                 let redisPort = configuration.GetValue<int>(getConfigKey Constants.EnvironmentVariables.RedisPort)
+                let redisTls = configuration.GetValue<bool>(getConfigKey Constants.EnvironmentVariables.RedisTls)
 
                 if String.IsNullOrWhiteSpace redisHost then
                     RepositoryCounterRecentResult.UnavailableRepositoryCounterRecentResult() :> IRepositoryCounterRecentResult
@@ -2202,7 +2203,36 @@ module Application =
                             .GetRequiredService<ILoggerFactory>()
                             .CreateLogger("RepositoryCounterRecentResult.Server")
 
-                    new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort, redisLog) :> IRepositoryCounterRecentResult)
+                    if redisTls then
+                        let redisUsername = configuration[getConfigKey Constants.EnvironmentVariables.RedisUsername]
+                        let redisPassword = configuration[getConfigKey Constants.EnvironmentVariables.RedisPassword]
+                        let encodedCaCertificate = configuration[getConfigKey Constants.EnvironmentVariables.RedisCaCertificate]
+
+                        if String.IsNullOrWhiteSpace redisUsername
+                           || String.IsNullOrWhiteSpace redisPassword
+                           || String.IsNullOrWhiteSpace encodedCaCertificate then
+                            invalidOp "Redis TLS requires an ACL username, password, and custom CA certificate."
+
+                        let caCertificatePem =
+                            encodedCaCertificate
+                            |> Convert.FromBase64String
+                            |> Encoding.UTF8.GetString
+
+                        new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(
+                            redisHost,
+                            effectivePort,
+                            redisUsername,
+                            redisPassword,
+                            caCertificatePem,
+                            redisLog
+                        )
+                        :> IRepositoryCounterRecentResult
+                    else
+                        new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort, redisLog)
+                        :> IRepositoryCounterRecentResult)
+            |> ignore
+
+            services.AddHostedService<RepositoryCounterRecentResult.RedisRepositoryCounterRecentResultWarmup>()
             |> ignore
 
             services.AddSingleton<IExactRelationshipStore> (fun _ ->

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -386,6 +386,22 @@ module Constants =
         [<Literal>]
         let RedisPort = "grace__redis__port"
 
+        /// The environment variable that enables certificate-validated TLS for Redis.
+        [<Literal>]
+        let RedisTls = "grace__redis__tls"
+
+        /// The environment variable that contains the Redis ACL username.
+        [<Literal>]
+        let RedisUsername = "grace__redis__username"
+
+        /// The environment variable that contains the Redis ACL password.
+        [<Literal>]
+        let RedisPassword = "grace__redis__password"
+
+        /// The environment variable that contains the Base64-encoded PEM certificate for the Redis custom trust root.
+        [<Literal>]
+        let RedisCaCertificate = "grace__redis__ca_certificate"
+
         /// The environment variable that selects the pub-sub provider.
         [<Literal>]
         let GracePubSubSystem = "grace__pubsub__system"

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -71,7 +71,8 @@ Aspire running and reports its process ID and log paths.
 For the disposable infrastructure lab, use `Invoke-GraceInfrastructureLab.ps1 -Action Deploy`. That runner generates
 the process-scoped Redis TLS and ACL material, deploys the matching endpoint, launches this wrapper, proves authenticated
 `PING` with custom-root and hostname validation, and clears its parent-process secrets before reporting readiness.
-Direct wrapper use without those settings retains the existing local Redis container.
+Direct wrapper use without those settings retains the existing local Redis container. Stop an existing `DebugAzure`
+process before another lab deployment; the runner rejects an occupied Grace Server URI before rotating Redis material.
 
 ## Verify Components
 

--- a/src/docs/ASPIRE_SETUP.md
+++ b/src/docs/ASPIRE_SETUP.md
@@ -68,6 +68,11 @@ system assignments, it performs one bounded restart that offers the authenticate
 environment is never reassigned by this flow; an existing SystemAdmin must grant access. Successful startup leaves
 Aspire running and reports its process ID and log paths.
 
+For the disposable infrastructure lab, use `Invoke-GraceInfrastructureLab.ps1 -Action Deploy`. That runner generates
+the process-scoped Redis TLS and ACL material, deploys the matching endpoint, launches this wrapper, proves authenticated
+`PING` with custom-root and hostname validation, and clears its parent-process secrets before reporting readiness.
+Direct wrapper use without those settings retains the existing local Redis container.
+
 ## Verify Components
 
 Open `http://localhost:18888` and confirm the following resources show

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -242,6 +242,14 @@ Messages are completed only after SQL processing succeeds or the durable usage f
 - `grace__redis__host`: optional Redis host for ten-minute repository-counter
   recent results.
 - `grace__redis__port`: Redis port; defaults to `6379` when a host is set.
+- `grace__redis__tls`: set to `true` for the infrastructure lab endpoint.
+- `grace__redis__username`: Redis ACL username required when TLS is enabled.
+- `grace__redis__password`: Redis ACL password required when TLS is enabled.
+- `grace__redis__ca_certificate`: Base64-encoded PEM custom root required when TLS is enabled.
+
+The infrastructure lab runner supplies all five secure-endpoint settings to `DebugAzure`, validates the generated CA
+and DNS hostname, completes authenticated `PING`, and clears its parent-process copies before reporting readiness.
+When these lab settings are absent, `DebugAzure` retains the existing unauthenticated local Redis container.
 
 When Redis is not configured or cannot be reached, recent-result reads return
 unknown. Addition processing may continue because retaining content is safe.


### PR DESCRIPTION
# Secure the infrastructure lab Redis connection

## Why this matters

DebugAzure should exercise Redis over a connection that resembles a deployed dependency, so local integration work catches TLS, trust, and authentication mistakes before production-shaped infrastructure is involved.

## What changed

- Configure the disposable ACI Redis lab with TLS on port 6380, ACL authentication, and no plaintext listener.
- Generate per-deployment CA, server certificate, ACL user, and password material in process without secret outputs or persistent secret files.
- Forward only the required TLS client settings to DebugAzure and require Grace.Server to authenticate and PING Redis during startup.
- Require an independent runner PING with certificate and hostname validation before reporting readiness, then clear parent-process secrets.
- Preserve the existing unauthenticated local Redis path.
- Document the lab workflow and add focused infrastructure, AppHost, and Redis client tests.

## Validation

- PowerShell parser checks passed.
- Infrastructure profile and redaction assertions passed.
- Lab and production Bicep builds passed.
- AppHost, Server.Unit.Tests, and Server.Tests Release builds passed with zero warnings and errors.
- Focused Redis unit tests passed: 9/9.
- MarkdownLint and `git diff --check` passed.
- Live `WhatIf`, `Deploy`, and `Verify` passed in the dedicated Grace Infrastructure Lab resource group.
- Grace.Server and the runner independently completed authenticated TLS PING with custom-root and hostname validation.
- Live plaintext PING was rejected; ACI exposed only port 6380.
- Redacted child inspection showed zero deployment-only Redis variables and zero stale Azure aliases.
- The dedicated resource group was deleted and `VerifyRemoved` confirmed it is absent.
- R1 found one sequential-run listener-binding defect; the accepted repair is verified by R2.
- GitHub `Validate` passed on exact head `362022c64010abf2f122581bf699128658d0bbed`.

## Known baseline limitation

The exact-base local Full run reached the recorded Aspire integration fixture failure: `Grace.Server.Tests` used stale localhost routing while the healthy server used a dynamic port. Exact-head GitHub `Validate` passed after the #976 endpoint repair.

Closes #976
