### PR TITLE
Implement Azure Managed Redis Microsoft Entra authentication

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -17,7 +17,9 @@ accepted General Purpose serverless baseline: `GP_S_Gen5_1`, 0.5 minimum and 1 m
 and keeps the database online at paid serverless rates after the allowance is exhausted. The profile also creates a
 Basic Azure Container Registry, one user-assigned managed identity,
 a Container Apps environment, and one externally reachable Grace Server replica. The Container App uses the identity
-to pull an immutable image without registry administrator credentials. Private networking and environment-specific
+to pull an immutable image without registry administrator credentials and to authenticate to Azure Managed Redis. The
+Redis database disables access-key authentication and grants that identity the stable `default` data-plane policy,
+which intentionally permits all Redis commands and keys for this Product V1 slice. Private networking and environment-specific
 reliability decisions remain separate work.
 
 ## Build and deploy Grace Server
@@ -99,10 +101,11 @@ Invoke-WebRequest -Uri "https://$fqdn/healthz"
 ```
 
 The complete deployment outputs the registry login server, public Grace Server hostname, deployed revision name, and
-managed-identity client and principal IDs for later slices. Re-running the complete deployment with a new digest creates
+managed-identity client and principal IDs. Re-running the complete deployment with a new digest creates
 a new immutable Container Apps revision. Do not pass registry passwords, administrator credentials, or access tokens as
-application settings. This tracer deliberately does not activate Grace's Redis client settings; issue #983 owns the
-Azure Managed Redis authentication and readiness contract.
+application settings. Grace receives only the Redis hostname, port, and explicit `MicrosoftEntra` mode. The server uses
+the same user-assigned identity selected by `AZURE_CLIENT_ID`; the Microsoft Redis extension acquires and refreshes its
+token, and startup must complete an authenticated `PING` before the configured integration is ready.
 
 Azure applies the SQL free allowance only when the subscription and database are eligible. The
 [current free offer](https://learn.microsoft.com/azure/azure-sql/database/free-offer) supports up to ten free-offer

--- a/infra/main.production.bicep
+++ b/infra/main.production.bicep
@@ -122,6 +122,7 @@ module sql 'modules/sql.bicep' = {
 module redis 'modules/redis.bicep' = {
   name: 'redis'
   params: {
+    graceServerPrincipalId: identity.outputs.principalId
     highAvailability: true
     location: location
     name: redisName
@@ -164,6 +165,8 @@ module graceServer 'modules/container-app.bicep' = {
     location: location
     name: containerAppName
     registryServer: registry.outputs.loginServer
+    redisHost: redis.outputs.hostName
+    redisPort: redis.outputs.port
     serviceBusEventSubscription: serviceBus.outputs.eventSubscriptionName
     serviceBusEventTopic: serviceBus.outputs.eventTopicName
     serviceBusGraceUsageSubscription: serviceBus.outputs.graceUsageSubscriptionName

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -52,6 +52,12 @@ param serviceBusGraceUsageSubscription string
 @description('Microsoft Entra Azure SQL connection string.')
 param sqlConnectionString string
 
+@description('Public TLS hostname of Azure Managed Redis.')
+param redisHost string
+
+@description('TLS port of Azure Managed Redis.')
+param redisPort int
+
 resource app 'Microsoft.App/containerApps@2024-03-01' = {
   name: name
   location: location
@@ -108,6 +114,9 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
               value: serviceBusGraceUsageSubscription
             }
             { name: 'grace__operations__sql__connectionstring', value: sqlConnectionString }
+            { name: 'grace__redis__authentication_mode', value: 'MicrosoftEntra' }
+            { name: 'grace__redis__host', value: redisHost }
+            { name: 'grace__redis__port', value: string(redisPort) }
           ]
           probes: [
             {

--- a/infra/modules/redis.bicep
+++ b/infra/modules/redis.bicep
@@ -13,6 +13,9 @@ param skuName string
 @description('Whether Redis uses a replicated high-availability pair.')
 param highAvailability bool
 
+@description('Object ID of the Grace Server managed identity authorized for Redis data-plane access.')
+param graceServerPrincipalId string
+
 resource redis 'Microsoft.Cache/redisEnterprise@2025-04-01' = {
   name: name
   location: location
@@ -31,11 +34,23 @@ resource database 'Microsoft.Cache/redisEnterprise/databases@2025-04-01' = {
   parent: redis
   name: 'default'
   properties: {
+    accessKeysAuthentication: 'Disabled'
     clientProtocol: 'Encrypted'
     clusteringPolicy: 'OSSCluster'
     evictionPolicy: 'VolatileLRU'
     modules: []
     port: 10000
+  }
+}
+
+resource graceServerAccess 'Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments@2025-04-01' = {
+  parent: database
+  name: 'graceServer'
+  properties: {
+    accessPolicyName: 'default'
+    user: {
+      objectId: graceServerPrincipalId
+    }
   }
 }
 

--- a/infra/tests/Assert-InfrastructureProfiles.ps1
+++ b/infra/tests/Assert-InfrastructureProfiles.ps1
@@ -10,6 +10,7 @@ $productionTemplatePath = Join-Path $infraRoot 'main.production.bicep'
 $infraReadmePath = Join-Path $infraRoot 'README.md'
 $serviceBusModulePath = Join-Path $infraRoot 'modules\service-bus.bicep'
 $sqlModulePath = Join-Path $infraRoot 'modules\sql.bicep'
+$redisModulePath = Join-Path $infraRoot 'modules\redis.bicep'
 $containerAppModulePath = Join-Path $infraRoot 'modules\container-app.bicep'
 $containerRegistryModulePath = Join-Path $infraRoot 'modules\container-registry.bicep'
 $redisContainerModulePath = Join-Path $infraRoot 'modules\redis-container.bicep'
@@ -65,6 +66,7 @@ $labTemplate = Get-Content -LiteralPath $labTemplatePath -Raw
 $productionTemplate = Get-Content -LiteralPath $productionTemplatePath -Raw
 $serviceBusModule = Get-Content -LiteralPath $serviceBusModulePath -Raw
 $sqlModule = Get-Content -LiteralPath $sqlModulePath -Raw
+$redisModule = Get-Content -LiteralPath $redisModulePath -Raw
 $containerAppModule = Get-Content -LiteralPath $containerAppModulePath -Raw
 $containerRegistryModule = Get-Content -LiteralPath $containerRegistryModulePath -Raw
 $redisContainerModule = Get-Content -LiteralPath $redisContainerModulePath -Raw
@@ -88,6 +90,14 @@ Assert-Pattern $productionTemplate 'useFreeLimit:\s*true' 'The production-shaped
 Assert-Pattern $productionTemplate "freeLimitExhaustionBehavior:\s*'BillOverUsage'" 'The production-shaped profile must remain online and bill at serverless rates after the free allowance.'
 Assert-Pattern $productionTemplate 'param\s+redisSkuName\s+string(\s|$)' 'The production-shaped profile must require a Redis SKU.'
 Assert-Pattern $productionTemplate 'highAvailability:\s*true' 'The production-shaped profile must enable Redis high availability.'
+Assert-Pattern $productionTemplate 'graceServerPrincipalId:\s*identity\.outputs\.principalId' 'Azure Managed Redis must authorize the Grace Server identity.'
+Assert-Pattern $productionTemplate 'redisHost:\s*redis\.outputs\.hostName' 'Grace Server must receive the Azure Managed Redis hostname.'
+Assert-Pattern $productionTemplate 'redisPort:\s*redis\.outputs\.port' 'Grace Server must receive the Azure Managed Redis TLS port.'
+
+Assert-Pattern $redisModule "accessKeysAuthentication:\s*'Disabled'" 'Azure Managed Redis must reject access-key authentication.'
+Assert-Pattern $redisModule 'Microsoft\.Cache/redisEnterprise/databases/accessPolicyAssignments@2025-04-01' 'Azure Managed Redis must use the stable access-policy assignment API.'
+Assert-Pattern $redisModule "accessPolicyName:\s*'default'" 'Azure Managed Redis must assign its stable default data-plane policy.'
+Assert-Pattern $redisModule 'objectId:\s*graceServerPrincipalId' 'Azure Managed Redis must assign the policy to the Grace Server identity.'
 
 Assert-Pattern $sqlModule "Microsoft\.Sql/servers/databases@2025-01-01" 'The SQL module must use the API version that supports free-limit behavior.'
 Assert-Pattern $sqlModule 'autoPauseDelay:\s*autoPauseDelayMinutes' 'The SQL module must apply the selected auto-pause delay.'
@@ -113,12 +123,15 @@ Assert-Pattern $containerAppModule "external:\s*true" 'Grace Server must expose 
 Assert-Pattern $containerAppModule 'targetPort:\s*5000' 'Grace Server ingress must target its documented HTTP port.'
 Assert-Pattern $containerAppModule 'registries:\s*\[[\s\S]*identity:\s*identityId' 'Grace Server must use its managed identity for registry pulls.'
 Assert-Pattern $containerAppModule "name:\s*'AZURE_CLIENT_ID'" 'Grace Server must select its user-assigned identity at runtime.'
+Assert-Pattern $containerAppModule "name:\s*'grace__redis__authentication_mode',\s*value:\s*'MicrosoftEntra'" 'Grace Server must explicitly select Microsoft Entra Redis authentication.'
+Assert-Pattern $containerAppModule "name:\s*'grace__redis__host',\s*value:\s*redisHost" 'Grace Server must receive the managed Redis hostname without a secret.'
+Assert-Pattern $containerAppModule "name:\s*'grace__redis__port',\s*value:\s*string\(redisPort\)" 'Grace Server must receive the managed Redis port without a secret.'
 Assert-Pattern $containerAppModule "type:\s*'Startup'" 'Grace Server must have a startup probe.'
 Assert-Pattern $containerAppModule "type:\s*'Readiness'" 'Grace Server must have a readiness probe.'
 Assert-Pattern $containerAppModule "type:\s*'Liveness'" 'Grace Server must have a liveness probe.'
 Assert-Pattern $containerAppModule "path:\s*'/healthz'" 'Grace Server HTTP probes must use the existing health endpoint.'
 Assert-PatternAbsent $containerAppModule '(registryPassword|passwordSecretRef|adminUserEnabled:\s*true)' 'The Container App must not use registry credentials.'
-Assert-PatternAbsent $containerAppModule 'grace__redis__' 'The Container App tracer must not activate Redis before issue #983 supplies its managed-identity contract.'
+Assert-PatternAbsent $containerAppModule '(grace__redis__(username|password|ca_certificate)|secretRef)' 'The Container App must not receive Redis credentials, custom trust, or secrets.'
 
 Assert-Pattern $graceServerDockerfile 'FROM\s+mcr\.microsoft\.com/dotnet/aspnet:10\.0\s+AS\s+final' 'The production image must use the ASP.NET runtime image.'
 Assert-Pattern $graceServerDockerfile 'dotnet publish[^\r\n]+-c Release' 'The production image must publish Grace Server in Release mode.'

--- a/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
+++ b/src/Grace.Server.Unit.Tests/RepositoryCounterRecentResult.Server.Tests.fs
@@ -6,10 +6,12 @@ open Grace.Shared
 open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
 open NUnit.Framework
+open Microsoft.Extensions.Logging.Abstractions
 open System
 open System.Security.Cryptography
 open System.Security.Cryptography.X509Certificates
 open System.Threading
+open StackExchange.Redis
 
 /// Covers the provider-neutral Redis recent-result wire contract without starting Redis.
 [<Parallelizable(ParallelScope.All)>]
@@ -49,6 +51,36 @@ type RepositoryCounterRecentResultTests() =
         Assert.That(configuration.SslHost, Is.EqualTo("redis.example.test"))
         Assert.That(configuration.User, Is.EqualTo("grace"))
         Assert.That(configuration.Password, Is.EqualTo("secret"))
+
+    /// Verifies Redis authentication stays explicit while preserving the existing local and lab modes.
+    [<Test>]
+    member _.RedisAuthenticationModeSelectsTheConfiguredCredentialPath() =
+        Assert.That(selectAuthenticationMode null false, Is.EqualTo(RedisAuthenticationMode.Unauthenticated))
+        Assert.That(selectAuthenticationMode "" true, Is.EqualTo(RedisAuthenticationMode.AclTls))
+        Assert.That(selectAuthenticationMode "MicrosoftEntra" false, Is.EqualTo(RedisAuthenticationMode.MicrosoftEntra))
+
+    /// Verifies Azure Managed Redis configuration is TLS-only RESP3 and never carries a static credential.
+    [<Test>]
+    member _.AzureManagedRedisBaseConfigurationIsSecretFreeTlsResp3() =
+        let loggerFactory = NullLoggerFactory.Instance
+        let configuration = configurationForAzureManagedRedis "redis.example.test" 10000 loggerFactory
+
+        Assert.That(configuration.Ssl, Is.True)
+        Assert.That(configuration.SslHost, Is.EqualTo("redis.example.test"))
+        Assert.That(configuration.Protocol, Is.EqualTo(RedisProtocol.Resp3))
+        Assert.That(configuration.LoggerFactory, Is.SameAs(loggerFactory))
+        Assert.That(configuration.User, Is.Null)
+        Assert.That(configuration.Password, Is.Null)
+
+    /// Verifies a misspelled authentication mode fails instead of silently falling back to a static or anonymous path.
+    [<Test>]
+    member _.UnknownRedisAuthenticationModeIsRejected() =
+        Assert.Throws<InvalidOperationException>(
+            Action (fun () ->
+                selectAuthenticationMode "AccessKey" false
+                |> ignore)
+        )
+        |> ignore
 
     /// Verifies cached changes round-trip without inventing a zero for missing or malformed values.
     [<Test>]

--- a/src/Grace.Server/Grace.Server.fsproj
+++ b/src/Grace.Server/Grace.Server.fsproj
@@ -151,6 +151,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.11" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.11" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.1" />
+		<PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
 		<PackageReference Include="Microsoft.OpenApi" Version="3.10.0" />
 		<PackageReference Include="Microsoft.Orleans.Clustering.AzureStorage" Version="10.2.2" />
 		<PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="10.2.2" />

--- a/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
+++ b/src/Grace.Server/RepositoryCounterRecentResult.Server.fs
@@ -4,6 +4,8 @@ open Grace.Shared
 open Grace.Actors
 open Grace.Types.Common
 open Grace.Types.RepositoryContentCounter
+open Azure.Core
+open Microsoft.Azure.StackExchangeRedis
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.Logging.Abstractions
 open Microsoft.Extensions.Hosting
@@ -18,6 +20,21 @@ open System.Threading.Tasks
 
 /// Provides a nonauthoritative Redis accelerator for recently completed repository counter operations.
 module RepositoryCounterRecentResult =
+
+    /// Identifies the one Redis credential contract Grace will use for the configured endpoint.
+    type RedisAuthenticationMode =
+        | Unauthenticated
+        | AclTls
+        | MicrosoftEntra
+
+    /// Selects an explicit hosted authentication mode while retaining the established local and lab defaults.
+    let selectAuthenticationMode (configuredMode: string) tls =
+        if String.IsNullOrWhiteSpace configuredMode then
+            if tls then AclTls else Unauthenticated
+        elif String.Equals(configuredMode, "MicrosoftEntra", StringComparison.OrdinalIgnoreCase) then
+            MicrosoftEntra
+        else
+            invalidOp $"Unsupported Redis authentication mode '{configuredMode}'."
 
     /// Defines the exact ten-minute lifetime required for recent counter results.
     let expiry = TimeSpan.FromMinutes 10.0
@@ -68,6 +85,15 @@ module RepositoryCounterRecentResult =
                     chain.Build serverCertificate)
         )
 
+        configuration
+
+    /// Builds the secret-free TLS and RESP3 baseline required before the Microsoft extension supplies an Entra token.
+    let configurationForAzureManagedRedis (host: string) (port: int) (loggerFactory: ILoggerFactory) =
+        let configuration = configurationForEndpoint host port
+        configuration.Ssl <- true
+        configuration.SslHost <- host
+        configuration.Protocol <- RedisProtocol.Resp3
+        configuration.LoggerFactory <- loggerFactory
         configuration
 
     /// Requires an explicit readiness probe when StackExchange.Redis returns its reconnecting multiplexer before a socket is connected.
@@ -144,9 +170,19 @@ module RepositoryCounterRecentResult =
                 Task.FromResult false
 
     /// Uses one lazy StackExchange.Redis connection with native reconnect, readiness proof, bounded commands, and structured failure evidence.
-    type RedisRepositoryCounterRecentResult private (configuration: ConfigurationOptions, log: ILogger) =
+    type RedisRepositoryCounterRecentResult private (configuration: ConfigurationOptions, credential: TokenCredential option, log: ILogger) =
 
-        let connection = lazy (task { return! ConnectionMultiplexer.ConnectAsync configuration })
+        let connection =
+            lazy
+                (task {
+                    match credential with
+                    | Some tokenCredential ->
+                        let! _ = configuration.ConfigureForAzureWithTokenCredentialAsync tokenCredential
+                        ()
+                    | None -> ()
+
+                    return! ConnectionMultiplexer.ConnectAsync configuration
+                })
 
         let database (cancellationToken: CancellationToken) : Task<IDatabase> =
             task {
@@ -168,14 +204,18 @@ module RepositoryCounterRecentResult =
             log.LogWarning(error, "Redis repository counter recent-result {Operation} failed; using nonauthoritative fallback {Fallback}.", operation, fallback)
 
         /// Creates the Redis accelerator with a no-op logger for focused callers that intentionally omit structured diagnostics.
-        new(host: string, port: int) = new RedisRepositoryCounterRecentResult(configurationForEndpoint host port, NullLogger.Instance)
+        new(host: string, port: int) = new RedisRepositoryCounterRecentResult(configurationForEndpoint host port, None, NullLogger.Instance)
 
         /// Creates the Redis accelerator for the existing unauthenticated local development endpoint.
-        new(host: string, port: int, log: ILogger) = new RedisRepositoryCounterRecentResult(configurationForEndpoint host port, log)
+        new(host: string, port: int, log: ILogger) = new RedisRepositoryCounterRecentResult(configurationForEndpoint host port, None, log)
 
         /// Creates the Redis accelerator for the TLS-only lab endpoint with its generated ACL credential and custom root.
         new(host: string, port: int, username: string, password: string, caCertificatePem: string, log: ILogger) =
-            new RedisRepositoryCounterRecentResult(configurationForSecureEndpoint host port username password caCertificatePem, log)
+            new RedisRepositoryCounterRecentResult(configurationForSecureEndpoint host port username password caCertificatePem, None, log)
+
+        /// Creates the Azure Managed Redis accelerator whose Entra token is acquired and refreshed by the Microsoft extension.
+        new(host: string, port: int, credential: TokenCredential, loggerFactory: ILoggerFactory, log: ILogger) =
+            new RedisRepositoryCounterRecentResult(configurationForAzureManagedRedis host port loggerFactory, Some credential, log)
 
         /// Completes an explicit authenticated PING before Grace reports the configured Redis integration ready.
         member _.PingAsync(cancellationToken: CancellationToken) =

--- a/src/Grace.Server/Startup.Server.fs
+++ b/src/Grace.Server/Startup.Server.fs
@@ -2192,18 +2192,27 @@ module Application =
 
                 let redisPort = configuration.GetValue<int>(getConfigKey Constants.EnvironmentVariables.RedisPort)
                 let redisTls = configuration.GetValue<bool>(getConfigKey Constants.EnvironmentVariables.RedisTls)
+                let redisAuthenticationMode = configuration[getConfigKey Constants.EnvironmentVariables.RedisAuthenticationMode]
 
                 if String.IsNullOrWhiteSpace redisHost then
                     RepositoryCounterRecentResult.UnavailableRepositoryCounterRecentResult() :> IRepositoryCounterRecentResult
                 else
                     let effectivePort = if redisPort > 0 then redisPort else 6379
 
-                    let redisLog =
-                        serviceProvider
-                            .GetRequiredService<ILoggerFactory>()
-                            .CreateLogger("RepositoryCounterRecentResult.Server")
+                    let loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>()
+                    let redisLog = loggerFactory.CreateLogger("RepositoryCounterRecentResult.Server")
 
-                    if redisTls then
+                    match RepositoryCounterRecentResult.selectAuthenticationMode redisAuthenticationMode redisTls with
+                    | RepositoryCounterRecentResult.RedisAuthenticationMode.MicrosoftEntra ->
+                        new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(
+                            redisHost,
+                            effectivePort,
+                            defaultAzureCredential.Value,
+                            loggerFactory,
+                            redisLog
+                        )
+                        :> IRepositoryCounterRecentResult
+                    | RepositoryCounterRecentResult.RedisAuthenticationMode.AclTls ->
                         let redisUsername = configuration[getConfigKey Constants.EnvironmentVariables.RedisUsername]
                         let redisPassword = configuration[getConfigKey Constants.EnvironmentVariables.RedisPassword]
                         let encodedCaCertificate = configuration[getConfigKey Constants.EnvironmentVariables.RedisCaCertificate]
@@ -2227,7 +2236,7 @@ module Application =
                             redisLog
                         )
                         :> IRepositoryCounterRecentResult
-                    else
+                    | RepositoryCounterRecentResult.RedisAuthenticationMode.Unauthenticated ->
                         new RepositoryCounterRecentResult.RedisRepositoryCounterRecentResult(redisHost, effectivePort, redisLog)
                         :> IRepositoryCounterRecentResult)
             |> ignore

--- a/src/Grace.Shared/Constants.Shared.fs
+++ b/src/Grace.Shared/Constants.Shared.fs
@@ -382,6 +382,10 @@ module Constants =
         [<Literal>]
         let RedisHost = "grace__redis__host"
 
+        /// The environment variable that selects the Redis credential path.
+        [<Literal>]
+        let RedisAuthenticationMode = "grace__redis__authentication_mode"
+
         /// The environment variable that contains the Redis port number.
         [<Literal>]
         let RedisPort = "grace__redis__port"

--- a/src/docs/ENVIRONMENT.md
+++ b/src/docs/ENVIRONMENT.md
@@ -241,6 +241,8 @@ Messages are completed only after SQL processing succeeds or the durable usage f
 
 - `grace__redis__host`: optional Redis host for ten-minute repository-counter
   recent results.
+- `grace__redis__authentication_mode`: set to `MicrosoftEntra` for Azure Managed Redis. When omitted, Grace preserves
+  the existing local or infrastructure-lab path selected by `grace__redis__tls`.
 - `grace__redis__port`: Redis port; defaults to `6379` when a host is set.
 - `grace__redis__tls`: set to `true` for the infrastructure lab endpoint.
 - `grace__redis__username`: Redis ACL username required when TLS is enabled.
@@ -250,6 +252,12 @@ Messages are completed only after SQL processing succeeds or the durable usage f
 The infrastructure lab runner supplies all five secure-endpoint settings to `DebugAzure`, validates the generated CA
 and DNS hostname, completes authenticated `PING`, and clears its parent-process copies before reporting readiness.
 When these lab settings are absent, `DebugAzure` retains the existing unauthenticated local Redis container.
+
+The production-shaped Container App sets `MicrosoftEntra`, the public TLS hostname, and port `10000`, but no Redis
+username, password, access key, token, or custom CA. Grace uses the user-assigned identity selected by `AZURE_CLIENT_ID`
+with `Microsoft.Azure.StackExchangeRedis`; the extension refreshes tokens and reauthenticates the RESP3 connection.
+The Azure Managed Redis database disables access keys and assigns the identity the stable `default` policy. That policy
+allows all commands and keys; a narrower custom ACL is outside this Product V1 deployment.
 
 When Redis is not configured or cannot be reached, recent-result reads return
 unknown. Addition processing may continue because retaining content is safe.


### PR DESCRIPTION
# Issue #983: Azure Managed Redis Microsoft Entra authentication

## Summary

Closes #983.

- Disables Azure Managed Redis access-key authentication and gives the deployed Grace Server user-assigned managed identity the stable `default` data-plane policy.
- Configures the production Container App with the Redis host, port, and explicit Microsoft Entra authentication mode.
- Uses `Microsoft.Azure.StackExchangeRedis` with the existing `StackExchange.Redis` 3.1.13 client to acquire and refresh tokens over TLS with RESP3.
- Adds focused configuration tests, infrastructure assertions, and deployment documentation.

## Supported world

One Azure Container Apps Grace Server replica connects to the retained Azure Managed Redis database with its existing user-assigned managed identity. The stable `default` policy grants full Redis data-plane access. Custom ACLs, static-key fallback, multi-replica Orleans readiness, private networking, and autoscaling are outside this PR.

## Validation

- Infrastructure profile assertions passed.
- Production Bicep compilation passed. Azure CLI reported only that a newer Bicep version is available.
- Release `Grace.Server.Unit.Tests` build passed with zero warnings and errors.
- Redis-focused tests passed: 12/12.
- MarkdownLint and `git diff --check` passed.
- Retained-resource deployment is healthy on `grace-server-development-260819--0000003`.
- A temporary probe in that existing replica used the deployed identity and shipped Redis libraries. It completed authenticated TLS/RESP3 setup, `SET=True`, `GET=True`, and `DEL=True`; the temporary key and probe files were deleted.

## Review note

The local worktree contains an unrelated, uncommitted `Microsoft.OpenApi` 3.10.0 to 3.10.2 update in `Grace.Server.fsproj`. This PR stages only the Issue #983 `Microsoft.Azure.StackExchangeRedis` package addition and does not include the OpenAPI update.
