### PR TITLE
Host Grace Server in Azure Container Apps

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -83,9 +83,9 @@ az deployment group create `
         developerPrincipalId='<developer-object-id>' `
         developerPrincipalName='<developer-upn>' `
         cosmosProvisionedThroughput=400 `
-        sqlSkuName='<provisioned-sql-sku>' `
-        sqlVCoreCapacity=1 `
-        sqlMaxSizeBytes=1073741824 `
+        sqlSkuName=GP_Gen5_2 `
+        sqlVCoreCapacity=2 `
+        sqlMaxSizeBytes=5368709120 `
         redisSkuName='<managed-redis-sku>' `
         graceServerImage=$image
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -82,7 +82,7 @@ az deployment group create `
         location=$location `
         developerPrincipalId='<developer-object-id>' `
         developerPrincipalName='<developer-upn>' `
-        cosmosProvisionedThroughput=400 `
+        cosmosProvisionedThroughput=1000 `
         sqlSkuName=GP_Gen5_2 `
         sqlVCoreCapacity=2 `
         sqlMaxSizeBytes=5368709120 `

--- a/infra/README.md
+++ b/infra/README.md
@@ -8,12 +8,101 @@ Both entry points share focused resource modules, but they make different capaci
 | Profile | Cosmos DB | Azure SQL Database | Azure Managed Redis | Intended use |
 | --- | --- | --- | --- | --- |
 | `main.lab.bicep` | Serverless | General Purpose serverless | TLS-only ACI Redis container | Short-lived infrastructure practice |
-| `main.production.bicep` | Provisioned throughput | Provisioned compute | Caller-selected SKU, two-node high availability | Development or production design input |
+| `main.production.bicep` | Provisioned throughput | Provisioned compute | Caller-selected SKU, two-node high availability | One production-shaped Grace Server deployment |
 
 The production-shaped profile deliberately has no parameter file. It requires explicit Cosmos throughput, SQL SKU and
 vCore capacity, SQL maximum size, and Redis SKU values. Those choices need workload analysis before real development or
-production deployment. It is not a complete production environment: networking, application hosting, secrets, and
-environment-specific reliability decisions remain separate work.
+production deployment. The profile also creates a Basic Azure Container Registry, one user-assigned managed identity,
+a Container Apps environment, and one externally reachable Grace Server replica. The Container App uses the identity
+to pull an immutable image without registry administrator credentials. Private networking and environment-specific
+reliability decisions remain separate work.
+
+## Build and deploy Grace Server
+
+The production container listens for HTTP on port 5000. Container Apps terminates public HTTPS and forwards requests to
+that port. A TCP startup probe checks that the process is listening; readiness and liveness probes call the existing
+`/healthz` route without changing that route's dependency semantics. The profile fixes both minimum and maximum replicas
+at one.
+
+The first deployment is intentionally explicit because the immutable image must exist before the Container App can run.
+Create the identity and registry, build the image in ACR, and then deploy the complete profile. These commands create
+billable Azure resources; review the subscription, resource group, names, cost, and cleanup plan before running them.
+
+PowerShell:
+
+```powershell
+$subscriptionId = '<subscription-id>'
+$resourceGroupName = '<resource-group-name>'
+$location = '<azure-region>'
+$environmentName = 'development'
+$deploymentSuffix = '<stable-unique-suffix>'
+$identityName = "grace-server-$environmentName-$deploymentSuffix"
+$registryName = "grace$($environmentName.Replace('-', ''))$($deploymentSuffix.Replace('-', ''))acr".ToLowerInvariant()
+
+az account set --subscription $subscriptionId
+
+az deployment group create `
+    --resource-group $resourceGroupName `
+    --name grace-server-identity `
+    --template-file ./infra/modules/managed-identity.bicep `
+    --parameters name=$identityName location=$location tags='{}'
+
+$principalId = az identity show `
+    --resource-group $resourceGroupName `
+    --name $identityName `
+    --query principalId `
+    --output tsv
+
+az deployment group create `
+    --resource-group $resourceGroupName `
+    --name grace-container-registry `
+    --template-file ./infra/modules/container-registry.bicep `
+    --parameters name=$registryName location=$location tags='{}' imagePullPrincipalId=$principalId
+
+az acr build `
+    --registry $registryName `
+    --image grace-server:tracer `
+    --file ./src/Grace.Server/Dockerfile `
+    ./src
+
+$digest = az acr repository show `
+    --name $registryName `
+    --image grace-server:tracer `
+    --query digest `
+    --output tsv
+$image = "$registryName.azurecr.io/grace-server@$digest"
+
+az deployment group create `
+    --resource-group $resourceGroupName `
+    --name grace-production `
+    --template-file ./infra/main.production.bicep `
+    --parameters `
+        environmentName=$environmentName `
+        deploymentSuffix=$deploymentSuffix `
+        location=$location `
+        developerPrincipalId='<developer-object-id>' `
+        developerPrincipalName='<developer-upn>' `
+        cosmosProvisionedThroughput=400 `
+        sqlSkuName='<provisioned-sql-sku>' `
+        sqlVCoreCapacity=1 `
+        sqlMaxSizeBytes=1073741824 `
+        redisSkuName='<managed-redis-sku>' `
+        graceServerImage=$image
+
+$fqdn = az deployment group show `
+    --resource-group $resourceGroupName `
+    --name grace-production `
+    --query properties.outputs.graceServerFqdn.value `
+    --output tsv
+
+Invoke-WebRequest -Uri "https://$fqdn/healthz"
+```
+
+The complete deployment outputs the registry login server, public Grace Server hostname, deployed revision name, and
+managed-identity client and principal IDs for later slices. Re-running the complete deployment with a new digest creates
+a new immutable Container Apps revision. Do not pass registry passwords, administrator credentials, or access tokens as
+application settings. This tracer deliberately does not activate Grace's Redis client settings; issue #983 owns the
+Azure Managed Redis authentication and readiness contract.
 
 ## Lab resources
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -8,11 +8,14 @@ Both entry points share focused resource modules, but they make different capaci
 | Profile | Cosmos DB | Azure SQL Database | Azure Managed Redis | Intended use |
 | --- | --- | --- | --- | --- |
 | `main.lab.bicep` | Serverless | General Purpose serverless | TLS-only ACI Redis container | Short-lived infrastructure practice |
-| `main.production.bicep` | Provisioned throughput | Provisioned compute | Caller-selected SKU, two-node high availability | One production-shaped Grace Server deployment |
+| `main.production.bicep` | Provisioned throughput | General Purpose serverless | Caller-selected SKU, two-node high availability | One production-shaped Grace Server deployment |
 
-The production-shaped profile deliberately has no parameter file. It requires explicit Cosmos throughput, SQL SKU and
-vCore capacity, SQL maximum size, and Redis SKU values. Those choices need workload analysis before real development or
-production deployment. The profile also creates a Basic Azure Container Registry, one user-assigned managed identity,
+The production-shaped profile deliberately has no parameter file. It requires explicit Cosmos throughput and Redis SKU
+values. Those choices need workload analysis before real development or production deployment. Azure SQL uses the
+accepted General Purpose serverless baseline: `GP_S_Gen5_1`, 0.5 minimum and 1 maximum vCore, 15-minute auto-pause, and
+32 GiB maximum data storage. The profile requests the monthly Azure SQL free allowance when the subscription is eligible
+and keeps the database online at paid serverless rates after the allowance is exhausted. The profile also creates a
+Basic Azure Container Registry, one user-assigned managed identity,
 a Container Apps environment, and one externally reachable Grace Server replica. The Container App uses the identity
 to pull an immutable image without registry administrator credentials. Private networking and environment-specific
 reliability decisions remain separate work.
@@ -83,9 +86,6 @@ az deployment group create `
         developerPrincipalId='<developer-object-id>' `
         developerPrincipalName='<developer-upn>' `
         cosmosProvisionedThroughput=1000 `
-        sqlSkuName=GP_Gen5_2 `
-        sqlVCoreCapacity=2 `
-        sqlMaxSizeBytes=5368709120 `
         redisSkuName='<managed-redis-sku>' `
         graceServerImage=$image
 
@@ -103,6 +103,12 @@ managed-identity client and principal IDs for later slices. Re-running the compl
 a new immutable Container Apps revision. Do not pass registry passwords, administrator credentials, or access tokens as
 application settings. This tracer deliberately does not activate Grace's Redis client settings; issue #983 owns the
 Azure Managed Redis authentication and readiness contract.
+
+Azure applies the SQL free allowance only when the subscription and database are eligible. The
+[current free offer](https://learn.microsoft.com/azure/azure-sql/database/free-offer) supports up to ten free-offer
+General Purpose databases per subscription. If no free-offer slot is available, resolve eligibility before deployment;
+do not change the exhaustion behavior to `AutoPause`, because that would make Grace unavailable for the rest of the
+month after the allowance is consumed.
 
 ## Lab resources
 

--- a/infra/main.production.bicep
+++ b/infra/main.production.bicep
@@ -191,5 +191,6 @@ output redisPort int = redis.outputs.port
 output containerRegistryLoginServer string = registry.outputs.loginServer
 output graceServerFqdn string = graceServer.outputs.fqdn
 output graceServerRevisionName string = graceServer.outputs.latestRevisionName
+output graceServerReadyRevisionName string = graceServer.outputs.latestReadyRevisionName
 output graceServerIdentityClientId string = identity.outputs.clientId
 output graceServerIdentityPrincipalId string = identity.outputs.principalId

--- a/infra/main.production.bicep
+++ b/infra/main.production.bicep
@@ -25,17 +25,6 @@ param developerPrincipalName string
 @minValue(400)
 param cosmosProvisionedThroughput int
 
-@description('Provisioned Azure SQL SKU name. Template evaluation rejects serverless SKU names.')
-param sqlSkuName string
-
-@description('Provisioned Azure SQL vCore capacity.')
-@minValue(1)
-param sqlVCoreCapacity int
-
-@description('Maximum Azure SQL database size in bytes.')
-@minValue(1073741824)
-param sqlMaxSizeBytes int
-
 @description('High-availability Azure Managed Redis SKU.')
 param redisSkuName string
 
@@ -51,9 +40,6 @@ param tags object = {
 
 var normalizedEnvironment = toLower(replace(environmentName, '-', ''))
 var normalizedSuffix = toLower(replace(deploymentSuffix, '-', ''))
-var validatedSqlSkuName = contains(toLower(sqlSkuName), '_s_')
-  ? fail('The production-shaped profile does not accept Azure SQL serverless SKU names.')
-  : sqlSkuName
 var storageName = take('grace${normalizedEnvironment}${normalizedSuffix}', 24)
 var cosmosName = take('grace-cosmos-${environmentName}-${normalizedSuffix}', 44)
 var serviceBusName = take('grace-sb-${environmentName}-${normalizedSuffix}', 50)
@@ -119,13 +105,17 @@ module sql 'modules/sql.bicep' = {
     administratorLogin: developerPrincipalName
     administratorObjectId: developerPrincipalId
     location: location
-    maxSizeBytes: sqlMaxSizeBytes
+    autoPauseDelayMinutes: 15
+    freeLimitExhaustionBehavior: 'BillOverUsage'
+    maxSizeBytes: 34359738368
+    minimumCapacity: '0.5'
     name: sqlServerName
-    serverless: false
-    skuCapacity: sqlVCoreCapacity
-    skuName: validatedSqlSkuName
+    serverless: true
+    skuCapacity: 1
+    skuName: 'GP_S_Gen5_1'
     tags: tags
     tenantId: tenant().tenantId
+    useFreeLimit: true
   }
 }
 

--- a/infra/main.production.bicep
+++ b/infra/main.production.bicep
@@ -39,6 +39,9 @@ param sqlMaxSizeBytes int
 @description('High-availability Azure Managed Redis SKU.')
 param redisSkuName string
 
+@description('Immutable Grace Server image in this deployment registry, including its sha256 digest.')
+param graceServerImage string
+
 @description('Common environment tags.')
 param tags object = {
   environment: environmentName
@@ -56,11 +59,28 @@ var cosmosName = take('grace-cosmos-${environmentName}-${normalizedSuffix}', 44)
 var serviceBusName = take('grace-sb-${environmentName}-${normalizedSuffix}', 50)
 var sqlServerName = take('grace-sql-${environmentName}-${normalizedSuffix}', 63)
 var redisName = take('grace-redis-${environmentName}-${normalizedSuffix}', 60)
+var registryName = take('grace${normalizedEnvironment}${normalizedSuffix}acr', 50)
+var identityName = take('grace-server-${environmentName}-${normalizedSuffix}', 128)
+var containerEnvironmentName = take('grace-${environmentName}-${normalizedSuffix}', 60)
+var containerAppName = take('grace-server-${environmentName}-${normalizedSuffix}', 32)
+var validatedGraceServerImage = contains(graceServerImage, '@sha256:')
+  ? graceServerImage
+  : fail('graceServerImage must be an immutable sha256 digest reference.')
+
+module identity 'modules/managed-identity.bicep' = {
+  name: 'grace-server-identity'
+  params: {
+    location: location
+    name: identityName
+    tags: tags
+  }
+}
 
 module storage 'modules/storage.bicep' = {
   name: 'storage'
   params: {
     developerPrincipalId: developerPrincipalId
+    graceServerPrincipalId: identity.outputs.principalId
     location: location
     name: storageName
     tags: tags
@@ -73,6 +93,7 @@ module cosmos 'modules/cosmos.bicep' = {
     containerName: 'grace-events'
     databaseName: 'grace-${environmentName}'
     developerPrincipalId: developerPrincipalId
+    graceServerPrincipalId: identity.outputs.principalId
     location: location
     name: cosmosName
     provisionedThroughput: cosmosProvisionedThroughput
@@ -85,6 +106,7 @@ module serviceBus 'modules/service-bus.bicep' = {
   name: 'service-bus'
   params: {
     developerPrincipalId: developerPrincipalId
+    graceServerPrincipalId: identity.outputs.principalId
     location: location
     name: serviceBusName
     tags: tags
@@ -118,6 +140,51 @@ module redis 'modules/redis.bicep' = {
   }
 }
 
+module registry 'modules/container-registry.bicep' = {
+  name: 'container-registry'
+  params: {
+    imagePullPrincipalId: identity.outputs.principalId
+    location: location
+    name: registryName
+    tags: tags
+  }
+}
+
+module containerEnvironment 'modules/container-app-environment.bicep' = {
+  name: 'container-app-environment'
+  params: {
+    location: location
+    name: containerEnvironmentName
+    tags: tags
+  }
+}
+
+module graceServer 'modules/container-app.bicep' = {
+  name: 'grace-server'
+  params: {
+    cosmosContainerName: cosmos.outputs.containerName
+    cosmosDatabaseName: cosmos.outputs.databaseName
+    cosmosEndpoint: cosmos.outputs.endpoint
+    environmentId: containerEnvironment.outputs.id
+    identityClientId: identity.outputs.clientId
+    identityId: identity.outputs.id
+    image: startsWith(validatedGraceServerImage, '${registry.outputs.loginServer}/')
+      ? validatedGraceServerImage
+      : fail('graceServerImage must be hosted by the registry created by this deployment.')
+    location: location
+    name: containerAppName
+    registryServer: registry.outputs.loginServer
+    serviceBusEventSubscription: serviceBus.outputs.eventSubscriptionName
+    serviceBusEventTopic: serviceBus.outputs.eventTopicName
+    serviceBusGraceUsageSubscription: serviceBus.outputs.graceUsageSubscriptionName
+    serviceBusGraceUsageTopic: serviceBus.outputs.graceUsageTopicName
+    serviceBusNamespace: '${serviceBus.outputs.namespaceName}.servicebus.windows.net'
+    sqlConnectionString: sql.outputs.entraConnectionString
+    storageAccountName: storage.outputs.accountName
+    tags: tags
+  }
+}
+
 output profile string = 'production-shaped-${environmentName}'
 output storageAccountName string = storage.outputs.accountName
 output cosmosEndpoint string = cosmos.outputs.endpoint
@@ -131,3 +198,8 @@ output serviceBusGraceUsageSubscription string = serviceBus.outputs.graceUsageSu
 output sqlConnectionString string = sql.outputs.entraConnectionString
 output redisHostName string = redis.outputs.hostName
 output redisPort int = redis.outputs.port
+output containerRegistryLoginServer string = registry.outputs.loginServer
+output graceServerFqdn string = graceServer.outputs.fqdn
+output graceServerRevisionName string = graceServer.outputs.latestRevisionName
+output graceServerIdentityClientId string = identity.outputs.clientId
+output graceServerIdentityPrincipalId string = identity.outputs.principalId

--- a/infra/modules/container-app-environment.bicep
+++ b/infra/modules/container-app-environment.bicep
@@ -1,0 +1,17 @@
+@description('Name of the Container Apps managed environment.')
+param name string
+
+@description('Azure region for the Container Apps managed environment.')
+param location string
+
+@description('Tags applied to the Container Apps managed environment.')
+param tags object
+
+resource environment 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {}
+}
+
+output id string = environment.id

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -158,3 +158,4 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
 
 output fqdn string = app.properties.configuration.ingress.fqdn
 output latestRevisionName string = app.properties.latestRevisionName
+output latestReadyRevisionName string = app.properties.latestReadyRevisionName

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -88,7 +88,14 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
             { name: 'ASPNETCORE_HTTP_PORTS', value: '5000' }
             { name: 'AZURE_CLIENT_ID', value: identityClientId }
             { name: 'grace__debug_environment', value: 'Azure' }
+            { name: 'grace__log_directory', value: '/tmp/grace-logs' }
+            { name: 'grace__pubsub__system', value: 'AzureServiceBus' }
+            { name: 'grace__orleans__clusterid', value: 'production' }
+            { name: 'grace__orleans__serviceid', value: 'grace-prod' }
             { name: 'grace__azure_storage__account_name', value: storageAccountName }
+            { name: 'grace__azure_storage__directoryversion_container_name', value: 'directoryversions' }
+            { name: 'grace__azure_storage__diff_container_name', value: 'diffs' }
+            { name: 'grace__azure_storage__zipfile_container_name', value: 'zipfiles' }
             { name: 'grace__azurecosmosdb__endpoint', value: cosmosEndpoint }
             { name: 'grace__azurecosmosdb__database_name', value: cosmosDatabaseName }
             { name: 'grace__azurecosmosdb__container_name', value: cosmosContainerName }

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -1,0 +1,153 @@
+@description('Name of the Grace Server Container App.')
+param name string
+
+@description('Azure region for Grace Server.')
+param location string
+
+@description('Tags applied to Grace Server.')
+param tags object
+
+@description('Resource ID of the Container Apps managed environment.')
+param environmentId string
+
+@description('Resource ID of the Grace Server user-assigned managed identity.')
+param identityId string
+
+@description('Client ID of the Grace Server user-assigned managed identity.')
+param identityClientId string
+
+@description('Azure Container Registry login server.')
+param registryServer string
+
+@description('Immutable Grace Server image reference, including its sha256 digest.')
+param image string
+
+@description('Azure Storage account name used by Orleans and Grace storage.')
+param storageAccountName string
+
+@description('Azure Cosmos DB endpoint.')
+param cosmosEndpoint string
+
+@description('Azure Cosmos DB database name.')
+param cosmosDatabaseName string
+
+@description('Azure Cosmos DB container name.')
+param cosmosContainerName string
+
+@description('Service Bus namespace hostname.')
+param serviceBusNamespace string
+
+@description('Grace event stream topic name.')
+param serviceBusEventTopic string
+
+@description('Grace Server event stream subscription name.')
+param serviceBusEventSubscription string
+
+@description('Grace usage topic name.')
+param serviceBusGraceUsageTopic string
+
+@description('Grace usage processor subscription name.')
+param serviceBusGraceUsageSubscription string
+
+@description('Microsoft Entra Azure SQL connection string.')
+param sqlConnectionString string
+
+resource app 'Microsoft.App/containerApps@2024-03-01' = {
+  name: name
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${identityId}': {}
+    }
+  }
+  properties: {
+    environmentId: environmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      ingress: {
+        allowInsecure: false
+        external: true
+        targetPort: 5000
+        transport: 'http'
+      }
+      registries: [
+        {
+          identity: identityId
+          server: registryServer
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'grace-server'
+          image: image
+          env: [
+            { name: 'ASPNETCORE_HTTP_PORTS', value: '5000' }
+            { name: 'AZURE_CLIENT_ID', value: identityClientId }
+            { name: 'grace__debug_environment', value: 'Azure' }
+            { name: 'grace__azure_storage__account_name', value: storageAccountName }
+            { name: 'grace__azurecosmosdb__endpoint', value: cosmosEndpoint }
+            { name: 'grace__azurecosmosdb__database_name', value: cosmosDatabaseName }
+            { name: 'grace__azurecosmosdb__container_name', value: cosmosContainerName }
+            { name: 'grace__azure_service_bus__namespace', value: serviceBusNamespace }
+            { name: 'grace__azure_service_bus__topic', value: serviceBusEventTopic }
+            { name: 'grace__azure_service_bus__subscription', value: serviceBusEventSubscription }
+            { name: 'grace__azure_service_bus__operational_facts_topic', value: serviceBusGraceUsageTopic }
+            {
+              name: 'grace__azure_service_bus__operational_facts_processor_subscription'
+              value: serviceBusGraceUsageSubscription
+            }
+            { name: 'grace__operations__sql__connectionstring', value: sqlConnectionString }
+          ]
+          probes: [
+            {
+              type: 'Startup'
+              tcpSocket: {
+                port: 5000
+              }
+              initialDelaySeconds: 1
+              periodSeconds: 5
+              failureThreshold: 30
+            }
+            {
+              type: 'Readiness'
+              httpGet: {
+                path: '/healthz'
+                port: 5000
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              failureThreshold: 3
+            }
+            {
+              type: 'Liveness'
+              httpGet: {
+                path: '/healthz'
+                port: 5000
+                scheme: 'HTTP'
+              }
+              initialDelaySeconds: 15
+              periodSeconds: 30
+              failureThreshold: 3
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 1
+      }
+    }
+  }
+}
+
+output fqdn string = app.properties.configuration.ingress.fqdn
+output latestRevisionName string = app.properties.latestRevisionName

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -1,0 +1,44 @@
+@description('Globally unique Azure Container Registry name.')
+param name string
+
+@description('Azure region for the registry.')
+param location string
+
+@description('Tags applied to the registry.')
+param tags object
+
+@description('Object ID of the managed identity that pulls Grace Server images.')
+param imagePullPrincipalId string
+
+var acrPullRoleDefinitionId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+)
+
+resource registry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    adminUserEnabled: false
+    dataEndpointEnabled: false
+    publicNetworkAccess: 'Enabled'
+    zoneRedundancy: 'Disabled'
+  }
+}
+
+resource imagePullAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(registry.id, imagePullPrincipalId, acrPullRoleDefinitionId)
+  scope: registry
+  properties: {
+    principalId: imagePullPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: acrPullRoleDefinitionId
+  }
+}
+
+output id string = registry.id
+output loginServer string = registry.properties.loginServer

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -17,6 +17,9 @@ param provisionedThroughput int = 400
 @description('Microsoft Entra principal that runs Grace during infrastructure validation.')
 param developerPrincipalId string
 
+@description('Optional managed-identity principal that runs Grace Server.')
+param graceServerPrincipalId string = ''
+
 @description('Grace Cosmos DB database name.')
 param databaseName string = 'grace-dev'
 
@@ -103,6 +106,16 @@ resource developerAccess 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignmen
   name: guid(account.id, developerPrincipalId, cosmosDataContributorRoleDefinitionId)
   properties: {
     principalId: developerPrincipalId
+    roleDefinitionId: cosmosDataContributorRoleDefinitionId
+    scope: account.id
+  }
+}
+
+resource graceServerAccess 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = if (!empty(graceServerPrincipalId)) {
+  parent: account
+  name: guid(account.id, graceServerPrincipalId, cosmosDataContributorRoleDefinitionId)
+  properties: {
+    principalId: graceServerPrincipalId
     roleDefinitionId: cosmosDataContributorRoleDefinitionId
     scope: account.id
   }

--- a/infra/modules/managed-identity.bicep
+++ b/infra/modules/managed-identity.bicep
@@ -1,0 +1,18 @@
+@description('Name of the user-assigned managed identity.')
+param name string
+
+@description('Azure region for the managed identity.')
+param location string
+
+@description('Tags applied to the managed identity.')
+param tags object
+
+resource identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: name
+  location: location
+  tags: tags
+}
+
+output id string = identity.id
+output clientId string = identity.properties.clientId
+output principalId string = identity.properties.principalId

--- a/infra/modules/service-bus.bicep
+++ b/infra/modules/service-bus.bicep
@@ -10,6 +10,9 @@ param tags object
 @description('Microsoft Entra principal that runs Grace during infrastructure validation.')
 param developerPrincipalId string
 
+@description('Optional managed-identity principal that runs Grace Server.')
+param graceServerPrincipalId string = ''
+
 @description('Grace event stream topic name.')
 param eventTopicName string = 'graceeventstream'
 
@@ -107,6 +110,16 @@ resource developerAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
   properties: {
     principalId: developerPrincipalId
     principalType: 'User'
+    roleDefinitionId: serviceBusDataOwnerRoleId
+  }
+}
+
+resource graceServerAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(graceServerPrincipalId)) {
+  name: guid(serviceBus.id, graceServerPrincipalId, serviceBusDataOwnerRoleId)
+  scope: serviceBus
+  properties: {
+    principalId: graceServerPrincipalId
+    principalType: 'ServicePrincipal'
     roleDefinitionId: serviceBusDataOwnerRoleId
   }
 }

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -36,6 +36,26 @@ param skuCapacity int
 @minValue(1073741824)
 param maxSizeBytes int
 
+@description('Idle minutes before a serverless database automatically pauses.')
+@minValue(15)
+param autoPauseDelayMinutes int = 60
+
+@description('Minimum vCore capacity available to a serverless database.')
+@allowed([
+  '0.5'
+])
+param minimumCapacity string = '0.5'
+
+@description('Whether to apply the Azure SQL monthly free allowance when the subscription is eligible.')
+param useFreeLimit bool = false
+
+@description('Behavior after an eligible database exhausts its monthly free allowance.')
+@allowed([
+  'AutoPause'
+  'BillOverUsage'
+])
+param freeLimitExhaustionBehavior string = 'AutoPause'
+
 @description('Optional public client IPv4 address allowed to connect to the lab database.')
 param clientIpAddress string = ''
 
@@ -89,8 +109,10 @@ resource database 'Microsoft.Sql/servers/databases@2025-01-01' = {
       zoneRedundant: false
     },
     serverless ? {
-      autoPauseDelay: 60
-      minCapacity: json('0.5')
+      autoPauseDelay: autoPauseDelayMinutes
+      freeLimitExhaustionBehavior: freeLimitExhaustionBehavior
+      minCapacity: json(minimumCapacity)
+      useFreeLimit: useFreeLimit
     } : {}
   )
 }

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -10,6 +10,9 @@ param tags object
 @description('Microsoft Entra principal that runs Grace during infrastructure validation.')
 param developerPrincipalId string
 
+@description('Optional managed-identity principal that runs Grace Server.')
+param graceServerPrincipalId string = ''
+
 var storageBlobDataContributorRoleId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions',
   'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
@@ -79,6 +82,26 @@ resource blobAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
     principalId: developerPrincipalId
     principalType: 'User'
     roleDefinitionId: storageBlobDataContributorRoleId
+  }
+}
+
+resource graceServerBlobAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(graceServerPrincipalId)) {
+  name: guid(account.id, graceServerPrincipalId, storageBlobDataContributorRoleId)
+  scope: account
+  properties: {
+    principalId: graceServerPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataContributorRoleId
+  }
+}
+
+resource graceServerTableAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(graceServerPrincipalId)) {
+  name: guid(account.id, graceServerPrincipalId, storageTableDataContributorRoleId)
+  scope: account
+  properties: {
+    principalId: graceServerPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageTableDataContributorRoleId
   }
 }
 

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -101,6 +101,7 @@ Assert-Pattern $productionTemplate "modules/container-app\.bicep" 'The productio
 Assert-Pattern $productionTemplate 'param\s+graceServerImage\s+string(\s|$)' 'The production-shaped profile must require an immutable Grace Server image.'
 Assert-Pattern $productionTemplate "startsWith\(validatedGraceServerImage, '\$\{registry\.outputs\.loginServer\}/'\)" 'Grace Server must use the registry created by its deployment.'
 Assert-Pattern $productionTemplate 'output\s+graceServerFqdn\s+string' 'The production-shaped profile must expose the Grace Server hostname.'
+Assert-Pattern $productionTemplate 'output\s+graceServerReadyRevisionName\s+string\s*=\s*graceServer\.outputs\.latestReadyRevisionName' 'The production-shaped profile must expose the latest ready Grace Server revision.'
 Assert-Pattern $productionTemplate 'output\s+graceServerIdentityClientId\s+string' 'The production-shaped profile must expose the Grace Server identity client ID.'
 Assert-Pattern $productionTemplate 'output\s+graceServerIdentityPrincipalId\s+string' 'The production-shaped profile must expose the Grace Server identity principal ID.'
 

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -7,6 +7,7 @@ $ErrorActionPreference = 'Stop'
 $infraRoot = Split-Path -Parent $PSScriptRoot
 $labTemplatePath = Join-Path $infraRoot 'main.lab.bicep'
 $productionTemplatePath = Join-Path $infraRoot 'main.production.bicep'
+$infraReadmePath = Join-Path $infraRoot 'README.md'
 $serviceBusModulePath = Join-Path $infraRoot 'modules\service-bus.bicep'
 $containerAppModulePath = Join-Path $infraRoot 'modules\container-app.bicep'
 $containerRegistryModulePath = Join-Path $infraRoot 'modules\container-registry.bicep'
@@ -67,6 +68,7 @@ $containerRegistryModule = Get-Content -LiteralPath $containerRegistryModulePath
 $redisContainerModule = Get-Content -LiteralPath $redisContainerModulePath -Raw
 $labRunner = Get-Content -LiteralPath $labRunnerPath -Raw
 $graceServerDockerfile = Get-Content -LiteralPath $graceServerDockerfilePath -Raw
+$infraReadme = Get-Content -LiteralPath $infraReadmePath -Raw
 
 Assert-Pattern $labTemplate 'serverless:\s*true' 'The lab profile must use serverless Cosmos and SQL modules.'
 Assert-Pattern $labTemplate "skuName:\s*'GP_S_Gen5_1'" 'The lab profile must use the agreed SQL serverless SKU.'
@@ -109,6 +111,8 @@ Assert-Pattern $graceServerDockerfile 'FROM\s+mcr\.microsoft\.com/dotnet/aspnet:
 Assert-Pattern $graceServerDockerfile 'dotnet publish[^\r\n]+-c Release' 'The production image must publish Grace Server in Release mode.'
 Assert-Pattern $graceServerDockerfile '/p:DebugSymbols=false' 'The production image must exclude debug symbols.'
 Assert-PatternAbsent $graceServerDockerfile 'dotnet tool install|dotnet/sdk:10\.0-preview|nano|dotnet-monitor' 'The production image must exclude debug SDK tooling.'
+
+Assert-Pattern $infraReadme 'sqlSkuName=GP_Gen5_2[\s\S]*sqlVCoreCapacity=2[\s\S]*sqlMaxSizeBytes=5368709120' 'The production deployment example must use an available West US 2 provisioned SQL configuration.'
 
 Assert-Pattern $redisContainerModule 'Microsoft\.ContainerInstance/containerGroups' 'The lab Redis module must deploy Azure Container Instances.'
 Assert-Pattern $redisContainerModule "image string = 'redis:7\.4-alpine'" 'The lab Redis module must pin its disposable Redis image tag.'

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -9,6 +9,7 @@ $labTemplatePath = Join-Path $infraRoot 'main.lab.bicep'
 $productionTemplatePath = Join-Path $infraRoot 'main.production.bicep'
 $infraReadmePath = Join-Path $infraRoot 'README.md'
 $serviceBusModulePath = Join-Path $infraRoot 'modules\service-bus.bicep'
+$sqlModulePath = Join-Path $infraRoot 'modules\sql.bicep'
 $containerAppModulePath = Join-Path $infraRoot 'modules\container-app.bicep'
 $containerRegistryModulePath = Join-Path $infraRoot 'modules\container-registry.bicep'
 $redisContainerModulePath = Join-Path $infraRoot 'modules\redis-container.bicep'
@@ -63,6 +64,7 @@ function Assert-PatternAbsent {
 $labTemplate = Get-Content -LiteralPath $labTemplatePath -Raw
 $productionTemplate = Get-Content -LiteralPath $productionTemplatePath -Raw
 $serviceBusModule = Get-Content -LiteralPath $serviceBusModulePath -Raw
+$sqlModule = Get-Content -LiteralPath $sqlModulePath -Raw
 $containerAppModule = Get-Content -LiteralPath $containerAppModulePath -Raw
 $containerRegistryModule = Get-Content -LiteralPath $containerRegistryModulePath -Raw
 $redisContainerModule = Get-Content -LiteralPath $redisContainerModulePath -Raw
@@ -75,13 +77,23 @@ Assert-Pattern $labTemplate "skuName:\s*'GP_S_Gen5_1'" 'The lab profile must use
 Assert-Pattern $labTemplate "modules/redis-container\.bicep" 'The lab profile must use the disposable Redis container module.'
 Assert-PatternAbsent $labTemplate "modules/redis\.bicep" 'The lab profile must not deploy Azure Managed Redis.'
 
-Assert-Pattern $productionTemplate 'serverless:\s*false' 'The production-shaped profile must use provisioned Cosmos and SQL modules.'
+Assert-Pattern $productionTemplate 'serverless:\s*false' 'The production-shaped profile must use provisioned Cosmos throughput.'
 Assert-Pattern $productionTemplate 'param\s+cosmosProvisionedThroughput\s+int(\s|$)' 'The production-shaped profile must require Cosmos throughput.'
-Assert-Pattern $productionTemplate 'param\s+sqlSkuName\s+string(\s|$)' 'The production-shaped profile must require a SQL SKU.'
-Assert-Pattern $productionTemplate 'validatedSqlSkuName' 'The production-shaped profile must reject SQL serverless SKU names.'
+Assert-Pattern $productionTemplate "skuName:\s*'GP_S_Gen5_1'" 'The production-shaped profile must use the approved General Purpose serverless SQL SKU.'
+Assert-Pattern $productionTemplate 'skuCapacity:\s*1' 'The production-shaped profile must cap SQL serverless compute at one vCore.'
+Assert-Pattern $productionTemplate 'maxSizeBytes:\s*34359738368' 'The production-shaped profile must cap SQL data storage at 32 GiB.'
+Assert-Pattern $productionTemplate 'autoPauseDelayMinutes:\s*15' 'The production-shaped profile must auto-pause SQL after 15 idle minutes.'
+Assert-Pattern $productionTemplate "minimumCapacity:\s*'0\.5'" 'The production-shaped profile must set the SQL minimum capacity to 0.5 vCore.'
+Assert-Pattern $productionTemplate 'useFreeLimit:\s*true' 'The production-shaped profile must request the SQL free offer when eligible.'
+Assert-Pattern $productionTemplate "freeLimitExhaustionBehavior:\s*'BillOverUsage'" 'The production-shaped profile must remain online and bill at serverless rates after the free allowance.'
 Assert-Pattern $productionTemplate 'param\s+redisSkuName\s+string(\s|$)' 'The production-shaped profile must require a Redis SKU.'
 Assert-Pattern $productionTemplate 'highAvailability:\s*true' 'The production-shaped profile must enable Redis high availability.'
-Assert-PatternAbsent $productionTemplate "skuName:\s*'GP_S_" 'The production-shaped profile must not embed a SQL serverless SKU.'
+
+Assert-Pattern $sqlModule "Microsoft\.Sql/servers/databases@2025-01-01" 'The SQL module must use the API version that supports free-limit behavior.'
+Assert-Pattern $sqlModule 'autoPauseDelay:\s*autoPauseDelayMinutes' 'The SQL module must apply the selected auto-pause delay.'
+Assert-Pattern $sqlModule 'minCapacity:\s*json\(minimumCapacity\)' 'The SQL module must apply the selected serverless minimum capacity.'
+Assert-Pattern $sqlModule 'useFreeLimit:\s*useFreeLimit' 'The SQL module must apply free-offer eligibility.'
+Assert-Pattern $sqlModule 'freeLimitExhaustionBehavior:\s*freeLimitExhaustionBehavior' 'The SQL module must apply the selected free-limit exhaustion behavior.'
 Assert-Pattern $productionTemplate "modules/container-registry\.bicep" 'The production-shaped profile must deploy Azure Container Registry.'
 Assert-Pattern $productionTemplate "modules/managed-identity\.bicep" 'The production-shaped profile must deploy a user-assigned managed identity.'
 Assert-Pattern $productionTemplate "modules/container-app-environment\.bicep" 'The production-shaped profile must deploy a Container Apps environment.'
@@ -113,7 +125,7 @@ Assert-Pattern $graceServerDockerfile '/p:DebugSymbols=false' 'The production im
 Assert-PatternAbsent $graceServerDockerfile 'dotnet tool install|dotnet/sdk:10\.0-preview|nano|dotnet-monitor' 'The production image must exclude debug SDK tooling.'
 
 Assert-Pattern $infraReadme 'cosmosProvisionedThroughput=1000' 'The production deployment example must use the accepted 1,000 RU/s manual Cosmos throughput.'
-Assert-Pattern $infraReadme 'sqlSkuName=GP_Gen5_2[\s\S]*sqlVCoreCapacity=2[\s\S]*sqlMaxSizeBytes=5368709120' 'The production deployment example must use an available West US 2 provisioned SQL configuration.'
+Assert-PatternAbsent $infraReadme 'sqlSkuName=|sqlVCoreCapacity=|sqlMaxSizeBytes=' 'The deployment example must not override the approved SQL serverless baseline.'
 
 Assert-Pattern $redisContainerModule 'Microsoft\.ContainerInstance/containerGroups' 'The lab Redis module must deploy Azure Container Instances.'
 Assert-Pattern $redisContainerModule "image string = 'redis:7\.4-alpine'" 'The lab Redis module must pin its disposable Redis image tag.'

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -8,10 +8,13 @@ $infraRoot = Split-Path -Parent $PSScriptRoot
 $labTemplatePath = Join-Path $infraRoot 'main.lab.bicep'
 $productionTemplatePath = Join-Path $infraRoot 'main.production.bicep'
 $serviceBusModulePath = Join-Path $infraRoot 'modules\service-bus.bicep'
+$containerAppModulePath = Join-Path $infraRoot 'modules\container-app.bicep'
+$containerRegistryModulePath = Join-Path $infraRoot 'modules\container-registry.bicep'
 $redisContainerModulePath = Join-Path $infraRoot 'modules\redis-container.bicep'
 $labRunnerPath = Join-Path (Split-Path -Parent $infraRoot) 'scripts\Invoke-GraceInfrastructureLab.ps1'
 $startDebugAzurePath = Join-Path (Split-Path -Parent $infraRoot) 'scripts\start-debugazure.ps1'
 $inventoryAssertionsPath = Join-Path (Split-Path -Parent $infraRoot) 'scripts\GraceInfrastructureLab.Inventory.ps1'
+$graceServerDockerfilePath = Join-Path (Split-Path -Parent $infraRoot) 'src\Grace.Server\Dockerfile'
 . $inventoryAssertionsPath
 
 function Assert-Pattern {
@@ -59,8 +62,11 @@ function Assert-PatternAbsent {
 $labTemplate = Get-Content -LiteralPath $labTemplatePath -Raw
 $productionTemplate = Get-Content -LiteralPath $productionTemplatePath -Raw
 $serviceBusModule = Get-Content -LiteralPath $serviceBusModulePath -Raw
+$containerAppModule = Get-Content -LiteralPath $containerAppModulePath -Raw
+$containerRegistryModule = Get-Content -LiteralPath $containerRegistryModulePath -Raw
 $redisContainerModule = Get-Content -LiteralPath $redisContainerModulePath -Raw
 $labRunner = Get-Content -LiteralPath $labRunnerPath -Raw
+$graceServerDockerfile = Get-Content -LiteralPath $graceServerDockerfilePath -Raw
 
 Assert-Pattern $labTemplate 'serverless:\s*true' 'The lab profile must use serverless Cosmos and SQL modules.'
 Assert-Pattern $labTemplate "skuName:\s*'GP_S_Gen5_1'" 'The lab profile must use the agreed SQL serverless SKU.'
@@ -74,6 +80,35 @@ Assert-Pattern $productionTemplate 'validatedSqlSkuName' 'The production-shaped 
 Assert-Pattern $productionTemplate 'param\s+redisSkuName\s+string(\s|$)' 'The production-shaped profile must require a Redis SKU.'
 Assert-Pattern $productionTemplate 'highAvailability:\s*true' 'The production-shaped profile must enable Redis high availability.'
 Assert-PatternAbsent $productionTemplate "skuName:\s*'GP_S_" 'The production-shaped profile must not embed a SQL serverless SKU.'
+Assert-Pattern $productionTemplate "modules/container-registry\.bicep" 'The production-shaped profile must deploy Azure Container Registry.'
+Assert-Pattern $productionTemplate "modules/managed-identity\.bicep" 'The production-shaped profile must deploy a user-assigned managed identity.'
+Assert-Pattern $productionTemplate "modules/container-app-environment\.bicep" 'The production-shaped profile must deploy a Container Apps environment.'
+Assert-Pattern $productionTemplate "modules/container-app\.bicep" 'The production-shaped profile must deploy Grace Server as a Container App.'
+Assert-Pattern $productionTemplate 'param\s+graceServerImage\s+string(\s|$)' 'The production-shaped profile must require an immutable Grace Server image.'
+Assert-Pattern $productionTemplate "startsWith\(validatedGraceServerImage, '\$\{registry\.outputs\.loginServer\}/'\)" 'Grace Server must use the registry created by its deployment.'
+Assert-Pattern $productionTemplate 'output\s+graceServerFqdn\s+string' 'The production-shaped profile must expose the Grace Server hostname.'
+Assert-Pattern $productionTemplate 'output\s+graceServerIdentityClientId\s+string' 'The production-shaped profile must expose the Grace Server identity client ID.'
+Assert-Pattern $productionTemplate 'output\s+graceServerIdentityPrincipalId\s+string' 'The production-shaped profile must expose the Grace Server identity principal ID.'
+
+Assert-Pattern $containerRegistryModule 'adminUserEnabled:\s*false' 'The registry must not enable administrator credentials.'
+Assert-Pattern $containerRegistryModule '7f951dda-4ed3-4680-a7ca-43fe172d538d' 'The registry module must grant managed-identity AcrPull access.'
+Assert-Pattern $containerAppModule 'minReplicas:\s*1' 'Grace Server must keep exactly one minimum replica.'
+Assert-Pattern $containerAppModule 'maxReplicas:\s*1' 'Grace Server must keep exactly one maximum replica.'
+Assert-Pattern $containerAppModule "external:\s*true" 'Grace Server must expose external HTTPS ingress.'
+Assert-Pattern $containerAppModule 'targetPort:\s*5000' 'Grace Server ingress must target its documented HTTP port.'
+Assert-Pattern $containerAppModule 'registries:\s*\[[\s\S]*identity:\s*identityId' 'Grace Server must use its managed identity for registry pulls.'
+Assert-Pattern $containerAppModule "name:\s*'AZURE_CLIENT_ID'" 'Grace Server must select its user-assigned identity at runtime.'
+Assert-Pattern $containerAppModule "type:\s*'Startup'" 'Grace Server must have a startup probe.'
+Assert-Pattern $containerAppModule "type:\s*'Readiness'" 'Grace Server must have a readiness probe.'
+Assert-Pattern $containerAppModule "type:\s*'Liveness'" 'Grace Server must have a liveness probe.'
+Assert-Pattern $containerAppModule "path:\s*'/healthz'" 'Grace Server HTTP probes must use the existing health endpoint.'
+Assert-PatternAbsent $containerAppModule '(registryPassword|passwordSecretRef|adminUserEnabled:\s*true)' 'The Container App must not use registry credentials.'
+Assert-PatternAbsent $containerAppModule 'grace__redis__' 'The Container App tracer must not activate Redis before issue #983 supplies its managed-identity contract.'
+
+Assert-Pattern $graceServerDockerfile 'FROM\s+mcr\.microsoft\.com/dotnet/aspnet:10\.0\s+AS\s+final' 'The production image must use the ASP.NET runtime image.'
+Assert-Pattern $graceServerDockerfile 'dotnet publish[^\r\n]+-c Release' 'The production image must publish Grace Server in Release mode.'
+Assert-Pattern $graceServerDockerfile '/p:DebugSymbols=false' 'The production image must exclude debug symbols.'
+Assert-PatternAbsent $graceServerDockerfile 'dotnet tool install|dotnet/sdk:10\.0-preview|nano|dotnet-monitor' 'The production image must exclude debug SDK tooling.'
 
 Assert-Pattern $redisContainerModule 'Microsoft\.ContainerInstance/containerGroups' 'The lab Redis module must deploy Azure Container Instances.'
 Assert-Pattern $redisContainerModule "image string = 'redis:7\.4-alpine'" 'The lab Redis module must pin its disposable Redis image tag.'

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -112,6 +112,7 @@ Assert-Pattern $graceServerDockerfile 'dotnet publish[^\r\n]+-c Release' 'The pr
 Assert-Pattern $graceServerDockerfile '/p:DebugSymbols=false' 'The production image must exclude debug symbols.'
 Assert-PatternAbsent $graceServerDockerfile 'dotnet tool install|dotnet/sdk:10\.0-preview|nano|dotnet-monitor' 'The production image must exclude debug SDK tooling.'
 
+Assert-Pattern $infraReadme 'cosmosProvisionedThroughput=1000' 'The production deployment example must use the accepted 1,000 RU/s manual Cosmos throughput.'
 Assert-Pattern $infraReadme 'sqlSkuName=GP_Gen5_2[\s\S]*sqlVCoreCapacity=2[\s\S]*sqlMaxSizeBytes=5368709120' 'The production deployment example must use an available West US 2 provisioned SQL configuration.'
 
 Assert-Pattern $redisContainerModule 'Microsoft\.ContainerInstance/containerGroups' 'The lab Redis module must deploy Azure Container Instances.'

--- a/src/Grace.Server/Dockerfile
+++ b/src/Grace.Server/Dockerfile
@@ -1,44 +1,24 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk@sha256:ea8bde36c11b6e7eec2656d0e59101d4462f6bd630730f2c8201ed0572b295d5 AS build
 WORKDIR /src
 
-# Restoring individual projects to take advantage of layer caching.
+# Cache the Grace Server project graph restore separately from source changes.
 COPY ["nuget.config", "nuget.config"]
-
-COPY ["Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj", "Grace.Aspire.ServiceDefaults/"]
-RUN dotnet restore "Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj"
-COPY Grace.Aspire.ServiceDefaults/ Grace.Aspire.ServiceDefaults/
-RUN dotnet build "Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj" --no-restore -c Release
-
+COPY ["Directory.Build.props", "Directory.Build.props"]
 COPY ["Grace.Types/Grace.Types.fsproj", "Grace.Types/"]
 COPY ["Grace.Shared/Grace.Shared.fsproj", "Grace.Shared/"]
-RUN dotnet restore "Grace.Types/Grace.Types.fsproj"
+COPY ["Grace.Actors/Grace.Actors.fsproj", "Grace.Actors/"]
+COPY ["Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj", "Grace.Orleans.CodeGen/"]
+COPY ["Grace.Server/Grace.Server.fsproj", "Grace.Server/"]
+RUN dotnet restore "Grace.Server/Grace.Server.fsproj" --runtime linux-x64
+
 COPY Grace.Types/ Grace.Types/
 COPY Grace.Shared/ Grace.Shared/
-RUN dotnet build "Grace.Types/Grace.Types.fsproj" --no-restore -c Release
-
-RUN dotnet restore "Grace.Shared/Grace.Shared.fsproj"
-COPY Grace.Shared/ Grace.Shared/
-RUN dotnet build "Grace.Shared/Grace.Shared.fsproj" --no-restore -c Release
-
-COPY ["Grace.Actors/Grace.Actors.fsproj", "Grace.Actors/"]
-RUN dotnet restore "Grace.Actors/Grace.Actors.fsproj"
 COPY Grace.Actors/ Grace.Actors/
-RUN dotnet build "Grace.Actors/Grace.Actors.fsproj" --no-restore -c Release
-
-COPY ["Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj", "Grace.Orleans.CodeGen/"]
-RUN dotnet restore "Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj"
 COPY Grace.Orleans.CodeGen/ Grace.Orleans.CodeGen/
-RUN dotnet build "Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj" --no-restore -c Release
-
-COPY ["Grace.Server/Grace.Server.fsproj", "Grace.Server/"]
-RUN dotnet restore "Grace.Server/Grace.Server.fsproj"
 COPY Grace.Server/ Grace.Server/
-RUN dotnet build "Grace.Server/Grace.Server.fsproj" --no-restore -c Release
-
-COPY Grace.Server/web.config /app/publish/web.config
 
 FROM build AS publish
-RUN dotnet publish "Grace.Server/Grace.Server.fsproj" -c Release -o /app/publish --verbosity m /p:UseAppHost=false /p:DebugType=None /p:DebugSymbols=false /p:PublishProfile=Properties/PublishProfiles/DisableContainerBuild.pubxml
+RUN dotnet publish "Grace.Server/Grace.Server.fsproj" --no-restore -c Release -o /app/publish --verbosity m /p:UseAppHost=false /p:DebugType=None /p:DebugSymbols=false /p:PublishProfile=Properties/PublishProfiles/DisableContainerBuild.pubxml
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app

--- a/src/Grace.Server/Dockerfile
+++ b/src/Grace.Server/Dockerfile
@@ -1,65 +1,4 @@
-#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-# Using the SDK image as the base instead of the aspnet image lets us run a shell for debugging.
-FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS base
-WORKDIR /app
-EXPOSE 5000
-EXPOSE 5001
-
-# Install required packages for a better terminal experience
-RUN apt-get update && apt-get install -y \
-    bash \
-    readline-common \
-    locales \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set locale to avoid character encoding issues
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LC_ALL=en_US.UTF-8
-
-# Set bash as the default shell
-SHELL ["/bin/bash", "-c"]
-
-# Add default bashrc with history and keybinding configurations
-RUN echo 'export PS1="\\u@\\h:\\w\\$ "' >> /etc/bash.bashrc && \
-    echo "HISTFILE=/root/.bash_history" >> /etc/bash.bashrc && \
-    echo "HISTSIZE=1000" >> /etc/bash.bashrc && \
-    echo "HISTFILESIZE=2000" >> /etc/bash.bashrc
-
-# Add .inputrc for keybinding corrections (up-arrow and others)
-RUN echo '"\e[A": history-search-backward' >> /root/.inputrc && \
-    echo '"\e[B": history-search-forward' >> /root/.inputrc && \
-    echo '"\e[C": forward-char' >> /root/.inputrc && \
-    echo '"\e[D": backward-char' >> /root/.inputrc
-
-# Optional: Install nano or other text editors for better usability
-RUN apt-get update && apt-get install -y nano && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Make sure bash is used as the default shell in interactive mode
-CMD ["/bin/bash"]
-
-# Set the PATH environment variable to include the dotnet tools directory
-ENV PATH="$PATH:/root/.dotnet/tools"
-
-# Set environment variables to configure ASP.NET Core
-ENV ASPNETCORE_HTTPS_PORT=5001
-ENV ASPNETCORE_HTTP_PORT=5000
-ENV DOTNET_GENERATE_ASPNET_CERTIFICATE=true
-ENV DOTNET_EnableDiagnostics=1
-
-# Install the dotnet tools globally
-RUN dotnet tool install dotnet-dump -g --verbosity q
-RUN dotnet tool install dotnet-gcdump -g --verbosity q
-RUN dotnet tool install dotnet-trace -g --verbosity q
-RUN dotnet tool install dotnet-counters -g --verbosity q
-RUN dotnet tool install dotnet-monitor -g --verbosity q
-
-#================================================================================================
-
-FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Restoring individual projects to take advantage of layer caching.
@@ -68,57 +7,43 @@ COPY ["nuget.config", "nuget.config"]
 COPY ["Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj", "Grace.Aspire.ServiceDefaults/"]
 RUN dotnet restore "Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj"
 COPY Grace.Aspire.ServiceDefaults/ Grace.Aspire.ServiceDefaults/
-RUN dotnet build "Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj" --no-restore -c Debug /p:DebugType=full
-
-COPY ["CosmosSerializer/CosmosJsonSerializer.csproj", "CosmosSerializer/"]
-RUN dotnet restore "CosmosSerializer/CosmosJsonSerializer.csproj"
-COPY CosmosSerializer/ CosmosSerializer/
-RUN dotnet build "CosmosSerializer/CosmosJsonSerializer.csproj" --no-restore -c Debug /p:DebugType=full
+RUN dotnet build "Grace.Aspire.ServiceDefaults/Grace.Aspire.ServiceDefaults.csproj" --no-restore -c Release
 
 COPY ["Grace.Types/Grace.Types.fsproj", "Grace.Types/"]
 COPY ["Grace.Shared/Grace.Shared.fsproj", "Grace.Shared/"]
 RUN dotnet restore "Grace.Types/Grace.Types.fsproj"
 COPY Grace.Types/ Grace.Types/
 COPY Grace.Shared/ Grace.Shared/
-RUN dotnet build "Grace.Types/Grace.Types.fsproj" --no-restore -c Debug /p:DebugType=full
+RUN dotnet build "Grace.Types/Grace.Types.fsproj" --no-restore -c Release
 
 RUN dotnet restore "Grace.Shared/Grace.Shared.fsproj"
 COPY Grace.Shared/ Grace.Shared/
-RUN dotnet build "Grace.Shared/Grace.Shared.fsproj" --no-restore -c Debug /p:DebugType=full
+RUN dotnet build "Grace.Shared/Grace.Shared.fsproj" --no-restore -c Release
 
 COPY ["Grace.Actors/Grace.Actors.fsproj", "Grace.Actors/"]
 RUN dotnet restore "Grace.Actors/Grace.Actors.fsproj"
 COPY Grace.Actors/ Grace.Actors/
-RUN dotnet build "Grace.Actors/Grace.Actors.fsproj" --no-restore -c Debug /p:DebugType=full
+RUN dotnet build "Grace.Actors/Grace.Actors.fsproj" --no-restore -c Release
 
 COPY ["Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj", "Grace.Orleans.CodeGen/"]
 RUN dotnet restore "Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj"
 COPY Grace.Orleans.CodeGen/ Grace.Orleans.CodeGen/
-RUN dotnet build "Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj" --no-restore -c Debug /p:DebugType=full
+RUN dotnet build "Grace.Orleans.CodeGen/Grace.Orleans.CodeGen.csproj" --no-restore -c Release
 
 COPY ["Grace.Server/Grace.Server.fsproj", "Grace.Server/"]
 RUN dotnet restore "Grace.Server/Grace.Server.fsproj"
 COPY Grace.Server/ Grace.Server/
-RUN dotnet build "Grace.Server/Grace.Server.fsproj" --no-restore -c Debug /p:DebugType=full
+RUN dotnet build "Grace.Server/Grace.Server.fsproj" --no-restore -c Release
 
 COPY Grace.Server/web.config /app/publish/web.config
 
-#================================================================================================
-
 FROM build AS publish
-RUN dotnet publish "Grace.Server/Grace.Server.fsproj" -c Debug -o /app/publish --verbosity m --no-build /p:UseAppHost=false /p:PublishProfile=Properties/PublishProfiles/DisableContainerBuild.pubxml
-#RUN ls -alR /app/publish
+RUN dotnet publish "Grace.Server/Grace.Server.fsproj" -c Release -o /app/publish --verbosity m /p:UseAppHost=false /p:DebugType=None /p:DebugSymbols=false /p:PublishProfile=Properties/PublishProfiles/DisableContainerBuild.pubxml
 
-#================================================================================================
-
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
+EXPOSE 5000
+ENV ASPNETCORE_HTTP_PORTS=5000
+ENV DOTNET_EnableDiagnostics=0
 COPY --from=publish /app/publish .
-
-# Copy .pdb files to a separate directory
-RUN mkdir -p /app/symbols
-RUN find /app -name "*.pdb" -exec cp {} /app/symbols/ \;
-
-# RUN ls -alR /app
-
 ENTRYPOINT ["dotnet", "Grace.Server.dll"]


### PR DESCRIPTION
# Grace Server Azure Container Apps tracer

## Outcome

Closes #986 by running one Grace Server image as one Azure Container Apps replica with managed identity,
external HTTPS ingress, health probes, and the immutable ACR image digest.

## Why this matters

This gives Grace a small, disposable Azure Container Apps hosting path that validates the server's existing
managed-identity startup configuration without making multi-replica or production-scale claims.

## Changes

- Pin the Docker SDK build stage to the compiler input that succeeds in local and ACR builds.
- Restore and publish the complete Grace Server project graph once, excluding unrelated ServiceDefaults work.
- Provide the server's required log, pub-sub, Orleans, and blob-container settings through the Container Apps
  environment list.

## Validation

- Infrastructure profile assertions and Bicep compilation passed.
- A clean no-cache local image build passed; the final image contains the runtime only, with no SDK, source tree,
  or PDB files.
- ACR build `cc1` passed with image digest
  `sha256:97645ff2eb8d68f36b3340b30f2aa7df2ce629291db0f6d76c5cd772e78dd33d`.
- ARM validation and what-if used only the approved resource graph.
- The deployed revision `grace-server-development-260819--0000001` is healthy, has one replica, uses the
  expected identity, image digest, HTTPS ingress, probes, and no Container Apps secrets or secret references.
- Public `GET /healthz` returned HTTP 200.
- Azure SQL reports General Purpose serverless, 0.5 minimum capacity, 1 capacity, and a 15-minute auto-pause;
  Cosmos reports 1,000 RU/s; Redis reports `Balanced_B0`; ACR is Basic with admin access disabled.

## Scope and retained environment

- This remains a Product V1, single-replica hosting tracer. It does not claim multi-replica Orleans support,
  Kubernetes, Dapr, a general container pipeline, or a production rollout.
- `global.json`, #983, and #987 are unchanged.
- At the maintainer's direction, `rg-grace-development-260819` remains available for further in-place iteration.
  Do not delete it until the maintainer explicitly authorizes cleanup.

## Review state

- Current head: `dd0db7e16064824bd4068f675255bd90109c422d`
- R1 discovery review: pending.
- GitHub Validate: pending for this head.
